### PR TITLE
feat(agents): claude-code session resume + per-conversation anchor (Phase 1)

### DIFF
--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -61,8 +61,15 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         args.push('--dangerously-skip-permissions');
       }
 
-      // Note: session resumption is not used with -p mode.
-      // Conversation context is managed by the gateway's ContextManager.
+      // The gateway decides whether to resume a warm session or bootstrap
+      // a fresh one with full history. `--resume` continues an existing
+      // session; `--session-id` pins a pre-allocated UUID so the gateway
+      // can resume the same id on later turns without parsing it back out.
+      if (request.resumeSessionId) {
+        args.push('--resume', request.resumeSessionId);
+      } else if (request.newSessionId) {
+        args.push('--session-id', request.newSessionId);
+      }
 
       // Add model configuration if provided
       if (request.model) {

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -30,6 +30,22 @@ async function run() {
   assert.ok(ids.includes('conv-b'), 'conv-b should be listed');
 
   console.log('✓ context keyed by conversationId');
+
+  // Session anchors are scoped per-window and survive setSessionAnchor /
+  // clearSessionAnchor / clearAllSessionAnchors as expected.
+  await cm.setSessionAnchor('conv-a', { agent: 'claude-code', sessionId: 'sid-a' });
+  await cm.setSessionAnchor('conv-b', { agent: 'claude-code', sessionId: 'sid-b' });
+  assert.strictEqual(cm.getWindow('conv-a')!.sessionAnchor?.sessionId, 'sid-a');
+  assert.strictEqual(cm.getWindow('conv-b')!.sessionAnchor?.sessionId, 'sid-b');
+
+  await cm.clearSessionAnchor('conv-a');
+  assert.strictEqual(cm.getWindow('conv-a')!.sessionAnchor, undefined);
+  assert.strictEqual(cm.getWindow('conv-b')!.sessionAnchor?.sessionId, 'sid-b');
+
+  cm.clearAllSessionAnchors();
+  assert.strictEqual(cm.getWindow('conv-b')!.sessionAnchor, undefined);
+
+  console.log('✓ session anchors set/clear/clearAll');
 }
 
 run().catch((err) => { console.error(err); process.exit(1); });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -47,12 +47,25 @@ export interface FileChangeRecord {
 
 // ── Context Window ─────────────────────────────────────────────────
 
+/**
+ * Tracks which agent CLI session is currently warm for this conversation.
+ * When the gateway runs the same agent again it can `--resume <sessionId>`
+ * and skip re-sending conversation history. Cleared on agent switch, on
+ * `/clear`/`/reset`, or when a resume attempt fails.
+ */
+export interface SessionAnchor {
+  agent: string;
+  sessionId: string;
+}
+
 export interface ContextWindow {
   id: string;
   turns: ContextTurn[];
   lastActive: number;
   /** Running estimate of total tokens in the window */
   totalTokens: number;
+  /** Warm CLI session, if any. */
+  sessionAnchor?: SessionAnchor;
 }
 
 // ── Configuration ──────────────────────────────────────────────────
@@ -154,6 +167,36 @@ export class ContextManager {
       if (window) this.archive(window);
       this.windows.delete(id);
     });
+  }
+
+  // ── Session anchors ────────────────────────────────────────────
+
+  async setSessionAnchor(windowId: string, anchor: SessionAnchor): Promise<void> {
+    return this.withLock(windowId, () => {
+      const window = this.windows.get(windowId);
+      if (!window) return;
+      window.sessionAnchor = anchor;
+      window.lastActive = Date.now();
+    });
+  }
+
+  async clearSessionAnchor(windowId: string): Promise<void> {
+    return this.withLock(windowId, () => {
+      const window = this.windows.get(windowId);
+      if (!window) return;
+      window.sessionAnchor = undefined;
+    });
+  }
+
+  /**
+   * Drop session anchors from every window. Called on global resets
+   * (workspace switch, `/reset`, default-agent change) so the next turn
+   * bootstraps a fresh CLI session with full history.
+   */
+  clearAllSessionAnchors(): void {
+    for (const window of this.windows.values()) {
+      window.sessionAnchor = undefined;
+    }
   }
 
   // ── Add turns ──────────────────────────────────────────────────

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -71,6 +71,19 @@ export interface AgentRequest {
     files?: string[];
     workingDir?: string;
   };
