### PR TITLE
feat(team): opt-in auto-dispatch for /team

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Edit `gateway.json`:
 }
 ```
 
+Auto-dispatch settings: `dispatcher.{agent, model}` (optional).
+
 ## Workspace Structure
 
 ```
@@ -166,7 +168,17 @@ When prompted, analyze requirements and provide...
 |---------|-------------|
 | `/workers` | List all workers in current workspace |
 | `/worker <name> <task>` | Run a specific worker |
-| `/team <task>` | Run workers in sequence |
+| `/team <name> [--all] <task>` | Run a named team (see below) |
+
+**Team dispatch details:**
+
+- `/team <name> [--all] <task>` — Run a named team. Members run sequentially with carry chain.
+  - Teams default to `dispatch: 'all'` (every member runs).
+  - Teams configured with `dispatch: 'auto'` first invoke a built-in dispatcher
+    that selects the relevant subset. Pass `--all` to bypass it for one call.
+  - Optional `dispatchHint` on each worker's `config.json` improves routing accuracy.
+  - The dispatcher's agent/model is configured under `gateway.json` `dispatcher.{agent, model}`,
+    defaulting to the gateway's default agent/model.
 
 ### Workspaces
 | Command | Description |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,6 +91,8 @@ npm run build:mac -w codey-mac  # 在 codey-mac/release/ 生成 DMG
 }
 ```
 
+Auto-dispatch 设置：`dispatcher.{agent, model}`（可选）。
+
 ## 工作区结构
 
 ```
@@ -166,7 +168,15 @@ file-system, git, web-search
 |------|------|
 | `/workers` | 列出当前工作区的所有工作者 |
 | `/worker <名称> <任务>` | 运行指定的工作者 |
-| `/team <任务>` | 按顺序运行工作者 |
+| `/team <名称> [--all] <任务>` | 运行指定的 team（详见下方） |
+
+**Team dispatch 说明：**
+
+- `/team <name> [--all] <task>` — 运行指定的 team，成员按顺序串行执行，输出会作为下一个成员的输入。
+  - 默认 `dispatch: 'all'`（所有成员参与）。
+  - 配置为 `dispatch: 'auto'` 的 team 会先调用内置 dispatcher，自动选择本次任务真正需要的成员子集。临时跳过 dispatcher 可以加 `--all` 标志。
+  - 在 worker 的 `config.json` 里加可选的 `dispatchHint` 字段（一句话）可以提升路由准确性。
+  - Dispatcher 用的 agent/model 在 `gateway.json` 的 `dispatcher.{agent, model}` 字段配置，未配置时回退到 gateway 默认 agent/model。
 
 ### 工作区
 | 命令 | 描述 |

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -550,6 +550,28 @@ app.whenReady().then(async () => {
     })
   )
 
