### PR TITLE
Compact team messages, live-stream worker output, surface team flow in right panel

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -761,11 +761,14 @@ app.whenReady().then(async () => {
   ipcMain.handle('chats:send', async (_e, payload: { chatId: string; text: string; attachments?: any[] }) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      const sink = (ev: any) => {
-        // Mirror each event to the renderer as a single `chats:event` channel
-        // so the frontend can route by chatId without sniffing event names.
-        sendToRenderer('chats:event', ev)
-      }
+      // No-op sink: events flow to the renderer via the global chatEventListener
+      // installed at boot (sendToRenderer 'chats:event'). Wiring a per-call sink
+      // here would deliver every event twice — and the second 'done' delivery
+      // would race past the just-cleared pendingAssistantId and trigger a chat
+      // refetch that overwrites the in-flight assistant message with the
+      // server's persisted version (with a different UUID), making selectedTurnId
+      // point at nothing and the right Context Panel go blank.
+      const sink = () => { /* no-op */ }
       return inProcessGateway.sendToChat(payload.chatId, payload.text, sink, payload.attachments)
     })
   )

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -14,7 +14,8 @@
     "build": "vite build && electron-builder",
     "build:mac": "vite build && electron-builder --mac",
     "build:mac:signed": "vite build && electron-builder --mac --publish never",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@codey/core": "*",
@@ -33,7 +34,8 @@
     "typescript": "^5.3.0",
     "vite": "^5.0.0",
     "vite-plugin-electron": "^0.28.0",
-    "vite-plugin-electron-renderer": "^0.14.5"
+    "vite-plugin-electron-renderer": "^0.14.5",
+    "vitest": "^4.1.5"
   },
   "build": {
     "appId": "com.codey.mac",
@@ -43,7 +45,13 @@
     },
     "mac": {
       "target": [
-        { "target": "dmg", "arch": ["arm64", "x64"] }
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        }
       ],
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icns",
@@ -61,9 +69,21 @@
       "dist-electron/**/*"
     ],
     "extraResources": [
-      { "from": "build/trayIconTemplate.png", "to": "trayIconTemplate.png" },
-      { "from": "build/trayIconTemplate@2x.png", "to": "trayIconTemplate@2x.png" },
-      { "from": "../workers", "to": "bundled-workers", "filter": ["**/*"] }
+      {
+        "from": "build/trayIconTemplate.png",
+        "to": "trayIconTemplate.png"
+      },
+      {
+        "from": "build/trayIconTemplate@2x.png",
+        "to": "trayIconTemplate@2x.png"
+      },
+      {
+        "from": "../workers",
+        "to": "bundled-workers",
+        "filter": [
+          "**/*"
+        ]
+      }
     ]
   }
 }

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { Chat, ChatMessage } from '../types'
 import { C } from '../theme'
