### PR TITLE
feat(codey-mac): light/dark theme with system follow-through

### DIFF
--- a/codey-mac/index.html
+++ b/codey-mac/index.html
@@ -4,14 +4,25 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Codey</title>
+    <script>
+      (function () {
+        try {
+          var m = localStorage.getItem('codey.theme');
+          if (m !== 'light' && m !== 'dark' && m !== 'system') m = 'system';
+          var eff = m === 'system'
+            ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            : m;
+          document.documentElement.dataset.theme = eff;
+          // Match Task 2 default vars so initial paint isn't white-on-white or vice versa.
+          var bg = eff === 'light' ? '#ffffff' : '#141414';
+          var fg = eff === 'light' ? '#1d1d1f' : '#f0f0f0';
+          document.documentElement.style.background = bg;
+          document.documentElement.style.color = fg;
+        } catch (e) {}
+      })();
+    </script>
     <style>
-      body {
-        margin: 0;
-        padding: 0;
-        background-color: #1a1a1a;
-        color: #fff;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      }
+      body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     </style>
   </head>
   <body>

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -4,7 +4,15 @@ import { ChatListPanel } from './components/ChatListPanel'
 import { SettingsOverlay } from './components/SettingsOverlay'
 import { ChatsProvider, useChats } from './hooks/useChats'
 import { useGateway } from './hooks/useGateway'
-import { C } from './theme'
+import {
+  C,
+  applyTheme,
+  getStoredThemeMode,
+  resolveEffectiveTheme,
+  paletteToCssVars,
+  darkPalette,
+  lightPalette,
+} from './theme'
 
 const Shell: React.FC = () => {
   const { isRunning } = useGateway()
@@ -33,6 +41,18 @@ const Shell: React.FC = () => {
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [state.order, state.workspaces, createChat, selectChat])
+
+  useEffect(() => {
+    applyTheme(getStoredThemeMode())
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => {
+      if (getStoredThemeMode() === 'system') {
+        document.documentElement.dataset.theme = resolveEffectiveTheme('system')
+      }
+    }
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
 
   return (
     <div style={styles.root}>
@@ -82,19 +102,28 @@ const Shell: React.FC = () => {
         {settingsOpen && <SettingsOverlay onClose={() => { setSettingsOpen(false); refreshWorkspaces() }} />}
       </div>
       <style>{`
-        html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
-        body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
-        * { box-sizing: border-box; }
-        ::-webkit-scrollbar { width: 5px; height: 5px; }
-        ::-webkit-scrollbar-track { background: transparent; }
-        ::-webkit-scrollbar-thumb { background: #3a3a3a; border-radius: 3px; }
-        textarea, input, select, button { font-family: inherit; }
-        input, select, textarea { color: ${C.fg}; }
-        @keyframes codey-pulse {
-          0%, 100% { opacity: 1; transform: scale(1); }
-          50% { opacity: 0.4; transform: scale(0.8); }
-        }
-      `}</style>
+  :root {
+${paletteToCssVars(darkPalette)}
+  }
+  :root[data-theme="light"] {
+${paletteToCssVars(lightPalette)}
+  }
+  :root[data-theme="dark"] {
+${paletteToCssVars(darkPalette)}
+  }
+  html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
+  * { box-sizing: border-box; }
+  ::-webkit-scrollbar { width: 5px; height: 5px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: ${C.scrollbar}; border-radius: 3px; }
+  textarea, input, select, button { font-family: inherit; }
+  input, select, textarea { color: ${C.fg}; }
+  @keyframes codey-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(0.8); }
+  }
+`}</style>
     </div>
   )
 }

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -67,7 +67,7 @@ const Shell: React.FC = () => {
         <div style={{
           ...styles.statusPill,
           borderColor: C.green + '55',
-          background: '#32D74B11',
+          background: C.green + '11',
           color: C.green,
         }}>
           <div style={{ width: 6, height: 6, borderRadius: '50%', background: C.green }} />

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -1,0 +1,70 @@
+// codey-mac/src/components/AppearanceTab.tsx
+import React from 'react'
+import { C, ThemeMode, useThemeMode, useEffectiveTheme } from '../theme'
+
+const OPTIONS: { value: ThemeMode; label: string }[] = [
+  { value: 'light',  label: 'Light'  },
+  { value: 'dark',   label: 'Dark'   },
+  { value: 'system', label: 'System' },
+]
+
+export const AppearanceTab: React.FC = () => {
+  const [mode, setMode] = useThemeMode()
+  const effective = useEffectiveTheme()
+
+  return (
+    <div style={styles.wrap}>
+      <div style={styles.row}>
+        <div style={styles.label}>Theme</div>
+        <div role="radiogroup" aria-label="Theme" style={styles.segmented}>
+          {OPTIONS.map(opt => {
+            const active = mode === opt.value
+            return (
+              <button
+                key={opt.value}
+                role="radio"
+                aria-checked={active}
+                onClick={() => setMode(opt.value)}
+                style={{
+                  ...styles.segBtn,
+                  background: active ? C.accent : 'transparent',
+                  color: active ? '#ffffff' : C.fg2,
+                }}
+              >
+                {opt.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+      {mode === 'system' && (
+        <div style={styles.hint}>
+          Currently following system: {effective === 'dark' ? 'Dark' : 'Light'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrap:  { padding: '20px', display: 'flex', flexDirection: 'column', gap: 10 },
+  row:   { display: 'flex', alignItems: 'center', gap: 16 },
+  label: { fontSize: 13, color: C.fg, width: 80 },
+  segmented: {
+    display: 'inline-flex',
+    background: C.surface2,
+    border: `1px solid ${C.border}`,
+    borderRadius: 6,
+    padding: 2,
+    gap: 2,
+  },
+  segBtn: {
+    border: 'none',
+    borderRadius: 4,
+    padding: '5px 14px',
+    fontSize: 12,
+    fontWeight: 500,
+    cursor: 'pointer',
+  },
+  hint: { fontSize: 11, color: C.fg3, marginLeft: 96 },
+}

--- a/codey-mac/src/components/ChannelsSection.tsx
+++ b/codey-mac/src/components/ChannelsSection.tsx
@@ -159,7 +159,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({ liveStatus, is
 
   return (
     <div>
-      {error && <div style={{ background: '#FF453A22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
+      {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
       <ChannelEditor
         label="Telegram"
         enabled={!!channels.telegram?.enabled}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -623,7 +623,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
             {isSending ? (
               <button
                 onClick={() => stopChat(chatId)}
-                style={{ ...styles.sendButton, background: '#e04040', cursor: 'pointer' }}
+                style={{ ...styles.sendButton, background: C.red, cursor: 'pointer' }}
                 title="Stop (Esc)"
               >
                 <StopIcon color="#fff" />
@@ -686,11 +686,11 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#6ab0f3', fontFamily: 'Menlo, Monaco, "Courier New", monospace',
     padding: '2px 0', userSelect: 'text',
   },
-  toolCallInfo: { color: '#888', fontStyle: 'italic' },
+  toolCallInfo: { color: C.fg3, fontStyle: 'italic' },
   toolCallSep: { borderTop: `1px solid ${C.border2}`, marginBottom: 6, marginTop: 4 },
-  chevron: { display: 'inline-block', fontSize: 13, marginRight: 4, transition: 'transform 0.15s ease', color: '#555' },
+  chevron: { display: 'inline-block', fontSize: 13, marginRight: 4, transition: 'transform 0.15s ease', color: C.fg3 },
   toolDetail: { marginLeft: 20, marginTop: 4, marginBottom: 6, padding: 8, background: 'rgba(0,0,0,0.3)', borderRadius: 6, border: `1px solid ${C.border}` },
-  orphanBanner: { padding: '8px 12px', background: '#ff950033', color: '#ffb84d', fontSize: 12, borderTop: `1px solid ${C.border}` },
+  orphanBanner: { padding: '8px 12px', background: C.warningBg, color: C.warningFg, fontSize: 12, borderTop: `1px solid ${C.border}` },
   dropOverlay: {
     position: 'absolute' as const, inset: 8, zIndex: 10,
     background: 'rgba(10, 132, 255, 0.08)',
@@ -770,7 +770,7 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', justifyContent: 'center',
   },
   uploadError: {
-    color: '#ff8a80', fontSize: 11, padding: '0 4px',
+    color: C.dangerFg, fontSize: 11, padding: '0 4px',
   },
   attachButton: {
     width: 32, height: 32, borderRadius: 8, border: 'none',

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -22,9 +22,9 @@ function preserveLineBreaks(src: string): string {
 
 export const Markdown: React.FC<MarkdownProps> = ({ children, variant = 'assistant' }) => {
   const onUser = variant === 'user'
-  const inlineCodeBg = onUser ? 'rgba(0,0,0,0.22)' : '#1a1a1a'
-  const inlineCodeFg = onUser ? '#f0f0f0' : '#e6e6e6'
-  const codeBlockBg = onUser ? 'rgba(0,0,0,0.25)' : '#141414'
+  const inlineCodeBg = onUser ? 'rgba(0,0,0,0.22)' : C.inlineCodeBg
+  const inlineCodeFg = onUser ? '#f0f0f0' : C.inlineCodeFg
+  const codeBlockBg = onUser ? 'rgba(0,0,0,0.25)' : C.codeBg
   const codeBlockBorder = onUser ? 'rgba(255,255,255,0.12)' : C.border2
   const linkColor = onUser ? '#cfe6ff' : C.accent
   const quoteBorder = onUser ? 'rgba(255,255,255,0.35)' : C.border2
@@ -121,7 +121,7 @@ export const Markdown: React.FC<MarkdownProps> = ({ children, variant = 'assista
                   fontSize: 12,
                   lineHeight: 1.5,
                   fontFamily: MONO,
-                  color: '#e6e6e6',
+                  color: C.codeFg,
                   position: 'relative',
                 }}
               >

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -5,9 +5,11 @@ import { WorkspacesTab } from './WorkspacesTab'
 import WorkersTab from './WorkersTab'
 import { useGateway } from '../hooks/useGateway'
 import { C } from '../theme'
+import { AppearanceTab } from './AppearanceTab'
 
-type Tab = 'workers' | 'workspaces' | 'status' | 'settings'
+type Tab = 'appearance' | 'workers' | 'workspaces' | 'status' | 'settings'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
+  { key: 'appearance', label: 'Appearance', icon: '◐', description: 'Theme & visual options' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
   { key: 'workers',    label: 'Workers',    icon: '☰', description: 'Personalities & teams' },
@@ -64,6 +66,7 @@ export const SettingsOverlay: React.FC<Props> = ({ onClose }) => {
           <main style={styles.main}>
             <div style={styles.mainHeader}>{activeTab.label}</div>
             <div style={styles.mainContent}>
+              {tab === 'appearance' && <AppearanceTab />}
               {tab === 'status'     && <StatusTab status={status} logs={logs} isRunning={isRunning} />}
               {tab === 'workspaces' && <WorkspacesTab isGatewayRunning={isRunning} />}
               {tab === 'workers'    && <WorkersTab />}

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -9,7 +9,7 @@ import { AppearanceTab } from './AppearanceTab'
 
 type Tab = 'appearance' | 'workers' | 'workspaces' | 'status' | 'settings'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
-  { key: 'appearance', label: 'Appearance', icon: '◐', description: 'Theme & visual options' },
+  { key: 'appearance', label: 'System',     icon: '◐', description: 'Theme & visual options' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
   { key: 'workers',    label: 'Workers',    icon: '☰', description: 'Personalities & teams' },

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -7,9 +7,9 @@ import { useGateway } from '../hooks/useGateway'
 import { C } from '../theme'
 import { AppearanceTab } from './AppearanceTab'
 
-type Tab = 'appearance' | 'workers' | 'workspaces' | 'status' | 'settings'
+type Tab = 'general' | 'workers' | 'workspaces' | 'status' | 'settings'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
-  { key: 'appearance', label: 'General',    icon: '◐', description: 'Theme & visual options' },
+  { key: 'general',    label: 'General',    icon: '⚙', description: 'Theme & visual options' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
   { key: 'workers',    label: 'Workers',    icon: '☰', description: 'Personalities & teams' },
@@ -66,7 +66,7 @@ export const SettingsOverlay: React.FC<Props> = ({ onClose }) => {
           <main style={styles.main}>
             <div style={styles.mainHeader}>{activeTab.label}</div>
             <div style={styles.mainContent}>
-              {tab === 'appearance' && <AppearanceTab />}
+              {tab === 'general'    && <AppearanceTab />}
               {tab === 'status'     && <StatusTab status={status} logs={logs} isRunning={isRunning} />}
               {tab === 'workspaces' && <WorkspacesTab isGatewayRunning={isRunning} />}
               {tab === 'workers'    && <WorkersTab />}

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -9,7 +9,7 @@ import { AppearanceTab } from './AppearanceTab'
 
 type Tab = 'appearance' | 'workers' | 'workspaces' | 'status' | 'settings'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
-  { key: 'appearance', label: 'System',     icon: '◐', description: 'Theme & visual options' },
+  { key: 'appearance', label: 'General',    icon: '◐', description: 'Theme & visual options' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
   { key: 'workers',    label: 'Workers',    icon: '☰', description: 'Personalities & teams' },

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -54,7 +54,7 @@ const selectStyle: React.CSSProperties = { ...inputStyle, cursor: 'pointer' }
 const pillButton = (variant: 'primary' | 'danger' | 'ghost'): React.CSSProperties => ({
   padding: '6px 12px', borderRadius: 7, fontSize: 12, fontWeight: 600,
   border: 'none', cursor: 'pointer',
-  background: variant === 'primary' ? C.accent : variant === 'danger' ? '#FF453A22' : C.surface3,
+  background: variant === 'primary' ? C.accent : variant === 'danger' ? C.red + '22' : C.surface3,
   color: variant === 'primary' ? '#fff' : variant === 'danger' ? C.red : C.fg2,
 })
 
@@ -89,13 +89,13 @@ const AgentInstallChip: React.FC<{
         title={status.path ? `Found at ${status.path}` : undefined}
         style={{
           display: 'inline-flex', alignItems: 'center', gap: 6,
-          color: '#34c759', fontSize: 11, fontWeight: 600,
+          color: C.green, fontSize: 11, fontWeight: 600,
           padding: '3px 8px', borderRadius: 999,
           background: 'rgba(52,199,89,0.12)',
           border: '1px solid rgba(52,199,89,0.35)',
         }}
       >
-        <span style={{ width: 6, height: 6, borderRadius: 3, background: '#34c759' }}/>
+        <span style={{ width: 6, height: 6, borderRadius: 3, background: C.green }}/>
         Installed
       </span>
     )
@@ -105,7 +105,7 @@ const AgentInstallChip: React.FC<{
       onClick={onInstall}
       style={{
         ...pillButton('ghost'),
-        color: '#ff9f0a',
+        color: C.warningFg,
         background: 'rgba(255,159,10,0.12)',
         border: '1px solid rgba(255,159,10,0.35)',
         display: 'inline-flex', alignItems: 'center', gap: 4,
@@ -444,7 +444,7 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
 
   return (
     <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
-      {error && <div style={{ background: '#FF453A22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
+      {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
 
       <Section title="Models" right={
         <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>

--- a/codey-mac/src/components/StatusTab.tsx
+++ b/codey-mac/src/components/StatusTab.tsx
@@ -120,7 +120,7 @@ export const StatusTab: React.FC<StatusTabProps> = ({ status, logs, isRunning })
         <div style={styles.sectionHead}>Logs</div>
         <div style={styles.logsBox}>
           {logs.length === 0
-            ? <div style={{ color: '#444' }}>No logs yet.</div>
+            ? <div style={{ color: C.fg3 }}>No logs yet.</div>
             : logs.map((l, i) => <div key={i}>{l}</div>)}
         </div>
       </div>
@@ -178,13 +178,13 @@ const styles: Record<string, React.CSSProperties> = {
     outline: 'none',
   },
   logsBox: {
-    background: '#0d0d0d',
+    background: C.logBg,
     borderRadius: 10,
     border: `1px solid ${C.border}`,
     padding: 12,
     fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
     fontSize: 11,
-    color: '#6a9955',
+    color: C.logFg,
     maxHeight: 180,
     overflowY: 'auto',
     lineHeight: 1.6,

--- a/codey-mac/src/components/TeamsSection.tsx
+++ b/codey-mac/src/components/TeamsSection.tsx
@@ -122,7 +122,7 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
           <button onClick={addTeam} style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.accent, border: `1px solid ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>+ New team</button>
         </div>
       </div>
-      {error && <div style={{ background: '#3a1a1a', color: '#ff8080', padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{error}</div>}
+      {error && <div style={{ background: C.dangerBg, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{error}</div>}
       {Object.keys(teams).length === 0 && <div style={{ fontSize: 12, color: C.fg3 }}>No teams yet. Click &quot;+ New team&quot;.</div>}
       {Object.entries(teams).map(([name, team]) => (
         <div key={name} style={{ marginBottom: 12, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6 }}>
@@ -146,7 +146,7 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
               </option>
               <option value="parallel" disabled>Parallel (coming soon)</option>
             </select>
-            <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: '#ff6060', border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
+            <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: C.dangerFg, border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
           </div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
             {team.members.map((m, i) => {
@@ -203,7 +203,7 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
             style={{ width: 520, padding: 20, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8 }}>
             <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 6 }}>New worker for "{creatingFor}"</div>
             <div style={{ fontSize: 12, color: C.fg3, marginBottom: 10 }}>The active coding agent will generate a personality and config from your description.</div>
-            {createError && <div style={{ background: '#3a1a1a', border: '1px solid #6a2a2a', color: '#ff8080', padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{createError}</div>}
+            {createError && <div style={{ background: C.dangerBg, border: `1px solid ${C.dangerBorder}`, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{createError}</div>}
             <textarea value={createPrompt} onChange={e => setCreatePrompt(e.target.value)} disabled={createBusy}
               placeholder="e.g. A reviewer that audits PRs for security issues, leans on Opus."
               style={{ width: '100%', minHeight: 120, padding: 10, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, fontFamily: 'inherit', fontSize: 13, resize: 'vertical' }} />

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -75,7 +75,7 @@ function CreatePanel({ loading, setLoading, onCreated, onCancel }: { loading: bo
     <div style={{ padding: 24, maxWidth: 640 }}>
       <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>Describe the worker</div>
       <div style={{ fontSize: 12, color: C.fg3, marginBottom: 12 }}>The active coding agent will generate a personality and config from your description.</div>
-      {error && <div style={{ background: '#3a1a1a', border: '1px solid #6a2a2a', color: '#ff8080', padding: 10, borderRadius: 6, marginBottom: 12, fontSize: 12 }}>{error}</div>}
+      {error && <div style={{ background: C.dangerBg, border: `1px solid ${C.dangerBorder}`, color: C.dangerFg, padding: 10, borderRadius: 6, marginBottom: 12, fontSize: 12 }}>{error}</div>}
       <textarea value={prompt} onChange={e => setPrompt(e.target.value)} placeholder="e.g. A reviewer that audits PRs for security issues, leans on Opus, uses file-system and git tools."
         style={{ width: '100%', minHeight: 160, padding: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, fontFamily: 'inherit', fontSize: 14, resize: 'vertical' }} />
       <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
@@ -144,9 +144,9 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
     <div style={{ padding: 24, maxWidth: 720 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
         <div style={{ fontSize: 18, fontWeight: 600 }}>{worker.name}</div>
-        <button onClick={confirmDelete} style={{ background: 'transparent', color: '#ff6060', border: `1px solid #6a2a2a`, padding: '6px 10px', borderRadius: 6, cursor: 'pointer', fontSize: 12 }}>Delete</button>
+        <button onClick={confirmDelete} style={{ background: 'transparent', color: C.dangerFg, border: `1px solid ${C.dangerBorder}`, padding: '6px 10px', borderRadius: 6, cursor: 'pointer', fontSize: 12 }}>Delete</button>
       </div>
-      {error && <div style={{ background: '#3a1a1a', border: '1px solid #6a2a2a', color: '#ff8080', padding: 10, borderRadius: 6, fontSize: 12 }}>{error}</div>}
+      {error && <div style={{ background: C.dangerBg, border: `1px solid ${C.dangerBorder}`, color: C.dangerFg, padding: 10, borderRadius: 6, fontSize: 12 }}>{error}</div>}
 
       <label style={labelStyle}>Role</label>
       <textarea value={role} onChange={e => setRole(e.target.value)} style={{ ...fieldStyle, minHeight: 60 }} />

--- a/codey-mac/src/components/WorkspacesTab.tsx
+++ b/codey-mac/src/components/WorkspacesTab.tsx
@@ -293,7 +293,7 @@ const MemorySection: React.FC<{ workspace: string }> = ({ workspace }) => {
           )}
         </div>
       </div>
-      {err && <div style={{ background: '#3a1a1a', color: '#ff8080', padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{err}</div>}
+      {err && <div style={{ background: C.dangerBg, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{err}</div>}
       {!loaded ? (
         <div style={{ fontSize: 12, color: C.fg3 }}>Loading…</div>
       ) : editing ? (
@@ -341,7 +341,7 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 12, fontWeight: 600,
   },
   error: {
-    background: '#ff453a22', color: '#ff8a82', border: `1px solid #ff453a55`,
+    background: C.dangerBg, color: C.dangerFg, border: `1px solid ${C.dangerBorder}`,
     borderRadius: 8, padding: '8px 12px', fontSize: 12, marginBottom: 12,
   },
   wsTopRow: {

--- a/codey-mac/src/components/toolFormat.tsx
+++ b/codey-mac/src/components/toolFormat.tsx
@@ -128,10 +128,10 @@ const lineDiff = (a: string, b: string): DiffLine[] => {
 const diffStyles: Record<string, React.CSSProperties> = {
   wrap: { fontFamily: 'Menlo, Monaco, "Courier New", monospace', fontSize: 11.5, lineHeight: 1.45, borderRadius: 4, overflow: 'hidden', border: `1px solid ${C.border}` },
   row: { display: 'flex', whiteSpace: 'pre', padding: '0 6px' },
-  add: { background: 'rgba(50,215,75,0.13)', color: '#7ee895' },
-  del: { background: 'rgba(255,69,58,0.13)', color: '#ff8a82' },
-  eq:  { color: '#9a9a9a' },
-  marker: { width: 14, color: '#666', flexShrink: 0 },
+  add: { background: 'rgba(50,215,75,0.13)', color: C.green },
+  del: { background: 'rgba(255,69,58,0.13)', color: C.dangerFg },
+  eq:  { color: C.fg2 },
+  marker: { width: 14, color: C.fg3, flexShrink: 0 },
 }
 
 const DiffView: React.FC<{ oldText: string; newText: string }> = ({ oldText, newText }) => {
@@ -155,10 +155,10 @@ const DiffView: React.FC<{ oldText: string; newText: string }> = ({ oldText, new
 // ── Detail rendering ──────────────────────────────────────────────────────────
 
 const detailStyles: Record<string, React.CSSProperties> = {
-  label: { fontSize: 10, color: '#777', fontFamily: 'Menlo, Monaco, "Courier New", monospace', marginBottom: 4, marginTop: 6, textTransform: 'uppercase', letterSpacing: 0.5 },
-  pre: { margin: 0, fontSize: 11.5, color: '#d0d0d0', fontFamily: 'Menlo, Monaco, "Courier New", monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-word' },
+  label: { fontSize: 10, color: C.fg3, fontFamily: 'Menlo, Monaco, "Courier New", monospace', marginBottom: 4, marginTop: 6, textTransform: 'uppercase', letterSpacing: 0.5 },
+  pre: { margin: 0, fontSize: 11.5, color: C.fg, fontFamily: 'Menlo, Monaco, "Courier New", monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-word' },
   block: { padding: 8, background: 'rgba(0,0,0,0.35)', borderRadius: 4, border: `1px solid ${C.border}` },
-  meta: { fontSize: 11, color: '#a0a0a0', fontFamily: 'Menlo, Monaco, "Courier New", monospace' },
+  meta: { fontSize: 11, color: C.fg2, fontFamily: 'Menlo, Monaco, "Courier New", monospace' },
   todoRow: { display: 'flex', gap: 6, alignItems: 'flex-start', fontSize: 12, padding: '2px 0', fontFamily: 'Menlo, Monaco, "Courier New", monospace' },
 }
 
@@ -167,11 +167,11 @@ const TodoList: React.FC<{ todos: Array<{ content?: string; status?: string; act
     {todos.map((t, i) => {
       const status = t.status ?? 'pending'
       const mark = status === 'completed' ? '✓' : status === 'in_progress' ? '◐' : '○'
-      const color = status === 'completed' ? C.green : status === 'in_progress' ? C.yellow : '#888'
+      const color = status === 'completed' ? C.green : status === 'in_progress' ? C.yellow : C.fg3
       return (
         <div key={i} style={detailStyles.todoRow}>
           <span style={{ color, width: 14, flexShrink: 0 }}>{mark}</span>
-          <span style={{ color: status === 'completed' ? '#888' : '#d0d0d0', textDecoration: status === 'completed' ? 'line-through' : 'none' }}>
+          <span style={{ color: status === 'completed' ? C.fg3 : C.fg, textDecoration: status === 'completed' ? 'line-through' : 'none' }}>
             {t.content ?? t.activeForm ?? ''}
           </span>
         </div>

--- a/codey-mac/src/theme.ts
+++ b/codey-mac/src/theme.ts
@@ -24,6 +24,20 @@ interface Palette {
   userBg: string
   aiBg: string
   scrollbar: string
+  // danger / error surfaces (used by error toasts in many components)
+  dangerBg: string
+  dangerBorder: string
+  dangerFg: string
+  // code / log surfaces (chat code blocks, inline code, status logs)
+  codeBg: string
+  codeFg: string
+  inlineCodeBg: string
+  inlineCodeFg: string
+  logBg: string
+  logFg: string
+  // warning (orange) surfaces — orphan banners, gateway-stopped notice
+  warningBg: string
+  warningFg: string
 }
 
 export const darkPalette: Palette = {
@@ -44,6 +58,17 @@ export const darkPalette: Palette = {
   userBg:    '#0A84FF',
   aiBg:      '#252525',
   scrollbar: '#3a3a3a',
+  dangerBg:      '#3a1a1a',
+  dangerBorder:  '#6a2a2a',
+  dangerFg:      '#ff8080',
+  codeBg:        '#141414',
+  codeFg:        '#e6e6e6',
+  inlineCodeBg:  '#1a1a1a',
+  inlineCodeFg:  '#e6e6e6',
+  logBg:         '#0d0d0d',
+  logFg:         '#6a9955',
+  warningBg:     '#ff950033',
+  warningFg:     '#ffb84d',
 }
 
 export const lightPalette: Palette = {
@@ -64,6 +89,17 @@ export const lightPalette: Palette = {
   userBg:    '#0A84FF',
   aiBg:      '#f5f5f7',
   scrollbar: '#c7c7cc',
+  dangerBg:      '#FFE5E5',
+  dangerBorder:  '#FFB3B3',
+  dangerFg:      '#C92A2A',
+  codeBg:        '#f5f5f7',
+  codeFg:        '#1d1d1f',
+  inlineCodeBg:  '#ebebef',
+  inlineCodeFg:  '#1d1d1f',
+  logBg:         '#fafafa',
+  logFg:         '#28792B',
+  warningBg:     '#FFE9C4',
+  warningFg:     '#A85D00',
 }
 
 // Token names mirror Palette keys; `C.bg` etc. resolve to `var(--bg)` at render time.

--- a/codey-mac/src/theme.ts
+++ b/codey-mac/src/theme.ts
@@ -1,4 +1,32 @@
-export const C = {
+// codey-mac/src/theme.ts
+import { useEffect, useState } from 'react'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+export type EffectiveTheme = 'light' | 'dark'
+
+const STORAGE_KEY = 'codey.theme'
+
+interface Palette {
+  bg: string
+  surface: string
+  surface2: string
+  surface3: string
+  border: string
+  border2: string
+  fg: string
+  fg2: string
+  fg3: string
+  accent: string
+  accentDim: string
+  green: string
+  red: string
+  yellow: string
+  userBg: string
+  aiBg: string
+  scrollbar: string
+}
+
+export const darkPalette: Palette = {
   bg:        '#141414',
   surface:   '#1e1e1e',
   surface2:  '#252525',
@@ -15,4 +43,84 @@ export const C = {
   yellow:    '#FFD60A',
   userBg:    '#0A84FF',
   aiBg:      '#252525',
+  scrollbar: '#3a3a3a',
+}
+
+export const lightPalette: Palette = {
+  bg:        '#ffffff',
+  surface:   '#f5f5f7',
+  surface2:  '#ebebef',
+  surface3:  '#e1e1e6',
+  border:    '#d2d2d7',
+  border2:   '#c7c7cc',
+  fg:        '#1d1d1f',
+  fg2:       '#6e6e73',
+  fg3:       '#8e8e93',
+  accent:    '#0A84FF',
+  accentDim: '#0A84FF22',
+  green:     '#34C759',
+  red:       '#FF3B30',
+  yellow:    '#FFCC00',
+  userBg:    '#0A84FF',
+  aiBg:      '#f5f5f7',
+  scrollbar: '#c7c7cc',
+}
+
+// Token names mirror Palette keys; `C.bg` etc. resolve to `var(--bg)` at render time.
+export const C = (Object.keys(darkPalette) as (keyof Palette)[]).reduce((acc, key) => {
+  acc[key] = `var(--${key})`
+  return acc
+}, {} as Record<keyof Palette, string>)
+
+export function paletteToCssVars(p: Palette): string {
+  return (Object.keys(p) as (keyof Palette)[])
+    .map(k => `  --${k}: ${p[k]};`)
+    .join('\n')
+}
+
+export function getStoredThemeMode(): ThemeMode {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v === 'light' || v === 'dark' || v === 'system') return v
+  } catch {}
+  return 'system'
+}
+
+export function resolveEffectiveTheme(mode: ThemeMode): EffectiveTheme {
+  if (mode === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return mode
+}
+
+export function applyTheme(mode: ThemeMode): EffectiveTheme {
+  const effective = resolveEffectiveTheme(mode)
+  document.documentElement.dataset.theme = effective
+  try { localStorage.setItem(STORAGE_KEY, mode) } catch {}
+  return effective
+}
+
+export function useThemeMode(): [ThemeMode, (m: ThemeMode) => void] {
+  const [mode, setModeState] = useState<ThemeMode>(getStoredThemeMode)
+  const setMode = (m: ThemeMode) => {
+    applyTheme(m)
+    setModeState(m)
+  }
+  return [mode, setMode]
+}
+
+export function useEffectiveTheme(): EffectiveTheme {
+  const [eff, setEff] = useState<EffectiveTheme>(() => resolveEffectiveTheme(getStoredThemeMode()))
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const recompute = () => setEff(resolveEffectiveTheme(getStoredThemeMode()))
+    mql.addEventListener('change', recompute)
+    const onStorage = (e: StorageEvent) => { if (e.key === STORAGE_KEY) recompute() }
+    window.addEventListener('storage', onStorage)
+    return () => {
+      mql.removeEventListener('change', recompute)
+      window.removeEventListener('storage', onStorage)
+    }
+  }, [])
+  return eff
 }

--- a/docs/superpowers/plans/2026-05-06-codey-mac-theme.md
+++ b/docs/superpowers/plans/2026-05-06-codey-mac-theme.md
@@ -1,0 +1,533 @@
+# codey-mac Light/Dark Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Light / Dark / System theme support to the codey-mac Electron app, with persistent user choice and live OS-appearance tracking when in System mode.
+
+**Architecture:** Refactor `src/theme.ts` so the exported `C` token object's values are `var(--token)` strings instead of literal hex. Two palettes (`darkPalette`, `lightPalette`) drive CSS custom properties scoped by a `data-theme` attribute on `<html>`. A pre-React inline script in `index.html` sets the attribute before first paint to avoid flicker. A new Appearance pane in the existing Settings modal lets the user pick the mode.
+
+**Tech Stack:** React 18, Electron, Vite, TypeScript, inline styles. No CSS framework, no test runner.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-codey-mac-theme-design.md`
+
+**Working directory for all commands:** `codey-mac/`
+
+---
+
+### Task 1: Define palettes and CSS-variable-backed `C` tokens
+
+**Files:**
+- Modify: `codey-mac/src/theme.ts` (full rewrite)
+
+- [ ] **Step 1: Replace `src/theme.ts` with palette definitions and var-backed `C`**
+
+```ts
+// codey-mac/src/theme.ts
+import { useEffect, useState } from 'react'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+export type EffectiveTheme = 'light' | 'dark'
+
+const STORAGE_KEY = 'codey.theme'
+
+interface Palette {
+  bg: string
+  surface: string
+  surface2: string
+  surface3: string
+  border: string
+  border2: string
+  fg: string
+  fg2: string
+  fg3: string
+  accent: string
+  accentDim: string
+  green: string
+  red: string
+  yellow: string
+  userBg: string
+  aiBg: string
+  scrollbar: string
+}
+
+export const darkPalette: Palette = {
+  bg:        '#141414',
+  surface:   '#1e1e1e',
+  surface2:  '#252525',
+  surface3:  '#2d2d2d',
+  border:    '#2e2e2e',
+  border2:   '#383838',
+  fg:        '#f0f0f0',
+  fg2:       '#a0a0a0',
+  fg3:       '#606060',
+  accent:    '#0A84FF',
+  accentDim: '#0A84FF22',
+  green:     '#32D74B',
+  red:       '#FF453A',
+  yellow:    '#FFD60A',
+  userBg:    '#0A84FF',
+  aiBg:      '#252525',
+  scrollbar: '#3a3a3a',
+}
+
+export const lightPalette: Palette = {
+  bg:        '#ffffff',
+  surface:   '#f5f5f7',
+  surface2:  '#ebebef',
+  surface3:  '#e1e1e6',
+  border:    '#d2d2d7',
+  border2:   '#c7c7cc',
+  fg:        '#1d1d1f',
+  fg2:       '#6e6e73',
+  fg3:       '#8e8e93',
+  accent:    '#0A84FF',
+  accentDim: '#0A84FF22',
+  green:     '#34C759',
+  red:       '#FF3B30',
+  yellow:    '#FFCC00',
+  userBg:    '#0A84FF',
+  aiBg:      '#f5f5f7',
+  scrollbar: '#c7c7cc',
+}
+
+// Token names mirror Palette keys; `C.bg` etc. resolve to `var(--bg)` at render time.
+export const C = (Object.keys(darkPalette) as (keyof Palette)[]).reduce((acc, key) => {
+  acc[key] = `var(--${key})`
+  return acc
+}, {} as Record<keyof Palette, string>)
+
+export function paletteToCssVars(p: Palette): string {
+  return (Object.keys(p) as (keyof Palette)[])
+    .map(k => `  --${k}: ${p[k]};`)
+    .join('\n')
+}
+
+export function getStoredThemeMode(): ThemeMode {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v === 'light' || v === 'dark' || v === 'system') return v
+  } catch {}
+  return 'system'
+}
+
+export function resolveEffectiveTheme(mode: ThemeMode): EffectiveTheme {
+  if (mode === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return mode
+}
+
+export function applyTheme(mode: ThemeMode): EffectiveTheme {
+  const effective = resolveEffectiveTheme(mode)
+  document.documentElement.dataset.theme = effective
+  try { localStorage.setItem(STORAGE_KEY, mode) } catch {}
+  return effective
+}
+
+export function useThemeMode(): [ThemeMode, (m: ThemeMode) => void] {
+  const [mode, setModeState] = useState<ThemeMode>(getStoredThemeMode)
+  const setMode = (m: ThemeMode) => {
+    applyTheme(m)
+    setModeState(m)
+  }
+  return [mode, setMode]
+}
+
+export function useEffectiveTheme(): EffectiveTheme {
+  const [eff, setEff] = useState<EffectiveTheme>(() => resolveEffectiveTheme(getStoredThemeMode()))
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const recompute = () => setEff(resolveEffectiveTheme(getStoredThemeMode()))
+    mql.addEventListener('change', recompute)
+    const onStorage = (e: StorageEvent) => { if (e.key === STORAGE_KEY) recompute() }
+    window.addEventListener('storage', onStorage)
+    return () => {
+      mql.removeEventListener('change', recompute)
+      window.removeEventListener('storage', onStorage)
+    }
+  }, [])
+  return eff
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run from `codey-mac/`:
+```
+npx tsc --noEmit -p tsconfig.json
+```
+Expected: no errors. Existing components that import `{ C }` keep working (same key set).
+
+- [ ] **Step 3: Commit**
+
+```
+git add codey-mac/src/theme.ts
+git commit -m "refactor(codey-mac): tokenize theme via CSS variables"
+```
+
+---
+
+### Task 2: Inject CSS-variable definitions and apply mode in App
+
+**Files:**
+- Modify: `codey-mac/src/App.tsx`
+
+- [ ] **Step 1: Update imports at the top of `App.tsx`**
+
+Find the existing line:
+```ts
+import { C } from './theme'
+```
+Replace with:
+```ts
+import {
+  C,
+  applyTheme,
+  getStoredThemeMode,
+  resolveEffectiveTheme,
+  paletteToCssVars,
+  darkPalette,
+  lightPalette,
+} from './theme'
+```
+
+- [ ] **Step 2: Add a theme-bootstrap effect inside the `Shell` component**
+
+Locate the `Shell` functional component in `App.tsx`. Immediately after its existing `useEffect` calls (or near the top of the component body, before the returned JSX), add:
+
+```tsx
+useEffect(() => {
+  applyTheme(getStoredThemeMode())
+  const mql = window.matchMedia('(prefers-color-scheme: dark)')
+  const onChange = () => {
+    if (getStoredThemeMode() === 'system') {
+      document.documentElement.dataset.theme = resolveEffectiveTheme('system')
+    }
+  }
+  mql.addEventListener('change', onChange)
+  return () => mql.removeEventListener('change', onChange)
+}, [])
+```
+
+- [ ] **Step 3: Replace hardcoded colors in the global `<style>` block**
+
+In `App.tsx`, find the `<style>{` ... `}</style>` block (around lines 84–98 in the current file). Replace its contents with:
+
+```tsx
+<style>{`
+  :root {
+${paletteToCssVars(darkPalette)}
+  }
+  :root[data-theme="light"] {
+${paletteToCssVars(lightPalette)}
+  }
+  :root[data-theme="dark"] {
+${paletteToCssVars(darkPalette)}
+  }
+  html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
+  * { box-sizing: border-box; }
+  ::-webkit-scrollbar { width: 5px; height: 5px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: ${C.scrollbar}; border-radius: 3px; }
+  textarea, input, select, button { font-family: inherit; }
+  input, select, textarea { color: ${C.fg}; }
+  @keyframes codey-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(0.8); }
+  }
+`}</style>
+```
+
+Note the `:root` (no attribute) default block — covers the brief moment before `data-theme` is set.
+
+- [ ] **Step 4: Type-check**
+
+```
+npx tsc --noEmit -p tsconfig.json
+```
+Expected: no errors. (The `C.scrollbar` access requires Task 1 to be merged — it adds the `scrollbar` token.)
+
+- [ ] **Step 5: Commit**
+
+```
+git add codey-mac/src/App.tsx
+git commit -m "feat(codey-mac): inject theme CSS variables and apply mode on mount"
+```
+
+---
+
+### Task 3: Pre-paint flicker prevention in `index.html`
+
+**Files:**
+- Modify: `codey-mac/index.html`
+
+- [ ] **Step 1: Add inline script that sets `data-theme` before React mounts**
+
+Replace the existing `<style>` block in `index.html` (it hardcodes `#1a1a1a` / `#fff` for the body) with a script + minimal style. New `index.html` body:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codey</title>
+    <script>
+      (function () {
+        try {
+          var m = localStorage.getItem('codey.theme');
+          if (m !== 'light' && m !== 'dark' && m !== 'system') m = 'system';
+          var eff = m === 'system'
+            ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            : m;
+          document.documentElement.dataset.theme = eff;
+          // Match Task 2 default vars so initial paint isn't white-on-white or vice versa.
+          var bg = eff === 'light' ? '#ffffff' : '#141414';
+          var fg = eff === 'light' ? '#1d1d1f' : '#f0f0f0';
+          document.documentElement.style.background = bg;
+          document.documentElement.style.color = fg;
+        } catch (e) {}
+      })();
+    </script>
+    <style>
+      body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add codey-mac/index.html
+git commit -m "feat(codey-mac): apply persisted theme before first paint"
+```
+
+---
+
+### Task 4: Add Appearance pane to Settings modal
+
+**Files:**
+- Create: `codey-mac/src/components/AppearanceTab.tsx`
+- Modify: `codey-mac/src/components/SettingsOverlay.tsx`
+
+- [ ] **Step 1: Create `AppearanceTab.tsx`**
+
+```tsx
+// codey-mac/src/components/AppearanceTab.tsx
+import React from 'react'
+import { C, ThemeMode, useThemeMode, useEffectiveTheme } from '../theme'
+
+const OPTIONS: { value: ThemeMode; label: string }[] = [
+  { value: 'light',  label: 'Light'  },
+  { value: 'dark',   label: 'Dark'   },
+  { value: 'system', label: 'System' },
+]
+
+export const AppearanceTab: React.FC = () => {
+  const [mode, setMode] = useThemeMode()
+  const effective = useEffectiveTheme()
+
+  return (
+    <div style={styles.wrap}>
+      <div style={styles.row}>
+        <div style={styles.label}>Theme</div>
+        <div role="radiogroup" aria-label="Theme" style={styles.segmented}>
+          {OPTIONS.map(opt => {
+            const active = mode === opt.value
+            return (
+              <button
+                key={opt.value}
+                role="radio"
+                aria-checked={active}
+                onClick={() => setMode(opt.value)}
+                style={{
+                  ...styles.segBtn,
+                  background: active ? C.accent : 'transparent',
+                  color: active ? '#ffffff' : C.fg2,
+                }}
+              >
+                {opt.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+      {mode === 'system' && (
+        <div style={styles.hint}>
+          Currently following system: {effective === 'dark' ? 'Dark' : 'Light'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrap:  { padding: '20px', display: 'flex', flexDirection: 'column', gap: 10 },
+  row:   { display: 'flex', alignItems: 'center', gap: 16 },
+  label: { fontSize: 13, color: C.fg, width: 80 },
+  segmented: {
+    display: 'inline-flex',
+    background: C.surface2,
+    border: `1px solid ${C.border}`,
+    borderRadius: 6,
+    padding: 2,
+    gap: 2,
+  },
+  segBtn: {
+    border: 'none',
+    borderRadius: 4,
+    padding: '5px 14px',
+    fontSize: 12,
+    fontWeight: 500,
+    cursor: 'pointer',
+  },
+  hint: { fontSize: 11, color: C.fg3, marginLeft: 96 },
+}
+```
+
+- [ ] **Step 2: Wire `AppearanceTab` into `SettingsOverlay.tsx`**
+
+In `codey-mac/src/components/SettingsOverlay.tsx`:
+
+(a) Add import at the top, after the existing component imports:
+```ts
+import { AppearanceTab } from './AppearanceTab'
+```
+
+(b) Update the `Tab` type (line 9):
+```ts
+type Tab = 'appearance' | 'workers' | 'workspaces' | 'status' | 'settings'
+```
+
+(c) Update the `TABS` constant (lines 10–15) — add Appearance as the first entry:
+```ts
+const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
+  { key: 'appearance', label: 'Appearance', icon: '◐', description: 'Theme & visual options' },
+  { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
+  { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
+  { key: 'workers',    label: 'Workers',    icon: '☰', description: 'Personalities & teams' },
+  { key: 'status',     label: 'Gateway',    icon: '◉', description: 'Server status & logs' },
+]
+```
+
+(d) Render the new tab — in the `mainContent` div (around line 67), add the line:
+```tsx
+{tab === 'appearance' && <AppearanceTab />}
+```
+…immediately above the existing `{tab === 'status' ...}` line.
+
+- [ ] **Step 3: Type-check**
+
+```
+npx tsc --noEmit -p tsconfig.json
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```
+git add codey-mac/src/components/AppearanceTab.tsx codey-mac/src/components/SettingsOverlay.tsx
+git commit -m "feat(codey-mac): add Appearance pane with Light/Dark/System control"
+```
+
+---
+
+### Task 5: Sweep for stray hardcoded hex colors
+
+**Files:**
+- Modify: any file in `codey-mac/src/` outside `theme.ts` containing literal hex colors that should be theme-aware.
+
+- [ ] **Step 1: Grep for hex literals outside `theme.ts`**
+
+Run from repo root:
+```
+grep -rn -E "#[0-9a-fA-F]{3,8}\\b" codey-mac/src --include="*.tsx" --include="*.ts" \
+  | grep -v "src/theme.ts"
+```
+
+- [ ] **Step 2: Categorize each result**
+
+For each match decide:
+- **Keep as-is:** intentionally fixed colors (e.g. macOS traffic-light buttons `#FF5F57` / `#E0443E` in `SettingsOverlay.tsx`, the `#0A84FF` in `userBg` if already routed through `C`, opaque overlays like `rgba(0,0,0,0.55)`).
+- **Replace with token:** colors that should adapt to theme. Use the closest existing `C.*` token. If no existing token fits (e.g. a one-off semantic like a destructive-button background), use the nearest of `C.surface2`, `C.border`, `C.fg2`, etc.
+
+If two or more files use the *same* untokenized color for the same purpose, add a new token to both palettes in `theme.ts` rather than duplicating the literal.
+
+- [ ] **Step 3: Make the replacements**
+
+Edit the affected files. For each replacement, verify the dark-mode output still matches the previous appearance (the dark palette values are unchanged from before this work).
+
+- [ ] **Step 4: Type-check**
+
+```
+cd codey-mac && npx tsc --noEmit -p tsconfig.json
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add codey-mac/src
+git commit -m "refactor(codey-mac): tokenize remaining hardcoded colors"
+```
+
+---
+
+### Task 6: Manual verification
+
+**No automated tests** (no test runner is configured for this repo).
+
+- [ ] **Step 1: Build and launch the dev app**
+
+From `codey-mac/`:
+```
+npm run dev
+```
+(or whatever the existing dev command is — check `codey-mac/package.json` `scripts`.)
+
+- [ ] **Step 2: Run the verification matrix**
+
+Walk through each item; record any failure and fix before completing the plan.
+
+1. Open Settings → Appearance. Toggle Light → Dark → System. Confirm:
+   - The entire UI updates instantly with no re-mount, no flicker, no layout shift.
+   - The active button in the segmented control highlights correctly.
+2. Set mode to **System**. Confirm the hint reads "Currently following system: <Dark|Light>" and matches the OS.
+3. With mode = System, change macOS appearance via System Settings → Appearance (or the Control Center toggle). Confirm the app follows live within ~1 second.
+4. With mode = Light (or Dark), change macOS appearance — confirm the app does **not** change (mode pin overrides).
+5. Quit the app and relaunch. Confirm the previously chosen mode is restored, with no white-flash on a dark mode launch and no dark-flash on a light mode launch.
+6. Spot-check each Settings sidebar tab and the main app tabs (Chat, Workspaces, Workers, Teams, Channels, Status) in **both** themes. Look for:
+   - Unreadable text (low contrast).
+   - Borders that disappear in light mode.
+   - Any element still showing a dark-mode color in light mode.
+7. Re-run the grep from Task 5 Step 1 and confirm no unexpected hex literals remain.
+
+- [ ] **Step 3: Final commit if any fixes were made**
+
+```
+git add codey-mac/src
+git commit -m "fix(codey-mac): theme polish from manual QA"
+```
+
+(Skip this step if no fixes were needed.)
+
+---
+
+## Self-review
+
+- **Spec coverage:**
+  - Theme model (light/dark/system, default system, persistence) → Task 1.
+  - CSS-variable mechanism + `theme.ts` rewrite → Task 1.
+  - `App.tsx` mount/listener + `<style>` injection → Task 2.
+  - Pre-paint flicker prevention → Task 3.
+  - Light palette values → Task 1 (`lightPalette`).
+  - Settings UI Appearance pane with segmented control + system hint → Task 4.
+  - Stray hex sweep → Task 5.
+  - Manual verification matrix → Task 6.
+- **Placeholder scan:** no TBD/TODO; every code step shows the exact code; commands are concrete.
+- **Type consistency:** `ThemeMode`, `EffectiveTheme`, `applyTheme`, `getStoredThemeMode`, `resolveEffectiveTheme`, `useThemeMode`, `useEffectiveTheme`, `paletteToCssVars`, `darkPalette`, `lightPalette` are defined in Task 1 and referenced unchanged in Tasks 2 and 4.

--- a/docs/superpowers/specs/2026-05-06-codey-mac-theme-design.md
+++ b/docs/superpowers/specs/2026-05-06-codey-mac-theme-design.md
@@ -1,0 +1,103 @@
+# codey-mac: Light/Dark Theme Support
+
+**Date:** 2026-05-06
+**Surface:** `codey-mac` (Electron + React desktop app)
+
+## Goal
+
+Add light/dark theme support to the codey-mac app. User can pick **Light**, **Dark**, or **System** (follows macOS appearance). The choice persists across launches and, when set to System, follows OS appearance changes live without restart.
+
+## Non-goals
+
+- Theming the gateway, web surfaces, or any non-Electron component.
+- Custom user-defined palettes.
+- Per-window or per-workspace themes.
+
+## Theme model
+
+- Modes: `'light' | 'dark' | 'system'`. Default: `'system'`.
+- Persisted to `localStorage` under key `codey.theme` (matches existing `codey.<key>` convention).
+- **Effective theme** is derived: if mode is `system`, read `window.matchMedia('(prefers-color-scheme: dark)').matches`; otherwise use the mode literal. The effective theme is applied; the mode (including `system`) is what gets persisted.
+
+## Mechanism: CSS variables
+
+The app currently uses inline styles with a `C` token object imported from `src/theme.ts`. `C` is referenced ~300+ times across ~12 components, often inside module-scope `styles` objects that compute once at load. Refactoring all those call sites is invasive; instead, route every token through CSS custom properties so component code is unchanged after the one-time `theme.ts` rewrite.
+
+### `src/theme.ts`
+
+- Define `darkPalette` and `lightPalette` constants with the same keys currently on `C`, plus a new `scrollbar` key.
+- Rewrite the exported `C` object so each value is a `var(--token)` string. Shape and key names unchanged. All existing `C.bg`, `C.fg`, etc. references keep working.
+- Export:
+  - `type ThemeMode = 'light' | 'dark' | 'system'`
+  - `applyTheme(mode: ThemeMode): void` — resolves effective theme, sets `document.documentElement.dataset.theme = 'light' | 'dark'`, writes mode to `localStorage`.
+  - `getStoredThemeMode(): ThemeMode` — reads `codey.theme`, falls back to `'system'`.
+  - `useThemeMode(): [ThemeMode, (m: ThemeMode) => void]` — React hook for the Settings UI; setter calls `applyTheme` and updates state.
+  - `useEffectiveTheme(): 'light' | 'dark'` — for the System-mode hint line in Settings.
+
+### `src/App.tsx`
+
+- On mount: call `applyTheme(getStoredThemeMode())`.
+- Subscribe to `window.matchMedia('(prefers-color-scheme: dark)')` `change` events; on change, if current mode is `system`, re-apply. Remove the listener on unmount.
+- Inject the CSS variable definitions in the existing global `<style>` tag, scoped by `[data-theme="light"]` and `[data-theme="dark"]` selectors on `:root`.
+- Replace any remaining hardcoded hex values in the global `<style>` (currently `#3a3a3a` scrollbar thumb) with `var(--scrollbar)`.
+
+### Pre-paint flicker prevention
+
+Persisted mode must be applied before first React render. Approach: in `index.html` (or `main.tsx` before React mounts), inline a tiny script that reads `localStorage.codey.theme`, resolves effective theme, and sets `document.documentElement.dataset.theme` synchronously. The same logic runs again inside React via `applyTheme`; redundancy is fine.
+
+## Light palette
+
+Tuned to match the existing macOS-style aesthetic (same `#0A84FF` accent, Apple system semantic colors).
+
+| Token | Dark | Light |
+|---|---|---|
+| `bg` | `#141414` | `#ffffff` |
+| `surface` | `#1e1e1e` | `#f5f5f7` |
+| `surface2` | `#252525` | `#ebebef` |
+| `surface3` | `#2d2d2d` | `#e1e1e6` |
+| `border` | `#2e2e2e` | `#d2d2d7` |
+| `border2` | `#383838` | `#c7c7cc` |
+| `fg` | `#f0f0f0` | `#1d1d1f` |
+| `fg2` | `#a0a0a0` | `#6e6e73` |
+| `fg3` | `#606060` | `#8e8e93` |
+| `accent` | `#0A84FF` | `#0A84FF` |
+| `accentDim` | `#0A84FF22` | `#0A84FF22` |
+| `green` | `#32D74B` | `#34C759` |
+| `red` | `#FF453A` | `#FF3B30` |
+| `yellow` | `#FFD60A` | `#FFCC00` |
+| `userBg` | `#0A84FF` | `#0A84FF` |
+| `aiBg` | `#252525` | `#f5f5f7` |
+| `scrollbar` (new) | `#3a3a3a` | `#c7c7cc` |
+
+## Settings UI
+
+Add an **Appearance** entry to the Settings modal sidebar (the modal redesigned in `8909de7`), placed at the top since it's a UI-level concern.
+
+Pane contents:
+
+```
+Theme    [ Light | Dark | System ]
+         Currently following system: Dark
+```
+
+- Three-option segmented control bound to `useThemeMode()`.
+- A hint line below the control:
+  - When mode is `system`: `Currently following system: <effective>`
+  - Otherwise: hidden (the segmented control already shows the choice).
+
+## Files changed
+
+- `codey-mac/src/theme.ts` — rewrite as described above.
+- `codey-mac/src/App.tsx` — apply on mount, subscribe to matchMedia, tokenize remaining hex literals in global `<style>`.
+- `codey-mac/index.html` (or `src/main.tsx`) — pre-paint sync script.
+- `codey-mac/src/components/SettingsOverlay.tsx` (and any related sidebar config file) — add Appearance entry + pane.
+
+After the refactor, grep `codey-mac/src` for hex color literals outside `theme.ts` and tokenize any survivors.
+
+## Verification (manual; no test runner configured)
+
+- Toggle Light / Dark / System in the Appearance pane → instant switch, no flicker, no re-mount.
+- Mode = System, change macOS System Settings → Appearance → app follows live.
+- Reload the app → persisted mode restored before first paint (no flash of wrong theme).
+- Spot-check each tab (Chat, Workspaces, Workers, Teams, Channels, Status, Settings) in both themes.
+- Confirm no remaining hardcoded hex colors outside `theme.ts`.


### PR DESCRIPTION
## Summary

- Adds Light / Dark / System theme support to the codey-mac desktop app.
- Theme tokens are now CSS variables (`--bg`, `--fg`, …) scoped by `[data-theme]` on `<html>`. The `C` token object in `src/theme.ts` resolves to `var(--*)` strings, so the ~300 existing `C.bg` / `C.fg` call sites work unchanged.
- New **General** entry in the Settings sidebar with a Light / Dark / System segmented control. System mode follows macOS appearance live via `matchMedia('(prefers-color-scheme: dark)')`. A small inline script in `index.html` applies the persisted choice before React mounts to prevent flicker.
- Sweep of stray hex literals across components → tokenized via new shared tokens (`dangerBg/Border/Fg`, `codeBg/Fg`, `inlineCodeBg/Fg`, `logBg/Fg`, `warningBg/Fg`).

Spec: `docs/superpowers/specs/2026-05-06-codey-mac-theme-design.md`
Plan: `docs/superpowers/plans/2026-05-06-codey-mac-theme.md`

## Test plan

- [ ] Settings → General → toggle Light / Dark / System; UI updates instantly with no flicker, no re-mount
- [ ] In System mode, change macOS appearance (System Settings or Control Center); app follows live
- [ ] In Light or Dark, change macOS appearance; app does NOT change (mode pin overrides)
- [ ] Quit and relaunch with each mode; persisted mode is restored before first paint
- [ ] Spot-check Chat, Workspaces, Workers, Teams, Channels, Status, Settings tabs in both themes — no unreadable text, no missing borders, no dark surfaces leaking into light mode

## Notes

- Pre-existing TS errors on `main` (`Chat.routes`, `ChatRoute` import in `codey-mac/src/types/index.ts` and `ChatTab.tsx`) are unrelated to this PR.
- Intentionally untokenized: macOS-style red close button in `SettingsOverlay`, white text/icons on solid color buttons, link/tool-call accent colors that sit on the fixed-blue user message bubble. `MenuBar.tsx` is dead code (never imported) and was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)