### PR TITLE
feat(mac): add file upload support with drag-drop and attachment preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ codey-mac/build/icon.iconset/
 
 # Private local docs (plans/specs)
 docs/
+
+.codey/

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -582,7 +582,54 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('chats:send', async (_e, payload: { chatId: string; text: string }) =>
+  ipcMain.handle('chats:upload', async (_e, chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      const chat = inProcessGateway.getChatManager().get(chatId)
+      if (!chat) throw new Error(`Chat not found: ${chatId}`)
+
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const cryptoMod = await import('crypto')
+
+      // Resolve workspace working directory
+      const workspacesRoot = (inProcessGateway as any).workspaceManager.getWorkspacesRoot()
+      const wsConfigPath = pathMod.join(workspacesRoot, chat.workspaceName, 'workspace.json')
+      let workingDir = (inProcessGateway as any).workingDir
+      if (fsMod.existsSync(wsConfigPath)) {
+        try {
+          const wsConfig = JSON.parse(fsMod.readFileSync(wsConfigPath, 'utf-8'))
+          if (wsConfig.workingDir) workingDir = wsConfig.workingDir
+        } catch { /* use default */ }
+      }
+
+      // Create .codey/uploads/ directory
+      const uploadsDir = pathMod.join(workingDir, '.codey', 'uploads')
+      fsMod.mkdirSync(uploadsDir, { recursive: true })
+
+      // Generate unique filename
+      const timestamp = Date.now()
+      const random = cryptoMod.randomBytes(4).toString('hex')
+      const safeName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_')
+      const uniqueName = `${timestamp}-${random}-${safeName}`
+      const filePath = pathMod.join(uploadsDir, uniqueName)
+
+      // Write file
+      const buffer = Buffer.from(data)
+      fsMod.writeFileSync(filePath, buffer)
+
+      const { randomUUID } = cryptoMod
+      return {
+        id: randomUUID(),
+        name: fileName,
+        path: filePath,
+        mimeType,
+        size: buffer.length,
+      }
+    })
+  )
+
+  ipcMain.handle('chats:send', async (_e, payload: { chatId: string; text: string; attachments?: any[] }) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
       const sink = (ev: any) => {
@@ -590,7 +637,7 @@ app.whenReady().then(async () => {
         // so the frontend can route by chatId without sniffing event names.
         sendToRenderer('chats:event', ev)
       }
-      return inProcessGateway.sendToChat(payload.chatId, payload.text, sink)
+      return inProcessGateway.sendToChat(payload.chatId, payload.text, sink, payload.attachments)
     })
   )
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1,5 +1,10 @@
-import { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, shell, dialog } from 'electron'
+import { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, shell, dialog, protocol, net } from 'electron'
 import { join } from 'path'
+import { pathToFileURL } from 'url'
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
+])
 import { WorkerManager, WorkspaceManager } from '@codey/core'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
@@ -104,6 +109,16 @@ function resolveDataRoot(): string {
     if (!fs.existsSync(root)) fs.mkdirSync(root, { recursive: true })
     if (!fs.existsSync(join(root, 'workers'))) fs.mkdirSync(join(root, 'workers'), { recursive: true })
     if (!fs.existsSync(join(root, 'workspaces'))) fs.mkdirSync(join(root, 'workspaces'), { recursive: true })
+    // Seed bundled workers into ~/.codey/workers/ on first run
+    const bundledDir = join(process.resourcesPath, 'bundled-workers')
+    if (fs.existsSync(bundledDir)) {
+      for (const name of fs.readdirSync(bundledDir)) {
+        const dest = join(root, 'workers', name)
+        if (!fs.existsSync(dest)) {
+          fs.cpSync(join(bundledDir, name), dest, { recursive: true })
+        }
+      }
+    }
   } catch { /* best-effort */ }
   return root
 }
