### PR TITLE
chore: release v0.2.1

### DIFF
--- a/codey-mac/build/entitlements.mac.plist
+++ b/codey-mac/build/entitlements.mac.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+</dict>
+</plist>

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",
@@ -13,6 +13,7 @@
     "dev": "vite",
     "build": "vite build && electron-builder",
     "build:mac": "vite build && electron-builder --mac",
+    "build:mac:signed": "vite build && electron-builder --mac --publish never",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -45,7 +46,15 @@
         { "target": "dmg", "arch": ["arm64", "x64"] }
       ],
       "category": "public.app-category.developer-tools",
-      "icon": "build/icon.icns"
+      "icon": "build/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "identity": "ou zixian (N59NN58KB2)",
+      "notarize": {
+        "teamId": "N59NN58KB2"
+      }
     },
     "files": [
       "dist/**/*",

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -10,8 +10,9 @@ interface Props {
 }
 
 export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId }) => {
-  const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace } = useChats()
-  const [, setWorkspaces] = useState<string[]>([])
+  const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace, refreshWorkspaces } = useChats()
+  const [addingWorkspace, setAddingWorkspace] = useState(false)
+  const [workspaces, setWorkspaces] = useState<string[]>([])
   const [lastWorkspace, setLastWorkspace] = useState<string>('')
   const [gatewayWorkspace, setGatewayWorkspace] = useState<string>('')
   const [renamingId, setRenamingId] = useState<string | null>(null)
@@ -23,20 +24,22 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
       apiService.getCurrentWorkspace()
         .then(w => { if (!cancelled) setGatewayWorkspace(w) })
         .catch(() => {})
+      apiService.getWorkspaces()
+        .then(w => {
+          if (cancelled) return
+          setWorkspaces(w)
+          setLastWorkspace(prev => {
+            if (prev && w.includes(prev)) return prev
+            const stored = localStorage.getItem('codey.lastWorkspace')
+            if (stored && w.includes(stored)) return stored
+            return w[0] ?? ''
+          })
+        })
+        .catch(() => {})
     }
     refresh()
     const id = setInterval(refresh, 5000)
     return () => { cancelled = true; clearInterval(id) }
-  }, [])
-
-  useEffect(() => {
-    apiService.getWorkspaces().then(w => {
-      setWorkspaces(w)
-      if (w.length > 0) {
-        const stored = localStorage.getItem('codey.lastWorkspace')
-        setLastWorkspace(stored && w.includes(stored) ? stored : w[0])
-      }
-    })
   }, [])
 
   useEffect(() => {
@@ -50,11 +53,33 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
     setLastWorkspace(chat.workspaceName)
   }
 
+  const handleAddWorkspace = async () => {
+    if (addingWorkspace) return
+    setAddingWorkspace(true)
+    try {
+      const dir = await apiService.pickDirectory()
+      if (!dir) return
+      const name = await apiService.createWorkspaceFromDir(dir)
+      const fresh = await apiService.getWorkspaces()
+      setWorkspaces(fresh)
+      await refreshWorkspaces()
+      const chat = await createChat(name)
+      setLastWorkspace(chat.workspaceName)
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to add workspace')
+    } finally {
+      setAddingWorkspace(false)
+    }
+  }
+
   const groups: Record<string, Chat[]> = {}
   for (const id of state.order) {
     const c = state.chats[id]
     if (!c) continue
     ;(groups[c.workspaceName] ??= []).push(c)
+  }
+  for (const ws of workspaces) {
+    if (!groups[ws]) groups[ws] = []
   }
   const groupNames = Object.keys(groups).sort()
 
@@ -94,7 +119,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
                 const active = chat.id === activeChatId
                 const flight = state.inFlight[chat.id]
                 const isRenaming = renamingId === chat.id
-                const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
+                const orphaned = workspaces.length > 0 && !workspaces.includes(chat.workspaceName)
                 return (
                   <div
                     key={chat.id}
@@ -153,17 +178,10 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
       <div style={styles.footer}>
         <button
           style={styles.settingsBtn}
-          onClick={async () => {
-            const ws = activeChatId && state.chats[activeChatId]?.workspaceName
-            if (!ws) return
-            try {
-              const info = await apiService.getWorkspaceInfo(ws)
-              if (info.workingDir) await window.codey.openPath(info.workingDir)
-            } catch {}
-          }}
-          disabled={!activeChatId || !state.chats[activeChatId!]?.workspaceName}
-          title="Open this chat's workspace folder in Finder"
-        >+ Open Workspace</button>
+          onClick={handleAddWorkspace}
+          disabled={addingWorkspace}
+          title="Pick a folder and create a new workspace + chat"
+        >{addingWorkspace ? 'Picking…' : '+ Add Workspace'}</button>
         <button style={styles.settingsBtn} onClick={onOpenSettings}>⚙ Settings</button>
       </div>
       <style>{`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Fix Mac chat list "+ Open Workspace" button — now opens a folder picker, creates a workspace, and starts a chat in it (mirrors the Workspaces tab "Add folder" flow).
- Workspaces added from the Workspaces tab now show up in the chat list automatically (list polls every 5s and renders empty workspace groups).
- Enable hardened runtime, entitlements, and notarization config for signed Mac builds; bump versions to 0.2.1.

## Test plan
- [ ] Click "+ Add Workspace" in the chat list → folder picker opens, picking a folder creates a workspace and a new chat in it.
- [ ] Add a workspace from the Workspaces tab → it appears in the chat list within ~5s with a "+" to start a chat.
- [ ] `npm run build:mac:signed` produces a signed/notarized DMG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)