### PR TITLE
Cross-surface chat linking (Mac ↔ Telegram/Discord/iMessage)

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -728,6 +728,34 @@ app.whenReady().then(async () => {
     })
   )
 
+  ipcMain.handle('chats:link', async (_e, chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      await inProcessGateway.linkChat(chatId, channel, channelUserId)
+    })
+  )
+
+  ipcMain.handle('chats:unlink', async (_e, chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      inProcessGateway.unlinkChat(chatId, channel, channelUserId)
+    })
+  )
+
+  ipcMain.handle('pairing:start', async (_e, channel: 'telegram' | 'discord' | 'imessage') =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.startPairing(channel)
+    })
+  )
+
+  ipcMain.handle('pairing:list', async () =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.listPairings()
+    })
+  )
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow()

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -230,6 +230,11 @@ async function bootInProcessCore() {
     void inProcessGateway.start().catch((err: any) => {
       sendToRenderer('gateway-log', `[core] gateway.start failed: ${err?.message ?? err}`)
     })
+    // Forward all chat stream events (including those triggered by channel
+    // messages on paired surfaces) to the renderer so the Mac UI stays in sync.
+    inProcessGateway.setChatEventListener((ev: any) => {
+      sendToRenderer('chats:event', ev)
+    })
   } catch (err: any) {
     sendToRenderer('gateway-log', `[core] Boot failed: ${err?.message ?? err}`)
   }

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -81,6 +81,10 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('chats:updateSelection', id, selection),
     updateAgentModel: (id: string, agent: string | null, model: string | null) =>
       ipcRenderer.invoke('chats:updateAgentModel', id, agent, model),
+    link: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
+      ipcRenderer.invoke('chats:link', chatId, channel, channelUserId),
+    unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
+      ipcRenderer.invoke('chats:unlink', chatId, channel, channelUserId),
     send: (payload: { chatId: string; text: string; attachments?: any[] }) =>
       ipcRenderer.invoke('chats:send', payload),
     stop: (chatId: string) => ipcRenderer.invoke('chats:stop', chatId),
@@ -89,6 +93,10 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.on('chats:event', listener)
       return () => ipcRenderer.removeListener('chats:event', listener)
     },