@@ -217,6 +232,23 @@ function createAppMenu() {
 }
 
 app.whenReady().then(async () => {
+  protocol.handle('codey-asset', async (request) => {
+    try {
+      const url = new URL(request.url)
+      const encoded = url.pathname.replace(/^\/+/, '')
+      const decoded = decodeURIComponent(encoded)
+      const path = await import('path')
+      const absPath = path.resolve(decoded)
+      // Only serve files inside a workspace's .codey/uploads/ directory.
+      if (!absPath.includes(`${path.sep}.codey${path.sep}uploads${path.sep}`)) {
+        return new Response('Forbidden', { status: 403 })
+      }
+      return await net.fetch(pathToFileURL(absPath).toString())
+    } catch (err) {
+      return new Response(`Error: ${(err as Error).message}`, { status: 500 })
+    }
+  })
+
   createAppMenu()
   createWindow()
   createTray()
@@ -603,8 +635,10 @@ app.whenReady().then(async () => {
         } catch { /* use default */ }
       }
 
-      // Create .codey/uploads/ directory
-      const uploadsDir = pathMod.join(workingDir, '.codey', 'uploads')
+      // Create .codey/uploads/ directory (always absolute so frontend / asset
+      // protocol can reference it regardless of process cwd)
+      const absWorkingDir = pathMod.resolve(workingDir || process.cwd())
+      const uploadsDir = pathMod.join(absWorkingDir, '.codey', 'uploads')
       fsMod.mkdirSync(uploadsDir, { recursive: true })
 
       // Generate unique filename

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -68,6 +68,8 @@ contextBridge.exposeInMainWorld('codey', {
     set: (updates: any) => ipcRenderer.invoke('agents:set', updates),
   },
   chats: {
+    upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+      ipcRenderer.invoke('chats:upload', chatId, fileName, mimeType, data),
     list: (workspaceName?: string) => ipcRenderer.invoke('chats:list', workspaceName),
     get: (id: string) => ipcRenderer.invoke('chats:get', id),
     create: (input: { workspaceName: string; selection?: any; title?: string }) =>
@@ -76,7 +78,7 @@ contextBridge.exposeInMainWorld('codey', {
     delete: (id: string) => ipcRenderer.invoke('chats:delete', id),
     updateSelection: (id: string, selection: any) =>
       ipcRenderer.invoke('chats:updateSelection', id, selection),
-    send: (payload: { chatId: string; text: string }) =>
+    send: (payload: { chatId: string; text: string; attachments?: any[] }) =>
       ipcRenderer.invoke('chats:send', payload),
     stop: (chatId: string) => ipcRenderer.invoke('chats:stop', chatId),
     onEvent: (handler: (ev: any) => void) => {

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -62,7 +62,8 @@
     ],
     "extraResources": [
       { "from": "build/trayIconTemplate.png", "to": "trayIconTemplate.png" },
-      { "from": "build/trayIconTemplate@2x.png", "to": "trayIconTemplate@2x.png" }
+      { "from": "build/trayIconTemplate@2x.png", "to": "trayIconTemplate@2x.png" },
+      { "from": "../workers", "to": "bundled-workers", "filter": ["**/*"] }
     ]
   }
 }

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -66,13 +66,15 @@ declare global {
         set: (updates: Record<string, { enabled?: boolean; defaultModel?: string }>) => Promise<IpcResult<void>>
       }
       chats: {
+        upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+          Promise<IpcResult<{ id: string; name: string; path: string; mimeType: string; size: number }>>
         list: (workspaceName?: string) => Promise<IpcResult<Chat[]>>
         get: (id: string) => Promise<IpcResult<Chat>>
         create: (input: { workspaceName: string; selection?: ChatSelection; title?: string }) => Promise<IpcResult<Chat>>
         rename: (id: string, title: string) => Promise<IpcResult<Chat>>
         delete: (id: string) => Promise<IpcResult<null>>
         updateSelection: (id: string, selection: ChatSelection) => Promise<IpcResult<Chat>>
-        send: (payload: { chatId: string; text: string }) => Promise<IpcResult<{ response: string; chatId: string; tokens?: number; durationSec?: number }>>
+        send: (payload: { chatId: string; text: string; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) => Promise<IpcResult<{ response: string; chatId: string; tokens?: number; durationSec?: number }>>
         stop: (chatId: string) => Promise<IpcResult<boolean>>
         onEvent: (handler: (ev: ChatStreamEvent) => void) => () => void
       }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -261,7 +261,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                             return next
                           })
                           const headline = formatHeadline(row.tool, row.input)
-                          const marker = row.done ? '✓' : '⋯'
                           const markerColor = row.done ? '#5c5' : '#6ab0f3'
                           return (
                             <div key={row.id}>
@@ -269,7 +268,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                                 style={{ ...styles.toolCallRow, cursor: detail ? 'pointer' : 'default' }}
                                 onClick={detail ? toggle : undefined}
                               >
-                                <span style={{ width: 14, color: markerColor, flexShrink: 0 }}>{marker}</span>
                                 {detail && (
                                   <span style={{ ...styles.chevron, transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
                                 )}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import type { ChatSelection } from '../types'
+import type { ChatSelection, FileAttachment } from '../types'
 import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
@@ -49,6 +49,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState('')
+  const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>([])
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const taRef = useRef<HTMLTextAreaElement>(null)
 
@@ -78,12 +81,68 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     await setSelection(chat.id, next)
   }
 
+  const uploadFiles = async (files: FileList | File[]) => {
+    const fileArray = Array.from(files)
+    const maxSize = 10 * 1024 * 1024 // 10MB
+    const maxAttachments = 10
+
+    for (const file of fileArray) {
+      if (pendingAttachments.length >= maxAttachments) break
+      if (file.size > maxSize) {
+        console.warn(`File ${file.name} exceeds 10MB limit`)
+        continue
+      }
+
+      try {
+        const buffer = await file.arrayBuffer()
+        const attachment = await apiService.chats.upload(chatId, file.name, file.type || 'application/octet-stream', buffer)
+        setPendingAttachments(prev => [...prev, attachment])
+      } catch (err) {
+        console.error(`Failed to upload ${file.name}:`, err)
+      }
+    }
+  }
+
+  const removeAttachment = (id: string) => {
+    setPendingAttachments(prev => prev.filter(a => a.id !== id))
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(false)
+  }
+
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(false)
+    if (e.dataTransfer.files.length > 0) {
+      await uploadFiles(e.dataTransfer.files)
+    }
+  }
+
+  const handleFilePick = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      await uploadFiles(e.target.files)
+      e.target.value = '' // reset so same file can be re-selected
+    }
+  }
+
   const send = async () => {
-    if (!input.trim() || !isGatewayRunning || !!flight) return
+    if ((!input.trim() && pendingAttachments.length === 0) || !isGatewayRunning || !!flight) return
     const text = input
+    const atts = pendingAttachments.length > 0 ? [...pendingAttachments] : undefined
     setInput('')
+    setPendingAttachments([])
     if (taRef.current) taRef.current.style.height = 'auto'
-    await sendMessage(chat.id, text)
+    await sendMessage(chat.id, text, atts)
   }
 
   const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -95,7 +154,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
 
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
-  const canSend = isGatewayRunning && !isSending && !!input.trim() && !orphaned
+  const canSend = isGatewayRunning && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
   const statusLabel = flight?.queuedPosition
     ? `Queued (#${flight.queuedPosition})`
     : flight?.agentStatus === 'thinking' ? 'Thinking…'
@@ -132,7 +191,17 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         </select>
       </div>
 
-      <div style={styles.messages}>
+      <div
+        style={{ ...styles.messages, position: 'relative' }}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {isDragging && (
+          <div style={styles.dropOverlay}>
+            <div style={styles.dropOverlayInner}>Drop files here</div>
+          </div>
+        )}
         {chat.messages.map(msg => {
           const isUser = msg.role === 'user'
           return (
@@ -220,6 +289,25 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                   )
                 })()}
                 {msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
+                {isUser && msg.attachments && msg.attachments.length > 0 && (
+                  <div style={styles.attachmentsContainer}>
+                    {msg.attachments.map(att => (
+                      <div key={att.id} style={styles.attachmentChip}>
+                        {att.mimeType.startsWith('image/') ? (
+                          <img
+                            src={`file://${att.path}`}
+                            alt={att.name}
+                            style={styles.attachmentThumb}
+                            onClick={() => window.codey?.openPath?.(att.path)}
+                          />
+                        ) : (
+                          <span style={styles.attachmentIcon}>📄</span>
+                        )}
+                        <span style={styles.attachmentName}>{att.name}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
               <div style={styles.tsLabel}>
                 <span>{fmtTime(msg.timestamp)}</span>
@@ -254,6 +342,39 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         </div>
       )}
       <div style={styles.inputContainer}>
+        {pendingAttachments.length > 0 && (
+          <div style={styles.pendingRow}>
+            {pendingAttachments.map(att => (
+              <div key={att.id} style={styles.pendingChip}>
+                {att.mimeType.startsWith('image/') ? (
+                  <img src={`file://${att.path}`} alt={att.name} style={styles.pendingThumb} />
+                ) : (
+                  <span style={{ fontSize: 11 }}>📄</span>
+                )}
+                <span style={styles.pendingName}>{att.name}</span>
+                <button onClick={() => removeAttachment(att.id)} style={styles.removeBtn}>×</button>
+              </div>
+            ))}
+          </div>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql"
+          style={{ display: 'none' }}
+          onChange={handleFilePick}
+        />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={!isGatewayRunning || isSending}
+          style={styles.attachButton}
+          title="Attach file"
+        >
+          <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={C.fg3} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+        </button>
         <textarea
           ref={taRef}
           value={input}
@@ -330,4 +451,55 @@ const styles: Record<string, React.CSSProperties> = {
   chevron: { display: 'inline-block', fontSize: 13, marginRight: 4, transition: 'transform 0.15s ease', color: '#555' },
   toolDetail: { marginLeft: 20, marginTop: 4, marginBottom: 6, padding: 8, background: 'rgba(0,0,0,0.3)', borderRadius: 6, border: `1px solid ${C.border}` },
   orphanBanner: { padding: '8px 12px', background: '#ff950033', color: '#ffb84d', fontSize: 12, borderTop: `1px solid ${C.border}` },
+  dropOverlay: {
+    position: 'absolute' as const, inset: 0, zIndex: 10,
+    background: 'rgba(0,0,0,0.6)', display: 'flex',
+    alignItems: 'center', justifyContent: 'center',
+    borderRadius: 8, border: `2px dashed ${C.accent}`,
+  },
+  dropOverlayInner: {
+    color: C.accent, fontSize: 16, fontWeight: 600,
+  },
+  attachmentsContainer: {
+    display: 'flex', flexWrap: 'wrap' as const, gap: 6, marginTop: 8,
+  },
+  attachmentChip: {
+    display: 'flex', alignItems: 'center', gap: 4,
+    background: 'rgba(255,255,255,0.08)', borderRadius: 6,
+    padding: '4px 8px', fontSize: 11, maxWidth: 180,
+  },
+  attachmentThumb: {
+    width: 32, height: 32, borderRadius: 4, objectFit: 'cover' as const, cursor: 'pointer',
+  },
+  attachmentIcon: { fontSize: 14 },
+  attachmentName: {
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+    color: C.fg2, maxWidth: 120,
+  },
+  pendingRow: {
+    display: 'flex', flexWrap: 'wrap' as const, gap: 6,
+    padding: '8px 14px 0', borderTop: `1px solid ${C.border}`,
+  },
+  pendingChip: {
+    display: 'flex', alignItems: 'center', gap: 4,
+    background: C.surface3, borderRadius: 6,
+    padding: '4px 6px', fontSize: 11,
+  },
+  pendingThumb: {
+    width: 24, height: 24, borderRadius: 3, objectFit: 'cover' as const,
+  },
+  pendingName: {
+    color: C.fg2, maxWidth: 100, overflow: 'hidden',
+    textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+  },
+  removeBtn: {
+    background: 'none', border: 'none', color: C.fg3,
+    cursor: 'pointer', fontSize: 14, padding: '0 2px', lineHeight: 1,
+  },
+  attachButton: {
+    width: 36, height: 36, borderRadius: 9, border: 'none',
+    background: C.surface3, display: 'flex', alignItems: 'center',
+    justifyContent: 'center', flexShrink: 0, cursor: 'pointer',
+    transition: 'background 0.15s',
+  },
 }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -39,6 +39,38 @@ const TypingDots: React.FC = () => {
   return <span style={{ letterSpacing: 2 }}>{'●'.repeat(n + 1).padEnd(3, '○')}</span>
 }
 
+const PaperclipIcon: React.FC<{ color: string }> = ({ color }) => (
+  <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21.44 11.05L12.25 20.24a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 11-2.83-2.83l8.49-8.48" />
+  </svg>
+)
+
+const UploadCloudIcon: React.FC<{ color: string; size?: number }> = ({ color, size = 32 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M16 16l-4-4-4 4" />
+    <path d="M12 12v9" />
+    <path d="M20.39 18.39A5 5 0 0018 9h-1.26A8 8 0 103 16.3" />
+    <path d="M16 16l-4-4-4 4" />
+  </svg>
+)
+
+const FileIcon: React.FC<{ color: string; size?: number }> = ({ color, size = 14 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+    <path d="M14 2v6h6" />
+  </svg>
+)
+
+const assetUrl = (absPath: string): string =>
+  `codey-asset://file/${encodeURIComponent(absPath)}`
+
+const formatBytes = (n: number): string => {
+  if (!Number.isFinite(n) || n < 0) return ''
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)} KB`
+  return `${(n / (1024 * 1024)).toFixed(n < 10 * 1024 * 1024 ? 1 : 0)} MB`
+}
+
 export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const { state, sendMessage, stopChat, setSelection, renameChat } = useChats()
   const chat = state.chats[chatId]
@@ -51,6 +83,8 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [titleDraft, setTitleDraft] = useState('')
   const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>([])
   const [isDragging, setIsDragging] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const dragDepthRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const taRef = useRef<HTMLTextAreaElement>(null)
@@ -85,11 +119,16 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     const fileArray = Array.from(files)
     const maxSize = 10 * 1024 * 1024 // 10MB
     const maxAttachments = 10
+    let count = pendingAttachments.length
+    const errors: string[] = []
 
     for (const file of fileArray) {
-      if (pendingAttachments.length >= maxAttachments) break
+      if (count >= maxAttachments) {
+        errors.push(`Limit of ${maxAttachments} attachments reached`)
+        break
+      }
       if (file.size > maxSize) {
-        console.warn(`File ${file.name} exceeds 10MB limit`)
+        errors.push(`${file.name} exceeds 10 MB`)
         continue
       }
 
@@ -97,9 +136,14 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         const buffer = await file.arrayBuffer()
         const attachment = await apiService.chats.upload(chatId, file.name, file.type || 'application/octet-stream', buffer)
         setPendingAttachments(prev => [...prev, attachment])
+        count++
       } catch (err) {
-        console.error(`Failed to upload ${file.name}:`, err)
+        errors.push(`${file.name}: ${(err as Error).message}`)
       }
+    }
+    if (errors.length > 0) {
+      setUploadError(errors.join(' · '))
+      window.setTimeout(() => setUploadError(null), 4000)
     }
   }
 
@@ -107,21 +151,33 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     setPendingAttachments(prev => prev.filter(a => a.id !== id))
   }
 
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!e.dataTransfer.types.includes('Files')) return
+    dragDepthRef.current += 1
+    setIsDragging(true)
+  }
+
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    setIsDragging(true)
+    if (e.dataTransfer.types.includes('Files')) {
+      e.dataTransfer.dropEffect = 'copy'
+    }
   }
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    setIsDragging(false)
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+    if (dragDepthRef.current === 0) setIsDragging(false)
   }
 
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
+    dragDepthRef.current = 0
     setIsDragging(false)
     if (e.dataTransfer.files.length > 0) {
       await uploadFiles(e.dataTransfer.files)
@@ -193,13 +249,18 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
 
       <div
         style={{ ...styles.messages, position: 'relative' }}
+        onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
         {isDragging && (
           <div style={styles.dropOverlay}>
-            <div style={styles.dropOverlayInner}>Drop files here</div>
+            <div style={styles.dropOverlayCard}>
+              <UploadCloudIcon color={C.accent} size={36} />
+              <div style={styles.dropOverlayTitle}>Drop to attach</div>
+              <div style={styles.dropOverlaySubtitle}>Up to 10 files · max 10 MB each</div>
+            </div>
           </div>
         )}
         {chat.messages.map(msg => {
@@ -289,21 +350,31 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 {msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
                 {isUser && msg.attachments && msg.attachments.length > 0 && (
                   <div style={styles.attachmentsContainer}>
-                    {msg.attachments.map(att => (
-                      <div key={att.id} style={styles.attachmentChip}>
-                        {att.mimeType.startsWith('image/') ? (
+                    {msg.attachments.map(att => {
+                      const isImage = att.mimeType.startsWith('image/')
+                      const open = () => window.codey?.openPath?.(att.path)
+                      if (isImage) {
+                        return (
                           <img
-                            src={`file://${att.path}`}
+                            key={att.id}
+                            src={assetUrl(att.path)}
                             alt={att.name}
-                            style={styles.attachmentThumb}
-                            onClick={() => window.codey?.openPath?.(att.path)}
+                            title={att.name}
+                            style={styles.attachmentImage}
+                            onClick={open}
                           />
-                        ) : (
-                          <span style={styles.attachmentIcon}>📄</span>
-                        )}
-                        <span style={styles.attachmentName}>{att.name}</span>
-                      </div>
-                    ))}
+                        )
+                      }
+                      return (
+                        <div key={att.id} style={styles.attachmentFileChip} onClick={open} title={`${att.name} · ${formatBytes(att.size)}`}>
+                          <div style={styles.attachmentFileIcon}><FileIcon color={C.fg2} /></div>
+                          <div style={styles.attachmentFileMeta}>
+                            <span style={styles.attachmentFileName}>{att.name}</span>
+                            <span style={styles.attachmentFileSize}>{formatBytes(att.size)}</span>
+                          </div>
+                        </div>
+                      )
+                    })}
                   </div>
                 )}
               </div>
