### PR TITLE
Add [ASK_USER:choice] click-to-answer buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ codey-mac/build/icon.iconset/
 docs/
 
 .codey/
+
+*.tsbuildinfo

--- a/codey-mac/.gitignore
+++ b/codey-mac/.gitignore
@@ -1,1 +1,0 @@
-*.tsbuildinfo

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -635,6 +635,7 @@ app.whenReady().then(async () => {
           response: result.response,
           tokens: result.tokens,
           durationSec: result.durationSec,
+          choices: (result as any).choices,   // forward when present
         })
       }
       return result

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -635,7 +635,7 @@ app.whenReady().then(async () => {
           response: result.response,
           tokens: result.tokens,
           durationSec: result.durationSec,
-          choices: (result as any).choices,   // forward when present
+          choices: result.choices,
         })
       }
       return result

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -38,7 +38,7 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.on('chat:token', listener)
       return () => ipcRenderer.removeListener('chat:token', listener)
     },
-    onDone: (handler: (msg: { conversationId: string; response: string }) => void) => {
+    onDone: (handler: (msg: { conversationId: string; response: string; tokens?: number; durationSec?: number; choices?: string[] }) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, msg: any) => handler(msg)
       ipcRenderer.on('chat:done', listener)
       return () => ipcRenderer.removeListener('chat:done', listener)

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -504,7 +504,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
             </div>
           </div>
         )}
