### PR TITLE
feat(mac): friendlier tool-call rendering in chat

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -4,6 +4,7 @@ import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
 import { Markdown } from './Markdown'
+import { formatHeadline, hasDetail as toolHasDetail, ToolDetail, normalizeTool } from './toolFormat'
 
 interface Props {
   chatId: string
@@ -135,48 +136,76 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 boxShadow: isUser ? 'none' : '0 1px 3px rgba(0,0,0,0.3)',
                 border: isUser ? 'none' : `1px solid ${C.border2}`,
               }}>
-                {msg.toolCalls && msg.toolCalls.length > 0 && (
-                  <>
-                    <div style={styles.toolCallsContainer}>
-                      {msg.toolCalls.map(tc => {
-                        const isExpanded = expandedIds.has(tc.id)
-                        const hasDetail = tc.type === 'tool_start' && !!tc.input
-                        const toggle = () => setExpandedIds(prev => {
-                          const next = new Set(prev)
-                          next.has(tc.id) ? next.delete(tc.id) : next.add(tc.id)
-                          return next
-                        })
-                        return (
-                          <div key={tc.id}>
-                            <div
-                              style={{
-                                ...styles.toolCallRow,
-                                ...(tc.type === 'tool_end' ? styles.toolCallEnd : {}),
-                                ...(tc.type === 'info' ? styles.toolCallInfo : {}),
-                                cursor: hasDetail ? 'pointer' : 'default',
-                              }}
-                              onClick={hasDetail ? toggle : undefined}
-                            >
-                              {tc.type === 'tool_end' && '✓ '}
-                              {tc.type === 'info' && '• '}
-                              {hasDetail && (
-                                <span style={{ ...styles.chevron, transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
-                              )}
-                              <span style={{ marginLeft: 2 }}>{tc.message}</span>
-                            </div>
-                            {hasDetail && isExpanded && (
-                              <div style={styles.toolDetail}>
-                                {tc.input && (<><div style={styles.detailLabel}>Input:</div><pre style={styles.detailPre}>{JSON.stringify(tc.input, null, 2)}</pre></>)}
-                                {tc.output && (<><div style={styles.detailLabel}>Output:</div><pre style={styles.detailPre}>{tc.output}</pre></>)}
+                {msg.toolCalls && msg.toolCalls.length > 0 && (() => {
+                  type Row =
+                    | { kind: 'call'; id: string; tool?: string; input?: Record<string, unknown>; output?: string; done: boolean }
+                    | { kind: 'info'; id: string; message: string }
+                  const rows: Row[] = []
+                  const pendingByTool = new Map<string, number>()
+                  for (const tc of msg.toolCalls) {
+                    if (tc.type === 'info') { rows.push({ kind: 'info', id: tc.id, message: tc.message }); continue }
+                    const key = normalizeTool(tc.tool)
+                    if (tc.type === 'tool_start') {
+                      const idx = rows.push({ kind: 'call', id: tc.id, tool: tc.tool, input: tc.input, done: false }) - 1
+                      pendingByTool.set(key, idx)
+                    } else {
+                      const idx = pendingByTool.get(key)
+                      if (idx != null) {
+                        const row = rows[idx] as Extract<Row, { kind: 'call' }>
+                        row.done = true
+                        if (tc.output) row.output = tc.output
+                        pendingByTool.delete(key)
+                      } else {
+                        rows.push({ kind: 'call', id: tc.id, tool: tc.tool, output: tc.output, done: true })
+                      }
+                    }
+                  }
+                  return (
+                    <>
+                      <div style={styles.toolCallsContainer}>
+                        {rows.map(row => {
+                          if (row.kind === 'info') {
+                            return (
+                              <div key={row.id} style={{ ...styles.toolCallRow, ...styles.toolCallInfo }}>
+                                <span>• {row.message}</span>
                               </div>
-                            )}
-                          </div>
-                        )
-                      })}
-                    </div>
-                    {msg.content && <div style={styles.toolCallSep} />}
-                  </>
-                )}
+                            )
+                          }
+                          const isExpanded = expandedIds.has(row.id)
+                          const detail = toolHasDetail(row.tool, row.input, row.output)
+                          const toggle = () => setExpandedIds(prev => {
+                            const next = new Set(prev)
+                            next.has(row.id) ? next.delete(row.id) : next.add(row.id)
+                            return next
+                          })
+                          const headline = formatHeadline(row.tool, row.input)
+                          const marker = row.done ? '✓' : '⋯'
+                          const markerColor = row.done ? '#5c5' : '#6ab0f3'
+                          return (
+                            <div key={row.id}>
+                              <div
+                                style={{ ...styles.toolCallRow, cursor: detail ? 'pointer' : 'default' }}
+                                onClick={detail ? toggle : undefined}
+                              >
+                                <span style={{ width: 14, color: markerColor, flexShrink: 0 }}>{marker}</span>
+                                {detail && (
+                                  <span style={{ ...styles.chevron, transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+                                )}
+                                <span style={{ marginLeft: 2, color: row.done ? '#9bbcd9' : '#6ab0f3' }}>{headline}</span>
+                              </div>
+                              {detail && isExpanded && (
+                                <div style={styles.toolDetail}>
+                                  <ToolDetail rawTool={row.tool} input={row.input} output={row.output} />
+                                </div>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                      {msg.content && <div style={styles.toolCallSep} />}
+                    </>
+                  )
+                })()}
                 {msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
               </div>
               <div style={styles.tsLabel}>
@@ -273,12 +302,9 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#6ab0f3', fontFamily: 'Menlo, Monaco, "Courier New", monospace',
     padding: '2px 0', userSelect: 'text',
   },
-  toolCallEnd: { color: '#5c5' },
   toolCallInfo: { color: '#888', fontStyle: 'italic' },
   toolCallSep: { borderTop: `1px solid ${C.border2}`, marginBottom: 6, marginTop: 4 },
-  chevron: { display: 'inline-block', fontSize: 10, marginRight: 4, transition: 'transform 0.15s ease', color: '#555' },
+  chevron: { display: 'inline-block', fontSize: 13, marginRight: 4, transition: 'transform 0.15s ease', color: '#555' },
   toolDetail: { marginLeft: 20, marginTop: 4, marginBottom: 6, padding: 8, background: 'rgba(0,0,0,0.3)', borderRadius: 6, border: `1px solid ${C.border}` },
-  detailLabel: { fontSize: 11, color: '#666', fontFamily: 'Menlo, Monaco, "Courier New", monospace', marginBottom: 4, textTransform: 'uppercase' },
-  detailPre: { margin: 0, fontSize: 11, color: '#ccc', fontFamily: 'Menlo, Monaco, "Courier New", monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-word' },
   orphanBanner: { padding: '8px 12px', background: '#ff950033', color: '#ffb84d', fontSize: 12, borderTop: `1px solid ${C.border}` },
 }

--- a/codey-mac/src/components/toolFormat.tsx
+++ b/codey-mac/src/components/toolFormat.tsx
@@ -1,0 +1,328 @@
+import React from 'react'
+import { C } from '../theme'
+
+type Input = Record<string, unknown> | undefined
+
+export type CanonicalTool =
+  | 'Read' | 'Write' | 'Edit' | 'Bash' | 'Grep' | 'Glob' | 'LS'
+  | 'WebFetch' | 'WebSearch' | 'TodoWrite' | 'Task' | 'Notebook'
+  | 'Patch' | 'Plan' | 'Other'
+
+const NAME_MAP: Record<string, CanonicalTool> = {
+  // claude-code
+  read: 'Read', write: 'Write', edit: 'Edit', multiedit: 'Edit',
+  bash: 'Bash', grep: 'Grep', glob: 'Glob', ls: 'LS',
+  webfetch: 'WebFetch', websearch: 'WebSearch',
+  todowrite: 'TodoWrite', todoread: 'TodoWrite',
+  task: 'Task', agent: 'Task',
+  notebookedit: 'Notebook',
+  // codex
+  shell: 'Bash', shell_command: 'Bash', local_shell_call: 'Bash', exec: 'Bash',
+  read_file: 'Read', write_file: 'Write', create_file: 'Write',
+  apply_patch: 'Patch', patch: 'Patch',
+  update_plan: 'Plan', plan: 'Plan',
+  web_search: 'WebSearch',
+  // opencode
+  list: 'LS',
+}
+
+export const normalizeTool = (raw: string | undefined): CanonicalTool => {
+  if (!raw) return 'Other'
+  return NAME_MAP[raw.toLowerCase()] ?? 'Other'
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : v == null ? '' : JSON.stringify(v))
+
+const basename = (p: string): string => {
+  const cleaned = p.replace(/\/+$/, '')
+  const i = cleaned.lastIndexOf('/')
+  return i >= 0 ? cleaned.slice(i + 1) : cleaned
+}
+
+const truncate = (s: string, n: number): string => (s.length <= n ? s : s.slice(0, n - 1) + '…')
+
+const oneLine = (s: string, n = 80): string => truncate(s.replace(/\s+/g, ' ').trim(), n)
+
+/** Build the compact headline shown on the tool-call row. */
+export const formatHeadline = (rawTool: string | undefined, input: Input): string => {
+  const tool = normalizeTool(rawTool)
+  const i = input ?? {}
+  const path = str(i.file_path ?? i.path ?? i.filename ?? i.notebook_path)
+  switch (tool) {
+    case 'Read': {
+      const range = i.offset != null || i.limit != null
+        ? ` [${i.offset ?? 0}${i.limit != null ? `:+${i.limit}` : ''}]`
+        : ''
+      return `Read(${path ? basename(path) : '?'})${range}`
+    }
+    case 'Write': return `Write(${path ? basename(path) : '?'})`
+    case 'Edit': return `Edit(${path ? basename(path) : '?'})`
+    case 'Notebook': return `NotebookEdit(${path ? basename(path) : '?'})`
+    case 'Bash': {
+      const cmd = str(i.command ?? i.cmd ?? i.script)
+      return `Bash(${oneLine(cmd, 70) || '?'})`
+    }
+    case 'Grep': {
+      const pat = str(i.pattern ?? i.query ?? i.regex)
+      const where = str(i.path ?? i.glob ?? '')
+      return `Grep(${oneLine(pat, 50)}${where ? ` in ${basename(where)}` : ''})`
+    }
+    case 'Glob': return `Glob(${str(i.pattern ?? i.glob ?? '?')})`
+    case 'LS': return `LS(${str(i.path ?? '.') || '.'})`
+    case 'WebFetch': {
+      const url = str(i.url ?? i.uri ?? '')
+      return `WebFetch(${oneLine(url, 60) || '?'})`
+    }
+    case 'WebSearch': return `WebSearch(${oneLine(str(i.query ?? i.q ?? ''), 60) || '?'})`
+    case 'TodoWrite': {
+      const todos = (i.todos as Array<unknown> | undefined) ?? []
+      return `TodoWrite${todos.length ? ` (${todos.length} items)` : ''}`
+    }
+    case 'Task': {
+      const desc = str(i.description ?? i.subagent_type ?? i.prompt ?? '')
+      return `Task(${oneLine(desc, 60) || '?'})`
+    }
+    case 'Patch': {
+      const target = str(i.path ?? i.file_path ?? '')
+      return `Patch(${target ? basename(target) : 'multi-file'})`
+    }
+    case 'Plan': return 'UpdatePlan'
+    default: {
+      const name = rawTool || 'tool'
+      const summary = Object.entries(i)
+        .slice(0, 2)
+        .map(([k, v]) => `${k}: ${oneLine(str(v), 30)}`)
+        .join(', ')
+      return summary ? `${name}(${summary})` : name
+    }
+  }
+}
+
+// ── Inline diff (line-level LCS) ──────────────────────────────────────────────
+
+type DiffLine = { kind: 'eq' | 'add' | 'del'; text: string }
+
+const lineDiff = (a: string, b: string): DiffLine[] => {
+  const A = a.split('\n')
+  const B = b.split('\n')
+  const m = A.length, n = B.length
+  // LCS table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = A[i] === B[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+  const out: DiffLine[] = []
+  let i = 0, j = 0
+  while (i < m && j < n) {
+    if (A[i] === B[j]) { out.push({ kind: 'eq', text: A[i] }); i++; j++ }
+    else if (dp[i + 1][j] >= dp[i][j + 1]) { out.push({ kind: 'del', text: A[i] }); i++ }
+    else { out.push({ kind: 'add', text: B[j] }); j++ }
+  }
+  while (i < m) out.push({ kind: 'del', text: A[i++] })
+  while (j < n) out.push({ kind: 'add', text: B[j++] })
+  return out
+}
+
+const diffStyles: Record<string, React.CSSProperties> = {
+  wrap: { fontFamily: 'Menlo, Monaco, "Courier New", monospace', fontSize: 11.5, lineHeight: 1.45, borderRadius: 4, overflow: 'hidden', border: `1px solid ${C.border}` },
+  row: { display: 'flex', whiteSpace: 'pre', padding: '0 6px' },
+  add: { background: 'rgba(50,215,75,0.13)', color: '#7ee895' },
+  del: { background: 'rgba(255,69,58,0.13)', color: '#ff8a82' },
+  eq:  { color: '#9a9a9a' },
+  marker: { width: 14, color: '#666', flexShrink: 0 },
+}
+
+const DiffView: React.FC<{ oldText: string; newText: string }> = ({ oldText, newText }) => {
+  const lines = lineDiff(oldText, newText)
+  return (
+    <div style={diffStyles.wrap}>
+      {lines.map((l, idx) => {
+        const style = l.kind === 'add' ? diffStyles.add : l.kind === 'del' ? diffStyles.del : diffStyles.eq
+        const marker = l.kind === 'add' ? '+' : l.kind === 'del' ? '-' : ' '
+        return (
+          <div key={idx} style={{ ...diffStyles.row, ...style }}>
+            <span style={diffStyles.marker}>{marker}</span>
+            <span>{l.text || ' '}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── Detail rendering ──────────────────────────────────────────────────────────
+
+const detailStyles: Record<string, React.CSSProperties> = {
+  label: { fontSize: 10, color: '#777', fontFamily: 'Menlo, Monaco, "Courier New", monospace', marginBottom: 4, marginTop: 6, textTransform: 'uppercase', letterSpacing: 0.5 },
+  pre: { margin: 0, fontSize: 11.5, color: '#d0d0d0', fontFamily: 'Menlo, Monaco, "Courier New", monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-word' },
+  block: { padding: 8, background: 'rgba(0,0,0,0.35)', borderRadius: 4, border: `1px solid ${C.border}` },
+  meta: { fontSize: 11, color: '#a0a0a0', fontFamily: 'Menlo, Monaco, "Courier New", monospace' },
+  todoRow: { display: 'flex', gap: 6, alignItems: 'flex-start', fontSize: 12, padding: '2px 0', fontFamily: 'Menlo, Monaco, "Courier New", monospace' },
+}
+
+const TodoList: React.FC<{ todos: Array<{ content?: string; status?: string; activeForm?: string }> }> = ({ todos }) => (
+  <div>
+    {todos.map((t, i) => {
+      const status = t.status ?? 'pending'
+      const mark = status === 'completed' ? '✓' : status === 'in_progress' ? '◐' : '○'
+      const color = status === 'completed' ? C.green : status === 'in_progress' ? C.yellow : '#888'
+      return (
+        <div key={i} style={detailStyles.todoRow}>
+          <span style={{ color, width: 14, flexShrink: 0 }}>{mark}</span>
+          <span style={{ color: status === 'completed' ? '#888' : '#d0d0d0', textDecoration: status === 'completed' ? 'line-through' : 'none' }}>
+            {t.content ?? t.activeForm ?? ''}
+          </span>
+        </div>
+      )
+    })}
+  </div>
+)
+
+const Block: React.FC<{ label: string; children: React.ReactNode; mono?: boolean }> = ({ label, children, mono = true }) => (
+  <>
+    <div style={detailStyles.label}>{label}</div>
+    <div style={mono ? detailStyles.block : undefined}>{children}</div>
+  </>
+)
+
+export const ToolDetail: React.FC<{
+  rawTool: string | undefined
+  input: Input
+  output?: string
+}> = ({ rawTool, input, output }) => {
+  const tool = normalizeTool(rawTool)
+  const i = input ?? {}
+  const Pre: React.FC<{ children: string }> = ({ children }) => <pre style={detailStyles.pre}>{children}</pre>
+
+  switch (tool) {
+    case 'Read': {
+      const path = str(i.file_path ?? i.path ?? i.filename)
+      return (
+        <>
+          <div style={detailStyles.meta}>{path || '(no path)'}</div>
+          {output && <Block label="Output"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'Edit': {
+      const path = str(i.file_path ?? i.path)
+      const oldS = str(i.old_string ?? i.oldText ?? '')
+      const newS = str(i.new_string ?? i.newText ?? '')
+      return (
+        <>
+          {path && <div style={detailStyles.meta}>{path}</div>}
+          {(oldS || newS) && (
+            <>
+              <div style={detailStyles.label}>Diff</div>
+              <DiffView oldText={oldS} newText={newS} />
+            </>
+          )}
+          {output && <Block label="Result"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'Write': {
+      const path = str(i.file_path ?? i.path)
+      const content = str(i.content ?? i.text ?? '')
+      return (
+        <>
+          {path && <div style={detailStyles.meta}>{path}</div>}
+          {content && <Block label="Content"><Pre>{content}</Pre></Block>}
+          {output && <Block label="Result"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'Bash': {
+      const cmd = str(i.command ?? i.cmd ?? i.script)
+      const desc = str(i.description ?? '')
+      return (
+        <>
+          {desc && <div style={detailStyles.meta}>{desc}</div>}
+          {cmd && <Block label="$"><Pre>{cmd}</Pre></Block>}
+          {output && <Block label="Output"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'Grep': {
+      const pat = str(i.pattern ?? i.query ?? i.regex)
+      const where = str(i.path ?? i.glob ?? '')
+      return (
+        <>
+          <div style={detailStyles.meta}>{pat}{where ? `  in ${where}` : ''}</div>
+          {output && <Block label="Matches"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'TodoWrite': {
+      const todos = (i.todos as Array<{ content?: string; status?: string; activeForm?: string }> | undefined) ?? []
+      return todos.length
+        ? <TodoList todos={todos} />
+        : output ? <Block label="Output"><Pre>{output}</Pre></Block> : null
+    }
+    case 'Patch': {
+      const patch = str(i.patch ?? i.diff ?? i.input ?? '')
+      return (
+        <>
+          {patch && <Block label="Patch"><Pre>{patch}</Pre></Block>}
+          {output && <Block label="Result"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'WebFetch':
+    case 'WebSearch': {
+      const url = str(i.url ?? i.query ?? i.q ?? '')
+      const prompt = str(i.prompt ?? '')
+      return (
+        <>
+          {url && <div style={detailStyles.meta}>{url}</div>}
+          {prompt && <Block label="Prompt"><Pre>{prompt}</Pre></Block>}
+          {output && <Block label="Output"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'Task': {
+      const desc = str(i.description ?? '')
+      const prompt = str(i.prompt ?? '')
+      const sub = str(i.subagent_type ?? '')
+      return (
+        <>
+          {sub && <div style={detailStyles.meta}>agent: {sub}</div>}
+          {desc && <div style={detailStyles.meta}>{desc}</div>}
+          {prompt && <Block label="Prompt"><Pre>{prompt}</Pre></Block>}
+          {output && <Block label="Result"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    case 'Plan': {
+      const plan = str(i.plan ?? i.explanation ?? '')
+      return (
+        <>
+          {plan && <Block label="Plan"><Pre>{plan}</Pre></Block>}
+          {output && <Block label="Result"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+    default: {
+      return (
+        <>
+          {input && Object.keys(input).length > 0 && (
+            <Block label="Input"><Pre>{JSON.stringify(input, null, 2)}</Pre></Block>
+          )}
+          {output && <Block label="Output"><Pre>{output}</Pre></Block>}
+        </>
+      )
+    }
+  }
+}
+
+/** Whether a tool call has any expandable detail worth rendering. */
+export const hasDetail = (rawTool: string | undefined, input: Input, output?: string): boolean => {
+  if (output) return true
+  if (!input) return false
+  const tool = normalizeTool(rawTool)
+  if (tool === 'Edit') return !!(input.old_string || input.new_string)
+  if (tool === 'TodoWrite') return Array.isArray(input.todos) && (input.todos as unknown[]).length > 0
+  return Object.keys(input).length > 0
+}


### PR DESCRIPTION
## Summary
- New `toolFormat.tsx` produces a readable one-line headline for each tool call (e.g. file reads, edits, bash commands) plus an optional expandable detail view, replacing the raw tool name + JSON input dump.
- `ChatTab` now pairs `tool_start` / `tool_end` events into a single row keyed by tool, so the chat no longer shows duplicate "running" / "done" entries for the same call.

## Test plan
- [ ] Open Codey app, run a chat that triggers tool calls (file reads, edits, bash) and verify each call shows one collapsed row with a sensible headline
- [ ] Click a row with detail and confirm input/output renders cleanly
- [ ] Verify no duplicate start/end rows for the same tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)