+  /**
+   * Resume an existing CLI session by id. When set, the gateway has decided
+   * conversation history lives in the CLI session, so `prompt` should carry
+   * only the current user turn. Mutually exclusive with `newSessionId`.
+   */
+  resumeSessionId?: string;
+  /**
+   * Pre-allocated UUID for a fresh CLI session. The adapter passes this to
+   * the CLI's session-id flag so the gateway can resume on later turns
+   * without waiting for the CLI to emit one. Mutually exclusive with
+   * `resumeSessionId`.
+   */
+  newSessionId?: string;
 }
 
 export interface StatusUpdate {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -219,6 +219,61 @@ export class Codey {
 
   private resetSession(): void {
     this.agentFactory.resetSessions();
+    this.contextManager.clearAllSessionAnchors();
+  }
+
+  /**
+   * Decide how to call the agent for this turn. Returns the prompt to send
+   * plus session flags. Resume mode: same agent already has a warm session
+   * for this conversation → skip history, attach `--resume`. Bootstrap mode:
+   * cold start (or agent changed) → build full-history prompt, pin a fresh
+   * UUID via `--session-id` so we can resume next turn.
+   *
+   * Currently only `claude-code` participates in resume; codex/opencode
+   * always bootstrap until their adapters support session ids.
+   */
+  private prepareAgentTurn(
+    ctxWindow: ContextWindow,
+    agent: CodingAgent,
+    rawPrompt: string,
+    memoryContext: string | undefined,
+  ): { prompt: string; resumeSessionId?: string; newSessionId?: string } {
+    if (agent === 'claude-code') {
+      const anchor = ctxWindow.sessionAnchor;
+      if (anchor && anchor.agent === 'claude-code') {
+        return { prompt: rawPrompt, resumeSessionId: anchor.sessionId };
+      }
+      return {
+        prompt: this.contextManager.buildPrompt(ctxWindow.id, rawPrompt, memoryContext),
+        newSessionId: randomUUID(),
+      };
+    }
+    return {
+      prompt: this.contextManager.buildPrompt(ctxWindow.id, rawPrompt, memoryContext),
+    };
+  }
+
+  /**
+   * After a turn completes, persist or invalidate the session anchor.
+   * Successful claude-code bootstrap → store the new id. Successful run
+   * by a different agent → invalidate any stale claude anchor so a later
+   * claude turn rebootstraps with the cross-agent history.
+   */
+  private async commitSessionAnchor(
+    ctxWindow: ContextWindow,
+    agent: CodingAgent,
+    newSessionId: string | undefined,
+    success: boolean,
+  ): Promise<void> {
+    if (!success) return;
+    if (agent === 'claude-code' && newSessionId) {
+      await this.contextManager.setSessionAnchor(ctxWindow.id, {
+        agent: 'claude-code',
+        sessionId: newSessionId,
+      });
+    } else if (agent !== 'claude-code' && ctxWindow.sessionAnchor) {
+      await this.contextManager.clearSessionAnchor(ctxWindow.id);
+    }
   }
 
   async start(): Promise<void> {
@@ -402,11 +457,8 @@ export class Codey {
       ? memoryStore.buildContext(parsed.prompt)
       : undefined;
 
-    // Build prompt with structured context + memory
-    const prompt = this.contextManager.buildPrompt(ctxWindow.id, parsed.prompt, memoryContext);
-
     // Skip empty prompts
-    if (!prompt.trim()) {
+    if (!parsed.prompt.trim()) {
       await this.sendResponse({
         chatId,
         channel,
@@ -430,17 +482,32 @@ export class Codey {
     const handler = this.handlers.get(channel);
     const onStream = handler?.streamText ? (text: string) => handler.streamText!(text) : undefined;
     const streamed = { active: false };
-    const response = await this.runWithFallback(agent, {
-      prompt,
+
+    let prep = this.prepareAgentTurn(ctxWindow, agent, parsed.prompt, memoryContext);
+    const buildRequest = (p: typeof prep): AgentRequest => ({
+      prompt: p.prompt,
       agent,
       model: parsed.model || this.getDefaultModelConfig(agent),
       timeout: this.tuiMode ? 1800000 : undefined, // 30 min for TUI
       interactive: this.tuiMode,
       onStream: onStream ? (text: string) => { streamed.active = true; onStream(text); } : undefined,
-      context: {
-        workingDir: this.workingDir,
-      },
+      context: { workingDir: this.workingDir },
+      resumeSessionId: p.resumeSessionId,
+      newSessionId: p.newSessionId,
     });
+
+    let response = await this.runWithFallback(agent, buildRequest(prep));
+
+    // Resume failed (CLI may have GC'd the session) — drop the anchor and
+    // retry once with a full-history bootstrap so we recover transparently.
+    if (!response.success && prep.resumeSessionId) {
+      this.logger.warn(`[claude-code] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
+      await this.contextManager.clearSessionAnchor(ctxWindow.id);
+      prep = this.prepareAgentTurn(ctxWindow, agent, parsed.prompt, memoryContext);
+      response = await this.runWithFallback(agent, buildRequest(prep));
+    }
+
+    await this.commitSessionAnchor(ctxWindow, agent, prep.newSessionId, response.success);
 
     // Save to structured context
     await this.contextManager.addUserTurn(ctxWindow.id, parsed.prompt);
@@ -1573,9 +1640,6 @@ Example: /model gpt-4.1 write a Python script`;
       ? memoryStore.buildContext(prompt)
       : undefined;
 
-    // Build prompt with structured context + memory
-    const fullPrompt = this.contextManager.buildPrompt(ctxWindow.id, prompt, memoryContext);
-
     const onStream = sse ? (text: string) => sse('stream', text) : undefined;
     const onStatus = sse ? (update: any) => sse('status', update) : undefined;
 
@@ -1621,14 +1685,28 @@ Example: /model gpt-4.1 write a Python script`;
     }
 
     // ── Single-step execution ─────────────────────────────────
-    const response = await this.runWithFallback(agent, {
-      prompt: fullPrompt,
+    let prep = this.prepareAgentTurn(ctxWindow, agent, prompt, memoryContext);
+    const buildHttpRequest = (p: typeof prep): AgentRequest => ({
+      prompt: p.prompt,
       agent,
       model,
       context: { workingDir: this.workingDir },
       onStream,
       onStatus,
+      resumeSessionId: p.resumeSessionId,
+      newSessionId: p.newSessionId,
     });
+
+    let response = await this.runWithFallback(agent, buildHttpRequest(prep));
+
+    if (!response.success && prep.resumeSessionId) {
+      this.logger.warn(`[claude-code] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
+      await this.contextManager.clearSessionAnchor(ctxWindow.id);
+      prep = this.prepareAgentTurn(ctxWindow, agent, prompt, memoryContext);
+      response = await this.runWithFallback(agent, buildHttpRequest(prep));
+    }
+
+    await this.commitSessionAnchor(ctxWindow, agent, prep.newSessionId, response.success);
 
     // Store turn in context
     await this.contextManager.addUserTurn(ctxWindow.id, prompt);


### PR DESCRIPTION
## Summary

Avoid resending the full conversation history on every claude-code turn within the same conversation. The gateway now pins a UUID via `--session-id` on the first turn and reuses it via `--resume <uuid>` on subsequent turns of the same agent in the same conversation, falling back to a full-history bootstrap if the CLI lost the session.

- **Resume mode** — claude-code agent + matching anchor → send only the current prompt with `--resume <uuid>`.
- **Bootstrap mode** — cold start, agent change, or no anchor → build full-history prompt and pin a freshly minted UUID via `--session-id` so the gateway can resume next turn.
- **Resume-failure fallback** — if `--resume` fails (CLI may have GC'd the session), drop the anchor and retry once with a full-history bootstrap. Transparent to the user.
- **Anchor invalidation** — `/clear`, `/reset`, workspace switch, default-agent change, and TTL expiry all clear anchors so the next turn re-bootstraps with cross-agent history.

`ContextManager` continues to record every turn structurally — switching to a different agent transparently picks up the full history because the bootstrap path still calls `buildPrompt`. Codex and OpenCode keep the legacy full-history-every-turn behaviour in this PR; Phase 2 wires them to resume.

## Changes

- `AgentRequest`: add `resumeSessionId` / `newSessionId` (`packages/core/src/types/index.ts`).
- `ContextWindow.sessionAnchor` plus `setSessionAnchor` / `clearSessionAnchor` / `clearAllSessionAnchors` methods (`packages/core/src/context.ts`).
- `ClaudeCodeAdapter` consumes `--resume <id>` / `--session-id <uuid>` (`packages/core/src/agents/claude-code.ts`).
- Gateway: `prepareAgentTurn` + `commitSessionAnchor` helpers, resume-failure retry, and `resetSession()` now also clears all anchors (`packages/gateway/src/gateway.ts`).
- Tests extended for anchor get/set/clear (`packages/core/src/context.test.ts`).

## Test plan

- [x] `tsc` clean in `packages/core` and `packages/gateway`.
- [x] `npx ts-node packages/core/src/context.test.ts` passes (existing keyed-by-id test + new anchor tests).
- [ ] Live smoke test: send two messages in the same chat with claude-code; verify the second one runs with `--resume <uuid>` and finishes faster (no history retransmit).
- [ ] Switch agent (`/agent codex`) mid-conversation; verify the next claude-code turn re-bootstraps with the full cross-agent history.
- [ ] `/clear` and `/reset` drop the anchor and the next turn bootstraps cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)