### PR TITLE
fix(core): auto-select workspace on load to prevent log ENOENT

### DIFF
--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -36,10 +36,23 @@ export class WorkspaceManager {
 
   async load(): Promise<void> {
     if (!this.currentWorkspace) {
-      // No workspace selected yet — don't materialize files at the workspaces
-      // root, or "memory"/"logs" will appear as phantom workspaces on the next
-      // listWorkspaces() call.
-      return;
+      // Auto-select a workspace so callers (logger setup, etc.) get real paths
+      // instead of resolving against the workspaces root — which would create
+      // phantom "logs"/"memory" entries and trip ENOENT on first write.
+      const existing = this.listWorkspaces();
+      const pick = existing.includes('default') ? 'default' : existing[0];
+      if (pick) {
+        this.currentWorkspace = pick;
+      } else {
+        const fallback = 'default';
+        const fallbackPath = path.join(this.workspacesDir, fallback);
+        fs.mkdirSync(fallbackPath, { recursive: true });
+        fs.writeFileSync(
+          path.join(fallbackPath, 'workspace.json'),
+          JSON.stringify({ workingDir: process.cwd() }, null, 2),
+        );
+        this.currentWorkspace = fallback;
+      }
     }
     const configPath = this.getConfigPath();
     const workspacePath = this.getWorkspacePath();


### PR DESCRIPTION
## Summary
- `WorkspaceManager.load()` was a no-op when no workspace was selected, leaving `currentWorkspace` empty.
- `Gateway.start()` then wired the logger to `workspaces/logs/app.log` (resolved against the workspaces root, with `logs/` never created), so the first channel-handler log write failed with `ENOENT` — e.g. `Failed to start telegram handler`.
- Fix: on `load()` with no current workspace, pick `default` if present, else the first listed workspace, else create `default`. The existing load path then materializes `logs/` as before.

## Test plan
- [ ] Start Codey with an empty `currentWorkspace` and verify telegram/discord handlers start without ENOENT.
- [ ] Confirm `workspaces/default/logs/app.log` is created and written to.
- [ ] Confirm starting with an existing workspace selected still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)