### PR TITLE
Add Codex-style right context panel to chat view

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -694,6 +694,13 @@ app.whenReady().then(async () => {
     })
   )
 
+  ipcMain.handle('chats:updateContextPanelOpen', async (_e, id: string, open: boolean | null) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.getChatManager().updateContextPanelOpen(id, open)
+    })
+  )
+
   ipcMain.handle('chats:stop', async (_e, chatId: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
@@ -824,4 +831,10 @@ ipcMain.handle('open-external', (_event, url: string) => {
 ipcMain.handle('shell:openPath', async (_event, p: string) => {
   if (typeof p !== 'string' || !p) return ''
   return await shell.openPath(p)
+})
+
+ipcMain.handle('shell:showItemInFolder', async (_event, p: string) => {
+  if (typeof p !== 'string' || !p) return false
+  shell.showItemInFolder(p)
+  return true
 })

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -89,6 +89,8 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('chats:link', chatId, channel, channelUserId),
     unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
       ipcRenderer.invoke('chats:unlink', chatId, channel, channelUserId),
+    updateContextPanelOpen: (id: string, open: boolean | null) =>
+      ipcRenderer.invoke('chats:updateContextPanelOpen', id, open),
     send: (payload: { chatId: string; text: string; attachments?: any[] }) =>
       ipcRenderer.invoke('chats:send', payload),
     stop: (chatId: string) => ipcRenderer.invoke('chats:stop', chatId),
@@ -107,6 +109,7 @@ contextBridge.exposeInMainWorld('codey', {
   },
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openPath: (path: string) => ipcRenderer.invoke('shell:openPath', path),
+  revealInFolder: (path: string) => ipcRenderer.invoke('shell:showItemInFolder', path),
   onLog: (handler: (msg: string) => void) => {
     const listener = (_e: Electron.IpcRendererEvent, msg: string) => handler(msg)
     ipcRenderer.on('gateway-log', listener)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -86,6 +86,7 @@ declare global {
         onEvent: (handler: (ev: ChatStreamEvent) => void) => () => void
         link: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<void>>
         unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<void>>
+        updateContextPanelOpen: (id: string, open: boolean | null) => Promise<IpcResult<Chat>>
       }
       pairing: {
         start: (channel: 'telegram' | 'discord' | 'imessage') => Promise<IpcResult<string>>
@@ -107,6 +108,7 @@ declare global {
       }
       openExternal: (url: string) => Promise<void>
       openPath: (path: string) => Promise<string>
+      revealInFolder: (path: string) => Promise<boolean>
       onLog: (handler: (msg: string) => void) => () => void
     }
   }

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -1,0 +1,159 @@
+import React from 'react'
+import type { Chat, ChatMessage } from '../types'
+import { C } from '../theme'
+
+interface Props {
+  chat: Chat
+  selectedTurnId: string | null
+  followLatest: boolean
+  /** 1-based index of the selected assistant turn in the chat (for "Turn N" display). */
+  selectedTurnIndex: number | null
+  /** Effective agent for this chat (resolved by ChatTab from override/worker/default). */
+  effectiveAgent: string
+  /** Effective model for this chat. May be undefined when no model is resolvable. */
+  effectiveModel?: string
+  /** Worker name actively bound to the selected turn, when chat selection is a worker. */
+  workerName?: string
+  /** Team name actively bound, when chat selection is a team. */
+  teamName?: string
+  width: number
+  onFollowLatest: () => void
+  onClose: () => void
+  onResize: (next: number) => void
+  onRevealFile: (absPath: string) => void
+}
+
+const fmtTime = (ts: number) =>
+  new Date(ts).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+
+const formatTokens = (n: number): string | null => {
+  if (!Number.isFinite(n) || n < 0) return null
+  if (n < 1000) return String(n)
+  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`
+  return `${Math.round(n / 1000)}k`
+}
+
+export const ChatContextPanel: React.FC<Props> = ({
+  chat, selectedTurnId, followLatest, selectedTurnIndex,
+  effectiveAgent, effectiveModel, workerName, teamName,
+  width, onFollowLatest, onClose, onResize, onRevealFile,
+}) => {
+  const turn: ChatMessage | undefined = selectedTurnId
+    ? chat.messages.find(m => m.id === selectedTurnId && m.role === 'assistant')
+    : undefined
+
+  // Resize drag handler
+  const onResizerMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault()
+    const startX = e.clientX
+    const startW = width
+    const move = (mv: MouseEvent) => {
+      const next = Math.max(260, Math.min(520, startW + (startX - mv.clientX)))
+      onResize(next)
+    }
+    const up = () => {
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }
+
+  return (
+    <div style={{ ...styles.root, width }}>
+      <div style={styles.resizer} onMouseDown={onResizerMouseDown} title="Drag to resize" />
+      {/* Header */}
+      <div style={styles.header}>
+        <div style={styles.headerMeta}>
+          {turn ? (
+            <>
+              <span style={styles.headerTitle}>Turn {selectedTurnIndex ?? '?'}</span>
+              <span style={styles.headerDot}>·</span>
+              <span style={styles.headerSub}>{fmtTime(turn.timestamp)}</span>
+              {turn.durationSec != null && Number.isFinite(turn.durationSec) && (
+                <><span style={styles.headerDot}>·</span><span style={styles.headerSub}>{turn.durationSec}s</span></>
+              )}
+              {(() => {
+                const t = turn.tokens != null ? formatTokens(turn.tokens) : null
+                return t ? <><span style={styles.headerDot}>·</span><span style={styles.headerSub}>{t} tok</span></> : null
+              })()}
+            </>
+          ) : (
+            <span style={styles.headerSub}>No turn selected</span>
+          )}
+        </div>
+        {!followLatest && (
+          <button style={styles.followPill} onClick={onFollowLatest} title="Follow live updates">Follow latest ↓</button>
+        )}
+        <button style={styles.closeBtn} onClick={onClose} aria-label="Close panel">×</button>
+      </div>
+
+      <div style={styles.body}>
+        {/* Run target */}
+        <Section title="Run target">
+          <div style={styles.runTargetRow}>
+            {teamName ? `Team: ${teamName}` : workerName ? `Worker: ${workerName}` : 'Direct chat'}
+          </div>
+          <div style={styles.runTargetSub}>
+            {effectiveAgent}{effectiveModel ? ` · ${effectiveModel}` : ''}
+          </div>
+        </Section>
+
+        {/* Tool timeline + Files touched + Attachments + Pending team are
+            added in later tasks. Placeholder for now: */}
+        {!turn && <div style={styles.emptyHint}>Send a message to see run context.</div>}
+      </div>
+    </div>
+  )
+}
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div style={styles.section}>
+    <div style={styles.sectionTitle}>{title}</div>
+    <div>{children}</div>
+  </div>
+)
+
+const styles: Record<string, React.CSSProperties> = {
+  root: {
+    position: 'relative',
+    height: '100%',
+    background: C.surface2,
+    borderLeft: `1px solid ${C.border}`,
+    display: 'flex',
+    flexDirection: 'column',
+    flexShrink: 0,
+  },
+  resizer: {
+    position: 'absolute',
+    left: -3, top: 0, bottom: 0, width: 6,
+    cursor: 'col-resize',
+    zIndex: 5,
+  },
+  header: {
+    display: 'flex', alignItems: 'center', gap: 8,
+    padding: '10px 12px', borderBottom: `1px solid ${C.border}`,
+    flexShrink: 0,
+  },
+  headerMeta: { flex: 1, display: 'flex', alignItems: 'center', gap: 6, minWidth: 0, flexWrap: 'wrap' },
+  headerTitle: { color: C.fg, fontSize: 12, fontWeight: 600 },
+  headerSub: { color: C.fg3, fontSize: 11, fontVariantNumeric: 'tabular-nums' },
+  headerDot: { color: C.fg3, fontSize: 11, opacity: 0.5 },
+  followPill: {
+    background: C.accent, color: '#fff', border: 'none',
+    borderRadius: 10, fontSize: 10, padding: '2px 8px', cursor: 'pointer',
+  },
+  closeBtn: {
+    background: 'transparent', border: 'none', color: C.fg2,
+    fontSize: 18, lineHeight: 1, padding: '0 4px', cursor: 'pointer',
+  },
+  body: { flex: 1, overflowY: 'auto', padding: '8px 12px' },
+  section: { marginBottom: 14 },
+  sectionTitle: {
+    color: C.fg3, fontSize: 10, fontWeight: 600, letterSpacing: 0.6,
+    textTransform: 'uppercase', marginBottom: 6,
+  },
+  runTargetRow: { color: C.fg, fontSize: 12 },
+  runTargetSub: { color: C.fg3, fontSize: 11, marginTop: 2 },
+  emptyHint: { color: C.fg3, fontSize: 11, fontStyle: 'italic', padding: '12px 0' },
+}

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -99,12 +99,147 @@ export const ChatContextPanel: React.FC<Props> = ({
           </div>
         </Section>
 
-        {/* Tool timeline + Files touched + Attachments + Pending team are
-            added in later tasks. Placeholder for now: */}
+        {turn && <ToolTimeline toolCalls={turn.toolCalls ?? []} />}
+        {turn && (turn.toolCalls?.length ?? 0) === 0 && (
+          <Section title="Tool calls">
+            <div style={styles.emptyHint}>No tool activity for this turn.</div>
+          </Section>
+        )}
         {!turn && <div style={styles.emptyHint}>Send a message to see run context.</div>}
       </div>
     </div>
   )
+}
+
+const ToolTimeline: React.FC<{ toolCalls: import('../types').ToolCallEntry[] }> = ({ toolCalls }) => {
+  const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
+
+  type Row =
+    | { kind: 'call'; id: string; tool?: string; input?: Record<string, unknown>; output?: string; done: boolean; message: string }
+    | { kind: 'info'; id: string; message: string }
+  const rows: Row[] = []
+  const startIdxById = new Map<string, number>()
+  for (const tc of toolCalls) {
+    if (tc.type === 'info') {
+      rows.push({ kind: 'info', id: tc.id, message: tc.message })
+      continue
+    }
+    if (tc.type === 'tool_start') {
+      const idx = rows.push({
+        kind: 'call', id: tc.id, tool: tc.tool, input: tc.input,
+        done: false, message: tc.message,
+      }) - 1
+      startIdxById.set(tc.id, idx)
+    } else { // tool_end
+      const idx = startIdxById.get(tc.id)
+      if (idx != null) {
+        const row = rows[idx] as Extract<Row, { kind: 'call' }>
+        row.done = true
+        if (tc.output) row.output = tc.output
+        if (tc.message) row.message = tc.message
+        startIdxById.delete(tc.id)
+      } else {
+        rows.push({
+          kind: 'call', id: tc.id, tool: tc.tool, output: tc.output,
+          done: true, message: tc.message,
+        })
+      }
+    }
+  }
+
+  if (rows.length === 0) return null
+  return (
+    <Section title="Tool calls">
+      <div style={timelineStyles.list}>
+        {rows.map(r => {
+          if (r.kind === 'info') {
+            return (
+              <div key={r.id} style={timelineStyles.infoRow}>
+                <span style={timelineStyles.iconInfo}>ⓘ</span>
+                <span>{r.message}</span>
+              </div>
+            )
+          }
+          const isOpen = expanded.has(r.id)
+          const hasDetail = !!r.input || !!r.output
+          const toggle = () => setExpanded(prev => {
+            const next = new Set(prev)
+            next.has(r.id) ? next.delete(r.id) : next.add(r.id)
+            return next
+          })
+          const icon = !r.done ? '▶' : '✓'
+          return (
+            <div key={r.id}>
+              <div
+                style={{ ...timelineStyles.callRow, cursor: hasDetail ? 'pointer' : 'default' }}
+                onClick={hasDetail ? toggle : undefined}
+              >
+                <span style={r.done ? timelineStyles.iconDone : timelineStyles.iconRunning}>{icon}</span>
+                <span style={timelineStyles.tool}>{r.tool ?? '(tool)'}</span>
+                <span style={timelineStyles.callMsg}>{r.message}</span>
+              </div>
+              {hasDetail && isOpen && (
+                <div style={timelineStyles.detail}>
+                  {r.input && (
+                    <>
+                      <div style={timelineStyles.detailLabel}>input</div>
+                      <pre style={timelineStyles.code}>{JSON.stringify(r.input, null, 2)}</pre>
+                    </>
+                  )}
+                  {r.output && (
+                    <>
+                      <div style={timelineStyles.detailLabel}>output</div>
+                      <pre style={timelineStyles.code}>{truncate(r.output, 2048)}</pre>
+                    </>
+                  )}
+                  {!r.done && !r.output && (
+                    <div style={timelineStyles.detailLabel}>(no result yet)</div>
+                  )}
+                  {r.done && !r.output && !r.input && (
+                    <div style={timelineStyles.detailLabel}>(no result)</div>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </Section>
+  )
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max) + `\n… (${s.length - max} more chars)`
+}
+
+const timelineStyles: Record<string, React.CSSProperties> = {
+  list: { display: 'flex', flexDirection: 'column', gap: 4 },
+  infoRow: {
+    display: 'flex', alignItems: 'flex-start', gap: 6,
+    color: C.fg3, fontSize: 11, fontStyle: 'italic',
+  },
+  callRow: {
+    display: 'flex', alignItems: 'flex-start', gap: 6,
+    fontSize: 12, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    padding: '2px 0',
+  },
+  tool: { color: '#9bbcd9', flexShrink: 0 },
+  callMsg: { color: C.fg2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  iconRunning: { color: '#6ab0f3', width: 12, flexShrink: 0 },
+  iconDone: { color: '#7ec97e', width: 12, flexShrink: 0 },
+  iconInfo: { color: C.fg3, width: 12, flexShrink: 0 },
+  detail: {
+    marginLeft: 18, marginTop: 4, marginBottom: 6,
+    padding: 8, background: 'rgba(0,0,0,0.3)',
+    border: `1px solid ${C.border}`, borderRadius: 6,
+    maxHeight: 280, overflowY: 'auto',
+  },
+  detailLabel: { color: C.fg3, fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 4 },
+  code: {
+    color: C.fg, fontSize: 11, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    margin: '4px 0 0 0', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+  },
 }
 
 const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -44,6 +44,23 @@ export const ChatContextPanel: React.FC<Props> = ({
     ? chat.messages.find(m => m.id === selectedTurnId && m.role === 'assistant')
     : undefined
 
+  const triggeringUserMsg: ChatMessage | undefined = (() => {
+    if (!turn) return undefined
+    const idx = chat.messages.findIndex(m => m.id === turn.id)
+    if (idx <= 0) return undefined
+    for (let i = idx - 1; i >= 0; i--) {
+      if (chat.messages[i].role === 'user') return chat.messages[i]
+    }
+    return undefined
+  })()
+
+  const latestAssistantId: string | null = (() => {
+    for (let i = chat.messages.length - 1; i >= 0; i--) {
+      if (chat.messages[i].role === 'assistant') return chat.messages[i].id
+    }
+    return null
+  })()
+
   // Resize drag handler
   const onResizerMouseDown = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -103,6 +120,12 @@ export const ChatContextPanel: React.FC<Props> = ({
 
         {turn && <ToolTimeline toolCalls={turn.toolCalls ?? []} />}
         {turn && <FilesTouched toolCalls={turn.toolCalls ?? []} workingDir={workingDir} onReveal={onRevealFile} />}
+        {triggeringUserMsg?.attachments && triggeringUserMsg.attachments.length > 0 && (
+          <AttachmentsSection attachments={triggeringUserMsg.attachments} />
+        )}
+        {chat.pendingTeam && turn && turn.id === latestAssistantId && (
+          <PendingTeamSection pending={chat.pendingTeam} />
+        )}
         {turn && (turn.toolCalls?.length ?? 0) === 0 && (
           <Section title="Tool calls">
             <div style={styles.emptyHint}>No tool activity for this turn.</div>
@@ -308,6 +331,75 @@ const timelineStyles: Record<string, React.CSSProperties> = {
     color: C.fg, fontSize: 11, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
     margin: '4px 0 0 0', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
   },
+}
+
+const AttachmentsSection: React.FC<{ attachments: import('../types').FileAttachment[] }> = ({ attachments }) => {
+  if (!attachments.length) return null
+  return (
+    <Section title="Attachments">
+      <div style={attStyles.row}>
+        {attachments.map(a => {
+          const isImage = a.mimeType.startsWith('image/')
+          if (isImage) {
+            return (
+              <img
+                key={a.id}
+                src={`codey-asset://file/${encodeURIComponent(a.path)}`}
+                alt={a.name}
+                title={a.name}
+                style={attStyles.img}
+                onClick={() => window.codey?.openPath?.(a.path)}
+              />
+            )
+          }
+          return (
+            <div key={a.id} style={attStyles.chip} title={a.name} onClick={() => window.codey?.openPath?.(a.path)}>
+              {a.name}
+            </div>
+          )
+        })}
+      </div>
+    </Section>
+  )
+}
+
+const attStyles: Record<string, React.CSSProperties> = {
+  row: { display: 'flex', flexWrap: 'wrap', gap: 6 },
+  img: {
+    width: 64, height: 64, objectFit: 'cover',
+    borderRadius: 6, border: `1px solid ${C.border2}`, cursor: 'pointer',
+  },
+  chip: {
+    padding: '4px 8px', background: C.surface3, border: `1px solid ${C.border2}`,
+    borderRadius: 6, fontSize: 11, color: C.fg2, cursor: 'pointer',
+    maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+}
+
+const PendingTeamSection: React.FC<{ pending: NonNullable<Chat['pendingTeam']> }> = ({ pending }) => {
+  // Both variants of PendingTeamState (mode: 'sequential' and mode: 'auto')
+  // expose askingWorker + question — see packages/core/src/types/pending-team.ts.
+  const workerName = pending.askingWorker
+  const question = pending.question
+  return (
+    <Section title="Pending team">
+      <div style={pendStyles.callout}>
+        <div style={pendStyles.title}>Waiting on input for {workerName}</div>
+        {question && <div style={pendStyles.body}>{question}</div>}
+        <div style={pendStyles.hint}>Type a reply in the chat to resume the team.</div>
+      </div>
+    </Section>
+  )
+}
+
+const pendStyles: Record<string, React.CSSProperties> = {
+  callout: {
+    background: 'rgba(255, 196, 0, 0.10)', border: '1px solid rgba(255, 196, 0, 0.35)',
+    borderRadius: 6, padding: '8px 10px',
+  },
+  title: { color: C.fg, fontSize: 12, fontWeight: 600, marginBottom: 4 },
+  body: { color: C.fg2, fontSize: 11, marginBottom: 6, whiteSpace: 'pre-wrap' },
+  hint: { color: C.fg3, fontSize: 10, fontStyle: 'italic' },
 }
 
 const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -16,6 +16,8 @@ interface Props {
   workerName?: string
   /** Team name actively bound, when chat selection is a team. */
   teamName?: string
+  /** Working directory of the workspace, used to render relative file paths. */
+  workingDir?: string
   width: number
   onFollowLatest: () => void
   onClose: () => void
@@ -35,7 +37,7 @@ const formatTokens = (n: number): string | null => {
 
 export const ChatContextPanel: React.FC<Props> = ({
   chat, selectedTurnId, followLatest, selectedTurnIndex,
-  effectiveAgent, effectiveModel, workerName, teamName,
+  effectiveAgent, effectiveModel, workerName, teamName, workingDir,
   width, onFollowLatest, onClose, onResize, onRevealFile,
 }) => {
   const turn: ChatMessage | undefined = selectedTurnId
@@ -100,6 +102,7 @@ export const ChatContextPanel: React.FC<Props> = ({
         </Section>
 
         {turn && <ToolTimeline toolCalls={turn.toolCalls ?? []} />}
+        {turn && <FilesTouched toolCalls={turn.toolCalls ?? []} workingDir={workingDir} onReveal={onRevealFile} />}
         {turn && (turn.toolCalls?.length ?? 0) === 0 && (
           <Section title="Tool calls">
             <div style={styles.emptyHint}>No tool activity for this turn.</div>
@@ -109,6 +112,71 @@ export const ChatContextPanel: React.FC<Props> = ({
       </div>
     </div>
   )
+}
+
+const FILE_TOOLS = new Set(['Read', 'Edit', 'Write', 'NotebookEdit'])
+
+const FilesTouched: React.FC<{
+  toolCalls: import('../types').ToolCallEntry[]
+  workingDir?: string
+  onReveal: (absPath: string) => void
+}> = ({ toolCalls, workingDir, onReveal }) => {
+  const paths: string[] = []
+  const seen = new Set<string>()
+  for (const tc of toolCalls) {
+    if (tc.type !== 'tool_start') continue
+    if (!tc.tool || !FILE_TOOLS.has(tc.tool)) continue
+    const p = (tc.input as any)?.file_path
+    if (typeof p !== 'string' || !p) continue
+    if (!seen.has(p)) { seen.add(p); paths.push(p) }
+  }
+  if (paths.length === 0) return null
+
+  const display = (abs: string): string => {
+    if (workingDir && abs.startsWith(workingDir)) {
+      const rel = abs.slice(workingDir.length).replace(/^\/+/, '')
+      return rel || abs
+    }
+    return abs
+  }
+
+  return (
+    <Section title="Files touched">
+      <div style={filesStyles.list}>
+        {paths.sort().map(p => (
+          <div key={p} style={filesStyles.row} title={p}>
+            <span style={filesStyles.path}>{display(p)}</span>
+            <button
+              style={filesStyles.iconBtn}
+              onClick={() => onReveal(p)}
+              title="Reveal in Finder"
+            >⤴</button>
+            <button
+              style={filesStyles.iconBtn}
+              onClick={() => navigator.clipboard.writeText(p)}
+              title="Copy path"
+            >⧉</button>
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
+}
+
+const filesStyles: Record<string, React.CSSProperties> = {
+  list: { display: 'flex', flexDirection: 'column', gap: 2 },
+  row: {
+    display: 'flex', alignItems: 'center', gap: 4,
+    padding: '2px 0', fontSize: 11,
+  },
+  path: {
+    flex: 1, color: C.fg2, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0,
+  },
+  iconBtn: {
+    background: 'transparent', border: 'none', color: C.fg3,
+    cursor: 'pointer', fontSize: 12, padding: '0 4px', flexShrink: 0,
+  },
 }
 
 const ToolTimeline: React.FC<{ toolCalls: import('../types').ToolCallEntry[] }> = ({ toolCalls }) => {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -111,6 +111,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     const n = v ? parseInt(v, 10) : NaN
     return Number.isFinite(n) ? Math.max(260, Math.min(520, n)) : 340
   })
+  const [winNarrow, setWinNarrow] = useState<boolean>(() => window.innerWidth < 900)
+  useEffect(() => {
+    const onResize = () => setWinNarrow(window.innerWidth < 900)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
   const dragDepthRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -212,7 +218,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     }
     return null
   })()
-  const panelOpen: boolean = chat?.contextPanelOpen ?? false
+  const panelOpen: boolean = !winNarrow && (chat?.contextPanelOpen ?? false)
 
   const selectionValue: string = chat.selection.type === 'worker'
     ? `worker:${chat.selection.name}`

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -64,6 +64,14 @@ const FileIcon: React.FC<{ color: string; size?: number }> = ({ color, size = 14
   </svg>
 )
 
+const PanelRightIcon: React.FC<{ color: string; size?: number; filled?: boolean }> = ({ color, size = 14, filled }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="15" y1="3" x2="15" y2="21" />
+    {filled && <rect x="15" y="3" width="6" height="18" rx="0" fill={color} stroke="none" />}
+  </svg>
+)
+
 const assetUrl = (absPath: string): string =>
   `codey-asset://file/${encodeURIComponent(absPath)}`
 
@@ -459,10 +467,11 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         )}
         <button
           onClick={() => setContextPanelOpen(chat.id, !panelOpen)}
-          style={styles.linkBtn}
+          style={{ ...styles.linkBtn, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: '4px 6px' }}
           title={panelOpen ? 'Hide context panel (⌘\\)' : 'Show context panel (⌘\\)'}
+          aria-label={panelOpen ? 'Hide context panel' : 'Show context panel'}
         >
-          {panelOpen ? '◧' : '◨'}
+          <PanelRightIcon color={C.fg} filled={panelOpen} />
         </button>
         <RouteIcons routes={chat.routes} />
         <button

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -167,6 +167,14 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     setSelectedTurnIdState(null)
   }, [chatId])
   useEffect(() => {
+    if (!chat) return
+    if (chat.contextPanelOpen !== undefined) return
+    const hasToolActivity = chat.messages.some(
+      m => m.role === 'assistant' && (m.toolCalls?.length ?? 0) > 0
+    )
+    if (hasToolActivity) setContextPanelOpen(chat.id, true)
+  }, [chat?.id, chat?.contextPanelOpen, lastMsg?.toolCalls?.length])
+  useEffect(() => {
     const h = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'i' || e.key === 'I')) {
         e.preventDefault()

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -189,7 +189,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   }, [chat?.id, chat?.contextPanelOpen, lastMsg?.toolCalls?.length])
   useEffect(() => {
     const h = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'i' || e.key === 'I')) {
+      // Cmd/Ctrl+Backslash mirrors VS Code's toggle-sidebar binding and avoids
+      // colliding with Electron's built-in Cmd+Shift+I devtools accelerator.
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === '\\') {
         e.preventDefault()
         if (chat) setContextPanelOpen(chat.id, !(chat.contextPanelOpen ?? false))
       }
@@ -458,7 +460,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         <button
           onClick={() => setContextPanelOpen(chat.id, !panelOpen)}
           style={styles.linkBtn}
-          title={panelOpen ? 'Hide context panel (⌘⇧I)' : 'Show context panel (⌘⇧I)'}
+          title={panelOpen ? 'Hide context panel (⌘\\)' : 'Show context panel (⌘\\)'}
         >
           {panelOpen ? '◧' : '◨'}
         </button>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -7,6 +7,7 @@ import { Markdown } from './Markdown'
 import { formatHeadline, hasDetail as toolHasDetail, ToolDetail, normalizeTool } from './toolFormat'
 import { RouteIcons } from './RouteIcons'
 import { PairingModal } from './PairingModal'
+import { ChatContextPanel } from './ChatContextPanel'
 
 interface Props {
   chatId: string
@@ -84,7 +85,7 @@ const AGENT_API_TYPE: Record<string, 'anthropic' | 'openai'> = {
 type ModelEntry = { apiType: 'anthropic' | 'openai'; model: string }
 
 export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
-  const { state, sendMessage, stopChat, setSelection, setAgentModel, renameChat } = useChats()
+  const { state, sendMessage, stopChat, setSelection, setAgentModel, renameChat, setContextPanelOpen } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -103,6 +104,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [pairings, setPairings] = useState<Array<{ channel: 'telegram'|'discord'|'imessage'; channelUserId: string }>>([])
   const [pairingModal, setPairingModal] = useState<null | 'telegram' | 'discord' | 'imessage'>(null)
+  const [followLatest, setFollowLatest] = useState(true)
+  const [selectedTurnIdState, setSelectedTurnIdState] = useState<string | null>(null)
+  const [panelWidth, setPanelWidth] = useState<number>(() => {
+    const v = localStorage.getItem('codey.contextPanelWidth')
+    const n = v ? parseInt(v, 10) : NaN
+    return Number.isFinite(n) ? Math.max(260, Math.min(520, n)) : 340
+  })
   const dragDepthRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -153,8 +161,43 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [flight, chatId])
+  useEffect(() => { localStorage.setItem('codey.contextPanelWidth', String(panelWidth)) }, [panelWidth])
+  useEffect(() => {
+    setFollowLatest(true)
+    setSelectedTurnIdState(null)
+  }, [chatId])
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'i' || e.key === 'I')) {
+        e.preventDefault()
+        if (chat) setContextPanelOpen(chat.id, !(chat.contextPanelOpen ?? false))
+      }
+    }
+    window.addEventListener('keydown', h)
+    return () => window.removeEventListener('keydown', h)
+  }, [chat?.id, chat?.contextPanelOpen])
 
   if (!chat) return null
+
+  const latestAssistantId: string | null = (() => {
+    for (let i = chat.messages.length - 1; i >= 0; i--) {
+      if (chat.messages[i].role === 'assistant') return chat.messages[i].id
+    }
+    return null
+  })()
+  const selectedTurnId: string | null = followLatest ? latestAssistantId : selectedTurnIdState
+  const selectedTurnIndex: number | null = (() => {
+    if (!selectedTurnId) return null
+    let n = 0
+    for (const m of chat.messages) {
+      if (m.role === 'assistant') {
+        n++
+        if (m.id === selectedTurnId) return n
+      }
+    }
+    return null
+  })()
+  const panelOpen: boolean = chat?.contextPanelOpen ?? false
 
   const selectionValue: string = chat.selection.type === 'worker'
     ? `worker:${chat.selection.name}`
@@ -275,6 +318,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     setInput('')
     setPendingAttachments([])
     if (taRef.current) taRef.current.style.height = 'auto'
+    setFollowLatest(true)
     await sendMessage(chat.id, text, atts)
   }
 
@@ -324,8 +368,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     : flight?.agentStatus === 'writing'  ? 'Writing…'
     : ''
 
+  const panelWorkerName = chat.selection.type === 'worker' ? chat.selection.name : undefined
+  const panelTeamName = chat.selection.type === 'team' ? chat.selection.name : undefined
+
   return (
-    <div style={styles.container}>
+    <div style={styles.outer}>
+      <div style={styles.container}>
       <div style={styles.header}>
         {editingTitle ? (
           <input
@@ -386,6 +434,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
             </select>
           </>
         )}
+        <button
+          onClick={() => setContextPanelOpen(chat.id, !panelOpen)}
+          style={styles.linkBtn}
+          title={panelOpen ? 'Hide context panel (⌘⇧I)' : 'Show context panel (⌘⇧I)'}
+        >
+          {panelOpen ? '◧' : '◨'}
+        </button>
         <RouteIcons routes={chat.routes} />
         <button
           onClick={onLinkButton}
@@ -414,12 +469,22 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         )}
         {chat.messages.map(msg => {
           const isUser = msg.role === 'user'
+          const isSelected = !isUser && msg.id === selectedTurnId && panelOpen
           return (
-            <div key={msg.id} style={{
-              display: 'flex', flexDirection: 'column',
-              alignItems: isUser ? 'flex-end' : 'flex-start',
-              marginBottom: 12,
-            }}>
+            <div key={msg.id}
+              onClick={isUser ? undefined : () => {
+                setSelectedTurnIdState(msg.id)
+                setFollowLatest(false)
+              }}
+              style={{
+                display: 'flex', flexDirection: 'column',
+                alignItems: isUser ? 'flex-end' : 'flex-start',
+                marginBottom: 12,
+                cursor: isUser ? 'default' : 'pointer',
+                paddingLeft: !isUser ? 6 : 0,
+                borderLeft: isSelected ? `2px solid ${C.accent}` : '2px solid transparent',
+              }}
+            >
               <div style={{
                 maxWidth: '72%', padding: '10px 14px',
                 borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
@@ -643,12 +708,31 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
       {pairingModal && (
         <PairingModal channel={pairingModal} onClose={() => setPairingModal(null)} />
       )}
+      </div>
+      {panelOpen && (
+        <ChatContextPanel
+          chat={chat}
+          selectedTurnId={selectedTurnId}
+          followLatest={followLatest}
+          selectedTurnIndex={selectedTurnIndex}
+          effectiveAgent={effectiveAgent}
+          effectiveModel={effectiveModel}
+          workerName={panelWorkerName}
+          teamName={panelTeamName}
+          width={panelWidth}
+          onFollowLatest={() => setFollowLatest(true)}
+          onClose={() => setContextPanelOpen(chat.id, false)}
+          onResize={setPanelWidth}
+          onRevealFile={(p) => apiService.revealInFolder(p)}
+        />
+      )}
     </div>
   )
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  container: { display: 'flex', flexDirection: 'column', height: '100%' },
+  outer: { display: 'flex', flexDirection: 'row', height: '100%', minHeight: 0 },
+  container: { display: 'flex', flexDirection: 'column', height: '100%', flex: 1, minWidth: 0 },
   header: {
     padding: '10px 16px', borderBottom: `1px solid ${C.border}`,
     display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -126,6 +126,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     if (!chat?.workspaceName) return
     apiService.getTeams(chat.workspaceName).then(t => setTeamNames(Object.keys(t))).catch(() => setTeamNames([]))
   }, [chat?.workspaceName])
+  const [workingDir, setWorkingDir] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (!chat?.workspaceName) return
+    apiService.getWorkspaceInfo(chat.workspaceName)
+      .then(info => setWorkingDir(info.workingDir))
+      .catch(() => setWorkingDir(undefined))
+  }, [chat?.workspaceName])
   useEffect(() => {
     if (!isGatewayRunning) return
     ;(async () => {
@@ -727,6 +734,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
           effectiveModel={effectiveModel}
           workerName={panelWorkerName}
           teamName={panelTeamName}
+          workingDir={workingDir}
           width={panelWidth}
           onFollowLatest={() => setFollowLatest(true)}
           onClose={() => setContextPanelOpen(chat.id, false)}

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -178,6 +178,7 @@ interface ChatsContextValue {
   deleteChat: (chatId: string) => Promise<void>
   setSelection: (chatId: string, selection: ChatSelection) => Promise<void>
   setAgentModel: (chatId: string, agent: string | null, model: string | null) => Promise<void>
+  setContextPanelOpen: (chatId: string, open: boolean | null) => Promise<void>
   sendMessage: (chatId: string, text: string, attachments?: FileAttachment[]) => Promise<void>
   stopChat: (chatId: string) => Promise<void>
   toggleWorkspace: (workspaceName: string) => void
@@ -324,6 +325,10 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     },
     async setAgentModel(chatId, agent, model) {
       const chat = await apiService.chats.updateAgentModel(chatId, agent, model)
+      dispatch({ type: 'upsert', chat })
+    },
+    async setContextPanelOpen(chatId, open) {
+      const chat = await apiService.chats.updateContextPanelOpen(chatId, open)
       dispatch({ type: 'upsert', chat })
     },
     async sendMessage(chatId, text, attachments) {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -80,6 +80,10 @@ export const apiService = {
   pickDirectory: async (): Promise<string | null> =>
     unwrap(await window.codey.dialog.pickDirectory()),
 
+  revealInFolder: async (absPath: string): Promise<void> => {
+    try { await window.codey.revealInFolder(absPath) } catch { /* silent no-op */ }
+  },
+
   // Teams
   getTeams: async (workspace?: string): Promise<Record<string, TeamConfigRaw>> =>
     unwrap(await window.codey.teams.get(workspace)),
@@ -153,6 +157,8 @@ export const apiService = {
       unwrap(await window.codey.chats.updateSelection(id, selection)),
     updateAgentModel: async (id: string, agent: string | null, model: string | null): Promise<Chat> =>
       unwrap(await window.codey.chats.updateAgentModel(id, agent, model)),
+    updateContextPanelOpen: async (id: string, open: boolean | null): Promise<Chat> =>
+      unwrap(await window.codey.chats.updateContextPanelOpen(id, open)),
     upload: async (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer): Promise<{ id: string; name: string; path: string; mimeType: string; size: number }> =>
       unwrap(await window.codey.chats.upload(chatId, fileName, mimeType, data)),
     send: async (chatId: string, text: string, attachments?: { id: string; name: string; path: string; mimeType: string; size: number }[]): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> =>

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -54,4 +54,8 @@ export interface Chat {
   routes?: ChatRoute[];
   /** Set while a /team run is paused waiting for the user to answer a worker's question. */
   pendingTeam?: PendingTeamState;
+  /** Per-chat preference for the right-side context panel in codey-mac.
+   *  undefined = user hasn't decided; auto-open logic applies on first tool call.
+   *  true/false = explicit user choice; honored verbatim. */
+  contextPanelOpen?: boolean;
 }

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -123,6 +123,17 @@ export class ChatManager {
     return chat;
   }
 
+  /** Set or clear the per-chat context-panel preference. Pass null to clear
+   *  (returns to "undecided" so auto-open logic applies again). */
+  updateContextPanelOpen(chatId: string, open: boolean | null): Chat {
+    const chat = this.requireChat(chatId);
+    if (open === null) delete chat.contextPanelOpen;
+    else chat.contextPanelOpen = open;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
   /** Set or clear pendingTeam state for a chat. Pass null to clear. */
   setPendingTeam(chatId: string, pending: NonNullable<Chat['pendingTeam']> | null): Chat {
     this.ensureLoaded();


### PR DESCRIPTION
## Summary

Adds a right-side context panel to the codey-mac chat view showing per-turn run context for the selected assistant message. Auto-follows the live turn during streaming, sticky on click.

**Sections (top to bottom, per selected turn):**
- Turn header — turn #, timestamp, duration, tokens, "Follow latest ↓" pill when sticky
- Run target — worker/team + agent · model
- Tool calls timeline — paired start/end rows with expandable input/output
- Files touched — paths from Read/Edit/Write/NotebookEdit, with reveal-in-finder + copy-path
- Attachments — files from the user message that triggered this turn
- Pending team callout — yellow notice when paused on \`[ASK_USER]\`

**Behavior:**
- Auto-follows latest assistant turn during streaming.
- Click any assistant message → panel becomes sticky on that turn (with left-border highlight); "Follow latest ↓" pill snaps it back.
- Per-chat open/closed preference persists; auto-opens once on the first tool-call activity in a brand-new chat.
- Resizable left edge, 260–520px clamp; width persisted globally.
- Auto-collapses when window <900px without overwriting the user preference.
- Toggle: header button (panel-right SVG icon) or **⌘\\\\** keyboard shortcut.

## Implementation notes

- New \`Chat.contextPanelOpen?: boolean\` field + \`ChatManager.updateContextPanelOpen()\` mutator (matches existing \`updateAgentModel\` pattern).
- New IPC: \`chats:updateContextPanelOpen\` and \`shell:showItemInFolder\`.
- All panel content is a read-side view of existing \`Chat\` / \`ChatMessage\` state — no new gateway logic, no new event types.
- Keyboard binding chosen as \`Cmd+\\\\\` to avoid colliding with Electron's \`Cmd+Shift+I\` Toggle DevTools accelerator.

## Test plan

- [ ] Start a new chat, send a tool-using prompt → panel auto-opens on first tool call.
- [ ] Toggle via header button and **⌘\\\\**; preference persists per chat across reload.
- [ ] Click an older assistant turn → panel switches, "Follow latest ↓" pill appears, left border highlights selected message.
- [ ] Click pill or send a new message → snaps back to newest.
- [ ] Tool timeline pairs start/end correctly; expand a row to see input JSON + truncated output.
- [ ] Files touched lists relative paths; reveal-in-finder works; copy-path works.
- [ ] User message with attachments → Attachments section renders thumbnails / chips for that turn's panel view.
- [ ] Run a \`/team\` that pauses with \`[ASK_USER]\` → Pending team callout appears on latest turn.
- [ ] Drag panel edge to resize; width persists across reload, clamped to 260–520px.
- [ ] Shrink window below 900px → panel hides; widen → reappears (preference unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)