### PR TITLE
fix: per-chat agent/model override for teams + dispatcher config passthrough

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -185,6 +185,7 @@ function buildRuntimeConfig(json: any): any {
     planner: json?.planner,
     context: json?.context,
     memory: json?.memory,
+    dispatcher: json?.dispatcher,
   }
 }
 

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -160,9 +160,15 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     await setSelection(chat.id, next)
   }
 
-  // Resolve which agent/model are *actually* used for this chat (override or default).
-  const effectiveAgent: string = chat.agent ?? defaultAgent ?? 'claude-code'
-  const effectiveModel: string | undefined = chat.model ?? agentDefaultModels[effectiveAgent]
+  // Resolve which agent/model are *actually* used for this chat.
+  // Priority: per-chat override → worker config → gateway fallback default.
+  const selectedWorker = chat.selection.type === 'worker'
+    ? workers.find(w => w.name === chat.selection.name)
+    : undefined
+  const workerAgent = selectedWorker?.config.codingAgent
+  const workerModel = selectedWorker?.config.model
+  const effectiveAgent: string = chat.agent ?? workerAgent ?? defaultAgent ?? 'claude-code'
+  const effectiveModel: string | undefined = chat.model ?? workerModel ?? agentDefaultModels[effectiveAgent]
   const apiTypeForAgent = AGENT_API_TYPE[effectiveAgent]
   const modelsForAgent = models.filter(m => m.apiType === apiTypeForAgent)
 
@@ -314,29 +320,33 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
             </optgroup>
           )}
         </select>
-        <select
-          value={chat.agent ?? ''}
-          onChange={e => onAgentChange(e.target.value)}
-          style={styles.workerSelect}
-          title={`Agent: ${effectiveAgent}${chat.agent ? ' (override)' : ' (default)'}`}
-        >
-          <option value="">{`Agent: ${effectiveAgent}`}</option>
-          {AGENT_NAMES.filter(n => enabledAgents.includes(n) || n === chat.agent).map(n => (
-            <option key={n} value={n}>{n}</option>
-          ))}
-        </select>
-        <select
-          value={chat.model ?? ''}
-          onChange={e => onModelChange(e.target.value)}
-          style={styles.workerSelect}
-          title={`Model: ${effectiveModel ?? 'unset'}${chat.model ? ' (override)' : ' (default)'}`}
-          disabled={modelsForAgent.length === 0}
-        >
-          <option value="">{`Model: ${effectiveModel ?? '(default)'}`}</option>
-          {modelsForAgent.map(m => (
-            <option key={m.model} value={m.model}>{m.model}</option>
-          ))}
-        </select>
+        {chat.selection.type !== 'team' && (
+          <>
+            <select
+              value={chat.agent ?? ''}
+              onChange={e => onAgentChange(e.target.value)}
+              style={styles.workerSelect}
+              title={`Agent: ${effectiveAgent}${chat.agent ? ' (override)' : workerAgent ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
+            >
+              <option value="">{`Agent: ${effectiveAgent}`}</option>
+              {AGENT_NAMES.filter(n => enabledAgents.includes(n) || n === chat.agent).map(n => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+            <select
+              value={chat.model ?? ''}
+              onChange={e => onModelChange(e.target.value)}
+              style={styles.workerSelect}
+              title={`Model: ${effectiveModel ?? 'unset'}${chat.model ? ' (override)' : workerModel ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
+              disabled={modelsForAgent.length === 0}
+            >
+              <option value="">{`Model: ${effectiveModel ?? '(default)'}`}</option>
+              {modelsForAgent.map(m => (
+                <option key={m.model} value={m.model}>{m.model}</option>
+              ))}
+            </select>
+          </>
+        )}
       </div>
 
       <div

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -30,7 +30,7 @@ export interface ChatMessage {
 }
 
 export type ChatSelection =
-  | { type: 'none' }
+  | { type: 'none'; name?: string }
   | { type: 'worker'; name: string }
   /** `name` identifies which team to run. Optional only for backward compat with chats persisted before per-team selection landed; the UI always sets it. */
   | { type: 'team'; name?: string };

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1440,6 +1440,8 @@ Example: /model gpt-4.1 write a Python script`;
     chatId: string,
     signal?: AbortSignal,
     opts: { forceAll?: boolean } = {},
+    chatAgent?: CodingAgent,
+    chatModel?: ModelConfig,
   ): Promise<{ response: string; tokens?: number }> {
     if (!team || !team.members || team.members.length === 0) {
       throw new Error(`Team not found or empty: ${teamName}`);
@@ -1473,9 +1475,9 @@ Example: /model gpt-4.1 write a Python script`;
       const memberName = runMembers[i];
       sink({ type: 'info', chatId, message: `Step ${i + 1}/${runMembers.length}: ${memberName}` });
       const stepPrompt = workerManager.buildWorkerPrompt(memberName, carry);
-      const codingAgent = (workerManager.getWorkerCodingAgent(memberName) ?? this.getDefaultAgent()) as CodingAgent;
+      const codingAgent = (workerManager.getWorkerCodingAgent(memberName) ?? chatAgent ?? this.getDefaultAgent()) as CodingAgent;
       const workerModel = workerManager.getWorkerModel(memberName);
-      const modelConfig = this.getModelConfig(codingAgent, workerModel);
+      const modelConfig = workerModel ? this.getModelConfig(codingAgent, workerModel) : chatModel ?? this.getDefaultModelConfig(codingAgent);
       const response = await this.runWithFallback(codingAgent, {
         prompt: stepPrompt,
         agent: codingAgent,
@@ -2008,7 +2010,7 @@ Example: /model gpt-4.1 write a Python script`;
           members: rawMembers,
           dispatch: (Array.isArray(rawTeam) ? 'all' : (rawTeam?.dispatch ?? 'all')) as 'all' | 'auto',
         };
-        const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, abortController.signal);
+        const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, abortController.signal, {}, agent, model);
         output = r.response;
         tokens = r.tokens;
       } else {


### PR DESCRIPTION
## Summary
- **Per-chat agent/model now works for teams**: `runTeamForChat` receives chat-level overrides so team workers respect the agent/model selected in the chat UI, instead of always falling back to `fallback.order[0]`.
- **Dispatcher settings persist**: `buildRuntimeConfig` passes the `dispatcher` block through to the gateway, so UI-configured dispatcher agent/model actually take effect.
- **Worker-aware dropdowns**: When a single worker is selected, agent/model dropdowns show the worker's configured values. Tooltips indicate the source (override / worker / default).
- **Team mode cleanup**: Agent and model dropdowns are hidden when a team is selected (teams manage their own per-worker config).

## Test plan
- [ ] Select a worker in Mac app chat → verify dropdowns show worker's agent/model
- [ ] Override agent via dropdown → verify override is used in gateway
- [ ] Select a team → verify agent/model dropdowns disappear
- [ ] Configure dispatcher settings in UI → verify they persist across restart
- [ ] Run a team with per-chat agent override → verify workers use the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)