### PR TITLE
Rework workspace UX in chat list and settings

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -312,14 +312,9 @@ app.whenReady().then(async () => {
       const pathMod = await import('path')
       const root = workspaceManager.getWorkspacesRoot()
       const configPath = pathMod.join(root, name, 'workspace.json')
-      if (!fsMod.existsSync(configPath)) {
-        return { workingDir: '', teams: {} as Record<string, string[]> }
-      }
+      if (!fsMod.existsSync(configPath)) return { workingDir: '' }
       const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
-      return {
-        workingDir: data.workingDir || '',
-        teams: (data.teams || {}) as Record<string, string[]>,
-      }
+      return { workingDir: data.workingDir || '' }
     })
   )
 
@@ -355,13 +350,46 @@ app.whenReady().then(async () => {
   )
 
   // ── Teams IPC ─────────────────────────────────────────────────────
-  ipcMain.handle('teams:get', async () =>
-    wrap(async () => workspaceManager?.getTeams() ?? {})
+  ipcMain.handle('teams:get', async (_e, name?: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      const target = name || workspaceManager.getCurrentWorkspace()
+      if (!target) return {} as Record<string, string[]>
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const configPath = pathMod.join(workspaceManager.getWorkspacesRoot(), target, 'workspace.json')
+      if (!fsMod.existsSync(configPath)) return {} as Record<string, string[]>
+      const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
+      return (data.teams || {}) as Record<string, string[]>
+    })
   )
 
-  ipcMain.handle('teams:set', async (_e, teams: Record<string, string[]>) =>
+  ipcMain.handle('teams:set', async (_e, nameOrTeams: string | Record<string, string[]>, maybeTeams?: Record<string, string[]>) =>
     wrap(async () => {
-      await workspaceManager?.setTeams(teams)
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      // Backward-compat: support both (teams) and (name, teams) call shapes.
+      let target: string
+      let teams: Record<string, string[]>
+      if (typeof nameOrTeams === 'string') {
+        target = nameOrTeams || workspaceManager.getCurrentWorkspace()
+        teams = maybeTeams || {}
+      } else {
+        target = workspaceManager.getCurrentWorkspace()
+        teams = nameOrTeams || {}
+      }
+      if (!target) throw new Error('No workspace specified')
+
+      if (target === workspaceManager.getCurrentWorkspace()) {
+        await workspaceManager.setTeams(teams)
+        return
+      }
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const configPath = pathMod.join(workspaceManager.getWorkspacesRoot(), target, 'workspace.json')
+      if (!fsMod.existsSync(configPath)) throw new Error(`Workspace "${target}" does not exist`)
+      const existing = JSON.parse(await fsMod.promises.readFile(configPath, 'utf-8'))
+      existing.teams = teams
+      await fsMod.promises.writeFile(configPath, JSON.stringify(existing, null, 2), 'utf-8')
     })
   )
 
@@ -588,4 +616,9 @@ ipcMain.handle('open-external', (_event, url: string) => {
   if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
     shell.openExternal(url)
   }
+})
+
+ipcMain.handle('shell:openPath', async (_event, p: string) => {
+  if (typeof p !== 'string' || !p) return ''
+  return await shell.openPath(p)
 })

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -23,8 +23,9 @@ contextBridge.exposeInMainWorld('codey', {
     pickDirectory: () => ipcRenderer.invoke('dialog:pickDirectory'),
   },
   teams: {
-    get: () => ipcRenderer.invoke('teams:get'),
-    set: (teams: Record<string, string[]>) => ipcRenderer.invoke('teams:set', teams),
+    get: (name?: string) => ipcRenderer.invoke('teams:get', name),
+    set: (name: string, teams: Record<string, string[]>) =>
+      ipcRenderer.invoke('teams:set', name, teams),
   },
   conversations: {
     list: () => ipcRenderer.invoke('conversations:list'),
@@ -87,6 +88,7 @@ contextBridge.exposeInMainWorld('codey', {
     status: () => ipcRenderer.invoke('gateway:status'),
   },
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
+  openPath: (path: string) => ipcRenderer.invoke('shell:openPath', path),
   onLog: (handler: (msg: string) => void) => {
     const listener = (_e: Electron.IpcRendererEvent, msg: string) => handler(msg)
     ipcRenderer.on('gateway-log', listener)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -25,7 +25,7 @@ declare global {
         list: () => Promise<IpcResult<string[]>>
         current: () => Promise<IpcResult<string>>
         switch: (name: string) => Promise<IpcResult<void>>
-        info: (name: string) => Promise<IpcResult<{ workingDir: string; teams: Record<string, string[]> }>>
+        info: (name: string) => Promise<IpcResult<{ workingDir: string }>>
         getMemory: (name: string) => Promise<IpcResult<string>>
         setMemory: (name: string, content: string) => Promise<IpcResult<void>>
         create: (dir: string) => Promise<IpcResult<string>>
@@ -35,8 +35,8 @@ declare global {
         pickDirectory: () => Promise<IpcResult<string | null>>
       }
       teams: {
-        get: () => Promise<IpcResult<Record<string, string[]>>>
-        set: (teams: Record<string, string[]>) => Promise<IpcResult<void>>
+        get: (name?: string) => Promise<IpcResult<Record<string, string[]>>>
+        set: (name: string, teams: Record<string, string[]>) => Promise<IpcResult<void>>
       }
       conversations: {
         list: () => Promise<IpcResult<string[]>>
@@ -84,6 +84,7 @@ declare global {
         } | null>>
       }
       openExternal: (url: string) => Promise<void>
+      openPath: (path: string) => Promise<string>
       onLog: (handler: (msg: string) => void) => () => void
     }
   }

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -13,8 +13,21 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
   const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace } = useChats()
   const [, setWorkspaces] = useState<string[]>([])
   const [lastWorkspace, setLastWorkspace] = useState<string>('')
+  const [gatewayWorkspace, setGatewayWorkspace] = useState<string>('')
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    const refresh = () => {
+      apiService.getCurrentWorkspace()
+        .then(w => { if (!cancelled) setGatewayWorkspace(w) })
+        .catch(() => {})
+    }
+    refresh()
+    const id = setInterval(refresh, 5000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [])
 
   useEffect(() => {
     apiService.getWorkspaces().then(w => {
@@ -30,9 +43,10 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
     if (lastWorkspace) localStorage.setItem('codey.lastWorkspace', lastWorkspace)
   }, [lastWorkspace])
 
-  const handleNewChat = async () => {
-    if (!lastWorkspace) return
-    const chat = await createChat(lastWorkspace)
+  const handleNewChat = async (workspaceName?: string) => {
+    const target = workspaceName || lastWorkspace
+    if (!target) return
+    const chat = await createChat(target)
     setLastWorkspace(chat.workspaceName)
   }
 
@@ -47,8 +61,13 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
   return (
     <div style={styles.root}>
       <div style={styles.header}>
-        <button style={styles.newBtn} onClick={handleNewChat} disabled={!lastWorkspace}>
-          + New Chat
+        <button
+          style={styles.newBtn}
+          onClick={() => handleNewChat()}
+          disabled={!lastWorkspace}
+          title={lastWorkspace ? `Create a new chat in "${lastWorkspace}"` : 'No workspace available'}
+        >
+          {lastWorkspace ? `+ New Chat in ${lastWorkspace}` : '+ New Chat'}
         </button>
       </div>
       <div style={styles.scroll}>
@@ -61,7 +80,15 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
             <div key={ws}>
               <div style={styles.groupHeader} onClick={() => toggleWorkspace(ws)}>
                 <span style={{ ...styles.chevron, transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)' }}>▸</span>
-                <span>{ws}</span>
+                <span style={styles.groupName}>{ws}</span>
+                {ws === gatewayWorkspace && (
+                  <span style={styles.gatewayBadge} title="Gateway default workspace — receives messages from chat platforms"/>
+                )}
+                <button
+                  style={styles.groupAddBtn}
+                  onClick={(e) => { e.stopPropagation(); handleNewChat(ws) }}
+                  title={`New chat in "${ws}"`}
+                >+</button>
               </div>
               {!collapsed && groups[ws].map(chat => {
                 const active = chat.id === activeChatId
@@ -124,6 +151,19 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
         })}
       </div>
       <div style={styles.footer}>
+        <button
+          style={styles.settingsBtn}
+          onClick={async () => {
+            const ws = activeChatId && state.chats[activeChatId]?.workspaceName
+            if (!ws) return
+            try {
+              const info = await apiService.getWorkspaceInfo(ws)
+              if (info.workingDir) await window.codey.openPath(info.workingDir)
+            } catch {}
+          }}
+          disabled={!activeChatId || !state.chats[activeChatId!]?.workspaceName}
+          title="Open this chat's workspace folder in Finder"
+        >+ Open Workspace</button>
         <button style={styles.settingsBtn} onClick={onOpenSettings}>⚙ Settings</button>
       </div>
       <style>{`
@@ -163,6 +203,16 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '6px 8px', color: C.fg3, fontSize: 12, fontWeight: 600,
     textTransform: 'uppercase', cursor: 'pointer', userSelect: 'none',
   },
+  groupName: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  groupAddBtn: {
+    background: 'transparent', border: 'none', color: C.fg3,
+    cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: '0 4px',
+  },
+  gatewayBadge: {
+    width: 8, height: 8, borderRadius: '50%',
+    background: C.green, boxShadow: `0 0 6px ${C.green}`,
+    flexShrink: 0,  
+  },
   chevron: { display: 'inline-block', fontSize: 12, lineHeight: 1, transition: 'transform 0.15s ease' },
   item: {
     display: 'flex', alignItems: 'center', gap: 6,
@@ -183,6 +233,6 @@ const styles: Record<string, React.CSSProperties> = {
   settingsBtn: {
     width: '100%', padding: '8px 10px', border: 'none',
     background: 'transparent', color: C.fg2, cursor: 'pointer',
-    textAlign: 'left', borderRadius: 6, fontSize: 15,
+    textAlign: 'left', borderRadius: 6, fontSize: 13,
   },
 }

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -10,7 +10,7 @@ type Tab = 'workers' | 'workspaces' | 'status' | 'settings'
 const TABS: { key: Tab; label: string }[] = [
   { key: 'workers',    label: 'Workers' },
   { key: 'workspaces', label: 'Workspaces' },
-  { key: 'status',     label: 'Status' },
+  { key: 'status',     label: 'Gateway' },
   { key: 'settings',   label: 'Settings' },
 ]
 
@@ -46,7 +46,7 @@ export const SettingsOverlay: React.FC<Props> = ({ onClose }) => {
       </div>
       <div style={styles.body}>
         {tab === 'status'     && <StatusTab status={status} logs={logs} isRunning={isRunning} />}
-        {tab === 'workspaces' && <WorkspacesTab isGatewayRunning={isRunning} onWorkspaceChange={() => {}} />}
+        {tab === 'workspaces' && <WorkspacesTab isGatewayRunning={isRunning} />}
         {tab === 'workers'    && <WorkersTab />}
         {tab === 'settings'   && <SettingsTab isGatewayRunning={isRunning} />}
       </div>

--- a/codey-mac/src/components/StatusTab.tsx
+++ b/codey-mac/src/components/StatusTab.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { GatewayStatus } from '../types'
+import { apiService } from '../services/api'
 import { C } from '../theme'
 
 interface StatusTabProps {
@@ -19,6 +20,31 @@ const formatUptime = (seconds: number): string => {
 }
 
 export const StatusTab: React.FC<StatusTabProps> = ({ status, logs, isRunning }) => {
+  const [workspaces, setWorkspaces] = useState<string[]>([])
+  const [current, setCurrent] = useState<string>('')
+  const [switching, setSwitching] = useState(false)
+
+  useEffect(() => {
+    Promise.all([
+      apiService.getWorkspaces().catch(() => [] as string[]),
+      apiService.getCurrentWorkspace().catch(() => ''),
+    ]).then(([ws, cur]) => {
+      setWorkspaces(ws)
+      setCurrent(cur)
+    })
+  }, [])
+
+  const handleSwitch = async (name: string) => {
+    if (!name || name === current || switching) return
+    setSwitching(true)
+    try {
+      await apiService.switchWorkspace(name)
+      setCurrent(name)
+    } finally {
+      setSwitching(false)
+    }
+  }
+
   const stats = [
     { label: 'Uptime',   value: isRunning ? formatUptime(status.uptime) : '—' },
     { label: 'Messages', value: isRunning ? String(status.messagesProcessed ?? 0) : '—' },
@@ -60,6 +86,27 @@ export const StatusTab: React.FC<StatusTabProps> = ({ status, logs, isRunning })
             <div style={styles.statValue}>{s.value}</div>
           </div>
         ))}
+      </div>
+
+      <div style={{ marginBottom: 20 }}>
+        <div style={styles.sectionHead}>Default Workspace</div>
+        <div style={styles.listItem}>
+          <span style={{ color: C.fg3, fontSize: 12 }}>
+            Used for messages from chat platforms (Telegram, Discord, iMessage)
+          </span>
+          <select
+            value={current}
+            onChange={e => handleSwitch(e.target.value)}
+            disabled={switching || workspaces.length === 0}
+            style={styles.select}
+          >
+            {workspaces.length === 0 && <option value="">No workspaces</option>}
+            {!current && workspaces.length > 0 && <option value="">— Select —</option>}
+            {workspaces.map(ws => (
+              <option key={ws} value={ws}>{ws}</option>
+            ))}
+          </select>
+        </div>
       </div>
 
       <div style={{ marginBottom: 20 }}>
@@ -126,6 +173,16 @@ const styles: Record<string, React.CSSProperties> = {
     border: `1px solid ${C.border}`,
     borderRadius: 8,
     padding: '10px 14px',
+  },
+  select: {
+    background: C.surface3,
+    color: C.fg,
+    border: `1px solid ${C.border2}`,
+    borderRadius: 6,
+    padding: '4px 8px',
+    fontSize: 12,
+    cursor: 'pointer',
+    outline: 'none',
   },
   logsBox: {
     background: '#0d0d0d',

--- a/codey-mac/src/components/WorkspacesTab.tsx
+++ b/codey-mac/src/components/WorkspacesTab.tsx
@@ -5,7 +5,6 @@ import TeamsSection from './TeamsSection'
 
 interface WorkspacesTabProps {
   isGatewayRunning: boolean
-  onWorkspaceChange?: (name: string) => void
 }
 
 const FolderIcon: React.FC<{ color: string }> = ({ color }) => (
@@ -44,12 +43,10 @@ const ChevronIcon: React.FC<{ color: string; open: boolean }> = ({ color, open }
 
 interface WorkspaceInfo {
   workingDir: string
-  teams: Record<string, string[]>
 }
 
-export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, onWorkspaceChange }) => {
+export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning }) => {
   const [workspaces, setWorkspaces] = useState<string[]>([])
-  const [currentWorkspace, setCurrentWorkspace] = useState<string>('')
   const [busyName, setBusyName] = useState<string>('')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string>('')
@@ -58,12 +55,8 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
 
   const loadWorkspaces = useCallback(async () => {
     try {
-      const [ws, cur] = await Promise.all([
-        apiService.getWorkspaces(),
-        apiService.getCurrentWorkspace().catch(() => ''),
-      ])
+      const ws = await apiService.getWorkspaces()
       setWorkspaces(ws)
-      if (cur) setCurrentWorkspace(cur)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load workspaces')
     }
@@ -90,30 +83,14 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
     if (!infoCache[name]) loadInfo(name)
   }
 
-  const switchWorkspace = async (name: string) => {
-    if (busyName || name === currentWorkspace) return
-    setBusyName(name); setError('')
-    try {
-      await apiService.switchWorkspace(name)
-      setCurrentWorkspace(name)
-      onWorkspaceChange?.(name)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to switch workspace')
-    } finally {
-      setBusyName('')
-    }
-  }
-
   const pickAndCreate = async () => {
     if (creating) return
     setCreating(true); setError('')
     try {
       const dir = await apiService.pickDirectory()
       if (!dir) return
-      const name = await apiService.createWorkspaceFromDir(dir)
+      await apiService.createWorkspaceFromDir(dir)
       await loadWorkspaces()
-      setCurrentWorkspace(name)
-      onWorkspaceChange?.(name)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create workspace')
     } finally {
@@ -128,12 +105,9 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
       setError('The "default" workspace is protected and cannot be deleted.')
       return
     }
-    const isActive = name === currentWorkspace
     const isLast = workspaces.length === 1
-    const extra = isActive
-      ? isLast
-        ? '\n\nThis is your only workspace. After deletion you will need to add a folder before starting a new chat.'
-        : '\n\nThis is the active workspace. Another workspace will be activated automatically.'
+    const extra = isLast
+      ? '\n\nThis is your only workspace. After deletion you will need to add a folder before starting a new chat.'
       : ''
     const ok = window.confirm(
       `Delete workspace "${name}"?\n\nThis removes the workspace folder (workspace.json, memory.md, logs). The original project directory it points to is NOT touched.${extra}`
@@ -147,11 +121,6 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
         const next = { ...prev }; delete next[name]; return next
       })
       if (expanded === name) setExpanded('')
-      if (isActive) {
-        const nextActive = await apiService.getCurrentWorkspace().catch(() => '')
-        setCurrentWorkspace(nextActive)
-        if (nextActive !== currentWorkspace) onWorkspaceChange?.(nextActive)
-      }
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to delete workspace')
     } finally {
@@ -190,7 +159,6 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           {workspaces.map(ws => {
-            const active = currentWorkspace === ws
             const isBusy = busyName === ws
             const isOpen = expanded === ws
             const info = infoCache[ws]
@@ -198,8 +166,8 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
               <div
                 key={ws}
                 style={{
-                  background: active ? C.surface3 : C.surface2,
-                  border: `1px solid ${active ? C.accent + '55' : C.border}`,
+                  background: C.surface2,
+                  border: `1px solid ${C.border}`,
                   borderRadius: 10,
                   cursor: isBusy ? 'wait' : 'default',
                   transition: 'border-color 0.15s, background 0.15s',
@@ -216,22 +184,11 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
                   }}
                 >
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-                    <ChevronIcon color={active ? C.accent : C.fg2} open={isOpen} />
-                    <FolderIcon color={active ? C.accent : C.fg2} />
-                    <span style={{ color: active ? C.accent : C.fg, fontSize: 14, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ws}</span>
+                    <ChevronIcon color={C.fg2} open={isOpen} />
+                    <FolderIcon color={C.fg2} />
+                    <span style={{ color: C.fg, fontSize: 14, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ws}</span>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                    {active ? (
-                      <span style={{ color: C.accent, fontSize: 11, fontWeight: 600 }}>Active</span>
-                    ) : (
-                      <button
-                        onClick={(e) => { e.stopPropagation(); switchWorkspace(ws) }}
-                        disabled={isBusy}
-                        style={styles.switchBtn}
-                      >
-                        Switch
-                      </button>
-                    )}
                     <button
                       onClick={(e) => removeWorkspace(ws, e)}
                       disabled={isBusy || ws === 'default'}
@@ -259,11 +216,7 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning, 
                     </div>
 
                     <div style={{ marginTop: 12 }}>
-                      {active ? (
-                        <TeamsSection workspace={ws} />
-                      ) : (
-                        <ReadOnlyTeams teams={info?.teams ?? {}} loaded={!!info} />
-                      )}
+                      <TeamsSection workspace={ws} />
                     </div>
                   </div>
                 )}
@@ -373,38 +326,6 @@ const MemorySection: React.FC<{ workspace: string }> = ({ workspace }) => {
   )
 }
 
-const ReadOnlyTeams: React.FC<{ teams: Record<string, string[]>; loaded: boolean }> = ({ teams, loaded }) => {
-  const entries = Object.entries(teams)
-  return (
-    <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
-        <div style={{ fontSize: 14, fontWeight: 600 }}>Teams</div>
-        <span style={{ fontSize: 11, color: C.fg3 }}>read-only — switch to edit</span>
-      </div>
-      {!loaded ? (
-        <div style={{ fontSize: 12, color: C.fg3 }}>Loading…</div>
-      ) : entries.length === 0 ? (
-        <div style={{ fontSize: 12, color: C.fg3 }}>No teams declared.</div>
-      ) : (
-        entries.map(([name, members]) => (
-          <div key={name} style={{ marginBottom: 8, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6 }}>
-            <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 6 }}>{name}</div>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-              {members.length === 0 ? (
-                <span style={{ fontSize: 12, color: C.fg3 }}>(empty)</span>
-              ) : (
-                members.map((m, i) => (
-                  <span key={`${m}-${i}`} style={{ padding: '4px 8px', background: C.surface2, borderRadius: 14, fontSize: 12 }}>{m}</span>
-                ))
-              )}
-            </div>
-          </div>
-        ))
-      )}
-    </div>
-  )
-}
-
 const styles: Record<string, React.CSSProperties> = {
   container: { padding: 20, height: '100%', overflowY: 'auto' },
   offlineContainer: {
@@ -429,10 +350,6 @@ const styles: Record<string, React.CSSProperties> = {
   iconBtn: {
     background: 'transparent', border: 'none', padding: 4, borderRadius: 6,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
-  },
-  switchBtn: {
-    background: 'transparent', color: C.accent, border: `1px solid ${C.accent}55`,
-    borderRadius: 6, padding: '3px 10px', fontSize: 11, fontWeight: 600, cursor: 'pointer',
   },
   expandedBody: {
     padding: '12px 16px 16px',

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -61,7 +61,7 @@ export const apiService = {
   switchWorkspace: async (name: string): Promise<void> =>
     unwrap(await window.codey.workspaces.switch(name)),
 
-  getWorkspaceInfo: async (name: string): Promise<{ workingDir: string; teams: Record<string, string[]> }> =>
+  getWorkspaceInfo: async (name: string): Promise<{ workingDir: string }> =>
     unwrap(await window.codey.workspaces.info(name)),
 
   getWorkspaceMemory: async (name: string): Promise<string> =>
@@ -80,11 +80,11 @@ export const apiService = {
     unwrap(await window.codey.dialog.pickDirectory()),
 
   // Teams
-  getTeams: async (_workspace?: string): Promise<Record<string, string[]>> =>
-    unwrap(await window.codey.teams.get()),
+  getTeams: async (workspace?: string): Promise<Record<string, string[]>> =>
+    unwrap(await window.codey.teams.get(workspace)),
 
-  setTeams: async (_workspace: string, teams: Record<string, string[]>): Promise<void> =>
-    unwrap(await window.codey.teams.set(teams)),
+  setTeams: async (workspace: string, teams: Record<string, string[]>): Promise<void> =>
+    unwrap(await window.codey.teams.set(workspace, teams)),
 
   // Chat — gateway is in-process; streaming comes via chat:token IPC events
   sendMessage: async (


### PR DESCRIPTION
## Summary

- Consolidate the gateway "current workspace" concept into a single dropdown in the **Gateway** status tab. It's only used for routing messages from chat platforms (Telegram/Discord/iMessage) without a chat ID, so framing it as the user's "active workspace" was misleading.
- **Chat list panel:**
  - New "📂 Open Workspace" button opens the active chat's workspace folder in Finder (via a new `shell:openPath` IPC)
  - "+ New Chat" now labels its target workspace inline, and each workspace group header gets its own "+" button so chat creation is no longer dependent on hidden state
  - Green status dot highlights whichever workspace is the gateway default, refreshed every 5s
- **Workspaces tab:** dropped the "Active" badge / Switch button / accent styling. Every workspace's Teams section is now editable — the `teams:get` / `teams:set` IPC is properly workspace-scoped instead of silently writing to whatever the gateway considers current.
- Trimmed `workspaces:info` payload to `{ workingDir }` (teams field was no longer consumed).

## Test plan

- [ ] Open the Gateway tab — "Default Workspace" dropdown lists all workspaces and switching persists across app restart
- [ ] Chat list shows green dot on the workspace selected in the Gateway tab; dot moves when you switch via the dropdown (within 5s)
- [ ] Top "+ New Chat" button label reflects the target workspace
- [ ] Per-workspace "+" buttons in group headers create a chat in that workspace
- [ ] "📂 Open Workspace" footer button opens Finder to the active chat's working directory; disabled when no chat is selected
- [ ] In the Workspaces tab, edit Teams in any (non-active) workspace and verify changes persist to that workspace's `workspace.json` and don't bleed into other workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)