+  },
+  pairing: {
+    start: (channel: 'telegram' | 'discord' | 'imessage') => ipcRenderer.invoke('pairing:start', channel),
+    list: () => ipcRenderer.invoke('pairing:list'),
   },
   gateway: {
     status: () => ipcRenderer.invoke('gateway:status'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -79,6 +79,18 @@ declare global {
         send: (payload: { chatId: string; text: string; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) => Promise<IpcResult<{ response: string; chatId: string; tokens?: number; durationSec?: number }>>
         stop: (chatId: string) => Promise<IpcResult<boolean>>
         onEvent: (handler: (ev: ChatStreamEvent) => void) => () => void
+        link: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<void>>
+        unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<void>>
+      }
+      pairing: {
+        start: (channel: 'telegram' | 'discord' | 'imessage') => Promise<IpcResult<string>>
+        list: () => Promise<IpcResult<Array<{
+          channel: 'telegram' | 'discord' | 'imessage'
+          channelUserId: string
+          prefs?: { workspace?: string; agent?: string; model?: string }
+          currentChatId?: string
+          createdAt: number
+        }>>>
       }
       gateway: {
         status: () => Promise<IpcResult<{

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -3,6 +3,7 @@ import { useChats } from '../hooks/useChats'
 import { apiService } from '../services/api'
 import type { Chat } from '../types'
 import { C } from '../theme'
+import { RouteIcons } from './RouteIcons'
 
 interface Props {
   onOpenSettings: () => void
@@ -155,6 +156,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
                     ) : (
                       <span style={styles.title}>{chat.title}</span>
                     )}
+                    <RouteIcons routes={chat.routes} />
                     {flight && <span style={styles.dot} />}
                     {!isRenaming && (
                       <button

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -5,6 +5,8 @@ import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
 import { Markdown } from './Markdown'
 import { formatHeadline, hasDetail as toolHasDetail, ToolDetail, normalizeTool } from './toolFormat'
+import { RouteIcons } from './RouteIcons'
+import { PairingModal } from './PairingModal'
 
 interface Props {
   chatId: string
@@ -98,12 +100,19 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>([])
   const [isDragging, setIsDragging] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
+  const [pairings, setPairings] = useState<Array<{ channel: 'telegram'|'discord'|'imessage'; channelUserId: string }>>([])
+  const [pairingModal, setPairingModal] = useState<null | 'telegram' | 'discord' | 'imessage'>(null)
   const dragDepthRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const taRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => { apiService.listWorkers().then(setWorkers) }, [])
+  useEffect(() => {
+    apiService.listPairings()
+      .then(p => setPairings(p as any))
+      .catch(() => {})
+  }, [])
   useEffect(() => {
     if (!isGatewayRunning) return
     ;(async () => {
@@ -264,6 +273,35 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     }
   }
 
+  const isLinked = (channel: string, userId: string) =>
+    chat.routes?.some(r => r.channel === channel && r.channelUserId === userId) ?? false
+
+  const onLinkButton = async () => {
+    if (pairings.length === 0) {
+      setPairingModal('telegram')
+      return
+    }
+    if (pairings.length === 1) {
+      const p = pairings[0]
+      if (isLinked(p.channel, p.channelUserId)) {
+        await apiService.unlinkChat(chat.id, p.channel, p.channelUserId)
+      } else {
+        await apiService.linkChat(chat.id, p.channel, p.channelUserId)
+      }
+      return
+    }
+    const choice = window.prompt(`Pick a pairing to toggle:\n${pairings.map((p, i) => `${i+1}. ${p.channel}:${p.channelUserId}`).join('\n')}\n\nEnter number:`)
+    const idx = choice ? parseInt(choice, 10) - 1 : -1
+    if (idx >= 0 && idx < pairings.length) {
+      const p = pairings[idx]
+      if (isLinked(p.channel, p.channelUserId)) {
+        await apiService.unlinkChat(chat.id, p.channel, p.channelUserId)
+      } else {
+        await apiService.linkChat(chat.id, p.channel, p.channelUserId)
+      }
+    }
+  }
+
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
   const canSend = isGatewayRunning && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
@@ -324,6 +362,14 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
             <option key={m.model} value={m.model}>{m.model}</option>
           ))}
         </select>
+        <RouteIcons routes={chat.routes} />
+        <button
+          onClick={onLinkButton}
+          style={styles.linkBtn}
+          title={chat.routes?.length ? 'Manage channel links' : 'Link to a channel'}
+        >
+          {chat.routes?.length ? '🔗' : '🔗+'}
+        </button>
       </div>
 
       <div
@@ -570,6 +616,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
           </div>
         </div>
       </div>
+      {pairingModal && (
+        <PairingModal channel={pairingModal} onClose={() => setPairingModal(null)} />
+      )}
     </div>
   )
 }
@@ -704,5 +753,15 @@ const styles: Record<string, React.CSSProperties> = {
     background: 'transparent', display: 'flex', alignItems: 'center',
     justifyContent: 'center', flexShrink: 0, cursor: 'pointer',
     transition: 'background 0.15s',
+  },
+  linkBtn: {
+    marginLeft: 6,
+    padding: '4px 8px',
+    background: 'transparent',
+    border: `1px solid ${C.border}`,
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: 12,
+    color: C.fg,
   },
 }

--- a/codey-mac/src/components/PairingModal.tsx
+++ b/codey-mac/src/components/PairingModal.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react'
+import { apiService } from '../services/api'
+import { C } from '../theme'
+
+export interface PairingModalProps {
+  channel: 'telegram' | 'discord' | 'imessage'
+  onClose: () => void
+}
+
+export function PairingModal({ channel, onClose }: PairingModalProps) {
+  const [code, setCode] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    apiService.startPairing(channel)
+      .then(c => { if (!cancelled) setCode(c) })
+      .catch(e => { if (!cancelled) setError(e.message) })
+    return () => { cancelled = true }
+  }, [channel])
+
+  return (
+    <div style={styles.backdrop} onClick={onClose}>
+      <div style={styles.modal} onClick={e => e.stopPropagation()}>
+        <h3 style={styles.title}>Pair with {channel}</h3>
+        {error && <p style={styles.error}>{error}</p>}
+        {!error && !code && <p style={styles.hint}>Generating code…</p>}
+        {code && (
+          <>
+            <p>On your {channel} app, send this command to the bot:</p>
+            <pre style={styles.code}>/pair {code}</pre>
+            <p style={styles.hint}>Code expires in 5 minutes.</p>
+          </>
+        )}
+        <button style={styles.close} onClick={onClose}>Close</button>
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: {
+    position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+    background: 'rgba(0,0,0,0.4)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    zIndex: 1000,
+  },
+  modal: {
+    background: C.bg,
+    color: C.fg,
+    border: `1px solid ${C.border}`,
+    borderRadius: 8,
+    padding: 24,
+    minWidth: 320,
+    maxWidth: 480,
+  },
+  title: { margin: '0 0 12px 0' },
+  hint: { color: C.fg2, fontSize: 12 },
+  error: { color: C.red },
+  code: {
+    background: C.surface2,
+    padding: '8px 12px',
+    borderRadius: 4,
+    fontSize: 16,
+    letterSpacing: 1,
+    margin: '8px 0',
+  },
+  close: {
+    marginTop: 12,
+    padding: '6px 12px',
+    background: C.accent,
+    color: C.fg,
+    border: 'none',
+    borderRadius: 4,
+    cursor: 'pointer',
+  },
+}

--- a/codey-mac/src/components/RouteIcons.tsx
+++ b/codey-mac/src/components/RouteIcons.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import type { ChatRoute } from '../types'
+
+const ICON: Record<ChatRoute['channel'], string> = {
+  telegram: '✈️',
+  discord: '💬',
+  imessage: '💙',
+}
+
+export function RouteIcons({ routes }: { routes?: ChatRoute[] }) {
+  if (!routes || routes.length === 0) return null
+  return (
+    <span style={styles.row} aria-label="linked channels">
+      {routes.map((r, i) => (
+        <span key={`${r.channel}-${i}`} title={`${r.channel}: ${r.channelUserId}`} style={styles.icon}>
+          {ICON[r.channel]}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  row: { display: 'inline-flex', gap: 2, marginLeft: 6, fontSize: 11 },
+  icon: { lineHeight: 1 },
+}

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -275,6 +275,12 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               title: ev.title,
             })
             delete pendingAssistantId.current[ev.chatId]
+          } else {
+            // Channel-driven turn (no Mac-side placeholder). Re-fetch the chat
+            // so the new user + assistant messages show up in the sidebar/view.
+            apiService.chats.get(ev.chatId)
+              .then(chat => dispatch({ type: 'upsert', chat }))
+              .catch(() => {})
           }
           break
         }
@@ -283,6 +289,10 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           if (asstId) {
             dispatch({ type: 'errorSend', chatId: ev.chatId, assistantMessageId: asstId, error: ev.message })
             delete pendingAssistantId.current[ev.chatId]
+          } else {
+            apiService.chats.get(ev.chatId)
+              .then(chat => dispatch({ type: 'upsert', chat }))
+              .catch(() => {})
           }
           break
         }

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -160,5 +160,26 @@ export const apiService = {
       unwrap(await window.codey.chats.stop(chatId)),
     onEvent: (handler: (ev: ChatStreamEvent) => void): (() => void) =>
       window.codey.chats.onEvent(handler),
+    link: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+      unwrap(await window.codey.chats.link(chatId, channel, channelUserId)),
+    unlink: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+      unwrap(await window.codey.chats.unlink(chatId, channel, channelUserId)),
   },
+
+  linkChat: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+    unwrap(await window.codey.chats.link(chatId, channel, channelUserId)),
+
+  unlinkChat: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+    unwrap(await window.codey.chats.unlink(chatId, channel, channelUserId)),
+
+  startPairing: async (channel: 'telegram' | 'discord' | 'imessage'): Promise<string> =>
+    unwrap(await window.codey.pairing.start(channel)),
+
+  listPairings: async (): Promise<Array<{
+    channel: 'telegram' | 'discord' | 'imessage'
+    channelUserId: string
+    prefs?: { workspace?: string; agent?: string; model?: string }
+    currentChatId?: string
+    createdAt: number
+  }>> => unwrap(await window.codey.pairing.list()),
 }

