### PR TITLE
fix(mac): live channel status + per-channel reconciler, drop NaNk token bug

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -146,11 +146,21 @@ async function bootInProcessCore() {
     await workspaceManager.switchWorkspace(workspaceManager.getCurrentWorkspace())
     const runtimeCfg = buildRuntimeConfig(coreConfigManager.get())
     inProcessGateway = new Codey(runtimeCfg, undefined, join(root, 'workspaces'), coreConfigManager, workerManager)
-    // Apply config changes to the running gateway when the renderer edits them
+    // Apply config changes to the running gateway when the renderer edits them.
+    // applyConfig is async so a missing await would swallow channel-start errors.
     coreConfigManager.on('change', (updated: any) => {
-      inProcessGateway?.applyConfig(buildRuntimeConfig(updated))
+      inProcessGateway?.applyConfig(buildRuntimeConfig(updated)).catch((err: any) => {
+        sendToRenderer('gateway-log', `[core] applyConfig failed: ${err?.message ?? err}`)
+      })
     })
     sendToRenderer('gateway-log', `[core] In-process core booted (root: ${root}, workers: ${workerManager.getAllWorkers().length}, agent: ${runtimeCfg.defaultAgent})`)
+    // Boot the gateway in the background so configured channels (telegram,
+    // discord, imessage) connect. Done after returning so IPC handler
+    // registration in app.whenReady() isn't blocked by network I/O
+    // (e.g. Telegram setMyCommands hanging).
+    void inProcessGateway.start().catch((err: any) => {
+      sendToRenderer('gateway-log', `[core] gateway.start failed: ${err?.message ?? err}`)
+    })
   } catch (err: any) {
     sendToRenderer('gateway-log', `[core] Boot failed: ${err?.message ?? err}`)
   }
