### PR TITLE
Global teams library, exclusive channel links, responsive layout (v0.3.6)

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -195,7 +195,15 @@ async function bootInProcessCore() {
     coreConfigManager = new ConfigManager(join(root, 'gateway.json'))
     workerManager = new WorkerManager(join(root, 'workers'))
     await workerManager.loadWorkers()
-    workspaceManager = new WorkspaceManager(workerManager, join(root, 'workspaces'))
+    // Teams are defined globally in gateway.json; the workspace just stores
+    // the names it has enabled. Inject a live provider so workspace.json edits
+    // never need to know about the global library shape.
+    workspaceManager = new WorkspaceManager(
+      workerManager,
+      join(root, 'workspaces'),
+      undefined,
+      () => coreConfigManager?.getTeams() ?? {},
+    )
     let existing = workspaceManager.listWorkspaces()
     if (existing.length === 0) {
       // Cold start (or user deleted every workspace): seed a "default"
@@ -206,7 +214,7 @@ async function bootInProcessCore() {
       fsMod.mkdirSync(defaultDir, { recursive: true })
       fsMod.writeFileSync(
         join(defaultDir, 'workspace.json'),
-        JSON.stringify({ workingDir: app.getPath('home'), teams: {} }, null, 2)
+        JSON.stringify({ workingDir: app.getPath('home'), teams: [] }, null, 2)
       )
       fsMod.writeFileSync(join(defaultDir, 'memory.md'), '# default — Project Memory\n')
       existing = workspaceManager.listWorkspaces()
@@ -329,20 +337,21 @@ app.whenReady().then(async () => {
   ipcMain.handle('workers:delete', async (_e, name: string) =>
     wrap(async () => {
       await workerManager?.deleteWorker(name)
-      // cascade: remove from all teams
-      if (workspaceManager) {
-        const teams = workspaceManager.getTeams()
+      // Cascade: remove the worker from every global team that referenced it.
+      // Teams are now defined globally, so we no longer walk per-workspace.
+      if (coreConfigManager) {
+        const teams = { ...coreConfigManager.getTeams() }
         let changed = false
-        for (const team of Object.keys(teams)) {
-          const raw = teams[team]
+        for (const teamName of Object.keys(teams)) {
+          const raw = teams[teamName]
           const arr = Array.isArray(raw) ? raw : raw.members
           const filtered = arr.filter((m: string) => m !== name)
           if (filtered.length !== arr.length) {
-            teams[team] = Array.isArray(raw) ? filtered : { ...raw, members: filtered }
+            teams[teamName] = Array.isArray(raw) ? filtered : { ...raw, members: filtered }
             changed = true
           }
         }
-        if (changed) await workspaceManager.setTeams(teams)
+        if (changed) coreConfigManager.setTeams(teams)
       }
     })
   )
@@ -434,39 +443,45 @@ app.whenReady().then(async () => {
     })
   )
 
-  // ── Teams IPC ─────────────────────────────────────────────────────
-  // Returns the raw TeamConfigRaw shape so the UI can surface dispatch mode.
+  // ── Workspace teams IPC (enabled names only) ─────────────────────
+  // Returns the names of global teams enabled for this workspace. Definitions
+  // live in `globalTeams`, not here.
   ipcMain.handle('teams:get', async (_e, name?: string) =>
     wrap(async () => {
       if (!workspaceManager) throw new Error('Workspace manager not ready')
       const target = name || workspaceManager.getCurrentWorkspace()
-      if (!target) return {} as Record<string, unknown>
+      if (!target) return [] as string[]
       const fsMod = await import('fs')
       const pathMod = await import('path')
       const configPath = pathMod.join(workspaceManager.getWorkspacesRoot(), target, 'workspace.json')
-      if (!fsMod.existsSync(configPath)) return {} as Record<string, unknown>
+      if (!fsMod.existsSync(configPath)) return [] as string[]
       const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
-      return (data.teams || {}) as Record<string, unknown>
+      if (Array.isArray(data.teams)) return data.teams.filter((n: any) => typeof n === 'string') as string[]
+      // Legacy: workspace held its own definitions. Surface its keys so the
+      // user can re-enable them once they're promoted to the global library.
+      if (data.teams && typeof data.teams === 'object') return Object.keys(data.teams)
+      return [] as string[]
     })
   )
 
-  ipcMain.handle('teams:set', async (_e, nameOrTeams: string | Record<string, unknown>, maybeTeams?: Record<string, unknown>) =>
+  ipcMain.handle('teams:set', async (_e, nameOrNames: string | string[], maybeNames?: string[]) =>
     wrap(async () => {
       if (!workspaceManager) throw new Error('Workspace manager not ready')
-      // Backward-compat: support both (teams) and (name, teams) call shapes.
+      // Accept both (names) and (workspaceName, names).
       let target: string
-      let teams: Record<string, any>
-      if (typeof nameOrTeams === 'string') {
-        target = nameOrTeams || workspaceManager.getCurrentWorkspace()
-        teams = maybeTeams || {}
+      let names: string[]
+      if (typeof nameOrNames === 'string') {
+        target = nameOrNames || workspaceManager.getCurrentWorkspace()
+        names = Array.isArray(maybeNames) ? maybeNames : []
       } else {
         target = workspaceManager.getCurrentWorkspace()
-        teams = nameOrTeams || {}
+        names = Array.isArray(nameOrNames) ? nameOrNames : []
       }
       if (!target) throw new Error('No workspace specified')
 
+      const sanitized = names.filter(n => typeof n === 'string' && n.trim().length > 0)
       if (target === workspaceManager.getCurrentWorkspace()) {
-        await workspaceManager.setTeams(teams)
+        await workspaceManager.setEnabledTeams(sanitized)
         return
       }
       const fsMod = await import('fs')
@@ -474,8 +489,25 @@ app.whenReady().then(async () => {
       const configPath = pathMod.join(workspaceManager.getWorkspacesRoot(), target, 'workspace.json')
       if (!fsMod.existsSync(configPath)) throw new Error(`Workspace "${target}" does not exist`)
       const existing = JSON.parse(await fsMod.promises.readFile(configPath, 'utf-8'))
-      existing.teams = teams
+      existing.teams = sanitized
       await fsMod.promises.writeFile(configPath, JSON.stringify(existing, null, 2), 'utf-8')
+    })
+  )
+
+  // ── Global teams IPC ──────────────────────────────────────────────
+  // The global team library: a Record<name, TeamConfigRaw>. Each workspace
+  // opts into a subset by listing names in its workspace.json `teams` array.
+  ipcMain.handle('globalTeams:get', async () =>
+    wrap(async () => coreConfigManager?.getTeams() ?? {})
+  )
+
+  ipcMain.handle('globalTeams:set', async (_e, teams: Record<string, unknown>) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      coreConfigManager.setTeams((teams ?? {}) as any)
+      // Re-resolve the active workspace so its team Map picks up library edits
+      // (e.g. members or dispatch mode changed under an enabled name).
+      try { workspaceManager?.setGlobalTeamsProvider(() => coreConfigManager!.getTeams()) } catch { /* ok */ }
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -24,8 +24,12 @@ contextBridge.exposeInMainWorld('codey', {
   },
   teams: {
     get: (name?: string) => ipcRenderer.invoke('teams:get', name),
-    set: (name: string, teams: Record<string, string[]>) =>
-      ipcRenderer.invoke('teams:set', name, teams),
+    set: (name: string, names: string[]) =>
+      ipcRenderer.invoke('teams:set', name, names),
+  },
+  globalTeams: {
+    get: () => ipcRenderer.invoke('globalTeams:get'),
+    set: (teams: Record<string, unknown>) => ipcRenderer.invoke('globalTeams:set', teams),
   },
   conversations: {
     list: () => ipcRenderer.invoke('conversations:list'),

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -36,8 +36,12 @@ declare global {
         pickDirectory: () => Promise<IpcResult<string | null>>
       }
       teams: {
-        get: (name?: string) => Promise<IpcResult<Record<string, TeamConfigRaw>>>
-        set: (name: string, teams: Record<string, TeamConfigRaw>) => Promise<IpcResult<void>>
+        get: (name?: string) => Promise<IpcResult<string[]>>
+        set: (name: string, names: string[]) => Promise<IpcResult<void>>
+      }
+      globalTeams: {
+        get: () => Promise<IpcResult<Record<string, TeamConfigRaw>>>
+        set: (teams: Record<string, TeamConfigRaw>) => Promise<IpcResult<void>>
       }
       conversations: {
         list: () => Promise<IpcResult<string[]>>

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -18,6 +18,14 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
   const [gatewayWorkspace, setGatewayWorkspace] = useState<string>('')
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
+  // Shrink the panel on narrow windows so the conversation column keeps
+  // breathing room. Matches the threshold used in ChatTab for the context panel.
+  const [narrow, setNarrow] = useState<boolean>(() => window.innerWidth < 600)
+  useEffect(() => {
+    const onResize = () => setNarrow(window.innerWidth < 600)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -85,7 +93,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
   const groupNames = Object.keys(groups).sort()
 
   return (
-    <div style={styles.root}>
+    <div style={{ ...styles.root, width: narrow ? 180 : 240 }}>
       <div style={styles.header}>
         <button
           style={styles.newBtn}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -239,7 +239,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   }, [])
   useEffect(() => {
     if (!chat?.workspaceName) return
-    apiService.getTeams(chat.workspaceName).then(t => setTeamNames(Object.keys(t))).catch(() => setTeamNames([]))
+    apiService.getTeams(chat.workspaceName).then(names => setTeamNames(names)).catch(() => setTeamNames([]))
   }, [chat?.workspaceName])
   const [workingDir, setWorkingDir] = useState<string | undefined>(undefined)
   useEffect(() => {
@@ -286,6 +286,15 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     return () => window.removeEventListener('keydown', handler)
   }, [flight, chatId])
   useEffect(() => { localStorage.setItem('codey.contextPanelWidth', String(panelWidth)) }, [panelWidth])
+  // Track window width so the context panel can shrink (or be hidden) when
+  // the user resizes Codey down — at small widths the middle column was
+  // collapsing to ~200px and wrapping CJK characters one per line.
+  const [windowWidth, setWindowWidth] = useState<number>(() => window.innerWidth)
+  useEffect(() => {
+    const onResize = () => setWindowWidth(window.innerWidth)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
   useEffect(() => {
     setFollowLatest(true)
     setSelectedTurnIdState(null)
@@ -820,7 +829,19 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
         <PairingModal channel={pairingModal} onClose={() => setPairingModal(null)} />
       )}
       </div>
-      {panelOpen && (
+      {/* The context panel only renders when there's room for both the chat
+          list (~180-240px) AND a usable conversation column (>= MIN_MIDDLE).
+          On very narrow windows we hide it entirely so the conversation
+          doesn't get squeezed to a single character per line. */}
+      {(() => {
+        if (!panelOpen) return null
+        const CHAT_LIST_W = windowWidth < 600 ? 180 : 240
+        const MIN_MIDDLE = 360
+        const MIN_PANEL = 260
+        const available = windowWidth - CHAT_LIST_W - MIN_MIDDLE
+        if (available < MIN_PANEL) return null
+        const effectiveWidth = Math.min(panelWidth, available)
+        return (
         <ChatContextPanel
           chat={chat}
           selectedTurnId={selectedTurnId}
@@ -831,7 +852,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
           workerName={panelWorkerName}
           teamName={panelTeamName}
           workingDir={workingDir}
-          width={Math.min(panelWidth, Math.max(240, Math.floor(window.innerWidth * 0.5)))}
+          width={effectiveWidth}
           onFollowLatest={() => setFollowLatest(true)}
           onClose={() => setContextPanelOpen(chat.id, false)}
           onResize={setPanelWidth}
@@ -841,7 +862,8 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
           }}
           isTurnStreaming={!!flight && selectedTurnId === lastMsg?.id}
         />
-      )}
+        )
+      })()}
     </div>
   )
 }

--- a/codey-mac/src/components/GlobalTeamsSection.tsx
+++ b/codey-mac/src/components/GlobalTeamsSection.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { apiService, WorkerDto } from '../services/api'
+import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
+import { C } from '../theme'
+
+// Mirrors TeamsSection's editor, but operates on the global team library
+// stored in gateway.json. Workspaces opt into these teams by name.
+
+type DispatchMode = 'all' | 'auto'
+interface TeamState { members: string[]; dispatch: DispatchMode }
+type TeamsState = Record<string, TeamState>
+
+function fromRaw(raw: TeamConfigRaw): TeamState {
+  if (Array.isArray(raw)) return { members: raw, dispatch: 'all' }
+  const dispatch: DispatchMode = raw?.dispatch === 'auto' ? 'auto' : 'all'
+  return { members: Array.isArray(raw?.members) ? raw.members : [], dispatch }
+}
+
+function toRaw(t: TeamState): TeamConfigRaw {
+  return t.dispatch === 'all' ? t.members : { members: t.members, dispatch: 'auto' }
+}
+
+function normalizeAll(raw: Record<string, TeamConfigRaw>): TeamsState {
+  const out: TeamsState = {}
+  for (const [k, v] of Object.entries(raw)) out[k] = fromRaw(v)
+  return out
+}
+
+function denormalizeAll(state: TeamsState): Record<string, TeamConfigRaw> {
+  const out: Record<string, TeamConfigRaw> = {}
+  for (const [k, v] of Object.entries(state)) out[k] = toRaw(v)
+  return out
+}
+
+export default function GlobalTeamsSection() {
+  const [teams, setTeams] = useState<TeamsState>({})
+  const [workers, setWorkers] = useState<WorkerDto[]>([])
+  const [savedAt, setSavedAt] = useState<number>(0)
+  const [error, setError] = useState<string | null>(null)
+  const saveTimer = useRef<number | null>(null)
+  const [dispatcherConfigured, setDispatcherConfigured] = useState(false)
+
+  const reload = useCallback(async () => {
+    setTeams(normalizeAll(await apiService.getGlobalTeams()))
+    setWorkers(await apiService.listWorkers())
+    const r = await window.codey.dispatcher.get()
+    if (r.ok) setDispatcherConfigured(!!(r.data.agent || r.data.model))
+  }, [])
+
+  useEffect(() => { reload() }, [reload])
+
+  const queueSave = (next: TeamsState) => {
+    setTeams(next); setError(null)
+    if (saveTimer.current) window.clearTimeout(saveTimer.current)
+    saveTimer.current = window.setTimeout(async () => {
+      try { await apiService.setGlobalTeams(denormalizeAll(next)); setSavedAt(Date.now()) }
+      catch (err: any) { setError(err.message || String(err)) }
+    }, 400)
+  }
+
+  const addTeam = () => {
+    let i = 1; while (teams[`team${i}`]) i++
+    queueSave({ ...teams, [`team${i}`]: { members: [], dispatch: 'all' } })
+  }
+  const renameTeam = (oldName: string, newName: string) => {
+    if (!newName || oldName === newName || teams[newName]) return
+    const next: TeamsState = {}
+    for (const [k, v] of Object.entries(teams)) next[k === oldName ? newName : k] = v
+    queueSave(next)
+  }
+  const removeTeam = (name: string) => {
+    const next = { ...teams }; delete next[name]; queueSave(next)
+  }
+  const setDispatch = (name: string, dispatch: DispatchMode) => {
+    queueSave({ ...teams, [name]: { ...teams[name], dispatch } })
+  }
+  const addMember = (team: string, member: string) => {
+    if (teams[team].members.includes(member)) return
+    queueSave({ ...teams, [team]: { ...teams[team], members: [...teams[team].members, member] } })
+  }
+  const removeMember = (team: string, idx: number) => {
+    queueSave({ ...teams, [team]: { ...teams[team], members: teams[team].members.filter((_, i) => i !== idx) } })
+  }
+  const reorderMember = (team: string, from: number, to: number) => {
+    if (from === to || from < 0 || to < 0) return
+    const members = [...teams[team].members]
+    if (from >= members.length || to >= members.length) return
+    const [moved] = members.splice(from, 1)
+    members.splice(to, 0, moved)
+    queueSave({ ...teams, [team]: { ...teams[team], members } })
+  }
+  const [drag, setDrag] = useState<{ team: string; idx: number } | null>(null)
+  const [dragOver, setDragOver] = useState<{ team: string; idx: number } | null>(null)
+  const [creatingFor, setCreatingFor] = useState<string | null>(null)
+  const [createPrompt, setCreatePrompt] = useState('')
+  const [createBusy, setCreateBusy] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  const submitCreate = async () => {
+    if (!creatingFor || !createPrompt.trim() || createBusy) return
+    setCreateBusy(true); setCreateError(null)
+    try {
+      const worker = await apiService.generateWorker(createPrompt)
+      const team = creatingFor
+      const next: TeamsState = { ...teams, [team]: { ...teams[team], members: [...teams[team].members, worker.name] } }
+      setWorkers(await apiService.listWorkers())
+      queueSave(next)
+      setCreatingFor(null); setCreatePrompt('')
+    } catch (err: any) {
+      setCreateError(err.message || String(err))
+    } finally {
+      setCreateBusy(false)
+    }
+  }
+
+  const available = (team: string) => workers.filter(w => !teams[team].members.includes(w.name))
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
+        Teams defined here are available to every workspace. Each workspace opts in by enabling the names it wants under Workspaces &rarr; Teams.
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 12, marginBottom: 8 }}>
+        {savedAt > 0 && Date.now() - savedAt < 2000 && <span style={{ fontSize: 11, color: C.green }}>✓ Saved</span>}
+        <button onClick={addTeam} style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.accent, border: `1px solid ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>+ New team</button>
+      </div>
+      {error && <div style={{ background: C.dangerBg, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{error}</div>}
+      {Object.keys(teams).length === 0 && <div style={{ fontSize: 12, color: C.fg3 }}>No teams yet. Click &quot;+ New team&quot;.</div>}
+      {Object.entries(teams).map(([name, team]) => (
+        <div key={name} style={{ marginBottom: 12, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+            <input defaultValue={name} onBlur={e => renameTeam(name, e.target.value.trim())}
+              style={{ flex: 1, background: 'transparent', color: C.fg, border: 'none', fontSize: 14, fontWeight: 600 }} />
+            <select
+              value={team.dispatch}
+              onChange={e => setDispatch(name, e.target.value as DispatchMode)}
+              title={dispatcherConfigured
+                ? 'Sequential: members run in order, output passed forward. Auto: a dispatcher picks the relevant subset.'
+                : 'Configure a dispatcher in Settings → Dispatcher (Auto Mode) to enable Auto.'}
+              style={{
+                background: C.surface2, color: C.fg, border: `1px solid ${C.border}`,
+                borderRadius: 6, padding: '3px 8px', fontSize: 11, cursor: 'pointer',
+              }}
+            >
+              <option value="all">Sequential</option>
+              <option value="auto" disabled={!dispatcherConfigured && team.dispatch !== 'auto'}>
+                Auto{!dispatcherConfigured ? ' (configure dispatcher first)' : ''}
+              </option>
+              <option value="parallel" disabled>Parallel (coming soon)</option>
+            </select>
+            <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: C.dangerFg, border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+            {team.members.map((m, i) => {
+              const isDragging = drag?.team === name && drag.idx === i
+              const isOver = dragOver?.team === name && dragOver.idx === i && !isDragging
+              return (
+                <span
+                  key={`${m}-${i}`}
+                  draggable
+                  onDragStart={e => { setDrag({ team: name, idx: i }); e.dataTransfer.effectAllowed = 'move' }}
+                  onDragOver={e => {
+                    if (drag?.team !== name) return
+                    e.preventDefault(); e.dataTransfer.dropEffect = 'move'
+                    if (dragOver?.team !== name || dragOver.idx !== i) setDragOver({ team: name, idx: i })
+                  }}
+                  onDrop={e => {
+                    e.preventDefault()
+                    if (drag?.team === name) reorderMember(name, drag.idx, i)
+                    setDrag(null); setDragOver(null)
+                  }}
+                  onDragEnd={() => { setDrag(null); setDragOver(null) }}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 4, padding: '4px 8px',
+                    background: C.surface2, borderRadius: 14, fontSize: 12,
+                    cursor: 'grab', opacity: isDragging ? 0.4 : 1,
+                    border: isOver ? `1px solid ${C.accent}` : '1px solid transparent',
+                  }}
+                >
+                  <span style={{ color: C.fg3, cursor: 'grab' }}>⋮⋮</span>
+                  {m}
+                  <button onClick={() => removeMember(name, i)} style={{ background: 'transparent', color: C.fg3, border: 'none', cursor: 'pointer', padding: 0 }}>×</button>
+                </span>
+              )
+            })}
+            <select value="" onChange={e => {
+                const v = e.target.value
+                if (!v) return
+                if (v === '__create__') { setCreatingFor(name); setCreatePrompt(''); setCreateError(null) }
+                else addMember(name, v)
+                e.target.value = ''
+              }}
+              style={{ background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, padding: '4px 8px', fontSize: 12 }}>
+              <option value="">+ add worker</option>
+              {available(name).map(w => <option key={w.name} value={w.name}>{w.name}</option>)}
+              <option value="__create__">+ Create new worker…</option>
+            </select>
+          </div>
+        </div>
+      ))}
+      {creatingFor && (
+        <div onClick={() => !createBusy && setCreatingFor(null)}
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
+          <div onClick={e => e.stopPropagation()}
+            style={{ width: 520, padding: 20, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8 }}>
+            <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 6 }}>New worker for "{creatingFor}"</div>
+            <div style={{ fontSize: 12, color: C.fg3, marginBottom: 10 }}>The active coding agent will generate a personality and config from your description.</div>
+            {createError && <div style={{ background: C.dangerBg, border: `1px solid ${C.dangerBorder}`, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{createError}</div>}
+            <textarea value={createPrompt} onChange={e => setCreatePrompt(e.target.value)} disabled={createBusy}
+              placeholder="e.g. A reviewer that audits PRs for security issues, leans on Opus."
+              style={{ width: '100%', minHeight: 120, padding: 10, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, fontFamily: 'inherit', fontSize: 13, resize: 'vertical' }} />
+            <div style={{ marginTop: 12, display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button onClick={() => setCreatingFor(null)} disabled={createBusy}
+                style={{ padding: '6px 14px', background: 'transparent', color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, cursor: 'pointer', fontSize: 12 }}>Cancel</button>
+              <button onClick={submitCreate} disabled={createBusy || !createPrompt.trim()}
+                style={{ padding: '6px 14px', background: createBusy ? C.fg3 : C.accent, color: 'white', border: 'none', borderRadius: 6, cursor: createBusy ? 'wait' : 'pointer', fontSize: 12, fontWeight: 600 }}>
+                {createBusy ? 'Generating…' : 'Create & Add'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -3,16 +3,18 @@ import { StatusTab } from './StatusTab'
 import { SettingsTab } from './SettingsTab'
 import { WorkspacesTab } from './WorkspacesTab'
 import WorkersTab from './WorkersTab'
+import { TeamsTab } from './TeamsTab'
 import { useGateway } from '../hooks/useGateway'
 import { C } from '../theme'
 import { AppearanceTab } from './AppearanceTab'
 
-type Tab = 'general' | 'workers' | 'workspaces' | 'status' | 'settings'
+type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
   { key: 'general',    label: 'General',    icon: '⚙', description: 'Theme & visual options' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
-  { key: 'workers',    label: 'Workers',    icon: '☰', description: 'Personalities & teams' },
+  { key: 'workers',    label: 'Workers',    icon: '☰', description: 'Personalities' },
+  { key: 'teams',      label: 'Teams',      icon: '⚉', description: 'Shared team library' },
   { key: 'status',     label: 'Gateway',    icon: '◉', description: 'Server status & logs' },
 ]
 
@@ -70,6 +72,7 @@ export const SettingsOverlay: React.FC<Props> = ({ onClose }) => {
               {tab === 'status'     && <StatusTab status={status} logs={logs} isRunning={isRunning} />}
               {tab === 'workspaces' && <WorkspacesTab isGatewayRunning={isRunning} />}
               {tab === 'workers'    && <WorkersTab />}
+              {tab === 'teams'      && <TeamsTab />}
               {tab === 'settings'   && <SettingsTab isGatewayRunning={isRunning} />}
             </div>
           </main>

--- a/codey-mac/src/components/TeamsSection.tsx
+++ b/codey-mac/src/components/TeamsSection.tsx
@@ -1,221 +1,118 @@
-import { useEffect, useState, useCallback, useRef } from 'react'
-import { apiService, WorkerDto } from '../services/api'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { apiService } from '../services/api'
 import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
 import { C } from '../theme'
 
-type DispatchMode = 'all' | 'auto'
-interface TeamState { members: string[]; dispatch: DispatchMode }
-type TeamsState = Record<string, TeamState>
+// Per-workspace teams editor. Teams are defined globally in Settings →
+// Teams; this component just toggles which of those names are enabled for
+// the workspace. Definitions (members, dispatch mode) are read-only here.
 
-function fromRaw(raw: TeamConfigRaw): TeamState {
-  if (Array.isArray(raw)) return { members: raw, dispatch: 'all' }
-  const dispatch: DispatchMode = raw?.dispatch === 'auto' ? 'auto' : 'all'
-  return { members: Array.isArray(raw?.members) ? raw.members : [], dispatch }
+interface TeamSummary {
+  name: string
+  members: string[]
+  dispatch: 'all' | 'auto'
 }
 
-function toRaw(t: TeamState): TeamConfigRaw {
-  return t.dispatch === 'all' ? t.members : { members: t.members, dispatch: 'auto' }
-}
-
-function normalizeAll(raw: Record<string, TeamConfigRaw>): TeamsState {
-  const out: TeamsState = {}
-  for (const [k, v] of Object.entries(raw)) out[k] = fromRaw(v)
-  return out
-}
-
-function denormalizeAll(state: TeamsState): Record<string, TeamConfigRaw> {
-  const out: Record<string, TeamConfigRaw> = {}
-  for (const [k, v] of Object.entries(state)) out[k] = toRaw(v)
-  return out
+function summarize(raw: Record<string, TeamConfigRaw>): TeamSummary[] {
+  return Object.entries(raw).map(([name, v]) => {
+    if (Array.isArray(v)) return { name, members: v, dispatch: 'all' as const }
+    const members = Array.isArray(v?.members) ? v.members : []
+    const dispatch: 'all' | 'auto' = v?.dispatch === 'auto' ? 'auto' : 'all'
+    return { name, members, dispatch }
+  })
 }
 
 export default function TeamsSection({ workspace }: { workspace: string }) {
-  const [teams, setTeams] = useState<TeamsState>({})
-  const [workers, setWorkers] = useState<WorkerDto[]>([])
-  const [savedAt, setSavedAt] = useState<number>(0)
+  const [library, setLibrary] = useState<TeamSummary[]>([])
+  const [enabled, setEnabled] = useState<Set<string>>(new Set())
+  const [savedAt, setSavedAt] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const saveTimer = useRef<number | null>(null)
 
-  const [dispatcherConfigured, setDispatcherConfigured] = useState(false)
-
   const reload = useCallback(async () => {
-    setTeams(normalizeAll(await apiService.getTeams(workspace)))
-    setWorkers(await apiService.listWorkers())
-    const r = await window.codey.dispatcher.get()
-    if (r.ok) setDispatcherConfigured(!!(r.data.agent || r.data.model))
+    const [lib, names] = await Promise.all([
+      apiService.getGlobalTeams(),
+      apiService.getTeams(workspace),
+    ])
+    setLibrary(summarize(lib))
+    setEnabled(new Set(names))
   }, [workspace])
 
   useEffect(() => { reload() }, [reload])
 
-  const queueSave = (next: TeamsState) => {
-    setTeams(next); setError(null)
+  const queueSave = (next: Set<string>) => {
+    setEnabled(next); setError(null)
     if (saveTimer.current) window.clearTimeout(saveTimer.current)
     saveTimer.current = window.setTimeout(async () => {
-      try { await apiService.setTeams(workspace, denormalizeAll(next)); setSavedAt(Date.now()) }
-      catch (err: any) { setError(err.unknown ? `Unknown workers: ${err.unknown.join(', ')}` : err.message) }
-    }, 400)
+      try { await apiService.setTeams(workspace, [...next]); setSavedAt(Date.now()) }
+      catch (err: any) { setError(err.message || String(err)) }
+    }, 300)
   }
 
-  const addTeam = () => {
-    let i = 1; while (teams[`team${i}`]) i++
-    queueSave({ ...teams, [`team${i}`]: { members: [], dispatch: 'all' } })
-  }
-  const renameTeam = (oldName: string, newName: string) => {
-    if (!newName || oldName === newName || teams[newName]) return
-    const next: TeamsState = {}
-    for (const [k, v] of Object.entries(teams)) next[k === oldName ? newName : k] = v
+  const toggle = (name: string) => {
+    const next = new Set(enabled)
+    if (next.has(name)) next.delete(name); else next.add(name)
     queueSave(next)
   }
-  const removeTeam = (name: string) => {
-    const next = { ...teams }; delete next[name]; queueSave(next)
-  }
-  const setDispatch = (name: string, dispatch: DispatchMode) => {
-    queueSave({ ...teams, [name]: { ...teams[name], dispatch } })
-  }
-  const addMember = (team: string, member: string) => {
-    if (teams[team].members.includes(member)) return
-    queueSave({ ...teams, [team]: { ...teams[team], members: [...teams[team].members, member] } })
-  }
-  const removeMember = (team: string, idx: number) => {
-    queueSave({ ...teams, [team]: { ...teams[team], members: teams[team].members.filter((_, i) => i !== idx) } })
-  }
-  const reorderMember = (team: string, from: number, to: number) => {
-    if (from === to || from < 0 || to < 0) return
-    const members = [...teams[team].members]
-    if (from >= members.length || to >= members.length) return
-    const [moved] = members.splice(from, 1)
-    members.splice(to, 0, moved)
-    queueSave({ ...teams, [team]: { ...teams[team], members } })
-  }
-  const [drag, setDrag] = useState<{ team: string; idx: number } | null>(null)
-  const [dragOver, setDragOver] = useState<{ team: string; idx: number } | null>(null)
-  const [creatingFor, setCreatingFor] = useState<string | null>(null)
-  const [createPrompt, setCreatePrompt] = useState('')
-  const [createBusy, setCreateBusy] = useState(false)
-  const [createError, setCreateError] = useState<string | null>(null)
 
-  const submitCreate = async () => {
-    if (!creatingFor || !createPrompt.trim() || createBusy) return
-    setCreateBusy(true); setCreateError(null)
-    try {
-      const worker = await apiService.generateWorker(createPrompt)
-      const team = creatingFor
-      const next: TeamsState = { ...teams, [team]: { ...teams[team], members: [...teams[team].members, worker.name] } }
-      setWorkers(await apiService.listWorkers())
-      queueSave(next)
-      setCreatingFor(null); setCreatePrompt('')
-    } catch (err: any) {
-      setCreateError(err.message || String(err))
-    } finally {
-      setCreateBusy(false)
-    }
-  }
-
-  const available = (team: string) => workers.filter(w => !teams[team].members.includes(w.name))
+  // Names enabled here but no longer present in the global library — surface
+  // them so the user knows why a previously-working team disappeared.
+  const orphans = useMemo(() => {
+    const libNames = new Set(library.map(t => t.name))
+    return [...enabled].filter(n => !libNames.has(n))
+  }, [enabled, library])
 
   return (
     <div style={{ marginTop: 24, padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
         <div style={{ fontSize: 14, fontWeight: 600 }}>Teams</div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-          {savedAt > 0 && Date.now() - savedAt < 2000 && <span style={{ fontSize: 11, color: C.green }}>✓ Saved</span>}
-          <button onClick={addTeam} style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.accent, border: `1px solid ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>+ New team</button>
-        </div>
+        {savedAt > 0 && Date.now() - savedAt < 2000 && <span style={{ fontSize: 11, color: C.green }}>✓ Saved</span>}
+      </div>
+      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 10 }}>
+        Pick which global teams to enable for this workspace. Edit definitions under Settings → Teams.
       </div>
       {error && <div style={{ background: C.dangerBg, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{error}</div>}
-      {Object.keys(teams).length === 0 && <div style={{ fontSize: 12, color: C.fg3 }}>No teams yet. Click &quot;+ New team&quot;.</div>}
-      {Object.entries(teams).map(([name, team]) => (
-        <div key={name} style={{ marginBottom: 12, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-            <input defaultValue={name} onBlur={e => renameTeam(name, e.target.value.trim())}
-              style={{ flex: 1, background: 'transparent', color: C.fg, border: 'none', fontSize: 14, fontWeight: 600 }} />
-            <select
-              value={team.dispatch}
-              onChange={e => setDispatch(name, e.target.value as DispatchMode)}
-              title={dispatcherConfigured
-                ? 'Sequential: members run in order, output passed forward. Auto: a dispatcher picks the relevant subset.'
-                : 'Configure a dispatcher in Settings → Dispatcher (Auto Mode) to enable Auto.'}
-              style={{
-                background: C.surface2, color: C.fg, border: `1px solid ${C.border}`,
-                borderRadius: 6, padding: '3px 8px', fontSize: 11, cursor: 'pointer',
-              }}
-            >
-              <option value="all">Sequential</option>
-              <option value="auto" disabled={!dispatcherConfigured && team.dispatch !== 'auto'}>
-                Auto{!dispatcherConfigured ? ' (configure dispatcher first)' : ''}
-              </option>
-              <option value="parallel" disabled>Parallel (coming soon)</option>
-            </select>
-            <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: C.dangerFg, border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
-          </div>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
-            {team.members.map((m, i) => {
-              const isDragging = drag?.team === name && drag.idx === i
-              const isOver = dragOver?.team === name && dragOver.idx === i && !isDragging
-              return (
-                <span
-                  key={`${m}-${i}`}
-                  draggable
-                  onDragStart={e => { setDrag({ team: name, idx: i }); e.dataTransfer.effectAllowed = 'move' }}
-                  onDragOver={e => {
-                    if (drag?.team !== name) return
-                    e.preventDefault(); e.dataTransfer.dropEffect = 'move'
-                    if (dragOver?.team !== name || dragOver.idx !== i) setDragOver({ team: name, idx: i })
-                  }}
-                  onDrop={e => {
-                    e.preventDefault()
-                    if (drag?.team === name) reorderMember(name, drag.idx, i)
-                    setDrag(null); setDragOver(null)
-                  }}
-                  onDragEnd={() => { setDrag(null); setDragOver(null) }}
-                  style={{
-                    display: 'inline-flex', alignItems: 'center', gap: 4, padding: '4px 8px',
-                    background: C.surface2, borderRadius: 14, fontSize: 12,
-                    cursor: 'grab', opacity: isDragging ? 0.4 : 1,
-                    border: isOver ? `1px solid ${C.accent}` : '1px solid transparent',
-                  }}
-                >
-                  <span style={{ color: C.fg3, cursor: 'grab' }}>⋮⋮</span>
-                  {m}
-                  <button onClick={() => removeMember(name, i)} style={{ background: 'transparent', color: C.fg3, border: 'none', cursor: 'pointer', padding: 0 }}>×</button>
-                </span>
-              )
-            })}
-            <select value="" onChange={e => {
-                const v = e.target.value
-                if (!v) return
-                if (v === '__create__') { setCreatingFor(name); setCreatePrompt(''); setCreateError(null) }
-                else addMember(name, v)
-                e.target.value = ''
-              }}
-              style={{ background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, padding: '4px 8px', fontSize: 12 }}>
-              <option value="">+ add worker</option>
-              {available(name).map(w => <option key={w.name} value={w.name}>{w.name}</option>)}
-              <option value="__create__">+ Create new worker…</option>
-            </select>
-          </div>
+      {library.length === 0 && (
+        <div style={{ fontSize: 12, color: C.fg3 }}>
+          No global teams defined yet. Go to Settings → Teams to create one.
         </div>
-      ))}
-      {creatingFor && (
-        <div onClick={() => !createBusy && setCreatingFor(null)}
-          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
-          <div onClick={e => e.stopPropagation()}
-            style={{ width: 520, padding: 20, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8 }}>
-            <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 6 }}>New worker for "{creatingFor}"</div>
-            <div style={{ fontSize: 12, color: C.fg3, marginBottom: 10 }}>The active coding agent will generate a personality and config from your description.</div>
-            {createError && <div style={{ background: C.dangerBg, border: `1px solid ${C.dangerBorder}`, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{createError}</div>}
-            <textarea value={createPrompt} onChange={e => setCreatePrompt(e.target.value)} disabled={createBusy}
-              placeholder="e.g. A reviewer that audits PRs for security issues, leans on Opus."
-              style={{ width: '100%', minHeight: 120, padding: 10, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, fontFamily: 'inherit', fontSize: 13, resize: 'vertical' }} />
-            <div style={{ marginTop: 12, display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-              <button onClick={() => setCreatingFor(null)} disabled={createBusy}
-                style={{ padding: '6px 14px', background: 'transparent', color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, cursor: 'pointer', fontSize: 12 }}>Cancel</button>
-              <button onClick={submitCreate} disabled={createBusy || !createPrompt.trim()}
-                style={{ padding: '6px 14px', background: createBusy ? C.fg3 : C.accent, color: 'white', border: 'none', borderRadius: 6, cursor: createBusy ? 'wait' : 'pointer', fontSize: 12, fontWeight: 600 }}>
-                {createBusy ? 'Generating…' : 'Create & Add'}
-              </button>
+      )}
+      {library.map(t => {
+        const on = enabled.has(t.name)
+        return (
+          <label key={t.name}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 10,
+              padding: '8px 10px', marginBottom: 6,
+              background: C.bg, border: `1px solid ${on ? C.accent : C.border}`,
+              borderRadius: 6, cursor: 'pointer',
+            }}>
+            <input type="checkbox" checked={on} onChange={() => toggle(t.name)} style={{ cursor: 'pointer' }} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 600 }}>
+                {t.name}
+                <span style={{ marginLeft: 8, color: C.fg3, fontWeight: 400, fontSize: 11 }}>
+                  {t.dispatch === 'auto' ? '[auto]' : '[sequential]'}
+                </span>
+              </div>
+              <div style={{ fontSize: 11, color: C.fg3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {t.members.length === 0 ? 'no members' : t.members.join(' → ')}
+              </div>
             </div>
-          </div>
+          </label>
+        )
+      })}
+      {orphans.length > 0 && (
+        <div style={{ marginTop: 10, padding: 8, background: C.dangerBg, color: C.dangerFg, borderRadius: 6, fontSize: 12 }}>
+          Enabled team{orphans.length > 1 ? 's' : ''} missing from the global library: {orphans.join(', ')}.
+          <button onClick={() => {
+              const next = new Set(enabled)
+              for (const n of orphans) next.delete(n)
+              queueSave(next)
+            }}
+            style={{ marginLeft: 8, background: 'transparent', color: C.dangerFg, border: `1px solid ${C.dangerBorder}`, borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontSize: 11 }}>
+            Remove
+          </button>
         </div>
       )}
     </div>

--- a/codey-mac/src/components/TeamsTab.tsx
+++ b/codey-mac/src/components/TeamsTab.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import GlobalTeamsSection from './GlobalTeamsSection'
+
+export const TeamsTab: React.FC = () => {
+  return (
+    <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
+      <GlobalTeamsSection />
+    </div>
+  )
+}

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -84,12 +84,19 @@ export const apiService = {
     try { await window.codey.revealInFolder(absPath) } catch { /* silent no-op */ }
   },
 
-  // Teams
-  getTeams: async (workspace?: string): Promise<Record<string, TeamConfigRaw>> =>
+  // Workspace teams — the names of global teams enabled for this workspace.
+  getTeams: async (workspace?: string): Promise<string[]> =>
     unwrap(await window.codey.teams.get(workspace)),
 
-  setTeams: async (workspace: string, teams: Record<string, TeamConfigRaw>): Promise<void> =>
-    unwrap(await window.codey.teams.set(workspace, teams)),
+  setTeams: async (workspace: string, names: string[]): Promise<void> =>
+    unwrap(await window.codey.teams.set(workspace, names)),
+
+  // Global team library — defined once, opted into per workspace.
+  getGlobalTeams: async (): Promise<Record<string, TeamConfigRaw>> =>
+    unwrap(await window.codey.globalTeams.get()),
+
+  setGlobalTeams: async (teams: Record<string, TeamConfigRaw>): Promise<void> =>
+    unwrap(await window.codey.globalTeams.set(teams)),
 
   // Chat — gateway is in-process; streaming comes via chat:token IPC events
   sendMessage: async (

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -23,8 +23,19 @@ export interface TeamConfig {
 
 export interface WorkspaceJson {
   workingDir: string;
-  teams?: Record<string, TeamConfigRaw>;
+  /**
+   * Names of global teams enabled for this workspace. Definitions live in the
+   * gateway-level team library; this is just the opt-in list.
+   *
+   * Legacy: an older `Record<string, TeamConfigRaw>` value is still accepted
+   * on read — its keys are treated as the enabled-name list, and the values
+   * are ignored (the global library is the source of truth).
+   */
+  teams?: string[] | Record<string, TeamConfigRaw>;
 }
+
+/** Returns the global team library. Injected so core stays independent of gateway config storage. */
+export type GlobalTeamsProvider = () => Record<string, TeamConfigRaw>;
 
 export class WorkspaceManager {
   private workspacesDir: string;
@@ -33,13 +44,28 @@ export class WorkspaceManager {
   private workerManager: WorkerManager;
   private memoryStore: MemoryStore;
   private teams: Map<string, TeamConfig> = new Map();
+  private enabledTeamNames: string[] = [];
+  private globalTeamsProvider: GlobalTeamsProvider;
   private logger: CoreLogger;
 
-  constructor(workerManager: WorkerManager, workspacesDir: string = './workspaces', logger?: CoreLogger) {
+  constructor(
+    workerManager: WorkerManager,
+    workspacesDir: string = './workspaces',
+    logger?: CoreLogger,
+    globalTeamsProvider?: GlobalTeamsProvider,
+  ) {
     this.workspacesDir = workspacesDir;
     this.workerManager = workerManager;
     this.memoryStore = new MemoryStore(this.getWorkspacePath());
     this.logger = logger || defaultLogger;
+    this.globalTeamsProvider = globalTeamsProvider || (() => ({}));
+  }
+
+  /** Swap the global teams provider after construction (e.g. once the gateway ConfigManager is wired up). */
+  setGlobalTeamsProvider(provider: GlobalTeamsProvider): void {
+    this.globalTeamsProvider = provider;
+    // Re-resolve so the current workspace immediately sees the live library.
+    this.resolveTeamsFromGlobal();
   }
 
   private getWorkspacePath(): string {
@@ -86,14 +112,18 @@ export class WorkspaceManager {
       this.logger.info(`[Workspace] No config found for ${this.currentWorkspace}, using defaults`);
     }
 
-    // Parse + validate teams against the global worker library. Accept legacy
-    // string[] form (= dispatch:'all') and the object form { members, dispatch }.
-    this.teams.clear();
-    const rawTeams = this.config?.teams || {};
-    for (const [teamName, raw] of Object.entries(rawTeams)) {
-      const normalized = this.normalizeTeam(teamName, raw);
-      if (normalized) this.teams.set(teamName, normalized);
+    // Workspace.teams is now a `string[]` of enabled team names; definitions
+    // come from the global library. Accept legacy `Record<...>` shape by
+    // using its keys as the enabled names — old workspaces keep working.
+    const rawTeamsField = this.config?.teams;
+    if (Array.isArray(rawTeamsField)) {
+      this.enabledTeamNames = rawTeamsField.filter(n => typeof n === 'string' && n.trim().length > 0);
+    } else if (rawTeamsField && typeof rawTeamsField === 'object') {
+      this.enabledTeamNames = Object.keys(rawTeamsField);
+    } else {
+      this.enabledTeamNames = [];
     }
+    this.resolveTeamsFromGlobal();
 
     if (!fs.existsSync(this.getMemoryPath())) {
       fs.writeFileSync(this.getMemoryPath(), `# ${this.currentWorkspace} — Project Memory\n`);
@@ -104,6 +134,21 @@ export class WorkspaceManager {
 
     this.memoryStore = new MemoryStore(workspacePath);
     await this.memoryStore.load();
+  }
+
+  /** Repopulate the in-memory team map from `enabledTeamNames` ∩ global library. */
+  private resolveTeamsFromGlobal(): void {
+    this.teams.clear();
+    const lib = this.globalTeamsProvider() || {};
+    for (const name of this.enabledTeamNames) {
+      const raw = lib[name];
+      if (raw === undefined) {
+        this.logger.warn(`[Workspace] Team "${name}" enabled on workspace but not defined in global library — skipping`);
+        continue;
+      }
+      const normalized = this.normalizeTeam(name, raw);
+      if (normalized) this.teams.set(name, normalized);
+    }
   }
 
   private normalizeTeam(name: string, raw: TeamConfigRaw): TeamConfig | null {
@@ -248,24 +293,28 @@ export class WorkspaceManager {
       .join('\n');
   }
 
-  async setTeams(teams: Record<string, TeamConfigRaw>): Promise<void> {
-    this.teams.clear();
-    for (const [name, raw] of Object.entries(teams)) {
-      const normalized = this.normalizeTeam(name, raw);
-      if (normalized) this.teams.set(name, normalized);
-    }
+  /**
+   * Replace the workspace's enabled-team list. Definitions are not stored here
+   * — they live in the global team library and are resolved on read.
+   * Names that don't exist in the global library are persisted anyway (so a
+   * later library edit lights them up) but logged.
+   */
+  async setEnabledTeams(names: string[]): Promise<void> {
+    const seen = new Set<string>();
+    this.enabledTeamNames = (names || []).filter(n => {
+      if (typeof n !== 'string' || !n.trim() || seen.has(n)) return false;
+      seen.add(n);
+      return true;
+    });
+    this.resolveTeamsFromGlobal();
     const configPath = this.getConfigPath();
     const existing = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
-    existing.teams = this.getTeams();
+    existing.teams = [...this.enabledTeamNames];
     await fs.promises.writeFile(configPath, JSON.stringify(existing, null, 2), 'utf-8');
   }
 
-  /** Returns team configs in their most compact form: legacy string[] when default dispatch, object form otherwise. */
-  getTeams(): Record<string, TeamConfigRaw> {
-    const result: Record<string, TeamConfigRaw> = {};
-    for (const [name, t] of this.teams.entries()) {
-      result[name] = t.dispatch === 'all' ? t.members : { members: t.members, dispatch: t.dispatch };
-    }
-    return result;
+  /** Names of global teams enabled for this workspace. */
+  getEnabledTeamNames(): string[] {
+    return [...this.enabledTeamNames];
   }
 }

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -50,6 +50,35 @@ export class ChatManager {
         }
       }
     }
+    this.reconcileExclusiveRoutes();
+  }
+
+  /**
+   * Enforce the one-channel-one-chat invariant for routes already on disk.
+   * Before addRoute became exclusive, the same (channel, channelUserId) could
+   * end up attached to multiple chats — leaving stale ✈ icons in the UI.
+   * Keep it on the most recently updated chat; strip from the rest.
+   */
+  private reconcileExclusiveRoutes(): void {
+    const owner = new Map<string, Chat>();
+    for (const chat of this.cache.values()) {
+      if (!chat.routes?.length) continue;
+      for (const r of chat.routes) {
+        const key = `${r.channel}:${r.channelUserId}`;
+        const incumbent = owner.get(key);
+        if (!incumbent || chat.updatedAt > incumbent.updatedAt) owner.set(key, chat);
+      }
+    }
+    for (const chat of this.cache.values()) {
+      if (!chat.routes?.length) continue;
+      const before = chat.routes.length;
+      chat.routes = chat.routes.filter(r =>
+        owner.get(`${r.channel}:${r.channelUserId}`)?.id === chat.id
+      );
+      if (chat.routes.length !== before) {
+        this.persist(chat);
+      }
+    }
   }
 
   private persist(chat: Chat): void {
@@ -197,7 +226,23 @@ export class ChatManager {
   }
 
   addRoute(chatId: string, route: ChatRoute): Chat {
+    this.ensureLoaded();
     const chat = this.requireChat(chatId);
+    // A given (channel, channelUserId) is exclusive: one channel-user maps to
+    // one chat at a time. Strip the route from every other chat first so the
+    // UI doesn't end up showing two chats as "linked" to the same Telegram /
+    // Discord / iMessage user.
+    for (const other of this.cache.values()) {
+      if (other.id === chatId || !other.routes?.length) continue;
+      const before = other.routes.length;
+      other.routes = other.routes.filter(r =>
+        !(r.channel === route.channel && r.channelUserId === route.channelUserId)
+      );
+      if (other.routes.length !== before) {
+        other.updatedAt = Date.now();
+        this.persist(other);
+      }
+    }
     chat.routes ??= [];
     const exists = chat.routes.some(r =>
       r.channel === route.channel &&

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { EventEmitter } from 'events';
-import { CodingAgent, FallbackConfig, FallbackEntry, ModelEntry } from '@codey/core';
+import { CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
 
 // ── Configuration types ─────────────────────────────────────────────
 
@@ -43,6 +43,12 @@ export interface GatewayConfigJson {
     agent?: CodingAgent;
     model?: string;
   };
+  /**
+   * Global team library. Each entry maps a team name to its members + dispatch
+   * mode. Workspaces opt into teams by listing their names in workspace.json's
+   * `teams: string[]` field.
+   */
+  teams?: Record<string, TeamConfigRaw>;
 }
 
 /** Reserved for future per-agent settings. Currently empty. */
@@ -91,6 +97,7 @@ export class ConfigManager extends EventEmitter {
     if (partial.models !== undefined) this.config.models = partial.models;
     if (partial.fallback !== undefined) this.config.fallback = partial.fallback;
     if (partial.dispatcher !== undefined) this.config.dispatcher = partial.dispatcher;
+    if (partial.teams !== undefined) this.config.teams = partial.teams;
     this.save();
   }
 
@@ -197,6 +204,14 @@ export class ConfigManager extends EventEmitter {
     } else {
       this.config.fallback.order.push({ agent: agent as CodingAgent, model: modelId || undefined });
     }
+    this.save();
+  }
+
+  // ── Global teams ───────────────────────────────────────────────────
+  getTeams(): Record<string, TeamConfigRaw> { return this.config.teams ?? {}; }
+
+  setTeams(teams: Record<string, TeamConfigRaw>): void {
+    this.config.teams = teams || {};
     this.save();
   }
 
@@ -368,6 +383,9 @@ function normalize(raw: Partial<GatewayConfigJson>): GatewayConfigJson {
       agent: raw.dispatcher.agent,
       model: raw.dispatcher.model,
     };
+  }
+  if (raw.teams && typeof raw.teams === 'object') {
+    out.teams = raw.teams as Record<string, TeamConfigRaw>;
   }
   return out;
 }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2987,12 +2987,19 @@ Example: /model gpt-4.1 write a Python script`;
     const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
     const wsConfigPath = path.join(workspacesRoot, chat.workspaceName, 'workspace.json');
     let workingDir = this.workingDir;
-    let chatWorkspaceTeams: Record<string, TeamConfigRaw> = {};
+    let chatWorkspaceTeamNames: string[] = [];
+    // The global team library, looked up against the workspace's enabled names below.
+    const globalTeams: Record<string, TeamConfigRaw> = this.configManager?.getTeams() ?? {};
     if (fs.existsSync(wsConfigPath)) {
       try {
         const wsConfig = JSON.parse(fs.readFileSync(wsConfigPath, 'utf-8'));
         if (wsConfig.workingDir) workingDir = wsConfig.workingDir;
-        if (wsConfig.teams && typeof wsConfig.teams === 'object') chatWorkspaceTeams = wsConfig.teams;
+        if (Array.isArray(wsConfig.teams)) {
+          chatWorkspaceTeamNames = wsConfig.teams.filter((n: any) => typeof n === 'string');
+        } else if (wsConfig.teams && typeof wsConfig.teams === 'object') {
+          // Legacy: workspace held its own definitions. Treat keys as the enabled names.
+          chatWorkspaceTeamNames = Object.keys(wsConfig.teams);
+        }
       } catch { /* use default */ }
     } else {
       this.chatSemaphore.release();
@@ -3060,14 +3067,15 @@ Example: /model gpt-4.1 write a Python script`;
         // even if WorkspaceManager has loaded A. Worker prompt bodies still come
         // from WorkerManager's loaded workers/ dir (a known limitation when the
         // active workspace differs from the chat's).
-        const teamNames = Object.keys(chatWorkspaceTeams);
+        // Only count enabled names that actually resolve in the global library.
+        const teamNames = chatWorkspaceTeamNames.filter(n => globalTeams[n] !== undefined);
         if (teamNames.length === 0) throw new Error(`No teams configured in workspace "${chat.workspaceName}"`);
         // Prefer the team named on the selection. Falling through to teamNames[0]
         // keeps legacy chats (persisted before per-team selection) working.
         const teamName = chat.selection.name && teamNames.includes(chat.selection.name)
           ? chat.selection.name
           : teamNames[0];
-        const rawTeam = chatWorkspaceTeams[teamName];
+        const rawTeam = globalTeams[teamName];
         const rawMembers: string[] = Array.isArray(rawTeam) ? rawTeam : (rawTeam?.members ?? []);
         if (!rawMembers || rawMembers.length === 0) throw new Error(`Team "${teamName}" is empty`);
         // Prefer the active workspace's normalized team (which carries dispatch mode);


### PR DESCRIPTION
## Summary
- **Global teams library** — teams now live in `gateway.json` as a shared library; each workspace opts in by name via `workspace.json` `teams: string[]`. New "Teams" tab in Settings edits the library; the per-workspace section becomes a checklist of names with member/dispatch summaries.
- **Exclusive channel links** — `ChatManager.addRoute` now strips the same `(channel, channelUserId)` from every other chat before attaching, enforcing one-channel-user → one-chat. A one-shot load-time reconciliation clears stale duplicates already on disk (most recently updated chat wins), so existing extra ✈ icons disappear on next boot.
- **Responsive layout** — `ChatTab` tracks window width and clamps the right context panel so the conversation column always retains ≥360px; the panel hides entirely on very narrow windows (re-appears on resize). `ChatListPanel` shrinks 240→180px below 600px.

## Test plan
- [ ] Open Settings → Teams; create a team, add workers, toggle dispatch mode, rename, delete. Verify it persists in `gateway.json` under `teams`.
- [ ] Open Workspaces tab → expand a workspace; toggle global teams on/off. Verify `workspace.json` `teams` becomes a `string[]` and `/team <name>` still runs.
- [ ] Verify legacy workspaces (with `Record<string, ...>` teams) still load and their team names appear pre-enabled in the checklist.
- [ ] Pair Telegram to chat A, then link the same Telegram user to chat B. Confirm chat A's ✈ icon disappears (no duplicate links).
- [ ] Restart the gateway with pre-existing duplicate routes on disk; confirm the reconciliation pass clears them.
- [ ] Resize the Codey window narrow with the right context panel open; verify the conversation column never collapses to one character per line and the panel hides instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)