@@ -340,71 +411,86 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         </div>
       )}
       <div style={styles.inputContainer}>
-        {pendingAttachments.length > 0 && (
-          <div style={styles.pendingRow}>
-            {pendingAttachments.map(att => (
-              <div key={att.id} style={styles.pendingChip}>
-                {att.mimeType.startsWith('image/') ? (
-                  <img src={`file://${att.path}`} alt={att.name} style={styles.pendingThumb} />
-                ) : (
-                  <span style={{ fontSize: 11 }}>📄</span>
-                )}
-                <span style={styles.pendingName}>{att.name}</span>
-                <button onClick={() => removeAttachment(att.id)} style={styles.removeBtn}>×</button>
-              </div>
-            ))}
+        {uploadError && (
+          <div style={styles.uploadError}>{uploadError}</div>
+        )}
+        <div style={styles.composer}>
+          {pendingAttachments.length > 0 && (
+            <div style={styles.pendingRow}>
+              {pendingAttachments.map(att => {
+                const isImage = att.mimeType.startsWith('image/')
+                if (isImage) {
+                  return (
+                    <div key={att.id} style={styles.pendingImageWrap} title={`${att.name} · ${formatBytes(att.size)}`}>
+                      <img src={assetUrl(att.path)} alt={att.name} style={styles.pendingImage} />
+                      <button onClick={() => removeAttachment(att.id)} style={styles.pendingRemoveBtn} aria-label="Remove">×</button>
+                    </div>
+                  )
+                }
+                return (
+                  <div key={att.id} style={styles.pendingFileChip} title={`${att.name} · ${formatBytes(att.size)}`}>
+                    <div style={styles.pendingFileIcon}><FileIcon color={C.fg2} size={16} /></div>
+                    <div style={styles.pendingFileMeta}>
+                      <span style={styles.pendingFileName}>{att.name}</span>
+                      <span style={styles.pendingFileSize}>{formatBytes(att.size)}</span>
+                    </div>
+                    <button onClick={() => removeAttachment(att.id)} style={styles.pendingFileRemoveBtn} aria-label="Remove">×</button>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+          <div style={styles.composerRow}>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql"
+              style={{ display: 'none' }}
+              onChange={handleFilePick}
+            />
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!isGatewayRunning || isSending}
+              style={styles.attachButton}
+              title="Attach file"
+            >
+              <PaperclipIcon color={isGatewayRunning && !isSending ? C.fg2 : C.fg3} />
+            </button>
+            <textarea
+              ref={taRef}
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKey}
+              onInput={e => {
+                const el = e.currentTarget
+                el.style.height = 'auto'
+                el.style.height = Math.min(el.scrollHeight, 120) + 'px'
+              }}
+              placeholder={isGatewayRunning ? (isSending ? 'Sending…' : 'Message Codey… (↵ to send)') : 'Start gateway to chat'}
+              disabled={!isGatewayRunning || isSending}
+              rows={1}
+              style={styles.input}
+            />
+            {isSending ? (
+              <button
+                onClick={() => stopChat(chatId)}
+                style={{ ...styles.sendButton, background: '#e04040', cursor: 'pointer' }}
+                title="Stop (Esc)"
+              >
+                <StopIcon color="#fff" />
+              </button>
+            ) : (
+              <button
+                onClick={send}
+                disabled={!canSend}
+                style={{ ...styles.sendButton, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
+              >
+                <SendIcon color={canSend ? '#fff' : C.fg3} />
+              </button>
+            )}
           </div>
-        )}
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          accept="image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql"
-          style={{ display: 'none' }}
-          onChange={handleFilePick}
-        />
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          disabled={!isGatewayRunning || isSending}
-          style={styles.attachButton}
-          title="Attach file"
-        >
-          <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={C.fg3} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M12 5v14M5 12h14" />
-          </svg>
-        </button>
-        <textarea
-          ref={taRef}
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          onKeyDown={handleKey}
-          onInput={e => {
-            const el = e.currentTarget
-            el.style.height = 'auto'
-            el.style.height = Math.min(el.scrollHeight, 120) + 'px'
-          }}
-          placeholder={isGatewayRunning ? (isSending ? 'Sending…' : 'Message Codey… (↵ to send)') : 'Start gateway to chat'}
-          disabled={!isGatewayRunning || isSending}
-          rows={1}
-          style={styles.input}
-        />
-        {isSending ? (
-          <button
-            onClick={() => stopChat(chatId)}
-            style={{ ...styles.sendButton, background: '#e04040', cursor: 'pointer' }}
-            title="Stop (Esc)"
-          >
-            <StopIcon color="#fff" />
-          </button>
-        ) : (
-          <button
-            onClick={send}
-            disabled={!canSend}
-            style={{ ...styles.sendButton, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
-          >
-            <SendIcon color={canSend ? '#fff' : C.fg3} />
-          </button>
-        )}
+        </div>
       </div>
     </div>
   )
@@ -427,10 +513,15 @@ const styles: Record<string, React.CSSProperties> = {
   typingRow: { display: 'flex', alignItems: 'center', gap: 8, color: C.fg3, fontSize: 13, marginBottom: 12 },
   tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, paddingLeft: 4, paddingRight: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
   tsMeta: { color: C.fg3, opacity: 0.55, fontVariantNumeric: 'tabular-nums' },
-  inputContainer: { padding: '12px 14px', borderTop: `1px solid ${C.border}`, display: 'flex', gap: 8, alignItems: 'flex-end', flexShrink: 0 },
+  inputContainer: { padding: '10px 14px 12px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 6, flexShrink: 0 },
+  composer: {
+    background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 12,
+    display: 'flex', flexDirection: 'column', overflow: 'hidden',
+  },
+  composerRow: { display: 'flex', gap: 6, alignItems: 'flex-end', padding: 6 },
   input: {
-    flex: 1, background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 10,
-    color: C.fg, fontSize: 13, padding: '10px 12px', outline: 'none', resize: 'none',
+    flex: 1, background: 'transparent', border: 'none', borderRadius: 8,
+    color: C.fg, fontSize: 13, padding: '8px 6px', outline: 'none', resize: 'none',
     lineHeight: 1.5, maxHeight: 120, overflowY: 'auto',
   },
   sendButton: {
@@ -450,53 +541,89 @@ const styles: Record<string, React.CSSProperties> = {
   toolDetail: { marginLeft: 20, marginTop: 4, marginBottom: 6, padding: 8, background: 'rgba(0,0,0,0.3)', borderRadius: 6, border: `1px solid ${C.border}` },
   orphanBanner: { padding: '8px 12px', background: '#ff950033', color: '#ffb84d', fontSize: 12, borderTop: `1px solid ${C.border}` },
   dropOverlay: {
-    position: 'absolute' as const, inset: 0, zIndex: 10,
-    background: 'rgba(0,0,0,0.6)', display: 'flex',
-    alignItems: 'center', justifyContent: 'center',
-    borderRadius: 8, border: `2px dashed ${C.accent}`,
+    position: 'absolute' as const, inset: 8, zIndex: 10,
+    background: 'rgba(10, 132, 255, 0.08)',
+    backdropFilter: 'blur(4px)',
+    WebkitBackdropFilter: 'blur(4px)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    borderRadius: 12, border: `2px dashed ${C.accent}`,
+    pointerEvents: 'none' as const,
   },
-  dropOverlayInner: {
-    color: C.accent, fontSize: 16, fontWeight: 600,
+  dropOverlayCard: {
+    display: 'flex', flexDirection: 'column' as const, alignItems: 'center', gap: 8,
+    padding: '20px 28px', background: C.surface2, borderRadius: 12,
+    border: `1px solid ${C.border2}`, boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
   },
+  dropOverlayTitle: { color: C.fg, fontSize: 14, fontWeight: 600 },
+  dropOverlaySubtitle: { color: C.fg3, fontSize: 11 },
   attachmentsContainer: {
     display: 'flex', flexWrap: 'wrap' as const, gap: 6, marginTop: 8,
   },
-  attachmentChip: {
-    display: 'flex', alignItems: 'center', gap: 4,
-    background: 'rgba(255,255,255,0.08)', borderRadius: 6,
-    padding: '4px 8px', fontSize: 11, maxWidth: 180,
+  attachmentImage: {
+    width: 96, height: 96, borderRadius: 8, objectFit: 'cover' as const, cursor: 'pointer',
+    border: `1px solid ${C.border2}`,
   },
-  attachmentThumb: {
-    width: 32, height: 32, borderRadius: 4, objectFit: 'cover' as const, cursor: 'pointer',
+  attachmentFileChip: {
+    display: 'flex', alignItems: 'center', gap: 8,
+    background: 'rgba(255,255,255,0.06)',
+    border: `1px solid ${C.border2}`, borderRadius: 8,
+    padding: '6px 10px', cursor: 'pointer', maxWidth: 220,
   },
-  attachmentIcon: { fontSize: 14 },
-  attachmentName: {
-    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
-    color: C.fg2, maxWidth: 120,
+  attachmentFileIcon: {
+    width: 28, height: 28, borderRadius: 6, background: C.surface3,
+    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
   },
+  attachmentFileMeta: { display: 'flex', flexDirection: 'column' as const, minWidth: 0, gap: 1 },
+  attachmentFileName: {
+    color: C.fg, fontSize: 12, fontWeight: 500,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const, maxWidth: 160,
+  },
+  attachmentFileSize: { color: C.fg3, fontSize: 10, fontVariantNumeric: 'tabular-nums' as const },
   pendingRow: {
-    display: 'flex', flexWrap: 'wrap' as const, gap: 6,
-    padding: '8px 14px 0', borderTop: `1px solid ${C.border}`,
+    display: 'flex', flexWrap: 'wrap' as const, gap: 8,
+    padding: '8px 8px 4px',
   },
-  pendingChip: {
-    display: 'flex', alignItems: 'center', gap: 4,
-    background: C.surface3, borderRadius: 6,
-    padding: '4px 6px', fontSize: 11,
+  pendingImageWrap: {
+    position: 'relative' as const, width: 56, height: 56,
+    borderRadius: 8, overflow: 'hidden', border: `1px solid ${C.border2}`,
   },
-  pendingThumb: {
-    width: 24, height: 24, borderRadius: 3, objectFit: 'cover' as const,
+  pendingImage: {
+    width: '100%', height: '100%', objectFit: 'cover' as const, display: 'block',
   },
-  pendingName: {
-    color: C.fg2, maxWidth: 100, overflow: 'hidden',
-    textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+  pendingRemoveBtn: {
+    position: 'absolute' as const, top: 2, right: 2,
+    width: 18, height: 18, borderRadius: 9, border: 'none',
+    background: 'rgba(0,0,0,0.7)', color: '#fff',
+    cursor: 'pointer', fontSize: 13, lineHeight: '16px', padding: 0,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
   },
-  removeBtn: {
-    background: 'none', border: 'none', color: C.fg3,
-    cursor: 'pointer', fontSize: 14, padding: '0 2px', lineHeight: 1,
+  pendingFileChip: {
+    display: 'flex', alignItems: 'center', gap: 8,
+    background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 8,
+    padding: '6px 6px 6px 10px', height: 56, boxSizing: 'border-box' as const,
+  },
+  pendingFileIcon: {
+    width: 32, height: 32, borderRadius: 6, background: C.surface3,
+    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+  },
+  pendingFileMeta: { display: 'flex', flexDirection: 'column' as const, minWidth: 0, gap: 2 },
+  pendingFileName: {
+    color: C.fg, fontSize: 12, fontWeight: 500,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const, maxWidth: 140,
+  },
+  pendingFileSize: { color: C.fg3, fontSize: 10, fontVariantNumeric: 'tabular-nums' as const },
+  pendingFileRemoveBtn: {
+    width: 22, height: 22, borderRadius: 11, border: 'none',
+    background: 'transparent', color: C.fg3,
+    cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+  uploadError: {
+    color: '#ff8a80', fontSize: 11, padding: '0 4px',
   },
   attachButton: {
-    width: 36, height: 36, borderRadius: 9, border: 'none',
-    background: C.surface3, display: 'flex', alignItems: 'center',
+    width: 32, height: 32, borderRadius: 8, border: 'none',
+    background: 'transparent', display: 'flex', alignItems: 'center',
     justifyContent: 'center', flexShrink: 0, cursor: 'pointer',
     transition: 'background 0.15s',
   },

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -29,7 +29,7 @@ type Action =
   | { type: 'streamToken'; chatId: string; token: string }
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: 'working' | 'writing' }
   | { type: 'queued'; chatId: string; position: number }
-  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number }
+  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
 
 function reorder(order: string[], chatId: string): string[] {
@@ -138,11 +138,13 @@ function reducer(state: State, action: Action): State {
           ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true }
           : m
       )
+      const updatedChat: Chat = { ...chat, messages, updatedAt: Date.now() }
+      if (action.title) updatedChat.title = action.title
       const inFlight = { ...state.inFlight }
       delete inFlight[action.chatId]
       return {
         ...state,
-        chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } },
+        chats: { ...state.chats, [chat.id]: updatedChat },
         order: reorder(state.order, chat.id),
         inFlight,
       }
@@ -269,6 +271,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               content: ev.response,
               tokens: ev.tokens,
               durationSec: ev.durationSec,
+              title: ev.title,
             })
             delete pendingAssistantId.current[ev.chatId]
           }

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useMemo, useReducer, useRef } from 'react'
 import { apiService } from '../services/api'
-import type { Chat, ChatSelection, ChatMessage, ToolCallEntry } from '../types'
+import type { Chat, ChatSelection, ChatMessage, ToolCallEntry, FileAttachment } from '../types'
 import type { ChatStreamEvent } from '../../../packages/gateway/src/chat-runner'
 
 interface InFlight {
@@ -175,7 +175,7 @@ interface ChatsContextValue {
   renameChat: (chatId: string, title: string) => Promise<void>
   deleteChat: (chatId: string) => Promise<void>
   setSelection: (chatId: string, selection: ChatSelection) => Promise<void>
-  sendMessage: (chatId: string, text: string) => Promise<void>
+  sendMessage: (chatId: string, text: string, attachments?: FileAttachment[]) => Promise<void>
   stopChat: (chatId: string) => Promise<void>
   toggleWorkspace: (workspaceName: string) => void
   refreshWorkspaces: () => Promise<void>
@@ -308,19 +308,20 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       const chat = await apiService.chats.updateSelection(chatId, selection)
       dispatch({ type: 'upsert', chat })
     },
-    async sendMessage(chatId, text) {
+    async sendMessage(chatId, text, attachments) {
       const assistantMessageId = `asst-${Date.now()}-${Math.random()}`
       const userMessage: ChatMessage = {
         id: `user-${Date.now()}-${Math.random()}`,
         role: 'user',
         content: text,
         timestamp: Date.now(),
+        attachments: attachments && attachments.length > 0 ? attachments : undefined,
         isComplete: true,
       }
       pendingAssistantId.current[chatId] = assistantMessageId
       dispatch({ type: 'startSend', chatId, userMessage, assistantMessageId })
       try {
-        await apiService.chats.send(chatId, text)
+        await apiService.chats.send(chatId, text, attachments)
       } catch (err) {
         dispatch({ type: 'errorSend', chatId, assistantMessageId, error: `Error: ${(err as Error).message}` })
         delete pendingAssistantId.current[chatId]

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -9,7 +9,7 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number }
+  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string }
   | { type: 'error'; chatId: string; message: string };
 
 function unwrap<T>(result: { ok: true; data: T } | { ok: false; error: string }): T {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -150,8 +150,10 @@ export const apiService = {
     },
     updateSelection: async (id: string, selection: ChatSelection): Promise<Chat> =>
       unwrap(await window.codey.chats.updateSelection(id, selection)),
-    send: async (chatId: string, text: string): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> =>
-      unwrap(await window.codey.chats.send({ chatId, text })),
+    upload: async (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer): Promise<{ id: string; name: string; path: string; mimeType: string; size: number }> =>
+      unwrap(await window.codey.chats.upload(chatId, fileName, mimeType, data)),
+    send: async (chatId: string, text: string, attachments?: { id: string; name: string; path: string; mimeType: string; size: number }[]): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> =>
+      unwrap(await window.codey.chats.send({ chatId, text, attachments })),
     stop: async (chatId: string): Promise<boolean> =>
       unwrap(await window.codey.chats.stop(chatId)),
     onEvent: (handler: (ev: ChatStreamEvent) => void): (() => void) =>

--- a/codey-mac/src/types/index.ts
+++ b/codey-mac/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { ChatMessage, ToolCallEntry, Chat, ChatSelection } from '@codey/core';
+export type { ChatMessage, ToolCallEntry, Chat, ChatSelection, FileAttachment } from '@codey/core';
 
 export interface GatewayStatus {
   status: string;

--- a/docs/superpowers/plans/2026-04-28-file-upload.md
+++ b/docs/superpowers/plans/2026-04-28-file-upload.md
@@ -1,0 +1,828 @@
+# File Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add image and file upload support to the macOS Electron app's Chat tab with drag-drop, attachment preview, and structured prompt injection for coding agents.
+
+**Architecture:** Files are uploaded via a new IPC channel, saved to the workspace's `.codey/uploads/` directory, and their paths are injected into the agent prompt via a structured `[Attachments]` section. The frontend adds drag-drop and a "+" button with preview chips.
+
+**Tech Stack:** TypeScript, React, Electron IPC, Node.js fs
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/core/src/types/chat.ts` | Modify | Add `FileAttachment` interface, add `attachments` to `ChatMessage` |
+| `packages/gateway/src/chat-runner.ts` | Modify | Add `attachments` param to `buildChatPrompt`, format structured prompt |
+| `packages/gateway/src/gateway.ts` | Modify | Pass `attachments` through `sendToChat` |
+| `codey-mac/electron/preload.ts` | Modify | Add `chats:upload` IPC bridge |
+| `codey-mac/electron/main.ts` | Modify | Add `chats:upload` handler, modify `chats:send` handler |
+| `codey-mac/src/services/api.ts` | Modify | Add `uploadFile` method, update `chats.send` signature |
+| `codey-mac/src/components/ChatTab.tsx` | Modify | Add attachment button, drag-drop, preview chips, message display |
+| `codey-mac/src/hooks/useChats.tsx` | Modify | Add `pendingAttachments` state, update `sendMessage` |
+
+---
+
+### Task 1: Add FileAttachment type to core
+
+**Files:**
+- Modify: `packages/core/src/types/chat.ts`
+
+- [ ] **Step 1: Add FileAttachment interface and update ChatMessage**
+
+Open `packages/core/src/types/chat.ts` and add the `FileAttachment` interface before `ChatMessage`, then add the `attachments` field to `ChatMessage`:
+
+```typescript
+export interface FileAttachment {
+  id: string;
+  name: string;        // original filename
+  path: string;        // absolute path on disk after save
+  mimeType: string;    // e.g. "image/png", "text/typescript"
+  size: number;        // bytes
+}
+
+export interface ToolCallEntry {
+  id: string;
+  type: 'tool_start' | 'tool_end' | 'info';
+  tool?: string;
+  message: string;
+  input?: Record<string, unknown>;
+  output?: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+  attachments?: FileAttachment[];
+  toolCalls?: ToolCallEntry[];
+  isComplete?: boolean;
+  /** Total tokens for the assistant response, set when the turn completes. */
+  tokens?: number;
+  /** Wall-clock seconds the agent took to produce the response. */
+  durationSec?: number;
+}
+
+// ... rest of file unchanged
+```
+
+- [ ] **Step 2: Build core package**
+
+Run from the monorepo root:
+
+```bash
+npm run build:core
+```
+
+Expected: Compiles without errors. Verify `packages/core/dist/types/chat.d.ts` now includes `FileAttachment`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/types/chat.ts packages/core/dist/
+git commit -m "feat(core): add FileAttachment type to ChatMessage"
+```
+
+---
+
+### Task 2: Update buildChatPrompt to handle attachments
+
+**Files:**
+- Modify: `packages/gateway/src/chat-runner.ts`
+
+- [ ] **Step 1: Update buildChatPrompt signature and logic**
+
+Open `packages/gateway/src/chat-runner.ts`. Replace the `buildChatPrompt` function:
+
+```typescript
+import { Chat, ChatMessage, FileAttachment, ToolCallEntry } from '@codey/core';
+
+// ... existing MAX_CONCURRENT_AGENTS, CHAT_CONTEXT_WINDOW, ChatStreamEvent, ChatStreamSink unchanged ...
+
+function formatAttachmentList(attachments: FileAttachment[]): string {
+  const lines = attachments.map(a => {
+    let desc = `- ${a.path} (${a.mimeType})`;
+    if (a.mimeType.startsWith('image/')) {
+      desc += ' [IMAGE - use vision to analyze]';
+    }
+    return desc;
+  });
+  return [
+    '[Attachments]',
+    ...lines,
+    '',
+    'Please review the attached files before responding.',
+    ...(
+      attachments.some(a => a.mimeType.startsWith('image/'))
+        ? ['For image files, analyze the visual content carefully.']
+        : []
+    ),
+    '',
+  ].join('\n');
+}
+
+/** Build the prompt string from the tail of the chat's message history + new user message. */
+export function buildChatPrompt(
+  chat: Chat,
+  userText: string,
+  attachments?: FileAttachment[],
+  windowSize = CHAT_CONTEXT_WINDOW,
+): string {
+  const tail = chat.messages.slice(-windowSize);
+  const lines: string[] = [];
+
+  // Prepend attachment context if present
+  if (attachments && attachments.length > 0) {
+    lines.push(formatAttachmentList(attachments));
+  }
+
+  for (const m of tail) {
+    const tag = m.role === 'user' ? 'User' : 'Assistant';
+    lines.push(`${tag}: ${m.content}`);
+  }
+  lines.push(`User: ${userText}`);
+  return lines.join('\n\n');
+}
+
+// assistantPrefixForSelection, RunSemaphore unchanged
+```
+
+- [ ] **Step 2: Build gateway package**
+
+```bash
+npm run build:gateway
+```
+
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/gateway/src/chat-runner.ts packages/gateway/dist/
+git commit -m "feat(gateway): support attachments in buildChatPrompt"
+```
+
+---
+
+### Task 3: Update sendToChat to accept attachments
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts`
+
+- [ ] **Step 1: Update sendToChat signature**
+
+Open `packages/gateway/src/gateway.ts`. Find the `sendToChat` method (around line 1783) and update its signature and the call to `buildChatPrompt`:
+
+Change the method signature from:
+```typescript
+async sendToChat(
+  chatId: string,
+  userText: string,
+  sink: ChatStreamSink,
+): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> {
+```
+
+To:
+```typescript
+async sendToChat(
+  chatId: string,
+  userText: string,
+  sink: ChatStreamSink,
+  attachments?: import('@codey/core').FileAttachment[],
+): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> {
+```
+
+- [ ] **Step 2: Update buildChatPrompt call**
+
+Find this line inside `sendToChat` (around line 1826):
+```typescript
+const prompt = assistantPrefixForSelection(chat) + buildChatPrompt(chat, userText);
+```
+
+Replace with:
+```typescript
+const prompt = assistantPrefixForSelection(chat) + buildChatPrompt(chat, userText, attachments);
+```
+
+- [ ] **Step 3: Persist attachments in user message**
+
+Find the `userMessage` creation (around line 1828):
+```typescript
+const userMessage: ChatMessage = {
+  id: randomUUID(),
+  role: 'user',
+  content: userText,
+  timestamp: started,
+  isComplete: true,
+};
+```
+
+Replace with:
+```typescript
+const userMessage: ChatMessage = {
+  id: randomUUID(),
+  role: 'user',
+  content: userText,
+  timestamp: started,
+  isComplete: true,
+  attachments: attachments && attachments.length > 0 ? attachments : undefined,
+};
+```
+
+- [ ] **Step 4: Build gateway package**
+
+```bash
+npm run build:gateway
+```
+
+Expected: Compiles without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts packages/gateway/dist/
+git commit -m "feat(gateway): pass attachments through sendToChat"
+```
+
+---
+
+### Task 4: Add IPC channels for file upload
+
+**Files:**
+- Modify: `codey-mac/electron/preload.ts`
+- Modify: `codey-mac/electron/main.ts`
+
+- [ ] **Step 1: Add chats:upload to preload.ts**
+
+Open `codey-mac/electron/preload.ts`. In the `chats` object, add `upload` before the existing `list` method:
+
+```typescript
+chats: {
+    upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+      ipcRenderer.invoke('chats:upload', chatId, fileName, mimeType, data),
+    list: (workspaceName?: string) => ipcRenderer.invoke('chats:list', workspaceName),
+    // ... rest unchanged
+```
+
+- [ ] **Step 2: Update chats:send payload in preload.ts**
+
+Change the `send` method in the `chats` object to accept attachments:
+
+```typescript
+    send: (payload: { chatId: string; text: string; attachments?: any[] }) =>
+      ipcRenderer.invoke('chats:send', payload),
+```
+
+- [ ] **Step 3: Add chats:upload handler in main.ts**
+
+Open `codey-mac/electron/main.ts`. Add the upload handler before the `chats:send` handler (before line 585):
+
+```typescript
+  ipcMain.handle('chats:upload', async (_e, chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      const chat = inProcessGateway.getChatManager().get(chatId)
+      if (!chat) throw new Error(`Chat not found: ${chatId}`)
+
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const cryptoMod = await import('crypto')
+
+      // Resolve workspace working directory
+      const workspacesRoot = (inProcessGateway as any).workspaceManager.getWorkspacesRoot()
+      const wsConfigPath = pathMod.join(workspacesRoot, chat.workspaceName, 'workspace.json')
+      let workingDir = (inProcessGateway as any).workingDir
+      if (fsMod.existsSync(wsConfigPath)) {
+        try {
+          const wsConfig = JSON.parse(fsMod.readFileSync(wsConfigPath, 'utf-8'))
+          if (wsConfig.workingDir) workingDir = wsConfig.workingDir
+        } catch { /* use default */ }
+      }
+
+      // Create .codey/uploads/ directory
+      const uploadsDir = pathMod.join(workingDir, '.codey', 'uploads')
+      fsMod.mkdirSync(uploadsDir, { recursive: true })
+
+      // Generate unique filename
+      const timestamp = Date.now()
+      const random = cryptoMod.randomBytes(4).toString('hex')
+      const safeName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_')
+      const uniqueName = `${timestamp}-${random}-${safeName}`
+      const filePath = pathMod.join(uploadsDir, uniqueName)
+
+      // Write file
+      const buffer = Buffer.from(data)
+      fsMod.writeFileSync(filePath, buffer)
+
+      const { randomUUID } = cryptoMod
+      return {
+        id: randomUUID(),
+        name: fileName,
+        path: filePath,
+        mimeType,
+        size: buffer.length,
+      }
+    })
+  )
+```
+
+- [ ] **Step 4: Update chats:send handler to pass attachments**
+
+Find the `chats:send` handler (line 585) and update it to pass attachments:
+
+```typescript
+  ipcMain.handle('chats:send', async (_e, payload: { chatId: string; text: string; attachments?: any[] }) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      const sink = (ev: any) => {
+        sendToRenderer('chats:event', ev)
+      }
+      return inProcessGateway.sendToChat(payload.chatId, payload.text, sink, payload.attachments)
+    })
+  )
+```
+
+- [ ] **Step 5: Build Electron**
+
+```bash
+cd codey-mac && npx tsc -p tsconfig.electron.json --noEmit
+```
+
+Expected: No type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/electron/preload.ts codey-mac/electron/main.ts
+git commit -m "feat(mac): add chats:upload IPC for file upload"
+```
+
+---
+
+### Task 5: Update API service
+
+**Files:**
+- Modify: `codey-mac/src/services/api.ts`
+
+- [ ] **Step 1: Add uploadFile method and update chats.send**
+
+Open `codey-mac/src/services/api.ts`. In the `apiService` object, update the `chats` section:
+
+```typescript
+export const apiService = {
+  // ... existing methods unchanged ...
+
+  chats: {
+    list: async (workspaceName?: string): Promise<Chat[]> =>
+      unwrap(await window.codey.chats.list(workspaceName)),
+    get: async (id: string): Promise<Chat> =>
+      unwrap(await window.codey.chats.get(id)),
+    create: async (input: { workspaceName: string; selection?: ChatSelection; title?: string }): Promise<Chat> =>
+      unwrap(await window.codey.chats.create(input)),
+    rename: async (id: string, title: string): Promise<Chat> =>
+      unwrap(await window.codey.chats.rename(id, title)),
+    delete: async (id: string): Promise<void> => {
+      unwrap(await window.codey.chats.delete(id))
+    },
+    updateSelection: async (id: string, selection: ChatSelection): Promise<Chat> =>
+      unwrap(await window.codey.chats.updateSelection(id, selection)),
+    upload: async (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer): Promise<{ id: string; name: string; path: string; mimeType: string; size: number }> =>
+      unwrap(await window.codey.chats.upload(chatId, fileName, mimeType, data)),
+    send: async (chatId: string, text: string, attachments?: { id: string; name: string; path: string; mimeType: string; size: number }[]): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> =>
+      unwrap(await window.codey.chats.send({ chatId, text, attachments })),
+    stop: async (chatId: string): Promise<boolean> =>
+      unwrap(await window.codey.chats.stop(chatId)),
+    onEvent: (handler: (ev: ChatStreamEvent) => void): (() => void) =>
+      window.codey.chats.onEvent(handler),
+  },
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd codey-mac && npx tsc --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/services/api.ts
+git commit -m "feat(mac): add uploadFile API and update chats.send signature"
+```
+
+---
+
+### Task 6: Add attachment UI to ChatTab
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx`
+
+- [ ] **Step 1: Add FileAttachment import and state**
+
+At the top of `ChatTab.tsx`, add the import:
+
+```typescript
+import type { ChatSelection, FileAttachment } from '../types'
+```
+
+Add state for pending attachments inside the `ChatTab` component, after the existing `useState` declarations (after line 51):
+
+```typescript
+  const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>([])
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+```
+
+- [ ] **Step 2: Add file upload handler functions**
+
+Add these functions inside the `ChatTab` component, before the `send` function:
+
+```typescript
+  const uploadFiles = async (files: FileList | File[]) => {
+    const fileArray = Array.from(files)
+    const maxSize = 10 * 1024 * 1024 // 10MB
+    const maxAttachments = 10
+
+    for (const file of fileArray) {
+      if (pendingAttachments.length >= maxAttachments) break
+      if (file.size > maxSize) {
+        console.warn(`File ${file.name} exceeds 10MB limit`)
+        continue
+      }
+
+      try {
+        const buffer = await file.arrayBuffer()
+        const attachment = await apiService.chats.upload(chatId, file.name, file.type || 'application/octet-stream', buffer)
+        setPendingAttachments(prev => [...prev, attachment])
+      } catch (err) {
+        console.error(`Failed to upload ${file.name}:`, err)
+      }
+    }
+  }
+
+  const removeAttachment = (id: string) => {
+    setPendingAttachments(prev => prev.filter(a => a.id !== id))
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(false)
+  }
+
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(false)
+    if (e.dataTransfer.files.length > 0) {
+      await uploadFiles(e.dataTransfer.files)
+    }
+  }
+
+  const handleFilePick = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      await uploadFiles(e.target.files)
+      e.target.value = '' // reset so same file can be re-selected
+    }
+  }
+```
+
+- [ ] **Step 3: Update send function to include attachments**
+
+Replace the existing `send` function:
+
+```typescript
+  const send = async () => {
+    if ((!input.trim() && pendingAttachments.length === 0) || !isGatewayRunning || !!flight) return
+    const text = input
+    const atts = pendingAttachments.length > 0 ? [...pendingAttachments] : undefined
+    setInput('')
+    setPendingAttachments([])
+    if (taRef.current) taRef.current.style.height = 'auto'
+    await sendMessage(chatId, text, atts)
+  }
+```
+
+- [ ] **Step 4: Add drag-drop overlay to messages area**
+
+Replace the messages `<div>` (the one with `style={styles.messages}`) to wrap it with drag-drop handlers:
+
+```tsx
+      <div
+        style={{ ...styles.messages, position: 'relative' }}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {isDragging && (
+          <div style={styles.dropOverlay}>
+            <div style={styles.dropOverlayInner}>Drop files here</div>
+          </div>
+        )}
+        {chat.messages.map(msg => {
+```
+
+- [ ] **Step 5: Add attachment display in user message bubbles**
+
+Inside the message rendering loop, after the content `<Markdown>` block and before the timestamp div, add attachment display for user messages:
+
+```tsx
+                {msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
+                {isUser && msg.attachments && msg.attachments.length > 0 && (
+                  <div style={styles.attachmentsContainer}>
+                    {msg.attachments.map(att => (
+                      <div key={att.id} style={styles.attachmentChip}>
+                        {att.mimeType.startsWith('image/') ? (
+                          <img
+                            src={`file://${att.path}`}
+                            alt={att.name}
+                            style={styles.attachmentThumb}
+                            onClick={() => window.codey?.openPath?.(att.path)}
+                          />
+                        ) : (
+                          <span style={styles.attachmentIcon}>📄</span>
+                        )}
+                        <span style={styles.attachmentName}>{att.name}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+```
+
+- [ ] **Step 6: Add pending attachment preview chips above input**
+
+Replace the `inputContainer` div to include the attachment preview area and the "+" button:
+
+```tsx
+      <div style={styles.inputContainer}>
+        {pendingAttachments.length > 0 && (
+          <div style={styles.pendingRow}>
+            {pendingAttachments.map(att => (
+              <div key={att.id} style={styles.pendingChip}>
+                {att.mimeType.startsWith('image/') ? (
+                  <img src={`file://${att.path}`} alt={att.name} style={styles.pendingThumb} />
+                ) : (
+                  <span style={{ fontSize: 11 }}>📄</span>
+                )}
+                <span style={styles.pendingName}>{att.name}</span>
+                <button onClick={() => removeAttachment(att.id)} style={styles.removeBtn}>×</button>
+              </div>
+            ))}
+          </div>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql"
+          style={{ display: 'none' }}
+          onChange={handleFilePick}
+        />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={!isGatewayRunning || isSending}
+          style={styles.attachButton}
+          title="Attach file"
+        >
+          <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={C.fg3} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+        </button>
+        <textarea
+```
+
+- [ ] **Step 7: Add styles**
+
+Add the new styles to the `styles` object at the bottom of the file:
+
+```typescript
+  dropOverlay: {
+    position: 'absolute' as const, inset: 0, zIndex: 10,
+    background: 'rgba(0,0,0,0.6)', display: 'flex',
+    alignItems: 'center', justifyContent: 'center',
+    borderRadius: 8, border: `2px dashed ${C.accent}`,
+  },
+  dropOverlayInner: {
+    color: C.accent, fontSize: 16, fontWeight: 600,
+  },
+  attachmentsContainer: {
+    display: 'flex', flexWrap: 'wrap' as const, gap: 6, marginTop: 8,
+  },
+  attachmentChip: {
+    display: 'flex', alignItems: 'center', gap: 4,
+    background: 'rgba(255,255,255,0.08)', borderRadius: 6,
+    padding: '4px 8px', fontSize: 11, maxWidth: 180,
+  },
+  attachmentThumb: {
+    width: 32, height: 32, borderRadius: 4, objectFit: 'cover' as const, cursor: 'pointer',
+  },
+  attachmentIcon: { fontSize: 14 },
+  attachmentName: {
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+    color: C.fg2, maxWidth: 120,
+  },
+  pendingRow: {
+    display: 'flex', flexWrap: 'wrap' as const, gap: 6,
+    padding: '8px 14px 0', borderTop: `1px solid ${C.border}`,
+  },
+  pendingChip: {
+    display: 'flex', alignItems: 'center', gap: 4,
+    background: C.surface3, borderRadius: 6,
+    padding: '4px 6px', fontSize: 11,
+  },
+  pendingThumb: {
+    width: 24, height: 24, borderRadius: 3, objectFit: 'cover' as const,
+  },
+  pendingName: {
+    color: C.fg2, maxWidth: 100, overflow: 'hidden',
+    textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+  },
+  removeBtn: {
+    background: 'none', border: 'none', color: C.fg3,
+    cursor: 'pointer', fontSize: 14, padding: '0 2px', lineHeight: 1,
+  },
+  attachButton: {
+    width: 36, height: 36, borderRadius: 9, border: 'none',
+    background: C.surface3, display: 'flex', alignItems: 'center',
+    justifyContent: 'center', flexShrink: 0, cursor: 'pointer',
+    transition: 'background 0.15s',
+  },
+```
+
+- [ ] **Step 8: Verify dev build compiles**
+
+```bash
+cd codey-mac && npx tsc --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): add file upload UI with drag-drop and attachment chips"
+```
+
+---
+
+### Task 7: Update useChats hook to pass attachments
+
+**Files:**
+- Modify: `codey-mac/src/hooks/useChats.tsx`
+
+- [ ] **Step 1: Update sendMessage to accept attachments**
+
+In `useChats.tsx`, find the `sendMessage` function in the context value (around line 311). Update it:
+
+```typescript
+    async sendMessage(chatId, text, attachments?) {
+      const assistantMessageId = `asst-${Date.now()}-${Math.random()}`
+      const userMessage: ChatMessage = {
+        id: `user-${Date.now()}-${Math.random()}`,
+        role: 'user',
+        content: text,
+        timestamp: Date.now(),
+        isComplete: true,
+        attachments: attachments && attachments.length > 0 ? attachments : undefined,
+      }
+      pendingAssistantId.current[chatId] = assistantMessageId
+      dispatch({ type: 'startSend', chatId, userMessage, assistantMessageId })
+      try {
+        await apiService.chats.send(chatId, text, attachments)
+      } catch (err) {
+        dispatch({ type: 'errorSend', chatId, assistantMessageId, error: `Error: ${(err as Error).message}` })
+        delete pendingAssistantId.current[chatId]
+      }
+    },
+```
+
+- [ ] **Step 2: Update the ChatsContextValue interface**
+
+Find the `ChatsContextValue` interface and update the `sendMessage` signature:
+
+```typescript
+interface ChatsContextValue {
+  state: State
+  createChat: (workspaceName: string) => Promise<Chat>
+  selectChat: (chatId: string | null) => void
+  renameChat: (chatId: string, title: string) => Promise<void>
+  deleteChat: (chatId: string) => Promise<void>
+  setSelection: (chatId: string, selection: ChatSelection) => Promise<void>
+  sendMessage: (chatId: string, text: string, attachments?: import('../types').FileAttachment[]) => Promise<void>
+  stopChat: (chatId: string) => Promise<void>
+  toggleWorkspace: (workspaceName: string) => void
+  refreshWorkspaces: () => Promise<void>
+}
+```
+
+- [ ] **Step 3: Add FileAttachment to the type import**
+
+At the top of the file, update the import:
+
+```typescript
+import type { Chat, ChatSelection, ChatMessage, ToolCallEntry, FileAttachment } from '../types'
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+cd codey-mac && npx tsc --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/hooks/useChats.tsx
+git commit -m "feat(mac): pass attachments through useChats sendMessage"
+```
+
+---
+
+### Task 8: Update types re-export
+
+**Files:**
+- Modify: `codey-mac/src/types/index.ts`
+
+- [ ] **Step 1: Add FileAttachment to re-export**
+
+```typescript
+export type { ChatMessage, ToolCallEntry, Chat, ChatSelection, FileAttachment } from '@codey/core';
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd codey-mac && npx tsc --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/types/index.ts
+git commit -m "feat(mac): re-export FileAttachment type"
+```
+
+---
+
+### Task 9: End-to-end verification
+
+- [ ] **Step 1: Build all packages from monorepo root**
+
+```bash
+cd /Users/jackou/Documents/projects/codey && npm run build
+```
+
+Expected: All packages compile without errors.
+
+- [ ] **Step 2: Launch the macOS app in dev mode**
+
+```bash
+cd codey-mac && npm run dev
+```
+
+Expected: App window opens without crashes.
+
+- [ ] **Step 3: Test file upload flow**
+
+1. Open a chat
+2. Click the "+" button — file picker should open
+3. Select a text file — preview chip should appear above input
+4. Type a message and send — message should include the attachment
+5. Verify the agent prompt includes the `[Attachments]` section (check gateway logs)
+
+- [ ] **Step 4: Test drag-and-drop**
+
+1. Drag a file from Finder onto the messages area
+2. "Drop files here" overlay should appear
+3. Drop the file — preview chip should appear
+4. Send the message
+
+- [ ] **Step 5: Test image upload**
+
+1. Upload a PNG image
+2. Verify thumbnail preview in the chip
+3. Send and verify the agent receives the image path with vision instruction
+
+- [ ] **Step 6: Final commit with all builds**
+
+```bash
+git add -A
+git commit -m "feat: file upload support in macOS chat — complete implementation"
+```

--- a/docs/superpowers/plans/2026-04-28-file-upload.md
+++ b/docs/superpowers/plans/2026-04-28-file-upload.md
@@ -345,7 +345,22 @@ Find the `chats:send` handler (line 585) and update it to pass attachments:
   )
 ```
 
-- [ ] **Step 5: Build Electron**
+- [ ] **Step 5: Update codey-api.d.ts type declarations**
+
+Open `codey-mac/src/codey-api.d.ts`. Add `upload` to the `chats` section and update `send`:
+
+```typescript
+      chats: {
+        upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+          Promise<IpcResult<{ id: string; name: string; path: string; mimeType: string; size: number }>>
+        list: (workspaceName?: string) => Promise<IpcResult<Chat[]>>
+        // ... existing methods
+        send: (payload: { chatId: string; text: string; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) =>
+          Promise<IpcResult<{ response: string; chatId: string; tokens?: number; durationSec?: number }>>
+        // ... rest unchanged
+```
+
+- [ ] **Step 6: Build Electron**
 
 ```bash
 cd codey-mac && npx tsc -p tsconfig.electron.json --noEmit
@@ -353,10 +368,10 @@ cd codey-mac && npx tsc -p tsconfig.electron.json --noEmit
 
 Expected: No type errors.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add codey-mac/electron/preload.ts codey-mac/electron/main.ts
+git add codey-mac/electron/preload.ts codey-mac/electron/main.ts codey-mac/src/codey-api.d.ts
 git commit -m "feat(mac): add chats:upload IPC for file upload"
 ```
 

--- a/docs/superpowers/specs/2026-04-28-file-upload-design.md
+++ b/docs/superpowers/specs/2026-04-28-file-upload-design.md
@@ -1,0 +1,209 @@
+# File Upload in macOS Chat
+
+## Overview
+
+Add image and file upload support to the macOS Electron app's Chat tab. Users can drag-and-drop files or click an attachment button to attach files to chat messages. Files are saved to the workspace directory and coding agents are explicitly instructed to review them.
+
+**Platform:** macOS App only (codey-mac)
+**File types:** Images (png, jpg, gif, webp) and text files (code, logs, configs, etc.)
+**Agent interaction:** Files saved to disk, paths included in structured prompt
+
+## Data Model
+
+### FileAttachment (new interface)
+
+```typescript
+// packages/core/src/types/chat.ts
+export interface FileAttachment {
+  id: string;
+  name: string;        // original filename
+  path: string;        // absolute path on disk after save
+  mimeType: string;    // e.g. "image/png", "text/typescript"
+  size: number;        // bytes
+}
+```
+
+### ChatMessage (modified)
+
+Add optional `attachments` field:
+
+```typescript
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+  attachments?: FileAttachment[];  // NEW
+  toolCalls?: ToolCallEntry[];
+  isComplete?: boolean;
+  tokens?: number;
+  durationSec?: number;
+}
+```
+
+## Frontend (ChatTab.tsx)
+
+### UI Components
+
+1. **Attachment button** ("+") to the left of the input textarea. Opens a native file picker supporting multiple selection. Filter: images + text files.
+
+2. **Drag-and-drop zone** over the entire messages area. On dragenter, show a dashed-border overlay with "Drop files here" text. On drop, process files.
+
+3. **Attachment preview chips** above the input textarea:
+   - Image files: thumbnail preview + filename
+   - Text files: file icon + filename + size
+   - Each chip has an "x" button to remove before sending
+   - Max display: 5 chips, "+N more" for overflow
+
+4. **Attachment display in user message bubbles:**
+   - Images: inline thumbnail (max 200x200, click to expand)
+   - Text files: filename + line count label
+
+### Interaction Flow
+
+1. User drags files or clicks "+" to select files
+2. Files are read as ArrayBuffer in the renderer
+3. Files are sent via `chats:upload` IPC to the main process
+4. Main process saves files to `{workspaceDir}/.codey/uploads/`
+5. Returns `FileAttachment` metadata
+6. Chips appear above input; user types message (optional) and sends
+7. `chats:send` payload includes both `text` and `attachments`
+
+### State Management
+
+In `useChats.tsx`, add a `pendingAttachments` state per chat:
+
+```typescript
+// Track files being staged before send
+const [pendingAttachments, setPendingAttachments] = useState<Record<string, FileAttachment[]>>({})
+```
+
+## IPC Layer
+
+### New: `chats:upload`
+
+**Preload (preload.ts):**
+```typescript
+chats: {
+  upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+    ipcRenderer.invoke('chats:upload', chatId, fileName, mimeType, data),
+  // ... existing methods
+}
+```
+
+**Main process (main.ts):**
+```typescript
+ipcMain.handle('chats:upload', async (_e, chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>
+  wrap(async () => {
+    // 1. Resolve workspace workingDir from chatId
+    // 2. Create .codey/uploads/ directory
+    // 3. Generate unique filename: {timestamp}-{random}-{originalName}
+    // 4. Write file
+    // 5. Return FileAttachment
+  })
+)
+```
+
+### Modified: `chats:send`
+
+**Payload change:**
+```typescript
+// Before
+{ chatId: string; text: string }
+
+// After
+{ chatId: string; text: string; attachments?: FileAttachment[] }
+```
+
+**Main process:** Pass attachments to `sendToChat`.
+
+## Backend (Gateway)
+
+### sendToChat (gateway.ts)
+
+Modify signature to accept optional attachments:
+
+```typescript
+async sendToChat(
+  chatId: string,
+  userText: string,
+  sink: ChatStreamSink,
+  attachments?: FileAttachment[],
+): Promise<{...}>
+```
+
+Pass attachments to `buildChatPrompt` and persist them in the `ChatMessage`.
+
+### buildChatPrompt (chat-runner.ts)
+
+When attachments are present, prepend a structured section:
+
+```
+[Attachments]
+- /path/to/screenshot.png (image/png)
+- /path/to/code.ts (text/typescript, 142 lines)
+
+Please review the attached files before responding to the user's message.
+For image files, use your vision capabilities to analyze them.
+
+User: <actual user message>
+```
+
+For image files, include a note about vision capabilities.
+For text files, include line count if detectable.
+
+### File Save Location
+
+Files are saved to `{workspaceWorkingDir}/.codey/uploads/`:
+- Hidden directory (prefixed with `.`) so it doesn't pollute the project
+- Unique filenames prevent collisions
+- No automatic cleanup (user can manually delete)
+
+## API Service (api.ts)
+
+```typescript
+// New method
+uploadFile: async (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer): Promise<FileAttachment> =>
+  unwrap(await window.codey.chats.upload(chatId, fileName, mimeType, data)),
+
+// Modified method
+chats: {
+  send: async (chatId: string, text: string, attachments?: FileAttachment[]): Promise<{...}> =>
+    unwrap(await window.codey.chats.send({ chatId, text, attachments })),
+}
+```
+
+## File Type Detection
+
+Use MIME type from the file input / drag event. Supported categories:
+
+| Category | MIME patterns | Agent behavior |
+|----------|---------------|----------------|
+| Images | image/* | Prompt notes vision capability |
+| Code | text/*, application/json, application/typescript | Line count included in prompt |
+| Other | * | Generic file reference |
+
+## Error Handling
+
+- File too large (>10MB): show error toast, don't upload
+- Upload fails: show error in attachment chip, allow retry
+- Workspace not found: disable attachment button
+- Unsupported file type: show warning, allow override
+
+## Failure Behavior
+
+- If `chats:send` fails after attachments are staged, pending attachments are preserved so the user can retry
+- If `chats:upload` fails (e.g. disk full), show error state on the chip and allow retry
+- Files already saved to disk are not rolled back on send failure (they remain in `.codey/uploads/`)
+
+## Compatibility
+
+- `attachments` is optional in all interfaces; existing callers (HTTP API, channel handlers) are unaffected
+- `processPromptHttp` is not changed — file upload is only available through the multi-chat `sendToChat` path
+- Telegram/Discord handlers continue to work with text-only messages
+
+## Limits
+
+- Max file size: 10MB per file
+- Max attachments per message: 10
+- No automatic cleanup of uploads directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -1,3 +1,11 @@
+export interface FileAttachment {
+  id: string;
+  name: string;        // original filename
+  path: string;        // absolute path on disk after save
+  mimeType: string;    // e.g. "image/png", "text/typescript"
+  size: number;        // bytes
+}
+
 export interface ToolCallEntry {
   id: string;
   type: 'tool_start' | 'tool_end' | 'info';
@@ -12,6 +20,7 @@ export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
+  attachments?: FileAttachment[];
   toolCalls?: ToolCallEntry[];
   isComplete?: boolean;
   /** Total tokens for the assistant response, set when the turn completes. */

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -1,4 +1,4 @@
-import { Chat, ChatMessage, ToolCallEntry } from '@codey/core';
+import { Chat, ChatMessage, FileAttachment, ToolCallEntry } from '@codey/core';
 
 export const MAX_CONCURRENT_AGENTS = 4;
 export const CHAT_CONTEXT_WINDOW = 40;
@@ -14,10 +14,43 @@ export type ChatStreamEvent =
 
 export type ChatStreamSink = (e: ChatStreamEvent) => void;
 
+function formatAttachmentList(attachments: FileAttachment[]): string {
+  const lines = attachments.map(a => {
+    let desc = `- ${a.path} (${a.mimeType})`;
+    if (a.mimeType.startsWith('image/')) {
+      desc += ' [IMAGE - use vision to analyze]';
+    }
+    return desc;
+  });
+  return [
+    '[Attachments]',
+    ...lines,
+    '',
+    'Please review the attached files before responding.',
+    ...(
+      attachments.some(a => a.mimeType.startsWith('image/'))
+        ? ['For image files, analyze the visual content carefully.']
+        : []
+    ),
+    '',
+  ].join('\n');
+}
+
 /** Build the prompt string from the tail of the chat's message history + new user message. */
-export function buildChatPrompt(chat: Chat, userText: string, windowSize = CHAT_CONTEXT_WINDOW): string {
+export function buildChatPrompt(
+  chat: Chat,
+  userText: string,
+  attachments?: FileAttachment[],
+  windowSize = CHAT_CONTEXT_WINDOW,
+): string {
   const tail = chat.messages.slice(-windowSize);
   const lines: string[] = [];
+
+  // Prepend attachment context if present
+  if (attachments && attachments.length > 0) {
+    lines.push(formatAttachmentList(attachments));
+  }
+
   for (const m of tail) {
     const tag = m.role === 'user' ? 'User' : 'Assistant';
     lines.push(`${tag}: ${m.content}`);

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -9,7 +9,7 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number }
+  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string }
   | { type: 'error'; chatId: string; message: string };
 
 export type ChatStreamSink = (e: ChatStreamEvent) => void;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1913,9 +1913,9 @@ Example: /model gpt-4.1 write a Python script`;
         tokens,
         durationSec,
       };
-      this.chatManager.appendMessage(chatId, assistantMessage);
+      const updated = this.chatManager.appendMessage(chatId, assistantMessage);
 
-      sink({ type: 'done', chatId, response: output, tokens, durationSec });
+      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title });
       return { response: output, chatId, tokens, durationSec };
     } catch (err) {
       const message = `Error: ${(err as Error).message}`;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1784,6 +1784,7 @@ Example: /model gpt-4.1 write a Python script`;
     chatId: string,
     userText: string,
     sink: ChatStreamSink,
+    attachments?: import('@codey/core').FileAttachment[],
   ): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> {
     const chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
@@ -1823,7 +1824,7 @@ Example: /model gpt-4.1 write a Python script`;
     // BEFORE persisting the user message. Persisting first would cause
     // buildChatPrompt to see the new turn in the tail AND get it appended
     // again as `User: ${userText}`, doubling the user message in the prompt.
-    const prompt = assistantPrefixForSelection(chat) + buildChatPrompt(chat, userText);
+    const prompt = assistantPrefixForSelection(chat) + buildChatPrompt(chat, userText, attachments);
 
     const userMessage: ChatMessage = {
       id: randomUUID(),
@@ -1831,6 +1832,7 @@ Example: /model gpt-4.1 write a Python script`;
       content: userText,
       timestamp: started,
       isComplete: true,
+      attachments: attachments && attachments.length > 0 ? attachments : undefined,
     };
     this.chatManager.appendMessage(chatId, userMessage);
 

--- a/workers/code-reviewer/config.json
+++ b/workers/code-reviewer/config.json
@@ -1,0 +1,11 @@
+{
+  "codingAgent": "claude-code",
+  "model": "claude-opus-4-6",
+  "tools": [
+    "Read",
+    "Edit",
+    "Grep",
+    "Glob",
+    "Bash"
+  ]
+}

--- a/workers/code-reviewer/personality.md
+++ b/workers/code-reviewer/personality.md
@@ -1,0 +1,14 @@
+# Worker: code-reviewer
+
+## Role
+Reviews code updates for issues, suggests improvements, and ensures quality standards are met.
+
+## Soul
+This worker is direct and methodical, examining code without assumptions and asking clarifying questions when context is unclear. They value clarity over cleverness and prioritize finding real issues over Nitpicks. Feedback is factual, actionable, and focused on what actually needs to change.
+
+## Instructions
+1. Examine the provided code changes or diff with careful attention to logic, structure, and edge cases.
+2. Identify any bugs, security concerns, performance issues, or deviations from the project patterns.
+3. Note specific, actionable improvements with clear reasoning.
+4. Distinguish between critical issues requiring fixes and suggestions worth considering.
+5. Present findings in a structured, easy-to-scan format without assuming intent the code doesn't show.


### PR DESCRIPTION
## Summary
- Add file upload feature to the macOS chat UI — users can drag-drop files or click the attachment button to upload files alongside chat messages
- Files are saved to `.codey/uploads/` in the workspace, and a structured `[Attachments]` section is prepended to the prompt so coding agents explicitly review attached files
- Support for image previews (inline thumbnails) and text file metadata (line count, size) in both preview chips and message bubbles

## Changes

### Core types
- Add `FileAttachment` interface and `attachments` field to `ChatMessage` (`packages/core/src/types/chat.ts`)

### Gateway
- Update `buildChatPrompt` to inject structured `[Attachments]` section with file paths and metadata (`packages/gateway/src/chat-runner.ts`)
- Pass attachments through `sendToChat` (`packages/gateway/src/gateway.ts`)

### Electron IPC
- Add `chats:upload` handler — receives file binary, saves to workspace, returns `FileAttachment` metadata (`codey-mac/electron/main.ts`)
- Update `chats:send` payload to accept optional `attachments` array
- Update `codey-api.d.ts` type declarations

### Frontend
- Attachment button (+) next to input bar opens file picker
- Drag-drop zone over message area with visual highlight
- Preview chips showing image thumbnails or file info with remove button
- Message bubbles display attachment previews
- `useChats` hook and API service updated to pass attachments through

## Test plan
- [ ] Drag an image file onto the chat area — preview chip appears with thumbnail
- [ ] Click "+" button and select a text file — chip shows filename and size
- [ ] Send message with attachments — agent receives structured prompt with file paths
- [ ] Remove attachment from preview before sending
- [ ] Send message without attachments — existing behavior unchanged
- [ ] Build passes: `npm run build` (core + gateway) and `npx tsc -p tsconfig.electron.json --noEmit` (mac)

🤖 Generated with [Claude Code](https://claude.com/claude-code)