+import { parseTeamMessage } from './teamMessageFormat'
 
 interface Props {
   chat: Chat
@@ -23,6 +24,9 @@ interface Props {
   onClose: () => void
   onResize: (next: number) => void
   onRevealFile: (absPath: string) => void
+  onScrollToStep: (messageId: string, stepNum: number) => void
+  /** True when the selected turn is the last assistant message and the chat is currently in flight. */
+  isTurnStreaming: boolean
 }
 
 const fmtTime = (ts: number) =>
@@ -38,7 +42,7 @@ const formatTokens = (n: number): string | null => {
 export const ChatContextPanel: React.FC<Props> = ({
   chat, selectedTurnId, followLatest, selectedTurnIndex,
   effectiveAgent, effectiveModel, workerName, teamName, workingDir,
-  width, onFollowLatest, onClose, onResize, onRevealFile,
+  width, onFollowLatest, onClose, onResize, onRevealFile, onScrollToStep, isTurnStreaming,
 }) => {
   const turn: ChatMessage | undefined = selectedTurnId
     ? chat.messages.find(m => m.id === selectedTurnId && m.role === 'assistant')
@@ -118,6 +122,13 @@ export const ChatContextPanel: React.FC<Props> = ({
           </div>
         </Section>
 
+        {turn && (
+          <TeamFlow
+            turn={turn}
+            isStreaming={isTurnStreaming}
+            onScrollToStep={onScrollToStep}
+          />
+        )}
         {turn && <ToolTimeline toolCalls={turn.toolCalls ?? []} />}
         {turn && <FilesTouched toolCalls={turn.toolCalls ?? []} workingDir={workingDir} onReveal={onRevealFile} />}
         {triggeringUserMsg?.attachments && triggeringUserMsg.attachments.length > 0 && (
@@ -200,6 +211,76 @@ const filesStyles: Record<string, React.CSSProperties> = {
     background: 'transparent', border: 'none', color: C.fg3,
     cursor: 'pointer', fontSize: 12, padding: '0 4px', flexShrink: 0,
   },
+}
+
+const TeamFlow: React.FC<{
+  turn: ChatMessage
+  isStreaming: boolean
+  onScrollToStep: (messageId: string, stepNum: number) => void
+}> = ({ turn, isStreaming, onScrollToStep }) => {
+  const parsed = parseTeamMessage(turn.content)
+  if (!parsed) return null
+  const infos = (turn.toolCalls ?? []).filter(tc => tc.type === 'info')
+  // Match info messages to steps by step number prefix ("Step N:" or "Step N/M:")
+  const reasonByStep = new Map<number, string>()
+  for (const info of infos) {
+    const m = info.message.match(/^Step\s+(\d+)/)
+    if (!m) continue
+    reasonByStep.set(parseInt(m[1], 10), info.message)
+  }
+  const lastIdx = parsed.steps.length - 1
+  return (
+    <Section title={`Team flow (${parsed.steps.length} step${parsed.steps.length === 1 ? '' : 's'})`}>
+      <div style={flowStyles.list}>
+        {parsed.steps.map((s, i) => {
+          const isRunning = isStreaming && i === lastIdx
+          const status: 'done' | 'running' = isRunning ? 'running' : 'done'
+          const reason = reasonByStep.get(s.step)
+          return (
+            <div
+              key={`${turn.id}::${s.step}`}
+              style={flowStyles.row}
+              onClick={() => onScrollToStep(turn.id, s.step)}
+              title="Click to jump to this step"
+            >
+              <span style={status === 'running' ? flowStyles.dotRunning : flowStyles.dotDone}>
+                {status === 'running' ? '●' : '✓'}
+              </span>
+              <div style={flowStyles.body}>
+                <div style={flowStyles.workerLine}>
+                  <span style={flowStyles.stepNum}>Step {s.step}</span>
+                  <span style={flowStyles.workerName}>{s.worker}</span>
+                </div>
+                {reason && <div style={flowStyles.reason}>{reason.replace(/^Step\s+\d+(?:\/\d+)?:\s*\S+\s*(?:—|—|-)?\s*/, '')}</div>}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </Section>
+  )
+}
+
+const flowStyles: Record<string, React.CSSProperties> = {
+  list: { display: 'flex', flexDirection: 'column', gap: 0, position: 'relative' },
+  row: {
+    display: 'flex', alignItems: 'flex-start', gap: 8,
+    padding: '6px 0', cursor: 'pointer',
+    borderBottom: `1px dashed ${C.border2}`,
+  },
+  dotRunning: {
+    color: '#6ab0f3', fontSize: 12, lineHeight: '16px',
+    width: 14, flexShrink: 0, textAlign: 'center' as const,
+  },
+  dotDone: {
+    color: '#7ec97e', fontSize: 12, lineHeight: '16px',
+    width: 14, flexShrink: 0, textAlign: 'center' as const,
+  },
+  body: { flex: 1, minWidth: 0 },
+  workerLine: { display: 'flex', alignItems: 'baseline', gap: 6 },
+  stepNum: { fontSize: 10, color: C.fg3, textTransform: 'uppercase' as const, letterSpacing: 0.5 },
+  workerName: { fontSize: 12, color: C.fg, fontWeight: 500 },
+  reason: { fontSize: 11, color: C.fg3, marginTop: 2, lineHeight: 1.4 },
 }
 
 const ToolTimeline: React.FC<{ toolCalls: import('../types').ToolCallEntry[] }> = ({ toolCalls }) => {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -92,6 +92,53 @@ const AGENT_API_TYPE: Record<string, 'anthropic' | 'openai'> = {
 }
 type ModelEntry = { apiType: 'anthropic' | 'openai'; model: string }
 
+const TeamMessage: React.FC<{
+  messageId: string
+  parsed: NonNullable<ReturnType<typeof parseTeamMessage>>
+  isStreaming: boolean
+  expanded: Set<string>
+  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
+}> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
+  const lastIdx = parsed.steps.length - 1
+  const toggle = (key: string) => setExpanded(prev => {
+    const next = new Set(prev)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    return next
+  })
+  return (
+    <div>
+      {parsed.summary && (
+        <div style={styles.teamSummary}>🧭 {parsed.summary}</div>
+      )}
+      {parsed.steps.map((s, i) => {
+        const baseKey = `${messageId}::${s.step}`
+        const isLastDuringStream = isStreaming && i === lastIdx
+        const collapsedMarker = baseKey + '::collapsed'
+        const isOpen = isLastDuringStream
+          ? !expanded.has(collapsedMarker)
+          : expanded.has(baseKey)
+        const onClick = () => toggle(isLastDuringStream ? collapsedMarker : baseKey)
+        const preview = extractPreview(s.output)
+        return (
+          <div key={baseKey} style={styles.teamStepCard}>
+            <div style={styles.teamStepHeader} onClick={onClick}>
+              <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+              <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
+              {!isOpen && <span style={styles.teamStepPreview}> · {preview}</span>}
+            </div>
+            {isOpen && (
+              <div style={styles.teamStepBody}>
+                <Markdown variant="assistant">{s.output}</Markdown>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const { state, sendMessage, stopChat, setSelection, setAgentModel, renameChat, setContextPanelOpen } = useChats()
   const chat = state.chats[chatId]
@@ -392,52 +439,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         await apiService.linkChat(chat.id, p.channel, p.channelUserId)
       }
     }
-  }
-
-  const TeamMessage: React.FC<{
-    messageId: string
-    parsed: NonNullable<ReturnType<typeof parseTeamMessage>>
-    isStreaming: boolean
-    expanded: Set<string>
-    setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
-  }> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
-    const lastIdx = parsed.steps.length - 1
-    const toggle = (key: string) => setExpanded(prev => {
-      const next = new Set(prev)
-      next.has(key) ? next.delete(key) : next.add(key)
-      return next
-    })
-    return (
-      <div>
-        {parsed.summary && (
-          <div style={styles.teamSummary}>🧭 {parsed.summary}</div>
-        )}
-        {parsed.steps.map((s, i) => {
-          const baseKey = `${messageId}::${s.step}`
-          const isLastDuringStream = isStreaming && i === lastIdx
-          const collapsedMarker = baseKey + '::collapsed'
-          const isOpen = isLastDuringStream
-            ? !expanded.has(collapsedMarker)
-            : expanded.has(baseKey)
-          const onClick = () => toggle(isLastDuringStream ? collapsedMarker : baseKey)
-          const preview = extractPreview(s.output)
-          return (
-            <div key={baseKey} style={styles.teamStepCard}>
-              <div style={styles.teamStepHeader} onClick={onClick}>
-                <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
-                <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
-                {!isOpen && <span style={styles.teamStepPreview}> · {preview}</span>}
-              </div>
-              {isOpen && (
-                <div style={styles.teamStepBody}>
-                  <Markdown variant="assistant">{s.output}</Markdown>
-                </div>
-              )}
-            </div>
-          )
-        })}
-      </div>
-    )
   }
 
   const isSending = !!flight

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -7,6 +7,7 @@ import { Markdown } from './Markdown'
 import { RouteIcons } from './RouteIcons'
 import { PairingModal } from './PairingModal'
 import { ChatContextPanel } from './ChatContextPanel'
+import { parseTeamMessage, extractPreview } from './teamMessageFormat'
 
 interface Props {
   chatId: string
@@ -112,6 +113,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [pairingModal, setPairingModal] = useState<null | 'telegram' | 'discord' | 'imessage'>(null)
   const [followLatest, setFollowLatest] = useState(true)
   const [selectedTurnIdState, setSelectedTurnIdState] = useState<string | null>(null)
+  const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set())
   const [panelWidth, setPanelWidth] = useState<number>(() => {
     const v = localStorage.getItem('codey.contextPanelWidth')
     const n = v ? parseInt(v, 10) : NaN
@@ -392,6 +394,52 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     }
   }
 
+  const TeamMessage: React.FC<{
+    messageId: string
+    parsed: NonNullable<ReturnType<typeof parseTeamMessage>>
+    isStreaming: boolean
+    expanded: Set<string>
+    setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
+  }> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
+    const lastIdx = parsed.steps.length - 1
+    const toggle = (key: string) => setExpanded(prev => {
+      const next = new Set(prev)
+      next.has(key) ? next.delete(key) : next.add(key)
+      return next
+    })
+    return (
+      <div>
+        {parsed.summary && (
+          <div style={styles.teamSummary}>🧭 {parsed.summary}</div>
+        )}
+        {parsed.steps.map((s, i) => {
+          const baseKey = `${messageId}::${s.step}`
+          const isLastDuringStream = isStreaming && i === lastIdx
+          const collapsedMarker = baseKey + '::collapsed'
+          const isOpen = isLastDuringStream
+            ? !expanded.has(collapsedMarker)
+            : expanded.has(baseKey)
+          const onClick = () => toggle(isLastDuringStream ? collapsedMarker : baseKey)
+          const preview = extractPreview(s.output)
+          return (
+            <div key={baseKey} style={styles.teamStepCard}>
+              <div style={styles.teamStepHeader} onClick={onClick}>
+                <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+                <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
+                {!isOpen && <span style={styles.teamStepPreview}> · {preview}</span>}
+              </div>
+              {isOpen && (
+                <div style={styles.teamStepBody}>
+                  <Markdown variant="assistant">{s.output}</Markdown>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
   const canSend = isGatewayRunning && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
@@ -534,7 +582,21 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 border: isUser ? 'none' : `1px solid ${isSelected ? C.accent : C.border2}`,
                 transition: 'box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease',
               }}>
-                {msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
+                {msg.content && (() => {
+                  if (isUser) return <Markdown variant="user">{msg.content}</Markdown>
+                  const parsed = parseTeamMessage(msg.content)
+                  if (!parsed) return <Markdown variant="assistant">{msg.content}</Markdown>
+                  const isStreaming = !!flight && msg === lastMsg
+                  return (
+                    <TeamMessage
+                      messageId={msg.id}
+                      parsed={parsed}
+                      isStreaming={isStreaming}
+                      expanded={expandedSteps}
+                      setExpanded={setExpandedSteps}
+                    />
+                  )
+                })()}
                 {isUser && msg.attachments && msg.attachments.length > 0 && (
                   <div style={styles.attachmentsContainer}>
                     {msg.attachments.map(att => {
@@ -909,4 +971,26 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 12,
     color: C.fg,
   },
+  teamSummary: {
+    fontSize: 13, fontWeight: 600, color: C.accent,
+    padding: '6px 8px', marginBottom: 8,
+    borderLeft: `3px solid ${C.accent}`, background: 'rgba(255,255,255,0.03)',
+    borderRadius: 4,
+  },
+  teamStepCard: { marginBottom: 6 },
+  teamStepHeader: {
+    display: 'flex', alignItems: 'baseline', cursor: 'pointer',
+    fontSize: 12, color: C.fg2, padding: '2px 0', userSelect: 'none' as const,
+  },
+  teamStepChevron: {
+    display: 'inline-block', fontSize: 11, marginRight: 6,
+    transition: 'transform 0.15s ease', color: C.fg3, flexShrink: 0,
+  },
+  teamStepLabel: { color: C.fg, fontWeight: 500 },
+  teamStepPreview: {
+    color: C.fg3, fontStyle: 'italic', marginLeft: 4,
+    whiteSpace: 'nowrap' as const, overflow: 'hidden' as const, textOverflow: 'ellipsis',
+    flex: 1, minWidth: 0,
+  },
+  teamStepBody: { marginTop: 4, marginLeft: 17 },
 }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -157,45 +157,15 @@ const StepBody: React.FC<{
   )
 }
 
-const ManagerSteps: React.FC<{
-  messageId: string
-  infos: { id: string; message: string }[]
-  expanded: Set<string>
-  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
-}> = ({ messageId, infos, expanded, setExpanded }) => {
-  const key = `${messageId}::manager-steps`
-  const open = expanded.has(key)
-  const toggle = () => setExpanded(prev => {
-    const next = new Set(prev)
-    if (next.has(key)) next.delete(key)
-    else next.add(key)
-    return next
-  })
-  return (
-    <div style={styles.managerStepsBox}>
-      <div style={styles.managerStepsHeader} onClick={toggle}>
-        <span style={{ ...styles.teamStepChevron, transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
-        <span>Manager routing ({infos.length})</span>
-      </div>
-      {open && (
-        <div style={styles.managerStepsList}>
-          {infos.map(i => (
-            <div key={i.id} style={styles.managerStepLine}>• {i.message}</div>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
+const stepDomId = (messageId: string, stepNum: number) => `step-${messageId}-${stepNum}`
 
 const TeamMessage: React.FC<{
   messageId: string
   parsed: NonNullable<ReturnType<typeof parseTeamMessage>>
-  infos: { id: string; message: string }[]
   isStreaming: boolean
   expanded: Set<string>
   setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
-}> = ({ messageId, parsed, infos, isStreaming, expanded, setExpanded }) => {
+}> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
   const lastIdx = parsed.steps.length - 1
   const toggle = (key: string) => setExpanded(prev => {
     const next = new Set(prev)
@@ -207,9 +177,6 @@ const TeamMessage: React.FC<{
     <div>
       {parsed.summary && (
         <div style={styles.teamSummary}>🧭 {parsed.summary}</div>
-      )}
-      {infos.length > 0 && (
-        <ManagerSteps messageId={messageId} infos={infos} expanded={expanded} setExpanded={setExpanded} />
       )}
       {parsed.steps.map((s, i) => {
         const baseKey = `${messageId}::${s.step}`
@@ -225,7 +192,7 @@ const TeamMessage: React.FC<{
           ? { ...styles.teamStepCard, ...styles.teamStepCardActive }
           : styles.teamStepCard
         return (
-          <div key={baseKey} style={cardStyle}>
+          <div key={baseKey} id={stepDomId(messageId, s.step)} style={cardStyle}>
             <div style={styles.teamStepHeader} onClick={onClick}>
               <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
               <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
@@ -695,15 +662,11 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                   if (isUser) return <Markdown variant="user">{msg.content}</Markdown>
                   const parsed = parseTeamMessage(msg.content)
                   if (!parsed) return <Markdown variant="assistant">{msg.content}</Markdown>
-                  const infos = (msg.toolCalls ?? [])
-                    .filter(tc => tc.type === 'info')
-                    .map(tc => ({ id: tc.id, message: tc.message }))
                   const isStreaming = !!flight && msg === lastMsg
                   return (
                     <TeamMessage
                       messageId={msg.id}
                       parsed={parsed}
-                      infos={infos}
                       isStreaming={isStreaming}
                       expanded={expandedSteps}
                       setExpanded={setExpandedSteps}
@@ -901,6 +864,15 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 onClose={() => setContextPanelOpen(chat.id, false)}
                 onResize={setPanelWidth}
                 onRevealFile={(p) => apiService.revealInFolder(p)}
+                onScrollToStep={(mid, step) => {
+                  document.getElementById(stepDomId(mid, step))?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                  setExpandedSteps(prev => {
+                    const next = new Set(prev)
+                    next.add(`${mid}::${step}`)
+                    return next
+                  })
+                }}
+                isTurnStreaming={!!flight && selectedTurnId === lastMsg?.id}
               />
             </div>
           </>
@@ -920,6 +892,15 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
             onClose={() => setContextPanelOpen(chat.id, false)}
             onResize={setPanelWidth}
             onRevealFile={(p) => apiService.revealInFolder(p)}
+            onScrollToStep={(mid, step) => {
+              document.getElementById(stepDomId(mid, step))?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+              setExpandedSteps(prev => {
+                const next = new Set(prev)
+                next.add(`${mid}::${step}`)
+                return next
+              })
+            }}
+            isTurnStreaming={!!flight && selectedTurnId === lastMsg?.id}
           />
         )
       )}
@@ -1127,16 +1108,6 @@ const styles: Record<string, React.CSSProperties> = {
   thinkingBody: {
     marginLeft: 17, marginBottom: 8, paddingLeft: 8,
     borderLeft: `2px solid ${C.border2}`, opacity: 0.85,
-  },
-  managerStepsBox: { marginBottom: 8 },
-  managerStepsHeader: {
-    display: 'flex', alignItems: 'center', cursor: 'pointer',
-    fontSize: 11, color: C.fg3, padding: '2px 0', userSelect: 'none' as const,
-  },
-  managerStepsList: { marginLeft: 17, marginTop: 4 },
-  managerStepLine: {
-    fontSize: 11, color: C.fg3, padding: '1px 0',
-    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
   },
   liveActivity: {
     display: 'flex', alignItems: 'center', gap: 6,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -238,12 +238,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     const n = v ? parseInt(v, 10) : NaN
     return Number.isFinite(n) ? Math.max(260, Math.min(520, n)) : 340
   })
-  const [winNarrow, setWinNarrow] = useState<boolean>(() => window.innerWidth < 900)
-  useEffect(() => {
-    const onResize = () => setWinNarrow(window.innerWidth < 900)
-    window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
-  }, [])
   const dragDepthRef = useRef(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -350,11 +344,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     return null
   })()
   const panelOpen: boolean = chat?.contextPanelOpen ?? false
-  const panelOverlay: boolean = panelOpen && winNarrow
-  const overlayPanelWidth: number = Math.min(
-    panelWidth,
-    Math.max(280, Math.floor(window.innerWidth * 0.55))
-  )
 
   const selectionValue: string = chat.selection.type === 'worker'
     ? `worker:${chat.selection.name}`
@@ -844,67 +833,31 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
       )}
       </div>
       {panelOpen && (
-        panelOverlay ? (
-          <>
-            <div
-              style={styles.panelBackdrop}
-              onClick={() => setContextPanelOpen(chat.id, false)}
-            />
-            <div style={styles.panelOverlay}>
-              <ChatContextPanel
-                chat={chat}
-                selectedTurnId={selectedTurnId}
-                followLatest={followLatest}
-                selectedTurnIndex={selectedTurnIndex}
-                effectiveAgent={effectiveAgent}
-                effectiveModel={effectiveModel}
-                workerName={panelWorkerName}
-                teamName={panelTeamName}
-                workingDir={workingDir}
-                width={overlayPanelWidth}
-                onFollowLatest={() => setFollowLatest(true)}
-                onClose={() => setContextPanelOpen(chat.id, false)}
-                onResize={setPanelWidth}
-                onRevealFile={(p) => apiService.revealInFolder(p)}
-                onScrollToStep={(mid, step) => {
-                  document.getElementById(stepDomId(mid, step))?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-                  setExpandedSteps(prev => {
-                    const next = new Set(prev)
-                    next.add(`${mid}::${step}`)
-                    return next
-                  })
-                }}
-                isTurnStreaming={!!flight && selectedTurnId === lastMsg?.id}
-              />
-            </div>
-          </>
-        ) : (
-          <ChatContextPanel
-            chat={chat}
-            selectedTurnId={selectedTurnId}
-            followLatest={followLatest}
-            selectedTurnIndex={selectedTurnIndex}
-            effectiveAgent={effectiveAgent}
-            effectiveModel={effectiveModel}
-            workerName={panelWorkerName}
-            teamName={panelTeamName}
-            workingDir={workingDir}
-            width={panelWidth}
-            onFollowLatest={() => setFollowLatest(true)}
-            onClose={() => setContextPanelOpen(chat.id, false)}
-            onResize={setPanelWidth}
-            onRevealFile={(p) => apiService.revealInFolder(p)}
-            onScrollToStep={(mid, step) => {
-              document.getElementById(stepDomId(mid, step))?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-              setExpandedSteps(prev => {
-                const next = new Set(prev)
-                next.add(`${mid}::${step}`)
-                return next
-              })
-            }}
-            isTurnStreaming={!!flight && selectedTurnId === lastMsg?.id}
-          />
-        )
+        <ChatContextPanel
+          chat={chat}
+          selectedTurnId={selectedTurnId}
+          followLatest={followLatest}
+          selectedTurnIndex={selectedTurnIndex}
+          effectiveAgent={effectiveAgent}
+          effectiveModel={effectiveModel}
+          workerName={panelWorkerName}
+          teamName={panelTeamName}
+          workingDir={workingDir}
+          width={Math.min(panelWidth, Math.max(240, Math.floor(window.innerWidth * 0.5)))}
+          onFollowLatest={() => setFollowLatest(true)}
+          onClose={() => setContextPanelOpen(chat.id, false)}
+          onResize={setPanelWidth}
+          onRevealFile={(p) => apiService.revealInFolder(p)}
+          onScrollToStep={(mid, step) => {
+            document.getElementById(stepDomId(mid, step))?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            setExpandedSteps(prev => {
+              const next = new Set(prev)
+              next.add(`${mid}::${step}`)
+              return next
+            })
+          }}
+          isTurnStreaming={!!flight && selectedTurnId === lastMsg?.id}
+        />
       )}
     </div>
   )
@@ -912,15 +865,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
 
 const styles: Record<string, React.CSSProperties> = {
   outer: { display: 'flex', flexDirection: 'row', height: '100%', minHeight: 0, position: 'relative' },
-  panelBackdrop: {
-    position: 'absolute', inset: 0, zIndex: 20,
-    background: 'rgba(0,0,0,0.35)',
-  },
-  panelOverlay: {
-    position: 'absolute', top: 0, right: 0, bottom: 0, zIndex: 21,
-    boxShadow: '-12px 0 32px rgba(0,0,0,0.45)',
-    display: 'flex',
-  },
   container: { display: 'flex', flexDirection: 'column', height: '100%', flex: 1, minWidth: 0 },
   header: {
     padding: '10px 16px', borderBottom: `1px solid ${C.border}`,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -8,6 +8,7 @@ import { RouteIcons } from './RouteIcons'
 import { PairingModal } from './PairingModal'
 import { ChatContextPanel } from './ChatContextPanel'
 import { parseTeamMessage, extractPreview } from './teamMessageFormat'
+import { formatHeadline, normalizeTool } from './toolFormat'
 
 interface Props {
   chatId: string
@@ -92,14 +93,108 @@ const AGENT_API_TYPE: Record<string, 'anthropic' | 'openai'> = {
 }
 type ModelEntry = { apiType: 'anthropic' | 'openai'; model: string }
 
+const splitParagraphs = (text: string): string[] =>
+  text.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean)
+
+const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }> = ({ toolCalls }) => {
+  if (!toolCalls || toolCalls.length === 0) return null
+  const pending = new Map<string, { id: string; tool?: string; input?: Record<string, unknown> }>()
+  let lastDone: { tool?: string; input?: Record<string, unknown> } | null = null
+  for (const tc of toolCalls) {
+    if (tc.type === 'tool_start') {
+      pending.set(normalizeTool(tc.tool), { id: tc.id, tool: tc.tool, input: tc.input })
+    } else if (tc.type === 'tool_end') {
+      const key = normalizeTool(tc.tool)
+      const p = pending.get(key)
+      if (p) { lastDone = { tool: p.tool, input: p.input }; pending.delete(key) }
+      else { lastDone = { tool: tc.tool } }
+    }
+  }
+  const active = pending.size > 0 ? Array.from(pending.values()).pop()! : null
+  const target = active ?? lastDone
+  if (!target) return null
+  const headline = formatHeadline(target.tool, target.input ?? {})
+  return (
+    <div style={styles.liveActivity}>
+      <span style={styles.liveActivityDot}>{active ? '●' : '○'}</span>
+      <span>{headline}</span>
+    </div>
+  )
+}
+
+const StepBody: React.FC<{
+  output: string
+  bodyKey: string
+  expanded: Set<string>
+  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
+}> = ({ output, bodyKey, expanded, setExpanded }) => {
+  const paragraphs = splitParagraphs(output)
+  const showAll = expanded.has(bodyKey)
+  if (paragraphs.length <= 1) {
+    return <Markdown variant="assistant">{output}</Markdown>
+  }
+  const last = paragraphs[paragraphs.length - 1]
+  const earlierCount = paragraphs.length - 1
+  const toggle = () => setExpanded(prev => {
+    const next = new Set(prev)
+    if (next.has(bodyKey)) next.delete(bodyKey)
+    else next.add(bodyKey)
+    return next
+  })
+  return (
+    <div>
+      <div style={styles.thinkingToggle} onClick={toggle}>
+        <span style={{ ...styles.teamStepChevron, transform: showAll ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+        <span>{showAll ? 'Hide thinking' : `Show thinking (${earlierCount} paragraph${earlierCount === 1 ? '' : 's'})`}</span>
+      </div>
+      {showAll && (
+        <div style={styles.thinkingBody}>
+          <Markdown variant="assistant">{paragraphs.slice(0, -1).join('\n\n')}</Markdown>
+        </div>
+      )}
+      <Markdown variant="assistant">{last}</Markdown>
+    </div>
+  )
+}
+
+const ManagerSteps: React.FC<{
+  messageId: string
+  infos: { id: string; message: string }[]
+  expanded: Set<string>
+  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
+}> = ({ messageId, infos, expanded, setExpanded }) => {
+  const key = `${messageId}::manager-steps`
+  const open = expanded.has(key)
+  const toggle = () => setExpanded(prev => {
+    const next = new Set(prev)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    return next
+  })
+  return (
+    <div style={styles.managerStepsBox}>
+      <div style={styles.managerStepsHeader} onClick={toggle}>
+        <span style={{ ...styles.teamStepChevron, transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+        <span>Manager routing ({infos.length})</span>
+      </div>
+      {open && (
+        <div style={styles.managerStepsList}>
+          {infos.map(i => (
+            <div key={i.id} style={styles.managerStepLine}>• {i.message}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 const TeamMessage: React.FC<{
   messageId: string
   parsed: NonNullable<ReturnType<typeof parseTeamMessage>>
-  isStreaming: boolean
+  infos: { id: string; message: string }[]
   expanded: Set<string>
   setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
-}> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
-  const lastIdx = parsed.steps.length - 1
+}> = ({ messageId, parsed, infos, expanded, setExpanded }) => {
   const toggle = (key: string) => setExpanded(prev => {
     const next = new Set(prev)
     if (next.has(key)) next.delete(key)
@@ -111,25 +206,24 @@ const TeamMessage: React.FC<{
       {parsed.summary && (
         <div style={styles.teamSummary}>🧭 {parsed.summary}</div>
       )}
-      {parsed.steps.map((s, i) => {
+      {infos.length > 0 && (
+        <ManagerSteps messageId={messageId} infos={infos} expanded={expanded} setExpanded={setExpanded} />
+      )}
+      {parsed.steps.map(s => {
         const baseKey = `${messageId}::${s.step}`
-        const isLastDuringStream = isStreaming && i === lastIdx
-        const collapsedMarker = baseKey + '::collapsed'
-        const isOpen = isLastDuringStream
-          ? !expanded.has(collapsedMarker)
-          : expanded.has(baseKey)
-        const onClick = () => toggle(isLastDuringStream ? collapsedMarker : baseKey)
+        const bodyKey = `${baseKey}::body`
+        const isOpen = expanded.has(baseKey)
         const preview = extractPreview(s.output)
         return (
           <div key={baseKey} style={styles.teamStepCard}>
-            <div style={styles.teamStepHeader} onClick={onClick}>
+            <div style={styles.teamStepHeader} onClick={() => toggle(baseKey)}>
               <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
               <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
               {!isOpen && <span style={styles.teamStepPreview}> · {preview}</span>}
             </div>
             {isOpen && (
               <div style={styles.teamStepBody}>
-                <Markdown variant="assistant">{s.output}</Markdown>
+                <StepBody output={s.output} bodyKey={bodyKey} expanded={expanded} setExpanded={setExpanded} />
               </div>
             )}
           </div>
@@ -583,16 +677,21 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 border: isUser ? 'none' : `1px solid ${isSelected ? C.accent : C.border2}`,
                 transition: 'box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease',
               }}>
+                {!isUser && !!flight && msg === lastMsg && (
+                  <LiveActivity toolCalls={msg.toolCalls} />
+                )}
                 {msg.content && (() => {
                   if (isUser) return <Markdown variant="user">{msg.content}</Markdown>
                   const parsed = parseTeamMessage(msg.content)
                   if (!parsed) return <Markdown variant="assistant">{msg.content}</Markdown>
-                  const isStreaming = !!flight && msg === lastMsg
+                  const infos = (msg.toolCalls ?? [])
+                    .filter(tc => tc.type === 'info')
+                    .map(tc => ({ id: tc.id, message: tc.message }))
                   return (
                     <TeamMessage
                       messageId={msg.id}
                       parsed={parsed}
-                      isStreaming={isStreaming}
+                      infos={infos}
                       expanded={expandedSteps}
                       setExpanded={setExpandedSteps}
                     />
@@ -994,4 +1093,31 @@ const styles: Record<string, React.CSSProperties> = {
     flex: 1, minWidth: 0,
   },
   teamStepBody: { marginTop: 4, marginLeft: 17 },
+  thinkingToggle: {
+    display: 'flex', alignItems: 'center', cursor: 'pointer',
+    fontSize: 11, color: C.fg3, padding: '2px 0', userSelect: 'none' as const,
+    marginBottom: 6,
+  },
+  thinkingBody: {
+    marginLeft: 17, marginBottom: 8, paddingLeft: 8,
+    borderLeft: `2px solid ${C.border2}`, opacity: 0.85,
+  },
+  managerStepsBox: { marginBottom: 8 },
+  managerStepsHeader: {
+    display: 'flex', alignItems: 'center', cursor: 'pointer',
+    fontSize: 11, color: C.fg3, padding: '2px 0', userSelect: 'none' as const,
+  },
+  managerStepsList: { marginLeft: 17, marginTop: 4 },
+  managerStepLine: {
+    fontSize: 11, color: C.fg3, padding: '1px 0',
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+  },
+  liveActivity: {
+    display: 'flex', alignItems: 'center', gap: 6,
+    fontSize: 11, color: C.fg3, fontStyle: 'italic',
+    padding: '2px 6px', marginBottom: 6,
+    background: 'rgba(106,176,243,0.08)',
+    borderRadius: 4, border: `1px solid ${C.border2}`,
+  },
+  liveActivityDot: { color: '#6ab0f3', fontSize: 9 },
 }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -4,7 +4,6 @@ import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
 import { Markdown } from './Markdown'
-import { formatHeadline, hasDetail as toolHasDetail, ToolDetail, normalizeTool } from './toolFormat'
 import { RouteIcons } from './RouteIcons'
 import { PairingModal } from './PairingModal'
 import { ChatContextPanel } from './ChatContextPanel'
@@ -98,7 +97,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const flight = state.inFlight[chatId]
 
   const [input, setInput] = useState('')
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   const [teamNames, setTeamNames] = useState<string[]>([])
   const [models, setModels] = useState<ModelEntry[]>([])
@@ -536,73 +534,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 border: isUser ? 'none' : `1px solid ${isSelected ? C.accent : C.border2}`,
                 transition: 'box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease',
               }}>
-                {msg.toolCalls && msg.toolCalls.length > 0 && (() => {
-                  type Row =
-                    | { kind: 'call'; id: string; tool?: string; input?: Record<string, unknown>; output?: string; done: boolean }
-                    | { kind: 'info'; id: string; message: string }
-                  const rows: Row[] = []
-                  const pendingByTool = new Map<string, number>()
-                  for (const tc of msg.toolCalls) {
-                    if (tc.type === 'info') { rows.push({ kind: 'info', id: tc.id, message: tc.message }); continue }
-                    const key = normalizeTool(tc.tool)
-                    if (tc.type === 'tool_start') {
-                      const idx = rows.push({ kind: 'call', id: tc.id, tool: tc.tool, input: tc.input, done: false }) - 1
-                      pendingByTool.set(key, idx)
-                    } else {
-                      const idx = pendingByTool.get(key)
-                      if (idx != null) {
-                        const row = rows[idx] as Extract<Row, { kind: 'call' }>
-                        row.done = true
-                        if (tc.output) row.output = tc.output
-                        pendingByTool.delete(key)
-                      } else {
-                        rows.push({ kind: 'call', id: tc.id, tool: tc.tool, output: tc.output, done: true })
-                      }
-                    }
-                  }
-                  return (
-                    <>
-                      <div style={styles.toolCallsContainer}>
-                        {rows.map(row => {
-                          if (row.kind === 'info') {
-                            return (
-                              <div key={row.id} style={{ ...styles.toolCallRow, ...styles.toolCallInfo }}>
-                                <span>• {row.message}</span>
-                              </div>
-                            )
-                          }
-                          const isExpanded = expandedIds.has(row.id)
-                          const detail = toolHasDetail(row.tool, row.input, row.output)
-                          const toggle = () => setExpandedIds(prev => {
-                            const next = new Set(prev)
-                            next.has(row.id) ? next.delete(row.id) : next.add(row.id)
-                            return next
-                          })
-                          const headline = formatHeadline(row.tool, row.input)
-                          return (
-                            <div key={row.id}>
-                              <div
-                                style={{ ...styles.toolCallRow, cursor: detail ? 'pointer' : 'default' }}
-                                onClick={detail ? toggle : undefined}
-                              >
-                                {detail && (
-                                  <span style={{ ...styles.chevron, transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
-                                )}
-                                <span style={{ marginLeft: 2, color: row.done ? '#9bbcd9' : '#6ab0f3' }}>{headline}</span>
-                              </div>
-                              {detail && isExpanded && (
-                                <div style={styles.toolDetail}>
-                                  <ToolDetail rawTool={row.tool} input={row.input} output={row.output} />
-                                </div>
-                              )}
-                            </div>
-                          )
-                        })}
-                      </div>
-                      {msg.content && <div style={styles.toolCallSep} />}
-                    </>
-                  )
-                })()}
                 {msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
                 {isUser && msg.attachments && msg.attachments.length > 0 && (
                   <div style={styles.attachmentsContainer}>
@@ -864,16 +795,6 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     flexShrink: 0, transition: 'background 0.15s',
   },
-  toolCallsContainer: { marginBottom: 6, display: 'flex', flexDirection: 'column', gap: 2 },
-  toolCallRow: {
-    display: 'flex', alignItems: 'flex-start', fontSize: 12,
-    color: '#6ab0f3', fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-    padding: '2px 0', userSelect: 'text',
-  },
-  toolCallInfo: { color: C.fg3, fontStyle: 'italic' },
-  toolCallSep: { borderTop: `1px solid ${C.border2}`, marginBottom: 6, marginTop: 4 },
-  chevron: { display: 'inline-block', fontSize: 13, marginRight: 4, transition: 'transform 0.15s ease', color: C.fg3 },
-  toolDetail: { marginLeft: 20, marginTop: 4, marginBottom: 6, padding: 8, background: 'rgba(0,0,0,0.3)', borderRadius: 6, border: `1px solid ${C.border}` },
   orphanBanner: { padding: '8px 12px', background: C.warningBg, color: C.warningFg, fontSize: 12, borderTop: `1px solid ${C.border}` },
   dropOverlay: {
     position: 'absolute' as const, inset: 8, zIndex: 10,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -293,7 +293,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     })()
   }, [isGatewayRunning])
   const lastMsg = chat?.messages?.[chat.messages.length - 1]
-  useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }) }, [chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length])
+  useEffect(() => {
+    if (followLatest) messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length, chat?.contextPanelOpen, followLatest])
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && flight) stopChat(chatId)

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -192,9 +192,11 @@ const TeamMessage: React.FC<{
   messageId: string
   parsed: NonNullable<ReturnType<typeof parseTeamMessage>>
   infos: { id: string; message: string }[]
+  isStreaming: boolean
   expanded: Set<string>
   setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
-}> = ({ messageId, parsed, infos, expanded, setExpanded }) => {
+}> = ({ messageId, parsed, infos, isStreaming, expanded, setExpanded }) => {
+  const lastIdx = parsed.steps.length - 1
   const toggle = (key: string) => setExpanded(prev => {
     const next = new Set(prev)
     if (next.has(key)) next.delete(key)
@@ -209,16 +211,25 @@ const TeamMessage: React.FC<{
       {infos.length > 0 && (
         <ManagerSteps messageId={messageId} infos={infos} expanded={expanded} setExpanded={setExpanded} />
       )}
-      {parsed.steps.map(s => {
+      {parsed.steps.map((s, i) => {
         const baseKey = `${messageId}::${s.step}`
         const bodyKey = `${baseKey}::body`
-        const isOpen = expanded.has(baseKey)
+        const isLastDuringStream = isStreaming && i === lastIdx
+        const collapsedMarker = baseKey + '::collapsed'
+        const isOpen = isLastDuringStream
+          ? !expanded.has(collapsedMarker)
+          : expanded.has(baseKey)
+        const onClick = () => toggle(isLastDuringStream ? collapsedMarker : baseKey)
         const preview = extractPreview(s.output)
+        const cardStyle = isLastDuringStream
+          ? { ...styles.teamStepCard, ...styles.teamStepCardActive }
+          : styles.teamStepCard
         return (
-          <div key={baseKey} style={styles.teamStepCard}>
-            <div style={styles.teamStepHeader} onClick={() => toggle(baseKey)}>
+          <div key={baseKey} style={cardStyle}>
+            <div style={styles.teamStepHeader} onClick={onClick}>
               <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
               <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
+              {isLastDuringStream && <span style={styles.teamStepRunning}>● running</span>}
               {!isOpen && <span style={styles.teamStepPreview}> · {preview}</span>}
             </div>
             {isOpen && (
@@ -687,11 +698,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                   const infos = (msg.toolCalls ?? [])
                     .filter(tc => tc.type === 'info')
                     .map(tc => ({ id: tc.id, message: tc.message }))
+                  const isStreaming = !!flight && msg === lastMsg
                   return (
                     <TeamMessage
                       messageId={msg.id}
                       parsed={parsed}
                       infos={infos}
+                      isStreaming={isStreaming}
                       expanded={expandedSteps}
                       setExpanded={setExpandedSteps}
                     />
@@ -1077,10 +1090,23 @@ const styles: Record<string, React.CSSProperties> = {
     borderLeft: `3px solid ${C.accent}`, background: 'rgba(255,255,255,0.03)',
     borderRadius: 4,
   },
-  teamStepCard: { marginBottom: 6 },
+  teamStepCard: {
+    marginBottom: 10, padding: '8px 10px',
+    background: 'rgba(255,255,255,0.025)',
+    border: `1px solid ${C.border2}`, borderRadius: 8,
+  },
+  teamStepCardActive: {
+    border: `1px solid ${C.accent}`,
+    boxShadow: `0 0 0 1px ${C.accentDim}`,
+    background: 'rgba(106,176,243,0.06)',
+  },
   teamStepHeader: {
     display: 'flex', alignItems: 'baseline', cursor: 'pointer',
     fontSize: 12, color: C.fg2, padding: '2px 0', userSelect: 'none' as const,
+  },
+  teamStepRunning: {
+    marginLeft: 8, fontSize: 10, color: '#6ab0f3',
+    fontStyle: 'italic',
   },
   teamStepChevron: {
     display: 'inline-block', fontSize: 11, marginRight: 6,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -7,7 +7,7 @@ import { Markdown } from './Markdown'
 import { RouteIcons } from './RouteIcons'
 import { PairingModal } from './PairingModal'
 import { ChatContextPanel } from './ChatContextPanel'
-import { parseTeamMessage, extractPreview } from './teamMessageFormat'
+import { parseTeamMessage } from './teamMessageFormat'
 import { formatHeadline, normalizeTool } from './toolFormat'
 
 interface Props {
@@ -167,12 +167,6 @@ const TeamMessage: React.FC<{
   setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
 }> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
   const lastIdx = parsed.steps.length - 1
-  const toggle = (key: string) => setExpanded(prev => {
-    const next = new Set(prev)
-    if (next.has(key)) next.delete(key)
-    else next.add(key)
-    return next
-  })
   return (
     <div>
       {parsed.summary && (
@@ -182,28 +176,22 @@ const TeamMessage: React.FC<{
         const baseKey = `${messageId}::${s.step}`
         const bodyKey = `${baseKey}::body`
         const isLastDuringStream = isStreaming && i === lastIdx
-        const collapsedMarker = baseKey + '::collapsed'
-        const isOpen = isLastDuringStream
-          ? !expanded.has(collapsedMarker)
-          : expanded.has(baseKey)
-        const onClick = () => toggle(isLastDuringStream ? collapsedMarker : baseKey)
-        const preview = extractPreview(s.output)
         const cardStyle = isLastDuringStream
           ? { ...styles.teamStepCard, ...styles.teamStepCardActive }
           : styles.teamStepCard
         return (
           <div key={baseKey} id={stepDomId(messageId, s.step)} style={cardStyle}>
-            <div style={styles.teamStepHeader} onClick={onClick}>
-              <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+            <div style={styles.teamStepHeader}>
               <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
               {isLastDuringStream && <span style={styles.teamStepRunning}>● running</span>}
-              {!isOpen && <span style={styles.teamStepPreview}> · {preview}</span>}
             </div>
-            {isOpen && (
-              <div style={styles.teamStepBody}>
+            <div style={styles.teamStepBody}>
+              {isLastDuringStream ? (
+                <Markdown variant="assistant">{s.output || '…'}</Markdown>
+              ) : (
                 <StepBody output={s.output} bodyKey={bodyKey} expanded={expanded} setExpanded={setExpanded} />
-              </div>
-            )}
+              )}
+            </div>
           </div>
         )
       })}
@@ -850,11 +838,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
           onRevealFile={(p) => apiService.revealInFolder(p)}
           onScrollToStep={(mid, step) => {
             document.getElementById(stepDomId(mid, step))?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-            setExpandedSteps(prev => {
-              const next = new Set(prev)
-              next.add(`${mid}::${step}`)
-              return next
-            })
           }}
           isTurnStreaming={!!flight && selectedTurnId === lastMsg?.id}
         />

--- a/codey-mac/src/components/teamMessageFormat.test.ts
+++ b/codey-mac/src/components/teamMessageFormat.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { parseTeamMessage, extractPreview } from './teamMessageFormat'
+
+describe('parseTeamMessage', () => {
+  it('returns null for plain text', () => {
+    expect(parseTeamMessage('hello world')).toBeNull()
+  })
+
+  it('returns null for content that lacks the team marker', () => {
+    expect(parseTeamMessage('### Some heading\n\nbody')).toBeNull()
+  })
+
+  it('parses summary + multiple steps', () => {
+    const input = [
+      '🧭 Manager summary: All done.',
+      '',
+      '### Step 1: alice',
+      '',
+      'alice did a thing.',
+      '',
+      '---',
+      '',
+      '### Step 2: bob',
+      '',
+      'bob also did a thing.',
+    ].join('\n')
+    const r = parseTeamMessage(input)
+    expect(r).not.toBeNull()
+    expect(r!.summary).toBe('All done.')
+    expect(r!.steps).toHaveLength(2)
+    expect(r!.steps[0]).toEqual({ step: 1, worker: 'alice', output: 'alice did a thing.' })
+    expect(r!.steps[1]).toEqual({ step: 2, worker: 'bob', output: 'bob also did a thing.' })
+  })
+
+  it('parses steps without a summary', () => {
+    const input = [
+      '### Step 1: alice',
+      '',
+      'output here',
+    ].join('\n')
+    const r = parseTeamMessage(input)
+    expect(r).not.toBeNull()
+    expect(r!.summary).toBeNull()
+    expect(r!.steps).toHaveLength(1)
+  })
+
+  it('preserves "(revision)" suffix in worker name', () => {
+    const input = '### Step 3: alice (revision)\n\nfixed it'
+    const r = parseTeamMessage(input)
+    expect(r!.steps[0].worker).toBe('alice (revision)')
+  })
+
+  it('returns null when any chunk fails to match the step pattern', () => {
+    const input = [
+      '🧭 Manager summary: x',
+      '',
+      'not a step heading at all',
+    ].join('\n')
+    expect(parseTeamMessage(input)).toBeNull()
+  })
+})
+
+describe('extractPreview', () => {
+  it('returns "(no output)" for empty', () => {
+    expect(extractPreview('')).toBe('(no output)')
+    expect(extractPreview('   \n\n  ')).toBe('(no output)')
+  })
+
+  it('takes first sentence of last non-empty paragraph', () => {
+    const text = 'First paragraph here.\n\nSecond paragraph. Has two sentences.'
+    expect(extractPreview(text)).toBe('Has two sentences.')
+  })
+
+  it('handles Chinese full stop', () => {
+    const text = '中间段落\n\n结论一。结论二。'
+    expect(extractPreview(text)).toBe('结论一。')
+  })
+
+  it('returns whole paragraph when no sentence terminator', () => {
+    expect(extractPreview('just a fragment')).toBe('just a fragment')
+  })
+
+  it('truncates long previews to ~120 chars with ellipsis', () => {
+    const long = 'a'.repeat(200)
+    const out = extractPreview(long)
+    expect(out.length).toBeLessThanOrEqual(121)
+    expect(out.endsWith('…')).toBe(true)
+  })
+})

--- a/codey-mac/src/components/teamMessageFormat.ts
+++ b/codey-mac/src/components/teamMessageFormat.ts
@@ -1,0 +1,59 @@
+export interface TeamStep {
+  step: number
+  worker: string
+  output: string
+}
+
+export interface ParsedTeamMessage {
+  summary: string | null
+  steps: TeamStep[]
+}
+
+const SUMMARY_PREFIX = '🧭 Manager summary: '
+const STEP_HEADING = /^### Step (\d+): (.+?)\n\n([\s\S]*)$/
+
+export function parseTeamMessage(content: string): ParsedTeamMessage | null {
+  if (!content) return null
+
+  let body = content
+  let summary: string | null = null
+
+  if (body.startsWith(SUMMARY_PREFIX)) {
+    const nl = body.indexOf('\n')
+    summary = body.slice(SUMMARY_PREFIX.length, nl === -1 ? undefined : nl).trim()
+    body = nl === -1 ? '' : body.slice(nl + 1).replace(/^\n+/, '')
+  }
+
+  if (!body.startsWith('### Step ')) return null
+
+  const chunks = body.split('\n\n---\n\n')
+  const steps: TeamStep[] = []
+  for (const chunk of chunks) {
+    const m = chunk.match(STEP_HEADING)
+    if (!m) return null
+    steps.push({
+      step: parseInt(m[1], 10),
+      worker: m[2].trim(),
+      output: m[3].trim(),
+    })
+  }
+  if (steps.length === 0) return null
+  return { summary, steps }
+}
+
+const MAX_PREVIEW = 120
+
+export function extractPreview(output: string): string {
+  const trimmed = output.trim()
+  if (!trimmed) return '(no output)'
+  const paragraphs = trimmed.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean)
+  const last = paragraphs[paragraphs.length - 1] ?? trimmed
+  // Split by western sentence boundaries (word + terminator + space), take last chunk
+  const westernParts = last.split(/(?<=\w[.!?])\s+/)
+  const chunk = westernParts[westernParts.length - 1].trim()
+  // Extract the first complete sentence from that chunk
+  const m = chunk.match(/^([^.!?。！？]*[.!?。！？])/)
+  const sentence = (m ? m[1] : chunk).trim()
+  if (sentence.length <= MAX_PREVIEW) return sentence
+  return sentence.slice(0, MAX_PREVIEW) + '…'
+}

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -31,6 +31,7 @@ type Action =
   | { type: 'queued'; chatId: string; position: number }
   | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
+  | { type: 'patchContextPanelOpen'; chatId: string; open: boolean | null }
 
 function reorder(order: string[], chatId: string): string[] {
   return [chatId, ...order.filter(id => id !== chatId)]
@@ -47,9 +48,30 @@ function reducer(state: State, action: Action): State {
     case 'setWorkspaces':
       return { ...state, workspaces: action.workspaces }
     case 'upsert': {
-      const chats = { ...state.chats, [action.chat.id]: action.chat }
+      // When an assistant message is in flight, the server's view does not
+      // include the streaming content (or even the placeholder). A blind
+      // overwrite would erase the in-progress message until 'done' fires —
+      // making the bubble appear to vanish whenever any field on the chat
+      // is touched mid-stream (e.g. toggling the context panel).
+      // Preserve the in-flight assistant message in that case.
+      const fl = state.inFlight[action.chat.id]
+      const existing = state.chats[action.chat.id]
+      let next = action.chat
+      if (fl && existing) {
+        const inFlightMsg = existing.messages.find(m => m.id === fl.assistantMessageId)
+        if (inFlightMsg && !next.messages.some(m => m.id === fl.assistantMessageId)) {
+          next = { ...next, messages: [...next.messages, inFlightMsg] }
+        }
+      }
+      const chats = { ...state.chats, [action.chat.id]: next }
       const order = state.order.includes(action.chat.id) ? state.order : [action.chat.id, ...state.order]
       return { ...state, chats, order: reorder(order, action.chat.id) }
+    }
+    case 'patchContextPanelOpen': {
+      const chat = state.chats[action.chatId]
+      if (!chat) return state
+      const updated: Chat = { ...chat, contextPanelOpen: action.open ?? undefined }
+      return { ...state, chats: { ...state.chats, [chat.id]: updated } }
     }
     case 'remove': {
       const chats = { ...state.chats }
@@ -329,8 +351,11 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       dispatch({ type: 'upsert', chat })
     },
     async setContextPanelOpen(chatId, open) {
-      const chat = await apiService.chats.updateContextPanelOpen(chatId, open)
-      dispatch({ type: 'upsert', chat })
+      // Optimistically patch the local state so we don't replace the chat
+      // (which would clobber an in-flight streaming assistant message).
+      // The server-side write happens in the background.
+      dispatch({ type: 'patchContextPanelOpen', chatId, open })
+      try { await apiService.chats.updateContextPanelOpen(chatId, open) } catch { /* swallow */ }
     },
     async sendMessage(chatId, text, attachments) {
       const assistantMessageId = `asst-${Date.now()}-${Math.random()}`

--- a/codey-mac/vitest.config.ts
+++ b/codey-mac/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/docs/superpowers/plans/2026-05-10-message-compaction.md
+++ b/docs/superpowers/plans/2026-05-10-message-compaction.md
@@ -1,0 +1,496 @@
+# Message Compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove inline tool-call rendering from the Mac chat view, and render Team Mode messages as collapsible per-step cards with a prominent manager summary.
+
+**Architecture:** Pure frontend change in `codey-mac/src/components/ChatTab.tsx`. Add a small parser module `teamMessageFormat.ts` that detects the `formatManagerParts` output shape (`🧭 Manager summary:` + `### Step N:` chunks) and returns structured data. ChatTab uses the parser to switch between plain Markdown and a custom card layout. The right Context Panel (`ChatContextPanel.tsx`) already shows tool calls and is unchanged.
+
+**Tech Stack:** React + TypeScript, existing `Markdown` component, no new deps.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-message-compaction-design.md`
+
+---
+
+## File Map
+
+- **Create:** `codey-mac/src/components/teamMessageFormat.ts` — parser + preview extractor.
+- **Create:** `codey-mac/src/components/teamMessageFormat.test.ts` — unit tests for the parser.
+- **Modify:** `codey-mac/src/components/ChatTab.tsx`
+  - Remove inline tool-call rendering block (`:539-605`).
+  - Remove `expandedIds` state (`:101`) and the `toolFormat` import (`:7`) once unreferenced.
+  - Remove dead style entries (`toolCallsContainer`, `toolCallRow`, `toolCallInfo`, `toolCallSep`, `chevron`, `toolDetail`).
+  - Add team-message card rendering using the new parser.
+  - Add per-step collapse state.
+
+The right Context Panel's auto-open effect (`:190-197`) stays — it is now the only entry point to tool detail.
+
+---
+
+## Test setup note
+
+`codey-mac` does not currently have a test runner. Add one in Task 1 (Vitest, since the project uses Vite) so the parser is testable. If the maintainer prefers no tests in this package, skip Task 1 and Task 2's test file — the parser is small enough to verify by hand.
+
+---
+
+## Task 1: Add Vitest to codey-mac
+
+**Files:**
+- Modify: `codey-mac/package.json`
+- Create: `codey-mac/vitest.config.ts`
+
+- [ ] **Step 1: Install Vitest**
+
+```bash
+cd codey-mac && npm install --save-dev vitest
+```
+
+- [ ] **Step 2: Add `test` script to package.json**
+
+In `codey-mac/package.json`, under `"scripts"`, add:
+
+```json
+"test": "vitest run"
+```
+
+- [ ] **Step 3: Create vitest.config.ts**
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})
+```
+
+- [ ] **Step 4: Verify Vitest runs (no tests yet → exits 0 with "no test files found")**
+
+Run: `cd codey-mac && npm test`
+Expected: exits successfully (Vitest may report "No test files found" — that's fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/package.json codey-mac/package-lock.json codey-mac/vitest.config.ts
+git commit -m "chore(codey-mac): add vitest for unit tests"
+```
+
+---
+
+## Task 2: Write parser failing tests
+
+**Files:**
+- Create: `codey-mac/src/components/teamMessageFormat.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { parseTeamMessage, extractPreview } from './teamMessageFormat'
+
+describe('parseTeamMessage', () => {
+  it('returns null for plain text', () => {
+    expect(parseTeamMessage('hello world')).toBeNull()
+  })
+
+  it('returns null for content that lacks the team marker', () => {
+    expect(parseTeamMessage('### Some heading\n\nbody')).toBeNull()
+  })
+
+  it('parses summary + multiple steps', () => {
+    const input = [
+      '🧭 Manager summary: All done.',
+      '',
+      '### Step 1: alice',
+      '',
+      'alice did a thing.',
+      '',
+      '---',
+      '',
+      '### Step 2: bob',
+      '',
+      'bob also did a thing.',
+    ].join('\n')
+    const r = parseTeamMessage(input)
+    expect(r).not.toBeNull()
+    expect(r!.summary).toBe('All done.')
+    expect(r!.steps).toHaveLength(2)
+    expect(r!.steps[0]).toEqual({ step: 1, worker: 'alice', output: 'alice did a thing.' })
+    expect(r!.steps[1]).toEqual({ step: 2, worker: 'bob', output: 'bob also did a thing.' })
+  })
+
+  it('parses steps without a summary', () => {
+    const input = [
+      '### Step 1: alice',
+      '',
+      'output here',
+    ].join('\n')
+    const r = parseTeamMessage(input)
+    expect(r).not.toBeNull()
+    expect(r!.summary).toBeNull()
+    expect(r!.steps).toHaveLength(1)
+  })
+
+  it('preserves "(revision)" suffix in worker name', () => {
+    const input = '### Step 3: alice (revision)\n\nfixed it'
+    const r = parseTeamMessage(input)
+    expect(r!.steps[0].worker).toBe('alice (revision)')
+  })
+
+  it('returns null when any chunk fails to match the step pattern', () => {
+    const input = [
+      '🧭 Manager summary: x',
+      '',
+      'not a step heading at all',
+    ].join('\n')
+    expect(parseTeamMessage(input)).toBeNull()
+  })
+})
+
+describe('extractPreview', () => {
+  it('returns "(no output)" for empty', () => {
+    expect(extractPreview('')).toBe('(no output)')
+    expect(extractPreview('   \n\n  ')).toBe('(no output)')
+  })
+
+  it('takes first sentence of last non-empty paragraph', () => {
+    const text = 'First paragraph here.\n\nSecond paragraph. Has two sentences.'
+    expect(extractPreview(text)).toBe('Has two sentences.')
+  })
+
+  it('handles Chinese full stop', () => {
+    const text = '中间段落\n\n结论一。结论二。'
+    expect(extractPreview(text)).toBe('结论一。')
+  })
+
+  it('returns whole paragraph when no sentence terminator', () => {
+    expect(extractPreview('just a fragment')).toBe('just a fragment')
+  })
+
+  it('truncates long previews to ~120 chars with ellipsis', () => {
+    const long = 'a'.repeat(200)
+    const out = extractPreview(long)
+    expect(out.length).toBeLessThanOrEqual(121)
+    expect(out.endsWith('…')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd codey-mac && npm test`
+Expected: FAIL — `teamMessageFormat` module not found.
+
+---
+
+## Task 3: Implement parser
+
+**Files:**
+- Create: `codey-mac/src/components/teamMessageFormat.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+```ts
+export interface TeamStep {
+  step: number
+  worker: string
+  output: string
+}
+
+export interface ParsedTeamMessage {
+  summary: string | null
+  steps: TeamStep[]
+}
+
+const SUMMARY_PREFIX = '🧭 Manager summary: '
+const STEP_HEADING = /^### Step (\d+): (.+?)\n\n([\s\S]*)$/
+
+export function parseTeamMessage(content: string): ParsedTeamMessage | null {
+  if (!content) return null
+
+  let body = content
+  let summary: string | null = null
+
+  if (body.startsWith(SUMMARY_PREFIX)) {
+    const nl = body.indexOf('\n')
+    summary = body.slice(SUMMARY_PREFIX.length, nl === -1 ? undefined : nl).trim()
+    body = nl === -1 ? '' : body.slice(nl + 1).replace(/^\n+/, '')
+  }
+
+  if (!body.startsWith('### Step ')) return null
+
+  const chunks = body.split('\n\n---\n\n')
+  const steps: TeamStep[] = []
+  for (const chunk of chunks) {
+    const m = chunk.match(STEP_HEADING)
+    if (!m) return null
+    steps.push({
+      step: parseInt(m[1], 10),
+      worker: m[2].trim(),
+      output: m[3].trim(),
+    })
+  }
+  if (steps.length === 0) return null
+  return { summary, steps }
+}
+
+const MAX_PREVIEW = 120
+
+export function extractPreview(output: string): string {
+  const trimmed = output.trim()
+  if (!trimmed) return '(no output)'
+  const paragraphs = trimmed.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean)
+  const last = paragraphs[paragraphs.length - 1] ?? trimmed
+  const m = last.match(/^([^.!?。！？]*[.!?。！？])/)
+  const sentence = (m ? m[1] : last).trim()
+  if (sentence.length <= MAX_PREVIEW) return sentence
+  return sentence.slice(0, MAX_PREVIEW) + '…'
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd codey-mac && npm test`
+Expected: PASS — all parser and preview tests green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/components/teamMessageFormat.ts codey-mac/src/components/teamMessageFormat.test.ts
+git commit -m "feat(codey-mac): add team message parser with preview extraction"
+```
+
+---
+
+## Task 4: Remove inline tool-call rendering
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx`
+
+- [ ] **Step 1: Delete the tool-call render block**
+
+In `ChatTab.tsx`, remove the entire block from line `539` through `605` — the `{msg.toolCalls && msg.toolCalls.length > 0 && (() => { ... })()}` IIFE. Leave the surrounding message bubble untouched. After deletion, the bubble's children begin directly with:
+
+```tsx
+{msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
+```
+
+- [ ] **Step 2: Remove `expandedIds` state**
+
+Delete line `101`:
+
+```tsx
+const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+```
+
+- [ ] **Step 3: Remove the `toolFormat` import**
+
+Delete line `7`:
+
+```tsx
+import { formatHeadline, hasDetail as toolHasDetail, ToolDetail, normalizeTool } from './toolFormat'
+```
+
+- [ ] **Step 4: Remove dead style entries**
+
+In the `styles` object (around line `867-876`), delete these keys:
+`toolCallsContainer`, `toolCallRow`, `toolCallInfo`, `toolCallSep`, `chevron`, `toolDetail`.
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+Run: `cd codey-mac && npx tsc --noEmit -p tsconfig.json`
+Expected: no errors. (If unused-import or unused-variable errors surface for anything else removed, fix by deleting the dead reference.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "refactor(codey-mac): remove inline tool-call rendering from messages"
+```
+
+---
+
+## Task 5: Render team messages as collapsible step cards
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx`
+
+- [ ] **Step 1: Add the parser import**
+
+At the top of `ChatTab.tsx`, alongside other imports from `./`, add:
+
+```tsx
+import { parseTeamMessage, extractPreview } from './teamMessageFormat'
+```
+
+- [ ] **Step 2: Add per-step collapse state**
+
+Inside the `ChatTab` component (near other `useState` hooks, e.g. just below where `expandedIds` was removed), add:
+
+```tsx
+const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set())
+```
+
+The set holds keys of the form `${msg.id}::${step}`.
+
+- [ ] **Step 3: Add the TeamMessage subcomponent**
+
+Place this component definition above the `ChatTab` component (or as a top-level helper inside the file, next to other small components like `TypingDots`):
+
+```tsx
+const TeamMessage: React.FC<{
+  messageId: string
+  parsed: ReturnType<typeof parseTeamMessage> & object
+  isStreaming: boolean
+  expanded: Set<string>
+  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
+}> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
+  const lastIdx = parsed.steps.length - 1
+  const toggle = (key: string) => setExpanded(prev => {
+    const next = new Set(prev)
+    next.has(key) ? next.delete(key) : next.add(key)
+    return next
+  })
+  return (
+    <div>
+      {parsed.summary && (
+        <div style={styles.teamSummary}>🧭 {parsed.summary}</div>
+      )}
+      {parsed.steps.map((s, i) => {
+        const key = `${messageId}::${s.step}`
+        const isLastDuringStream = isStreaming && i === lastIdx
+        const isOpen = isLastDuringStream
+          ? !expanded.has(key + '::collapsed')
+          : expanded.has(key)
+        const onClick = () => {
+          if (isLastDuringStream) toggle(key + '::collapsed')
+          else toggle(key)
+        }
+        const preview = extractPreview(s.output)
+        return (
+          <div key={key} style={styles.teamStepCard}>
+            <div style={styles.teamStepHeader} onClick={onClick}>
+              <span style={{ ...styles.teamStepChevron, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+              <span style={styles.teamStepLabel}>Step {s.step}: {s.worker}</span>
+              {!isOpen && <span style={styles.teamStepPreview}> · {preview}</span>}
+            </div>
+            {isOpen && (
+              <div style={styles.teamStepBody}>
+                <Markdown variant="assistant">{s.output}</Markdown>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+Note the inverted-collapse trick for the streaming step: it defaults to expanded, and clicking adds a `::collapsed` marker to the set. Once streaming ends, the step uses normal collapse semantics (default collapsed, click to expand).
+
+- [ ] **Step 4: Add the styles**
+
+In the `styles` object, add:
+
+```tsx
+teamSummary: {
+  fontSize: 13, fontWeight: 600, color: C.accent,
+  padding: '6px 8px', marginBottom: 8,
+  borderLeft: `3px solid ${C.accent}`, background: 'rgba(255,255,255,0.03)',
+  borderRadius: 4,
+},
+teamStepCard: { marginBottom: 6 },
+teamStepHeader: {
+  display: 'flex', alignItems: 'baseline', cursor: 'pointer',
+  fontSize: 12, color: C.fg2, padding: '2px 0', userSelect: 'none',
+},
+teamStepChevron: {
+  display: 'inline-block', fontSize: 11, marginRight: 6,
+  transition: 'transform 0.15s ease', color: C.fg3, flexShrink: 0,
+},
+teamStepLabel: { color: C.fg, fontWeight: 500 },
+teamStepPreview: {
+  color: C.fg3, fontStyle: 'italic', marginLeft: 4,
+  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+  flex: 1, minWidth: 0,
+},
+teamStepBody: { marginTop: 4, marginLeft: 17 },
+```
+
+- [ ] **Step 5: Wire it into the message bubble**
+
+In `ChatTab.tsx`, replace the line that currently renders message content for non-user messages:
+
+```tsx
+{msg.content && <Markdown variant={isUser ? 'user' : 'assistant'}>{msg.content}</Markdown>}
+```
+
+with:
+
+```tsx
+{msg.content && (() => {
+  if (isUser) return <Markdown variant="user">{msg.content}</Markdown>
+  const parsed = parseTeamMessage(msg.content)
+  if (!parsed) return <Markdown variant="assistant">{msg.content}</Markdown>
+  const isStreaming = !!flight && msg === lastMsg
+  return (
+    <TeamMessage
+      messageId={msg.id}
+      parsed={parsed}
+      isStreaming={isStreaming}
+      expanded={expandedSteps}
+      setExpanded={setExpandedSteps}
+    />
+  )
+})()}
+```
+
+- [ ] **Step 6: Verify TypeScript compiles**
+
+Run: `cd codey-mac && npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 7: Manual smoke test in dev**
+
+Run: `cd codey-mac && npm run dev`
+
+Open the app, run a `/team <name> <task>` against a test workspace with at least 2 workers, and verify:
+- While streaming: the in-progress step card is expanded; earlier steps are collapsed with one-line preview.
+- After streaming ends: all step cards are collapsed; clicking expands.
+- The manager summary line appears at the top in accent color (only when present).
+- The right Context Panel still shows tool calls and updates as before.
+- A non-team chat (`/chat` style) message renders as plain Markdown without any card wrapper.
+- No tool-call rows appear inside any message bubble.
+
+If any check fails, fix in this task before committing. (If you can't run the UI in this environment, say so explicitly — type-check passing is necessary but not sufficient.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(codey-mac): collapsible per-step cards for team messages"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** A → Task 4. B (parser, preview rule, collapse default, streaming-step expanded, no info lines, no summary → omit, fall-through for non-team) → Tasks 2/3/5.
+- **Type consistency:** `parseTeamMessage` return shape (`{summary, steps[]}`) is used identically in tests and TeamMessage component.
+- **No placeholders:** every code step shows the actual code; every command has expected output.
+- **Backend untouched:** other channels and gateway behavior unaffected.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-10-message-compaction.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-10-message-compaction-design.md
+++ b/docs/superpowers/specs/2026-05-10-message-compaction-design.md
@@ -52,7 +52,7 @@ The Mac UI parses any assistant message whose content matches this pattern and r
 - **Manager summary line** (if present): rendered at the top, visually emphasized (slightly larger / accent color). When `final_summary` is missing, nothing is shown in its place.
 - **Each Step**: a collapsible card.
   - Collapsed (default for completed steps): one row showing `▶ Step N: <worker> · <preview>`.
-    - `<preview>` = the **first sentence of the last non-empty paragraph** of the worker's output. "Sentence" = up to the first `。`/`.`/`!`/`?` (Chinese or ASCII), or the whole paragraph if no terminator. Truncated to ~120 chars with `…`.
+    - `<preview>` = a one-sentence excerpt from the last non-empty paragraph of the worker's output. For ASCII text, this is the last sentence of that paragraph (agents typically conclude at the end). For CJK text (no spaces between sentences), this is the first CJK-terminated sentence of the paragraph. If no terminator is present, the whole paragraph is used. Truncated to ~120 chars with `…`.
     - If the worker output is empty, preview shows `(no output)`.
   - Expanded: full worker markdown rendered with the existing `<Markdown>` component.
 - **Step status while running**: when a streaming response is in progress, the **last** parsed step is treated as "in progress" and rendered expanded by default; all earlier steps render collapsed. Once streaming completes (message no longer the streaming target), the last step also collapses.

--- a/docs/superpowers/specs/2026-05-10-message-compaction-design.md
+++ b/docs/superpowers/specs/2026-05-10-message-compaction-design.md
@@ -1,0 +1,79 @@
+# Message Compaction in Mac Chat View
+
+Date: 2026-05-10
+Status: Draft
+
+## Problem
+
+Two sources of clutter in the Mac chat view:
+
+1. **Inline tool calls** in every assistant message duplicate what the right Context Panel already shows (added in 2026-05-09).
+2. **Team Mode messages** show every worker's full output and every manager step inline, so the screen is dominated by intermediate reasoning rather than the final result. The user wants conclusions front-and-center, with worker detail available on demand.
+
+## Scope
+
+Pure frontend rendering change in `codey-mac/src/components/ChatTab.tsx`. No changes to gateway/core or to other channels (Telegram/Discord/iMessage/TUI) — those channels do not render `toolCalls` and the assistant text they receive stays unchanged.
+
+## Design
+
+### A. Remove inline tool display from messages
+
+- Remove the `msg.toolCalls`-driven block in `ChatTab.tsx:539-605` (the tool-call list, expandable detail, and the `toolCallSep` separator that goes with it).
+- Keep the `toolCalls` data on the message — the right Context Panel (`ChatContextPanel.tsx`) still consumes it.
+- Remove the now-dead style entries (`toolCallsContainer`, `toolCallRow`, `toolCallInfo`, `toolCallSep`, `toolDetail`) and the `expandedIds` state and `toolFormat` imports if they are no longer referenced after the removal.
+- Auto-open of the context panel when tool activity appears (`ChatTab.tsx:193-197`) stays — that behavior is now the only way users see tool activity in the new flow.
+
+### B. Fold worker output in Team Mode
+
+`formatManagerParts` (`gateway.ts:1911`) already produces a deterministic structure:
+
+```
+🧭 Manager summary: <final_summary>     (only when finalSummary is non-empty)
+
+### Step 1: <worker>                    (or "<worker> (revision)")
+
+<worker output markdown>
+
+---
+
+### Step 2: <worker>
+
+<worker output markdown>
+```
+
+The Mac UI parses any assistant message whose content matches this pattern and renders it as a structured card instead of one big markdown blob.
+
+**Parser:**
+- Detect `🧭 Manager summary: ` prefix → extract summary line, strip from body.
+- Split remaining body on `\n\n---\n\n`.
+- For each chunk, match `^### Step (\d+): (.+?)\n\n([\s\S]*)$`. If any chunk fails to match, fall back to plain Markdown rendering of the whole message (no parsing applied).
+
+**Render:**
+- **Manager summary line** (if present): rendered at the top, visually emphasized (slightly larger / accent color). When `final_summary` is missing, nothing is shown in its place.
+- **Each Step**: a collapsible card.
+  - Collapsed (default for completed steps): one row showing `▶ Step N: <worker> · <preview>`.
+    - `<preview>` = the **first sentence of the last non-empty paragraph** of the worker's output. "Sentence" = up to the first `。`/`.`/`!`/`?` (Chinese or ASCII), or the whole paragraph if no terminator. Truncated to ~120 chars with `…`.
+    - If the worker output is empty, preview shows `(no output)`.
+  - Expanded: full worker markdown rendered with the existing `<Markdown>` component.
+- **Step status while running**: when a streaming response is in progress, the **last** parsed step is treated as "in progress" and rendered expanded by default; all earlier steps render collapsed. Once streaming completes (message no longer the streaming target), the last step also collapses.
+- **Manager `Step X: worker — reason` info messages**: completely removed from the inline view. The right Context Panel's tool timeline already shows worker switches.
+
+**Non-team / single-worker / plain-chat messages**: unchanged. The parser only activates when the content begins with either `🧭 Manager summary:` or `### Step 1:` — anything else falls through to existing `<Markdown>` rendering.
+
+### Out of scope
+
+- Backend changes to `formatManagerParts` output format (the marker `🧭 Manager summary:` and `### Step N:` headings are the contract this depends on).
+- Any change to how Telegram/Discord/iMessage/TUI render team output.
+- Persisting per-step expand/collapse state across app reloads.
+
+## Edge cases
+
+- **No final summary** (manager fallback paths, mid-run halts): summary line area is omitted entirely. No placeholder text.
+- **Truncated step output** (`truncatePerStep` is set in some persisted-team paths in `gateway.ts:2053,2230,2302`): preview takes the last paragraph of the truncated text — acceptable.
+- **Message edited via streaming**: parsing re-runs on every render; no caching needed for these short structures.
+- **Worker output containing `\n\n---\n\n`**: would split incorrectly. Acceptable risk — agent output rarely contains that exact triple-newline-fenced separator. If a chunk fails the `### Step N:` regex match, the whole message falls back to plain Markdown rendering, so the worst case is graceful degradation.
+
+## Files touched
+
+- `codey-mac/src/components/ChatTab.tsx` — remove inline tool block; add team-message parser and collapsible step card rendering.
+- Possibly a small helper extracted to a new file (`teamMessageFormat.ts`) if parser logic exceeds ~40 lines, to keep `ChatTab.tsx` focused.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "typescript": "^5.3.0",
         "vite": "^5.0.0",
         "vite-plugin-electron": "^0.28.0",
-        "vite-plugin-electron-renderer": "^0.14.5"
+        "vite-plugin-electron-renderer": "^0.14.5",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -965,6 +966,40 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1254,6 +1289,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1271,6 +1324,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1286,6 +1357,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1623,6 +1712,35 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1632,6 +1750,263 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2036,6 +2411,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2086,6 +2468,17 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2152,6 +2545,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2160,6 +2564,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2392,6 +2803,92 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
@@ -2814,6 +3311,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -3334,6 +3841,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3958,6 +4475,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -4664,6 +5191,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4800,11 +5334,31 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4880,6 +5434,24 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-type": {
@@ -6340,6 +6912,267 @@
         "node": ">= 0.6.3"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
@@ -6439,6 +7272,16 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
       "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -7668,6 +8511,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7801,6 +8655,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7820,6 +8681,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -7846,9 +8720,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -8403,6 +9277,47 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -8743,6 +9658,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8896,6 +9818,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -8905,6 +9834,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stealthy-require": {
       "version": "1.1.1",
@@ -9306,6 +10242,50 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -9914,6 +10894,659 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10019,6 +11652,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -10231,7 +11881,8 @@
         "undici": "^5.28.0"
       },
       "devDependencies": {
-        "typescript": "^5.9.0"
+        "typescript": "^5.9.0",
+        "vitest": "^4.1.5"
       }
     },
     "packages/gateway": {

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -37,6 +37,11 @@ interface StreamEvent {
     content?: string;
   }>;
   tool_use_id?: string;
+  // stream_event (emitted with --include-partial-messages)
+  event?: {
+    type: string;
+    delta?: { type?: string; text?: string };
+  };
 }
 
 export class ClaudeCodeAdapter extends BaseAgentAdapter {
@@ -55,6 +60,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       const args = [
         '--verbose',
         '--output-format', 'stream-json',
+        '--include-partial-messages',
       ];
 
       // Only skip permissions for non-interactive (chat platform) usage
@@ -139,16 +145,31 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         }
       };
 
+      // With --include-partial-messages, the SDK emits stream_event deltas
+      // before the final assistant event. We stream from those deltas so the
+      // UI updates token-by-token; the final assistant event then re-emits
+      // the same text in one block — skip the onStream call there to avoid
+      // double-rendering, but still record blocks (tool_use) and tally.
+      let streamedFromDeltas = false;
       const processEvent = (event: StreamEvent) => {
         this.debug(`[claude-code] Event: ${event.type} ${event.subtype || ''}`);
 
         if (event.type === 'system' && event.session_id) {
           this.sessionId = event.session_id;
+        } else if (event.type === 'stream_event' && event.event?.type === 'content_block_delta') {
+          const delta = event.event.delta;
+          if (delta?.type === 'text_delta' && delta.text) {
+            streamedText += delta.text;
+            request.onStream?.(delta.text);
+            streamedFromDeltas = true;
+          }
         } else if (event.type === 'assistant' && event.message?.content) {
           for (const block of event.message.content) {
             if (block.type === 'text' && block.text) {
-              streamedText += block.text;
-              request.onStream?.(block.text);
+              if (!streamedFromDeltas) {
+                streamedText += block.text;
+                request.onStream?.(block.text);
+              }
             } else if (block.type === 'tool_use' && block.name) {
               // Tool invocation — record it
               const toolName = block.name;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2426,6 +2426,7 @@ Example: /model gpt-4.1 write a Python script`;
     const useManager = team.dispatch === 'auto' && !opts.forceAll;
 
     if (useManager) {
+      let isFirstStep = true;
       const result = await this.runManagerLoop(
         team,
         prompt,
@@ -2438,6 +2439,10 @@ Example: /model gpt-4.1 write a Python script`;
             chatId,
             message: `Step ${step}: ${worker}${isRevision ? ' (revision)' : ''} — ${reason}`,
           });
+          const label = isRevision ? `${worker} (revision)` : worker;
+          const sep = isFirstStep ? '' : '\n\n---\n\n';
+          sink({ type: 'stream', chatId, token: `${sep}### Step ${step}: ${label}\n\n` });
+          isFirstStep = false;
         },
         runOneWorker,
       );
@@ -2487,7 +2492,10 @@ Example: /model gpt-4.1 write a Python script`;
     for (let i = 0; i < team.members.length; i++) {
       if (signal?.aborted) break;
       const memberName = team.members[i];
-      sink({ type: 'info', chatId, message: `Step ${i + 1}/${team.members.length}: ${memberName}` });
+      const stepNum = i + 1;
+      sink({ type: 'info', chatId, message: `Step ${stepNum}/${team.members.length}: ${memberName}` });
+      const sep = i === 0 ? '' : '\n\n---\n\n';
+      sink({ type: 'stream', chatId, token: `${sep}### Step ${stepNum}: ${memberName}\n\n` });
       const seqRoster = team.members.map(n => ({ name: n, hint: workerManager.getDispatchHint(n) }));
       const seqNextName = team.members[i + 1];
       const seqNextWorker = seqNextName
@@ -2504,7 +2512,7 @@ Example: /model gpt-4.1 write a Python script`;
       const modelConfig = workerModel ? this.getModelConfig(codingAgent, workerModel) : chatModel ?? this.getDefaultModelConfig(codingAgent);
       const response = await runOneWorker(memberName, stepPrompt, codingAgent, modelConfig);
       if (!response.success) {
-        parts.push(`### ${memberName}\n\n`);
+        parts.push(`### Step ${stepNum}: ${memberName}\n\n`);
         break;
       }
       const ask = parseAskUser(response.output);
@@ -2525,7 +2533,7 @@ Example: /model gpt-4.1 write a Python script`;
         sink({ type: 'stream', chatId, token: rendered6.text });
         return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + rendered6.text : rendered6.text, choices: rendered6.choices };
       }
-      parts.push(`### ${memberName}\n\n${response.output}`);
+      parts.push(`### Step ${stepNum}: ${memberName}\n\n${response.output}`);
       carry = response.output;
     }
     return { response: parts.join('\n\n---\n\n') };

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2950,9 +2950,20 @@ Example: /model gpt-4.1 write a Python script`;
     const chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
 
+    // Persisted alongside the assistant message at completion. Declared here
+    // so the sink wrapper can capture 'info' events into it (see below).
+    const toolCalls: ToolCallEntry[] = [];
+
     // Tee every sink event to the registered global listener so other surfaces
-    // (e.g., the Mac app) see channel-driven chat updates too.
+    // (e.g., the Mac app) see channel-driven chat updates too. Also capture
+    // 'info' events into the persisted toolCalls array so the right Context
+    // Panel still shows manager routing reasons after a chat reload (info
+    // events come from team-mode orchestration via direct sink calls and
+    // never go through onStatus, so they would otherwise vanish on persist).
     const sink: ChatStreamSink = (ev) => {
+      if (ev.type === 'info') {
+        toolCalls.push({ id: randomUUID(), type: 'info', message: ev.message });
+      }
       try { sinkParam(ev); } catch { /* swallow */ }
       if (this.chatEventListener) {
         try { this.chatEventListener(ev); } catch { /* swallow */ }
@@ -3012,7 +3023,6 @@ Example: /model gpt-4.1 write a Python script`;
       ? this.getModelConfig(agent, chat.model)
       : this.getDefaultModelConfig(agent);
 
-    const toolCalls: ToolCallEntry[] = [];
     let streamedText = '';
 
     const onStream = (text: string) => {


### PR DESCRIPTION
## Summary

Reworks how team-mode chats render in the Mac app and fixes several streaming bugs surfaced along the way.

**Display**
- Removes inline tool-call rendering from message bubbles — the right Context Panel already shows tool calls, no need to duplicate.
- Team messages render as one card per worker step. Each card always shows its conclusion (last paragraph); intermediate "thinking" paragraphs collapse behind a `Show thinking (N paragraphs)` toggle.
- Active step (currently streaming) gets accent border + `● running` badge and shows full output live.
- Live activity pill above the streaming bubble shows the worker's current tool call (e.g. `● Reading src/foo.ts`).
- Right Context Panel gets a new **Team flow** section: per-step status (✓ done / ● running) + worker name + manager's routing reason, with click-to-jump scrolling to the matching step card.

**Live streaming (the big one)**
- `claude-code` adapter now passes `--include-partial-messages` and handles `stream_event` deltas, so the UI gets token-level streaming instead of one chunk per assistant turn.
- Gateway emits structured `### Step N: <worker>` headers as stream tokens before each worker runs (both manager-loop and sequential paths), so step cards appear and grow live as tokens arrive.

**Bug fixes**
- IPC double-delivery: `chats:send` was wiring a per-call sink that fired alongside the global `chatEventListener`, so every event reached the renderer twice. The second `done` delivery raced past the cleared `pendingAssistantId` and refetched the chat, replacing the in-flight assistant message with the server's persisted version (different UUID) — making `selectedTurnId` point at nothing and the right Context Panel go blank. Per-call sink is now a no-op.
- `setContextPanelOpen` round-tripped through the API and dispatched `upsert` with the server's chat, which doesn't know about the client-side streaming placeholder. The streaming bubble would vanish until `done` fired. Now patches `contextPanelOpen` locally and background-syncs.
- Defensive `upsert` reducer preserves any in-flight assistant message that the server's payload doesn't include.
- Context panel always docks side-by-side now; dropped the overlay+backdrop mode that hid the chat on narrow windows.
- Manager `info` events (Step routing reasons) were sent only via sink, not pushed into the gateway's persisted toolCalls array — so they vanished on chat reload. Now captured.

## Test plan

- [ ] `npm run build` succeeds
- [ ] `cd codey-mac && npm test` — 11 parser tests pass
- [ ] `cd codey-mac && npm run dev`, then in the app:
  - [ ] Single-worker chat: streaming visibly progresses token-by-token; right panel shows tool calls live and after completion
  - [ ] `/team` chat: each worker's step card appears and grows live; conclusion visible by default after completion; "Show thinking" toggle works
  - [ ] Right panel "Team flow" section lists steps with status; clicking a step scrolls to its card
  - [ ] Toggle right panel mid-stream — streaming message stays visible, no blank panel
  - [ ] After completion, panel still shows full Tool calls / Team flow history (not just Run target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)