### PR TITLE
feat: per-model fallback chain + Mac UX cleanup

### DIFF
--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -58,8 +58,8 @@ declare global {
         rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
       }
       fallback: {
-        get: () => Promise<IpcResult<{ enabled: boolean; order: string[] }>>
-        set: (fb: { enabled: boolean; order: string[] }) => Promise<IpcResult<void>>
+        get: () => Promise<IpcResult<{ enabled: boolean; order: Array<{ agent: string; model?: string }> }>>
+        set: (fb: { enabled: boolean; order: Array<{ agent: string; model?: string }> }) => Promise<IpcResult<void>>
       }
       agents: {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string }>>>

--- a/codey-mac/src/components/ChannelsSection.tsx
+++ b/codey-mac/src/components/ChannelsSection.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { C } from '../theme'
+
+// Mirrors the renderer-side channel config shape. Kept local since this is
+// the only consumer.
+interface ChannelsCfg {
+  telegram?: { enabled: boolean; botToken: string; notifyChatId?: string }
+  discord?:  { enabled: boolean; botToken: string }
+  imessage?: { enabled: boolean }
+}
+
+const inputStyle: React.CSSProperties = {
+  background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 7,
+  color: C.fg, fontSize: 13, padding: '6px 10px', outline: 'none', width: 180,
+}
+const pillButton = (variant: 'ghost'): React.CSSProperties => ({
+  padding: '6px 12px', borderRadius: 7, fontSize: 12, fontWeight: 600,
+  border: 'none', cursor: 'pointer',
+  background: C.surface3, color: C.fg2,
+})
+
+const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
+  <div onClick={() => onChange(!on)} style={{
+    width: 36, height: 20, borderRadius: 10, flexShrink: 0,
+    background: on ? C.accent : C.surface3,
+    border: `1px solid ${on ? C.accent : C.border2}`,
+    cursor: 'pointer', position: 'relative', transition: 'all 0.2s',
+  }}>
+    <div style={{
+      position: 'absolute', top: 1, left: on ? 17 : 1,
+      width: 16, height: 16, borderRadius: '50%', background: '#fff',
+      transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.3)',
+    }}/>
+  </div>
+)
+
+interface ChannelField {
+  label: string
+  value: string
+  secret?: boolean
+  onChange: (next: string) => void
+}
+
+const ChannelEditor: React.FC<{
+  label: string
+  enabled: boolean
+  liveStatus?: 'connected' | 'disabled'
+  onToggle: (enabled: boolean) => Promise<void> | void
+  fields: ChannelField[]
+  note?: string
+}> = ({ label, enabled, liveStatus, onToggle, fields, note }) => {
+  const [open, setOpen] = useState(false)
+  // Local buffers so typing isn't blocked by per-keystroke IPC writes.
+  // Commit on blur instead.
+  const [drafts, setDrafts] = useState<string[]>(fields.map(f => f.value))
+  useEffect(() => { setDrafts(fields.map(f => f.value)) }, [fields.map(f => f.value).join('|')])
+
+  return (
+    <div style={{
+      background: C.surface2, border: `1px solid ${C.border}`,
+      borderRadius: 8, marginBottom: 8, overflow: 'hidden',
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '10px 14px',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10}}>
+          <span style={{ color: C.fg, fontSize: 13, flex: 0.3 }}>{label}</span>
+          {(fields.length > 0 || note) && (
+            <button 
+            onClick={() => setOpen(o => !o)} 
+            style={{ ...pillButton('ghost'), padding: '2px 8px', fontSize: 11, flex: 0.7 }}>
+              {open ? 'Hide' : 'Configure'}
+            </button>
+          )}
+          {liveStatus && (
+            <span style={{
+              alignSelf: 'flex-end',
+              fontSize: 10, fontWeight: 600, letterSpacing: 0.4, textTransform: 'uppercase',
+              color: liveStatus === 'connected' ? C.green : C.fg3,
+            }}>
+              {liveStatus === 'connected' ? '● Connected' : '○ Off'}
+            </span>
+          )}
+        </div>
+
+        <Toggle on={enabled} onChange={v => { void onToggle(v) }}/>
+      </div>
+      {open && (
+        <div style={{ padding: '0 14px 12px', borderTop: `1px solid ${C.border}` }}>
+          {note && <div style={{ color: C.fg3, fontSize: 11, padding: '10px 0' }}>{note}</div>}
+          {fields.map((f, i) => (
+            <div key={f.label} style={{ display: 'grid', gridTemplateColumns: '120px 1fr', gap: 8, alignItems: 'center', marginTop: 10 }}>
+              <label style={{ color: C.fg3, fontSize: 12 }}>{f.label}</label>
+              <input
+                type={f.secret ? 'password' : 'text'}
+                value={drafts[i] ?? ''}
+                onChange={e => setDrafts(d => { const n = d.slice(); n[i] = e.target.value; return n })}
+                onBlur={() => { if (drafts[i] !== f.value) f.onChange(drafts[i] ?? '') }}
+                style={{ ...inputStyle, width: '100%' }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const unwrap = <T,>(r: { ok: boolean; data?: T; error?: string }): T => {
+  if (!r?.ok) throw new Error(r?.error ?? 'IPC failed')
+  return r.data as T
+}
+
+export interface ChannelsSectionProps {
+  liveStatus?: { telegram?: boolean; discord?: boolean; imessage?: boolean }
+  isGatewayRunning: boolean
+}
+
+export const ChannelsSection: React.FC<ChannelsSectionProps> = ({ liveStatus, isGatewayRunning }) => {
+  const [channels, setChannels] = useState<ChannelsCfg>({})
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setError(null)
+    try {
+      const cfg = unwrap(await window.codey.config.get())
+      setChannels((cfg as any)?.channels ?? {})
+    } catch (e: any) { setError(e?.message ?? String(e)) }
+  }, [])
+
+  useEffect(() => { if (isGatewayRunning) reload() }, [isGatewayRunning, reload])
+
+  if (!isGatewayRunning) return null
+
+  // ConfigManager.update() does Object.assign on channels, so we must send
+  // the full per-channel object rather than a partial — otherwise omitted
+  // fields would be wiped.
+  const persist = async (next: ChannelsCfg, key: keyof ChannelsCfg) => {
+    setChannels(next)
+    const patch: any = { [key]: next[key] }
+    await unwrap(await window.codey.config.set({ channels: patch }))
+  }
+  const setTelegram = (patch: Partial<NonNullable<ChannelsCfg['telegram']>>) => {
+    const cur = channels.telegram ?? { enabled: false, botToken: '' }
+    return persist({ ...channels, telegram: { ...cur, ...patch } }, 'telegram')
+  }
+  const setDiscord = (patch: Partial<NonNullable<ChannelsCfg['discord']>>) => {
+    const cur = channels.discord ?? { enabled: false, botToken: '' }
+    return persist({ ...channels, discord: { ...cur, ...patch } }, 'discord')
+  }
+  const setIMessage = (patch: Partial<NonNullable<ChannelsCfg['imessage']>>) => {
+    const cur = channels.imessage ?? { enabled: false }
+    return persist({ ...channels, imessage: { ...cur, ...patch } }, 'imessage')
+  }
+
+  const liveLabel = (active?: boolean): 'connected' | 'disabled' =>
+    active ? 'connected' : 'disabled'
+
+  return (
+    <div>
+      {error && <div style={{ background: '#FF453A22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
+      <ChannelEditor
+        label="Telegram"
+        enabled={!!channels.telegram?.enabled}
+        liveStatus={liveLabel(liveStatus?.telegram)}
+        onToggle={enabled => setTelegram({ enabled })}
+        fields={[
+          { label: 'Bot Token', value: channels.telegram?.botToken ?? '', secret: true,
+            onChange: v => setTelegram({ botToken: v }) },
+          { label: 'Notify Chat ID', value: channels.telegram?.notifyChatId ?? '',
+            onChange: v => setTelegram({ notifyChatId: v || undefined }) },
+        ]}
+      />
+      <ChannelEditor
+        label="Discord"
+        enabled={!!channels.discord?.enabled}
+        liveStatus={liveLabel(liveStatus?.discord)}
+        onToggle={enabled => setDiscord({ enabled })}
+        fields={[
+          { label: 'Bot Token', value: channels.discord?.botToken ?? '', secret: true,
+            onChange: v => setDiscord({ botToken: v }) },
+        ]}
+      />
+      <ChannelEditor
+        label="iMessage"
+        enabled={!!channels.imessage?.enabled}
+        liveStatus={liveLabel(liveStatus?.imessage)}
+        onToggle={enabled => setIMessage({ enabled })}
+        fields={[]}
+        note="Requires macOS Messages.app and Full Disk Access for the Codey app."
+      />
+    </div>
+  )
+}

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -218,8 +218,8 @@ const styles: Record<string, React.CSSProperties> = {
   empty: { color: C.fg3, fontSize: 12, padding: 12, textAlign: 'center' },
   groupHeader: {
     display: 'flex', alignItems: 'center', gap: 6,
-    padding: '6px 8px', color: C.fg3, fontSize: 12, fontWeight: 600,
-    textTransform: 'uppercase', cursor: 'pointer', userSelect: 'none',
+    padding: '6px 8px', color: C.fg3, fontSize: 13, fontWeight: 600,
+    cursor: 'pointer', userSelect: 'none',
   },
   groupName: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   groupAddBtn: {

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -11,7 +11,7 @@ const TABS: { key: Tab; label: string }[] = [
   { key: 'workers',    label: 'Workers' },
   { key: 'workspaces', label: 'Workspaces' },
   { key: 'status',     label: 'Gateway' },
-  { key: 'settings',   label: 'Settings' },
+  { key: 'settings',   label: 'AI Models' },
 ]
 
 interface Props { onClose: () => void }

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -15,13 +15,16 @@ interface ModelEntry {
   provider?: string
 }
 interface AgentSlot { enabled?: boolean; defaultModel?: string }
-interface FallbackCfg { enabled: boolean; order: string[] }
-interface ChannelsCfg {
-  telegram?: { enabled: boolean; botToken: string; notifyChatId?: string }
-  discord?:  { enabled: boolean; botToken: string }
-  imessage?: { enabled: boolean }
-}
+interface FallbackEntry { agent: string; model?: string }
+interface FallbackCfg { enabled: boolean; order: FallbackEntry[] }
 
+// Each agent expects a specific apiType — surfacing this in the UI keeps users
+// from picking a model the agent's CLI cannot actually authenticate against.
+const AGENT_API_TYPE: Record<string, ApiType> = {
+  'claude-code': 'anthropic',
+  'opencode': 'openai',
+  'codex': 'openai',
+}
 const AGENT_NAMES = ['claude-code', 'opencode', 'codex'] as const
 
 // ── Shared style atoms ───────────────────────────────────────────────
@@ -69,68 +72,6 @@ const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on,
     }}/>
   </div>
 )
-
-// ── Channel editor row ──────────────────────────────────────────────
-
-interface ChannelField {
-  label: string
-  value: string
-  secret?: boolean
-  onChange: (next: string) => void
-}
-
-const ChannelEditor: React.FC<{
-  label: string
-  enabled: boolean
-  onToggle: (enabled: boolean) => Promise<void> | void
-  fields: ChannelField[]
-  note?: string
-}> = ({ label, enabled, onToggle, fields, note }) => {
-  const [open, setOpen] = useState(false)
-  // Local buffers so typing isn't blocked by per-keystroke IPC writes.
-  // Commit on blur instead.
-  const [drafts, setDrafts] = useState<string[]>(fields.map(f => f.value))
-  useEffect(() => { setDrafts(fields.map(f => f.value)) }, [fields.map(f => f.value).join('|')])
-
-  return (
-    <div style={{
-      background: C.surface2, border: `1px solid ${C.border}`,
-      borderRadius: 8, marginBottom: 8, overflow: 'hidden',
-    }}>
-      <div style={{
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        padding: '10px 14px',
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <span style={{ color: C.fg, fontSize: 13 }}>{label}</span>
-          {(fields.length > 0 || note) && (
-            <button onClick={() => setOpen(o => !o)} style={{ ...pillButton('ghost'), padding: '2px 8px', fontSize: 11 }}>
-              {open ? 'Hide' : 'Configure'}
-            </button>
-          )}
-        </div>
-        <Toggle on={enabled} onChange={v => { void onToggle(v) }}/>
-      </div>
-      {open && (
-        <div style={{ padding: '0 14px 12px', borderTop: `1px solid ${C.border}` }}>
-          {note && <div style={{ color: C.fg3, fontSize: 11, padding: '10px 0' }}>{note}</div>}
-          {fields.map((f, i) => (
-            <div key={f.label} style={{ display: 'grid', gridTemplateColumns: '120px 1fr', gap: 8, alignItems: 'center', marginTop: 10 }}>
-              <label style={{ color: C.fg3, fontSize: 12 }}>{f.label}</label>
-              <input
-                type={f.secret ? 'password' : 'text'}
-                value={drafts[i] ?? ''}
-                onChange={e => setDrafts(d => { const n = d.slice(); n[i] = e.target.value; return n })}
-                onBlur={() => { if (drafts[i] !== f.value) f.onChange(drafts[i] ?? '') }}
-                style={{ ...inputStyle, width: '100%' }}
-              />
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
 
 // ── Model row (view + edit) ─────────────────────────────────────────
 
@@ -217,36 +158,130 @@ const ModelRow: React.FC<{
   )
 }
 
-// ── Fallback reorderer (simple up/down controls — drag-free) ────────
+// ── Fallback chain editor (agent + optional model per step) ─────────
 
 const FallbackList: React.FC<{
-  order: string[]
-  onChange: (next: string[]) => void
-}> = ({ order, onChange }) => {
-  const move = (i: number, dir: -1 | 1) => {
-    const j = i + dir
-    if (j < 0 || j >= order.length) return
+  order: FallbackEntry[]
+  models: ModelEntry[]
+  enabledAgents: string[]
+  disabledAgents: string[]
+  onChange: (next: FallbackEntry[]) => void
+}> = ({ order, models, enabledAgents, disabledAgents, onChange }) => {
+  const [dragIdx, setDragIdx] = useState<number | null>(null)
+  const [dropIdx, setDropIdx] = useState<number | null>(null)
+
+  const reorder = (from: number, to: number) => {
+    if (from === to || from < 0 || to < 0 || from >= order.length || to > order.length) return
     const next = order.slice()
-    ;[next[i], next[j]] = [next[j], next[i]]
+    const [moved] = next.splice(from, 1)
+    next.splice(to > from ? to - 1 : to, 0, moved)
     onChange(next)
   }
+  const remove = (i: number) => onChange(order.filter((_, idx) => idx !== i))
+  const update = (i: number, patch: Partial<FallbackEntry>) => {
+    const next = order.slice()
+    next[i] = { ...next[i], ...patch }
+    // Switching agents may invalidate the pinned model — clear it when the
+    // apiType no longer matches so we don't ship an unusable combo.
+    if (patch.agent && next[i].model) {
+      const m = models.find(mm => mm.model === next[i].model)
+      if (m && AGENT_API_TYPE[next[i].agent] && m.apiType !== AGENT_API_TYPE[next[i].agent]) {
+        next[i] = { agent: next[i].agent }
+      }
+    }
+    onChange(next)
+  }
+  const add = () => {
+    const agent = enabledAgents[0] ?? 'claude-code'
+    onChange([...order, { agent }])
+  }
+
+  const modelsForAgent = (agent: string) => {
+    const want = AGENT_API_TYPE[agent]
+    return [...models]
+      .filter(m => !want || m.apiType === want)
+      .sort((a, b) => a.model.localeCompare(b.model))
+  }
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-      {order.map((a, i) => (
-        <div key={a} style={{
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
-          padding: '10px 14px',
-        }}>
-          <div style={{ color: C.fg, fontSize: 13 }}>
-            <span style={{ color: C.fg3, marginRight: 8 }}>{i + 1}.</span>{a}
-          </div>
-          <div style={{ display: 'flex', gap: 4 }}>
-            <button onClick={() => move(i, -1)} disabled={i === 0} style={{ ...pillButton('ghost'), opacity: i === 0 ? 0.4 : 1 }}>↑</button>
-            <button onClick={() => move(i, +1)} disabled={i === order.length - 1} style={{ ...pillButton('ghost'), opacity: i === order.length - 1 ? 0.4 : 1 }}>↓</button>
-          </div>
+      {order.length === 0 && (
+        <div style={{ color: C.fg3, fontSize: 12, padding: '6px 0' }}>
+          No fallback steps. Add one to build a chain.
         </div>
-      ))}
+      )}
+      {order.map((entry, i) => {
+        const isDragging = dragIdx === i
+        const showInsertAbove = dropIdx === i && dragIdx !== null && dragIdx !== i && dragIdx !== i - 1
+        const isDisabled = disabledAgents.includes(entry.agent)
+        return (
+          <React.Fragment key={i}>
+            {showInsertAbove && <div style={{ height: 2, background: C.accent, borderRadius: 1 }}/>}
+            <div
+              draggable
+              onDragStart={e => {
+                setDragIdx(i)
+                e.dataTransfer.effectAllowed = 'move'
+                // Firefox needs setData to start a drag; value is unused.
+                e.dataTransfer.setData('text/plain', String(i))
+              }}
+              onDragOver={e => {
+                if (dragIdx === null) return
+                e.preventDefault()
+                e.dataTransfer.dropEffect = 'move'
+                const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect()
+                const before = e.clientY < rect.top + rect.height / 2
+                setDropIdx(before ? i : i + 1)
+              }}
+              onDragEnd={() => { setDragIdx(null); setDropIdx(null) }}
+              onDrop={e => {
+                e.preventDefault()
+                if (dragIdx !== null && dropIdx !== null) reorder(dragIdx, dropIdx)
+                setDragIdx(null); setDropIdx(null)
+              }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                background: C.surface2, border: `1px solid ${isDragging ? C.accent : C.border}`, borderRadius: 8,
+                padding: '8px 12px',
+                opacity: isDragging ? 0.4 : 1,
+                cursor: 'grab',
+              }}
+            >
+              <span style={{ color: C.fg3, fontSize: 14, cursor: 'grab', userSelect: 'none' }} title="Drag to reorder">⋮⋮</span>
+              <span style={{ color: C.fg3, fontSize: 12, width: 18 }}>{i + 1}.</span>
+              <select
+                value={entry.agent}
+                onChange={e => update(i, { agent: e.target.value })}
+                style={{ ...selectStyle, width: 130 }}
+              >
+                {AGENT_NAMES.map(a => (
+                  <option key={a} value={a}>{a}{disabledAgents.includes(a) ? ' (off)' : ''}</option>
+                ))}
+              </select>
+              <select
+                value={entry.model ?? ''}
+                onChange={e => update(i, { model: e.target.value || undefined })}
+                style={{ ...selectStyle, flex: 1, minWidth: 0 }}
+              >
+                <option value="">(default)</option>
+                {modelsForAgent(entry.agent).map(m => (
+                  <option key={m.model} value={m.model}>{m.model} [{m.apiType}]</option>
+                ))}
+              </select>
+              {isDisabled && (
+                <span style={{ color: C.fg3, fontSize: 10 }} title="This agent is disabled and will be skipped">skipped</span>
+              )}
+              <button onClick={() => remove(i)} style={pillButton('danger')}>✕</button>
+            </div>
+            {dropIdx === order.length && i === order.length - 1 && dragIdx !== null && dragIdx !== i && (
+              <div style={{ height: 2, background: C.accent, borderRadius: 1 }}/>
+            )}
+          </React.Fragment>
+        )
+      })}
+      <div>
+        <button onClick={add} style={pillButton('ghost')}>+ Add step</button>
+      </div>
     </div>
   )
 }
@@ -257,21 +292,18 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const [models, setModels] = useState<ModelEntry[]>([])
   const [agents, setAgents] = useState<Record<string, AgentSlot>>({})
   const [fallback, setFallback] = useState<FallbackCfg>({ enabled: true, order: [] })
-  const [channels, setChannels] = useState<ChannelsCfg>({})
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const reload = useCallback(async () => {
     setError(null)
     try {
-      const [m, a, f, cfg] = await Promise.all([
+      const [m, a, f] = await Promise.all([
         unwrap(await window.codey.models.list()),
         unwrap(await window.codey.agents.get()),
         unwrap(await window.codey.fallback.get()),
-        unwrap(await window.codey.config.get()),
       ])
       setModels(m); setAgents(a as any); setFallback(f as FallbackCfg)
-      setChannels((cfg as any)?.channels ?? {})
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
@@ -312,69 +344,11 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
     await unwrap(await window.codey.fallback.set(fb))
   }
 
-  // ConfigManager.update() does Object.assign on channels, so we must send
-  // the full per-channel object (e.g. { telegram: { enabled, botToken, ... } })
-  // rather than a partial — otherwise omitted fields would be wiped.
-  const persistChannels = async (next: ChannelsCfg, patchKey: keyof ChannelsCfg) => {
-    setChannels(next)
-    const patch: any = { [patchKey]: next[patchKey] }
-    await unwrap(await window.codey.config.set({ channels: patch }))
-  }
-  const setTelegram = (patch: Partial<NonNullable<ChannelsCfg['telegram']>>) => {
-    const cur = channels.telegram ?? { enabled: false, botToken: '' }
-    const next = { ...channels, telegram: { ...cur, ...patch } }
-    return persistChannels(next, 'telegram')
-  }
-  const setDiscord = (patch: Partial<NonNullable<ChannelsCfg['discord']>>) => {
-    const cur = channels.discord ?? { enabled: false, botToken: '' }
-    const next = { ...channels, discord: { ...cur, ...patch } }
-    return persistChannels(next, 'discord')
-  }
-  const setIMessage = (patch: Partial<NonNullable<ChannelsCfg['imessage']>>) => {
-    const cur = channels.imessage ?? { enabled: false }
-    const next = { ...channels, imessage: { ...cur, ...patch } }
-    return persistChannels(next, 'imessage')
-  }
-
   const enabledAgents = AGENT_NAMES.filter(a => agents[a]?.enabled !== false)
-  // Ensure fallback.order is coherent with enabled agents
-  const liveOrder = fallback.order.length
-    ? fallback.order.filter(a => enabledAgents.includes(a as any))
-      .concat(enabledAgents.filter(a => !fallback.order.includes(a)))
-    : enabledAgents.slice()
 
   return (
     <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
       {error && <div style={{ background: '#FF453A22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
-
-      <Section title="Channels"/>
-      <ChannelEditor
-        label="Telegram"
-        enabled={!!channels.telegram?.enabled}
-        onToggle={enabled => setTelegram({ enabled })}
-        fields={[
-          { label: 'Bot Token', value: channels.telegram?.botToken ?? '', secret: true,
-            onChange: v => setTelegram({ botToken: v }) },
-          { label: 'Notify Chat ID', value: channels.telegram?.notifyChatId ?? '',
-            onChange: v => setTelegram({ notifyChatId: v || undefined }) },
-        ]}
-      />
-      <ChannelEditor
-        label="Discord"
-        enabled={!!channels.discord?.enabled}
-        onToggle={enabled => setDiscord({ enabled })}
-        fields={[
-          { label: 'Bot Token', value: channels.discord?.botToken ?? '', secret: true,
-            onChange: v => setDiscord({ botToken: v }) },
-        ]}
-      />
-      <ChannelEditor
-        label="iMessage"
-        enabled={!!channels.imessage?.enabled}
-        onToggle={enabled => setIMessage({ enabled })}
-        fields={[]}
-        note="Requires macOS Messages.app and Full Disk Access for the Codey app."
-      />
 
       <Section title="Models" right={
         <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
@@ -426,10 +400,13 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
       {fallback.enabled ? (
         <>
           <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
-            When an agent fails, the gateway tries these agents in order.
+            When a request fails, the gateway tries each step in order. Pin a specific model to retry the same agent with a different model.
           </div>
           <FallbackList
-            order={liveOrder}
+            order={fallback.order}
+            models={models}
+            enabledAgents={enabledAgents}
+            disabledAgents={AGENT_NAMES.filter(a => agents[a]?.enabled === false)}
             onChange={next => updateFallback({ ...fallback, order: next })}
           />
         </>

--- a/codey-mac/src/components/StatusTab.tsx
+++ b/codey-mac/src/components/StatusTab.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { GatewayStatus } from '../types'
 import { apiService } from '../services/api'
 import { C } from '../theme'
+import { ChannelsSection } from './ChannelsSection'
 
 interface StatusTabProps {
   status: GatewayStatus
@@ -50,12 +51,6 @@ export const StatusTab: React.FC<StatusTabProps> = ({ status, logs, isRunning })
     { label: 'Messages', value: isRunning ? String(status.messagesProcessed ?? 0) : '—' },
     { label: 'Errors',   value: isRunning ? String(status.errors ?? 0) : '—' },
     { label: 'Status',   value: isRunning ? 'OK' : '—' },
-  ]
-
-  const channels = [
-    { name: 'Telegram', active: !!status.channels?.telegram },
-    { name: 'Discord',  active: !!status.channels?.discord },
-    { name: 'iMessage', active: !!status.channels?.imessage },
   ]
 
   return (
@@ -111,16 +106,14 @@ export const StatusTab: React.FC<StatusTabProps> = ({ status, logs, isRunning })
 
       <div style={{ marginBottom: 20 }}>
         <div style={styles.sectionHead}>Channels</div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          {channels.map(ch => (
-            <div key={ch.name} style={styles.listItem}>
-              <span style={{ color: C.fg, fontSize: 13 }}>{ch.name}</span>
-              <span style={{ color: ch.active ? C.green : C.fg3, fontSize: 12, fontWeight: 500 }}>
-                {ch.active ? 'Connected' : 'Disabled'}
-              </span>
-            </div>
-          ))}
-        </div>
+        <ChannelsSection
+          isGatewayRunning={isRunning}
+          liveStatus={{
+            telegram: !!status.channels?.telegram,
+            discord:  !!status.channels?.discord,
+            imessage: !!status.channels?.imessage,
+          }}
+        />
       </div>
 
       <div>

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -54,9 +54,20 @@ export interface ModelEntry {
   provider?: string;      // optional human label (anthropic, minimax, openai, …)
 }
 
+export interface FallbackEntry {
+  agent: CodingAgent;
+  /**
+   * Optional model id from the global ModelEntry catalog. When omitted, the
+   * gateway resolves the agent's defaultModel at run time. Two entries with
+   * the same agent but different models are valid (e.g. claude-code with
+   * sonnet → claude-code with haiku).
+   */
+  model?: string;
+}
+
 export interface FallbackConfig {
   enabled: boolean;
-  order: CodingAgent[];
+  order: FallbackEntry[];
 }
 
 export interface AgentRequest {

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { EventEmitter } from 'events';
-import { FallbackConfig, ModelEntry } from '@codey/core';
+import { CodingAgent, FallbackConfig, FallbackEntry, ModelEntry } from '@codey/core';
 
 // ── Configuration types ─────────────────────────────────────────────
 
@@ -126,6 +126,9 @@ export class ConfigManager extends EventEmitter {
       const slot = this.config.agents[agent];
       if (slot && slot.defaultModel === oldId) slot.defaultModel = newId;
     }
+    for (const entry of this.config.fallback.order) {
+      if (entry.model === oldId) entry.model = newId;
+    }
     this.save();
     return true;
   }
@@ -136,6 +139,9 @@ export class ConfigManager extends EventEmitter {
     for (const agent of Object.keys(this.config.agents) as (keyof typeof this.config.agents)[]) {
       const slot = this.config.agents[agent];
       if (slot && slot.defaultModel === modelId) slot.defaultModel = undefined;
+    }
+    for (const entry of this.config.fallback.order) {
+      if (entry.model === modelId) entry.model = undefined;
     }
     if (this.config.models.length !== before) {
       this.save();
@@ -167,8 +173,13 @@ export class ConfigManager extends EventEmitter {
   // ── Fallback config ────────────────────────────────────────────────
   getFallback(): FallbackConfig { return this.config.fallback; }
 
-  setFallback(fb: FallbackConfig): void {
-    this.config.fallback = fb;
+  /**
+   * Accepts either the canonical FallbackConfig or a legacy
+   * `{ enabled, order: string[] }` payload (still sent by older UI clients).
+   * Both shapes are normalized to FallbackEntry[] before being persisted.
+   */
+  setFallback(fb: { enabled?: boolean; order?: Array<FallbackEntry | CodingAgent | string> }): void {
+    this.config.fallback = normalizeFallback(fb, this.config.fallback);
     this.save();
   }
 
@@ -245,13 +256,47 @@ export class ConfigManager extends EventEmitter {
       const on = slot?.enabled !== false;
       console.log(`  ${on ? '✅' : '❌'} ${a} → ${slot?.defaultModel || '(no model)'}`);
     }
-    console.log(`\nFallback: ${this.config.fallback.enabled ? '✅' : '❌'} order=${this.config.fallback.order.join(' → ')}`);
+    console.log(`\nFallback: ${this.config.fallback.enabled ? '✅' : '❌'} order=${formatFallbackOrder(this.config.fallback.order)}`);
     console.log(`\nDev:\n  Log Level: ${this.config.dev.logLevel}`);
     console.log('─'.repeat(40) + '\n');
   }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+const KNOWN_AGENTS: ReadonlySet<CodingAgent> = new Set(['claude-code', 'opencode', 'codex']);
+
+/**
+ * Coerce a raw fallback blob (legacy `string[]` order or new `FallbackEntry[]`)
+ * into the canonical FallbackConfig shape. Unknown agents get dropped; missing
+ * model ids are kept and validated lazily at run time so a stale model rename
+ * doesn't silently delete user-configured fallback steps.
+ */
+export function formatFallbackOrder(order: FallbackEntry[]): string {
+  return order.map(e => (e.model ? `${e.agent}(${e.model})` : e.agent)).join(' → ');
+}
+
+function normalizeFallback(raw: any, defaults: FallbackConfig): FallbackConfig {
+  if (!raw || typeof raw !== 'object') return defaults;
+  const order: FallbackEntry[] = Array.isArray(raw.order)
+    ? raw.order
+        .map((e: any): FallbackEntry | null => {
+          if (typeof e === 'string') {
+            return KNOWN_AGENTS.has(e as CodingAgent) ? { agent: e as CodingAgent } : null;
+          }
+          if (e && typeof e === 'object' && typeof e.agent === 'string' && KNOWN_AGENTS.has(e.agent)) {
+            const model = typeof e.model === 'string' && e.model.length > 0 ? e.model : undefined;
+            return model ? { agent: e.agent, model } : { agent: e.agent };
+          }
+          return null;
+        })
+        .filter((x: FallbackEntry | null): x is FallbackEntry => x !== null)
+    : defaults.order;
+  return {
+    enabled: typeof raw.enabled === 'boolean' ? raw.enabled : defaults.enabled,
+    order,
+  };
+}
 
 function getDefaultConfig(): GatewayConfigJson {
   return {
@@ -272,7 +317,14 @@ function getDefaultConfig(): GatewayConfigJson {
       { apiType: 'anthropic', model: 'claude-haiku-4-5',  provider: 'anthropic' },
       { apiType: 'openai',    model: 'gpt-5',             provider: 'openai' },
     ],
-    fallback: { enabled: true, order: ['claude-code', 'opencode', 'codex'] },
+    fallback: {
+      enabled: true,
+      order: [
+        { agent: 'claude-code' },
+        { agent: 'opencode' },
+        { agent: 'codex' },
+      ],
+    },
     dev: { logLevel: 'info' },
   };
 }
@@ -303,7 +355,7 @@ function normalize(raw: Partial<GatewayConfigJson> & { models?: any[] }): Gatewa
     channels: raw.channels ?? defaults.channels,
     agents: { ...defaults.agents, ...rawAgents },
     models,
-    fallback: raw.fallback ?? defaults.fallback,
+    fallback: normalizeFallback(raw.fallback, defaults.fallback),
     dev: raw.dev ?? defaults.dev,
   };
 }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry } from '@codey/core';
+import { AgentRequest, AgentResponse, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -1503,26 +1503,68 @@ Example: /model gpt-4.1 write a Python script`;
     const fb = this.config.fallback;
     if (fb && fb.enabled === false) return response;
 
-    // Prefer the user-configured order; else fall back to all enabled agents.
-    const ordered = (fb?.order && fb.order.length > 0 ? fb.order : this.getEnabledAgents())
-      .filter(a => a !== agent)
-      .filter(a => this.config.agents?.[a]?.enabled !== false);
-    for (const fallbackAgent of ordered) {
-      this.logger.warn(`Agent ${agent} failed, trying ${fallbackAgent}...`);
-      const fallbackResponse = await this.agentFactory.run(fallbackAgent, {
+    // Prefer the user-configured order; else default to every enabled agent
+    // with no specific model (resolved to that agent's defaultModel below).
+    const rawOrder: FallbackEntry[] = fb?.order && fb.order.length > 0
+      ? fb.order
+      : this.getEnabledAgents().map(a => ({ agent: a }));
+
+    // Skip the (agent, model) we just tried so we don't infinite-loop on the
+    // same combination. Same agent with a different model is allowed.
+    const originalModel = request.model?.model;
+    const seen = new Set<string>([`${agent}::${originalModel ?? ''}`]);
+
+    for (const entry of rawOrder) {
+      if (this.config.agents?.[entry.agent]?.enabled === false) continue;
+      const resolvedModel = this.resolveFallbackModel(entry);
+      if (!resolvedModel) {
+        this.logger.warn(`Skipping fallback ${entry.agent}${entry.model ? `(${entry.model})` : ''}: no usable model config`);
+        continue;
+      }
+      const key = `${entry.agent}::${resolvedModel.model}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const label = `${entry.agent}(${resolvedModel.model})`;
+      this.logger.warn(`Agent ${agent} failed, trying ${label}...`);
+      const fallbackResponse = await this.agentFactory.run(entry.agent, {
         ...request,
-        agent: fallbackAgent,
-        model: this.getDefaultModelConfig(fallbackAgent),
+        agent: entry.agent,
+        model: resolvedModel,
       });
       if (fallbackResponse.success) {
-        fallbackResponse.output = `[Fallback: ${agent} → ${fallbackAgent}]\n\n${fallbackResponse.output}`;
+        const fromLabel = originalModel ? `${agent}(${originalModel})` : agent;
+        fallbackResponse.output = `[Fallback: ${fromLabel} → ${label}]\n\n${fallbackResponse.output}`;
         return fallbackResponse;
       }
-      this.logger.error(`Fallback agent ${fallbackAgent} also failed: ${fallbackResponse.error || fallbackResponse.output}`);
+      this.logger.error(`Fallback ${label} also failed: ${fallbackResponse.error || fallbackResponse.output}`);
     }
 
-    // All agents failed, return original error
+    // All fallbacks failed, return original error
     return response;
+  }
+
+  /**
+   * Resolve a fallback entry to a ModelConfig. When `entry.model` references a
+   * known ModelEntry, copy its apiType/apiKey/baseUrl through so the adapter
+   * can spawn the CLI with the right env vars. Falls back to the agent's
+   * default model when no override is set.
+   */
+  private resolveFallbackModel(entry: FallbackEntry): ModelConfig | undefined {
+    if (!entry.model) return this.getDefaultModelConfig(entry.agent);
+    const modelEntry = this.configManager?.getModel(entry.model);
+    if (modelEntry) {
+      return {
+        provider: modelEntry.provider ?? (modelEntry.apiType === 'anthropic' ? 'anthropic' : 'openai'),
+        model: modelEntry.model,
+        apiKey: modelEntry.apiKey,
+        baseUrl: modelEntry.baseUrl,
+        apiType: modelEntry.apiType,
+      };
+    }
+    // Model id not in catalog — fall through to the agent's gateway-side
+    // resolver (handles bare anthropic/openai/google ids by prefix).
+    return this.getModelConfig(entry.agent, entry.model);
   }
 
   private checkRateLimit(userId: string): boolean {

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { ConfigManager } from './config';
+import { ConfigManager, formatFallbackOrder } from './config';
 import { Logger } from './logger';
 import { handleCommand } from './cli';
 import { GatewayConfig } from '@codey/core';
@@ -62,7 +62,7 @@ function startGateway(): void {
     logger.info(`Default agent: ${configManager.getDefaultAgent()}`);
     logger.info(`Default model: ${configManager.getDefaultModel()}`);
     logger.info(`Models in catalog: ${configManager.listModels().length}`);
-    logger.info(`Fallback: ${configManager.getFallback().enabled ? 'on' : 'off'} (${configManager.getFallback().order.join(' → ')})`);
+    logger.info(`Fallback: ${configManager.getFallback().enabled ? 'on' : 'off'} (${formatFallbackOrder(configManager.getFallback().order)})`);
     logger.info(`Log level: ${configManager.getLogLevel()}`);
 
     const gateway = new Codey(gatewayConfig, logger, './workspaces', configManager, workerManager);


### PR DESCRIPTION
## Summary
- Fallback config now stores ordered `(agent, model?)` entries instead of bare agent names — pin a specific model per step (e.g. `claude-code(sonnet) → claude-code(haiku) → opencode`). Legacy `string[]` orders migrate transparently on load; runtime dedupes by `(agent, resolved-model)` against the failed combo so same-agent/different-model is allowed.
- Mac fallback editor: drag-and-drop reordering, agent + model dropdowns per step, model list filtered by the agent's apiType, disabled-agent rows stay editable but get a `skipped` tag.
- Channels editor moved from the Settings tab to the Gateway tab (combined with the live Connected/Off indicator); Settings becomes AI-Models-only.
- Workspace names in the chat list render with original case instead of forced uppercase.

## Test plan
- [ ] Boot with a legacy `gateway.json` whose `fallback.order` is `["claude-code","opencode","codex"]` — entries should appear in the new UI and re-save as objects
- [ ] Add a same-agent step with a different model, force the first agent to fail, confirm the fallback model is invoked
- [ ] Disable an agent that's referenced in the fallback chain — the row stays in the editor with a `skipped` tag, runtime skips it
- [ ] Drag a step to a new position; verify drop indicator and reordered persistence
- [ ] Channels: toggle Telegram/Discord/iMessage from the Gateway tab; live `● Connected` indicator updates while the editable controls work
- [ ] Workspaces with mixed-case names render exactly as named in the chat list

🤖 Generated with [Claude Code](https://claude.com/claude-code)