### PR TITLE
feat(agents): wire codex + opencode session resume (Phase 2)

### DIFF
--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,46 +1,153 @@
 import { spawn, ChildProcess } from 'child_process';
-import { AgentRequest, AgentResponse } from '../types';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { AgentRequest, AgentResponse, AgentStateEntry } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
 
+/**
+ * Codex emits JSONL events to stdout when invoked with `--json`.
+ * The shapes below are observed; unknown fields are tolerated.
+ */
+interface CodexEvent {
+  type: string;
+  thread_id?: string;
+  message?: string;
+  text?: string;
+  delta?: string;
+  // tool_use-shaped events
+  name?: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+  status?: string;
+  // turn.completed
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: { message?: string };
+}
+
+/**
+ * Codex adapter using the real CLI surface (`codex exec` / `codex exec resume`).
+ *
+ * The previous implementation called a non-existent `codex complete --prompt`
+ * subcommand. We now:
+ *   - spawn `codex exec --json -o <file>` for fresh runs;
+ *   - spawn `codex exec resume <thread_id> --json -o <file>` when the gateway
+ *     hands us a `resumeSessionId`;
+ *   - read the final assistant message from the `--output-last-message` file
+ *     (most reliable single source of truth for response text);
+ *   - extract the thread id from the `thread.started` event so the gateway
+ *     can resume on later turns.
+ */
 export class CodexAdapter extends BaseAgentAdapter {
   name = 'codex';
 
   async run(request: AgentRequest): Promise<AgentResponse> {
     return new Promise((resolve) => {
-      const args = [
-        'complete',
-        '--prompt',
-        request.prompt,
-        '--stream',
-        'false'
-      ];
+      // Tempfile for `--output-last-message`. Cleaned up after the run.
+      const outFile = path.join(os.tmpdir(), `codex-out-${randomUUID()}.txt`);
 
-      // Add model configuration if provided
-      if (request.model) {
+      const args = ['exec'];
+      if (request.resumeSessionId) {
+        args.push('resume', request.resumeSessionId);
+      }
+      args.push(
+        '--json',
+        '--skip-git-repo-check',
+        '--dangerously-bypass-approvals-and-sandbox',
+        '-o', outFile,
+      );
+      if (request.model?.model) {
         args.push('--model', request.model.model);
-        
-        if (request.model.baseUrl) {
-          args.push('--api-base', request.model.baseUrl);
-        }
       }
-
       if (request.context?.workingDir) {
-        args.push('--dir', request.context.workingDir);
+        args.push('--cd', request.context.workingDir);
       }
+      args.push(request.prompt);
 
       const { applyModelEnv } = require('./env') as typeof import('./env');
       const env = applyModelEnv({ ...process.env }, request.model, 'openai');
+
       const childProcess: ChildProcess = spawn('codex', args, {
-        stdio: ['pipe', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         env,
+        cwd: request.context?.workingDir || undefined,
       });
 
-      let stdout = '';
+      const startTime = Date.now();
+      let resolved = false;
       let stderr = '';
+      let buffer = '';
+      let capturedThreadId: string | undefined;
+      let streamedText = '';
+      let errorMessage: string | undefined;
+      const statusUpdates: string[] = [];
+      const states: AgentStateEntry[] = [];
+
+      const safeResolve = (response: AgentResponse) => {
+        if (resolved) return;
+        resolved = true;
+        try { fs.unlinkSync(outFile); } catch { /* best-effort cleanup */ }
+        resolve(response);
+      };
+
+      const handleEvent = (event: CodexEvent) => {
+        switch (event.type) {
+          case 'thread.started':
+            if (event.thread_id) capturedThreadId = event.thread_id;
+            break;
+          case 'agent.message.delta':
+          case 'message.delta':
+          case 'response.output_text.delta':
+            // Stream incremental text — field names vary between codex
+            // versions; accept whichever carries it.
+            if (event.delta) {
+              streamedText += event.delta;
+              request.onStream?.(event.delta);
+            } else if (event.text) {
+              streamedText += event.text;
+              request.onStream?.(event.text);
+            }
+            break;
+          case 'tool_use':
+          case 'tool_call':
+          case 'shell_command':
+            if (event.name || event.status) {
+              statusUpdates.push(`${event.name ?? 'tool'}: ${event.status ?? 'running'}`);
+              states.push({
+                source: event.name ?? 'tool',
+                status: event.status,
+                input: event.input,
+                output: event.output,
+              });
+            }
+            break;
+          case 'turn.failed':
+          case 'error':
+            errorMessage = event.error?.message ?? event.message ?? 'Codex turn failed';
+            break;
+          // 'turn.started' / 'turn.completed' carry no text we need here.
+        }
+      };
 
       childProcess.stdout?.on('data', (data: Buffer) => {
-        stdout += data.toString();
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('{')) continue;
+          try {
+            handleEvent(JSON.parse(trimmed) as CodexEvent);
+          } catch {
+            // Non-JSON or partial — skip.
+          }
+        }
       });
 
       childProcess.stderr?.on('data', (data: Buffer) => {
@@ -48,23 +155,62 @@ export class CodexAdapter extends BaseAgentAdapter {
       });
 
       childProcess.on('close', (code: number | null) => {
-        if (code === 0) {
-          resolve(this.createResponse(stdout.trim()));
-        } else {
-          resolve(this.createResponse(stderr || 'Codex failed', false));
+        // Drain any leftover line.
+        if (buffer.trim().startsWith('{')) {
+          try { handleEvent(JSON.parse(buffer.trim()) as CodexEvent); } catch { /* ignore */ }
         }
+
+        const duration = Math.round((Date.now() - startTime) / 1000);
+
+        // Prefer the final-message file (deterministic), fall back to streamed
+        // deltas if the file is missing or empty.
+        let output = '';
+        try {
+          if (fs.existsSync(outFile)) {
+            output = fs.readFileSync(outFile, 'utf-8').trim();
+          }
+        } catch { /* fall through to streamedText */ }
+        if (!output) output = streamedText.trim();
+
+        const response: AgentResponse = {
+          success: code === 0 && !errorMessage && !!output,
+          output,
+          error: errorMessage ?? (code !== 0 ? (stderr.trim() || `Codex exited with code ${code}`) : undefined),
+          duration,
+          statusUpdates,
+          states,
+          sessionId: capturedThreadId,
+        };
+
+        if (!response.success && !response.error) {
+          response.error = 'Codex returned empty response';
+        }
+
+        safeResolve(response);
       });
 
       childProcess.on('error', (err: Error) => {
+        const duration = Math.round((Date.now() - startTime) / 1000);
         const spawnError = new AgentSpawnError(this.name, err.message);
-        resolve(this.createResponse(spawnError.message, false));
+        safeResolve({
+          success: false,
+          output: spawnError.message,
+          error: spawnError.message,
+          duration,
+        });
       });
 
-      // Timeout (default 15 minutes)
       const timeout = request.timeout || 900000;
       setTimeout(() => {
+        if (resolved) return;
         childProcess.kill();
-        resolve(this.createResponse(`Timeout after ${Math.round(timeout / 60000)} minutes`, false));
+        const duration = Math.round((Date.now() - startTime) / 1000);
+        safeResolve({
+          success: false,
+          output: `Timeout after ${Math.round(timeout / 60000)} minutes`,
+          error: 'timeout',
+          duration,
+        });
       }, timeout);
     });
   }

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -5,6 +5,7 @@ import { AgentSpawnError } from '../errors';
 
 interface OpenCodeEvent {
   type: string;
+  sessionID?: string;
   part?: {
     type: string;
     text?: string;
@@ -41,6 +42,13 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
     return new Promise((resolve) => {
       const args = ['run', '--format', 'json'];
 
+      // Resume an existing session when the gateway has a warm anchor for
+      // this conversation. OpenCode generates the session id itself on
+      // bootstrap; we capture it from the first event below.
+      if (request.resumeSessionId) {
+        args.push('-s', request.resumeSessionId);
+      }
+
       // Add model configuration if provided
       if (request.model?.model) {
         args.push('--model', request.model.model);
@@ -66,6 +74,10 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       let stderr = '';
       const statusUpdates: string[] = [];
       const states: NonNullable<AgentResponse['states']> = [];
+      // Captured from the top-level `sessionID` field present on every event
+      // (e.g. `step_start`, `text`, `step_finish`). The first event we see
+      // tells us which session OpenCode opened so the gateway can resume it.
+      let capturedSessionId: string | undefined;
 
       const safeResolve = (response: AgentResponse) => {
         if (!resolved) {
@@ -88,6 +100,10 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
           if (!line.trim()) continue;
           try {
             const event: OpenCodeEvent = JSON.parse(line);
+
+            if (!capturedSessionId && event.sessionID) {
+              capturedSessionId = event.sessionID;
+            }
 
             // Stream text events immediately
             if (event.type === 'text' && event.part?.text) {
@@ -176,11 +192,15 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
 
         const output = textParts.join('');
         if (output) {
-          safeResolve(this.createResponse(output, true, tokens, duration, statusUpdates, states));
+          const resp = this.createResponse(output, true, tokens, duration, statusUpdates, states);
+          resp.sessionId = capturedSessionId;
+          safeResolve(resp);
         } else {
           const error = stderr.trim() || `OpenCode exited with code ${code}`;
           this.debug(`[opencode] Error: ${error}`);
-          safeResolve(this.createResponse(error, false, undefined, duration, statusUpdates, states));
+          const resp = this.createResponse(error, false, undefined, duration, statusUpdates, states);
+          resp.sessionId = capturedSessionId;
+          safeResolve(resp);
         }
       });
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -118,6 +118,13 @@ export interface AgentResponse {
   duration?: number; // in seconds
   statusUpdates?: string[];
   states?: AgentStateEntry[];
+  /**
+   * Session id captured from the CLI on this run when the CLI generates
+   * its own id (codex `thread_id`, opencode `sessionID`). Adapters that
+   * accept a pre-allocated `newSessionId` (claude-code) leave this unset —
+   * the gateway already knows the id it sent.
+   */
+  sessionId?: string;
 }
 
 // Channel configuration

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -223,14 +223,15 @@ export class Codey {
   }
 
   /**
-   * Decide how to call the agent for this turn. Returns the prompt to send
-   * plus session flags. Resume mode: same agent already has a warm session
-   * for this conversation → skip history, attach `--resume`. Bootstrap mode:
-   * cold start (or agent changed) → build full-history prompt, pin a fresh
-   * UUID via `--session-id` so we can resume next turn.
+   * Decide how to call the agent for this turn. Resume mode: the same agent
+   * already has a warm CLI session for this conversation → send only the
+   * current prompt, attach the agent's resume flag. Bootstrap mode: cold
+   * start, agent change, or no warm anchor → build a full-history prompt.
    *
-   * Currently only `claude-code` participates in resume; codex/opencode
-   * always bootstrap until their adapters support session ids.
+   * claude-code lets us pre-allocate a UUID and pin it via `--session-id`,
+   * so we know the id before the run. codex and opencode generate the id
+   * themselves; the adapters surface it via `response.sessionId` and the
+   * gateway records it in `commitSessionAnchor` post-run.
    */
   private prepareAgentTurn(
     ctxWindow: ContextWindow,
@@ -238,40 +239,54 @@ export class Codey {
     rawPrompt: string,
     memoryContext: string | undefined,
   ): { prompt: string; resumeSessionId?: string; newSessionId?: string } {
-    if (agent === 'claude-code') {
-      const anchor = ctxWindow.sessionAnchor;
-      if (anchor && anchor.agent === 'claude-code') {
-        return { prompt: rawPrompt, resumeSessionId: anchor.sessionId };
-      }
-      return {
-        prompt: this.contextManager.buildPrompt(ctxWindow.id, rawPrompt, memoryContext),
-        newSessionId: randomUUID(),
-      };
+    const anchor = ctxWindow.sessionAnchor;
+    if (anchor && anchor.agent === agent) {
+      return { prompt: rawPrompt, resumeSessionId: anchor.sessionId };
     }
-    return {
+    const bootstrap: { prompt: string; newSessionId?: string } = {
       prompt: this.contextManager.buildPrompt(ctxWindow.id, rawPrompt, memoryContext),
     };
+    if (agent === 'claude-code') {
+      // claude-code accepts a pre-allocated UUID via `--session-id`.
+      bootstrap.newSessionId = randomUUID();
+    }
+    return bootstrap;
   }
 
   /**
    * After a turn completes, persist or invalidate the session anchor.
-   * Successful claude-code bootstrap → store the new id. Successful run
-   * by a different agent → invalidate any stale claude anchor so a later
-   * claude turn rebootstraps with the cross-agent history.
+   *
+   * - claude-code success → store the pre-allocated `newSessionId`.
+   * - codex / opencode success → store the id the CLI emitted on the run
+   *   (returned via `response.sessionId`).
+   * - Resume run that succeeded → leave the existing anchor alone.
+   * - Run by a different agent than the current anchor → drop the anchor so
+   *   the next turn for the previous agent re-bootstraps with the
+   *   cross-agent history.
    */
   private async commitSessionAnchor(
     ctxWindow: ContextWindow,
     agent: CodingAgent,
+    response: AgentResponse,
     newSessionId: string | undefined,
-    success: boolean,
+    resumed: boolean,
   ): Promise<void> {
-    if (!success) return;
-    if (agent === 'claude-code' && newSessionId) {
+    if (!response.success) return;
+
+    if (resumed) {
+      // Anchor already correct — nothing to do.
+      return;
+    }
+
+    const anchorId = newSessionId ?? response.sessionId;
+    if (anchorId) {
       await this.contextManager.setSessionAnchor(ctxWindow.id, {
-        agent: 'claude-code',
-        sessionId: newSessionId,
+        agent,
+        sessionId: anchorId,
       });
-    } else if (agent !== 'claude-code' && ctxWindow.sessionAnchor) {
+    } else if (ctxWindow.sessionAnchor && ctxWindow.sessionAnchor.agent !== agent) {
+      // Different agent ran successfully but didn't surface a session id —
+      // invalidate the stale anchor so a later turn re-bootstraps.
       await this.contextManager.clearSessionAnchor(ctxWindow.id);
     }
   }
@@ -496,18 +511,20 @@ export class Codey {
       newSessionId: p.newSessionId,
     });
 
+    const initialResume = prep.resumeSessionId;
     let response = await this.runWithFallback(agent, buildRequest(prep));
 
     // Resume failed (CLI may have GC'd the session) — drop the anchor and
     // retry once with a full-history bootstrap so we recover transparently.
     if (!response.success && prep.resumeSessionId) {
-      this.logger.warn(`[claude-code] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
+      this.logger.warn(`[${agent}] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
       await this.contextManager.clearSessionAnchor(ctxWindow.id);
       prep = this.prepareAgentTurn(ctxWindow, agent, parsed.prompt, memoryContext);
       response = await this.runWithFallback(agent, buildRequest(prep));
     }
 
-    await this.commitSessionAnchor(ctxWindow, agent, prep.newSessionId, response.success);
+    const resumed = !!initialResume && !!prep.resumeSessionId;
+    await this.commitSessionAnchor(ctxWindow, agent, response, prep.newSessionId, resumed);
 
     // Save to structured context
     await this.contextManager.addUserTurn(ctxWindow.id, parsed.prompt);
@@ -1697,16 +1714,18 @@ Example: /model gpt-4.1 write a Python script`;
       newSessionId: p.newSessionId,
     });
 
+    const initialResume = prep.resumeSessionId;
     let response = await this.runWithFallback(agent, buildHttpRequest(prep));
 
     if (!response.success && prep.resumeSessionId) {
-      this.logger.warn(`[claude-code] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
+      this.logger.warn(`[${agent}] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
       await this.contextManager.clearSessionAnchor(ctxWindow.id);
       prep = this.prepareAgentTurn(ctxWindow, agent, prompt, memoryContext);
       response = await this.runWithFallback(agent, buildHttpRequest(prep));
     }
 
-    await this.commitSessionAnchor(ctxWindow, agent, prep.newSessionId, response.success);
+    const resumed = !!initialResume && !!prep.resumeSessionId;
+    await this.commitSessionAnchor(ctxWindow, agent, response, prep.newSessionId, resumed);
 
     // Store turn in context
     await this.contextManager.addUserTurn(ctxWindow.id, prompt);


### PR DESCRIPTION
## Summary

Stacked on top of #22 (Phase 1). Extends the per-conversation session anchor system to all three agent CLIs — within the same conversation + same agent we now resume the warm CLI session for codex and opencode too, not just claude-code.

- **Codex adapter rewrite** — replaces the non-existent \`codex complete --prompt\` invocation with the real CLI surface: \`codex exec --json -o <file>\` for fresh runs and \`codex exec resume <thread_id> --json -o <file>\` for resume. Captures \`thread_id\` from the \`thread.started\` JSONL event. Reads final assistant text from \`--output-last-message <tempfile>\` for a deterministic single source of truth, falling back to streamed deltas.
- **OpenCode resume** — passes \`-s <sessionID>\` to \`opencode run\` when resuming. Captures the top-level \`sessionID\` field present on every JSON event from the first event seen.
- **\`AgentResponse.sessionId\`** — adapters that don't accept a pre-allocated UUID (codex/opencode) return the CLI-generated id here. claude-code keeps using \`--session-id <uuid>\` (pre-allocated) and doesn't need this.
- **Gateway generalised** — \`prepareAgentTurn\` now treats all three agents uniformly: any anchor matching the current agent enters resume mode. \`commitSessionAnchor\` reads \`newSessionId ?? response.sessionId\` to record the right id, and skips re-anchoring on a successful resume (the anchor is already correct).
- **Resume-failure fallback** generalised — log message no longer hardcodes claude-code.

## Changes

- \`packages/core/src/agents/codex.ts\` — full rewrite to use \`codex exec\` / \`codex exec resume\`, JSONL parsing, \`--output-last-message\` tempfile.
- \`packages/core/src/agents/opencode.ts\` — \`-s\` flag for resume, capture \`sessionID\` from first event.
- \`packages/core/src/types/index.ts\` — \`AgentResponse.sessionId\`.
- \`packages/gateway/src/gateway.ts\` — generalise \`prepareAgentTurn\` / \`commitSessionAnchor\`.

## CLI signal shapes (verified via live spike)

- **Codex**: \`{\"type\":\"thread.started\",\"thread_id\":\"<uuid>\"}\` on first event.
- **OpenCode**: every event includes a top-level \`\"sessionID\":\"ses_...\"\` field; capture from the first one.

## Test plan

- [x] \`tsc\` clean in \`packages/core\` and \`packages/gateway\`.
- [x] \`npx ts-node packages/core/src/context.test.ts\` passes.
- [ ] **OpenCode live smoke test**: two consecutive turns with opencode in the same chat → the second should carry \`-s ses_...\` and start with the prior session loaded.
- [ ] **Codex live smoke test** (blocked on refreshing codex auth — local install was returning 401 token_expired during the spike): two consecutive codex turns → second should be \`codex exec resume <thread_id>\`. Confirm the JSONL event names for tool/text deltas in a real successful run; the \`--output-last-message\` path is robust regardless of streaming-event naming.
- [ ] Mixed-agent flow: claude-code → codex → claude-code in the same conversation. Each cross-agent transition should bootstrap with the full cross-agent history; consecutive same-agent turns should resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)