@@ -199,6 +209,11 @@ app.whenReady().then(async () => {
   createWindow()
   createTray()
   await bootInProcessCore()
+
+  // ── Gateway status IPC ────────────────────────────────────────────
+  ipcMain.handle('gateway:status', async () =>
+    wrap(async () => inProcessGateway?.getHealthStatus() ?? null)
+  )
 
   // ── Workers IPC ──────────────────────────────────────────────────
   ipcMain.handle('workers:list', async () =>

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -75,6 +75,9 @@ contextBridge.exposeInMainWorld('codey', {
       return () => ipcRenderer.removeListener('chats:event', listener)
     },
   },
+  gateway: {
+    status: () => ipcRenderer.invoke('gateway:status'),
+  },
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   onLog: (handler: (msg: string) => void) => {
     const listener = (_e: Electron.IpcRendererEvent, msg: string) => handler(msg)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -67,6 +67,14 @@ declare global {
         send: (payload: { chatId: string; text: string }) => Promise<IpcResult<{ response: string; chatId: string; tokens?: number; durationSec?: number }>>
         onEvent: (handler: (ev: ChatStreamEvent) => void) => () => void
       }
+      gateway: {
+        status: () => Promise<IpcResult<{
+          status: 'healthy' | 'degraded'
+          uptime: number
+          channels: { telegram: boolean; discord: boolean; imessage: boolean }
+          stats: { messagesProcessed: number; activeConversations: number; errors: number }
+        } | null>>
+      }
       openExternal: (url: string) => Promise<void>
       onLog: (handler: (msg: string) => void) => () => void
     }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -19,7 +19,8 @@ const SendIcon: React.FC<{ color: string }> = ({ color }) => (
 const fmtTime = (ts: number) =>
   new Date(ts).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 
-const formatTokens = (n: number): string => {
+const formatTokens = (n: number): string | null => {
+  if (!Number.isFinite(n) || n < 0) return null
   if (n < 1000) return String(n)
   if (n < 10_000) return `${(n / 1000).toFixed(1)}k`
   return `${Math.round(n / 1000)}k`
@@ -180,13 +181,18 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
               </div>
               <div style={styles.tsLabel}>
                 <span>{fmtTime(msg.timestamp)}</span>
-                {(msg.tokens != null || msg.durationSec != null) && (
-                  <span style={styles.tsMeta}>
-                    {msg.tokens != null && `${formatTokens(msg.tokens)} tok`}
-                    {msg.tokens != null && msg.durationSec != null && ' · '}
-                    {msg.durationSec != null && `${msg.durationSec}s`}
-                  </span>
-                )}
+                {(() => {
+                  const tokStr = msg.tokens != null ? formatTokens(msg.tokens) : null
+                  const durStr = msg.durationSec != null && Number.isFinite(msg.durationSec) ? `${msg.durationSec}s` : null
+                  if (!tokStr && !durStr) return null
+                  return (
+                    <span style={styles.tsMeta}>
+                      {tokStr && `${tokStr} tok`}
+                      {tokStr && durStr && ' · '}
+                      {durStr}
+                    </span>
+                  )
+                })()}
               </div>
             </div>
           )

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -105,26 +105,10 @@ export const Markdown: React.FC<MarkdownProps> = ({ children, variant = 'assista
               {children}
             </td>
           ),
-          code: ({ inline, className, children, ...props }: any) => {
-            const content = String(children ?? '').replace(/\n$/, '')
-            if (inline) {
-              return (
-                <code
-                  {...props}
-                  style={{
-                    background: inlineCodeBg,
-                    color: inlineCodeFg,
-                    padding: '1px 6px',
-                    borderRadius: 4,
-                    fontSize: 12,
-                    fontFamily: MONO,
-                  }}
-                >
-                  {content}
-                </code>
-              )
-            }
-            const lang = /language-(\w+)/.exec(className || '')?.[1]
+          pre: ({ children }: any) => {
+            const child: any = React.Children.toArray(children)[0]
+            const className: string = child?.props?.className ?? ''
+            const lang = /language-(\w+)/.exec(className)?.[1]
             return (
               <div
                 style={{
@@ -156,8 +140,29 @@ export const Markdown: React.FC<MarkdownProps> = ({ children, variant = 'assista
                     {lang}
                   </div>
                 )}
-                <code style={{ fontFamily: MONO }}>{content}</code>
+                {children}
               </div>
+            )
+          },
+          code: ({ className, children, ...props }: any) => {
+            const isBlock = /language-/.test(className || '')
+            if (isBlock) {
+              return <code className={className} style={{ fontFamily: MONO }}>{children}</code>
+            }
+            return (
+              <code
+                {...props}
+                style={{
+                  background: inlineCodeBg,
+                  color: inlineCodeFg,
+                  padding: '1px 6px',
+                  borderRadius: 4,
+                  fontSize: 12,
+                  fontFamily: MONO,
+                }}
+              >
+                {children}
+              </code>
             )
           },
         }}

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -16,6 +16,11 @@ interface ModelEntry {
 }
 interface AgentSlot { enabled?: boolean; defaultModel?: string }
 interface FallbackCfg { enabled: boolean; order: string[] }
+interface ChannelsCfg {
+  telegram?: { enabled: boolean; botToken: string; notifyChatId?: string }
+  discord?:  { enabled: boolean; botToken: string }
+  imessage?: { enabled: boolean }
+}
 
 const AGENT_NAMES = ['claude-code', 'opencode', 'codex'] as const
 
@@ -64,6 +69,68 @@ const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on,
     }}/>
   </div>
 )
+
+// ── Channel editor row ──────────────────────────────────────────────
+
+interface ChannelField {
+  label: string
+  value: string
+  secret?: boolean
+  onChange: (next: string) => void
+}
+
+const ChannelEditor: React.FC<{
+  label: string
+  enabled: boolean
+  onToggle: (enabled: boolean) => Promise<void> | void
+  fields: ChannelField[]
+  note?: string
+}> = ({ label, enabled, onToggle, fields, note }) => {
+  const [open, setOpen] = useState(false)
+  // Local buffers so typing isn't blocked by per-keystroke IPC writes.
+  // Commit on blur instead.
+  const [drafts, setDrafts] = useState<string[]>(fields.map(f => f.value))
+  useEffect(() => { setDrafts(fields.map(f => f.value)) }, [fields.map(f => f.value).join('|')])
+
+  return (
+    <div style={{
+      background: C.surface2, border: `1px solid ${C.border}`,
+      borderRadius: 8, marginBottom: 8, overflow: 'hidden',
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '10px 14px',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ color: C.fg, fontSize: 13 }}>{label}</span>
+          {(fields.length > 0 || note) && (
+            <button onClick={() => setOpen(o => !o)} style={{ ...pillButton('ghost'), padding: '2px 8px', fontSize: 11 }}>
+              {open ? 'Hide' : 'Configure'}
+            </button>
+          )}
+        </div>
+        <Toggle on={enabled} onChange={v => { void onToggle(v) }}/>
+      </div>
+      {open && (
+        <div style={{ padding: '0 14px 12px', borderTop: `1px solid ${C.border}` }}>
+          {note && <div style={{ color: C.fg3, fontSize: 11, padding: '10px 0' }}>{note}</div>}
+          {fields.map((f, i) => (
+            <div key={f.label} style={{ display: 'grid', gridTemplateColumns: '120px 1fr', gap: 8, alignItems: 'center', marginTop: 10 }}>
+              <label style={{ color: C.fg3, fontSize: 12 }}>{f.label}</label>
+              <input
+                type={f.secret ? 'password' : 'text'}
+                value={drafts[i] ?? ''}
+                onChange={e => setDrafts(d => { const n = d.slice(); n[i] = e.target.value; return n })}
+                onBlur={() => { if (drafts[i] !== f.value) f.onChange(drafts[i] ?? '') }}
+                style={{ ...inputStyle, width: '100%' }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
 
 // ── Model row (view + edit) ─────────────────────────────────────────
 
@@ -186,18 +253,21 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const [models, setModels] = useState<ModelEntry[]>([])
   const [agents, setAgents] = useState<Record<string, AgentSlot>>({})
   const [fallback, setFallback] = useState<FallbackCfg>({ enabled: true, order: [] })
+  const [channels, setChannels] = useState<ChannelsCfg>({})
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const reload = useCallback(async () => {
     setError(null)
     try {
-      const [m, a, f] = await Promise.all([
+      const [m, a, f, cfg] = await Promise.all([
         unwrap(await window.codey.models.list()),
         unwrap(await window.codey.agents.get()),
         unwrap(await window.codey.fallback.get()),
+        unwrap(await window.codey.config.get()),
       ])
       setModels(m); setAgents(a as any); setFallback(f as FallbackCfg)
+      setChannels((cfg as any)?.channels ?? {})
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
@@ -238,6 +308,30 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
     await unwrap(await window.codey.fallback.set(fb))
   }
 
+  // ConfigManager.update() does Object.assign on channels, so we must send
+  // the full per-channel object (e.g. { telegram: { enabled, botToken, ... } })
+  // rather than a partial — otherwise omitted fields would be wiped.
+  const persistChannels = async (next: ChannelsCfg, patchKey: keyof ChannelsCfg) => {
+    setChannels(next)
+    const patch: any = { [patchKey]: next[patchKey] }
+    await unwrap(await window.codey.config.set({ channels: patch }))
+  }
+  const setTelegram = (patch: Partial<NonNullable<ChannelsCfg['telegram']>>) => {
+    const cur = channels.telegram ?? { enabled: false, botToken: '' }
+    const next = { ...channels, telegram: { ...cur, ...patch } }
+    return persistChannels(next, 'telegram')
+  }
+  const setDiscord = (patch: Partial<NonNullable<ChannelsCfg['discord']>>) => {
+    const cur = channels.discord ?? { enabled: false, botToken: '' }
+    const next = { ...channels, discord: { ...cur, ...patch } }
+    return persistChannels(next, 'discord')
+  }
+  const setIMessage = (patch: Partial<NonNullable<ChannelsCfg['imessage']>>) => {
+    const cur = channels.imessage ?? { enabled: false }
+    const next = { ...channels, imessage: { ...cur, ...patch } }
+    return persistChannels(next, 'imessage')
+  }
+
   const enabledAgents = AGENT_NAMES.filter(a => agents[a]?.enabled !== false)
   // Ensure fallback.order is coherent with enabled agents
   const liveOrder = fallback.order.length
@@ -248,6 +342,35 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   return (
     <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
       {error && <div style={{ background: '#FF453A22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
+
+      <Section title="Channels"/>
+      <ChannelEditor
+        label="Telegram"
+        enabled={!!channels.telegram?.enabled}
+        onToggle={enabled => setTelegram({ enabled })}
+        fields={[
+          { label: 'Bot Token', value: channels.telegram?.botToken ?? '', secret: true,
+            onChange: v => setTelegram({ botToken: v }) },
+          { label: 'Notify Chat ID', value: channels.telegram?.notifyChatId ?? '',
+            onChange: v => setTelegram({ notifyChatId: v || undefined }) },
+        ]}
+      />
+      <ChannelEditor
+        label="Discord"
+        enabled={!!channels.discord?.enabled}
+        onToggle={enabled => setDiscord({ enabled })}
+        fields={[
+          { label: 'Bot Token', value: channels.discord?.botToken ?? '', secret: true,
+            onChange: v => setDiscord({ botToken: v }) },
+        ]}
+      />
+      <ChannelEditor
+        label="iMessage"
+        enabled={!!channels.imessage?.enabled}
+        onToggle={enabled => setIMessage({ enabled })}
+        fields={[]}
+        note="Requires macOS Messages.app and Full Disk Access for the Codey app."
+      />
 
       <Section title="Models" right={
         <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>

--- a/codey-mac/src/hooks/useGateway.ts
+++ b/codey-mac/src/hooks/useGateway.ts
@@ -8,8 +8,18 @@ export interface GatewayStatus {
   channels: { telegram: boolean; discord: boolean; imessage: boolean }
 }
 
+const EMPTY_STATUS: GatewayStatus = {
+  status: 'starting',
+  uptime: 0,
+  messagesProcessed: 0,
+  errors: 0,
+  channels: { telegram: false, discord: false, imessage: false },
+}
+
 export const useGateway = () => {
   const [logs, setLogs] = useState<string[]>(['Gateway running in-process'])
+  const [status, setStatus] = useState<GatewayStatus>(EMPTY_STATUS)
+  const [isRunning, setIsRunning] = useState(false)
 
   useEffect(() => {
     const off = window.codey.onLog(msg => {
@@ -18,15 +28,37 @@ export const useGateway = () => {
     return off
   }, [])
 
+  useEffect(() => {
+    let stopped = false
+    const tick = async () => {
+      try {
+        const res = await window.codey.gateway.status()
+        if (stopped) return
+        if (res.ok && res.data) {
+          const d = res.data
+          setStatus({
+            status: d.status,
+            uptime: d.uptime,
+            messagesProcessed: d.stats.messagesProcessed,
+            errors: d.stats.errors,
+            channels: d.channels,
+          })
+          setIsRunning(true)
+        } else {
+          setIsRunning(false)
+        }
+      } catch {
+        if (!stopped) setIsRunning(false)
+      }
+    }
+    tick()
+    const id = setInterval(tick, 3000)
+    return () => { stopped = true; clearInterval(id) }
+  }, [])
+
   return {
-    isRunning: true,
-    status: {
-      status: 'healthy' as const,
-      uptime: 0,
-      messagesProcessed: 0,
-      errors: 0,
-      channels: { telegram: false, discord: false, imessage: false },
-    },
+    isRunning,
+    status,
     logs,
     start: async () => {},
     stop: async () => {},

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChatMessage, ToolCallEntry } from '@codey/core';
+import { AgentRequest, AgentResponse, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -133,9 +133,53 @@ export class Codey {
   }
 
   /** Apply runtime config changes (e.g. from the API). */
-  applyConfig(config: GatewayConfig): void {
+  async applyConfig(config: GatewayConfig): Promise<void> {
+    const prevChannels = this.config.channels;
     this.config = config;
     this.logger.info(`[Config] Applied: agent=${config.defaultAgent}, model=${this.getEffectiveModel()}`);
+    await this.reconcileChannels(prevChannels, config.channels);
+  }
+
+  /**
+   * Start, stop, or restart channel handlers to match the desired config.
+   * A channel is restarted when its config payload changes (e.g. token edit).
+   */
+  private async reconcileChannels(prev: ChannelConfig, next: ChannelConfig): Promise<void> {
+    await this.reconcileChannel('telegram', prev.telegram, next.telegram, () => new TelegramHandler());
+    await this.reconcileChannel('discord',  prev.discord,  next.discord,  () => new DiscordHandler());
+    const prevIm = prev.imessage?.enabled ? prev.imessage : undefined;
+    const nextIm = next.imessage?.enabled ? next.imessage : undefined;
+    await this.reconcileChannel('imessage', prevIm, nextIm, () => new IMessageHandler());
+  }
+
+  private async reconcileChannel(
+    name: 'telegram' | 'discord' | 'imessage',
+    prev: any | undefined,
+    next: any | undefined,
+    factory: () => ChannelHandler,
+  ): Promise<void> {
+    const same = JSON.stringify(prev ?? null) === JSON.stringify(next ?? null);
+    if (same && (next ? this.handlers.has(name) : !this.handlers.has(name))) return;
+
+    const existing = this.handlers.get(name);
+    if (existing) {
+      try { await existing.stop(); }
+      catch (e) { this.logger.error(`Failed to stop ${name} handler: ${e}`); }
+      this.handlers.delete(name);
+      this.logger.info(`${name} handler stopped`);
+    }
+
+    if (next) {
+      try {
+        const handler = factory();
+        handler.onMessage(this.handleMessage.bind(this));
+        await handler.start(next);
+        this.handlers.set(name, handler);
+        this.logger.info(`${name} handler started`);
+      } catch (e) {
+        this.logger.error(`Failed to start ${name} handler: ${e}`);
+      }
+    }
   }
 
   getWorkspaceList(): string[] {
@@ -187,32 +231,8 @@ export class Codey {
     this.logger.setLogFile(this.workspaceManager.getLogPath());
     this.logger.setErrorLogFile(this.workspaceManager.getErrorLogPath());
 
-    // Start Telegram
-    if (this.config.channels.telegram) {
-      const handler = new TelegramHandler();
-      handler.onMessage(this.handleMessage.bind(this));
-      await handler.start(this.config.channels.telegram);
-      this.handlers.set('telegram', handler);
-      this.logger.info('Telegram handler started');
-    }
-
-    // Start Discord
-    if (this.config.channels.discord) {
-      const handler = new DiscordHandler();
-      handler.onMessage(this.handleMessage.bind(this));
-      await handler.start(this.config.channels.discord);
-      this.handlers.set('discord', handler);
-      this.logger.info('Discord handler started');
-    }
-
-    // Start iMessage
-    if (this.config.channels.imessage?.enabled) {
-      const handler = new IMessageHandler();
-      handler.onMessage(this.handleMessage.bind(this));
-      await handler.start(this.config.channels.imessage);
-      this.handlers.set('imessage', handler);
-      this.logger.info('iMessage handler started');
-    }
+    // Start configured channels (telegram/discord/imessage)
+    await this.reconcileChannels({}, this.config.channels);
 
     // Start context cleanup interval
     this.conversationCleanupInterval = setInterval(() => {
@@ -579,14 +599,7 @@ export class Codey {
       }
     }
 
-    const tokenInfo = response.tokens
-      ? `\n\n📊 Tokens: ${response.tokens.total.toLocaleString()} (in: ${response.tokens.input.toLocaleString()}, out: ${response.tokens.output.toLocaleString()}${response.tokens.cache ? `, cache read: ${response.tokens.cache.read.toLocaleString()}` : ''})`
-      : '';
-    const durationInfo = response.duration
-      ? `\n⏱️ Time: ${response.duration}s`
-      : '';
-
-    return response.output + tokenInfo + durationInfo + toolSummary;
+    return response.output + toolSummary;
   }
 
   private async handleCommand(message: UserMessage, parsed: ParsedCommand): Promise<void> {
@@ -1176,15 +1189,8 @@ Example: /model gpt-4.1 write a Python script`;
       context: { workingDir: this.workingDir },
     });
 
-    const tokenInfo = response.tokens
-      ? `\n\n📊 Tokens: ${response.tokens.total.toLocaleString()} (in: ${response.tokens.input}, out: ${response.tokens.output})`
-      : '';
-    const durationInfo = response.duration
-      ? `\n⏱️ Time: ${response.duration}s`
-      : '';
-
     const replyText = response.success
-      ? `✅ **${worker.name}** completed:\n\n${response.output}${tokenInfo}${durationInfo}`
+      ? `✅ **${worker.name}** completed:\n\n${response.output}`
       : `❌ **${worker.name}** failed: ${response.error}`;
 
     await this.sendResponse({
@@ -1759,7 +1765,7 @@ Example: /model gpt-4.1 write a Python script`;
           onStatus,
         });
         output = response?.success ? this.formatAgentResponse(response) : (streamedText || '');
-        tokens = (response as any)?.tokens;
+        tokens = (response as any)?.tokens?.total;
       }
 
       const durationSec = Math.round((Date.now() - started) / 1000);


### PR DESCRIPTION
## Summary
- The Mac Settings/Status panels showed every channel as **Disabled** even when `gateway.json` had Telegram on. Three causes piled up: the in-process gateway was constructed but never `start()`ed, `useGateway` returned a hardcoded `{ telegram: false, ... }` stub, and there was no UI to toggle channels. Telegram also couldn't be re-enabled at runtime — `applyConfig` only mutated state without starting/stopping handlers.
- Worker chat replies showed `NaNk tok · 15s` because the chat path stored the whole `{ total, input, output, cache? }` object in a `tokens?: number` field, so `n / 1000` became `NaN`.
- Message bodies also carried a redundant `📊 Tokens / ⏱️ Time` trailer on top of the inline `tok · Ns` footer.

## Changes
**Gateway**
- `applyConfig` is now async and calls a new per-channel `reconcileChannels()` that starts, stops, or restarts handlers when the config block changes. `start()` shares the same path so there's no duplicated startup logic.
- Chat-runner reads `tokens.total` instead of the whole tokens object.
- Dropped the appended `📊 Tokens` / `⏱️ Time` trailers from `formatAgentResponse` and the worker-completion reply — the Mac UI surfaces this inline and the data is still on the IPC payload.

**Mac Electron main**
- Boots the in-process gateway in the background so IPC handler registration in `app.whenReady()` isn't blocked by Telegram's `setMyCommands` network call.
- Adds a `gateway:status` IPC backed by `getHealthStatus()`.
- `config:change` listener awaits the new async `applyConfig` and surfaces failures to the log pane.

**Renderer**
- `preload.ts` + `codey-api.d.ts`: expose `window.codey.gateway.status()`.
- `useGateway`: polls `gateway:status` every 3 s to drive both the channel pills and the running indicator.
- `SettingsTab`: new **Channels** section with per-channel toggles and a collapsible token editor (Telegram bot token + notify chat ID, Discord bot token, iMessage on/off). Token inputs commit on blur to avoid IPC-per-keystroke; saves go through `config:set`, which fires the existing change listener and triggers the reconciler — so flipping Telegram on connects the bot live, no restart.
- `ChatTab`: hardened `formatTokens` against non-finite values so a stray bad value can't render `NaNk` again.

**Markdown** (pre-existing in working tree, included for cohesion)
- Render fenced code blocks via the `pre` renderer so the language label and copy chrome attach to the block, while inline code styling stays unchanged.

## Test plan
- [ ] Launch the Mac app, open Settings — Telegram should show **Connected** within ~3 s if a valid token is configured.
- [ ] Toggle Discord/iMessage off and on without restarting; the Status tab pill should follow.
- [ ] Edit Telegram bot token in Settings, blur the field — handler restarts (check Logs).
- [ ] Send a chat message — footer shows e.g. `1.2k tok · 14s` instead of `NaNk tok`.
- [ ] Confirm message bodies no longer end with `📊 Tokens` / `⏱️ Time` blocks.
- [ ] Run gateway via CLI (`npm start`) to confirm standalone path still starts channels (the refactored `start()` reconciles from `{}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)