--- a/codey-mac/src/types/index.ts
+++ b/codey-mac/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { ChatMessage, ToolCallEntry, Chat, ChatSelection, FileAttachment } from '@codey/core';
+export type { ChatMessage, ToolCallEntry, Chat, ChatSelection, FileAttachment, ChatRoute } from '@codey/core';
 
 export interface GatewayStatus {
   status: string;

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -1,3 +1,5 @@
+import { ChatRoute } from './route';
+
 export interface FileAttachment {
   id: string;
   name: string;        // original filename
@@ -46,4 +48,6 @@ export interface Chat {
   agent?: 'claude-code' | 'opencode' | 'codex';
   /** Per-chat model override (model id from the global catalog). Falls back to the agent's default model when unset. */
   model?: string;
+  /** Attached channel routes. Absent or empty means Mac-only. */
+  routes?: ChatRoute[];
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -218,3 +218,4 @@ export interface GatewayConfig {
 }
 
 export * from './chat';
+export * from './route';

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,0 +1,14 @@
+export type ChannelKind = 'telegram' | 'discord' | 'imessage';
+
+export interface ChatRoute {
+  channel: ChannelKind;
+  /** Channel-side user identifier (e.g. Telegram user id, Discord user id, iMessage handle). */
+  channelUserId: string;
+  /**
+   * Channel-side conversation identifier (e.g. Telegram chat id, Discord channel id).
+   * For 1:1 DM channels this often equals channelUserId; we store both for clarity.
+   */
+  channelChatId: string;
+  /** Unix ms when this route was attached. */
+  attachedAt: number;
+}

--- a/packages/gateway/src/channels/base.ts
+++ b/packages/gateway/src/channels/base.ts
@@ -1,4 +1,4 @@
-import { UserMessage, GatewayResponse } from '@codey/core';
+import { UserMessage, GatewayResponse, ChatRoute } from '@codey/core';
 
 export interface ChannelHandler {
   name: string;
@@ -8,6 +8,7 @@ export interface ChannelHandler {
   onMessage(callback: (message: UserMessage) => Promise<void>): void;
   streamText?(text: string): void;
   sendStartupMessage?(text: string): Promise<void>;
+  sendToRoute?(route: ChatRoute, text: string): Promise<void>;
 }
 
 // Base class for channel handlers

--- a/packages/gateway/src/channels/discord.ts
+++ b/packages/gateway/src/channels/discord.ts
@@ -1,6 +1,6 @@
 import { Client, GatewayIntentBits, Message, TextChannel } from 'discord.js';
 import { BaseChannelHandler } from './base';
-import { UserMessage, GatewayResponse } from '@codey/core';
+import { UserMessage, GatewayResponse, ChatRoute } from '@codey/core';
 
 export class DiscordHandler extends BaseChannelHandler {
   name = 'discord';
@@ -54,6 +54,14 @@ export class DiscordHandler extends BaseChannelHandler {
     const channel = await this.client.channels.fetch(response.chatId);
     if (channel && channel instanceof TextChannel) {
       await channel.send(response.text);
+    }
+  }
+
+  async sendToRoute(route: ChatRoute, text: string): Promise<void> {
+    if (route.channel !== 'discord' || !this.client) return;
+    const channel = await this.client.channels.fetch(route.channelChatId).catch(() => null);
+    if (channel && channel instanceof TextChannel) {
+      await channel.send(text);
     }
   }
 }

--- a/packages/gateway/src/channels/imessage.ts
+++ b/packages/gateway/src/channels/imessage.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { exec } from 'child_process';
 import { BaseChannelHandler } from './base';
-import { UserMessage, GatewayResponse } from '@codey/core';
+import { UserMessage, GatewayResponse, ChatRoute } from '@codey/core';
 
 // iMessage handler using macOS AppleScript
 // Note: Requires Mac OS and iMessage enabled
@@ -33,6 +33,25 @@ export class IMessageHandler extends BaseChannelHandler {
       exec(`osascript -e '${script}'`, (error) => {
         if (error) {
           console.error('[iMessage] Send error:', error.message);
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  async sendToRoute(route: ChatRoute, text: string): Promise<void> {
+    if (route.channel !== 'imessage') return;
+    const script = `
+      tell application "Messages"
+        send "${this.escapeString(text)}" to buddy "${route.channelChatId}"
+      end tell
+    `;
+    return new Promise((resolve, reject) => {
+      exec(`osascript -e '${script}'`, (error) => {
+        if (error) {
+          console.error('[iMessage] sendToRoute error:', error.message);
           reject(error);
         } else {
           resolve();

--- a/packages/gateway/src/channels/telegram.ts
+++ b/packages/gateway/src/channels/telegram.ts
@@ -1,6 +1,6 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { BaseChannelHandler } from './base';
-import { UserMessage, GatewayResponse } from '@codey/core';
+import { UserMessage, GatewayResponse, ChatRoute } from '@codey/core';
 
 /**
  * Convert markdown to Telegram HTML.
@@ -153,6 +153,11 @@ export class TelegramHandler extends BaseChannelHandler {
     }
 
     await this.bot.sendMessage(response.chatId, markdownToTelegramHtml(response.text), options);
+  }
+
+  async sendToRoute(route: ChatRoute, text: string): Promise<void> {
+    if (route.channel !== 'telegram' || !this.bot) return;
+    await this.bot.sendMessage(route.channelChatId, text);
   }
 
   private startTyping(chatId: string): void {

--- a/packages/gateway/src/chats.test.ts
+++ b/packages/gateway/src/chats.test.ts
@@ -1,0 +1,54 @@
+// Run: npx ts-node packages/gateway/src/chats.test.ts
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+
+async function run() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+  fs.mkdirSync(path.join(root, 'main'), { recursive: true });
+
+  const mgr = new ChatManager(root);
+  const chat = mgr.create({ workspaceName: 'main', title: 't' });
+
+  const r = mgr.addRoute(chat.id, {
+    channel: 'telegram',
+    channelUserId: 'u1',
+    channelChatId: 'u1',
+    attachedAt: 1,
+  });
+  assert.strictEqual(r.routes?.length, 1);
+  assert.strictEqual(r.routes?.[0].channel, 'telegram');
+
+  mgr.addRoute(chat.id, {
+    channel: 'telegram',
+    channelUserId: 'u1',
+    channelChatId: 'u1',
+    attachedAt: 2,
+  });
+  assert.strictEqual(mgr.get(chat.id)?.routes?.length, 1);
+
+  const found = mgr.findByRoute('telegram', 'u1', 'u1');
+  assert.strictEqual(found?.id, chat.id);
+  assert.strictEqual(mgr.findByRoute('telegram', 'u1', 'other'), undefined);
+
+  const after = mgr.removeRoute(chat.id, 'telegram', 'u1', 'u1');
+  assert.strictEqual(after.routes?.length ?? 0, 0);
+  assert.strictEqual(mgr.findByRoute('telegram', 'u1', 'u1'), undefined);
+
+  const r2 = mgr.addRoute(chat.id, {
+    channel: 'discord',
+    channelUserId: 'd1',
+    channelChatId: 'd1',
+    attachedAt: 3,
+  });
+  assert.strictEqual(r2.routes?.length, 1);
+  const reloaded = new ChatManager(root);
+  assert.strictEqual(reloaded.findByRoute('discord', 'd1', 'd1')?.id, chat.id);
+
+  fs.rmSync(root, { recursive: true, force: true });
+  console.log('chats.test ok');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { Chat, ChatMessage, ChatSelection } from '@codey/core';
+import { Chat, ChatMessage, ChatSelection, ChatRoute, ChannelKind } from '@codey/core';
 import { Logger } from './logger';
 
 const log = Logger.getInstance();
@@ -153,6 +153,50 @@ export class ChatManager {
     if (fs.existsSync(dir)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  }
+
+  addRoute(chatId: string, route: ChatRoute): Chat {
+    const chat = this.requireChat(chatId);
+    chat.routes ??= [];
+    const exists = chat.routes.some(r =>
+      r.channel === route.channel &&
+      r.channelUserId === route.channelUserId &&
+      r.channelChatId === route.channelChatId
+    );
+    if (!exists) {
+      chat.routes.push(route);
+      chat.updatedAt = Date.now();
+      this.persist(chat);
+    }
+    return chat;
+  }
+
+  removeRoute(chatId: string, channel: ChannelKind, channelUserId: string, channelChatId: string): Chat {
+    const chat = this.requireChat(chatId);
+    if (!chat.routes) return chat;
+    const before = chat.routes.length;
+    chat.routes = chat.routes.filter(r =>
+      !(r.channel === channel && r.channelUserId === channelUserId && r.channelChatId === channelChatId)
+    );
+    if (chat.routes.length !== before) {
+      chat.updatedAt = Date.now();
+      this.persist(chat);
+    }
+    return chat;
+  }
+
+  findByRoute(channel: ChannelKind, channelUserId: string, channelChatId: string): Chat | undefined {
+    this.ensureLoaded();
+    for (const chat of this.cache.values()) {
+      if (chat.routes?.some(r =>
+        r.channel === channel &&
+        r.channelUserId === channelUserId &&
+        r.channelChatId === channelChatId
+      )) {
+        return chat;
+      }
+    }
+    return undefined;
   }
 
   private requireChat(chatId: string): Chat {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry } from '@codey/core';
+import { AgentRequest, AgentResponse, ChannelKind, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -12,6 +12,8 @@ import { TaskPlanner, TaskPlan, PlanStep } from '@codey/core';
 import { WorkspaceManager } from '@codey/core';
 import { WorkerManager } from '@codey/core';
 import { ChatManager } from './chats';
+import { PairingStore, ChannelBinding } from './pairings';
+import { summarizePriorHistory } from './summary';
 import { buildChatPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink } from './chat-runner';
 
 interface ParsedCommand {
@@ -39,6 +41,7 @@ export class Codey {
   private planner: TaskPlanner;
   private workspaceManager: WorkspaceManager;
   private chatManager: ChatManager;
+  private pairingStore: PairingStore;
   private configManager?: ConfigManager;
   private chatSemaphore = new RunSemaphore();
   private chatAborts: Map<string, AbortController> = new Map();
@@ -140,6 +143,7 @@ export class Codey {
     const wm = workerManager || new WorkerManager('./workers');
     this.workspaceManager = new WorkspaceManager(wm, workspaceDir || './workspaces', this.logger);
     this.chatManager = new ChatManager(this.workspaceManager.getWorkspacesRoot());
+    this.pairingStore = new PairingStore(path.join(process.cwd(), 'pairings.json'));
     this.COOLDOWN_MS = config.rateLimitMs || 3000; // Default 3 seconds
   }
 
@@ -199,6 +203,53 @@ export class Codey {
 
   getWorkspaceManager(): WorkspaceManager { return this.workspaceManager; }
   getChatManager(): ChatManager { return this.chatManager; }
+
+  /** Mac calls this to start a pairing flow. Returns a 6-digit code shown in the UI. */
+  public startPairing(channel: ChannelKind): string {
+    return this.pairingStore.startPairing({ channel });
+  }
+
+  public listPairings(): ChannelBinding[] {
+    return this.pairingStore.list();
+  }
+
+  /** Get the pairing store directly (used by command handlers in later tasks). */
+  public getPairingStore(): PairingStore {
+    return this.pairingStore;
+  }
+
+  /**
+   * Mac calls this to attach a channel route to an existing chat.
+   * Pushes a one-time summary to the channel after attaching.
+   */
+  public async linkChat(chatId: string, channel: ChannelKind, channelUserId: string): Promise<void> {
+    const binding = this.pairingStore.findByChannelUser(channel, channelUserId);
+    if (!binding) throw new Error(`No pairing for ${channel}:${channelUserId}`);
+
+    // 1:1 DM model — channelChatId equals channelUserId. See spec §Identity.
+    const channelChatId = channelUserId;
+    const route: ChatRoute = { channel, channelUserId, channelChatId, attachedAt: Date.now() };
+
+    this.chatManager.addRoute(chatId, route);
+    this.pairingStore.setCurrentChat(channel, channelUserId, chatId);
+
+    const chat = this.chatManager.get(chatId);
+    if (!chat) return;
+    const summary = summarizePriorHistory(chat);
+    const handler = this.handlers.get(channel);
+    if (handler?.sendToRoute) {
+      try {
+        await handler.sendToRoute(route, summary);
+      } catch (err) {
+        this.logger.warn(`linkChat: failed to push summary to ${channel}: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  public unlinkChat(chatId: string, channel: ChannelKind, channelUserId: string): void {
+    const channelChatId = channelUserId;
+    this.chatManager.removeRoute(chatId, channel, channelUserId, channelChatId);
+  }
 
   getAgentFactory(): AgentFactory { return this.agentFactory; }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -522,7 +522,17 @@ export class Codey {
   }
 
   private async processPrompt(message: UserMessage, parsed: ParsedCommand): Promise<void> {
-    const { userId, chatId, channel, id: messageId } = message;
+    const { userId, channel, id: messageId } = message;
+
+    // Channel-side: if this user has a paired binding, prefer their current chat
+    // over the channel-derived chatId.
+    let chatId = message.chatId;
+    if (this.isPairableChannel(channel)) {
+      const binding = this.pairingStore.findByChannelUser(channel, userId);
+      if (binding?.currentChatId) {
+        chatId = binding.currentChatId;
+      }
+    }
 
     // Get or create structured context window keyed by conversationId
     const conversationId = message.conversationId ?? `${message.channel}-${message.chatId}`;
@@ -774,6 +784,12 @@ export class Codey {
         break;
       case 'agent':
         await this.cmdAgent(args, chatId, channel);
+        if (this.isPairableChannel(channel) && args.length > 0) {
+          const a = args[0].toLowerCase();
+          if (['claude-code', 'opencode', 'codex'].includes(a)) {
+            this.pairingStore.updatePrefs(channel, message.userId, { agent: a as 'claude-code' | 'opencode' | 'codex' });
+          }
+        }
         break;
       case 'agents':
         await this.cmdAgents(chatId, channel);
@@ -800,6 +816,9 @@ export class Codey {
       case 'workspace':
       case 'ws':
         await this.cmdWorkspace(args, chatId, channel);
+        if (this.isPairableChannel(channel) && args.length > 0) {
+          this.pairingStore.updatePrefs(channel, message.userId, { workspace: args.join(' ') });
+        }
         break;
       case 'workspaces':
       case 'wss':
@@ -818,6 +837,18 @@ export class Codey {
         break;
       case 'remember':
         await this.cmdRemember(args, message);
+        break;
+      case 'pair':
+        await this.cmdPair(args, message);
+        break;
+      case 'new':
+        await this.cmdNewChat(args, message);
+        break;
+      case 'list':
+        await this.cmdListChats(message);
+        break;
+      case 'switch':
+        await this.cmdSwitchChat(args, message);
         break;
       default:
         return;
@@ -1153,6 +1184,115 @@ export class Codey {
       channel,
       text: `\ud83e\udde0 Remembered: ${entry.content}`,
     });
+  }
+
+  private isPairableChannel(channel: ChannelType): channel is 'telegram' | 'discord' | 'imessage' {
+    return channel === 'telegram' || channel === 'discord' || channel === 'imessage';
+  }
+
+  private async cmdPair(args: string[], message: UserMessage): Promise<void> {
+    const { chatId, channel, userId } = message;
+    if (!this.isPairableChannel(channel)) {
+      await this.sendResponse({ chatId, channel, text: 'Pairing is only available on Telegram, Discord, or iMessage.' });
+      return;
+    }
+    const code = args[0];
+    if (!code || !/^\d{6}$/.test(code)) {
+      await this.sendResponse({ chatId, channel, text: 'Usage: /pair <6-digit code from the Mac app>' });
+      return;
+    }
+    const ok = this.pairingStore.completePairing(code, { channel, channelUserId: userId });
+    await this.sendResponse({
+      chatId,
+      channel,
+      text: ok
+        ? '✅ Paired. Use /new to start a chat, or link an existing chat from the Mac app.'
+        : '❌ Invalid or expired code.',
+    });
+  }
+
+  private async cmdNewChat(args: string[], message: UserMessage): Promise<void> {
+    const { chatId, channel, userId } = message;
+    if (!this.isPairableChannel(channel)) {
+      await this.sendResponse({ chatId, channel, text: '/new is only available on paired channels.' });
+      return;
+    }
+    const binding = this.pairingStore.findByChannelUser(channel, userId);
+    if (!binding) {
+      await this.sendResponse({ chatId, channel, text: 'You need to /pair first.' });
+      return;
+    }
+    const workspace = binding.prefs?.workspace ?? this.workspaceManager.getCurrentWorkspace();
+    const title = args.join(' ').trim() || undefined;
+    const chat = this.chatManager.create({ workspaceName: workspace, title });
+    if (binding.prefs?.agent || binding.prefs?.model) {
+      this.chatManager.updateAgentModel(chat.id, binding.prefs.agent, binding.prefs.model);
+    }
+    this.chatManager.addRoute(chat.id, {
+      channel,
+      channelUserId: userId,
+      channelChatId: userId,
+      attachedAt: Date.now(),
+    });
+    this.pairingStore.setCurrentChat(channel, userId, chat.id);
+    await this.sendResponse({
+      chatId,
+      channel,
+      text: `Started chat "${chat.title}" (${chat.id.slice(0, 8)}). Send messages to continue.`,
+    });
+  }
+
+  private async cmdListChats(message: UserMessage): Promise<void> {
+    const { chatId, channel, userId } = message;
+    if (!this.isPairableChannel(channel)) {
+      await this.sendResponse({ chatId, channel, text: '/list is only available on paired channels.' });
+      return;
+    }
+    const binding = this.pairingStore.findByChannelUser(channel, userId);
+    if (!binding) {
+      await this.sendResponse({ chatId, channel, text: 'You need to /pair first.' });
+      return;
+    }
+    const all = this.chatManager.list().filter(c =>
+      c.routes?.some(r => r.channel === channel && r.channelUserId === userId)
+    );
+    if (all.length === 0) {
+      await this.sendResponse({ chatId, channel, text: 'No linked chats yet. /new <title> to start one.' });
+      return;
+    }
+    const lines = all.slice(0, 10).map(c => {
+      const marker = c.id === binding.currentChatId ? '→' : ' ';
+      return `${marker} ${c.id.slice(0, 8)}  ${c.title}`;
+    });
+    await this.sendResponse({ chatId, channel, text: lines.join('\n') });
+  }
+
+  private async cmdSwitchChat(args: string[], message: UserMessage): Promise<void> {
+    const { chatId, channel, userId } = message;
+    if (!this.isPairableChannel(channel)) {
+      await this.sendResponse({ chatId, channel, text: '/switch is only available on paired channels.' });
+      return;
+    }
+    const prefix = args[0];
+    if (!prefix) {
+      await this.sendResponse({ chatId, channel, text: 'Usage: /switch <chat-id-prefix>' });
+      return;
+    }
+    const binding = this.pairingStore.findByChannelUser(channel, userId);
+    if (!binding) {
+      await this.sendResponse({ chatId, channel, text: 'You need to /pair first.' });
+      return;
+    }
+    const target = this.chatManager.list().find(c =>
+      c.id.startsWith(prefix) &&
+      c.routes?.some(r => r.channel === channel && r.channelUserId === userId)
+    );
+    if (!target) {
+      await this.sendResponse({ chatId, channel, text: `No matching linked chat for "${prefix}".` });
+      return;
+    }
+    this.pairingStore.setCurrentChat(channel, userId, target.id);
+    await this.sendResponse({ chatId, channel, text: `Switched to "${target.title}".` });
   }
 
   private async cmdPlan(args: string[], chatId: string, channel: ChannelType): Promise<void> {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -47,6 +47,7 @@ export class Codey {
   private chatSemaphore = new RunSemaphore();
   private chatAborts: Map<string, AbortController> = new Map();
   private turnQueue: TurnQueue;
+  private chatEventListener: ((ev: any) => void) | undefined;
 
   // Rate limiting: userId -> last request timestamp
   private userCooldowns: Map<string, number> = new Map();
@@ -212,6 +213,10 @@ export class Codey {
 
   getWorkspaceManager(): WorkspaceManager { return this.workspaceManager; }
   getChatManager(): ChatManager { return this.chatManager; }
+
+  public setChatEventListener(fn: (ev: any) => void): void {
+    this.chatEventListener = fn;
+  }
 
   /** Mac calls this to start a pairing flow. Returns a 6-digit code shown in the UI. */
   public startPairing(channel: ChannelKind): string {
@@ -565,6 +570,16 @@ export class Codey {
   private async runOneTurn(message: UserMessage, parsed: ParsedCommand): Promise<void> {
     const { userId, chatId, channel, id: messageId } = message;
 
+    // Channel-side with a linked Codey chat → route through sendToChat so the
+    // Codey Chat record is updated and the Mac app sees the events.
+    if (this.isPairableChannel(channel)) {
+      const binding = this.pairingStore.findByChannelUser(channel, userId);
+      if (binding?.currentChatId) {
+        await this.runChannelTurnViaChat(message, parsed, binding.currentChatId);
+        return;
+      }
+    }
+
     // Channel-side: if this user has a paired binding with a current chat,
     // use it for Codey-side state (context window, fan-out lookup). Replies
     // continue to use `chatId` (the channel-side chat id) for routing.
@@ -682,6 +697,43 @@ export class Codey {
     // send the reply to every other attached route too.
     if (codeyChatId) {
       await this.fanOutToOtherRoutes(codeyChatId, channel, userId, replyText);
+    }
+  }
+
+  private async runChannelTurnViaChat(
+    message: UserMessage,
+    parsed: ParsedCommand,
+    codeyChatId: string,
+  ): Promise<void> {
+    const { chatId, channel, userId, id: messageId } = message;
+
+    // Sink: forward `done` to the originating channel + fan out to other routes.
+    // Streamed tokens are not relayed to channels (channels only get the final
+    // formatted response, matching the existing behavior).
+    const sink = (ev: any) => {
+      if (ev?.type === 'done' && typeof ev.response === 'string') {
+        // Fire-and-forget — channel sends are non-blocking from the sink's view.
+        void this.sendResponse({
+          chatId,
+          channel,
+          text: ev.response,
+          replyTo: messageId,
+        }).then(() => this.fanOutToOtherRoutes(codeyChatId, channel, userId, ev.response));
+      } else if (ev?.type === 'error' && typeof ev.message === 'string') {
+        void this.sendResponse({
+          chatId,
+          channel,
+          text: `❌ ${ev.message}`,
+          replyTo: messageId,
+        });
+      }
+      // Ignore stream/tool_* events for channel surfaces.
+    };
+
+    try {
+      await this.sendToChat(codeyChatId, parsed.prompt ?? message.text ?? '', sink);
+    } catch (err) {
+      this.logger.error(`runChannelTurnViaChat failed: ${(err as Error).message}`);
     }
   }
 
@@ -2079,11 +2131,20 @@ Example: /model gpt-4.1 write a Python script`;
   async sendToChat(
     chatId: string,
     userText: string,
-    sink: ChatStreamSink,
+    sinkParam: ChatStreamSink,
     attachments?: import('@codey/core').FileAttachment[],
   ): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> {
     const chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
+
+    // Tee every sink event to the registered global listener so other surfaces
+    // (e.g., the Mac app) see channel-driven chat updates too.
+    const sink: ChatStreamSink = (ev) => {
+      try { sinkParam(ev); } catch { /* swallow */ }
+      if (this.chatEventListener) {
+        try { this.chatEventListener(ev); } catch { /* swallow */ }
+      }
+    };
 
     // Queue if at capacity
     if ((this.chatSemaphore as any).running >= (this.chatSemaphore as any).max) {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -15,6 +15,7 @@ import { ChatManager } from './chats';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { buildChatPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink } from './chat-runner';
+import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 
 interface ParsedCommand {
   command: string;
@@ -45,6 +46,7 @@ export class Codey {
   private configManager?: ConfigManager;
   private chatSemaphore = new RunSemaphore();
   private chatAborts: Map<string, AbortController> = new Map();
+  private turnQueue: TurnQueue;
 
   // Rate limiting: userId -> last request timestamp
   private userCooldowns: Map<string, number> = new Map();
@@ -144,6 +146,13 @@ export class Codey {
     this.workspaceManager = new WorkspaceManager(wm, workspaceDir || './workspaces', this.logger);
     this.chatManager = new ChatManager(this.workspaceManager.getWorkspacesRoot());
     this.pairingStore = new PairingStore(path.join(process.cwd(), 'pairings.json'));
+    this.turnQueue = new TurnQueue(async (_chatId, batch) => {
+      // No coalescing in this version: process each queued message in order.
+      for (const item of batch) {
+        if (!item.payload) continue;
+        await this.runOneTurn(item.payload.message, item.payload.parsed);
+      }
+    });
     this.COOLDOWN_MS = config.rateLimitMs || 3000; // Default 3 seconds
   }
 
@@ -471,8 +480,9 @@ export class Codey {
       return;
     }
 
-    // Check rate limit
-    if (!this.checkAndSetRateLimit(message.userId, message)) {
+    // Check rate limit (keyed by Codey chat id when available, else by user id)
+    const cooldownKey = this.cooldownKeyFor(message);
+    if (!this.checkAndSetRateLimit(cooldownKey, message)) {
       return;
     }
 
@@ -507,6 +517,14 @@ export class Codey {
     }
   }
 
+  private cooldownKeyFor(message: UserMessage): string {
+    if (this.isPairableChannel(message.channel)) {
+      const binding = this.pairingStore.findByChannelUser(message.channel, message.userId);
+      if (binding?.currentChatId) return `chat:${binding.currentChatId}`;
+    }
+    return `user:${message.userId}`;
+  }
+
   private checkAndSetRateLimit(userId: string, message: UserMessage): boolean {
     if (this.checkRateLimit(userId)) {
       this.userCooldowns.set(userId, Date.now());
@@ -522,20 +540,45 @@ export class Codey {
   }
 
   private async processPrompt(message: UserMessage, parsed: ParsedCommand): Promise<void> {
-    const { userId, channel, id: messageId } = message;
+    const { userId, chatId, channel } = message;
 
-    // Channel-side: if this user has a paired binding, prefer their current chat
-    // over the channel-derived chatId.
-    let chatId = message.chatId;
+    let codeyChatId: string | undefined;
+    if (this.isPairableChannel(channel)) {
+      const binding = this.pairingStore.findByChannelUser(channel, userId);
+      if (binding?.currentChatId) codeyChatId = binding.currentChatId;
+    }
+
+    // Queue key: prefer the Codey chat id; fall back to the channel-derived id
+    // so non-paired channels and Mac users still get per-conversation serialization.
+    // Note: 'tui' is mapped to 'mac' for queueing purposes (Surface doesn't know 'tui').
+    const queueKey = codeyChatId ?? `${channel}-${chatId}`;
+
+    this.turnQueue.submit(queueKey, {
+      surface: (channel === 'tui' ? 'mac' : channel) as Surface,
+      text: parsed.prompt ?? '',
+      userId,
+      timestamp: Date.now(),
+      payload: { message, parsed },
+    });
+  }
+
+  private async runOneTurn(message: UserMessage, parsed: ParsedCommand): Promise<void> {
+    const { userId, chatId, channel, id: messageId } = message;
+
+    // Channel-side: if this user has a paired binding with a current chat,
+    // use it for Codey-side state (context window, fan-out lookup). Replies
+    // continue to use `chatId` (the channel-side chat id) for routing.
+    let codeyChatId: string | undefined;
     if (this.isPairableChannel(channel)) {
       const binding = this.pairingStore.findByChannelUser(channel, userId);
       if (binding?.currentChatId) {
-        chatId = binding.currentChatId;
+        codeyChatId = binding.currentChatId;
       }
     }
 
     // Get or create structured context window keyed by conversationId
-    const conversationId = message.conversationId ?? `${message.channel}-${message.chatId}`;
+    const conversationId = message.conversationId
+      ?? (codeyChatId ? `chat-${codeyChatId}` : `${message.channel}-${message.chatId}`);
     const ctxWindow = await this.contextManager.getOrCreate(conversationId);
 
     // Build memory context from workspace memory store
@@ -634,6 +677,32 @@ export class Codey {
       text: replyText,
       replyTo: messageId,
     });
+
+    // Fan-out: if this message belongs to a Codey chat with multiple routes,
+    // send the reply to every other attached route too.
+    if (codeyChatId) {
+      await this.fanOutToOtherRoutes(codeyChatId, channel, userId, replyText);
+    }
+  }
+
+  private async fanOutToOtherRoutes(
+    codeyChatId: string,
+    originChannel: ChannelType,
+    originUserId: string,
+    text: string,
+  ): Promise<void> {
+    const chat = this.chatManager.get(codeyChatId);
+    if (!chat?.routes) return;
+    for (const route of chat.routes) {
+      if (route.channel === originChannel && route.channelUserId === originUserId) continue;
+      const handler = this.handlers.get(route.channel);
+      if (!handler?.sendToRoute) continue;
+      try {
+        await handler.sendToRoute(route, text);
+      } catch (err) {
+        this.logger.warn(`fanOut: failed to send to ${route.channel}: ${(err as Error).message}`);
+      }
+    }
   }
 
   /**

--- a/packages/gateway/src/pairings.test.ts
+++ b/packages/gateway/src/pairings.test.ts
@@ -1,0 +1,45 @@
+// Run: npx ts-node packages/gateway/src/pairings.test.ts
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PairingStore } from './pairings';
+
+async function run() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-pair-'));
+  const file = path.join(dir, 'pairings.json');
+  const store = new PairingStore(file);
+
+  const code = store.startPairing({ channel: 'telegram' });
+  assert.match(code, /^\d{6}$/);
+  assert.strictEqual(store.findByChannelUser('telegram', 'u1'), undefined);
+
+  const ok = store.completePairing(code, { channel: 'telegram', channelUserId: 'u1' });
+  assert.strictEqual(ok, true);
+  const binding = store.findByChannelUser('telegram', 'u1');
+  assert.ok(binding);
+  assert.strictEqual(binding!.channelUserId, 'u1');
+
+  const second = store.completePairing(code, { channel: 'telegram', channelUserId: 'u2' });
+  assert.strictEqual(second, false);
+
+  store.updatePrefs('telegram', 'u1', { workspace: 'main', agent: 'claude-code', model: 'sonnet-4-6' });
+  const reloaded = new PairingStore(file);
+  const b2 = reloaded.findByChannelUser('telegram', 'u1');
+  assert.strictEqual(b2?.prefs?.workspace, 'main');
+  assert.strictEqual(b2?.prefs?.agent, 'claude-code');
+
+  store.startPairing({ channel: 'telegram' });
+  store.completePairing(store.startPairing({ channel: 'discord' }), { channel: 'discord', channelUserId: 'd1' });
+  const tg = reloaded.listForChannel('telegram');
+  assert.strictEqual(tg.length, 1);
+
+  const c2 = store.startPairing({ channel: 'telegram', ttlMs: 0 });
+  await new Promise(r => setTimeout(r, 5));
+  assert.strictEqual(store.completePairing(c2, { channel: 'telegram', channelUserId: 'u3' }), false);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  console.log('pairings.test ok');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/packages/gateway/src/pairings.ts
+++ b/packages/gateway/src/pairings.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ChannelKind } from '@codey/core';
+
+export interface PairingPrefs {
+  workspace?: string;
+  agent?: 'claude-code' | 'opencode' | 'codex';
+  model?: string;
+}
+
+export interface ChannelBinding {
+  channel: ChannelKind;
+  channelUserId: string;
+  prefs?: PairingPrefs;
+  /** Per-binding "current chat" id used for the implicit-routing rule. */
+  currentChatId?: string;
+  createdAt: number;
+}
+
+interface PendingCode {
+  code: string;
+  channel: ChannelKind;
+  expiresAt: number;
+}
+
+interface PersistShape {
+  bindings: ChannelBinding[];
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+export class PairingStore {
+  private bindings: ChannelBinding[] = [];
+  private pending = new Map<string, PendingCode>();
+
+  constructor(private readonly file: string) {
+    this.load();
+  }
+
+  private load(): void {
+    if (!fs.existsSync(this.file)) return;
+    try {
+      const raw = fs.readFileSync(this.file, 'utf8');
+      const data = JSON.parse(raw) as PersistShape;
+      this.bindings = data.bindings ?? [];
+    } catch {
+      this.bindings = [];
+    }
+  }
+
+  private persist(): void {
+    fs.mkdirSync(path.dirname(this.file), { recursive: true });
+    const tmp = `${this.file}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify({ bindings: this.bindings }, null, 2), 'utf8');
+    fs.renameSync(tmp, this.file);
+  }
+
+  startPairing(input: { channel: ChannelKind; ttlMs?: number }): string {
+    const code = String(Math.floor(Math.random() * 1_000_000)).padStart(6, '0');
+    const ttl = input.ttlMs ?? DEFAULT_TTL_MS;
+    this.pending.set(code, {
+      code,
+      channel: input.channel,
+      expiresAt: Date.now() + ttl,
+    });
+    return code;
+  }
+
+  completePairing(code: string, input: { channel: ChannelKind; channelUserId: string }): boolean {
+    const entry = this.pending.get(code);
+    if (!entry) return false;
+    this.pending.delete(code);
+    if (entry.channel !== input.channel) return false;
+    if (Date.now() > entry.expiresAt) return false;
+
+    this.bindings = this.bindings.filter(b =>
+      !(b.channel === input.channel && b.channelUserId === input.channelUserId)
+    );
+    this.bindings.push({
+      channel: input.channel,
+      channelUserId: input.channelUserId,
+      createdAt: Date.now(),
+    });
+    this.persist();
+    return true;
+  }
+
+  findByChannelUser(channel: ChannelKind, channelUserId: string): ChannelBinding | undefined {
+    return this.bindings.find(b => b.channel === channel && b.channelUserId === channelUserId);
+  }
+
+  listForChannel(channel: ChannelKind): ChannelBinding[] {
+    return this.bindings.filter(b => b.channel === channel);
+  }
+
+  list(): ChannelBinding[] {
+    return [...this.bindings];
+  }
+
+  updatePrefs(channel: ChannelKind, channelUserId: string, patch: PairingPrefs): void {
+    const b = this.findByChannelUser(channel, channelUserId);
+    if (!b) return;
+    b.prefs = { ...(b.prefs ?? {}), ...patch };
+    this.persist();
+  }
+
+  setCurrentChat(channel: ChannelKind, channelUserId: string, chatId: string | undefined): void {
+    const b = this.findByChannelUser(channel, channelUserId);
+    if (!b) return;
+    if (chatId) b.currentChatId = chatId;
+    else delete b.currentChatId;
+    this.persist();
+  }
+
+  remove(channel: ChannelKind, channelUserId: string): void {
+    const before = this.bindings.length;
+    this.bindings = this.bindings.filter(b =>
+      !(b.channel === channel && b.channelUserId === channelUserId)
+    );
+    if (this.bindings.length !== before) this.persist();
+  }
+}

--- a/packages/gateway/src/summary.ts
+++ b/packages/gateway/src/summary.ts
@@ -1,0 +1,24 @@
+import { Chat } from '@codey/core';
+
+/**
+ * Summarize prior chat history into 3–5 sentences. Used when a chat is first linked to a channel,
+ * so the channel user gets a brief catch-up message.
+ *
+ * v1 implementation is intentionally local and deterministic: take the last 6 messages, truncate
+ * each, and stitch them. We can swap in an LLM call later without changing call sites.
+ */
+export function summarizePriorHistory(chat: Chat, opts?: { maxMessages?: number; perMessageChars?: number }): string {
+  const max = opts?.maxMessages ?? 6;
+  const cap = opts?.perMessageChars ?? 160;
+  const tail = chat.messages.slice(-max);
+  if (tail.length === 0) {
+    return `📋 Picking up chat "${chat.title}" (no prior history).`;
+  }
+  const lines = tail.map(m => {
+    const who = m.role === 'user' ? 'You' : 'Agent';
+    const text = m.content.replace(/\s+/g, ' ').trim();
+    const cut = text.length <= cap ? text : text.slice(0, cap) + '…';
+    return `${who}: ${cut}`;
+  });
+  return `📋 Picking up chat "${chat.title}". Recent context:\n${lines.join('\n')}`;
+}

--- a/packages/gateway/src/turn-queue.test.ts
+++ b/packages/gateway/src/turn-queue.test.ts
@@ -1,0 +1,31 @@
+// Run: npx ts-node packages/gateway/src/turn-queue.test.ts
+import * as assert from 'assert';
+import { TurnQueue, QueuedMessage } from './turn-queue';
+
+async function run() {
+  const seen: string[][] = [];
+  const q = new TurnQueue(async (chatId, batch: QueuedMessage[]) => {
+    seen.push(batch.map(m => `${m.surface}:${m.text}`));
+    await new Promise(r => setTimeout(r, 20));
+    return { chatId };
+  });
+
+  q.submit('c1', { surface: 'mac', text: 'a', userId: 'u', timestamp: 1 });
+  q.submit('c1', { surface: 'telegram', text: 'b', userId: 'u', timestamp: 2 });
+  q.submit('c1', { surface: 'mac', text: 'c', userId: 'u', timestamp: 3 });
+
+  await q.drain();
+
+  assert.deepStrictEqual(seen, [
+    ['mac:a'],
+    ['telegram:b', 'mac:c'],
+  ]);
+
+  q.submit('c2', { surface: 'discord', text: 'x', userId: 'u', timestamp: 4 });
+  await q.drain();
+  assert.deepStrictEqual(seen[2], ['discord:x']);
+
+  console.log('turn-queue.test ok');
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/packages/gateway/src/turn-queue.ts
+++ b/packages/gateway/src/turn-queue.ts
@@ -5,6 +5,8 @@ export interface QueuedMessage {
   text: string;
   userId: string;
   timestamp: number;
+  /** Optional payload used by the gateway runner. */
+  payload?: any;
 }
 
 export type TurnRunner = (chatId: string, batch: QueuedMessage[]) => Promise<unknown>;

--- a/packages/gateway/src/turn-queue.ts
+++ b/packages/gateway/src/turn-queue.ts
@@ -1,0 +1,56 @@
+export type Surface = 'mac' | 'telegram' | 'discord' | 'imessage';
+
+export interface QueuedMessage {
+  surface: Surface;
+  text: string;
+  userId: string;
+  timestamp: number;
+}
+
+export type TurnRunner = (chatId: string, batch: QueuedMessage[]) => Promise<unknown>;
+
+interface ChatState {
+  running: boolean;
+  pending: QueuedMessage[];
+  active?: Promise<void>;
+}
+
+export class TurnQueue {
+  private states = new Map<string, ChatState>();
+
+  constructor(private readonly runner: TurnRunner) {}
+
+  submit(chatId: string, msg: QueuedMessage): void {
+    const s = this.states.get(chatId) ?? { running: false, pending: [] };
+    this.states.set(chatId, s);
+    s.pending.push(msg);
+    if (!s.running) this.kick(chatId);
+  }
+
+  private kick(chatId: string): void {
+    const s = this.states.get(chatId);
+    if (!s || s.running || s.pending.length === 0) return;
+    s.running = true;
+    const batch = s.pending.splice(0, s.pending.length);
+    s.active = (async () => {
+      try {
+        await this.runner(chatId, batch);
+      } finally {
+        s.running = false;
+        if (s.pending.length > 0) {
+          this.kick(chatId);
+        } else {
+          this.states.delete(chatId);
+        }
+      }
+    })();
+  }
+
+  async drain(): Promise<void> {
+    while (true) {
+      const promises = [...this.states.values()].map(s => s.active).filter(Boolean) as Promise<void>[];
+      if (promises.length === 0) return;
+      await Promise.all(promises);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- One **Chat** entity with attachable channel **routes**; explicit, bidirectional linking between the Mac app and Telegram / Discord / iMessage.
- 6-digit pairing flow: Mac shows code → user sends \`/pair <code>\` from the channel → bound. Per-pairing prefs (workspace, agent, model) and per-user "current chat".
- Channel slash commands: \`/pair\`, \`/new\`, \`/list\`, \`/switch\`. Plain channel messages route to the user's current Codey chat.
- Channel-driven turns now flow through \`sendToChat\`, so the Codey \`Chat\` record is updated **and** the Mac UI receives \`chats:event\` (new global listener registered by the Mac main process).
- Replies fan out to every attached route plus the originating channel.
- Per-chat serialization via \`TurnQueue\` (no coalescing in v1) replaces per-user cooldown.
- Mac UI: route icons in sidebar + chat header, header link/unlink button, pairing modal.
- Mac UI now re-fetches the chat on remote \`done\`/\`error\` events so channel-driven messages render even without a local pending placeholder.

## Out of scope (v1)
- Coalescing buffered messages into a single multi-line turn (queue currently serializes one at a time).
- \`executePlannedTask\` not updated for the linked-chat reroute (planner path keeps legacy chatId behavior).
- iMessage channel reply uses the existing AppleScript send.

## Test plan
- [ ] Pair Telegram via \`/pair <code>\`; expect "✅ Paired".
- [ ] From Mac, click 🔗+ on a chat to link it to Telegram; the channel receives a one-line history summary.
- [ ] From Telegram, send a message: assistant reply lands in Telegram **and** the message + reply appear in the linked Mac chat in real time.
- [ ] \`/new test\` from a paired channel creates a chat that appears in the Mac sidebar with a route icon.
- [ ] \`/list\` and \`/switch <id-prefix>\` cycle the active chat.
- [ ] Restart gateway + Mac app: linked chat persists; messages still route correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)