+  // ── Dispatcher IPC ────────────────────────────────────────────────
+  // The dispatcher block selects the agent + model that decides which workers
+  // a `dispatch: 'auto'` team uses. Empty values mean "use gateway default".
+  ipcMain.handle('dispatcher:get', async () =>
+    wrap(async () => {
+      const cfg = coreConfigManager?.get()
+      return { agent: cfg?.dispatcher?.agent, model: cfg?.dispatcher?.model }
+    })
+  )
+
+  ipcMain.handle('dispatcher:set', async (_e, updates: { agent?: string; model?: string } | null | undefined) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      const agent = updates?.agent || undefined
+      const model = updates?.model || undefined
+      // ConfigManager.update() skips dispatcher when partial.dispatcher === undefined,
+      // so we always pass an explicit object. Both fields undefined keeps the slot
+      // present-but-empty, which the gateway reads identically to "no override".
+      coreConfigManager.update({ dispatcher: { agent: agent as any, model } })
+    })
+  )
+
   // ── Fallback IPC ──────────────────────────────────────────────────
   ipcMain.handle('fallback:get', async () =>
     wrap(async () => coreConfigManager?.getFallback() ?? { enabled: true, order: [] })

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -328,8 +328,13 @@ app.whenReady().then(async () => {
         const teams = workspaceManager.getTeams()
         let changed = false
         for (const team of Object.keys(teams)) {
-          const filtered = teams[team].filter((m: string) => m !== name)
-          if (filtered.length !== teams[team].length) { teams[team] = filtered; changed = true }
+          const raw = teams[team]
+          const arr = Array.isArray(raw) ? raw : raw.members
+          const filtered = arr.filter((m: string) => m !== name)
+          if (filtered.length !== arr.length) {
+            teams[team] = Array.isArray(raw) ? filtered : { ...raw, members: filtered }
+            changed = true
+          }
         }
         if (changed) await workspaceManager.setTeams(teams)
       }
@@ -434,7 +439,14 @@ app.whenReady().then(async () => {
       const configPath = pathMod.join(workspaceManager.getWorkspacesRoot(), target, 'workspace.json')
       if (!fsMod.existsSync(configPath)) return {} as Record<string, string[]>
       const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
-      return (data.teams || {}) as Record<string, string[]>
+      // Flatten TeamConfigRaw → string[] for UI (dispatch mode not yet surfaced in UI)
+      // TODO: surface dispatch mode in UI
+      const raw: Record<string, unknown> = data.teams || {}
+      const result: Record<string, string[]> = {}
+      for (const [k, v] of Object.entries(raw)) {
+        result[k] = Array.isArray(v) ? v : (v as any).members ?? []
+      }
+      return result
     })
   )
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -429,33 +429,27 @@ app.whenReady().then(async () => {
   )
 
   // ── Teams IPC ─────────────────────────────────────────────────────
+  // Returns the raw TeamConfigRaw shape so the UI can surface dispatch mode.
   ipcMain.handle('teams:get', async (_e, name?: string) =>
     wrap(async () => {
       if (!workspaceManager) throw new Error('Workspace manager not ready')
       const target = name || workspaceManager.getCurrentWorkspace()
-      if (!target) return {} as Record<string, string[]>
+      if (!target) return {} as Record<string, unknown>
       const fsMod = await import('fs')
       const pathMod = await import('path')
       const configPath = pathMod.join(workspaceManager.getWorkspacesRoot(), target, 'workspace.json')
-      if (!fsMod.existsSync(configPath)) return {} as Record<string, string[]>
+      if (!fsMod.existsSync(configPath)) return {} as Record<string, unknown>
       const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
-      // Flatten TeamConfigRaw → string[] for UI (dispatch mode not yet surfaced in UI)
-      // TODO: surface dispatch mode in UI
-      const raw: Record<string, unknown> = data.teams || {}
-      const result: Record<string, string[]> = {}
-      for (const [k, v] of Object.entries(raw)) {
-        result[k] = Array.isArray(v) ? v : (v as any).members ?? []
-      }
-      return result
+      return (data.teams || {}) as Record<string, unknown>
     })
   )
 
-  ipcMain.handle('teams:set', async (_e, nameOrTeams: string | Record<string, string[]>, maybeTeams?: Record<string, string[]>) =>
+  ipcMain.handle('teams:set', async (_e, nameOrTeams: string | Record<string, unknown>, maybeTeams?: Record<string, unknown>) =>
     wrap(async () => {
       if (!workspaceManager) throw new Error('Workspace manager not ready')
       // Backward-compat: support both (teams) and (name, teams) call shapes.
       let target: string
-      let teams: Record<string, string[]>
+      let teams: Record<string, any>
       if (typeof nameOrTeams === 'string') {
         target = nameOrTeams || workspaceManager.getCurrentWorkspace()
         teams = maybeTeams || {}

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -63,6 +63,10 @@ contextBridge.exposeInMainWorld('codey', {
     get: () => ipcRenderer.invoke('fallback:get'),
     set: (fb: any) => ipcRenderer.invoke('fallback:set', fb),
   },
+  dispatcher: {
+    get: () => ipcRenderer.invoke('dispatcher:get'),
+    set: (updates: { agent?: string; model?: string }) => ipcRenderer.invoke('dispatcher:set', updates),
+  },
   agents: {
     get: () => ipcRenderer.invoke('agents:get'),
     set: (updates: any) => ipcRenderer.invoke('agents:set', updates),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -61,6 +61,10 @@ declare global {
         get: () => Promise<IpcResult<{ enabled: boolean; order: Array<{ agent: string; model?: string }> }>>
         set: (fb: { enabled: boolean; order: Array<{ agent: string; model?: string }> }) => Promise<IpcResult<void>>
       }
+      dispatcher: {
+        get: () => Promise<IpcResult<{ agent?: string; model?: string }>>
+        set: (updates: { agent?: string; model?: string }) => Promise<IpcResult<void>>
+      }
       agents: {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string }>>>
         set: (updates: Record<string, { enabled?: boolean; defaultModel?: string }>) => Promise<IpcResult<void>>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -1,5 +1,6 @@
 import type { Chat, ChatSelection } from '../../packages/core/src/types/chat'
 import type { ChatStreamEvent } from '../../packages/gateway/src/chat-runner'
+import type { TeamConfigRaw } from '../../packages/core/src/workspace'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
@@ -35,8 +36,8 @@ declare global {
         pickDirectory: () => Promise<IpcResult<string | null>>
       }
       teams: {
-        get: (name?: string) => Promise<IpcResult<Record<string, string[]>>>
-        set: (name: string, teams: Record<string, string[]>) => Promise<IpcResult<void>>
+        get: (name?: string) => Promise<IpcResult<Record<string, TeamConfigRaw>>>
+        set: (name: string, teams: Record<string, TeamConfigRaw>) => Promise<IpcResult<void>>
       }
       conversations: {
         list: () => Promise<IpcResult<string[]>>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -89,6 +89,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [input, setInput] = useState('')
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [workers, setWorkers] = useState<WorkerDto[]>([])
+  const [teamNames, setTeamNames] = useState<string[]>([])
   const [models, setModels] = useState<ModelEntry[]>([])
   const [enabledAgents, setEnabledAgents] = useState<string[]>([...AGENT_NAMES])
   const [defaultAgent, setDefaultAgent] = useState<string | null>(null)
@@ -104,6 +105,10 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const taRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => { apiService.listWorkers().then(setWorkers) }, [])
+  useEffect(() => {
+    if (!chat?.workspaceName) return
+    apiService.getTeams(chat.workspaceName).then(t => setTeamNames(Object.keys(t))).catch(() => setTeamNames([]))
+  }, [chat?.workspaceName])
   useEffect(() => {
     if (!isGatewayRunning) return
     ;(async () => {
@@ -144,13 +149,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const selectionValue: string = chat.selection.type === 'worker'
     ? `worker:${chat.selection.name}`
     : chat.selection.type === 'team'
-      ? 'team'
+      ? `team:${chat.selection.name ?? ''}`
       : 'none'
 
   const onSelectionChange = async (v: string) => {
     let next: ChatSelection
     if (v === 'none') next = { type: 'none' }
-    else if (v === 'team') next = { type: 'team' }
+    else if (v.startsWith('team:')) next = { type: 'team', name: v.slice('team:'.length) }
     else next = { type: 'worker', name: v.slice('worker:'.length) }
     await setSelection(chat.id, next)
   }
@@ -298,8 +303,16 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         <div style={{ flex: 1 }} />
         <select value={selectionValue} onChange={e => onSelectionChange(e.target.value)} style={styles.workerSelect}>
           <option value="none">No worker</option>
-          <option value="team">Team</option>
-          {workers.map(w => <option key={w.name} value={`worker:${w.name}`}>{w.name}</option>)}
+          {workers.length > 0 && (
+            <optgroup label="Workers">
+              {workers.map(w => <option key={w.name} value={`worker:${w.name}`}>{w.name}</option>)}
+            </optgroup>
+          )}
+          {teamNames.length > 0 && (
+            <optgroup label="Teams">
+              {teamNames.map(n => <option key={n} value={`team:${n}`}>{n}</option>)}
+            </optgroup>
+          )}
         </select>
         <select
           value={chat.agent ?? ''}

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -355,6 +355,7 @@ type InstallStatus = { installed: boolean; path?: string }
 export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) => {
   const [models, setModels] = useState<ModelEntry[]>([])
   const [fallback, setFallback] = useState<FallbackCfg>({ enabled: true, order: [] })
+  const [dispatcher, setDispatcher] = useState<{ agent: string; model: string }>({ agent: '', model: '' })
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Probe runs async after the rest of the panel paints — the chip flips from
@@ -376,11 +377,13 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const reload = useCallback(async () => {
     setError(null)
     try {
-      const [m, f] = await Promise.all([
+      const [m, f, d] = await Promise.all([
         unwrap(await window.codey.models.list()),
         unwrap(await window.codey.fallback.get()),
+        unwrap(await window.codey.dispatcher.get()),
       ])
       setModels(m); setFallback(f as FallbackCfg)
+      setDispatcher({ agent: d.agent ?? '', model: d.model ?? '' })
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
@@ -414,6 +417,23 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
     setFallback(fb)
     await unwrap(await window.codey.fallback.set(fb))
   }
+
+  const updateDispatcher = async (next: { agent: string; model: string }) => {
+    setDispatcher(next)
+    await unwrap(await window.codey.dispatcher.set({
+      agent: next.agent || undefined,
+      model: next.model || undefined,
+    }))
+  }
+
+  // Mirror the fallback editor's filter: when an agent is picked, only show
+  // models compatible with its apiType. When no agent is picked, show all.
+  const dispatcherModels = (() => {
+    const want = dispatcher.agent ? AGENT_API_TYPE[dispatcher.agent] : undefined
+    return [...models]
+      .filter(m => !want || m.apiType === want)
+      .sort((a, b) => a.model.localeCompare(b.model))
+  })()
 
   // Enablement is derived from priority-list membership now; the chat header
   // and fallback "+ Add step" both use this to decide what an agent looks
@@ -486,6 +506,44 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
           Fallback is off — only Row 1 (the default) will run. Failures surface as errors instead of trying the rest of the list.
         </div>
       )}
+
+      <Section title="Dispatcher (Auto Mode)"/>
+      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
+        When a team is configured with <code>dispatch: 'auto'</code>, this agent + model decides which workers participate. Leave both blank to use the gateway default.
+      </div>
+      <div style={fieldStyle}>
+        <span style={{ color: C.fg, fontSize: 13 }}>Agent</span>
+        <select
+          value={dispatcher.agent}
+          onChange={e => {
+            const nextAgent = e.target.value
+            // Drop the pinned model if it's not compatible with the new agent.
+            const want = nextAgent ? AGENT_API_TYPE[nextAgent] : undefined
+            const m = models.find(mm => mm.model === dispatcher.model)
+            const keepModel = !dispatcher.model || !want || (m && m.apiType === want)
+            updateDispatcher({ agent: nextAgent, model: keepModel ? dispatcher.model : '' })
+          }}
+          style={selectStyle}
+        >
+          <option value="">Use default</option>
+          {AGENT_NAMES.map(a => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+      </div>
+      <div style={fieldStyle}>
+        <span style={{ color: C.fg, fontSize: 13 }}>Model</span>
+        <select
+          value={dispatcher.model}
+          onChange={e => updateDispatcher({ agent: dispatcher.agent, model: e.target.value })}
+          style={selectStyle}
+        >
+          <option value="">Use default</option>
+          {dispatcherModels.map(m => (
+            <option key={m.model} value={m.model}>{m.model} [{m.apiType}]</option>
+          ))}
+        </select>
+      </div>
     </div>
   )
 }

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -509,9 +509,17 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
 
       <Section title="Dispatcher (Auto Mode)"/>
       <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
-        When a team is configured with <code>dispatch: 'auto'</code>, this agent + model decides which workers participate. Leave both blank to use the gateway default.
+        When a team's mode is set to <strong>Auto</strong>, this agent + model picks the relevant subset of workers for each task. Leave both as <em>Use default</em> to fall back to the gateway default agent + model.
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
+        padding: '8px 12px',
+      }}>
+        <span style={{
+          color: C.fg3, fontSize: 11, fontWeight: 400,
+          width: 56, letterSpacing: 0.3,
+        }}>ROUTER</span>
         <select
           value={dispatcher.agent}
           onChange={e => {

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -511,8 +511,7 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
       <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
         When a team is configured with <code>dispatch: 'auto'</code>, this agent + model decides which workers participate. Leave both blank to use the gateway default.
       </div>
-      <div style={fieldStyle}>
-        <span style={{ color: C.fg, fontSize: 13 }}>Agent</span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <select
           value={dispatcher.agent}
           onChange={e => {
@@ -523,20 +522,17 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
             const keepModel = !dispatcher.model || !want || (m && m.apiType === want)
             updateDispatcher({ agent: nextAgent, model: keepModel ? dispatcher.model : '' })
           }}
-          style={selectStyle}
+          style={{ ...selectStyle, width: 130 }}
         >
           <option value="">Use default</option>
           {AGENT_NAMES.map(a => (
             <option key={a} value={a}>{a}</option>
           ))}
         </select>
-      </div>
-      <div style={fieldStyle}>
-        <span style={{ color: C.fg, fontSize: 13 }}>Model</span>
         <select
           value={dispatcher.model}
           onChange={e => updateDispatcher({ agent: dispatcher.agent, model: e.target.value })}
-          style={selectStyle}
+          style={{ ...selectStyle, flex: 1, minWidth: 0 }}
         >
           <option value="">Use default</option>
           {dispatcherModels.map(m => (

--- a/codey-mac/src/components/TeamsSection.tsx
+++ b/codey-mac/src/components/TeamsSection.tsx
@@ -1,57 +1,87 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { apiService, WorkerDto } from '../services/api'
+import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
 import { C } from '../theme'
 
+type DispatchMode = 'all' | 'auto'
+interface TeamState { members: string[]; dispatch: DispatchMode }
+type TeamsState = Record<string, TeamState>
+
+function fromRaw(raw: TeamConfigRaw): TeamState {
+  if (Array.isArray(raw)) return { members: raw, dispatch: 'all' }
+  const dispatch: DispatchMode = raw?.dispatch === 'auto' ? 'auto' : 'all'
+  return { members: Array.isArray(raw?.members) ? raw.members : [], dispatch }
+}
+
+function toRaw(t: TeamState): TeamConfigRaw {
+  return t.dispatch === 'all' ? t.members : { members: t.members, dispatch: 'auto' }
+}
+
+function normalizeAll(raw: Record<string, TeamConfigRaw>): TeamsState {
+  const out: TeamsState = {}
+  for (const [k, v] of Object.entries(raw)) out[k] = fromRaw(v)
+  return out
+}
+
+function denormalizeAll(state: TeamsState): Record<string, TeamConfigRaw> {
+  const out: Record<string, TeamConfigRaw> = {}
+  for (const [k, v] of Object.entries(state)) out[k] = toRaw(v)
+  return out
+}
+
 export default function TeamsSection({ workspace }: { workspace: string }) {
-  const [teams, setTeams] = useState<Record<string, string[]>>({})
+  const [teams, setTeams] = useState<TeamsState>({})
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   const [savedAt, setSavedAt] = useState<number>(0)
   const [error, setError] = useState<string | null>(null)
   const saveTimer = useRef<number | null>(null)
 
   const reload = useCallback(async () => {
-    setTeams(await apiService.getTeams(workspace))
+    setTeams(normalizeAll(await apiService.getTeams(workspace)))
     setWorkers(await apiService.listWorkers())
   }, [workspace])
 
   useEffect(() => { reload() }, [reload])
 
-  const queueSave = (next: Record<string, string[]>) => {
+  const queueSave = (next: TeamsState) => {
     setTeams(next); setError(null)
     if (saveTimer.current) window.clearTimeout(saveTimer.current)
     saveTimer.current = window.setTimeout(async () => {
-      try { await apiService.setTeams(workspace, next); setSavedAt(Date.now()) }
+      try { await apiService.setTeams(workspace, denormalizeAll(next)); setSavedAt(Date.now()) }
       catch (err: any) { setError(err.unknown ? `Unknown workers: ${err.unknown.join(', ')}` : err.message) }
     }, 400)
   }
 
   const addTeam = () => {
     let i = 1; while (teams[`team${i}`]) i++
-    queueSave({ ...teams, [`team${i}`]: [] })
+    queueSave({ ...teams, [`team${i}`]: { members: [], dispatch: 'all' } })
   }
   const renameTeam = (oldName: string, newName: string) => {
     if (!newName || oldName === newName || teams[newName]) return
-    const next: Record<string, string[]> = {}
+    const next: TeamsState = {}
     for (const [k, v] of Object.entries(teams)) next[k === oldName ? newName : k] = v
     queueSave(next)
   }
   const removeTeam = (name: string) => {
     const next = { ...teams }; delete next[name]; queueSave(next)
   }
+  const setDispatch = (name: string, dispatch: DispatchMode) => {
+    queueSave({ ...teams, [name]: { ...teams[name], dispatch } })
+  }
   const addMember = (team: string, member: string) => {
-    if (teams[team].includes(member)) return
-    queueSave({ ...teams, [team]: [...teams[team], member] })
+    if (teams[team].members.includes(member)) return
+    queueSave({ ...teams, [team]: { ...teams[team], members: [...teams[team].members, member] } })
   }
   const removeMember = (team: string, idx: number) => {
-    queueSave({ ...teams, [team]: teams[team].filter((_, i) => i !== idx) })
+    queueSave({ ...teams, [team]: { ...teams[team], members: teams[team].members.filter((_, i) => i !== idx) } })
   }
   const reorderMember = (team: string, from: number, to: number) => {
     if (from === to || from < 0 || to < 0) return
-    const members = [...teams[team]]
+    const members = [...teams[team].members]
     if (from >= members.length || to >= members.length) return
     const [moved] = members.splice(from, 1)
     members.splice(to, 0, moved)
-    queueSave({ ...teams, [team]: members })
+    queueSave({ ...teams, [team]: { ...teams[team], members } })
   }
   const [drag, setDrag] = useState<{ team: string; idx: number } | null>(null)
   const [dragOver, setDragOver] = useState<{ team: string; idx: number } | null>(null)
@@ -66,7 +96,7 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
     try {
       const worker = await apiService.generateWorker(createPrompt)
       const team = creatingFor
-      const next = { ...teams, [team]: [...teams[team], worker.name] }
+      const next: TeamsState = { ...teams, [team]: { ...teams[team], members: [...teams[team].members, worker.name] } }
       setWorkers(await apiService.listWorkers())
       queueSave(next)
       setCreatingFor(null); setCreatePrompt('')
@@ -77,7 +107,7 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
     }
   }
 
-  const available = (team: string) => workers.filter(w => !teams[team].includes(w.name))
+  const available = (team: string) => workers.filter(w => !teams[team].members.includes(w.name))
 
   return (
     <div style={{ marginTop: 24, padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
@@ -90,15 +120,26 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
       </div>
       {error && <div style={{ background: '#3a1a1a', color: '#ff8080', padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{error}</div>}
       {Object.keys(teams).length === 0 && <div style={{ fontSize: 12, color: C.fg3 }}>No teams yet. Click &quot;+ New team&quot;.</div>}
-      {Object.entries(teams).map(([name, members]) => (
+      {Object.entries(teams).map(([name, team]) => (
         <div key={name} style={{ marginBottom: 12, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
             <input defaultValue={name} onBlur={e => renameTeam(name, e.target.value.trim())}
               style={{ flex: 1, background: 'transparent', color: C.fg, border: 'none', fontSize: 14, fontWeight: 600 }} />
+            <label
+              title="When on, a built-in dispatcher picks the relevant subset of members for each task. Off (default): every member runs sequentially."
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11, color: C.fg3, userSelect: 'none', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={team.dispatch === 'auto'}
+                onChange={e => setDispatch(name, e.target.checked ? 'auto' : 'all')}
+                style={{ cursor: 'pointer' }}
+              />
+              Auto-dispatch
+            </label>
             <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: '#ff6060', border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
           </div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
-            {members.map((m, i) => {
+            {team.members.map((m, i) => {
               const isDragging = drag?.team === name && drag.idx === i
               const isOver = dragOver?.team === name && dragOver.idx === i && !isDragging
               return (

--- a/codey-mac/src/components/TeamsSection.tsx
+++ b/codey-mac/src/components/TeamsSection.tsx
@@ -36,9 +36,13 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
   const [error, setError] = useState<string | null>(null)
   const saveTimer = useRef<number | null>(null)
 
+  const [dispatcherConfigured, setDispatcherConfigured] = useState(false)
+
   const reload = useCallback(async () => {
     setTeams(normalizeAll(await apiService.getTeams(workspace)))
     setWorkers(await apiService.listWorkers())
+    const r = await window.codey.dispatcher.get()
+    if (r.ok) setDispatcherConfigured(!!(r.data.agent || r.data.model))
   }, [workspace])
 
   useEffect(() => { reload() }, [reload])
@@ -125,17 +129,23 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
             <input defaultValue={name} onBlur={e => renameTeam(name, e.target.value.trim())}
               style={{ flex: 1, background: 'transparent', color: C.fg, border: 'none', fontSize: 14, fontWeight: 600 }} />
-            <label
-              title="When on, a built-in dispatcher picks the relevant subset of members for each task. Off (default): every member runs sequentially."
-              style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11, color: C.fg3, userSelect: 'none', cursor: 'pointer' }}>
-              <input
-                type="checkbox"
-                checked={team.dispatch === 'auto'}
-                onChange={e => setDispatch(name, e.target.checked ? 'auto' : 'all')}
-                style={{ cursor: 'pointer' }}
-              />
-              Auto-dispatch
-            </label>
+            <select
+              value={team.dispatch}
+              onChange={e => setDispatch(name, e.target.value as DispatchMode)}
+              title={dispatcherConfigured
+                ? 'Sequential: members run in order, output passed forward. Auto: a dispatcher picks the relevant subset.'
+                : 'Configure a dispatcher in Settings → Dispatcher (Auto Mode) to enable Auto.'}
+              style={{
+                background: C.surface2, color: C.fg, border: `1px solid ${C.border}`,
+                borderRadius: 6, padding: '3px 8px', fontSize: 11, cursor: 'pointer',
+              }}
+            >
+              <option value="all">Sequential</option>
+              <option value="auto" disabled={!dispatcherConfigured && team.dispatch !== 'auto'}>
+                Auto{!dispatcherConfigured ? ' (configure dispatcher first)' : ''}
+              </option>
+              <option value="parallel" disabled>Parallel (coming soon)</option>
+            </select>
             <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: '#ff6060', border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
           </div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -1,6 +1,7 @@
 // IPC proxy — all calls go through window.codey.* (Electron preload)
 
 import type { Chat, ChatSelection } from '../types'
+import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
 
 // Inline ChatStreamEvent to avoid cross-package import
 export type ChatStreamEvent =
@@ -80,10 +81,10 @@ export const apiService = {
     unwrap(await window.codey.dialog.pickDirectory()),
 
   // Teams
-  getTeams: async (workspace?: string): Promise<Record<string, string[]>> =>
+  getTeams: async (workspace?: string): Promise<Record<string, TeamConfigRaw>> =>
     unwrap(await window.codey.teams.get(workspace)),
 
-  setTeams: async (workspace: string, teams: Record<string, string[]>): Promise<void> =>
+  setTeams: async (workspace: string, teams: Record<string, TeamConfigRaw>): Promise<void> =>
     unwrap(await window.codey.teams.set(workspace, teams)),
 
   // Chat — gateway is in-process; streaming comes via chat:token IPC events

--- a/gateway.json.example
+++ b/gateway.json.example
@@ -75,5 +75,9 @@
   "dev": {
     "logLevel": "info",
     "logFile": "gateway.log"
+  },
+  "dispatcher": {
+    "agent": "claude-code",
+    "model": "claude-haiku-4-5"
   }
 }

--- a/packages/core/src/dispatcher-personality.ts
+++ b/packages/core/src/dispatcher-personality.ts
@@ -1,0 +1,21 @@
+/**
+ * Built-in personality used when running the auto-dispatcher. Not user-editable.
+ * Kept short on purpose — the dispatcher is a routing role, not a coder.
+ */
+export const DISPATCHER_PERSONALITY = {
+  role: 'Task router that selects the subset of workers needed for a task.',
+  instructions: [
+    'You are a task router for a team of specialized workers.',
+    'Given a TASK and a list of WORKERS (each with a one-line hint),',
+    'select the SUBSET that should handle this task.',
+    '',
+    'Rules:',
+    '- Preserve the input order of names. Do not reorder.',
+    '- If you are unsure whether a worker is needed, INCLUDE it.',
+    '- Never invent worker names; only use names from the provided list.',
+    '- Output JSON ONLY, no prose, no markdown fences.',
+    '',
+    'Output schema:',
+    '{"selected": ["name", ...], "reason": "<one short sentence>"}',
+  ].join('\n'),
+};

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -1,0 +1,159 @@
+import { AgentRequest, AgentResponse, CodingAgent, ModelConfig } from './types';
+import { DISPATCHER_PERSONALITY } from './dispatcher-personality';
+
+export interface DispatchMember {
+  name: string;
+  hint: string;
+}
+
+export interface DispatchInput {
+  task: string;
+  members: DispatchMember[];
+}
+
+export interface DispatchResult {
+  /** Subset of input member names, sorted to match members' input order. */
+  selected: string[];
+  /** One-sentence explanation surfaced to the user. */
+  reason: string;
+  /** True when dispatcher failed and the caller should run all members. */
+  fallback: boolean;
+  /** Optional human-readable detail about the fallback cause. */
+  fallbackReason?: string;
+}
+
+export type DispatcherRunner = (req: AgentRequest) => Promise<AgentResponse>;
+
+export interface DispatcherOptions {
+  agent: CodingAgent;
+  model?: ModelConfig;
+  runner: DispatcherRunner;
+  /** Hard timeout in ms. Default 30_000. */
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export function buildDispatcherPrompt(input: DispatchInput): string {
+  const lines: string[] = [];
+  lines.push('# Dispatcher');
+  lines.push('## Role');
+  lines.push(DISPATCHER_PERSONALITY.role);
+  lines.push('## Instructions');
+  lines.push(DISPATCHER_PERSONALITY.instructions);
+  lines.push('## Task');
+  lines.push(input.task);
+  lines.push('## Workers');
+  for (const m of input.members) {
+    lines.push(`- ${m.name}: ${m.hint || '(no description)'}`);
+  }
+  return lines.join('\n\n');
+}
+
+/**
+ * Extract the first balanced {...} object from a string and JSON.parse it.
+ * Tolerates leading/trailing prose, markdown fences, and nested objects.
+ * Returns null if no parseable object is found.
+ */
+export function extractJsonObject(text: string): unknown | null {
+  if (!text) return null;
+  const start = text.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let inStr = false;
+  let escape = false;
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (inStr) {
+      if (escape) { escape = false; continue; }
+      if (c === '\\') { escape = true; continue; }
+      if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') { inStr = true; continue; }
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) {
+        const slice = text.slice(start, i + 1);
+        try { return JSON.parse(slice); } catch { return null; }
+      }
+    }
+  }
+  return null;
+}
+
+function asStringArray(v: unknown): string[] | null {
+  if (!Array.isArray(v)) return null;
+  if (!v.every(x => typeof x === 'string')) return null;
+  return v as string[];
+}
+
+export async function runDispatcher(
+  input: DispatchInput,
+  opts: DispatcherOptions,
+): Promise<DispatchResult> {
+  const memberNames = input.members.map(m => m.name);
+  const allFallback = (reason: string): DispatchResult => ({
+    selected: memberNames,
+    reason: '',
+    fallback: true,
+    fallbackReason: reason,
+  });
+
+  if (input.members.length === 0) {
+    return { selected: [], reason: '', fallback: false };
+  }
+
+  const prompt = buildDispatcherPrompt(input);
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Compose AbortSignal that fires on either user signal or our timeout.
+  const ac = new AbortController();
+  const onUserAbort = () => ac.abort();
+  if (opts.signal) {
+    if (opts.signal.aborted) ac.abort();
+    else opts.signal.addEventListener('abort', onUserAbort, { once: true });
+  }
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+
+  let response: AgentResponse;
+  try {
+    response = await opts.runner({
+      prompt,
+      agent: opts.agent,
+      model: opts.model,
+      signal: ac.signal,
+    });
+  } catch (err) {
+    return allFallback(`runner threw: ${(err as Error).message}`);
+  } finally {
+    clearTimeout(timer);
+    if (opts.signal) opts.signal.removeEventListener('abort', onUserAbort);
+  }
+
+  if (!response.success) {
+    return allFallback(response.error || 'runner returned non-success');
+  }
+
+  const obj = extractJsonObject(response.output) as { selected?: unknown; reason?: unknown } | null;
+  if (!obj) return allFallback('no JSON object in dispatcher output');
+
+  const selectedRaw = asStringArray(obj.selected);
+  if (!selectedRaw) return allFallback('selected is not a string array');
+
+  // Filter unknown names; preserve input order.
+  const known = new Set(memberNames);
+  const filtered = selectedRaw.filter(n => known.has(n));
+  if (filtered.length === 0) return allFallback('selection empty after filtering unknowns');
+
+  // Reorder to match input order so callers' carry-chain semantics are preserved.
+  const indexOf = new Map(memberNames.map((n, i) => [n, i]));
+  const ordered = Array.from(new Set(filtered)).sort(
+    (a, b) => (indexOf.get(a) ?? 0) - (indexOf.get(b) ?? 0),
+  );
+
+  const reason = typeof obj.reason === 'string' ? obj.reason.trim() : '';
+  return { selected: ordered, reason, fallback: false };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,5 @@ export * from './agents';
 export * from './errors';
 export * from './planner';
 export * from './context';
+export * from './dispatcher';
+export * from './dispatcher-personality';

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -32,7 +32,8 @@ export interface ChatMessage {
 export type ChatSelection =
   | { type: 'none' }
   | { type: 'worker'; name: string }
-  | { type: 'team' };
+  /** `name` identifies which team to run. Optional only for backward compat with chats persisted before per-team selection landed; the UI always sets it. */
+  | { type: 'team'; name?: string };
 
 export interface Chat {
   id: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -215,6 +215,13 @@ export interface GatewayConfig {
   planner?: PlannerSettings;
   context?: ContextSettings;
   memory?: MemorySettings;
+  /** Optional auto-dispatcher settings used when a team has dispatch: 'auto'. */
+  dispatcher?: {
+    /** Coding agent to use for the dispatch decision. Defaults to gateway default. */
+    agent?: CodingAgent;
+    /** Model name (must exist in the global model catalog). Defaults to default agent's default model. */
+    model?: string;
+  };
 }
 
 export * from './chat';

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -11,6 +11,13 @@ export interface WorkerConfig {
   codingAgent: 'claude-code' | 'opencode' | 'codex';
   model: string;
   tools: string[];
+  /**
+   * Optional one-line summary fed to the auto-dispatcher when this worker
+   * appears in a team with `dispatch: 'auto'`. When unset, the dispatcher
+   * uses the first line of `personality.role` truncated to 120 chars.
+   * `personality.soul` and `.instructions` are never sent to the dispatcher.
+   */
+  dispatchHint?: string;
 }
 
 export interface Worker {

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -172,6 +172,22 @@ export class WorkerManager {
     return this.getWorker(name)?.config.model || '';
   }
 
+  /**
+   * Returns the one-line summary the auto-dispatcher should see for this worker.
+   * Prefers `config.dispatchHint`; otherwise falls back to the first line of
+   * `personality.role` truncated to 120 characters. Empty string if the worker
+   * is unknown.
+   */
+  getDispatchHint(name: string): string {
+    const w = this.getWorker(name);
+    if (!w) return '';
+    if (w.config.dispatchHint && w.config.dispatchHint.trim()) {
+      return w.config.dispatchHint.trim();
+    }
+    const firstLine = (w.personality.role || '').split('\n')[0].trim();
+    return firstLine.length > 120 ? firstLine.slice(0, 117) + '...' : firstLine;
+  }
+
   buildWorkerPrompt(name: string, task: string): string {
     const worker = this.getWorker(name);
     if (!worker) return task;

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -32,7 +32,7 @@ export class WorkspaceManager {
   private config: WorkspaceJson | null = null;
   private workerManager: WorkerManager;
   private memoryStore: MemoryStore;
-  private teams: Map<string, string[]> = new Map();
+  private teams: Map<string, TeamConfig> = new Map();
   private logger: CoreLogger;
 
   constructor(workerManager: WorkerManager, workspacesDir: string = './workspaces', logger?: CoreLogger) {
@@ -86,20 +86,13 @@ export class WorkspaceManager {
       this.logger.info(`[Workspace] No config found for ${this.currentWorkspace}, using defaults`);
     }
 
-    // Parse + validate teams against the global worker library.
+    // Parse + validate teams against the global worker library. Accept legacy
+    // string[] form (= dispatch:'all') and the object form { members, dispatch }.
     this.teams.clear();
     const rawTeams = this.config?.teams || {};
-    for (const [teamName, members] of Object.entries(rawTeams)) {
-      if (!Array.isArray(members)) {
-        this.logger.error(`[Workspace] Team "${teamName}" is not an array — skipping`);
-        continue;
-      }
-      const unknown = members.filter(m => !this.workerManager.hasWorker(m));
-      if (unknown.length > 0) {
-        this.logger.error(`[Workspace] Team "${teamName}" references unknown workers: ${unknown.join(', ')} — skipping`);
-        continue;
-      }
-      this.teams.set(teamName.toLowerCase(), members);
+    for (const [teamName, raw] of Object.entries(rawTeams)) {
+      const normalized = this.normalizeTeam(teamName, raw);
+      if (normalized) this.teams.set(teamName.toLowerCase(), normalized);
     }
 
     if (!fs.existsSync(this.getMemoryPath())) {
@@ -111,6 +104,31 @@ export class WorkspaceManager {
 
     this.memoryStore = new MemoryStore(workspacePath);
     await this.memoryStore.load();
+  }
+
+  private normalizeTeam(name: string, raw: TeamConfigRaw): TeamConfig | null {
+    let members: string[];
+    let dispatch: TeamDispatchMode = 'all';
+
+    if (Array.isArray(raw)) {
+      members = raw;
+    } else if (raw && typeof raw === 'object' && Array.isArray(raw.members)) {
+      members = raw.members;
+      if (raw.dispatch === 'auto' || raw.dispatch === 'all') dispatch = raw.dispatch;
+      else if (raw.dispatch !== undefined) {
+        this.logger.warn(`[Workspace] Team "${name}" has invalid dispatch="${raw.dispatch}" — defaulting to "all"`);
+      }
+    } else {
+      this.logger.error(`[Workspace] Team "${name}" has invalid shape — skipping`);
+      return null;
+    }
+
+    const unknown = members.filter(m => !this.workerManager.hasWorker(m));
+    if (unknown.length > 0) {
+      this.logger.error(`[Workspace] Team "${name}" references unknown workers: ${unknown.join(', ')} — skipping`);
+      return null;
+    }
+    return { members, dispatch };
   }
 
   async switchWorkspace(workspaceId: string): Promise<boolean> {
@@ -209,7 +227,7 @@ export class WorkspaceManager {
     });
   }
 
-  getTeam(name: string): string[] | undefined {
+  getTeam(name: string): TeamConfig | undefined {
     return this.teams.get(name.toLowerCase());
   }
 
@@ -220,14 +238,18 @@ export class WorkspaceManager {
   listTeams(): string {
     if (this.teams.size === 0) return 'No teams declared for this workspace.';
     return Array.from(this.teams.entries())
-      .map(([name, members]) => `• **${name}** → ${members.join(' → ')}`)
+      .map(([name, t]) => {
+        const mode = t.dispatch === 'auto' ? ' [auto]' : '';
+        return `• **${name}**${mode} → ${t.members.join(' → ')}`;
+      })
       .join('\n');
   }
 
-  async setTeams(teams: Record<string, string[]>): Promise<void> {
+  async setTeams(teams: Record<string, TeamConfigRaw>): Promise<void> {
     this.teams.clear();
-    for (const [name, members] of Object.entries(teams)) {
-      this.teams.set(name, members);
+    for (const [name, raw] of Object.entries(teams)) {
+      const normalized = this.normalizeTeam(name, raw);
+      if (normalized) this.teams.set(name.toLowerCase(), normalized);
     }
     const configPath = this.getConfigPath();
     const existing = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
@@ -235,10 +257,11 @@ export class WorkspaceManager {
     await fs.promises.writeFile(configPath, JSON.stringify(existing, null, 2), 'utf-8');
   }
 
-  getTeams(): Record<string, string[]> {
-    const result: Record<string, string[]> = {};
-    for (const [name, members] of this.teams.entries()) {
-      result[name] = members;
+  /** Returns team configs in their most compact form: legacy string[] when default dispatch, object form otherwise. */
+  getTeams(): Record<string, TeamConfigRaw> {
+    const result: Record<string, TeamConfigRaw> = {};
+    for (const [name, t] of this.teams.entries()) {
+      result[name] = t.dispatch === 'all' ? t.members : { members: t.members, dispatch: t.dispatch };
     }
     return result;
   }

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -10,9 +10,20 @@ const defaultLogger: CoreLogger = {
   error: (msg: string) => console.error(msg),
 };
 
+export type TeamDispatchMode = 'all' | 'auto';
+
+/** Raw team value as it can appear in workspace.json. */
+export type TeamConfigRaw = string[] | { members: string[]; dispatch?: TeamDispatchMode };
+
+/** Normalized team value used at runtime. */
+export interface TeamConfig {
+  members: string[];
+  dispatch: TeamDispatchMode;
+}
+
 export interface WorkspaceJson {
   workingDir: string;
-  teams?: Record<string, string[]>;
+  teams?: Record<string, TeamConfigRaw>;
 }
 
 export class WorkspaceManager {

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -253,7 +253,7 @@ export class WorkspaceManager {
     }
     const configPath = this.getConfigPath();
     const existing = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
-    existing.teams = teams;
+    existing.teams = this.getTeams();
     await fs.promises.writeFile(configPath, JSON.stringify(existing, null, 2), 'utf-8');
   }
 

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -62,7 +62,7 @@ export function buildChatPrompt(
 export function assistantPrefixForSelection(chat: Chat): string {
   switch (chat.selection.type) {
     case 'worker': return `[worker:${chat.selection.name}]\n`;
-    case 'team': return `[team]\n`;
+    case 'team': return `[team:${chat.selection.name ?? '(unset)'}]\n`;
     default: return '';
   }
 }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -38,6 +38,11 @@ export interface GatewayConfigJson {
     logLevel: 'debug' | 'info' | 'warn' | 'error';
     logFile?: string;
   };
+  /** See GatewayConfig.dispatcher in @codey/core types. Optional. */
+  dispatcher?: {
+    agent?: CodingAgent;
+    model?: string;
+  };
 }
 
 /** Reserved for future per-agent settings. Currently empty. */

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -90,6 +90,7 @@ export class ConfigManager extends EventEmitter {
     if (partial.dev) Object.assign(this.config.dev, partial.dev);
     if (partial.models !== undefined) this.config.models = partial.models;
     if (partial.fallback !== undefined) this.config.fallback = partial.fallback;
+    if (partial.dispatcher !== undefined) this.config.dispatcher = partial.dispatcher;
     this.save();
   }
 
@@ -354,7 +355,7 @@ function getDefaultConfig(): GatewayConfigJson {
 /** Fill in any missing top-level fields with defaults so downstream code can assume shape. */
 function normalize(raw: Partial<GatewayConfigJson>): GatewayConfigJson {
   const defaults = getDefaultConfig();
-  return {
+  const out: GatewayConfigJson = {
     gateway: { ...defaults.gateway, ...(raw.gateway ?? {}) },
     channels: raw.channels ?? defaults.channels,
     agents: { ...defaults.agents, ...(raw.agents ?? {}) },
@@ -362,4 +363,11 @@ function normalize(raw: Partial<GatewayConfigJson>): GatewayConfigJson {
     fallback: normalizeFallback(raw.fallback, defaults.fallback),
     dev: raw.dev ?? defaults.dev,
   };
+  if (raw.dispatcher && typeof raw.dispatcher === 'object') {
+    out.dispatcher = {
+      agent: raw.dispatcher.agent,
+      model: raw.dispatcher.model,
+    };
+  }
+  return out;
 }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1371,6 +1371,8 @@ Example: /model gpt-4.1 write a Python script`;
       header =
         `⚠️ Auto-dispatch failed (${dispatchInfo.fallbackReason ?? 'unknown'}), running all members.\n` +
         `👥 Running team **${teamName}** (${runMembers.join(' → ')})`;
+    } else if (dispatch === 'auto' && opts.forceAll) {
+      header = `👥 Running team **${teamName}** (${runMembers.join(' → ')}) [--all override]`;
     } else {
       header = `👥 Running team **${teamName}** (${runMembers.join(' → ')})`;
     }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1993,7 +1993,11 @@ Example: /model gpt-4.1 write a Python script`;
         // active workspace differs from the chat's).
         const teamNames = Object.keys(chatWorkspaceTeams);
         if (teamNames.length === 0) throw new Error(`No teams configured in workspace "${chat.workspaceName}"`);
-        const teamName = teamNames[0];
+        // Prefer the team named on the selection. Falling through to teamNames[0]
+        // keeps legacy chats (persisted before per-team selection) working.
+        const teamName = chat.selection.name && teamNames.includes(chat.selection.name)
+          ? chat.selection.name
+          : teamNames[0];
         const rawTeam = chatWorkspaceTeams[teamName];
         const rawMembers: string[] = Array.isArray(rawTeam) ? rawTeam : (rawTeam?.members ?? []);
         if (!rawMembers || rawMembers.length === 0) throw new Error(`Team "${teamName}" is empty`);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -9,7 +9,7 @@ import { Logger } from './logger';
 import { ContextManager, ContextWindow } from '@codey/core';
 import { MemoryStore } from '@codey/core';
 import { TaskPlanner, TaskPlan, PlanStep } from '@codey/core';
-import { WorkspaceManager } from '@codey/core';
+import { WorkspaceManager, TeamConfigRaw } from '@codey/core';
 import { WorkerManager } from '@codey/core';
 import { ChatManager } from './chats';
 import { buildChatPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink } from './chat-runner';
@@ -1327,13 +1327,13 @@ Example: /model gpt-4.1 write a Python script`;
     await this.sendResponse({
       chatId,
       channel,
-      text: `👥 Running team **${teamName}** (${members.join(' → ')})\nTask: ${task.substring(0, 100)}${task.length > 100 ? '...' : ''}`,
+      text: `👥 Running team **${teamName}** (${members.members.join(' → ')})\nTask: ${task.substring(0, 100)}${task.length > 100 ? '...' : ''}`,
     });
 
     let currentTask = task;
     const results: string[] = [];
 
-    for (const memberName of members) {
+    for (const memberName of members.members) {
       const worker = workerManager.getWorker(memberName);
       if (!worker) {
         results.push(`**${memberName}**: ❌ not found in global library`);
@@ -1842,7 +1842,7 @@ Example: /model gpt-4.1 write a Python script`;
     const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
     const wsConfigPath = path.join(workspacesRoot, chat.workspaceName, 'workspace.json');
     let workingDir = this.workingDir;
-    let chatWorkspaceTeams: Record<string, string[]> = {};
+    let chatWorkspaceTeams: Record<string, TeamConfigRaw> = {};
     if (fs.existsSync(wsConfigPath)) {
       try {
         const wsConfig = JSON.parse(fs.readFileSync(wsConfigPath, 'utf-8'));
@@ -1919,7 +1919,8 @@ Example: /model gpt-4.1 write a Python script`;
         const teamNames = Object.keys(chatWorkspaceTeams);
         if (teamNames.length === 0) throw new Error(`No teams configured in workspace "${chat.workspaceName}"`);
         const teamName = teamNames[0];
-        const members = chatWorkspaceTeams[teamName];
+        const rawTeam = chatWorkspaceTeams[teamName];
+        const members: string[] = Array.isArray(rawTeam) ? rawTeam : (rawTeam?.members ?? []);
         if (!members || members.length === 0) throw new Error(`Team "${teamName}" is empty`);
         const r = await this.runTeamForChat(teamName, members, prompt, workingDir, sink, chatId, abortController.signal);
         output = r.response;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry } from '@codey/core';
+import { AgentRequest, AgentResponse, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runDispatcher, DispatchResult } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -60,7 +60,7 @@ export class Codey {
   // Pre-compiled regex patterns for parseCommand
   private static readonly REGEX_COMMAND = /^\/(\w+)(?:\s+(.*))?$/;
   private static readonly REGEX_WORKER = /\/worker\s+(\w+)\s+(.+)/i;
-  private static readonly REGEX_TEAM = /\/team\s+(\w+)\s+(.+)/i;
+  private static readonly REGEX_TEAM = /\/team\s+(\w+)(?:\s+(--all))?\s+(?!--all\s*$)(.+)/i;
   private static readonly REGEX_AGENT_PROMPT = /\/agent\s+(claude-code|opencode|codex)\s+(.+)/i;
   private static readonly REGEX_AGENT = /\/agent\s+(claude-code|opencode|codex)/i;
   private static readonly REGEX_MODEL_PROMPT = /\/model\s+(\S+)(?:\s+(.+))?/i;
@@ -108,6 +108,18 @@ export class Codey {
     if (!modelName) return undefined;
     return this.getModelConfig(agent, modelName);
   }
+
+  private getDispatcherAgentAndModel(): { agent: CodingAgent; model?: ModelConfig } {
+    const cfg = this.config.dispatcher;
+    const agent = (cfg?.agent as CodingAgent | undefined) ?? this.getDefaultAgent();
+    const modelName = cfg?.model;
+    const model = modelName ? this.getModelConfig(agent, modelName) : this.getDefaultModelConfig(agent);
+    return { agent, model };
+  }
+
+  private dispatcherRunner = (req: AgentRequest): Promise<AgentResponse> => {
+    return this.runWithFallback(req.agent, req);
+  };
 
   private conversationCleanupInterval?: NodeJS.Timeout;
 
@@ -740,9 +752,13 @@ export class Codey {
       case 'worker':
         await this.cmdWorker(args, message, parsed.prompt);
         break;
-      case 'team':
-        await this.runTeamTask(message, args[0] || '', args.slice(1).join(' ') || parsed.prompt);
+      case 'team': {
+        const teamName = args[0] || '';
+        const forceAll = args.includes('--all');
+        const taskArgs = args.slice(1).filter(a => a !== '--all').join(' ');
+        await this.runTeamTask(message, teamName, taskArgs || parsed.prompt, { forceAll });
         break;
+      }
       case 'teams':
         await this.cmdTeams(chatId, channel);
         break;
@@ -795,7 +811,7 @@ export class Codey {
         `- Send any message to get coding help from the active agent`,
         `- /worker <name> <task> — run a specific worker`,
         `- /teams — list teams for this workspace`,
-        `- /team <name> <task> — run a named team in sequence`,
+        `- /team <name> [--all] <task> — run a named team. Use --all to bypass auto-dispatch when team mode is "auto".`,
         `- /parallel <prompt> — run all agents in parallel`,
         `- /agent <name> — switch agent (${agents})`,
         `- /workspace <name> — switch workspace`,
@@ -1139,7 +1155,7 @@ export class Codey {
 /workers - List all workers in the global library
 /worker <name> <task> - Run a specific worker
 /teams - List teams declared on this workspace
-/team <name> <task> - Run a named team in sequence
+/team <name> [--all] <task> - Run a team. Use --all to bypass auto-dispatch when team mode is "auto".
 
 \ud83e\udd16 Agents (legacy)
 /parallel <prompt> - Run all agents in parallel
@@ -1298,7 +1314,12 @@ Example: /model gpt-4.1 write a Python script`;
     });
   }
 
-  private async runTeamTask(message: UserMessage, teamName: string, task: string): Promise<void> {
+  private async runTeamTask(
+    message: UserMessage,
+    teamName: string,
+    task: string,
+    opts: { forceAll?: boolean } = {},
+  ): Promise<void> {
     const { chatId, channel } = message;
 
     if (!teamName || !task.trim()) {
@@ -1306,13 +1327,13 @@ Example: /model gpt-4.1 write a Python script`;
       await this.sendResponse({
         chatId,
         channel,
-        text: `Usage: /team <name> <task>\n\nTeams on this workspace:\n${teamList}`,
+        text: `Usage: /team <name> [--all] <task>\n\nTeams on this workspace:\n${teamList}`,
       });
       return;
     }
 
-    const members = this.workspaceManager.getTeam(teamName);
-    if (!members) {
+    const team = this.workspaceManager.getTeam(teamName);
+    if (!team) {
       const teamList = this.workspaceManager.listTeams();
       await this.sendResponse({
         chatId,
@@ -1323,17 +1344,46 @@ Example: /model gpt-4.1 write a Python script`;
     }
 
     const workerManager = this.workspaceManager.getWorkerManager();
+    const { members, dispatch } = team;
+    let runMembers = members;
+    let dispatchInfo: DispatchResult | null = null;
 
+    if (dispatch === 'auto' && !opts.forceAll) {
+      const { agent: dAgent, model: dModel } = this.getDispatcherAgentAndModel();
+      dispatchInfo = await runDispatcher(
+        {
+          task,
+          members: members.map(name => ({ name, hint: workerManager.getDispatchHint(name) })),
+        },
+        { agent: dAgent, model: dModel, runner: this.dispatcherRunner },
+      );
+      if (!dispatchInfo.fallback) runMembers = dispatchInfo.selected;
+    }
+
+    let header: string;
+    if (dispatch === 'auto' && dispatchInfo && !dispatchInfo.fallback) {
+      const skipped = members.filter(m => !runMembers.includes(m));
+      header =
+        `🧭 Dispatched **${teamName}**: ${runMembers.join(' → ')}` +
+        (skipped.length ? ` (skipped: ${skipped.join(', ')})` : '') +
+        (dispatchInfo.reason ? `\nReason: ${dispatchInfo.reason}` : '');
+    } else if (dispatch === 'auto' && dispatchInfo && dispatchInfo.fallback) {
+      header =
+        `⚠️ Auto-dispatch failed (${dispatchInfo.fallbackReason ?? 'unknown'}), running all members.\n` +
+        `👥 Running team **${teamName}** (${runMembers.join(' → ')})`;
+    } else {
+      header = `👥 Running team **${teamName}** (${runMembers.join(' → ')})`;
+    }
     await this.sendResponse({
       chatId,
       channel,
-      text: `👥 Running team **${teamName}** (${members.members.join(' → ')})\nTask: ${task.substring(0, 100)}${task.length > 100 ? '...' : ''}`,
+      text: `${header}\nTask: ${task.substring(0, 100)}${task.length > 100 ? '...' : ''}`,
     });
 
     let currentTask = task;
     const results: string[] = [];
 
-    for (const memberName of members.members) {
+    for (const memberName of runMembers) {
       const worker = workerManager.getWorker(memberName);
       if (!worker) {
         results.push(`**${memberName}**: ❌ not found in global library`);
@@ -1381,23 +1431,45 @@ Example: /model gpt-4.1 write a Python script`;
 
   private async runTeamForChat(
     teamName: string,
-    members: string[],
+    team: { members: string[]; dispatch: 'all' | 'auto' },
     prompt: string,
     workingDir: string,
     sink: ChatStreamSink,
     chatId: string,
     signal?: AbortSignal,
+    opts: { forceAll?: boolean } = {},
   ): Promise<{ response: string; tokens?: number }> {
-    if (!members || members.length === 0) {
+    if (!team || !team.members || team.members.length === 0) {
       throw new Error(`Team not found or empty: ${teamName}`);
     }
     const workerManager = this.workspaceManager.getWorkerManager();
+
+    let runMembers = team.members;
+    let dispatchInfo: DispatchResult | null = null;
+    if (team.dispatch === 'auto' && !opts.forceAll) {
+      const { agent: dAgent, model: dModel } = this.getDispatcherAgentAndModel();
+      dispatchInfo = await runDispatcher(
+        {
+          task: prompt,
+          members: team.members.map(n => ({ name: n, hint: workerManager.getDispatchHint(n) })),
+        },
+        { agent: dAgent, model: dModel, runner: this.dispatcherRunner, signal },
+      );
+      if (!dispatchInfo.fallback) runMembers = dispatchInfo.selected;
+      if (dispatchInfo.fallback) {
+        sink({ type: 'info', chatId, message: `Auto-dispatch failed (${dispatchInfo.fallbackReason ?? 'unknown'}), running all members` });
+      } else {
+        const skipped = team.members.filter(m => !runMembers.includes(m));
+        sink({ type: 'info', chatId, message: `Dispatched ${runMembers.join(' → ')}` + (skipped.length ? ` (skipped: ${skipped.join(', ')})` : '') });
+      }
+    }
+
     let carry = prompt;
     const parts: string[] = [];
-    for (let i = 0; i < members.length; i++) {
+    for (let i = 0; i < runMembers.length; i++) {
       if (signal?.aborted) break;
-      const memberName = members[i];
-      sink({ type: 'info', chatId, message: `Step ${i + 1}/${members.length}: ${memberName}` });
+      const memberName = runMembers[i];
+      sink({ type: 'info', chatId, message: `Step ${i + 1}/${runMembers.length}: ${memberName}` });
       const stepPrompt = workerManager.buildWorkerPrompt(memberName, carry);
       const codingAgent = (workerManager.getWorkerCodingAgent(memberName) ?? this.getDefaultAgent()) as CodingAgent;
       const workerModel = workerManager.getWorkerModel(memberName);
@@ -1447,14 +1519,15 @@ Example: /model gpt-4.1 write a Python script`;
       }
       
       // Check for team command
-      const teamMatch = text.match(/\/team\s+(\w+)\s+(.+)/i);
+      const teamMatch = text.match(Codey.REGEX_TEAM);
       if (teamMatch) {
+        const forceAll = teamMatch[2] === '--all';
         return {
           command: 'team',
-          args: [teamMatch[1]],
+          args: [teamMatch[1], ...(forceAll ? ['--all'] : [])],
           agent: this.getDefaultAgent() as CodingAgent,
           model: undefined,
-          prompt: teamMatch[2]
+          prompt: teamMatch[3]
         };
       }
 
@@ -1920,9 +1993,16 @@ Example: /model gpt-4.1 write a Python script`;
         if (teamNames.length === 0) throw new Error(`No teams configured in workspace "${chat.workspaceName}"`);
         const teamName = teamNames[0];
         const rawTeam = chatWorkspaceTeams[teamName];
-        const members: string[] = Array.isArray(rawTeam) ? rawTeam : (rawTeam?.members ?? []);
-        if (!members || members.length === 0) throw new Error(`Team "${teamName}" is empty`);
-        const r = await this.runTeamForChat(teamName, members, prompt, workingDir, sink, chatId, abortController.signal);
+        const rawMembers: string[] = Array.isArray(rawTeam) ? rawTeam : (rawTeam?.members ?? []);
+        if (!rawMembers || rawMembers.length === 0) throw new Error(`Team "${teamName}" is empty`);
+        // Prefer the active workspace's normalized team (which carries dispatch mode);
+        // fall back to building a TeamConfig inline from the chat's raw config.
+        const wsTeam = this.workspaceManager.getTeam(teamName);
+        const team = wsTeam ?? {
+          members: rawMembers,
+          dispatch: (Array.isArray(rawTeam) ? 'all' : (rawTeam?.dispatch ?? 'all')) as 'all' | 'auto',
+        };
+        const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, abortController.signal);
         output = r.response;
         tokens = r.tokens;
       } else {

--- a/scripts/test-dispatcher.md
+++ b/scripts/test-dispatcher.md
@@ -1,0 +1,43 @@
+# Auto-Dispatch Manual Test Checklist
+
+Project has no test runner; this is the canonical verification surface for the team auto-dispatch feature.
+
+## Setup
+
+Two workers in `./workers/`:
+- `architect` with `## Role\nDesigns systems`
+- `reviewer` with `## Role\nAudits code`
+
+Workspace `./workspaces/test/workspace.json`:
+
+```json
+{
+  "workingDir": "/tmp/scratch",
+  "teams": {
+    "legacy": ["architect", "reviewer"],
+    "auto":   { "members": ["architect", "reviewer"], "dispatch": "auto" }
+  }
+}
+```
+
+`gateway.json` should have a `dispatcher` block configured (see `gateway.json.example`).
+
+Run `npm run dev`, switch to workspace `test`, then exercise each case below.
+
+## Cases
+
+1. **Legacy format unchanged.** `/team legacy refactor module X` → both workers run, sequential carry chain, no dispatcher invocation. Header: `👥 Running team **legacy** (architect → reviewer)`.
+
+2. **`dispatch: 'all'` explicit.** Edit team to `{ "members": [...], "dispatch": "all" }`, repeat command, same behavior as 1.
+
+3. **`dispatch: 'auto'` happy path.** `/team auto fix typo in README` → header is `🧭 Dispatched **auto**: <selected> (skipped: <others>)\nReason: <one line>`. Exact selection depends on the dispatcher model.
+
+4. **Auto fallback on bad model.** Set `gateway.json` `dispatcher.model` to a non-existent name. Repeat command. Header is `⚠️ Auto-dispatch failed (...), running all members.\n👥 Running team **auto** (architect → reviewer)`.
+
+5. **`--all` flag overrides.** With dispatch:'auto' team, run `/team auto --all do task` → no dispatcher invoked, full team runs. Header includes the `[--all override]` suffix.
+
+6. **`--all` requires task.** `/team auto --all` (no task) → usage hint, no execution.
+
+7. **Unknown name filter.** Configure dispatcher to a model that the workspace doesn't actually run (or temporarily monkey-patch a stub) returning `{"selected":["ghost"], "reason":""}`. Confirm header says `⚠️ Auto-dispatch failed (selection empty after filtering unknowns), running all members.`.
+
+Each case should produce an obviously visible header difference and a sane `📊 Team results` summary.

--- a/scripts/verify/dispatcher-parse.ts
+++ b/scripts/verify/dispatcher-parse.ts
@@ -1,0 +1,71 @@
+import * as assert from 'assert';
+import { AgentRequest, AgentResponse } from '../../packages/core/src/types';
+import { runDispatcher, extractJsonObject, buildDispatcherPrompt } from '../../packages/core/src/dispatcher';
+
+function makeRunner(output: string, success = true): (r: AgentRequest) => Promise<AgentResponse> {
+  return async () => ({ success, output, error: success ? undefined : output });
+}
+
+async function main() {
+  const members = [
+    { name: 'architect', hint: 'designs systems' },
+    { name: 'frontend',  hint: 'builds UI' },
+    { name: 'reviewer',  hint: 'audits code' },
+  ];
+
+  // 1. Happy path: pure JSON
+  let r = await runDispatcher({ task: 't', members },
+    { agent: 'claude-code', runner: makeRunner('{"selected":["frontend","reviewer"],"reason":"UI change"}') });
+  assert.deepStrictEqual(r.selected, ['frontend', 'reviewer']);
+  assert.strictEqual(r.fallback, false);
+  assert.strictEqual(r.reason, 'UI change');
+
+  // 2. Reorder to input order
+  r = await runDispatcher({ task: 't', members },
+    { agent: 'claude-code', runner: makeRunner('{"selected":["reviewer","architect"],"reason":""}') });
+  assert.deepStrictEqual(r.selected, ['architect', 'reviewer'], 'reorder to input order');
+
+  // 3. Markdown-wrapped JSON
+  r = await runDispatcher({ task: 't', members },
+    { agent: 'claude-code', runner: makeRunner('Sure, here:\n```json\n{"selected":["architect"],"reason":"x"}\n```\n') });
+  assert.deepStrictEqual(r.selected, ['architect']);
+  assert.strictEqual(r.fallback, false);
+
+  // 4. Filter unknown names
+  r = await runDispatcher({ task: 't', members },
+    { agent: 'claude-code', runner: makeRunner('{"selected":["frontend","ghost"],"reason":""}') });
+  assert.deepStrictEqual(r.selected, ['frontend']);
+  assert.strictEqual(r.fallback, false);
+
+  // 5. Empty selection → fallback (all members)
+  r = await runDispatcher({ task: 't', members },
+    { agent: 'claude-code', runner: makeRunner('{"selected":[],"reason":""}') });
+  assert.strictEqual(r.fallback, true);
+  assert.deepStrictEqual(r.selected, ['architect', 'frontend', 'reviewer']);
+
+  // 6. Non-JSON → fallback
+  r = await runDispatcher({ task: 't', members },
+    { agent: 'claude-code', runner: makeRunner('I cannot do that') });
+  assert.strictEqual(r.fallback, true);
+
+  // 7. Runner non-success → fallback
+  r = await runDispatcher({ task: 't', members },
+    { agent: 'claude-code', runner: makeRunner('boom', false) });
+  assert.strictEqual(r.fallback, true);
+
+  // 8. extractJsonObject edge cases
+  assert.deepStrictEqual(extractJsonObject('{"a":1}'), { a: 1 });
+  assert.deepStrictEqual(extractJsonObject('noise {"a":{"b":2}} more'), { a: { b: 2 } });
+  assert.strictEqual(extractJsonObject(''), null);
+  assert.strictEqual(extractJsonObject('no braces here'), null);
+  assert.strictEqual(extractJsonObject('{ broken'), null);
+
+  // 9. Prompt builder includes role + member lines
+  const prompt = buildDispatcherPrompt({ task: 'do thing', members });
+  assert.ok(prompt.includes('Task router'));
+  assert.ok(prompt.includes('do thing'));
+  assert.ok(prompt.includes('- architect: designs systems'));
+
+  console.log('OK dispatcher-parse');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/verify/gateway-team-regex.ts
+++ b/scripts/verify/gateway-team-regex.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert';
+
+const RE = /\/team\s+(\w+)(?:\s+(--all))?\s+(?!--all\s*$)(.+)/i;
+
+function parse(text: string) {
+  const m = text.match(RE);
+  if (!m) return null;
+  return { name: m[1], forceAll: m[2] === '--all', task: m[3] };
+}
+
+assert.deepStrictEqual(parse('/team review do thing'),
+  { name: 'review', forceAll: false, task: 'do thing' });
+assert.deepStrictEqual(parse('/team review --all do thing'),
+  { name: 'review', forceAll: true, task: 'do thing' });
+assert.deepStrictEqual(parse('/team review --all   multi word task'),
+  { name: 'review', forceAll: true, task: 'multi word task' });
+assert.strictEqual(parse('/team'), null);
+assert.deepStrictEqual(parse('/team review --all'), null,
+  'cannot match without task');
+
+console.log('OK gateway-team-regex');

--- a/scripts/verify/workers-dispatch-hint.ts
+++ b/scripts/verify/workers-dispatch-hint.ts
@@ -6,37 +6,53 @@ import { WorkerManager } from '../../packages/core/src/workers';
 
 async function main() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-verify-'));
-  const wDir = path.join(tmp, 'workers');
-  fs.mkdirSync(path.join(wDir, 'with-hint'), { recursive: true });
-  fs.mkdirSync(path.join(wDir, 'no-hint'), { recursive: true });
-  fs.mkdirSync(path.join(wDir, 'long-role'), { recursive: true });
+  try {
+    const wDir = path.join(tmp, 'workers');
+    for (const n of ['with-hint', 'no-hint', 'long-role', 'whitespace-hint', 'empty-hint']) {
+      fs.mkdirSync(path.join(wDir, n), { recursive: true });
+    }
 
-  fs.writeFileSync(path.join(wDir, 'with-hint', 'personality.md'),
-    '# with-hint\n\n## Role\nIgnored when hint present\n\n## Soul\nx\n\n## Instructions\ny\n');
-  fs.writeFileSync(path.join(wDir, 'with-hint', 'config.json'),
-    JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [], dispatchHint: '  Reviews PRs  ' }));
+    fs.writeFileSync(path.join(wDir, 'with-hint', 'personality.md'),
+      '# with-hint\n\n## Role\nIgnored when hint present\n\n## Soul\nx\n\n## Instructions\ny\n');
+    fs.writeFileSync(path.join(wDir, 'with-hint', 'config.json'),
+      JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [], dispatchHint: '  Reviews PRs  ' }));
 
-  fs.writeFileSync(path.join(wDir, 'no-hint', 'personality.md'),
-    '# no-hint\n\n## Role\nDesigns systems\nMore detail on next line\n\n## Soul\nx\n');
-  fs.writeFileSync(path.join(wDir, 'no-hint', 'config.json'),
-    JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
+    fs.writeFileSync(path.join(wDir, 'no-hint', 'personality.md'),
+      '# no-hint\n\n## Role\nDesigns systems\nMore detail on next line\n\n## Soul\nx\n');
+    fs.writeFileSync(path.join(wDir, 'no-hint', 'config.json'),
+      JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
 
-  const longRole = 'A'.repeat(200);
-  fs.writeFileSync(path.join(wDir, 'long-role', 'personality.md'),
-    `# long-role\n\n## Role\n${longRole}\n`);
-  fs.writeFileSync(path.join(wDir, 'long-role', 'config.json'),
-    JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
+    const longRole = 'A'.repeat(200);
+    fs.writeFileSync(path.join(wDir, 'long-role', 'personality.md'),
+      `# long-role\n\n## Role\n${longRole}\n`);
+    fs.writeFileSync(path.join(wDir, 'long-role', 'config.json'),
+      JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
 
-  const wm = new WorkerManager(wDir);
-  await wm.loadWorkers();
+    fs.writeFileSync(path.join(wDir, 'whitespace-hint', 'personality.md'),
+      '# whitespace-hint\n\n## Role\nFallback used\n');
+    fs.writeFileSync(path.join(wDir, 'whitespace-hint', 'config.json'),
+      JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [], dispatchHint: '   ' }));
 
-  assert.strictEqual(wm.getDispatchHint('with-hint'), 'Reviews PRs', 'trims and uses dispatchHint');
-  assert.strictEqual(wm.getDispatchHint('no-hint'), 'Designs systems', 'falls back to role first line');
-  const long = wm.getDispatchHint('long-role');
-  assert.strictEqual(long.length, 120, 'truncates long role to 120 chars');
-  assert.ok(long.endsWith('...'), 'truncated value ends with ellipsis');
-  assert.strictEqual(wm.getDispatchHint('missing'), '', 'unknown worker returns empty string');
+    fs.writeFileSync(path.join(wDir, 'empty-hint', 'personality.md'),
+      '# empty-hint\n\n## Role\nFallback used\n');
+    fs.writeFileSync(path.join(wDir, 'empty-hint', 'config.json'),
+      JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [], dispatchHint: '' }));
 
-  console.log('OK workers-dispatch-hint');
+    const wm = new WorkerManager(wDir);
+    await wm.loadWorkers();
+
+    assert.strictEqual(wm.getDispatchHint('with-hint'), 'Reviews PRs', 'trims and uses dispatchHint');
+    assert.strictEqual(wm.getDispatchHint('no-hint'), 'Designs systems', 'falls back to role first line');
+    const long = wm.getDispatchHint('long-role');
+    assert.strictEqual(long.length, 120, 'truncates long role to 120 chars');
+    assert.ok(long.endsWith('...'), 'truncated value ends with ellipsis');
+    assert.strictEqual(wm.getDispatchHint('missing'), '', 'unknown worker returns empty string');
+    assert.strictEqual(wm.getDispatchHint('whitespace-hint'), 'Fallback used', 'whitespace-only hint falls through to role');
+    assert.strictEqual(wm.getDispatchHint('empty-hint'), 'Fallback used', 'empty-string hint falls through to role');
+
+    console.log('OK workers-dispatch-hint');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 }
 main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/verify/workers-dispatch-hint.ts
+++ b/scripts/verify/workers-dispatch-hint.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as assert from 'assert';
+import { WorkerManager } from '../../packages/core/src/workers';
+
+async function main() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-verify-'));
+  const wDir = path.join(tmp, 'workers');
+  fs.mkdirSync(path.join(wDir, 'with-hint'), { recursive: true });
+  fs.mkdirSync(path.join(wDir, 'no-hint'), { recursive: true });
+  fs.mkdirSync(path.join(wDir, 'long-role'), { recursive: true });
+
+  fs.writeFileSync(path.join(wDir, 'with-hint', 'personality.md'),
+    '# with-hint\n\n## Role\nIgnored when hint present\n\n## Soul\nx\n\n## Instructions\ny\n');
+  fs.writeFileSync(path.join(wDir, 'with-hint', 'config.json'),
+    JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [], dispatchHint: '  Reviews PRs  ' }));
+
+  fs.writeFileSync(path.join(wDir, 'no-hint', 'personality.md'),
+    '# no-hint\n\n## Role\nDesigns systems\nMore detail on next line\n\n## Soul\nx\n');
+  fs.writeFileSync(path.join(wDir, 'no-hint', 'config.json'),
+    JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
+
+  const longRole = 'A'.repeat(200);
+  fs.writeFileSync(path.join(wDir, 'long-role', 'personality.md'),
+    `# long-role\n\n## Role\n${longRole}\n`);
+  fs.writeFileSync(path.join(wDir, 'long-role', 'config.json'),
+    JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
+
+  const wm = new WorkerManager(wDir);
+  await wm.loadWorkers();
+
+  assert.strictEqual(wm.getDispatchHint('with-hint'), 'Reviews PRs', 'trims and uses dispatchHint');
+  assert.strictEqual(wm.getDispatchHint('no-hint'), 'Designs systems', 'falls back to role first line');
+  const long = wm.getDispatchHint('long-role');
+  assert.strictEqual(long.length, 120, 'truncates long role to 120 chars');
+  assert.ok(long.endsWith('...'), 'truncated value ends with ellipsis');
+  assert.strictEqual(wm.getDispatchHint('missing'), '', 'unknown worker returns empty string');
+
+  console.log('OK workers-dispatch-hint');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/verify/workspace-team-normalize.ts
+++ b/scripts/verify/workspace-team-normalize.ts
@@ -26,6 +26,7 @@ async function main() {
         modern: { members: ['a'], dispatch: 'auto' },
         explicit_all: { members: ['a', 'b'], dispatch: 'all' },
         bad_dispatch: { members: ['a'], dispatch: 'parallel' },
+        unknown_team: ['a', 'ghost'],
       },
     }));
 
@@ -38,6 +39,7 @@ async function main() {
     assert.deepStrictEqual(ws.getTeam('modern'), { members: ['a'], dispatch: 'auto' }, 'modern preserved');
     assert.deepStrictEqual(ws.getTeam('explicit_all'), { members: ['a', 'b'], dispatch: 'all' }, 'explicit all');
     assert.deepStrictEqual(ws.getTeam('bad_dispatch'), { members: ['a'], dispatch: 'all' }, 'invalid dispatch falls back to all');
+    assert.strictEqual(ws.getTeam('unknown_team'), undefined, 'team with unknown worker is dropped');
 
     const list = ws.listTeams();
     assert.ok(list.includes('**modern** [auto]'), 'list shows [auto] tag');

--- a/scripts/verify/workspace-team-normalize.ts
+++ b/scripts/verify/workspace-team-normalize.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as assert from 'assert';
+import { WorkerManager } from '../../packages/core/src/workers';
+import { WorkspaceManager } from '../../packages/core/src/workspace';
+
+async function main() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-verify-'));
+  try {
+    const workersDir = path.join(tmp, 'workers');
+    const workspacesDir = path.join(tmp, 'workspaces');
+    fs.mkdirSync(path.join(workersDir, 'a'), { recursive: true });
+    fs.mkdirSync(path.join(workersDir, 'b'), { recursive: true });
+    for (const n of ['a', 'b']) {
+      fs.writeFileSync(path.join(workersDir, n, 'personality.md'), `# ${n}\n\n## Role\nrole-${n}\n`);
+      fs.writeFileSync(path.join(workersDir, n, 'config.json'),
+        JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
+    }
+
+    fs.mkdirSync(path.join(workspacesDir, 'ws'), { recursive: true });
+    fs.writeFileSync(path.join(workspacesDir, 'ws', 'workspace.json'), JSON.stringify({
+      workingDir: '/tmp',
+      teams: {
+        legacy: ['a', 'b'],
+        modern: { members: ['a'], dispatch: 'auto' },
+        explicit_all: { members: ['a', 'b'], dispatch: 'all' },
+        bad_dispatch: { members: ['a'], dispatch: 'parallel' },
+      },
+    }));
+
+    const wm = new WorkerManager(workersDir);
+    await wm.loadWorkers();
+    const ws = new WorkspaceManager(wm, workspacesDir);
+    await ws.switchWorkspace('ws');
+
+    assert.deepStrictEqual(ws.getTeam('legacy'), { members: ['a', 'b'], dispatch: 'all' }, 'legacy → all');
+    assert.deepStrictEqual(ws.getTeam('modern'), { members: ['a'], dispatch: 'auto' }, 'modern preserved');
+    assert.deepStrictEqual(ws.getTeam('explicit_all'), { members: ['a', 'b'], dispatch: 'all' }, 'explicit all');
+    assert.deepStrictEqual(ws.getTeam('bad_dispatch'), { members: ['a'], dispatch: 'all' }, 'invalid dispatch falls back to all');
+
+    const list = ws.listTeams();
+    assert.ok(list.includes('**modern** [auto]'), 'list shows [auto] tag');
+    assert.ok(list.includes('**legacy** →'), 'list omits tag for default mode');
+
+    console.log('OK workspace-team-normalize');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- Adds opt-in `dispatch: 'auto'` mode to `/team`. A built-in dispatcher (an LLM call) routes each task to the relevant subset of workers; selected workers run sequentially with the existing carry chain.
- New `--all` flag on `/team` bypasses auto-dispatch for one call (e.g. `/team review --all do thing`).
- Backward compatible: legacy `string[]` team configs in `workspace.json` keep their current behavior (`dispatch: 'all'`). Workers can declare an optional `dispatchHint` to improve routing accuracy.
- codey-mac settings panel adds a "Dispatcher (Auto Mode)" section (agent + model dropdowns, persisted to `gateway.json` `dispatcher.{agent, model}`).

## Architecture

- `packages/core/src/dispatcher.ts` — `runDispatcher` with JSON-tolerant output parsing, AbortSignal composition (user signal + 30s timeout), and well-defined fallback (`fallback: true` + `fallbackReason`) for every failure mode (non-success runner, malformed JSON, empty selection, all-unknown selection).
- `packages/core/src/workspace.ts` — `WorkspaceManager` now stores normalized `TeamConfig` (`{ members, dispatch }`) and accepts both `string[]` and object forms in `workspace.json`.
- `packages/gateway/src/gateway.ts` — `runTeamTask` and `runTeamForChat` invoke the dispatcher as a pre-step when `dispatch === 'auto'` and surface three header variants (regular / dispatch success with skipped + reason / fallback warning).

## Test plan

Project has no test runner; verification surface lives under `scripts/verify/` and `scripts/test-dispatcher.md`.

- [x] \`npm run build:core\` clean
- [x] \`npm run build:gateway\` clean
- [x] \`npx tsc --noEmit\` from \`codey-mac/\` clean
- [x] \`scripts/verify/dispatcher-parse.ts\` — 9 cases (happy path, reorder, markdown-wrapped JSON, unknown-name filter, empty selection fallback, non-JSON fallback, runner non-success fallback, JSON extractor edges, prompt builder content)
- [x] \`scripts/verify/workers-dispatch-hint.ts\` — 7 cases including whitespace-only and empty-string hint fallback
- [x] \`scripts/verify/workspace-team-normalize.ts\` — 5 cases including invalid dispatch and unknown-worker rejection
- [x] \`scripts/verify/gateway-team-regex.ts\` — \`/team\` regex with optional \`--all\` flag
- [ ] Manual end-to-end via \`scripts/test-dispatcher.md\` (requires live dispatcher model — not run in CI; please exercise locally before merge)

## Known limitations

- Clearing both dispatcher dropdowns in codey-mac persists \`"dispatcher": {}\` rather than removing the key entirely. Functionally identical to absent (\`?.agent\` / \`?.model\` both \`undefined\`).
- \`runTeamForChat\` accepts an optional \`forceAll\` parameter but no chat-side caller currently passes it — left as a hook for future chat UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)