### PR TITLE
fix(gateway): handle user abort cleanly in team auto mode

### DIFF
--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1989,9 +1989,15 @@ Example: /model gpt-4.1 write a Python script`;
       );
 
       if (result.fallback) {
+        if (signal?.aborted) {
+          return { response: '' };
+        }
         sink({ type: 'info', chatId, message: `Auto-routing failed (${result.fallbackReason}), running all members` });
         // fall through to all-members path below
       } else {
+        if (signal?.aborted) {
+          return { response: this.formatManagerParts(result.parts, result.finalSummary) };
+        }
         if (result.fallbackMidRun) {
           sink({ type: 'info', chatId, message: `Manager halted mid-run: ${result.fallbackMidRun.reason}` });
         }
@@ -2559,9 +2565,9 @@ Example: /model gpt-4.1 write a Python script`;
         });
         output = response?.success ? this.formatAgentResponse(response) : (streamedText || '');
         tokens = (response as any)?.tokens?.total;
-        if (abortController.signal.aborted && !output) {
-          output = 'Stopped';
-        }
+      }
+      if (abortController.signal.aborted && !output) {
+        output = 'Stopped';
       }
 
       const durationSec = Math.round((Date.now() - started) / 1000);


### PR DESCRIPTION
## Summary

When the user pressed Esc during team auto mode, the gateway showed a misleading **"Auto-routing failed (Stopped), running all members"** message and then no-op'd through every team member because the abort signal was still set. The chat assistant message ended up empty.

Root cause: a user abort surfaces from `runManager` as `fallback: true, fallbackReason: 'Stopped'`, which `runTeamForChat` was treating identically to a real Manager planning failure.

## Changes

`packages/gateway/src/gateway.ts`:
- In `runTeamForChat`, when `runManagerLoop` returns `fallback: true` and `signal.aborted`, return an empty response immediately — no all-members fallback, no misleading info message.
- On the success branch, also skip the "Manager halted mid-run" info message when the halt was a user abort.
- Lifted the existing `aborted && !output ? 'Stopped'` fallback in the chat-runner so it applies to both team and single-agent paths (team aborts now show "Stopped" instead of empty content).

## Test plan

- [ ] Start team auto run in Mac chat, press Esc mid-Manager-call → chat shows "Stopped", input unblocks, no "Auto-routing failed" / "running all members" message
- [ ] Start team auto run, press Esc mid-worker → chat shows partial worker output (or "Stopped" if nothing got produced), no "Manager halted mid-run" message
- [ ] Single-agent abort behavior unchanged — Esc still produces "Stopped" content

🤖 Generated with [Claude Code](https://claude.com/claude-code)