-        {chat.messages.map(msg => {
+        {chat.messages.map((msg, idx) => {
           const isUser = msg.role === 'user'
           const isSelected = !isUser && msg.id === selectedTurnId && panelOpen
           return (
@@ -634,6 +634,26 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                   </div>
                 )}
               </div>
+              {msg.role === 'assistant'
+                && msg.choices
+                && msg.choices.length > 0
+                && idx === chat.messages.length - 1
+                && chat.messages[chat.messages.length - 1]?.role !== 'user'
+                && (
+                  <div style={styles.choiceRow}>
+                    {msg.choices.map((label, i) => (
+                      <button
+                        key={i}
+                        style={styles.choiceButton}
+                        disabled={isSending || !!flight}
+                        onClick={() => { void sendMessage(chat.id, label) }}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                )
+              }
               <div style={styles.tsLabel}>
                 <span>{fmtTime(msg.timestamp)}</span>
                 {(() => {
@@ -935,6 +955,22 @@ const styles: Record<string, React.CSSProperties> = {
   },
   uploadError: {
     color: C.dangerFg, fontSize: 11, padding: '0 4px',
+  },
+  choiceRow: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: 8,
+    marginTop: 8,
+    marginLeft: 12,
+  },
+  choiceButton: {
+    padding: '6px 12px',
+    borderRadius: 6,
+    border: `1px solid ${C.border2}`,
+    background: C.surface3,
+    color: C.fg,
+    cursor: 'pointer',
+    fontSize: 13,
   },
   attachButton: {
     width: 32, height: 32, borderRadius: 8, border: 'none',

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -514,7 +514,8 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 marginBottom: 12,
                 cursor: isUser ? 'default' : 'pointer',
                 paddingLeft: !isUser ? 6 : 0,
-                borderLeft: isSelected ? `2px solid ${C.accent}` : '2px solid transparent',
+                transform: isSelected ? 'translateY(-3px)' : 'translateY(0)',
+                transition: 'transform 0.18s ease',
               }}
             >
               <div style={{
@@ -522,8 +523,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
                 background: isUser ? C.userBg : C.aiBg,
                 color: isUser ? '#ffffff' : C.fg, fontSize: 13, lineHeight: 1.55, wordBreak: 'break-word',
-                boxShadow: isUser ? 'none' : '0 1px 3px rgba(0,0,0,0.3)',
-                border: isUser ? 'none' : `1px solid ${C.border2}`,
+                boxShadow: isUser
+                  ? 'none'
+                  : (isSelected
+                      ? `0 10px 24px ${C.accentDim}, 0 6px 14px ${C.accentDim}`
+                      : '0 1px 3px rgba(0,0,0,0.18)'),
+                border: isUser ? 'none' : `1px solid ${isSelected ? C.accent : C.border2}`,
+                transition: 'box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease',
               }}>
                 {msg.toolCalls && msg.toolCalls.length > 0 && (() => {
                   type Row =

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -228,7 +228,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     }
     return null
   })()
-  const panelOpen: boolean = !winNarrow && (chat?.contextPanelOpen ?? false)
+  const panelOpen: boolean = chat?.contextPanelOpen ?? false
+  const panelOverlay: boolean = panelOpen && winNarrow
+  const overlayPanelWidth: number = Math.min(
+    panelWidth,
+    Math.max(280, Math.floor(window.innerWidth * 0.55))
+  )
 
   const selectionValue: string = chat.selection.type === 'worker'
     ? `worker:${chat.selection.name}`
@@ -748,29 +753,65 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
       )}
       </div>
       {panelOpen && (
-        <ChatContextPanel
-          chat={chat}
-          selectedTurnId={selectedTurnId}
-          followLatest={followLatest}
-          selectedTurnIndex={selectedTurnIndex}
-          effectiveAgent={effectiveAgent}
-          effectiveModel={effectiveModel}
-          workerName={panelWorkerName}
-          teamName={panelTeamName}
-          workingDir={workingDir}
-          width={panelWidth}
-          onFollowLatest={() => setFollowLatest(true)}
-          onClose={() => setContextPanelOpen(chat.id, false)}
-          onResize={setPanelWidth}
-          onRevealFile={(p) => apiService.revealInFolder(p)}
-        />
+        panelOverlay ? (
+          <>
+            <div
+              style={styles.panelBackdrop}
+              onClick={() => setContextPanelOpen(chat.id, false)}
+            />
+            <div style={styles.panelOverlay}>
+              <ChatContextPanel
+                chat={chat}
+                selectedTurnId={selectedTurnId}
+                followLatest={followLatest}
+                selectedTurnIndex={selectedTurnIndex}
+                effectiveAgent={effectiveAgent}
+                effectiveModel={effectiveModel}
+                workerName={panelWorkerName}
+                teamName={panelTeamName}
+                workingDir={workingDir}
+                width={overlayPanelWidth}
+                onFollowLatest={() => setFollowLatest(true)}
+                onClose={() => setContextPanelOpen(chat.id, false)}
+                onResize={setPanelWidth}
+                onRevealFile={(p) => apiService.revealInFolder(p)}
+              />
+            </div>
+          </>
+        ) : (
+          <ChatContextPanel
+            chat={chat}
+            selectedTurnId={selectedTurnId}
+            followLatest={followLatest}
+            selectedTurnIndex={selectedTurnIndex}
+            effectiveAgent={effectiveAgent}
+            effectiveModel={effectiveModel}
+            workerName={panelWorkerName}
+            teamName={panelTeamName}
+            workingDir={workingDir}
+            width={panelWidth}
+            onFollowLatest={() => setFollowLatest(true)}
+            onClose={() => setContextPanelOpen(chat.id, false)}
+            onResize={setPanelWidth}
+            onRevealFile={(p) => apiService.revealInFolder(p)}
+          />
+        )
       )}
     </div>
   )
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  outer: { display: 'flex', flexDirection: 'row', height: '100%', minHeight: 0 },
+  outer: { display: 'flex', flexDirection: 'row', height: '100%', minHeight: 0, position: 'relative' },
+  panelBackdrop: {
+    position: 'absolute', inset: 0, zIndex: 20,
+    background: 'rgba(0,0,0,0.35)',
+  },
+  panelOverlay: {
+    position: 'absolute', top: 0, right: 0, bottom: 0, zIndex: 21,
+    boxShadow: '-12px 0 32px rgba(0,0,0,0.45)',
+    display: 'flex',
+  },
   container: { display: 'flex', flexDirection: 'column', height: '100%', flex: 1, minWidth: 0 },
   header: {
     padding: '10px 16px', borderBottom: `1px solid ${C.border}`,

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -29,7 +29,7 @@ type Action =
   | { type: 'streamToken'; chatId: string; token: string }
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: 'working' | 'writing' }
   | { type: 'queued'; chatId: string; position: number }
-  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string }
+  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
 
 function reorder(order: string[], chatId: string): string[] {
@@ -135,7 +135,7 @@ function reducer(state: State, action: Action): State {
       if (!chat) return state
       const messages = chat.messages.map(m =>
         m.id === action.assistantMessageId
-          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true }
+          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true, choices: action.choices }
           : m
       )
       const updatedChat: Chat = { ...chat, messages, updatedAt: Date.now() }
@@ -274,6 +274,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               tokens: ev.tokens,
               durationSec: ev.durationSec,
               title: ev.title,
+              choices: ev.choices,
             })
             delete pendingAssistantId.current[ev.chatId]
           } else {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -10,7 +10,7 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string }
+  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
   | { type: 'error'; chatId: string; message: string };
 
 function unwrap<T>(result: { ok: true; data: T } | { ok: false; error: string }): T {

--- a/docs/superpowers/plans/2026-05-10-ask-user-choice-buttons.md
+++ b/docs/superpowers/plans/2026-05-10-ask-user-choice-buttons.md
@@ -1,0 +1,1122 @@
+# ASK_USER Choice Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let workers/agents present yes/no and pick-one questions as click-to-answer buttons in Mac app, Telegram, and Discord, with text fallback in iMessage and TUI.
+
+**Architecture:** Add a `[ASK_USER:choice]: q | A | B` marker variant parsed in `@codey/core`, thread an `options: string[]` field through the gateway pause/render path, extend `ChannelHandler.sendMessage` to carry choices, and render native buttons in each channel (text + numbered list for non-button channels, with gateway-side digit→option mapping).
+
+**Tech Stack:** TypeScript, vitest (core tests), Telegraf (Telegram), discord.js, Electron + React (Mac app).
+
+**Spec:** `docs/superpowers/specs/2026-05-10-ask-user-choice-buttons-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `packages/core/src/utils/ask-user.ts` — extend types + regex for `:choice`
+- `packages/core/src/utils/ask-user.test.ts` — new cases
+- `packages/core/src/types/pending-team.ts` — add `options?: string[]`
+- `packages/core/src/types/chat.ts` — add `Chat.lastAskedOptions`, `ChatMessage.choices`
+- `packages/core/src/types/index.ts` — `GatewayResponse.choices`
+- `packages/core/src/workers.ts` — prompt updates (3 spots)
+- `packages/gateway/src/team-pause.ts` — `renderQuestion` returning `{ text, choices? }`
+- `packages/gateway/src/gateway.ts` — thread choices through pause sites, plain-chat parsing, digit mapping
+- `packages/gateway/src/channels/base.ts` — extend `sendMessage` signature
+- `packages/gateway/src/channels/telegram.ts` — inline keyboard + callback_query
+- `packages/gateway/src/channels/discord.ts` — ActionRow + button interaction
+- `packages/gateway/src/channels/imessage.ts` — numbered list append
+- `packages/gateway/src/channels/tui.ts` — numbered list append
+- `codey-mac/electron/main.ts` — pass choices via `chat:done`
+- `codey-mac/electron/preload.ts` — expose choices field
+- `codey-mac/src/services/api.ts` — `ChatStreamEvent` carries choices
+- `codey-mac/src/hooks/useChats.tsx` — store choices on last assistant message
+- `codey-mac/src/components/ChatTab.tsx` — render button row
+
+---
+
+## Task 1: Extend parser for `[ASK_USER:choice]`
+
+**Files:**
+- Modify: `packages/core/src/utils/ask-user.ts`
+- Test: `packages/core/src/utils/ask-user.test.ts`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `packages/core/src/utils/ask-user.test.ts`:
+
+```ts
+describe('parseAskUser (choice variant)', () => {
+  it('parses two options', () => {
+    const out = parseAskUser('[ASK_USER:choice]: merge into main? | yes | no');
+    expect(out).toEqual({
+      preamble: '',
+      question: 'merge into main?',
+      options: ['yes', 'no'],
+    });
+  });
+
+  it('parses many options and trims whitespace', () => {
+    const out = parseAskUser('[ASK_USER:choice]: pick db?  |  postgres  | sqlite |  mysql ');
+    expect(out?.options).toEqual(['postgres', 'sqlite', 'mysql']);
+  });
+
+  it('caps at 8 options', () => {
+    const opts = Array.from({ length: 12 }, (_, i) => `o${i}`).join(' | ');
+    const out = parseAskUser(`[ASK_USER:choice]: q? | ${opts}`);
+    expect(out?.options).toHaveLength(8);
+    expect(out?.options?.[0]).toBe('o0');
+    expect(out?.options?.[7]).toBe('o7');
+  });
+
+  it('skips empty option segments', () => {
+    const out = parseAskUser('[ASK_USER:choice]: q? | a | | b |   ');
+    expect(out?.options).toEqual(['a', 'b']);
+  });
+
+  it('degrades to plain text when fewer than 2 valid options remain', () => {
+    const out = parseAskUser('[ASK_USER:choice]: only one? | yes');
+    expect(out).toEqual({ preamble: '', question: 'only one? | yes' });
+    expect((out as any).options).toBeUndefined();
+  });
+
+  it('degrades when no pipe present', () => {
+    const out = parseAskUser('[ASK_USER:choice]: just a question');
+    expect(out).toEqual({ preamble: '', question: 'just a question' });
+  });
+
+  it('preserves preamble for choice marker', () => {
+    const text = 'I looked into it.\n[ASK_USER:choice]: which? | a | b';
+    const out = parseAskUser(text);
+    expect(out?.preamble).toBe('I looked into it.');
+    expect(out?.options).toEqual(['a', 'b']);
+  });
+});
+
+describe('parseAsk (choice variant)', () => {
+  it('returns user kind with options', () => {
+    const out = parseAsk('[ASK_USER:choice]: q? | a | b');
+    expect(out).toEqual({ kind: 'user', preamble: '', question: 'q?', options: ['a', 'b'] });
+  });
+
+  it('does not treat [ASK: name]:choice as a team-choice variant', () => {
+    // v1: only [ASK_USER] supports :choice. [ASK: name:choice] is unrecognized.
+    const out = parseAsk('[ASK: alice:choice]: q? | a | b');
+    // Either parses as a plain team ask (target="alice:choice") or skips —
+    // both are acceptable; we assert it does NOT carry an options field.
+    if (out?.kind === 'team') {
+      expect((out as any).options).toBeUndefined();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/utils/ask-user.test.ts`
+Expected: 8 failing tests (the 7 new choice tests fail; existing tests still pass).
+
+- [ ] **Step 3: Implement the parser changes**
+
+Replace `packages/core/src/utils/ask-user.ts` with:
+
+```ts
+export interface AskUser {
+  /** Worker output before the marker line (joined with \n, trimmed of trailing whitespace). */
+  preamble: string;
+  /** The question text after `[ASK_USER]:` (or `[ASK_USER:choice]:` before the first `|`). */
+  question: string;
+  /** Present only when the marker was `[ASK_USER:choice]:` with >= 2 valid options. */
+  options?: string[];
+}
+
+export interface AskTeam {
+  preamble: string;
+  /** The teammate the asking worker has nominated to answer. */
+  target: string;
+  question: string;
+}
+
+export type AskMarker =
+  | ({ kind: 'user' } & AskUser)
+  | ({ kind: 'team' } & AskTeam);
+
+const USER_MARKER_RE = /^\s*\[ASK_USER(?::choice)?\]\s*:\s*(.*)$/;
+const USER_CHOICE_MARKER_RE = /^\s*\[ASK_USER:choice\]\s*:\s*(.*)$/;
+const TEAM_MARKER_RE = /^\s*\[ASK\s*:\s*([^\]]+?)\s*\]\s*:\s*(.*)$/;
+
+const MAX_OPTIONS = 8;
+
+function splitChoicePayload(payload: string): { question: string; options?: string[] } {
+  const parts = payload.split('|').map(s => s.trim());
+  const question = parts.shift() ?? '';
+  const options = parts.filter(p => p.length > 0).slice(0, MAX_OPTIONS);
+  if (options.length < 2) return { question: payload.trim() };
+  return { question, options };
+}
+
+/**
+ * Detect a `[ASK_USER]: <question>` or `[ASK_USER:choice]: <q> | <a> | <b>` marker.
+ * Returns null when no marker is present or the question is blank.
+ */
+export function parseAskUser(output: string): AskUser | null {
+  if (!output) return null;
+  const lines = output.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const choiceMatch = lines[i].match(USER_CHOICE_MARKER_RE);
+    if (choiceMatch) {
+      const { question, options } = splitChoicePayload(choiceMatch[1]);
+      if (!question) return null;
+      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+      return options ? { preamble, question, options } : { preamble, question };
+    }
+    const userMatch = lines[i].match(USER_MARKER_RE);
+    if (!userMatch) continue;
+    const question = userMatch[1].trim();
+    if (!question) return null;
+    const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+    return { preamble, question };
+  }
+  return null;
+}
+
+/**
+ * Detect either a `[ASK_USER]:`/`[ASK_USER:choice]:` or `[ASK: <teammate>]:` marker line.
+ * Returns the first marker found (in document order) or null.
+ */
+export function parseAsk(output: string): AskMarker | null {
+  if (!output) return null;
+  const lines = output.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const choiceMatch = line.match(USER_CHOICE_MARKER_RE);
+    if (choiceMatch) {
+      const { question, options } = splitChoicePayload(choiceMatch[1]);
+      if (!question) return null;
+      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+      return options
+        ? { kind: 'user', preamble, question, options }
+        : { kind: 'user', preamble, question };
+    }
+    const userMatch = line.match(USER_MARKER_RE);
+    if (userMatch) {
+      const question = userMatch[1].trim();
+      if (!question) return null;
+      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+      return { kind: 'user', preamble, question };
+    }
+    const teamMatch = line.match(TEAM_MARKER_RE);
+    if (teamMatch) {
+      const target = teamMatch[1].trim();
+      const question = teamMatch[2].trim();
+      if (!target || !question) continue;
+      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+      return { kind: 'team', target, preamble, question };
+    }
+  }
+  return null;
+}
+```
+
+Note: `USER_MARKER_RE` is matched only if `USER_CHOICE_MARKER_RE` did NOT match on the same line, so order matters in the loop body. Choice match is tested first.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/utils/ask-user.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/utils/ask-user.ts packages/core/src/utils/ask-user.test.ts
+git commit -m "feat(core): parse [ASK_USER:choice] marker with option list"
+```
+
+---
+
+## Task 2: Persist options on PendingTeamState, Chat, ChatMessage, GatewayResponse
+
+**Files:**
+- Modify: `packages/core/src/types/pending-team.ts`
+- Modify: `packages/core/src/types/chat.ts`
+- Modify: `packages/core/src/types/index.ts`
+
+- [ ] **Step 1: Extend `PendingTeamState`**
+
+In `packages/core/src/types/pending-team.ts`, add `options?: string[]` to BOTH variants of the union:
+
+```ts
+export type PendingTeamState =
+  | {
+      teamName: string;
+      task: string;
+      mode: 'sequential';
+      memberIndex: number;
+      carry: string;
+      askingWorker: string;
+      question: string;
+      /** Options when worker emitted [ASK_USER:choice]; absent for free-text questions. */
+      options?: string[];
+      askedAt: number;
+    }
+  | {
+      teamName: string;
+      task: string;
+      mode: 'auto';
+      history: ManagerHistoryEntry[];
+      lastWorker: string;
+      lastOutput: string;
+      partsSoFar: PendingPart[];
+      seenWorkers: string[];
+      step: number;
+      askingWorker: string;
+      question: string;
+      options?: string[];
+      askedAt: number;
+    };
+```
+
+- [ ] **Step 2: Extend `Chat` and `ChatMessage`**
+
+In `packages/core/src/types/chat.ts`:
+
+Add to `ChatMessage`:
+```ts
+  /** Option labels when this assistant message ended in [ASK_USER:choice]. */
+  choices?: string[];
+```
+
+Add to `Chat`:
+```ts
+  /** Last unanswered choice question in a non-team chat. Cleared on next user message. */
+  lastAskedOptions?: { messageId: string; options: string[] };
+```
+
+- [ ] **Step 3: Extend `GatewayResponse`**
+
+In `packages/core/src/types/index.ts`, add to `GatewayResponse`:
+```ts
+  /** When present, the response is asking the user to pick from these options. */
+  choices?: string[];
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd packages/core && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/types/pending-team.ts packages/core/src/types/chat.ts packages/core/src/types/index.ts
+git commit -m "feat(core): add options/choices fields on PendingTeamState, Chat, ChatMessage, GatewayResponse"
+```
+
+---
+
+## Task 3: `renderQuestion` returns `{ text, choices? }`
+
+**Files:**
+- Modify: `packages/gateway/src/team-pause.ts`
+- Test: `packages/gateway/src/team-pause.test.ts` (create if absent)
+
+- [ ] **Step 1: Add failing tests**
+
+Create or append `packages/gateway/src/team-pause.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { renderQuestion, renderQuestionMessage } from './team-pause';
+
+describe('renderQuestion', () => {
+  it('returns text only for free-text question', () => {
+    const r = renderQuestion('coder', 'I looked.', 'which db?');
+    expect(r.text).toContain('which db?');
+    expect(r.choices).toBeUndefined();
+  });
+
+  it('returns text + choices for a choice question', () => {
+    const r = renderQuestion('coder', '', 'merge?', ['yes', 'no']);
+    expect(r.text).toContain('merge?');
+    expect(r.choices).toEqual(['yes', 'no']);
+  });
+
+  it('renderQuestionMessage stays string-typed for legacy callers', () => {
+    const t = renderQuestionMessage('coder', '', 'q?');
+    expect(typeof t).toBe('string');
+    expect(t).toContain('q?');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/gateway && npx vitest run src/team-pause.test.ts`
+Expected: fails because `renderQuestion` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Replace `packages/gateway/src/team-pause.ts`:
+
+```ts
+import { PendingTeamState, parseAsk } from '@codey/core';
+
+export function stripAskMarker(output: string): string {
+  const ask = parseAsk(output);
+  return ask ? ask.preamble : output;
+}
+
+export interface QuestionRender {
+  text: string;
+  choices?: string[];
+}
+
+export function renderQuestion(
+  workerName: string,
+  preamble: string,
+  question: string,
+  options?: string[],
+  truncate = 500,
+): QuestionRender {
+  const head = preamble.trim();
+  const trimmedHead = head.length > truncate ? head.substring(0, truncate) + '…' : head;
+  const intro = `❓ **${workerName}** needs your input:`;
+  const body = `${question}`;
+  const footer = options && options.length > 0
+    ? '_Tap an option below, or type your own answer._'
+    : '_Reply with your answer to continue, or send a slash command to cancel._';
+  const text = [trimmedHead, intro, body, footer].filter(Boolean).join('\n\n');
+  return options && options.length > 0 ? { text, choices: options } : { text };
+}
+
+/** Legacy string-returning helper kept for callers that don't yet pass choices through. */
+export function renderQuestionMessage(
+  workerName: string,
+  preamble: string,
+  question: string,
+  truncate = 500,
+): string {
+  return renderQuestion(workerName, preamble, question, undefined, truncate).text;
+}
+
+export function renderCancelNotice(pending: PendingTeamState): string {
+  return `Cancelled paused team \`${pending.teamName}\` (was waiting on: ${pending.question}).`;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/gateway && npx vitest run src/team-pause.test.ts`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/team-pause.ts packages/gateway/src/team-pause.test.ts
+git commit -m "feat(gateway): renderQuestion returns text + optional choices"
+```
+
+---
+
+## Task 4: Thread `options` through gateway pause call sites
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts`
+
+Update all five sites that currently call `renderQuestionMessage(...)` to persist `options` on `PendingTeamState` and pass them through. The sites are at approximately lines 2016, 2152, 2253, 2341, 2436, 2489 (six calls total — Task 6 covers the plain-chat case separately; this task handles the existing pause paths).
+
+- [ ] **Step 1: Read the current pause sites**
+
+Run: `grep -n "renderQuestionMessage\|persistPendingTeam" packages/gateway/src/gateway.ts | head -30`
+
+Note: each call to `renderQuestionMessage(workerName, preamble, question)` lives near a `persistPendingTeam(...)` call (or builds a `PendingTeamState` object inline).
+
+- [ ] **Step 2: For each of the five team-pause sites, do the following pattern**
+
+For every call to `renderQuestionMessage(askWorkerName, preamble, ask.question)`:
+
+a. The corresponding `persistPendingTeam` payload (or inline `PendingTeamState`) MUST set `options: ask.options` (when `ask` is from `parseAsk`/`parseAskUser` it now has an `options?: string[]` field). Example, around `gateway.ts:2479`:
+
+```ts
+this.persistPendingTeam(chatId, {
+  mode: 'sequential',
+  teamName,
+  task: prompt,
+  memberIndex: i,
+  carry,
+  askingWorker: memberName,
+  question: ask.question,
+  options: ask.options,           // ← new
+  askedAt: Date.now(),
+});
+```
+
+b. Replace the `renderQuestionMessage(...)` call with `renderQuestion(...)` (import is already adjacent). Capture both pieces:
+
+```ts
+const rendered = renderQuestion(askWorkerName, preamble, ask.question, ask.options);
+```
+
+c. Each site needs to emit BOTH the visible text AND the choices. Since current call sites either return a `{ response: string }` from a private method (handled by `sendChatResponse` later) or call `sink({ type: 'stream', ... })`, do this:
+
+- Where the function returns `{ response }`: continue returning `rendered.text`. Choices flow separately via the saved `pendingTeam.options` (channels read it from the chat in Task 8/9/12) and via the `GatewayResponse.choices` field on the eventual send. Set `gatewayResponse.choices = rendered.choices` on the response object passed to `sendChatResponse`.
+- Where the call uses `sink({ type: 'stream', ..., token: text })`: emit text via stream, then emit a new sink event (added in Task 6 below) `{ type: 'choices', chatId, choices }` when `rendered.choices` is defined.
+
+For Task 4 specifically, focus on persisting `options` on `PendingTeamState` and swapping `renderQuestionMessage` → `renderQuestion`. Channel-side rendering is wired up in later tasks.
+
+- [ ] **Step 3: Update the resume path to clear `options`**
+
+In `resumeTeamFromAnswer`, the existing code already replaces `pendingTeam` with a fresh state for the next pause if it happens. No change needed.
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd packages/gateway && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): persist option list on PendingTeamState and emit via renderQuestion"
+```
+
+---
+
+## Task 5: Gateway digit→option mapping at message intake
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts`
+- Test: `packages/gateway/src/digit-mapping.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/digit-mapping.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveChoiceDigit } from './digit-mapping';
+
+describe('resolveChoiceDigit', () => {
+  const opts = ['yes', 'no', 'maybe'];
+
+  it('maps "1" to first option', () => {
+    expect(resolveChoiceDigit('1', opts)).toBe('yes');
+  });
+
+  it('maps "  2 " to second option (whitespace tolerated)', () => {
+    expect(resolveChoiceDigit('  2 ', opts)).toBe('no');
+  });
+
+  it('returns null for out-of-range digit', () => {
+    expect(resolveChoiceDigit('5', opts)).toBeNull();
+    expect(resolveChoiceDigit('0', opts)).toBeNull();
+  });
+
+  it('returns null for non-digit text', () => {
+    expect(resolveChoiceDigit('yes', opts)).toBeNull();
+    expect(resolveChoiceDigit('1!', opts)).toBeNull();
+  });
+
+  it('returns null when options is empty or absent', () => {
+    expect(resolveChoiceDigit('1', [])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/gateway && npx vitest run src/digit-mapping.test.ts`
+Expected: fail (module missing).
+
+- [ ] **Step 3: Implement the helper**
+
+Create `packages/gateway/src/digit-mapping.ts`:
+
+```ts
+/**
+ * If `text` is a bare digit `n` and `options[n-1]` exists, return that option.
+ * Otherwise return null (caller should pass the original text through unchanged).
+ */
+export function resolveChoiceDigit(text: string, options: string[]): string | null {
+  if (!options || options.length === 0) return null;
+  const m = text.match(/^\s*(\d+)\s*$/);
+  if (!m) return null;
+  const idx = parseInt(m[1], 10) - 1;
+  if (idx < 0 || idx >= options.length) return null;
+  return options[idx];
+}
+```
+
+- [ ] **Step 4: Wire it into the gateway message handler**
+
+In `packages/gateway/src/gateway.ts`, locate `handleMessage` (around the `pendingChat?.pendingTeam` check near line 509). BEFORE the existing pendingTeam branch, insert digit mapping:
+
+```ts
+import { resolveChoiceDigit } from './digit-mapping';
+// ...
+async handleMessage(message: UserMessage) {
+  // ...load chat + pendingChat as before...
+
+  // Digit → option resolution for choice questions (works for both pendingTeam
+  // and plain-chat lastAskedOptions). Mutates `message.text` so downstream
+  // handling sees the resolved option string.
+  const pendingOpts = pendingChat?.pendingTeam?.options ?? pendingChat?.lastAskedOptions?.options;
+  if (pendingOpts && pendingOpts.length > 0) {
+    const resolved = resolveChoiceDigit(message.text, pendingOpts);
+    if (resolved !== null) {
+      message = { ...message, text: resolved };
+    }
+  }
+
+  // Clear lastAskedOptions on ANY user message (button click or otherwise).
+  if (pendingChat?.lastAskedOptions) {
+    this.getChatManager().clearLastAskedOptions(pendingChat.id); // helper added in Task 6
+  }
+
+  // ...rest of handleMessage unchanged...
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd packages/gateway && npx vitest run src/digit-mapping.test.ts`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/digit-mapping.ts packages/gateway/src/digit-mapping.test.ts packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): map digit replies to choice options on message intake"
+```
+
+---
+
+## Task 6: Plain-chat ASK_USER parsing + `lastAskedOptions`
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts`
+- Modify: `packages/core/src/chat-manager.ts` (or wherever `ChatManager` is defined — find with `grep -rn "class ChatManager" packages/core/src`)
+
+- [ ] **Step 1: Locate the plain-chat completion path**
+
+Run: `grep -n "type: 'done'\|sink({ type: 'done'" packages/gateway/src/gateway.ts`
+
+There should be a site (near line 3057) where the final agent response is emitted via `sink({ type: 'done', ... })`. This is the plain-chat path that bypasses team mode.
+
+- [ ] **Step 2: Add `clearLastAskedOptions` helper on the chat manager**
+
+In the file that defines `ChatManager` (search with `grep -rn "class ChatManager\|export class ChatManager" packages`), add:
+
+```ts
+clearLastAskedOptions(chatId: string): void {
+  const chat = this.get(chatId);
+  if (!chat || !chat.lastAskedOptions) return;
+  delete chat.lastAskedOptions;
+  this.persist(chat);   // use whatever the existing persist method is called
+}
+
+setLastAskedOptions(chatId: string, messageId: string, options: string[]): void {
+  const chat = this.get(chatId);
+  if (!chat) return;
+  chat.lastAskedOptions = { messageId, options };
+  this.persist(chat);
+}
+```
+
+(Adapt the persist method name to match existing code.)
+
+- [ ] **Step 3: Parse ASK_USER on plain-chat completion**
+
+In `gateway.ts` near the `sink({ type: 'done', ..., response: output, ... })` site, BEFORE emitting `done`:
+
+```ts
+import { parseAskUser } from '@codey/core';
+// ...
+
+// Plain-chat ASK_USER detection: if the agent's final output contains the
+// marker, surface the choices to the channel and persist on the chat for
+// digit-mapping on the next reply. Team flows already handled this earlier.
+let choices: string[] | undefined;
+const plainAsk = parseAskUser(output);
+if (plainAsk?.options && plainAsk.options.length >= 2) {
+  choices = plainAsk.options;
+  // The assistant message ID is whatever ID the chat manager assigned to
+  // the just-recorded message. If unavailable, omit messageId — the gateway
+  // clears lastAskedOptions on any next user message regardless.
+  const lastMsg = updated.messages[updated.messages.length - 1];
+  if (lastMsg) {
+    this.getChatManager().setLastAskedOptions(chatId, lastMsg.id, plainAsk.options);
+    // Also stamp choices on the persisted message so the Mac app can render
+    // buttons when this chat is reloaded mid-question.
+    lastMsg.choices = plainAsk.options;
+    this.getChatManager().updateMessage(chatId, lastMsg);  // use existing API
+  }
+}
+
+sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title, choices });
+```
+
+If `updateMessage` isn't a method, mutate-then-persist using whatever the chat manager exposes. Worst case: re-save the whole chat via the existing save method.
+
+- [ ] **Step 4: Add the `'choices'` event to `ChatStreamEvent`**
+
+In `codey-mac/src/services/api.ts`, extend the union:
+
+```ts
+export type ChatStreamEvent =
+  | { type: 'queued'; chatId: string; position: number }
+  | { type: 'tool_start'; chatId: string; tool?: string; message: string; input?: Record<string, unknown> }
+  | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
+  | { type: 'info'; chatId: string; message: string }
+  | { type: 'stream'; chatId: string; token: string }
+  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
+  | { type: 'error'; chatId: string; message: string };
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd packages/gateway && npx tsc --noEmit && cd ../core && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts packages/core/src codey-mac/src/services/api.ts
+git commit -m "feat(gateway): parse [ASK_USER:choice] in plain chat and persist options on chat"
+```
+
+---
+
+## Task 7: Extend `ChannelHandler.sendMessage` for choices (text-only fallback channels)
+
+**Files:**
+- Modify: `packages/gateway/src/channels/base.ts`
+- Modify: `packages/gateway/src/channels/imessage.ts`
+- Modify: `packages/gateway/src/channels/tui.ts`
+
+The `GatewayResponse` now carries `choices?: string[]`. Text-only channels render them as a numbered list appended to the message.
+
+- [ ] **Step 1: Add helper in base**
+
+In `packages/gateway/src/channels/base.ts`, add:
+
+```ts
+export function formatChoicesAsText(text: string, choices?: string[]): string {
+  if (!choices || choices.length === 0) return text;
+  const list = choices.map((c, i) => `${i + 1}) ${c}`).join('\n');
+  return `${text}\n\n${list}\n\n_Reply with the number or the option text._`;
+}
+```
+
+- [ ] **Step 2: Update imessage handler**
+
+In `packages/gateway/src/channels/imessage.ts`, locate `sendMessage(response: GatewayResponse)` and prefix the actual send with:
+
+```ts
+import { formatChoicesAsText } from './base';
+// ...
+async sendMessage(response: GatewayResponse): Promise<void> {
+  const text = formatChoicesAsText(response.text, response.choices);
+  // ...existing send logic, but use `text` instead of `response.text`...
+}
+```
+
+- [ ] **Step 3: Update tui handler**
+
+Same pattern in `packages/gateway/src/channels/tui.ts`.
+
+- [ ] **Step 4: Type-check + manual smoke**
+
+Run: `cd packages/gateway && npx tsc --noEmit`
+
+(No automated test here — channel handlers are I/O-bound. Manual verification happens in Task 14.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/channels/base.ts packages/gateway/src/channels/imessage.ts packages/gateway/src/channels/tui.ts
+git commit -m "feat(channels): render choices as numbered list in imessage/tui"
+```
+
+---
+
+## Task 8: Telegram inline keyboard + callback_query
+
+**Files:**
+- Modify: `packages/gateway/src/channels/telegram.ts`
+
+- [ ] **Step 1: Add inline keyboard on send**
+
+Locate `sendMessage(response: GatewayResponse)` in `packages/gateway/src/channels/telegram.ts`. The current code calls something like `bot.telegram.sendMessage(chatId, text, { ... })`. Add a conditional `reply_markup`:
+
+```ts
+async sendMessage(response: GatewayResponse): Promise<void> {
+  // ...existing setup (chatId resolution, markdown options, etc.)...
+
+  const extra: any = { /* existing options */ };
+  if (response.choices && response.choices.length > 0) {
+    // Wrap rows at 3 buttons. callback_data must be <= 64 bytes; fall back
+    // to indexed payload for long labels.
+    const buttons = response.choices.map((label, idx) => {
+      const callback_data = Buffer.byteLength(label, 'utf8') <= 60 ? label : `opt:${idx}`;
+      return { text: label, callback_data };
+    });
+    const rows: typeof buttons[] = [];
+    for (let i = 0; i < buttons.length; i += 3) rows.push(buttons.slice(i, i + 3));
+    extra.reply_markup = { inline_keyboard: rows };
+  }
+
+  await this.bot.telegram.sendMessage(chatId, response.text, extra);
+}
+```
+
+- [ ] **Step 2: Handle `callback_query`**
+
+In `start(config)`, after the existing `bot.on('text', ...)` handler, add:
+
+```ts
+this.bot.on('callback_query', async (ctx) => {
+  const data = (ctx.callbackQuery as any).data as string | undefined;
+  const fromId = ctx.from?.id?.toString();
+  const chatId = ctx.chat?.id?.toString();
+  if (!data || !fromId || !chatId) {
+    await ctx.answerCbQuery();
+    return;
+  }
+  // Resolve indexed payload if needed. We don't have chat state here; the
+  // gateway's intake will pass the literal text through as the answer.
+  // For "opt:N" payloads we cannot map without state — keep them as-is and
+  // let the gateway resolve via lastAskedOptions/pendingTeam.options.
+  let text = data;
+  if (/^opt:\d+$/.test(data)) {
+    // Emit the digit form so the gateway's digit-mapping resolves it.
+    // "opt:0" → "1", "opt:1" → "2", etc.
+    const idx = parseInt(data.slice(4), 10);
+    text = String(idx + 1);
+  }
+  await ctx.answerCbQuery();   // dismiss spinner
+  this.emitMessage({
+    id: `tg-${Date.now()}`,
+    channel: 'telegram',
+    userId: fromId,
+    username: ctx.from?.username ?? fromId,
+    chatId,
+    text,
+    timestamp: Date.now(),
+  });
+});
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd packages/gateway && npx tsc --noEmit`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/gateway/src/channels/telegram.ts
+git commit -m "feat(channels): telegram inline keyboard buttons for [ASK_USER:choice]"
+```
+
+---
+
+## Task 9: Discord buttons + interaction handler
+
+**Files:**
+- Modify: `packages/gateway/src/channels/discord.ts`
+
+- [ ] **Step 1: Render buttons on send**
+
+At the top of `packages/gateway/src/channels/discord.ts`, ensure imports include:
+
+```ts
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Interaction, Message, TextChannel } from 'discord.js';
+```
+
+In `sendMessage(response: GatewayResponse)`, locate the call that sends `response.text` to a Discord channel. Adapt:
+
+```ts
+async sendMessage(response: GatewayResponse): Promise<void> {
+  // ...resolve channel...
+  const components: any[] = [];
+  if (response.choices && response.choices.length > 0) {
+    // Discord: max 5 buttons per row, 5 rows = 25 total. Our cap is 8.
+    const buttons = response.choices.slice(0, 25).map((label, idx) =>
+      new ButtonBuilder()
+        // customId must be <= 100 chars; option labels are short by convention.
+        // Use index-based id to keep it bounded and to allow remapping on click.
+        .setCustomId(`ask_user:${idx}`)
+        .setLabel(label.length > 80 ? label.slice(0, 77) + '…' : label)
+        .setStyle(ButtonStyle.Secondary)
+    );
+    for (let i = 0; i < buttons.length; i += 5) {
+      const row = new ActionRowBuilder<ButtonBuilder>().addComponents(buttons.slice(i, i + 5));
+      components.push(row);
+    }
+  }
+  await channel.send({ content: response.text, components });
+}
+```
+
+- [ ] **Step 2: Wire interaction handler**
+
+In `start(config)`, after the existing `messageCreate` handler, add:
+
+```ts
+this.client.on('interactionCreate', async (interaction: Interaction) => {
+  if (!interaction.isButton()) return;
+  const m = interaction.customId.match(/^ask_user:(\d+)$/);
+  if (!m) return;
+  const idx = parseInt(m[1], 10);
+  // Emit the digit form so the gateway resolves via lastAskedOptions/pendingTeam.options.
+  const text = String(idx + 1);
+  await interaction.update({ components: [] }).catch(() => { /* already updated */ });
+  this.emitMessage({
+    id: `dc-${interaction.id}`,
+    channel: 'discord',
+    userId: interaction.user.id,
+    username: interaction.user.username,
+    chatId: interaction.channelId,
+    text,
+    timestamp: Date.now(),
+  });
+});
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd packages/gateway && npx tsc --noEmit`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/gateway/src/channels/discord.ts
+git commit -m "feat(channels): discord buttons for [ASK_USER:choice]"
+```
+
+---
+
+## Task 10: Mac app — pipe choices through IPC and render buttons
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts`
+- Modify: `codey-mac/electron/preload.ts`
+- Modify: `codey-mac/src/hooks/useChats.tsx`
+- Modify: `codey-mac/src/components/ChatTab.tsx`
+
+- [ ] **Step 1: Pass choices through IPC `chat:done`**
+
+In `codey-mac/electron/main.ts`, locate the `sendToRenderer('chat:done', { ... })` call inside the `chat:send` handler (around line 633). Update:
+
+```ts
+if (result?.response) {
+  sendToRenderer('chat:done', {
+    conversationId: convId,
+    response: result.response,
+    tokens: result.tokens,
+    durationSec: result.durationSec,
+    choices: (result as any).choices,   // forward when present
+  })
+}
+```
+
+Also confirm `processPromptHttp` in `packages/gateway/src/gateway.ts` returns `choices` in its result object. If it doesn't yet, locate the return statement (search `return { response: output` in gateway.ts) and add `choices: plainAsk?.options ?? undefined` (reusing the `plainAsk` from Task 6, or by re-parsing if `plainAsk` is out of scope).
+
+- [ ] **Step 2: Expose in preload**
+
+In `codey-mac/electron/preload.ts`, find the `chat.onDone` registration (search `chat:done`) and ensure the forwarded payload type includes `choices?: string[]`. Add to the inline type if it's typed explicitly.
+
+- [ ] **Step 3: Persist choices on the assistant message in the chat store**
+
+In `codey-mac/src/hooks/useChats.tsx`, locate where `done` events from `chat.onDone` (or the equivalent stream listener for `done` event type) update the assistant message. Add `choices: msg.choices` to the message update so the message in state carries `choices?: string[]`.
+
+(The `ChatMessage` core type already has `choices?: string[]` from Task 2.)
+
+- [ ] **Step 4: Render buttons in ChatTab**
+
+In `codey-mac/src/components/ChatTab.tsx`, locate the message-rendering JSX (look for where assistant messages are rendered with `<Markdown>` or similar). Add, beneath the message bubble:
+
+```tsx
+{msg.role === 'assistant'
+  && msg.choices
+  && msg.choices.length > 0
+  && idx === messages.length - 1
+  && messages[messages.length - 1]?.role !== 'user'
+  && (
+    <div style={styles.choiceRow}>
+      {msg.choices.map((label, i) => (
+        <button
+          key={i}
+          style={styles.choiceButton}
+          disabled={isSending || !!flight}
+          onClick={() => {
+            // Send the option text as a normal user message.
+            void sendMessage(chat.id, label)
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}
+```
+
+Add styles near the existing styles object:
+
+```ts
+choiceRow: {
+  display: 'flex',
+  flexWrap: 'wrap' as const,
+  gap: 8,
+  marginTop: 8,
+  marginLeft: 12,
+},
+choiceButton: {
+  padding: '6px 12px',
+  borderRadius: 6,
+  border: `1px solid ${C.fg3}`,
+  background: C.bg2,
+  color: C.fg1,
+  cursor: 'pointer',
+  fontSize: 13,
+},
+```
+
+(Adapt `C` palette names to whatever the file actually imports — check existing button styles in the same file.)
+
+- [ ] **Step 5: Build the Mac app**
+
+Run: `cd codey-mac && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/electron/main.ts codey-mac/electron/preload.ts codey-mac/src/hooks/useChats.tsx codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): render choice buttons under assistant messages with [ASK_USER:choice]"
+```
+
+---
+
+## Task 11: Worker prompt updates
+
+**Files:**
+- Modify: `packages/core/src/workers.ts`
+
+- [ ] **Step 1: Read the three prompt sites**
+
+Run: `grep -n "ASK_USER" packages/core/src/workers.ts`
+
+Three prompts mention `[ASK_USER]`: solo worker (~line 203), sequential member (~line 242), auto-routed worker (~line 284).
+
+- [ ] **Step 2: Append the choice-marker instruction at each site**
+
+In each prompt, locate the existing line about `[ASK_USER]: <your question>` and immediately after it, add:
+
+```ts
+'When the question is yes/no or a pick-one from a small set (≤ 8) of explicit options, prefer `[ASK_USER:choice]: <question> | <option 1> | <option 2>` so the user can answer with a tap. Use the free-text `[ASK_USER]:` form for open-ended questions.',
+```
+
+Match the surrounding array/string-concat style of each prompt. Keep wording identical across the three so the LLM behavior is consistent.
+
+- [ ] **Step 3: Update existing manager-prompt tests if they snapshot prompt text**
+
+Run: `cd packages/core && npx vitest run`
+Expected: pass. If any snapshot tests fail, update them to include the new line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/workers.ts packages/core/src/manager-prompt.test.ts
+git commit -m "feat(workers): teach workers to emit [ASK_USER:choice] for yes/no questions"
+```
+
+---
+
+## Task 12: End-to-end manual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build everything**
+
+Run: `npm run build` from the repo root (or build per package if no root script).
+Expected: clean build.
+
+- [ ] **Step 2: Spawn a test team with a worker that emits a choice marker**
+
+Create a temporary worker `workspaces/<test-workspace>/workers/choice-asker.md`:
+
+```markdown
+You are a tester. On your first turn, output exactly:
+
+[ASK_USER:choice]: Should I proceed with plan A? | yes | no | tell me more
+
+Then stop.
+```
+
+Register the worker via the Mac app Workers tab and add it to a single-member team `choice-test`.
+
+- [ ] **Step 3: Mac app — verify buttons**
+
+In the Mac app, run `/team choice-test do anything`. Expected:
+- The worker output renders as a message
+- Three buttons "yes" / "no" / "tell me more" appear below it
+- Clicking "yes" sends "yes" as a user message, resumes the team, buttons disappear
+
+- [ ] **Step 4: Telegram — verify inline keyboard**
+
+Pair the chat to a Telegram channel. Repeat. Expected: inline keyboard with three buttons appears. Tapping sends the selection.
+
+- [ ] **Step 5: Discord — verify buttons**
+
+Pair to Discord. Repeat. Expected: three button row appears under the message.
+
+- [ ] **Step 6: iMessage / TUI — verify numbered list + digit reply**
+
+Pair to iMessage (or use the TUI channel). Repeat. Expected:
+- Message ends with `1) yes\n2) no\n3) tell me more`
+- Replying `2` resolves to "no" and resumes the team
+
+- [ ] **Step 7: Verify plain-chat (non-team) coverage**
+
+In a non-team chat (selection: none), prompt the agent: "Ask me with [ASK_USER:choice]: do you want coffee? | yes | no". Expected: agent emits the marker, buttons appear in Mac app, tapping sends the answer as the next user message.
+
+- [ ] **Step 8: Verify graceful degradation**
+
+Trigger a worker to output `[ASK_USER:choice]: only one? | yes` (one option). Expected: rendered as a plain free-text ASK_USER (no buttons), team pauses, user can reply with anything.
+
+- [ ] **Step 9: Cleanup**
+
+Delete the test worker and team.
+
+```bash
+# No commit — manual verification only.
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+- Protocol with `:choice` suffix, `|` separator, 2–8 options, graceful degradation → Task 1 ✓
+- Worker prompt update (3 sites) → Task 11 ✓
+- Render helper returning `{ text, choices? }` → Task 3 ✓
+- `PendingTeamState.options`, `Chat.lastAskedOptions`, `ChatMessage.choices`, `GatewayResponse.choices` → Task 2 ✓
+- Gateway threading through pause sites → Task 4 ✓
+- Plain-chat ASK_USER parsing → Task 6 ✓
+- Digit→option mapping → Task 5 ✓
+- Text-fallback channels (imessage, tui) → Task 7 ✓
+- Telegram buttons + callback → Task 8 ✓
+- Discord buttons + interaction → Task 9 ✓
+- Mac app rendering → Task 10 ✓
+- Tests for parser, render, digit mapping → Tasks 1, 3, 5 ✓
+- E2E manual verification → Task 12 ✓
+
+Risks called out in spec:
+- 64-byte Telegram `callback_data` limit → handled in Task 8 with `opt:N` indexed fallback
+- 100-char Discord customId + 80-char label → handled in Task 9
+- Race between button click and free-text reply → existing single-flight handles it (no extra code)
+
+Type consistency: `options: string[]` used uniformly across `AskUser`, `PendingTeamState`, `ChatMessage.choices` (renamed to `choices` at presentation boundary), `GatewayResponse.choices`, `Chat.lastAskedOptions.options`. The "options vs choices" naming split is intentional: `options` = the parsed marker payload internal to gateway/core; `choices` = the user-facing presentation field on the response/message.

--- a/docs/superpowers/specs/2026-05-10-ask-user-choice-buttons-design.md
+++ b/docs/superpowers/specs/2026-05-10-ask-user-choice-buttons-design.md
@@ -1,0 +1,183 @@
+# ASK_USER Choice Buttons
+
+Date: 2026-05-10
+Status: Draft
+
+## Problem
+
+When a worker (or any agent run) needs user confirmation — a Yes/No, a permission-like accept/reject, or a pick-one-of-few decision — the only way for the user to answer today is to type free text. The marker `[ASK_USER]: <question>` pauses the team and waits for a textual reply.
+
+This is needlessly slow for the common case. The user knows exactly which option they want; they should be able to tap a button instead of typing.
+
+## Goals
+
+- Let workers express that a question is a closed-choice question (Yes/No, A/B/C).
+- Render those questions as native click-to-answer UI in channels that support it (Mac app, Telegram, Discord).
+- Degrade gracefully on channels without button affordances (iMessage, TUI): show a numbered list, accept the digit as the answer.
+- Continue accepting free-text replies in all cases — buttons are a shortcut, not a constraint.
+- Cover both the team pause flow and any plain-chat agent output that contains the marker.
+
+## Non-Goals
+
+- Intercepting CLI-level permission prompts (Claude Code / Codex / OpenCode). Those are owned by the agent process and not visible to the gateway.
+- Multi-select questions. v1 is single-select only.
+- Rich UI beyond labelled buttons (no images, no menu groups).
+- Persistent UI state after the question is answered (buttons should be ephemeral; the chat record stores the answer as plain text).
+
+## Protocol
+
+New marker:
+
+```
+[ASK_USER:choice]: <question> | <option 1> | <option 2> [| <option N>]
+```
+
+Rules:
+
+- The marker still occupies a single line, same as `[ASK_USER]:` and `[ASK: name]:`.
+- The question is the text after `:` and before the first ` | `.
+- Options are everything after, split on `|` and trimmed.
+- **At least 2 non-empty options** are required. If a parser sees the `:choice` suffix but ends up with fewer than 2 valid options, it falls back to treating the line as a plain `[ASK_USER]:` with the entire payload as the question (graceful degradation).
+- Options containing a literal `|` are not supported; workers are instructed to rephrase. We do not invent an escape syntax in v1.
+- Maximum 8 options. Beyond that, the parser keeps the first 8 and drops the rest (logged at debug).
+- Empty / whitespace-only options are skipped.
+
+Worker prompts (`packages/core/src/workers.ts`, three locations: solo worker, sequential team member, auto-routed worker) gain one sentence:
+
+> When the question is a yes/no or pick-one of a small set of explicit options, use `[ASK_USER:choice]: <question> | <option 1> | <option 2>`. For open-ended questions keep using `[ASK_USER]: <question>`.
+
+## Architecture
+
+### Parsing (`packages/core/src/utils/ask-user.ts`)
+
+Extend the `AskUser` type:
+
+```ts
+export interface AskUser {
+  preamble: string;
+  question: string;
+  options?: string[];     // present only for choice variants; at least 2 entries when present
+}
+```
+
+`AskMarker` keeps the same shape; the `'user'` variant carries the optional `options`.
+
+Update both regexes to accept an optional `:choice` suffix:
+
+```
+/^\s*\[ASK_USER(?::choice)?\]\s*:\s*(.*)$/
+```
+
+When `:choice` is present:
+1. Split the captured payload on `|`.
+2. First segment = question.
+3. Remaining segments = options. Trim each; drop empties; cap at 8.
+4. If fewer than 2 options remain, drop the `options` field (downgrade to plain text question).
+
+The `[ASK: <teammate>]:` regex is unchanged and does not gain a choice variant in v1 — workers cannot offer buttons when delegating to peers (the recipient is another LLM, not a user).
+
+### Render payload (`packages/gateway/src/team-pause.ts`)
+
+`renderQuestionMessage` keeps returning a `string` (the visible message body). A new helper exports the choices alongside it so callers can pass both to the channel:
+
+```ts
+export interface QuestionRender {
+  text: string;
+  choices?: string[];   // present when worker emitted choice options
+}
+
+export function renderQuestion(
+  workerName: string,
+  preamble: string,
+  question: string,
+  options?: string[],
+  truncate = 500,
+): QuestionRender;
+```
+
+`renderQuestionMessage` becomes a thin wrapper that returns `.text` for code paths that don't yet thread choices through.
+
+### Channel transport
+
+`ChannelAdapter.send(route, payload)` today accepts a string. Extend the signature to:
+
+```ts
+type SendPayload = string | { text: string; choices?: string[] };
+send(route: ChatRoute, payload: SendPayload): Promise<void>;
+```
+
+Default behaviour for any handler that doesn't override: stringify and send `text` only. Telegram / Discord / Mac app override to render buttons.
+
+Gateway call sites that currently do `channel.send(route, renderQuestionMessage(...))` change to `channel.send(route, renderQuestion(...))`. Five call sites exist (`gateway.ts:2016, 2152, 2253, 2341, 2436, 2489`); all five are pause-emitting paths and all should pass the new payload.
+
+### Pending state and plain-chat coverage
+
+Two flows now parse `[ASK_USER:choice]`:
+
+1. **Team / worker flow** (existing) — pauses via `PendingTeamState`. Both variants gain `options?: string[]`, persisted alongside the question so resume logging and digit-mapping fallback can resolve the option text.
+2. **Plain chat flow** (new) — when an agent's response in a non-team chat contains the marker, the gateway parses it and forwards the choices to the channel, but does **not** create a `pendingTeam`. The user's next message (button tap or typed text) is just a normal next turn for the agent. To support digit mapping in this flow, persist `lastAskedOptions?: { options: string[]; messageId: string }` on the `Chat` record; clear it whenever the user sends any new message.
+
+Mac app render condition (covers both flows): render the button row on a message whose `choices` is present **iff** that message is the latest assistant message AND no user message has been sent after it. This decouples rendering from `pendingTeam` and works uniformly for team pauses and plain chat.
+
+Digit-mapping condition (gateway-side, channel-agnostic): if the incoming user text matches `/^\s*(\d+)\s*$/` and `chat.pendingTeam?.options` OR `chat.lastAskedOptions?.options` is present and in range, replace the text with the resolved option before continuing normal handling. After resolution (or after any non-matching message), clear `lastAskedOptions`.
+
+### Channel implementations
+
+| Channel | Behaviour |
+|---|---|
+| **Mac app** (`codey-mac/src/components/ChatTab.tsx`) | Messages carry an optional `choices: string[]` field, persisted alongside text. Render the button row only when the message is the most recent assistant message AND the chat still has `pendingTeam` set (i.e., the question hasn't been answered yet). Clicking a button sends the option text as a normal user message; once the answer is consumed and `pendingTeam` clears, the buttons stop rendering on subsequent re-renders / reloads. |
+| **Telegram** (`packages/gateway/src/channels/telegram.ts`) | When `choices` is present, attach `reply_markup: { inline_keyboard: [[{ text, callback_data: text }, ...]] }`. Wrap rows at 3 buttons. Subscribe to `callback_query`; on event, emit a `UserMessage` with the button text as `text`, then call `answerCallbackQuery` to dismiss the loading spinner. |
+| **Discord** (`packages/gateway/src/channels/discord.ts`) | Build `ActionRowBuilder<ButtonBuilder>` with up to 5 buttons per row (Discord cap). `customId` = stable hash so we can correlate; button label = option text. On `InteractionCreate` of type `Button`, emit a `UserMessage` and call `interaction.update({ components: [] })` to disable. |
+| **iMessage** (`packages/gateway/src/channels/imessage.ts`) | Append `\n\n1) <option1>\n2) <option2>\n...` to the text. No native buttons. |
+| **TUI** (`packages/gateway/src/channels/tui.ts`) | Same as iMessage. |
+
+### Digit mapping for text-fallback channels
+
+When a chat has `pendingTeam` set AND `pendingTeam.options` is present:
+
+- If the incoming user message text matches `/^\s*(\d+)\s*$/` and the number is in range `[1, options.length]`, replace the text with `options[n-1]` before invoking `resumeTeamFromAnswer`.
+- Otherwise pass the text through unchanged (free-text reply still works).
+
+This mapping lives in the gateway (channel-agnostic), so it works for any channel that doesn't render buttons.
+
+### Worker-prompt update
+
+In `packages/core/src/workers.ts`, the three prompt templates that already mention `[ASK_USER]:` (solo worker, sequential team member, auto-routed worker) each gain the additional sentence described above in the Protocol section.
+
+## Data Flow
+
+1. Worker (LLM) emits `[ASK_USER:choice]: 要合并到 main 吗？ | 是 | 否 | 让我看 diff` as its final output.
+2. Gateway's `parseAsk` returns `{ kind: 'user', question, options: ['是','否','让我看 diff'], preamble }`.
+3. Gateway persists `PendingTeamState` (including `options`) and calls `channel.send(route, renderQuestion(...))`.
+4. Channel adapter renders text + buttons (Telegram/Discord/Mac app) or text + numbered list (iMessage/TUI).
+5. User taps button → channel emits a `UserMessage` whose text is the option label.
+   User types `2` on iMessage → gateway maps digit to `options[1]` ("否") before resume.
+   User types "actually let's hold off" → passed through unchanged (free text).
+6. `resumeTeamFromAnswer` runs as today; no changes to the resume logic itself.
+
+## Testing
+
+- **`ask-user.test.ts`** — add cases:
+  - basic choice parse with 2 / 3 / 8 options
+  - degradation when `:choice` is present but no `|`
+  - degradation when only 1 valid option after trim
+  - cap at 8
+  - `|` whitespace tolerance
+  - `[ASK: name]:` unaffected
+- **`team-pause` rendering** — verify `renderQuestion` returns both text and choices, that choices are absent for plain ASK_USER.
+- **Gateway digit mapping** — unit test mapping `"2"` → `options[1]`, out-of-range left as-is, no mapping when `options` absent.
+- **Manual** — verify Mac app button render+click, Telegram inline keyboard, Discord buttons end-to-end on a real team with a choice question.
+
+## Risks / Open Questions
+
+- **`|` in option text**: workers are instructed to rephrase. We accept that a small fraction of malformed markers will degrade to plain text rather than introducing an escape grammar.
+- **Telegram callback_data 64-byte limit**: option text longer than 64 bytes won't fit in `callback_data`. Mitigation: when an option exceeds 60 bytes, fall back to indexed callback data (`"opt:0"`, `"opt:1"`) and resolve via the persisted `pendingTeam.options` on the gateway side. Implement only if/when we hit this in practice — v1 caps option labels at 60 visible chars by convention in the prompt instruction.
+- **Discord 5-buttons-per-row + 5-row cap (25 max)**: our 8-option cap is well under.
+- **Race between button click and free-text reply**: both arrive as `UserMessage`s; existing single-flight + `pendingTeam` consumption handles this — whichever lands first resumes, the other is treated as a new turn.
+
+## Out of Scope (deferred)
+
+- Multi-select.
+- Rich UI (icons, descriptions).
+- Intercepting CLI permission prompts.
+- Choice variant for `[ASK: <teammate>]:` (workers don't ask other workers via buttons).

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -30,6 +30,8 @@ export interface ChatMessage {
   tokens?: number;
   /** Wall-clock seconds the agent took to produce the response. */
   durationSec?: number;
+  /** Option labels when this assistant message ended in [ASK_USER:choice]. */
+  choices?: string[];
 }
 
 export type ChatSelection =
@@ -58,4 +60,6 @@ export interface Chat {
    *  undefined = user hasn't decided; auto-open logic applies on first tool call.
    *  true/false = explicit user choice; honored verbatim. */
   contextPanelOpen?: boolean;
+  /** Last unanswered choice question in a non-team chat. Cleared on next user message. */
+  lastAskedOptions?: { messageId: string; options: string[] };
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -27,6 +27,8 @@ export interface GatewayResponse {
   channel: ChannelType;
   text: string;
   replyTo?: string;
+  /** When present, the response is asking the user to pick from these options. */
+  choices?: string[];
 }
 
 // Coding agent types

--- a/packages/core/src/types/pending-team.ts
+++ b/packages/core/src/types/pending-team.ts
@@ -18,6 +18,8 @@ export type PendingTeamState =
       carry: string;
       askingWorker: string;
       question: string;
+      /** Options when worker emitted [ASK_USER:choice]; absent for free-text questions. */
+      options?: string[];
       askedAt: number;
     }
   | {
@@ -32,5 +34,6 @@ export type PendingTeamState =
       step: number;
       askingWorker: string;
       question: string;
+      options?: string[];
       askedAt: number;
     };

--- a/packages/core/src/utils/ask-user.test.ts
+++ b/packages/core/src/utils/ask-user.test.ts
@@ -150,9 +150,12 @@ describe('parseAsk (choice variant)', () => {
     expect(out).toEqual({ kind: 'user', preamble: '', question: 'q?', options: ['a', 'b'] });
   });
 
-  it('does not treat [ASK: name]:choice as a team-choice variant', () => {
+  it('does not treat [ASK: name:choice] as a team-choice variant', () => {
     const out = parseAsk('[ASK: alice:choice]: q? | a | b');
+    expect(out?.kind).toBe('team');
     if (out?.kind === 'team') {
+      expect(out.target).toBe('alice:choice');
+      expect(out.question).toBe('q? | a | b');
       expect((out as any).options).toBeUndefined();
     }
   });

--- a/packages/core/src/utils/ask-user.test.ts
+++ b/packages/core/src/utils/ask-user.test.ts
@@ -96,3 +96,64 @@ describe('parseAsk', () => {
     });
   });
 });
+
+describe('parseAskUser (choice variant)', () => {
+  it('parses two options', () => {
+    const out = parseAskUser('[ASK_USER:choice]: merge into main? | yes | no');
+    expect(out).toEqual({
+      preamble: '',
+      question: 'merge into main?',
+      options: ['yes', 'no'],
+    });
+  });
+
+  it('parses many options and trims whitespace', () => {
+    const out = parseAskUser('[ASK_USER:choice]: pick db?  |  postgres  | sqlite |  mysql ');
+    expect(out?.options).toEqual(['postgres', 'sqlite', 'mysql']);
+  });
+
+  it('caps at 8 options', () => {
+    const opts = Array.from({ length: 12 }, (_, i) => `o${i}`).join(' | ');
+    const out = parseAskUser(`[ASK_USER:choice]: q? | ${opts}`);
+    expect(out?.options).toHaveLength(8);
+    expect(out?.options?.[0]).toBe('o0');
+    expect(out?.options?.[7]).toBe('o7');
+  });
+
+  it('skips empty option segments', () => {
+    const out = parseAskUser('[ASK_USER:choice]: q? | a | | b |   ');
+    expect(out?.options).toEqual(['a', 'b']);
+  });
+
+  it('degrades to plain text when fewer than 2 valid options remain', () => {
+    const out = parseAskUser('[ASK_USER:choice]: only one? | yes');
+    expect(out).toEqual({ preamble: '', question: 'only one? | yes' });
+    expect((out as any).options).toBeUndefined();
+  });
+
+  it('degrades when no pipe present', () => {
+    const out = parseAskUser('[ASK_USER:choice]: just a question');
+    expect(out).toEqual({ preamble: '', question: 'just a question' });
+  });
+
+  it('preserves preamble for choice marker', () => {
+    const text = 'I looked into it.\n[ASK_USER:choice]: which? | a | b';
+    const out = parseAskUser(text);
+    expect(out?.preamble).toBe('I looked into it.');
+    expect(out?.options).toEqual(['a', 'b']);
+  });
+});
+
+describe('parseAsk (choice variant)', () => {
+  it('returns user kind with options', () => {
+    const out = parseAsk('[ASK_USER:choice]: q? | a | b');
+    expect(out).toEqual({ kind: 'user', preamble: '', question: 'q?', options: ['a', 'b'] });
+  });
+
+  it('does not treat [ASK: name]:choice as a team-choice variant', () => {
+    const out = parseAsk('[ASK: alice:choice]: q? | a | b');
+    if (out?.kind === 'team') {
+      expect((out as any).options).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/src/utils/ask-user.ts
+++ b/packages/core/src/utils/ask-user.ts
@@ -18,8 +18,7 @@ export type AskMarker =
   | ({ kind: 'user' } & AskUser)
   | ({ kind: 'team' } & AskTeam);
 
-const USER_MARKER_RE = /^\s*\[ASK_USER(?::choice)?\]\s*:\s*(.*)$/;
-const USER_CHOICE_MARKER_RE = /^\s*\[ASK_USER:choice\]\s*:\s*(.*)$/;
+const USER_MARKER_RE = /^\s*\[ASK_USER(:choice)?\]\s*:\s*(.*)$/;
 const TEAM_MARKER_RE = /^\s*\[ASK\s*:\s*([^\]]+?)\s*\]\s*:\s*(.*)$/;
 
 const MAX_OPTIONS = 8;
@@ -40,18 +39,18 @@ export function parseAskUser(output: string): AskUser | null {
   if (!output) return null;
   const lines = output.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
-    const choiceMatch = lines[i].match(USER_CHOICE_MARKER_RE);
-    if (choiceMatch) {
-      const { question, options } = splitChoicePayload(choiceMatch[1]);
+    const m = lines[i].match(USER_MARKER_RE);
+    if (!m) continue;
+    const isChoice = !!m[1];
+    const payload = m[2];
+    const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+    if (isChoice) {
+      const { question, options } = splitChoicePayload(payload);
       if (!question) return null;
-      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
       return options ? { preamble, question, options } : { preamble, question };
     }
-    const userMatch = lines[i].match(USER_MARKER_RE);
-    if (!userMatch) continue;
-    const question = userMatch[1].trim();
+    const question = payload.trim();
     if (!question) return null;
-    const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
     return { preamble, question };
   }
   return null;
@@ -66,20 +65,20 @@ export function parseAsk(output: string): AskMarker | null {
   const lines = output.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const choiceMatch = line.match(USER_CHOICE_MARKER_RE);
-    if (choiceMatch) {
-      const { question, options } = splitChoicePayload(choiceMatch[1]);
-      if (!question) return null;
+    const m = line.match(USER_MARKER_RE);
+    if (m) {
+      const isChoice = !!m[1];
+      const payload = m[2];
       const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
-      return options
-        ? { kind: 'user', preamble, question, options }
-        : { kind: 'user', preamble, question };
-    }
-    const userMatch = line.match(USER_MARKER_RE);
-    if (userMatch) {
-      const question = userMatch[1].trim();
+      if (isChoice) {
+        const { question, options } = splitChoicePayload(payload);
+        if (!question) return null;
+        return options
+          ? { kind: 'user', preamble, question, options }
+          : { kind: 'user', preamble, question };
+      }
+      const question = payload.trim();
       if (!question) return null;
-      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
       return { kind: 'user', preamble, question };
     }
     const teamMatch = line.match(TEAM_MARKER_RE);

--- a/packages/core/src/utils/ask-user.ts
+++ b/packages/core/src/utils/ask-user.ts
@@ -1,8 +1,10 @@
 export interface AskUser {
   /** Worker output before the marker line (joined with \n, trimmed of trailing whitespace). */
   preamble: string;
-  /** The question text after `[ASK_USER]:`, trimmed. */
+  /** The question text after `[ASK_USER]:` (or `[ASK_USER:choice]:` before the first `|`). */
   question: string;
+  /** Present only when the marker was `[ASK_USER:choice]:` with >= 2 valid options. */
+  options?: string[];
 }
 
 export interface AskTeam {
@@ -16,20 +18,38 @@ export type AskMarker =
   | ({ kind: 'user' } & AskUser)
   | ({ kind: 'team' } & AskTeam);
 
-const USER_MARKER_RE = /^\s*\[ASK_USER\]\s*:\s*(.*)$/;
+const USER_MARKER_RE = /^\s*\[ASK_USER(?::choice)?\]\s*:\s*(.*)$/;
+const USER_CHOICE_MARKER_RE = /^\s*\[ASK_USER:choice\]\s*:\s*(.*)$/;
 const TEAM_MARKER_RE = /^\s*\[ASK\s*:\s*([^\]]+?)\s*\]\s*:\s*(.*)$/;
 
+const MAX_OPTIONS = 8;
+
+function splitChoicePayload(payload: string): { question: string; options?: string[] } {
+  const parts = payload.split('|').map(s => s.trim());
+  const question = parts.shift() ?? '';
+  const options = parts.filter(p => p.length > 0).slice(0, MAX_OPTIONS);
+  if (options.length < 2) return { question: payload.trim() };
+  return { question, options };
+}
+
 /**
- * Detect a `[ASK_USER]: <question>` marker line in worker output.
+ * Detect a `[ASK_USER]: <question>` or `[ASK_USER:choice]: <question> | <option1> | <option2>...` marker line in worker output.
  * Returns null when no marker is present or the question is blank.
  */
 export function parseAskUser(output: string): AskUser | null {
   if (!output) return null;
   const lines = output.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(USER_MARKER_RE);
-    if (!m) continue;
-    const question = m[1].trim();
+    const choiceMatch = lines[i].match(USER_CHOICE_MARKER_RE);
+    if (choiceMatch) {
+      const { question, options } = splitChoicePayload(choiceMatch[1]);
+      if (!question) return null;
+      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+      return options ? { preamble, question, options } : { preamble, question };
+    }
+    const userMatch = lines[i].match(USER_MARKER_RE);
+    if (!userMatch) continue;
+    const question = userMatch[1].trim();
     if (!question) return null;
     const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
     return { preamble, question };
@@ -38,7 +58,7 @@ export function parseAskUser(output: string): AskUser | null {
 }
 
 /**
- * Detect either a `[ASK_USER]: q` or `[ASK: <teammate>]: q` marker line.
+ * Detect either a `[ASK_USER]: q`, `[ASK_USER:choice]: q | a | b`, or `[ASK: <teammate>]: q` marker line.
  * Returns the first marker found (in document order) or null.
  */
 export function parseAsk(output: string): AskMarker | null {
@@ -46,6 +66,15 @@ export function parseAsk(output: string): AskMarker | null {
   const lines = output.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    const choiceMatch = line.match(USER_CHOICE_MARKER_RE);
+    if (choiceMatch) {
+      const { question, options } = splitChoicePayload(choiceMatch[1]);
+      if (!question) return null;
+      const preamble = lines.slice(0, i).join('\n').replace(/\s+$/, '');
+      return options
+        ? { kind: 'user', preamble, question, options }
+        : { kind: 'user', preamble, question };
+    }
     const userMatch = line.match(USER_MARKER_RE);
     if (userMatch) {
       const question = userMatch[1].trim();

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -201,6 +201,7 @@ export class WorkerManager {
       worker.personality.instructions,
       `## Pause for user input`,
       'If you cannot proceed without information from the user, output a single line `[ASK_USER]: <your question>` and stop. Do not guess. Do not continue the work.',
+      'When the question is yes/no or a pick-one from a small set (≤ 8) of explicit options, prefer `[ASK_USER:choice]: <question> | <option 1> | <option 2>` so the user can answer with a tap. Use the free-text `[ASK_USER]:` form for open-ended questions.',
       `## Task`,
       task,
     ].join('\n\n');
@@ -240,6 +241,7 @@ export class WorkerManager {
       nextSection,
       `## Pause for user input`,
       'If you cannot proceed without information from the user, output a single line `[ASK_USER]: <your question>` and stop. Do not guess.',
+      'When the question is yes/no or a pick-one from a small set (≤ 8) of explicit options, prefer `[ASK_USER:choice]: <question> | <option 1> | <option 2>` so the user can answer with a tap. Use the free-text `[ASK_USER]:` form for open-ended questions.',
       `## Task`,
       task,
     ].join('\n\n');
@@ -282,6 +284,7 @@ export class WorkerManager {
         'If you need information you do not have:',
         '1. First check the Teammates list. If a teammate plausibly knows the answer, output a single line `[ASK: <teammate>]: <your question>` and stop. The team will route the question to that teammate directly.',
         '2. If no teammate could plausibly answer, output a single line `[ASK_USER]: <your question>` and stop. The manager will decide whether to ask the user or route to a teammate.',
+        'When the question is yes/no or a pick-one from a small set (≤ 8) of explicit options, prefer `[ASK_USER:choice]: <question> | <option 1> | <option 2>` so the user can answer with a tap. Use the free-text `[ASK_USER]:` form for open-ended questions.',
         'Use exactly one marker per output. Do not guess. Do not continue the work after emitting a marker.',
       ].join('\n'),
       `## Task`,

--- a/packages/gateway/src/channels/base.ts
+++ b/packages/gateway/src/channels/base.ts
@@ -30,3 +30,9 @@ export abstract class BaseChannelHandler implements ChannelHandler {
     }
   }
 }
+
+export function formatChoicesAsText(text: string, choices?: string[]): string {
+  if (!choices || choices.length === 0) return text;
+  const list = choices.map((c, i) => `${i + 1}) ${c}`).join('\n');
+  return `${text}\n\n${list}\n\n_Reply with the number or the option text._`;
+}

--- a/packages/gateway/src/channels/discord.ts
+++ b/packages/gateway/src/channels/discord.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Message, TextChannel } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Client, GatewayIntentBits, Interaction, Message, TextChannel } from 'discord.js';
 import { BaseChannelHandler } from './base';
 import { UserMessage, GatewayResponse, ChatRoute } from '@codey/core';
 
@@ -19,6 +19,24 @@ export class DiscordHandler extends BaseChannelHandler {
 
     this.client.once('ready', () => {
       console.log(`[Discord] Logged in as ${this.client?.user?.tag}`);
+    });
+
+    this.client.on('interactionCreate', async (interaction: Interaction) => {
+      if (!interaction.isButton()) return;
+      const m = interaction.customId.match(/^ask_user:(\d+)$/);
+      if (!m) return;
+      const idx = parseInt(m[1], 10);
+      const text = String(idx + 1); // digit form; gateway maps via lastAskedOptions/pendingTeam.options
+      await interaction.update({ components: [] }).catch(() => { /* already updated */ });
+      this.emitMessage({
+        id: `dc-${interaction.id}`,
+        channel: 'discord',
+        userId: interaction.user.id,
+        username: interaction.user.username,
+        chatId: interaction.channelId,
+        text,
+        timestamp: Date.now(),
+      });
     });
 
     this.client.on('messageCreate', (msg: Message) => {
@@ -53,7 +71,20 @@ export class DiscordHandler extends BaseChannelHandler {
 
     const channel = await this.client.channels.fetch(response.chatId);
     if (channel && channel instanceof TextChannel) {
-      await channel.send(response.text);
+      const components: ActionRowBuilder<ButtonBuilder>[] = [];
+      if (response.choices && response.choices.length > 0) {
+        const buttons = response.choices.slice(0, 25).map((label, idx) =>
+          new ButtonBuilder()
+            .setCustomId(`ask_user:${idx}`)
+            .setLabel(label.length > 80 ? label.slice(0, 77) + '…' : label)
+            .setStyle(ButtonStyle.Secondary)
+        );
+        for (let i = 0; i < buttons.length; i += 5) {
+          const row = new ActionRowBuilder<ButtonBuilder>().addComponents(buttons.slice(i, i + 5));
+          components.push(row);
+        }
+      }
+      await channel.send({ content: response.text, components });
     }
   }
 

--- a/packages/gateway/src/channels/discord.ts
+++ b/packages/gateway/src/channels/discord.ts
@@ -6,6 +6,7 @@ export class DiscordHandler extends BaseChannelHandler {
   name = 'discord';
   private client?: Client;
   private config?: { botToken: string };
+  private lastChoiceMessageByChannel = new Map<string, string>(); // channelId → messageId
 
   async start(config: { botToken: string }): Promise<void> {
     this.config = config;
@@ -69,8 +70,19 @@ export class DiscordHandler extends BaseChannelHandler {
   async sendMessage(response: GatewayResponse): Promise<void> {
     if (!this.client) return;
 
-    const channel = await this.client.channels.fetch(response.chatId);
+    const channelId = response.chatId;
+    const channel = await this.client.channels.fetch(channelId);
     if (channel && channel instanceof TextChannel) {
+      // Clear stale choice buttons from the previous bot message (if any)
+      const prior = this.lastChoiceMessageByChannel.get(channelId);
+      if (prior) {
+        try {
+          const msg = await channel.messages.fetch(prior);
+          await msg.edit({ components: [] });
+        } catch { /* deleted or too old */ }
+        this.lastChoiceMessageByChannel.delete(channelId);
+      }
+
       const components: ActionRowBuilder<ButtonBuilder>[] = [];
       if (response.choices && response.choices.length > 0) {
         const buttons = response.choices.slice(0, 25).map((label, idx) =>
@@ -84,7 +96,12 @@ export class DiscordHandler extends BaseChannelHandler {
           components.push(row);
         }
       }
-      await channel.send({ content: response.text, components });
+      const sent = await channel.send({ content: response.text, components });
+      // Track this message so the next sendMessage can clear its buttons if the user
+      // types a free-text reply instead of clicking
+      if (response.choices && response.choices.length > 0) {
+        this.lastChoiceMessageByChannel.set(channelId, sent.id);
+      }
     }
   }
 

--- a/packages/gateway/src/channels/imessage.ts
+++ b/packages/gateway/src/channels/imessage.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { exec } from 'child_process';
-import { BaseChannelHandler } from './base';
+import { BaseChannelHandler, formatChoicesAsText } from './base';
 import { UserMessage, GatewayResponse, ChatRoute } from '@codey/core';
 
 // iMessage handler using macOS AppleScript
@@ -23,9 +23,10 @@ export class IMessageHandler extends BaseChannelHandler {
   }
 
   async sendMessage(response: GatewayResponse): Promise<void> {
+    const text = formatChoicesAsText(response.text, response.choices);
     const script = `
       tell application "Messages"
-        send "${this.escapeString(response.text)}" to buddy "${response.chatId}"
+        send "${this.escapeString(text)}" to buddy "${response.chatId}"
       end tell
     `;
 

--- a/packages/gateway/src/channels/telegram.ts
+++ b/packages/gateway/src/channels/telegram.ts
@@ -67,6 +67,7 @@ export class TelegramHandler extends BaseChannelHandler {
   name = 'telegram';
   private bot?: TelegramBot;
   private typingIntervals: Map<string, NodeJS.Timeout> = new Map();
+  private lastChoiceMessageByChat = new Map<string, number>(); // chatId → message_id
 
   private notifyChatId?: string;
 
@@ -123,7 +124,7 @@ export class TelegramHandler extends BaseChannelHandler {
       this.emitMessage(message);
     });
 
-    this.bot.on('callback_query', (query: TelegramBot.CallbackQuery) => {
+    this.bot.on('callback_query', async (query: TelegramBot.CallbackQuery) => {
       const data = query.data;
       const fromId = query.from?.id?.toString();
       const chatId = query.message?.chat?.id?.toString();
@@ -138,6 +139,14 @@ export class TelegramHandler extends BaseChannelHandler {
         text = String(idx + 1);
       }
       this.bot!.answerCallbackQuery(query.id).catch(() => {}); // dismiss the spinner
+      // Clear buttons on the clicked message so it can't be clicked again
+      try {
+        await this.bot!.editMessageReplyMarkup(
+          { inline_keyboard: [] },
+          { chat_id: chatId, message_id: query.message?.message_id },
+        );
+      } catch { /* message too old or already edited; ignore */ }
+      this.lastChoiceMessageByChat.delete(chatId);
       const message: UserMessage = {
         id: `tg-${Date.now()}`,
         channel: 'telegram',
@@ -169,8 +178,22 @@ export class TelegramHandler extends BaseChannelHandler {
   async sendMessage(response: GatewayResponse): Promise<void> {
     if (!this.bot) return;
 
+    const chatId = response.chatId;
+
     // Stop typing indicator when sending a response
-    this.stopTyping(response.chatId);
+    this.stopTyping(chatId);
+
+    // Clear stale choice buttons from the previous bot message (if any)
+    const prior = this.lastChoiceMessageByChat.get(chatId);
+    if (prior !== undefined) {
+      try {
+        await this.bot.editMessageReplyMarkup(
+          { inline_keyboard: [] },
+          { chat_id: chatId, message_id: prior },
+        );
+      } catch { /* message too old or already edited; ignore */ }
+      this.lastChoiceMessageByChat.delete(chatId);
+    }
 
     const options: TelegramBot.SendMessageOptions = {
       parse_mode: 'HTML',
@@ -193,7 +216,12 @@ export class TelegramHandler extends BaseChannelHandler {
       options.reply_markup = { inline_keyboard: rows };
     }
 
-    await this.bot.sendMessage(response.chatId, markdownToTelegramHtml(response.text), options);
+    const sent = await this.bot.sendMessage(chatId, markdownToTelegramHtml(response.text), options);
+    // Track this message so the next sendMessage can clear its buttons if the user
+    // types a free-text reply instead of clicking
+    if (response.choices && response.choices.length > 0) {
+      this.lastChoiceMessageByChat.set(chatId, sent.message_id);
+    }
   }
 
   async sendToRoute(route: ChatRoute, text: string): Promise<void> {

--- a/packages/gateway/src/channels/telegram.ts
+++ b/packages/gateway/src/channels/telegram.ts
@@ -123,6 +123,33 @@ export class TelegramHandler extends BaseChannelHandler {
       this.emitMessage(message);
     });
 
+    this.bot.on('callback_query', (query: TelegramBot.CallbackQuery) => {
+      const data = query.data;
+      const fromId = query.from?.id?.toString();
+      const chatId = query.message?.chat?.id?.toString();
+      if (!data || !fromId || !chatId) {
+        this.bot!.answerCallbackQuery(query.id).catch(() => {});
+        return;
+      }
+      // Resolve indexed payload to a digit so the gateway's digit-mapping picks it up.
+      let text = data;
+      if (/^opt:\d+$/.test(data)) {
+        const idx = parseInt(data.slice(4), 10);
+        text = String(idx + 1);
+      }
+      this.bot!.answerCallbackQuery(query.id).catch(() => {}); // dismiss the spinner
+      const message: UserMessage = {
+        id: `tg-${Date.now()}`,
+        channel: 'telegram',
+        userId: fromId,
+        username: query.from?.username ?? fromId,
+        chatId,
+        text,
+        timestamp: Date.now(),
+      };
+      this.emitMessage(message);
+    });
+
     console.log('[Telegram] Handler started');
   }
 
@@ -150,6 +177,20 @@ export class TelegramHandler extends BaseChannelHandler {
     };
     if (response.replyTo) {
       options.reply_to_message_id = parseInt(response.replyTo);
+    }
+
+    if (response.choices && response.choices.length > 0) {
+      // Telegram callback_data limit is 64 bytes. Long labels fall back to indexed
+      // payload ("opt:N"); the channel intake below maps "opt:N" back to digit "N+1"
+      // and the gateway's digit-mapping helper resolves it via pendingTeam.options /
+      // lastAskedOptions.options.
+      const buttons = response.choices.map((label, idx) => {
+        const data = Buffer.byteLength(label, 'utf8') <= 60 ? label : `opt:${idx}`;
+        return { text: label, callback_data: data };
+      });
+      const rows: TelegramBot.InlineKeyboardButton[][] = [];
+      for (let i = 0; i < buttons.length; i += 3) rows.push(buttons.slice(i, i + 3));
+      options.reply_markup = { inline_keyboard: rows };
     }
 
     await this.bot.sendMessage(response.chatId, markdownToTelegramHtml(response.text), options);

--- a/packages/gateway/src/channels/tui.ts
+++ b/packages/gateway/src/channels/tui.ts
@@ -1,7 +1,7 @@
 import * as readline from 'readline';
 import { marked } from 'marked';
 import { markedTerminal } from 'marked-terminal';
-import { BaseChannelHandler } from './base';
+import { BaseChannelHandler, formatChoicesAsText } from './base';
 import { GatewayResponse, UserMessage } from '@codey/core';
 
 marked.use(markedTerminal() as any);
@@ -93,6 +93,7 @@ export class TuiHandler extends BaseChannelHandler {
   }
 
   async sendMessage(response: GatewayResponse): Promise<void> {
+    const text = formatChoicesAsText(response.text, response.choices);
     // Clear timer
     if (this.timerInterval) {
       clearInterval(this.timerInterval);
@@ -104,8 +105,8 @@ export class TuiHandler extends BaseChannelHandler {
       process.stdout.write('\r\x1b[J'); // clear current line
     }
 
-    if (response.text) {
-      console.log(`\n${this.renderMarkdown(response.text)}`);
+    if (text) {
+      console.log(`\n${this.renderMarkdown(text)}`);
     }
 
     console.log(`\n${SEPARATOR}\n`);

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -9,7 +9,7 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string }
+  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
   | { type: 'error'; chatId: string; message: string };
 
 export type ChatStreamSink = (e: ChatStreamEvent) => void;

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -134,6 +134,24 @@ export class ChatManager {
     return chat;
   }
 
+  /** Set lastAskedOptions on a non-team chat (the question message id + options). */
+  setLastAskedOptions(chatId: string, messageId: string, options: string[]): void {
+    const chat = this.cache.get(chatId);
+    if (!chat) return;
+    chat.lastAskedOptions = { messageId, options };
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+  }
+
+  /** Clear lastAskedOptions when the user sends any reply. */
+  clearLastAskedOptions(chatId: string): void {
+    const chat = this.cache.get(chatId);
+    if (!chat || !chat.lastAskedOptions) return;
+    delete chat.lastAskedOptions;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+  }
+
   /** Set or clear pendingTeam state for a chat. Pass null to clear. */
   setPendingTeam(chatId: string, pending: NonNullable<Chat['pendingTeam']> | null): Chat {
     this.ensureLoaded();

--- a/packages/gateway/src/digit-mapping.test.ts
+++ b/packages/gateway/src/digit-mapping.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { resolveChoiceDigit } from './digit-mapping';
+
+describe('resolveChoiceDigit', () => {
+  const opts = ['yes', 'no', 'maybe'];
+
+  it('maps "1" to first option', () => {
+    expect(resolveChoiceDigit('1', opts)).toBe('yes');
+  });
+
+  it('maps "  2 " to second option (whitespace tolerated)', () => {
+    expect(resolveChoiceDigit('  2 ', opts)).toBe('no');
+  });
+
+  it('returns null for out-of-range digit', () => {
+    expect(resolveChoiceDigit('5', opts)).toBeNull();
+    expect(resolveChoiceDigit('0', opts)).toBeNull();
+  });
+
+  it('returns null for non-digit text', () => {
+    expect(resolveChoiceDigit('yes', opts)).toBeNull();
+    expect(resolveChoiceDigit('1!', opts)).toBeNull();
+  });
+
+  it('returns null when options is empty', () => {
+    expect(resolveChoiceDigit('1', [])).toBeNull();
+  });
+});

--- a/packages/gateway/src/digit-mapping.ts
+++ b/packages/gateway/src/digit-mapping.ts
@@ -1,0 +1,12 @@
+/**
+ * If `text` is a bare digit `n` and `options[n-1]` exists, return that option.
+ * Otherwise return null (caller should pass the original text through unchanged).
+ */
+export function resolveChoiceDigit(text: string, options: string[]): string | null {
+  if (!options || options.length === 0) return null;
+  const m = text.match(/^\s*(\d+)\s*$/);
+  if (!m) return null;
+  const idx = parseInt(m[1], 10) - 1;
+  if (idx < 0 || idx >= options.length) return null;
+  return options[idx];
+}

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2816,7 +2816,7 @@ Example: /model gpt-4.1 write a Python script`;
     prompt: string,
     sse?: (event: string, data: string) => void,
     conversationId?: string,
-  ): Promise<{ response: string; conversationId: string; tokens?: number; durationSec?: number }> {
+  ): Promise<{ response: string; conversationId: string; tokens?: number; durationSec?: number; choices?: string[] }> {
     const agent = this.getDefaultAgent();
     const model = this.getDefaultModelConfig(agent);
 
@@ -2922,11 +2922,14 @@ Example: /model gpt-4.1 write a Python script`;
       });
     }
 
+    const formattedResponse = this.formatAgentResponse(response);
+    const httpAsk = parseAskUser(formattedResponse);
     return {
-      response: this.formatAgentResponse(response),
+      response: formattedResponse,
       conversationId: ctxId,
       tokens: response.tokens?.total,
       durationSec: response.duration,
+      ...(httpAsk.options && httpAsk.options.length >= 2 ? { choices: httpAsk.options } : {}),
     };
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -17,6 +17,7 @@ import { summarizePriorHistory } from './summary';
 import { buildChatPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
+import { resolveChoiceDigit } from './digit-mapping';
 
 interface ParsedCommand {
   command: string;
@@ -496,7 +497,9 @@ export class Codey {
     };
   }
 
-  private async handleMessage(message: UserMessage): Promise<void> {
+  private async handleMessage(messageParam: UserMessage): Promise<void> {
+    let message = messageParam;
+
     // Skip if already processing
     if (this.processingMessages.has(message.id)) {
       return;
@@ -523,6 +526,17 @@ export class Codey {
 
     try {
       this.logger.info(`[INPUT] ${message.channel}/${message.username}: ${message.text}`);
+
+      // Digit → option resolution for choice questions (works for both pendingTeam
+      // and plain-chat lastAskedOptions). Mutates `message.text` so downstream
+      // handling sees the resolved option string.
+      const pendingOpts = pendingChat?.pendingTeam?.options ?? pendingChat?.lastAskedOptions?.options;
+      if (pendingOpts && pendingOpts.length > 0) {
+        const resolved = resolveChoiceDigit(message.text, pendingOpts);
+        if (resolved !== null) {
+          message = { ...message, text: resolved };
+        }
+      }
 
       if (pending) {
         if (isSlash) {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1694,6 +1694,7 @@ Example: /model gpt-4.1 write a Python script`;
           step: number;
           askingWorker: string;
           question: string;
+          options?: string[];
         };
       }
   > {
@@ -1717,7 +1718,7 @@ Example: /model gpt-4.1 write a Python script`;
     let directNext: { worker: string; instruction: string } | null = null;
     // When set, the next Manager turn arbitrates this pending question
     // (used when a worker emits `[ASK_USER]:` or forwards to an unknown target).
-    let pendingArbitration: { worker: string; question: string } | null = null;
+    let pendingArbitration: { worker: string; question: string; options?: string[] } | null = null;
     // Number of consecutive direct forwards since the last Manager turn.
     let forwardHops = 0;
 
@@ -1778,6 +1779,7 @@ Example: /model gpt-4.1 write a Python script`;
               step,
               askingWorker: pendingArbitration.worker,
               question: pendingArbitration.question,
+              options: pendingArbitration.options,
             },
           };
         }
@@ -1844,11 +1846,11 @@ Example: /model gpt-4.1 write a Python script`;
           continue;
         }
         // Invalid target or hop cap exceeded → Manager arbitrates.
-        pendingArbitration = { worker: turnNext, question: ask.question };
+        pendingArbitration = { worker: turnNext, question: ask.question, options: undefined };
         continue;
       }
       // kind === 'user' → Manager arbitrates whether to route or escalate.
-      pendingArbitration = { worker: turnNext, question: ask.question };
+      pendingArbitration = { worker: turnNext, question: ask.question, options: ask.options };
     }
 
     // Cap exhausted without explicit done — request a final summary.
@@ -2008,10 +2010,10 @@ Example: /model gpt-4.1 write a Python script`;
           step: p.step,
           askingWorker: p.askingWorker,
           question: p.question,
-          options: undefined,
+          options: p.options,
           askedAt: Date.now(),
         });
-        const rendered1 = renderQuestion(askWorkerName, '', p.question, undefined);
+        const rendered1 = renderQuestion(askWorkerName, '', p.question, p.options);
         await this.sendResponse({
           chatId: message.chatId,
           channel: message.channel,
@@ -2443,10 +2445,10 @@ Example: /model gpt-4.1 write a Python script`;
           step: p.step,
           askingWorker: p.askingWorker,
           question: p.question,
-          options: undefined,
+          options: p.options,
           askedAt: Date.now(),
         });
-        const rendered5 = renderQuestion(askWorkerName, '', p.question, undefined);
+        const rendered5 = renderQuestion(askWorkerName, '', p.question, p.options);
         sink({ type: 'stream', chatId, token: rendered5.text });
         return { response: rendered5.text, choices: rendered5.choices };
       } else {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2929,7 +2929,7 @@ Example: /model gpt-4.1 write a Python script`;
       conversationId: ctxId,
       tokens: response.tokens?.total,
       durationSec: response.duration,
-      ...(httpAsk.options && httpAsk.options.length >= 2 ? { choices: httpAsk.options } : {}),
+      ...(httpAsk?.options && httpAsk.options.length >= 2 ? { choices: httpAsk.options } : {}),
     };
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -538,6 +538,11 @@ export class Codey {
         }
       }
 
+      // Clear lastAskedOptions on ANY user message (button click / digit / free text).
+      if (pendingChat?.lastAskedOptions) {
+        this.chatManager.clearLastAskedOptions(pendingChat.id);
+      }
+
       if (pending) {
         if (isSlash) {
           try { this.chatManager.setPendingTeam(message.chatId, null); } catch (_) { /* ignore */ }
@@ -3084,7 +3089,23 @@ Example: /model gpt-4.1 write a Python script`;
       };
       const updated = this.chatManager.appendMessage(chatId, assistantMessage);
 
-      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title });
+      // Plain-chat ASK_USER:choice detection. Team flows handled this earlier in
+      // their own pause paths. For non-team chats, surface the options to the
+      // channel and persist on the chat so the next user reply can be digit-mapped.
+      let plainChoices: string[] | undefined;
+      if (!updated.pendingTeam) {
+        const plainAsk = parseAskUser(output);
+        if (plainAsk?.options && plainAsk.options.length >= 2) {
+          plainChoices = plainAsk.options;
+          const lastMsg = updated.messages[updated.messages.length - 1];
+          if (lastMsg && lastMsg.role === 'assistant') {
+            lastMsg.choices = plainAsk.options;
+            this.chatManager.setLastAskedOptions(chatId, lastMsg.id, plainAsk.options);
+          }
+        }
+      }
+
+      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title, choices: plainChoices });
       return { response: output, chatId, tokens, durationSec };
     } catch (err) {
       const message = `Error: ${(err as Error).message}`;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -16,7 +16,7 @@ import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { buildChatPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
-import { renderQuestionMessage, renderCancelNotice, stripAskMarker } from './team-pause';
+import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
 
 interface ParsedCommand {
   command: string;
@@ -2008,12 +2008,15 @@ Example: /model gpt-4.1 write a Python script`;
           step: p.step,
           askingWorker: p.askingWorker,
           question: p.question,
+          options: undefined,
           askedAt: Date.now(),
         });
+        const rendered1 = renderQuestion(askWorkerName, '', p.question, undefined);
         await this.sendResponse({
           chatId: message.chatId,
           channel: message.channel,
-          text: renderQuestionMessage(askWorkerName, '', p.question),
+          text: rendered1.text,
+          choices: rendered1.choices,
         });
         return;
       }
@@ -2144,12 +2147,15 @@ Example: /model gpt-4.1 write a Python script`;
           carry: pending.carry,
           askingWorker: memberName,
           question: ask.question,
+          options: ask.options,
           askedAt: Date.now(),
         });
+        const rendered2 = renderQuestion(memberName, ask.preamble, ask.question, ask.options);
         await this.sendResponse({
           chatId: message.chatId,
           channel: message.channel,
-          text: renderQuestionMessage(memberName, ask.preamble, ask.question),
+          text: rendered2.text,
+          choices: rendered2.choices,
         });
         return;
       }
@@ -2245,12 +2251,15 @@ Example: /model gpt-4.1 write a Python script`;
         step: pending.step + 1,
         askingWorker: turn.next,
         question: ask.question,
+        options: ask.options,
         askedAt: Date.now(),
       });
+      const rendered3 = renderQuestion(turn.next, ask.preamble, ask.question, ask.options);
       await this.sendResponse({
         chatId: message.chatId,
         channel: message.channel,
-        text: renderQuestionMessage(turn.next, ask.preamble, ask.question),
+        text: rendered3.text,
+        choices: rendered3.choices,
       });
       return;
     }
@@ -2332,13 +2341,16 @@ Example: /model gpt-4.1 write a Python script`;
           carry: currentTask,
           askingWorker: memberName,
           question: ask.question,
+          options: ask.options,
           askedAt: Date.now(),
         };
         this.persistPendingTeam(chatId, pending);
+        const rendered4 = renderQuestion(worker.name, ask.preamble, ask.question, ask.options);
         await this.sendResponse({
           chatId,
           channel,
-          text: renderQuestionMessage(worker.name, ask.preamble, ask.question),
+          text: rendered4.text,
+          choices: rendered4.choices,
         });
         return;
       }
@@ -2364,7 +2376,7 @@ Example: /model gpt-4.1 write a Python script`;
     opts: { forceAll?: boolean } = {},
     chatAgent?: CodingAgent,
     chatModel?: ModelConfig,
-  ): Promise<{ response: string; tokens?: number }> {
+  ): Promise<{ response: string; tokens?: number; choices?: string[] }> {
     if (!team || !team.members || team.members.length === 0) {
       throw new Error(`Team not found or empty: ${teamName}`);
     }
@@ -2431,11 +2443,12 @@ Example: /model gpt-4.1 write a Python script`;
           step: p.step,
           askingWorker: p.askingWorker,
           question: p.question,
+          options: undefined,
           askedAt: Date.now(),
         });
-        const text = renderQuestionMessage(askWorkerName, '', p.question);
-        sink({ type: 'stream', chatId, token: text });
-        return { response: text };
+        const rendered5 = renderQuestion(askWorkerName, '', p.question, undefined);
+        sink({ type: 'stream', chatId, token: rendered5.text });
+        return { response: rendered5.text, choices: rendered5.choices };
       } else {
         if (signal?.aborted) {
           return { response: this.formatManagerParts(result.parts, result.finalSummary) };
@@ -2484,11 +2497,12 @@ Example: /model gpt-4.1 write a Python script`;
           carry,
           askingWorker: memberName,
           question: ask.question,
+          options: ask.options,
           askedAt: Date.now(),
         });
-        const text = renderQuestionMessage(askWorkerName, ask.preamble, ask.question);
-        sink({ type: 'stream', chatId, token: text });
-        return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + text : text };
+        const rendered6 = renderQuestion(askWorkerName, ask.preamble, ask.question, ask.options);
+        sink({ type: 'stream', chatId, token: rendered6.text });
+        return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + rendered6.text : rendered6.text, choices: rendered6.choices };
       }
       parts.push(`### ${memberName}\n\n${response.output}`);
       carry = response.output;

--- a/packages/gateway/src/team-pause.test.ts
+++ b/packages/gateway/src/team-pause.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { renderQuestion, renderQuestionMessage } from './team-pause';
+
+describe('renderQuestion', () => {
+  it('returns text only for free-text question', () => {
+    const r = renderQuestion('coder', 'I looked.', 'which db?');
+    expect(r.text).toContain('which db?');
+    expect(r.choices).toBeUndefined();
+  });
+
+  it('returns text + choices for a choice question', () => {
+    const r = renderQuestion('coder', '', 'merge?', ['yes', 'no']);
+    expect(r.text).toContain('merge?');
+    expect(r.choices).toEqual(['yes', 'no']);
+  });
+
+  it('renderQuestionMessage stays string-typed for legacy callers', () => {
+    const t = renderQuestionMessage('coder', '', 'q?');
+    expect(typeof t).toBe('string');
+    expect(t).toContain('q?');
+  });
+});

--- a/packages/gateway/src/team-pause.ts
+++ b/packages/gateway/src/team-pause.ts
@@ -1,28 +1,41 @@
 import { PendingTeamState, parseAsk } from '@codey/core';
 
-/**
- * Returns the worker output with the [ASK_USER] / [ASK: name] marker line
- * removed (and any trailing content after it). Used when persisting pause
- * state so the marker doesn't leak into the rendered run log on resume.
- */
 export function stripAskMarker(output: string): string {
   const ask = parseAsk(output);
   return ask ? ask.preamble : output;
 }
 
-/** User-visible message rendered when a team pauses on a worker question. */
+export interface QuestionRender {
+  text: string;
+  choices?: string[];
+}
+
+export function renderQuestion(
+  workerName: string,
+  preamble: string,
+  question: string,
+  options?: string[],
+  truncate = 500,
+): QuestionRender {
+  const head = preamble.trim();
+  const trimmedHead = head.length > truncate ? head.substring(0, truncate) + '…' : head;
+  const intro = `❓ **${workerName}** needs your input:`;
+  const body = `${question}`;
+  const footer = options && options.length > 0
+    ? '_Tap an option below, or type your own answer._'
+    : '_Reply with your answer to continue, or send a slash command to cancel._';
+  const text = [trimmedHead, intro, body, footer].filter(Boolean).join('\n\n');
+  return options && options.length > 0 ? { text, choices: options } : { text };
+}
+
+/** Legacy string-returning helper kept for callers that don't yet pass choices through. */
 export function renderQuestionMessage(
   workerName: string,
   preamble: string,
   question: string,
   truncate = 500,
 ): string {
-  const head = preamble.trim();
-  const trimmedHead = head.length > truncate ? head.substring(0, truncate) + '…' : head;
-  const intro = `❓ **${workerName}** needs your input:`;
-  const body = `${question}`;
-  const footer = '_Reply with your answer to continue, or send a slash command to cancel._';
-  return [trimmedHead, intro, body, footer].filter(Boolean).join('\n\n');
+  return renderQuestion(workerName, preamble, question, undefined, truncate).text;
 }
 
 /** Notice shown when a slash command arrives while a team is paused. */

--- a/workers/code-reviewer/personality.md
+++ b/workers/code-reviewer/personality.md
@@ -1,14 +1,16 @@
 # Worker: code-reviewer
 
 ## Role
-Reviews code updates for issues, suggests improvements, and ensures quality standards are met.
+Reviews code changes, tests features when needed, and provides critical, fact-based feedback on quality and completeness.
 
 ## Soul
-This worker is direct and methodical, examining code without assumptions and asking clarifying questions when context is unclear. They value clarity over cleverness and prioritize finding real issues over Nitpicks. Feedback is factual, actionable, and focused on what actually needs to change.
+A blunt, no-nonsense reviewer who prioritizes correctness and facts over diplomacy. Verifies everything personally rather than taking statements at face value, and delivers honest feedback without sugarcoating. Catches gaps between what code claims to do and what it actually does.
 
 ## Instructions
-1. Examine the provided code changes or diff with careful attention to logic, structure, and edge cases.
-2. Identify any bugs, security concerns, performance issues, or deviations from the project patterns.
-3. Note specific, actionable improvements with clear reasoning.
-4. Distinguish between critical issues requiring fixes and suggestions worth considering.
-5. Present findings in a structured, easy-to-scan format without assuming intent the code doesn't show.
+1. Examine the submitted code or changeset and understand its purpose and scope
+2. Verify the implementation matches the intended behavior by reading the code carefully
+3. Test the features directly if verification is needed
+4. Check that all bullet points or requirements have been addressed
+5. Provide specific, fact-based feedback with references to the actual code
+6. Flag issues, bugs, or areas needing improvement with concrete examples
+7. Acknowledge what works well when warranted

--- a/workspaces/default/workspace.json
+++ b/workspaces/default/workspace.json
@@ -1,6 +1,10 @@
 {
   "workingDir": "./",
   "teams": {
-    "review": ["architect", "executor"]
+    "review": [
+      "architect",
+      "executor",
+      "code-reviewer"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds a new `[ASK_USER:choice]: question | option1 | option2` marker variant so workers and agents can present yes/no and pick-one questions as click-to-answer buttons.
- Renders native buttons in Mac app, Telegram (inline keyboard), and Discord (action rows). iMessage and TUI fall back to a numbered list with gateway-side digit→option mapping.
- Covers both the existing team-pause flow (`PendingTeamState.options`) and plain-chat flow (new `Chat.lastAskedOptions`). Free-text replies remain fully supported alongside button clicks.
- Auto-clears stale button markup on subsequent bot messages (Telegram `editMessageReplyMarkup`, Discord `message.edit({ components: [] })`) so old buttons don't stay clickable after a free-text answer.

Spec: `docs/superpowers/specs/2026-05-10-ask-user-choice-buttons-design.md`
Plan: `docs/superpowers/plans/2026-05-10-ask-user-choice-buttons.md`

## Test Plan

- [x] Unit tests for parser (`ask-user.test.ts`, 22 cases incl. degradation, 8-option cap, whitespace, preamble preservation)
- [x] Unit tests for `renderQuestion` (`team-pause.test.ts`)
- [x] Unit tests for digit mapping (`digit-mapping.test.ts`)
- [x] Full build (`npm run build`) — tsc + Mac DMG package — clean
- [ ] Manual: Mac app — click button, free-text reply, plain-chat coverage, graceful degradation (single-option marker falls back to free-text)
- [ ] Manual: Telegram — inline keyboard appears, click sends answer, previous buttons cleared on next bot message
- [ ] Manual: Discord — button row appears, click sends answer, previous buttons cleared on next bot message
- [ ] Manual: iMessage / TUI — numbered list appears, replying with digit resolves to option label

🤖 Generated with [Claude Code](https://claude.com/claude-code)