### PR TITLE
feat(mac): model dropdown in worker settings

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -135,7 +135,8 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
       } catch { /* surface via dropdown placeholders */ }
     })()
   }, [isGatewayRunning])
-  useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }) }, [chat?.messages?.length])
+  const lastMsg = chat?.messages?.[chat.messages.length - 1]
+  useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }) }, [chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length])
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && flight) stopChat(chatId)

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -2,6 +2,13 @@ import { useEffect, useState, useCallback } from 'react'
 import { apiService, WorkerDto } from '../services/api'
 import { C } from '../theme'
 
+interface ModelEntry { apiType: 'anthropic' | 'openai'; model: string }
+const AGENT_API_TYPE: Record<string, 'anthropic' | 'openai'> = {
+  'claude-code': 'anthropic',
+  'opencode': 'openai',
+  'codex': 'openai',
+}
+
 type Mode = { kind: 'idle' } | { kind: 'select'; name: string } | { kind: 'create' }
 
 export default function WorkersTab() {
@@ -93,12 +100,22 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [models, setModels] = useState<ModelEntry[]>([])
+
+  useEffect(() => {
+    window.codey.models.list().then(r => { if (r.ok) setModels(r.data as ModelEntry[]) }).catch(() => {})
+  }, [])
 
   useEffect(() => {
     setRole(worker.personality.role); setSoul(worker.personality.soul); setInstructions(worker.personality.instructions)
     setCodingAgent(worker.config.codingAgent); setModel(worker.config.model); setToolsText(worker.config.tools.join(', '))
     setSaved(false); setError(null)
   }, [worker.name])
+
+  const filteredModels = models.filter(m => {
+    const want = AGENT_API_TYPE[codingAgent]
+    return !want || m.apiType === want
+  })
 
   const save = async () => {
     setSaving(true); setError(null)
@@ -141,14 +158,29 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
       <textarea value={instructions} onChange={e => setInstructions(e.target.value)} style={{ ...fieldStyle, minHeight: 140 }} />
 
       <label style={labelStyle}>Coding Agent</label>
-      <select value={codingAgent} onChange={e => setCodingAgent(e.target.value as any)} style={fieldStyle}>
+      <select value={codingAgent} onChange={e => {
+        const next = e.target.value as any
+        setCodingAgent(next)
+        // Reset model if incompatible with the new agent
+        const want = AGENT_API_TYPE[next]
+        const compatible = models.some(m => m.model === model && (!want || m.apiType === want))
+        if (!compatible) {
+          const first = models.find(m => !want || m.apiType === want)
+          setModel(first?.model ?? '')
+        }
+      }} style={fieldStyle}>
         <option value="claude-code">claude-code</option>
         <option value="opencode">opencode</option>
         <option value="codex">codex</option>
       </select>
 
       <label style={labelStyle}>Model</label>
-      <input value={model} onChange={e => setModel(e.target.value)} style={fieldStyle} />
+      <select value={model} onChange={e => setModel(e.target.value)} style={{ ...fieldStyle, cursor: 'pointer' }}>
+        {filteredModels.map(m => (
+          <option key={m.model} value={m.model}>{m.model}</option>
+        ))}
+        {filteredModels.length === 0 && <option value={model}>{model || '(no models available)'}</option>}
+      </select>
 
       <label style={labelStyle}>Tools (comma-separated)</label>
       <input value={toolsText} onChange={e => setToolsText(e.target.value)} style={fieldStyle} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Replace free-text model input in worker settings with a `<select>` dropdown
- Models are filtered by the selected coding agent's API type (`anthropic` for claude-code, `openai` for opencode/codex)
- Auto-resets model when switching agents if the current model is incompatible
- Fetches available models from `window.codey.models.list()` on editor mount

## Test plan
- [ ] Open worker settings, verify model field is a dropdown
- [ ] Switch coding agent, verify model list filters appropriately
- [ ] Switch to an agent where current model is incompatible, verify it auto-selects a valid model
- [ ] Save and reload, verify settings persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)