### PR TITLE
feat(mac): expandable workspace UI with path, memory editor, teams

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, shell } from 'electron'
+import { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, shell, dialog } from 'electron'
 import { join } from 'path'
 import { WorkerManager, WorkspaceManager } from '@codey/core'
 import { Codey } from '@codey/gateway/dist/gateway'
@@ -143,7 +143,24 @@ async function bootInProcessCore() {
     workerManager = new WorkerManager(join(root, 'workers'))
     await workerManager.loadWorkers()
     workspaceManager = new WorkspaceManager(workerManager, join(root, 'workspaces'))
-    await workspaceManager.switchWorkspace(workspaceManager.getCurrentWorkspace())
+    let existing = workspaceManager.listWorkspaces()
+    if (existing.length === 0) {
+      // Cold start (or user deleted every workspace): seed a "default"
+      // workspace pointing at the user's home directory so chats can be
+      // created without first picking a folder.
+      const fsMod = await import('fs')
+      const defaultDir = join(root, 'workspaces', 'default')
+      fsMod.mkdirSync(defaultDir, { recursive: true })
+      fsMod.writeFileSync(
+        join(defaultDir, 'workspace.json'),
+        JSON.stringify({ workingDir: app.getPath('home'), teams: {} }, null, 2)
+      )
+      fsMod.writeFileSync(join(defaultDir, 'memory.md'), '# default — Project Memory\n')
+      existing = workspaceManager.listWorkspaces()
+    }
+    if (existing.length > 0) {
+      await workspaceManager.switchWorkspace(existing[0])
+    }
     const runtimeCfg = buildRuntimeConfig(coreConfigManager.get())
     inProcessGateway = new Codey(runtimeCfg, undefined, join(root, 'workspaces'), coreConfigManager, workerManager)
     // Apply config changes to the running gateway when the renderer edits them.
@@ -262,6 +279,83 @@ app.whenReady().then(async () => {
   ipcMain.handle('workspaces:switch', async (_e, name: string) =>
     wrap(async () => {
       await workspaceManager?.switchWorkspace(name)
+    })
+  )
+
+  ipcMain.handle('workspaces:memory:get', async (_e, name: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const root = workspaceManager.getWorkspacesRoot()
+      const memPath = pathMod.join(root, name, 'memory.md')
+      if (!fsMod.existsSync(memPath)) return ''
+      return fsMod.readFileSync(memPath, 'utf-8')
+    })
+  )
+
+  ipcMain.handle('workspaces:memory:set', async (_e, name: string, content: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      if (typeof content !== 'string') throw new Error('Content must be a string')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const root = workspaceManager.getWorkspacesRoot()
+      const wsDir = pathMod.join(root, name)
+      if (!fsMod.existsSync(wsDir) || !fsMod.statSync(wsDir).isDirectory()) {
+        throw new Error(`Workspace "${name}" does not exist`)
+      }
+      const memPath = pathMod.join(wsDir, 'memory.md')
+      await fsMod.promises.writeFile(memPath, content, 'utf-8')
+    })
+  )
+
+  ipcMain.handle('workspaces:info', async (_e, name: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const root = workspaceManager.getWorkspacesRoot()
+      const configPath = pathMod.join(root, name, 'workspace.json')
+      if (!fsMod.existsSync(configPath)) {
+        return { workingDir: '', teams: {} as Record<string, string[]> }
+      }
+      const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
+      return {
+        workingDir: data.workingDir || '',
+        teams: (data.teams || {}) as Record<string, string[]>,
+      }
+    })
+  )
+
+  ipcMain.handle('workspaces:create', async (_e, dir: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      if (!dir || typeof dir !== 'string') throw new Error('A directory is required')
+      const fsMod = await import('fs')
+      if (!fsMod.existsSync(dir) || !fsMod.statSync(dir).isDirectory()) {
+        throw new Error(`Not a directory: ${dir}`)
+      }
+      return workspaceManager.findOrCreateByDir(dir)
+    })
+  )
+
+  ipcMain.handle('workspaces:delete', async (_e, name: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      await workspaceManager.deleteWorkspace(name)
+      inProcessGateway?.getChatManager().cascadeDeleteWorkspace(name)
+    })
+  )
+
+  ipcMain.handle('dialog:pickDirectory', async () =>
+    wrap(async () => {
+      const result = await dialog.showOpenDialog(mainWindow ?? undefined as any, {
+        title: 'Select project folder',
+        properties: ['openDirectory', 'createDirectory'],
+      })
+      if (result.canceled || result.filePaths.length === 0) return null
+      return result.filePaths[0]
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -13,6 +13,14 @@ contextBridge.exposeInMainWorld('codey', {
     list: () => ipcRenderer.invoke('workspaces:list'),
     current: () => ipcRenderer.invoke('workspaces:current'),
     switch: (name: string) => ipcRenderer.invoke('workspaces:switch', name),
+    info: (name: string) => ipcRenderer.invoke('workspaces:info', name),
+    getMemory: (name: string) => ipcRenderer.invoke('workspaces:memory:get', name),
+    setMemory: (name: string, content: string) => ipcRenderer.invoke('workspaces:memory:set', name, content),
+    create: (dir: string) => ipcRenderer.invoke('workspaces:create', dir),
+    delete: (name: string) => ipcRenderer.invoke('workspaces:delete', name),
+  },
+  dialog: {
+    pickDirectory: () => ipcRenderer.invoke('dialog:pickDirectory'),
   },
   teams: {
     get: () => ipcRenderer.invoke('teams:get'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -25,6 +25,14 @@ declare global {
         list: () => Promise<IpcResult<string[]>>
         current: () => Promise<IpcResult<string>>
         switch: (name: string) => Promise<IpcResult<void>>
+        info: (name: string) => Promise<IpcResult<{ workingDir: string; teams: Record<string, string[]> }>>
+        getMemory: (name: string) => Promise<IpcResult<string>>
+        setMemory: (name: string, content: string) => Promise<IpcResult<void>>
+        create: (dir: string) => Promise<IpcResult<string>>
+        delete: (name: string) => Promise<IpcResult<void>>
+      }
+      dialog: {
+        pickDirectory: () => Promise<IpcResult<string | null>>
       }
       teams: {
         get: () => Promise<IpcResult<Record<string, string[]>>>

--- a/codey-mac/src/components/WorkspacesTab.tsx
+++ b/codey-mac/src/components/WorkspacesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { apiService } from '../services/api'
 import { C } from '../theme'
 import TeamsSection from './TeamsSection'
@@ -20,50 +20,142 @@ const PlusIcon: React.FC<{ color: string }> = ({ color }) => (
   </svg>
 )
 
+const TrashIcon: React.FC<{ color: string }> = ({ color }) => (
+  <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z" />
+  </svg>
+)
+
+const ChevronIcon: React.FC<{ color: string; open: boolean }> = ({ color, open }) => (
+  <svg
+    width={12}
+    height={12}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }}
+  >
+    <path d="M9 18l6-6-6-6" />
+  </svg>
+)
+
+interface WorkspaceInfo {
+  workingDir: string
+  teams: Record<string, string[]>
+}
+
 export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, onWorkspaceChange }) => {
   const [workspaces, setWorkspaces] = useState<string[]>([])
   const [currentWorkspace, setCurrentWorkspace] = useState<string>('')
-  const [loading, setLoading] = useState(false)
+  const [busyName, setBusyName] = useState<string>('')
   const [creating, setCreating] = useState(false)
-  const [newName, setNewName] = useState('')
+  const [error, setError] = useState<string>('')
+  const [expanded, setExpanded] = useState<string>('')
+  const [infoCache, setInfoCache] = useState<Record<string, WorkspaceInfo>>({})
 
-  useEffect(() => {
-    if (isGatewayRunning) loadWorkspaces()
-  }, [isGatewayRunning])
-
-  const loadWorkspaces = async () => {
+  const loadWorkspaces = useCallback(async () => {
     try {
-      const ws = await apiService.getWorkspaces()
+      const [ws, cur] = await Promise.all([
+        apiService.getWorkspaces(),
+        apiService.getCurrentWorkspace().catch(() => ''),
+      ])
       setWorkspaces(ws)
-    } catch (error) {
-      console.error('Failed to load workspaces:', error)
+      if (cur) setCurrentWorkspace(cur)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load workspaces')
     }
+  }, [])
+
+  useEffect(() => { if (isGatewayRunning) loadWorkspaces() }, [isGatewayRunning, loadWorkspaces])
+
+  const loadInfo = useCallback(async (name: string) => {
+    try {
+      const info = await apiService.getWorkspaceInfo(name)
+      setInfoCache(prev => ({ ...prev, [name]: info }))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : `Failed to load info for ${name}`)
+    }
+  }, [])
+
+  const toggleExpand = (name: string, ev: React.MouseEvent) => {
+    ev.stopPropagation()
+    if (expanded === name) {
+      setExpanded('')
+      return
+    }
+    setExpanded(name)
+    if (!infoCache[name]) loadInfo(name)
   }
 
   const switchWorkspace = async (name: string) => {
-    if (loading || name === currentWorkspace) return
-    setLoading(true)
+    if (busyName || name === currentWorkspace) return
+    setBusyName(name); setError('')
     try {
       await apiService.switchWorkspace(name)
       setCurrentWorkspace(name)
       onWorkspaceChange?.(name)
-    } catch (error) {
-      console.error('Failed to switch workspace:', error)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to switch workspace')
     } finally {
-      setLoading(false)
+      setBusyName('')
     }
   }
 
-  const cancelCreate = () => { setCreating(false); setNewName('') }
-
-  const submitCreate = async () => {
-    const name = newName.trim()
-    if (!name) { cancelCreate(); return }
+  const pickAndCreate = async () => {
+    if (creating) return
+    setCreating(true); setError('')
     try {
-      // Optimistic: add to list if API doesn't have a create endpoint yet
-      setWorkspaces(prev => prev.includes(name) ? prev : [...prev, name])
+      const dir = await apiService.pickDirectory()
+      if (!dir) return
+      const name = await apiService.createWorkspaceFromDir(dir)
+      await loadWorkspaces()
+      setCurrentWorkspace(name)
+      onWorkspaceChange?.(name)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create workspace')
     } finally {
-      cancelCreate()
+      setCreating(false)
+    }
+  }
+
+  const removeWorkspace = async (name: string, ev: React.MouseEvent) => {
+    ev.stopPropagation()
+    if (busyName) return
+    if (name === 'default') {
+      setError('The "default" workspace is protected and cannot be deleted.')
+      return
+    }
+    const isActive = name === currentWorkspace
+    const isLast = workspaces.length === 1
+    const extra = isActive
+      ? isLast
+        ? '\n\nThis is your only workspace. After deletion you will need to add a folder before starting a new chat.'
+        : '\n\nThis is the active workspace. Another workspace will be activated automatically.'
+      : ''
+    const ok = window.confirm(
+      `Delete workspace "${name}"?\n\nThis removes the workspace folder (workspace.json, memory.md, logs). The original project directory it points to is NOT touched.${extra}`
+    )
+    if (!ok) return
+    setBusyName(name); setError('')
+    try {
+      await apiService.deleteWorkspace(name)
+      setWorkspaces(prev => prev.filter(w => w !== name))
+      setInfoCache(prev => {
+        const next = { ...prev }; delete next[name]; return next
+      })
+      if (expanded === name) setExpanded('')
+      if (isActive) {
+        const nextActive = await apiService.getCurrentWorkspace().catch(() => '')
+        setCurrentWorkspace(nextActive)
+        if (nextActive !== currentWorkspace) onWorkspaceChange?.(nextActive)
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete workspace')
+    } finally {
+      setBusyName('')
     }
   }
 
@@ -82,63 +174,233 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
       <div style={styles.header}>
         <span style={{ color: C.fg, fontSize: 16, fontWeight: 600 }}>Workspaces</span>
         <button
-          onClick={() => setCreating(v => !v)}
-          style={styles.newBtn}
+          onClick={pickAndCreate}
+          disabled={creating}
+          style={{ ...styles.newBtn, opacity: creating ? 0.6 : 1 }}
         >
           <PlusIcon color={C.accent} />
-          New
+          {creating ? 'Picking…' : 'Add folder'}
         </button>
       </div>
 
-      {creating && (
-        <div style={styles.createRow}>
-          <input
-            autoFocus
-            value={newName}
-            onChange={e => setNewName(e.target.value)}
-            placeholder="Workspace name…"
-            style={styles.createInput}
-            onKeyDown={e => {
-              if (e.key === 'Enter') submitCreate()
-              if (e.key === 'Escape') cancelCreate()
-            }}
-          />
-          <button onClick={submitCreate} style={styles.createSubmit}>Create</button>
-        </div>
-      )}
+      {error && <div style={styles.error}>{error}</div>}
 
       {workspaces.length === 0 ? (
-        <div style={{ color: C.fg3, padding: '20px 0' }}>No workspaces found</div>
+        <div style={{ color: C.fg3, padding: '20px 0' }}>No workspaces yet — click "Add folder" to pick one.</div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           {workspaces.map(ws => {
             const active = currentWorkspace === ws
+            const isBusy = busyName === ws
+            const isOpen = expanded === ws
+            const info = infoCache[ws]
             return (
               <div
                 key={ws}
-                onClick={() => switchWorkspace(ws)}
                 style={{
                   background: active ? C.surface3 : C.surface2,
                   border: `1px solid ${active ? C.accent + '55' : C.border}`,
                   borderRadius: 10,
-                  padding: '14px 16px',
-                  cursor: loading ? 'wait' : 'pointer',
-                  transition: 'all 0.15s',
+                  cursor: isBusy ? 'wait' : 'default',
+                  transition: 'border-color 0.15s, background 0.15s',
+                  opacity: isBusy ? 0.6 : 1,
+                  overflow: 'hidden',
                 }}
               >
-                <div style={styles.wsTopRow}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <div
+                  onClick={(e) => toggleExpand(ws, e)}
+                  style={{
+                    ...styles.wsTopRow,
+                    padding: '14px 16px',
+                    cursor: isBusy ? 'wait' : 'pointer',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                    <ChevronIcon color={active ? C.accent : C.fg2} open={isOpen} />
                     <FolderIcon color={active ? C.accent : C.fg2} />
-                    <span style={{ color: active ? C.accent : C.fg, fontSize: 14, fontWeight: 600 }}>{ws}</span>
+                    <span style={{ color: active ? C.accent : C.fg, fontSize: 14, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ws}</span>
                   </div>
-                  {active && <span style={{ color: C.accent, fontSize: 11, fontWeight: 600 }}>Active</span>}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                    {active ? (
+                      <span style={{ color: C.accent, fontSize: 11, fontWeight: 600 }}>Active</span>
+                    ) : (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); switchWorkspace(ws) }}
+                        disabled={isBusy}
+                        style={styles.switchBtn}
+                      >
+                        Switch
+                      </button>
+                    )}
+                    <button
+                      onClick={(e) => removeWorkspace(ws, e)}
+                      disabled={isBusy || ws === 'default'}
+                      title={ws === 'default' ? 'The default workspace is protected' : `Delete ${ws}`}
+                      style={{ ...styles.iconBtn, opacity: (isBusy || ws === 'default') ? 0.3 : 0.85, cursor: (isBusy || ws === 'default') ? 'not-allowed' : 'pointer' }}
+                    >
+                      <TrashIcon color={C.fg2} />
+                    </button>
+                  </div>
                 </div>
+
+                {isOpen && (
+                  <div style={styles.expandedBody}>
+                    <div style={styles.fieldRow}>
+                      <div style={styles.fieldLabel}>Path</div>
+                      {info ? (
+                        <code style={styles.pathValue}>{info.workingDir || '—'}</code>
+                      ) : (
+                        <span style={{ color: C.fg3, fontSize: 12 }}>Loading…</span>
+                      )}
+                    </div>
+
+                    <div style={{ marginTop: 12 }}>
+                      <MemorySection workspace={ws} />
+                    </div>
+
+                    <div style={{ marginTop: 12 }}>
+                      {active ? (
+                        <TeamsSection workspace={ws} />
+                      ) : (
+                        <ReadOnlyTeams teams={info?.teams ?? {}} loaded={!!info} />
+                      )}
+                    </div>
+                  </div>
+                )}
               </div>
             )
           })}
         </div>
       )}
-      {currentWorkspace && <TeamsSection workspace={currentWorkspace} />}
+    </div>
+  )
+}
+
+const MemorySection: React.FC<{ workspace: string }> = ({ workspace }) => {
+  const [content, setContent] = useState<string>('')
+  const [draft, setDraft] = useState<string>('')
+  const [loaded, setLoaded] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [savedAt, setSavedAt] = useState(0)
+  const [err, setErr] = useState<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoaded(false); setEditing(false); setErr('')
+    apiService.getWorkspaceMemory(workspace)
+      .then(text => {
+        if (cancelled) return
+        setContent(text); setDraft(text); setLoaded(true)
+      })
+      .catch(e => { if (!cancelled) setErr(e instanceof Error ? e.message : 'Failed to load memory') })
+    return () => { cancelled = true }
+  }, [workspace])
+
+  const save = async () => {
+    if (saving || draft === content) { setEditing(false); return }
+    setSaving(true); setErr('')
+    try {
+      await apiService.setWorkspaceMemory(workspace, draft)
+      setContent(draft); setSavedAt(Date.now()); setEditing(false)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to save memory')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const cancel = () => { setDraft(content); setEditing(false); setErr('') }
+
+  return (
+    <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>Memory</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          {savedAt > 0 && Date.now() - savedAt < 2000 && <span style={{ fontSize: 11, color: C.green }}>✓ Saved</span>}
+          {editing ? (
+            <>
+              <button
+                onClick={cancel}
+                disabled={saving}
+                style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, cursor: 'pointer' }}
+              >Cancel</button>
+              <button
+                onClick={save}
+                disabled={saving || draft === content}
+                style={{ padding: '4px 10px', fontSize: 12, background: C.accentDim, color: C.accent, border: `1px solid ${C.accent}55`, borderRadius: 6, cursor: 'pointer', opacity: (saving || draft === content) ? 0.6 : 1 }}
+              >{saving ? 'Saving…' : 'Save'}</button>
+            </>
+          ) : (
+            <button
+              onClick={() => setEditing(true)}
+              disabled={!loaded}
+              style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.accent, border: `1px solid ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}
+            >Edit</button>
+          )}
+        </div>
+      </div>
+      {err && <div style={{ background: '#3a1a1a', color: '#ff8080', padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{err}</div>}
+      {!loaded ? (
+        <div style={{ fontSize: 12, color: C.fg3 }}>Loading…</div>
+      ) : editing ? (
+        <textarea
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          spellCheck={false}
+          style={{
+            width: '100%', minHeight: 220, resize: 'vertical',
+            background: C.bg, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6,
+            padding: 10, fontSize: 12,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            outline: 'none', boxSizing: 'border-box',
+          }}
+        />
+      ) : (
+        <pre
+          onDoubleClick={() => setEditing(true)}
+          title="Double-click to edit"
+          style={{
+            margin: 0, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6,
+            fontSize: 12, color: content ? C.fg : C.fg3,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+            maxHeight: 240, overflowY: 'auto', cursor: 'text',
+          }}
+        >{content || '(empty — click Edit to add notes)'}</pre>
+      )}
+    </div>
+  )
+}
+
+const ReadOnlyTeams: React.FC<{ teams: Record<string, string[]>; loaded: boolean }> = ({ teams, loaded }) => {
+  const entries = Object.entries(teams)
+  return (
+    <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>Teams</div>
+        <span style={{ fontSize: 11, color: C.fg3 }}>read-only — switch to edit</span>
+      </div>
+      {!loaded ? (
+        <div style={{ fontSize: 12, color: C.fg3 }}>Loading…</div>
+      ) : entries.length === 0 ? (
+        <div style={{ fontSize: 12, color: C.fg3 }}>No teams declared.</div>
+      ) : (
+        entries.map(([name, members]) => (
+          <div key={name} style={{ marginBottom: 8, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 6 }}>{name}</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              {members.length === 0 ? (
+                <span style={{ fontSize: 12, color: C.fg3 }}>(empty)</span>
+              ) : (
+                members.map((m, i) => (
+                  <span key={`${m}-${i}`} style={{ padding: '4px 8px', background: C.surface2, borderRadius: 14, fontSize: 12 }}>{m}</span>
+                ))
+              )}
+            </div>
+          </div>
+        ))
+      )}
     </div>
   )
 }
@@ -146,63 +408,45 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
 const styles: Record<string, React.CSSProperties> = {
   container: { padding: 20, height: '100%', overflowY: 'auto' },
   offlineContainer: {
-    display: 'flex',
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: '100%',
+    display: 'flex', flex: 1, alignItems: 'center', justifyContent: 'center', height: '100%',
   },
   header: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 16,
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16,
   },
   newBtn: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 6,
-    padding: '7px 12px',
-    borderRadius: 8,
-    border: 'none',
-    background: C.accentDim,
-    color: C.accent,
-    cursor: 'pointer',
-    fontSize: 12,
-    fontWeight: 600,
+    display: 'flex', alignItems: 'center', gap: 6,
+    padding: '7px 12px', borderRadius: 8, border: 'none',
+    background: C.accentDim, color: C.accent, cursor: 'pointer',
+    fontSize: 12, fontWeight: 600,
   },
-  createRow: {
-    background: C.surface2,
-    border: `1px solid ${C.border2}`,
-    borderRadius: 10,
-    padding: 14,
-    marginBottom: 12,
-    display: 'flex',
-    gap: 8,
-  },
-  createInput: {
-    flex: 1,
-    background: C.surface3,
-    border: `1px solid ${C.border2}`,
-    borderRadius: 7,
-    color: C.fg,
-    fontSize: 13,
-    padding: '8px 10px',
-    outline: 'none',
-  },
-  createSubmit: {
-    padding: '8px 14px',
-    borderRadius: 7,
-    border: 'none',
-    background: C.accent,
-    color: '#fff',
-    cursor: 'pointer',
-    fontSize: 12,
-    fontWeight: 600,
+  error: {
+    background: '#ff453a22', color: '#ff8a82', border: `1px solid #ff453a55`,
+    borderRadius: 8, padding: '8px 12px', fontSize: 12, marginBottom: 12,
   },
   wsTopRow: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
+  },
+  iconBtn: {
+    background: 'transparent', border: 'none', padding: 4, borderRadius: 6,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+  switchBtn: {
+    background: 'transparent', color: C.accent, border: `1px solid ${C.accent}55`,
+    borderRadius: 6, padding: '3px 10px', fontSize: 11, fontWeight: 600, cursor: 'pointer',
+  },
+  expandedBody: {
+    padding: '12px 16px 16px',
+    borderTop: `1px solid ${C.border}`,
+  },
+  fieldRow: {
+    display: 'flex', flexDirection: 'column', gap: 4,
+  },
+  fieldLabel: {
+    fontSize: 11, fontWeight: 600, color: C.fg3, textTransform: 'uppercase', letterSpacing: 0.5,
+  },
+  pathValue: {
+    fontSize: 12, color: C.fg, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6, padding: '6px 10px',
+    wordBreak: 'break-all',
   },
 }

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -61,6 +61,24 @@ export const apiService = {
   switchWorkspace: async (name: string): Promise<void> =>
     unwrap(await window.codey.workspaces.switch(name)),
 
+  getWorkspaceInfo: async (name: string): Promise<{ workingDir: string; teams: Record<string, string[]> }> =>
+    unwrap(await window.codey.workspaces.info(name)),
+
+  getWorkspaceMemory: async (name: string): Promise<string> =>
+    unwrap(await window.codey.workspaces.getMemory(name)),
+
+  setWorkspaceMemory: async (name: string, content: string): Promise<void> =>
+    unwrap(await window.codey.workspaces.setMemory(name, content)),
+
+  createWorkspaceFromDir: async (dir: string): Promise<string> =>
+    unwrap(await window.codey.workspaces.create(dir)),
+
+  deleteWorkspace: async (name: string): Promise<void> =>
+    unwrap(await window.codey.workspaces.delete(name)),
+
+  pickDirectory: async (): Promise<string | null> =>
+    unwrap(await window.codey.dialog.pickDirectory()),
+
   // Teams
   getTeams: async (_workspace?: string): Promise<Record<string, string[]>> =>
     unwrap(await window.codey.teams.get()),

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -10,7 +10,7 @@ export interface WorkspaceJson {
 
 export class WorkspaceManager {
   private workspacesDir: string;
-  private currentWorkspace: string = 'default';
+  private currentWorkspace: string = '';
   private config: WorkspaceJson | null = null;
   private workerManager: WorkerManager;
   private memoryStore: MemoryStore;
@@ -35,6 +35,12 @@ export class WorkspaceManager {
   }
 
   async load(): Promise<void> {
+    if (!this.currentWorkspace) {
+      // No workspace selected yet — don't materialize files at the workspaces
+      // root, or "memory"/"logs" will appear as phantom workspaces on the next
+      // listWorkspaces() call.
+      return;
+    }
     const configPath = this.getConfigPath();
     const workspacePath = this.getWorkspacePath();
 
@@ -75,8 +81,9 @@ export class WorkspaceManager {
   }
 
   async switchWorkspace(workspaceId: string): Promise<boolean> {
+    if (!workspaceId || !workspaceId.trim()) return false;
     const workspacePath = path.join(this.workspacesDir, workspaceId);
-    if (!fs.existsSync(workspacePath)) return false;
+    if (!fs.existsSync(workspacePath) || !fs.statSync(workspacePath).isDirectory()) return false;
     this.currentWorkspace = workspaceId;
     await this.load();
     return true;
@@ -129,11 +136,44 @@ export class WorkspaceManager {
     return fs.existsSync(memoryPath) ? fs.readFileSync(memoryPath, 'utf-8') : '';
   }
 
+  async deleteWorkspace(name: string): Promise<void> {
+    if (name === 'default') {
+      throw new Error('The "default" workspace is protected and cannot be deleted.');
+    }
+    const target = path.join(this.workspacesDir, name);
+    if (!fs.existsSync(target)) {
+      throw new Error(`Workspace "${name}" does not exist`);
+    }
+    const resolved = path.resolve(target);
+    const root = path.resolve(this.workspacesDir);
+    if (!resolved.startsWith(root + path.sep)) {
+      throw new Error(`Refusing to delete workspace outside of workspaces root`);
+    }
+    const wasActive = name === this.currentWorkspace;
+    await fs.promises.rm(resolved, { recursive: true, force: true });
+    console.log(`[Workspace] Deleted workspace: ${name}`);
+
+    if (wasActive) {
+      this.currentWorkspace = '';
+      this.config = null;
+      this.teams.clear();
+      const remaining = this.listWorkspaces();
+      if (remaining.length > 0) {
+        await this.switchWorkspace(remaining[0]);
+      }
+    }
+  }
+
   listWorkspaces(): string[] {
-    if (!fs.existsSync(this.workspacesDir)) return ['default'];
-    return fs.readdirSync(this.workspacesDir).filter(d =>
-      fs.statSync(path.join(this.workspacesDir, d)).isDirectory()
-    );
+    if (!fs.existsSync(this.workspacesDir)) return [];
+    return fs.readdirSync(this.workspacesDir).filter(d => {
+      const dir = path.join(this.workspacesDir, d);
+      if (!fs.statSync(dir).isDirectory()) return false;
+      // Only directories with a workspace.json count as workspaces; this
+      // filters out stray dirs (logs/, memory/) that may have leaked into
+      // the workspaces root.
+      return fs.existsSync(path.join(dir, 'workspace.json'));
+    });
   }
 
   getTeam(name: string): string[] | undefined {


### PR DESCRIPTION
## Summary
- Each workspace row in **Workspaces** is now expandable. The body shows the workspace's `workingDir` (full path), a click-to-edit `memory.md` editor, and the team list — editable for the active workspace, read-only for inactive ones.
- The trash icon is now enabled on the active workspace; if other workspaces remain, deleting the active one auto-switches to a sibling, otherwise current state is cleared and the UI prompts the user to add a folder.
- Boot auto-seeds a `default` workspace (pointing at `~`) if none exist, and `default` is now protected from deletion in both core and UI as a safety net.

## Bug fixes bundled
- `WorkspaceManager.load()` no-ops when no workspace is selected — previously it materialized `memory.md`, `logs/`, and `memory/` at the workspaces root, which then surfaced as phantom workspaces named `logs` and `memory`.
- `listWorkspaces()` now filters to directories that contain a `workspace.json`, so any stray sibling directories cannot leak into the list.

## Files changed
- `packages/core/src/workspace.ts` — `load` guard, `listWorkspaces` filter, relaxed `deleteWorkspace`, `default` protection.
- `codey-mac/electron/main.ts` — new `workspaces:info`, `workspaces:memory:get`, `workspaces:memory:set` IPC; boot auto-seed for `default`.
- `codey-mac/electron/preload.ts` + `codey-mac/src/codey-api.d.ts` — exposed the new IPC.
- `codey-mac/src/services/api.ts` — `getWorkspaceInfo`, `getWorkspaceMemory`, `setWorkspaceMemory`.
- `codey-mac/src/components/WorkspacesTab.tsx` — expandable cards, memory editor, read-only teams view, switch button, deletion guards.

## Test plan
- [ ] Launch the app, expand a workspace row — full working dir path, memory editor, and team section all render.
- [ ] Edit and save `memory.md` from the expanded view; reopen and verify the change persists.
- [ ] Switch into another workspace, edit teams there, switch away and re-expand — teams render read-only with the saved members.
- [ ] Delete the active workspace with another available — UI auto-switches to a remaining one.
- [ ] Delete every non-default workspace; trash on `default` is disabled and tooltipped "The default workspace is protected".
- [ ] Manually delete `~/.codey/workspaces/default` (or the dev `workspaces/default`), relaunch — boot recreates it pointing at `~`.
- [ ] Confirm `logs` / `memory` no longer appear in the workspace list after a fresh launch with an empty workspaces folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)