### PR TITLE
feat: global voice input with macOS helper and gateway endpoints

### DIFF
--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -17,6 +17,30 @@ interface ModelEntry {
 interface AgentSlot { enabled?: boolean }
 interface FallbackEntry { agent: string; model?: string }
 interface FallbackCfg { enabled: boolean; order: FallbackEntry[] }
+interface VoiceCfg {
+  enabled: boolean
+  hotkey: string
+  modelPath: string
+  language: string
+  injection: 'paste' | 'ax'
+}
+const VOICE_DEFAULT: VoiceCfg = {
+  enabled: false,
+  hotkey: 'F5',
+  modelPath: '~/.codey/models/ggml-tiny.bin',
+  language: 'auto',
+  injection: 'paste',
+}
+const VOICE_LANGUAGES: Array<{ value: string; label: string }> = [
+  { value: 'auto', label: 'Auto-detect' },
+  { value: 'en', label: 'English' },
+  { value: 'zh', label: 'Chinese' },
+  { value: 'ja', label: 'Japanese' },
+  { value: 'ko', label: 'Korean' },
+  { value: 'es', label: 'Spanish' },
+  { value: 'fr', label: 'French' },
+  { value: 'de', label: 'German' },
+]
 
 // Each agent expects a specific apiType — surfacing this in the UI keeps users
 // from picking a model the agent's CLI cannot actually authenticate against.
@@ -362,6 +386,8 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   // a neutral "checking…" to green/install once the result lands.
   const [installStatus, setInstallStatus] = useState<Record<string, InstallStatus>>({})
   const [checkingInstalls, setCheckingInstalls] = useState(false)
+  const [voice, setVoice] = useState<VoiceCfg>(VOICE_DEFAULT)
+  const [voiceSavedMsg, setVoiceSavedMsg] = useState<string | null>(null)
 
   const refreshInstallStatus = useCallback(async () => {
     setCheckingInstalls(true)
@@ -377,13 +403,15 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const reload = useCallback(async () => {
     setError(null)
     try {
-      const [m, f, d] = await Promise.all([
+      const [m, f, d, cfg] = await Promise.all([
         unwrap(await window.codey.models.list()),
         unwrap(await window.codey.fallback.get()),
         unwrap(await window.codey.dispatcher.get()),
+        unwrap(await window.codey.config.get()),
       ])
       setModels(m); setFallback(f as FallbackCfg)
       setDispatcher({ agent: d.agent ?? '', model: d.model ?? '' })
+      setVoice({ ...VOICE_DEFAULT, ...(cfg?.voice ?? {}) })
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
@@ -416,6 +444,18 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const updateFallback = async (fb: FallbackCfg) => {
     setFallback(fb)
     await unwrap(await window.codey.fallback.set(fb))
+  }
+
+  const updateVoice = async (patch: Partial<VoiceCfg>) => {
+    const next = { ...voice, ...patch }
+    setVoice(next)
+    try {
+      await unwrap(await window.codey.config.set({ voice: next }))
+      setVoiceSavedMsg('Saved')
+      setTimeout(() => setVoiceSavedMsg(null), 1500)
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
   }
 
   const updateDispatcher = async (next: { agent: string; model: string }) => {
@@ -547,6 +587,63 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
             <option key={m.model} value={m.model}>{m.model} [{m.apiType}]</option>
           ))}
         </select>
+      </div>
+
+      <Section title="Voice input" right={
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {voiceSavedMsg && <span style={{ color: C.green, fontSize: 11 }}>{voiceSavedMsg}</span>}
+          <span style={{ color: C.fg3, fontSize: 11 }}>{voice.enabled ? 'Enabled' : 'Disabled'}</span>
+          <Toggle on={voice.enabled} onChange={enabled => updateVoice({ enabled })}/>
+        </div>
+      }/>
+      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
+        System-wide voice input via the native <code>codey-voice</code> helper (macOS). Press the hotkey anywhere to start/stop recording — transcribed text is injected at your cursor. Requires the helper app running with Microphone + Accessibility permissions.
+      </div>
+      <div style={fieldStyle}>
+        <span style={{ color: C.fg, fontSize: 13 }}>Hotkey</span>
+        <input
+          value={voice.hotkey}
+          onChange={e => setVoice({ ...voice, hotkey: e.target.value })}
+          onBlur={() => updateVoice({ hotkey: voice.hotkey })}
+          placeholder="e.g. F5"
+          style={inputStyle}
+        />
+      </div>
+      <div style={fieldStyle}>
+        <span style={{ color: C.fg, fontSize: 13 }}>Language</span>
+        <select
+          value={voice.language}
+          onChange={e => updateVoice({ language: e.target.value })}
+          style={selectStyle}
+        >
+          {VOICE_LANGUAGES.map(l => (
+            <option key={l.value} value={l.value}>{l.label}</option>
+          ))}
+        </select>
+      </div>
+      <div style={fieldStyle}>
+        <span style={{ color: C.fg, fontSize: 13 }}>Injection mode</span>
+        <select
+          value={voice.injection}
+          onChange={e => updateVoice({ injection: e.target.value as 'paste' | 'ax' })}
+          style={selectStyle}
+        >
+          <option value="paste">Paste (⌘V — works everywhere)</option>
+          <option value="ax">Accessibility API (no clipboard touch)</option>
+        </select>
+      </div>
+      <div style={{ ...fieldStyle, alignItems: 'flex-start', flexDirection: 'column', gap: 6 }}>
+        <span style={{ color: C.fg, fontSize: 13 }}>Whisper model path</span>
+        <input
+          value={voice.modelPath}
+          onChange={e => setVoice({ ...voice, modelPath: e.target.value })}
+          onBlur={() => updateVoice({ modelPath: voice.modelPath })}
+          placeholder="~/.codey/models/ggml-tiny.bin"
+          style={{ ...inputStyle, width: '100%' }}
+        />
+        <span style={{ color: C.fg3, fontSize: 11 }}>
+          Must be a ggml <code>.bin</code> under <code>~/.codey/models/</code>. Run <code>make download-model</code> in <code>voice/</code> to fetch the default multilingual tiny model.
+        </span>
       </div>
     </div>
   )

--- a/gateway.json.example
+++ b/gateway.json.example
@@ -79,5 +79,12 @@
   "dispatcher": {
     "agent": "claude-code",
     "model": "claude-haiku-4-5"
+  },
+  "voice": {
+    "enabled": false,
+    "hotkey": "F5",
+    "modelPath": "~/.codey/models/ggml-tiny.bin",
+    "language": "auto",
+    "injection": "paste"
   }
 }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -49,6 +49,14 @@ export interface GatewayConfigJson {
    * `teams: string[]` field.
    */
   teams?: Record<string, TeamConfigRaw>;
+  /** Voice input helper (native macOS app) configuration. */
+  voice?: {
+    enabled: boolean;
+    hotkey: string;
+    modelPath: string;
+    language: string;
+    injection: 'paste' | 'ax';
+  };
 }
 
 /** Reserved for future per-agent settings. Currently empty. */
@@ -98,6 +106,7 @@ export class ConfigManager extends EventEmitter {
     if (partial.fallback !== undefined) this.config.fallback = partial.fallback;
     if (partial.dispatcher !== undefined) this.config.dispatcher = partial.dispatcher;
     if (partial.teams !== undefined) this.config.teams = partial.teams;
+    if (partial.voice !== undefined) this.config.voice = partial.voice;
     this.save();
   }
 
@@ -386,6 +395,9 @@ function normalize(raw: Partial<GatewayConfigJson>): GatewayConfigJson {
   }
   if (raw.teams && typeof raw.teams === 'object') {
     out.teams = raw.teams as Record<string, TeamConfigRaw>;
+  }
+  if (raw.voice && typeof raw.voice === 'object') {
+    out.voice = raw.voice;
   }
   return out;
 }

--- a/packages/gateway/src/health.ts
+++ b/packages/gateway/src/health.ts
@@ -24,6 +24,7 @@ export class ApiServer {
   private port: number;
   private getStatus: () => HealthStatus;
   private configManager: ConfigManager;
+  private _voiceStatus: string = 'idle';
 
   constructor(port: number, getStatus: () => HealthStatus, configManager: ConfigManager) {
     this.port = port;
@@ -73,6 +74,109 @@ export class ApiServer {
         res.end(JSON.stringify({ ready }));
         return;
       }
+
+      // ── Voice endpoints ───────────────────────────────────────────
+
+      // CORS: block browser-origin requests to /voice/* (native clients send no Origin)
+      if (url?.startsWith('/voice/') && req.headers.origin) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Browser requests to voice endpoints are not allowed' }));
+        return;
+      }
+
+      if (url?.startsWith('/voice/') && process.platform !== 'darwin') {
+        res.writeHead(501, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Voice input is only supported on macOS' }));
+        return;
+      }
+
+      if (url === '/voice/status' && req.method === 'GET') {
+        const voice = this.configManager.get().voice;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          configured: !!voice,
+          enabled: voice?.enabled ?? false,
+          state: this._voiceStatus ?? null,
+        }));
+        return;
+      }
+
+      if (url === '/voice/status' && req.method === 'POST') {
+        let body = '';
+        req.on('data', chunk => body += chunk);
+        req.on('end', () => {
+          try {
+            const { status } = JSON.parse(body);
+            // Store latest helper status in memory (not persisted to config)
+            this._voiceStatus = status;
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true }));
+          } catch {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Invalid JSON' }));
+          }
+        });
+        return;
+      }
+
+      if (url === '/voice/config' && req.method === 'GET') {
+        const voice = this.configManager.get().voice;
+        if (!voice) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Voice not configured' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(voice, null, 2));
+        return;
+      }
+
+      if (url === '/voice/config' && req.method === 'PUT') {
+        let body = '';
+        req.on('data', chunk => body += chunk);
+        req.on('end', () => {
+          try {
+            const patch = JSON.parse(body);
+
+            // Validate modelPath if present
+            if (patch.modelPath !== undefined) {
+              const p = patch.modelPath as string;
+              const home = process.env.HOME || '';
+              const allowedPrefixes = [
+                `${home}/.codey/models/`,
+                `${home}/Library/Application Support/Codey/`,
+              ];
+              if (!p.startsWith('/')) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'modelPath must be an absolute path' }));
+                return;
+              }
+              if (!p.endsWith('.bin')) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'modelPath must end with .bin' }));
+                return;
+              }
+              if (!allowedPrefixes.some(prefix => p.startsWith(prefix))) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'modelPath must be under ~/.codey/models/ or ~/Library/Application Support/Codey/' }));
+                return;
+              }
+            }
+
+            const current = this.configManager.get();
+            const updated = { ...current, voice: { ...current.voice, ...patch } };
+            this.configManager.update(updated);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(updated.voice, null, 2));
+          } catch {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Invalid JSON' }));
+          }
+        });
+        return;
+      }
+
+      // ── Existing endpoints ────────────────────────────────────────
 
       if (url === '/config' && req.method === 'GET') {
         try {

--- a/voice/.gitignore
+++ b/voice/.gitignore
@@ -1,0 +1,4 @@
+.build/
+deps/
+models/
+*.a

--- a/voice/Makefile
+++ b/voice/Makefile
@@ -1,0 +1,63 @@
+# Codey Voice — build whisper.cpp and the Swift helper
+WHISPER_DIR := whisper.cpp
+BUILD_DIR   := $(WHISPER_DIR)/build
+DEPS_DIR    := .build/deps
+
+.PHONY: all build-whisper setup-deps build run clean
+
+all: build
+
+# ── Build whisper.cpp via CMake ─────────────────────────────────────
+build-whisper:
+	@echo "[voice] Building whisper.cpp …"
+	cmake -S $(WHISPER_DIR) -B $(BUILD_DIR) \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DWHISPER_BUILD_TESTS=OFF \
+		-DWHISPER_BUILD_EXAMPLES=OFF \
+		-DGGML_METAL=ON
+	cmake --build $(BUILD_DIR) --config Release -j$$(sysctl -n hw.ncpu)
+
+# ── Copy headers + libs into deps/ ──────────────────────────────────
+setup-deps: build-whisper
+	@echo "[voice] Collecting deps …"
+	mkdir -p $(DEPS_DIR)/include $(DEPS_DIR)/lib
+	# Headers for the system library module map
+	cp -f $(WHISPER_DIR)/include/whisper.h           Sources/WhisperBridge/include/
+	cp -f $(WHISPER_DIR)/ggml/include/ggml.h         Sources/WhisperBridge/include/
+	cp -f $(WHISPER_DIR)/ggml/include/ggml-cpu.h     Sources/WhisperBridge/include/
+	cp -f $(WHISPER_DIR)/ggml/include/ggml-alloc.h   Sources/WhisperBridge/include/
+	cp -f $(WHISPER_DIR)/ggml/include/ggml-backend.h Sources/WhisperBridge/include/
+	cp -f $(WHISPER_DIR)/ggml/include/ggml-metal.h   Sources/WhisperBridge/include/
+	# Static libraries
+	mkdir -p $(DEPS_DIR)/lib
+	cp -f $(BUILD_DIR)/src/libwhisper.a               $(DEPS_DIR)/lib/ 2>/dev/null || true
+	cp -f $(BUILD_DIR)/ggml/src/libggml.a             $(DEPS_DIR)/lib/ 2>/dev/null || true
+	cp -f $(BUILD_DIR)/ggml/src/libggml-cpu.a         $(DEPS_DIR)/lib/ 2>/dev/null || true
+	cp -f $(BUILD_DIR)/ggml/src/libggml-base.a        $(DEPS_DIR)/lib/ 2>/dev/null || true
+	cp -f $(BUILD_DIR)/ggml/src/ggml-metal/libggml-metal.a $(DEPS_DIR)/lib/ 2>/dev/null || true
+	@echo "[voice] Done. Deps in $(DEPS_DIR)/"
+
+# ── Swift build ─────────────────────────────────────────────────────
+build: setup-deps
+	swift build -c release
+
+# ── Run ─────────────────────────────────────────────────────────────
+run: build
+	@.build/release/CodeyVoice
+
+# ── Download tiny model ─────────────────────────────────────────────
+MODEL_URL := https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin
+
+download-model:
+	@mkdir -p $(HOME)/.codey/models
+	@if [ ! -f $(HOME)/.codey/models/ggml-tiny.bin ]; then \
+		echo "[voice] Downloading ggml-tiny.bin …"; \
+		curl -L -o $(HOME)/.codey/models/ggml-tiny.bin $(MODEL_URL); \
+	else \
+		echo "[voice] Model already exists."; \
+	fi
+
+# ── Clean ───────────────────────────────────────────────────────────
+clean:
+	rm -rf $(BUILD_DIR) $(DEPS_DIR) .build Sources/WhisperBridge/include/*.h

--- a/voice/Package.swift
+++ b/voice/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "CodeyVoice",
+    platforms: [.macOS(.v13)],
+    targets: [
+        // whisper.cpp — pre-built via CMake, headers + static libs in .build/deps/
+        .systemLibrary(
+            name: "WhisperBridge",
+            pkgConfig: nil,
+            providers: []
+        ),
+        .executableTarget(
+            name: "CodeyVoice",
+            dependencies: ["WhisperBridge"],
+            path: "Sources/CodeyVoice",
+            cSettings: [
+                .headerSearchPath("../../.build/deps/include"),
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-L.build/deps/lib"]),
+                .linkedFramework("Cocoa"),
+                .linkedFramework("Carbon"),
+                .linkedFramework("CoreAudio"),
+                .linkedFramework("AVFoundation"),
+                .linkedFramework("AudioToolbox"),
+            ]
+        ),
+    ]
+)

--- a/voice/Sources/CodeyVoice/AudioCapture.swift
+++ b/voice/Sources/CodeyVoice/AudioCapture.swift
@@ -1,0 +1,99 @@
+import AVFoundation
+import Foundation
+
+/// Captures microphone audio at 16 kHz mono Float32 using AVAudioEngine.
+final class AudioCapture {
+    private let engine = AVAudioEngine()
+    private var pcmBuffer: [Float] = []
+    private let sampleRate: Double = 16000
+    private let maxDurationSeconds: Double = 300  // 5-minute cap
+    private(set) var isRecording = false
+
+    /// Called with the full PCM buffer when recording stops.
+    var onRecordingComplete: (([Float]) -> Void)?
+
+    /// Request microphone permission.
+    static func requestPermission() async -> Bool {
+        if #available(macOS 14.0, *) {
+            return await AVCaptureDevice.requestAccess(for: .audio)
+        } else {
+            return await withCheckedContinuation { cont in
+                AVCaptureDevice.requestAccess(for: .audio) { granted in
+                    cont.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    func startRecording() throws {
+        guard !isRecording else { return }
+
+        let inputNode = engine.inputNode
+        let inputFormat = inputNode.inputFormat(forBus: 0)
+
+        // Install tap at device sample rate, we'll resample to 16 kHz
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+            self?.processBuffer(buffer)
+        }
+
+        pcmBuffer.removeAll()
+        try engine.start()
+        isRecording = true
+    }
+
+    func stopRecording() {
+        guard isRecording else { return }
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        isRecording = false
+        onRecordingComplete?(pcmBuffer)
+    }
+
+    private func processBuffer(_ buffer: AVAudioPCMBuffer) {
+        let frameLength = Int(buffer.frameLength)
+        guard let channelData = buffer.floatChannelData else { return }
+
+        let srcRate = buffer.format.sampleRate
+        let channelCount = Int(buffer.format.channelCount)
+
+        // Mix to mono if stereo
+        var mono = [Float](repeating: 0, count: frameLength)
+        for ch in 0..<channelCount {
+            let ptr = channelData[ch]
+            for i in 0..<frameLength {
+                mono[i] += ptr[i]
+            }
+        }
+        if channelCount > 1 {
+            let scale = 1.0 / Float(channelCount)
+            for i in 0..<frameLength { mono[i] *= scale }
+        }
+
+        // Resample to 16 kHz if needed
+        if srcRate != sampleRate {
+            let ratio = srcRate / sampleRate
+            let outCount = Int(Double(frameLength) / ratio)
+            var resampled = [Float](repeating: 0, count: outCount)
+            for i in 0..<outCount {
+                let srcIdx = Double(i) * ratio
+                let idx0 = Int(srcIdx)
+                let frac = Float(srcIdx - Double(idx0))
+                if idx0 + 1 < frameLength {
+                    resampled[i] = mono[idx0] * (1 - frac) + mono[idx0 + 1] * frac
+                } else if idx0 < frameLength {
+                    resampled[i] = mono[idx0]
+                }
+            }
+            pcmBuffer.append(contentsOf: resampled)
+        } else {
+            pcmBuffer.append(contentsOf: mono)
+        }
+
+        // Auto-stop at buffer cap
+        if Double(pcmBuffer.count) / sampleRate >= maxDurationSeconds {
+            DispatchQueue.main.async { [weak self] in
+                self?.stopRecording()
+            }
+        }
+    }
+}

--- a/voice/Sources/CodeyVoice/GatewayClient.swift
+++ b/voice/Sources/CodeyVoice/GatewayClient.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Communicates with the Codey Node gateway over HTTP localhost.
+final class GatewayClient {
+    private let baseURL: URL
+    private let session: URLSession
+    private(set) var isReachable = false
+
+    init(port: Int = 3001) {
+        self.baseURL = URL(string: "http://127.0.0.1:\(port)")!
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 3
+        self.session = URLSession(configuration: config)
+    }
+
+    /// Poll gateway health. Returns true if reachable.
+    func checkHealth() async -> Bool {
+        let url = baseURL.appendingPathComponent("voice/status")
+        do {
+            let (_, response) = try await session.data(from: url)
+            let ok = (response as? HTTPURLResponse)?.statusCode == 200
+            isReachable = ok
+            return ok
+        } catch {
+            isReachable = false
+            return false
+        }
+    }
+
+    /// Fetch voice config from gateway.
+    func fetchConfig() async -> VoiceConfig? {
+        let url = baseURL.appendingPathComponent("voice/config")
+        do {
+            let (data, response) = try await session.data(from: url)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+            return try JSONDecoder().decode(VoiceConfig.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Report current status to gateway.
+    func reportStatus(_ status: String) async {
+        var request = URLRequest(url: baseURL.appendingPathComponent("voice/status"))
+        request.httpMethod = "POST"
+        request.httpBody = try? JSONEncoder().encode(["status": status])
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        _ = try? await session.data(for: request)
+    }
+}

--- a/voice/Sources/CodeyVoice/HotkeyManager.swift
+++ b/voice/Sources/CodeyVoice/HotkeyManager.swift
@@ -1,0 +1,83 @@
+import Carbon.HIToolbox
+import Foundation
+
+/// Registers a global hotkey (F5 by default) via Carbon Event Manager.
+/// Calls `onToggle` on each tap. Thread-safe via main queue dispatch.
+final class HotkeyManager {
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    let onToggle: () -> Void
+
+    init(onToggle: @escaping () -> Void) {
+        self.onToggle = onToggle
+    }
+
+    func register() {
+        // Install application event handler
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+
+        let handler: EventHandlerUPP = { _, event, _ -> OSStatus in
+            // Retrieve the hotkey ID from the event to verify it's ours
+            var hotKeyID = EventHotKeyID()
+            let status = GetEventParameter(
+                event,
+                EventParamName(kEventParamDirectObject),
+                EventParamType(typeEventHotKeyID),
+                nil,
+                MemoryLayout<EventHotKeyID>.size,
+                nil,
+                &hotKeyID
+            )
+            guard status == noErr, hotKeyID.id == 1 else { return OSStatus(eventNotHandledErr) }
+
+            DispatchQueue.main.async {
+                HotkeyManager._shared?.onToggle()
+            }
+            return noErr
+        }
+
+        // Keep a static reference so the C callback can reach the instance
+        HotkeyManager._shared = self
+
+        InstallApplicationEventHandler(
+            handler,
+            1,
+            &eventType,
+            nil,
+            &eventHandler
+        )
+
+        // Register F5 (key code 96)
+        var hotKeyID = EventHotKeyID(signature: OSType(0x4356_4F58), id: 1) // "CVOX"
+        RegisterEventHotKey(
+            UInt32(kVK_F5),
+            0, // no modifiers
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+    }
+
+    func unregister() {
+        if let ref = hotKeyRef {
+            UnregisterEventHotKey(ref)
+            hotKeyRef = nil
+        }
+        if let ref = eventHandler {
+            RemoveEventHandler(ref)
+            eventHandler = nil
+        }
+        HotkeyManager._shared = nil
+    }
+
+    deinit {
+        unregister()
+    }
+
+    /// Static reference for the C callback closure.
+    private static var _shared: HotkeyManager?
+}

--- a/voice/Sources/CodeyVoice/StatusItem.swift
+++ b/voice/Sources/CodeyVoice/StatusItem.swift
@@ -1,0 +1,109 @@
+import Cocoa
+
+/// Menu bar status item with state indicator and settings.
+final class StatusItem {
+    private let item: NSStatusItem
+    private var stateMenuItem: NSMenuItem!
+    private var toggleMenuItem: NSMenuItem!
+
+    enum State: Equatable {
+        case idle
+        case recording
+        case transcribing
+        case gatewayDown
+        case error(String)
+        case permissionsNeeded
+
+        var icon: String {
+            switch self {
+            case .idle: return "mic"
+            case .recording: return "mic.fill"
+            case .transcribing: return "waveform"
+            case .gatewayDown: return "mic.slash"
+            case .error: return "exclamationmark.triangle"
+            case .permissionsNeeded: return "lock.shield"
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .idle: return "Ready"
+            case .recording: return "Recording…"
+            case .transcribing: return "Transcribing…"
+            case .gatewayDown: return "Gateway offline"
+            case .error(let msg): return "Error: \(msg)"
+            case .permissionsNeeded: return "Permissions needed"
+            }
+        }
+    }
+
+    var onToggle: (() -> Void)?
+    var onSettings: (() -> Void)?
+    var onQuit: (() -> Void)?
+
+    init() {
+        item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        setupMenu()
+        updateState(.idle)
+    }
+
+    func updateState(_ state: State) {
+        if let button = item.button {
+            let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .medium)
+            button.image = NSImage(systemSymbolName: state.icon, accessibilityDescription: "Codey Voice")?
+                .withSymbolConfiguration(config)
+            if case .recording = state {
+                button.appearsDisabled = false
+            }
+        }
+        stateMenuItem.title = state.label
+        toggleMenuItem.title = (state == .recording) ? "Stop Recording (F5)" : "Start Recording (F5)"
+    }
+
+    private func setupMenu() {
+        let menu = NSMenu()
+
+        stateMenuItem = NSMenuItem(title: "Ready", action: nil, keyEquivalent: "")
+        stateMenuItem.isEnabled = false
+        menu.addItem(stateMenuItem)
+
+        menu.addItem(.separator())
+
+        toggleMenuItem = NSMenuItem(title: "Start Recording (F5)", action: #selector(toggleAction), keyEquivalent: "")
+        toggleMenuItem.target = self
+        menu.addItem(toggleMenuItem)
+
+        let settingsItem = NSMenuItem(title: "Settings…", action: #selector(settingsAction), keyEquivalent: ",")
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
+        menu.addItem(.separator())
+
+        let quitItem = NSMenuItem(title: "Quit Codey Voice", action: #selector(quitAction), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        item.menu = menu
+    }
+
+    @objc private func toggleAction() { onToggle?() }
+    @objc private func settingsAction() { onSettings?() }
+    @objc private func quitAction() { onQuit?() }
+
+    // MARK: - Permission prompt
+
+    func showPermissionAlert(missing: [String]) {
+        let alert = NSAlert()
+        alert.messageText = "Permissions Required"
+        alert.informativeText = "Codey Voice needs the following permissions:\n\n" +
+            missing.map { "• \($0)" }.joined(separator: "\n") +
+            "\n\nGrant these in System Settings → Privacy & Security."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Open System Settings")
+        alert.addButton(withTitle: "Later")
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy")!)
+        }
+    }
+}

--- a/voice/Sources/CodeyVoice/TextInjector.swift
+++ b/voice/Sources/CodeyVoice/TextInjector.swift
@@ -1,0 +1,129 @@
+import Cocoa
+import CoreGraphics
+
+/// Injects text into the currently focused UI element.
+final class TextInjector {
+    private let mode: VoiceConfig.InjectionMode
+
+    init(mode: VoiceConfig.InjectionMode = .paste) {
+        self.mode = mode
+    }
+
+    /// Inject text at the current cursor position.
+    func inject(_ text: String) {
+        guard !isSecureFieldFocused() else { return }
+        switch mode {
+        case .paste:
+            injectViaPaste(text)
+        case .ax:
+            injectViaAX(text)
+        }
+    }
+
+    /// Returns true if the focused UI element is a secure text field (password input).
+    private func isSecureFieldFocused() -> Bool {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
+              let focused = focusedRef else {
+            return false
+        }
+        var roleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(focused as! AXUIElement, kAXRoleAttribute as CFString, &roleRef)
+        return (roleRef as? String) == "AXSecureTextField"
+    }
+
+    // MARK: - Paste approach (primary)
+
+    /// Copy text to pasteboard, synthesize ⌘V, restore old clipboard.
+    private func injectViaPaste(_ text: String) {
+        let pasteboard = NSPasteboard.general
+
+        // Save existing content (string/RTF only to avoid large clipboard images)
+        let safeTypes: Set<NSPasteboard.PasteboardType> = [.string, .init("public.rtf")]
+        var savedItems: [[NSPasteboard.PasteboardType: Data]] = []
+        for item in 0..<(pasteboard.pasteboardItems?.count ?? 0) {
+            guard let item = pasteboard.pasteboardItems?[item] else { continue }
+            var dict: [NSPasteboard.PasteboardType: Data] = [:]
+            for type in item.types where safeTypes.contains(type) {
+                if let data = item.data(forType: type) {
+                    dict[type] = data
+                }
+            }
+            if !dict.isEmpty {
+                savedItems.append(dict)
+            }
+        }
+
+        // Write our text
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        // Small delay to let the pasteboard settle
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            // Synthesize ⌘V
+            let source = CGEventSource(stateID: .hidSystemState)
+
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)  // V
+            keyDown?.flags = .maskCommand
+            keyDown?.post(tap: .cghidEventTap)
+
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
+            keyUp?.flags = .maskCommand
+            keyUp?.post(tap: .cghidEventTap)
+
+            // Restore old clipboard after a brief delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                pasteboard.clearContents()
+                let items: [NSPasteboardItem] = savedItems.map { dict in
+                    let item = NSPasteboardItem()
+                    for (type, data) in dict {
+                        item.setData(data, forType: type)
+                    }
+                    return item
+                }
+                pasteboard.writeObjects(items)
+            }
+        }
+    }
+
+    // MARK: - AX API approach (fallback)
+
+    /// Use Accessibility API to set the focused element's value directly.
+    private func injectViaAX(_ text: String) {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedRef
+        )
+        guard result == .success, let focused = focusedRef else {
+            // Fallback to paste if AX fails
+            injectViaPaste(text)
+            return
+        }
+
+        let focusedElement = focused as! AXUIElement
+
+        // Try setting selected text first (inserts at cursor)
+        let setResult = AXUIElementSetAttributeValue(
+            focusedElement,
+            kAXSelectedTextAttribute as CFString,
+            text as CFTypeRef
+        )
+
+        if setResult != .success {
+            // Fallback: set the entire value
+            let valueResult = AXUIElementSetAttributeValue(
+                focusedElement,
+                kAXValueAttribute as CFString,
+                text as CFTypeRef
+            )
+            if valueResult != .success {
+                // Last resort: paste
+                injectViaPaste(text)
+            }
+        }
+    }
+}

--- a/voice/Sources/CodeyVoice/VoiceConfig.swift
+++ b/voice/Sources/CodeyVoice/VoiceConfig.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct VoiceConfig: Codable {
+    var enabled: Bool = false
+    var hotkey: String = "F5"
+    var modelPath: String
+    var language: String = "auto"
+    var injection: InjectionMode = .paste
+
+    enum InjectionMode: String, Codable {
+        case paste
+        case ax
+    }
+
+    static var `default`: VoiceConfig {
+        let modelsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codey/models")
+        return VoiceConfig(
+            modelPath: modelsDir.appendingPathComponent("ggml-tiny.bin").path
+        )
+    }
+}

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -1,0 +1,208 @@
+import Cocoa
+import Foundation
+
+/// Central coordinator that wires hotkey, audio, whisper, and text injection together.
+final class VoiceCoordinator {
+    enum State {
+        case idle
+        case recording
+        case transcribing
+    }
+
+    private var state: State = .idle
+    private var config: VoiceConfig
+
+    private let gateway: GatewayClient
+    private let audioCapture: AudioCapture
+    private let whisper: WhisperEngine
+    private var textInjector: TextInjector
+    private var hotkeyManager: HotkeyManager?
+    private var statusItem: StatusItem?
+    private var pollTimer: Timer?
+    private let gatewayPort: Int
+
+    init(gatewayPort: Int = 3001) {
+        self.gatewayPort = gatewayPort
+        self.config = VoiceConfig.default
+        self.gateway = GatewayClient(port: gatewayPort)
+        self.audioCapture = AudioCapture()
+        self.whisper = WhisperEngine()
+        self.textInjector = TextInjector(mode: .paste)
+    }
+
+    func start() {
+        // Set up status bar UI
+        let item = StatusItem()
+        item.onToggle = { [weak self] in self?.handleToggle() }
+        item.onSettings = { [weak self] in self?.openSettings() }
+        item.onQuit = { NSApp.terminate(nil) }
+        self.statusItem = item
+
+        // Register global hotkey
+        let hotkey = HotkeyManager { [weak self] in self?.handleToggle() }
+        hotkey.register()
+        self.hotkeyManager = hotkey
+
+        // Set up audio completion handler
+        audioCapture.onRecordingComplete = { [weak self] buffer in
+            self?.handleAudioComplete(buffer)
+        }
+
+        // Check permissions
+        checkPermissions()
+
+        // Load model
+        Task {
+            await loadModel()
+        }
+
+        // Start polling gateway
+        startGatewayPolling()
+    }
+
+    // MARK: - Toggle handler
+
+    private func handleToggle() {
+        switch state {
+        case .idle:
+            startRecording()
+        case .recording:
+            stopRecording()
+        case .transcribing:
+            break // ignore toggle while transcribing
+        }
+    }
+
+    private func startRecording() {
+        do {
+            try audioCapture.startRecording()
+            state = .recording
+            statusItem?.updateState(.recording)
+            Task { await gateway.reportStatus("recording") }
+        } catch {
+            statusItem?.updateState(.error(error.localizedDescription))
+        }
+    }
+
+    private func stopRecording() {
+        audioCapture.stopRecording()
+        // onRecordingComplete callback handles the rest
+    }
+
+    // MARK: - Audio → Whisper → Inject pipeline
+
+    private func handleAudioComplete(_ buffer: [Float]) {
+        guard !buffer.isEmpty else {
+            state = .idle
+            statusItem?.updateState(.idle)
+            return
+        }
+
+        state = .transcribing
+        statusItem?.updateState(.transcribing)
+        Task { await gateway.reportStatus("transcribing") }
+
+        Task {
+            do {
+                let text = try await whisper.transcribe(audio: buffer, language: config.language)
+                if !text.isEmpty {
+                    textInjector.inject(text)
+                }
+                state = .idle
+                statusItem?.updateState(.idle)
+                Task { await gateway.reportStatus("idle") }
+            } catch {
+                state = .idle
+                statusItem?.updateState(.error(error.localizedDescription))
+                Task { await gateway.reportStatus("error") }
+            }
+        }
+    }
+
+    // MARK: - Model loading
+
+    private func loadModel() async {
+        let path = config.modelPath
+        // Expand ~ in path
+        let expandedPath = NSString(string: path).expandingTildeInPath
+        guard FileManager.default.fileExists(atPath: expandedPath) else {
+            statusItem?.updateState(.error("Model not found: \(expandedPath)"))
+            return
+        }
+        do {
+            try whisper.loadModel(at: expandedPath)
+        } catch {
+            statusItem?.updateState(.error(error.localizedDescription))
+        }
+    }
+
+    // MARK: - Gateway polling
+
+    private func startGatewayPolling() {
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            Task {
+                let reachable = await self.gateway.checkHealth()
+                if !reachable && self.state == .idle {
+                    self.statusItem?.updateState(.gatewayDown)
+                }
+
+                // Fetch updated config
+                if let newConfig = await self.gateway.fetchConfig() {
+                    self.applyConfig(newConfig)
+                }
+            }
+        }
+        // Fire immediately
+        pollTimer?.fire()
+    }
+
+    private func applyConfig(_ newConfig: VoiceConfig) {
+        let oldPath = config.modelPath
+        config = newConfig
+        textInjector = TextInjector(mode: newConfig.injection)
+
+        if newConfig.modelPath != oldPath {
+            Task { await loadModel() }
+        }
+    }
+
+    // MARK: - Permissions
+
+    private func checkPermissions() {
+        Task {
+            var missing: [String] = []
+
+            // Microphone
+            let micGranted = await AudioCapture.requestPermission()
+            if !micGranted {
+                missing.append("Microphone")
+            }
+
+            // Accessibility (for hotkey + AX injection)
+            let axGranted = AXIsProcessTrusted()
+            if !axGranted {
+                missing.append("Accessibility")
+            }
+
+            if !missing.isEmpty {
+                statusItem?.updateState(.permissionsNeeded)
+                statusItem?.showPermissionAlert(missing: missing)
+            }
+        }
+    }
+
+    // MARK: - Teardown
+
+    func applicationWillTerminate() {
+        pollTimer?.invalidate()
+        whisper.shutdown()
+    }
+
+    // MARK: - Settings
+
+    private func openSettings() {
+        let url = URL(string: "http://127.0.0.1:\(gatewayPort)/config")!
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/voice/Sources/CodeyVoice/WhisperEngine.swift
+++ b/voice/Sources/CodeyVoice/WhisperEngine.swift
@@ -1,0 +1,111 @@
+import Foundation
+import WhisperBridge
+
+/// Wraps whisper.cpp for audio transcription.
+final class WhisperEngine {
+    private var ctx: OpaquePointer?
+    private let queue = DispatchQueue(label: "whisper-inference", qos: .userInitiated)
+
+    var isLoaded: Bool { ctx != nil }
+
+    /// Load a ggml model from disk. Dispatches onto the inference queue to avoid races.
+    func loadModel(at path: String) throws {
+        try queue.sync {
+            if ctx != nil {
+                whisper_free(ctx)
+                ctx = nil
+            }
+            ctx = whisper_init_from_file(path)
+            guard ctx != nil else {
+                throw WhisperError.modelLoadFailed(path)
+            }
+        }
+    }
+
+    /// Explicit teardown — call from VoiceCoordinator.applicationWillTerminate.
+    /// Must not be called while a `transcribe` is in flight.
+    func shutdown() {
+        queue.sync {
+            if let ctx {
+                whisper_free(ctx)
+            }
+            ctx = nil
+        }
+    }
+
+    /// Transcribe 16 kHz mono Float32 audio. Returns UTF-8 text.
+    func transcribe(audio: [Float], language: String = "auto") async throws -> String {
+        return try await withCheckedThrowingContinuation { cont in
+            queue.async { [weak self] in
+                guard let self, let ctx = self.ctx else {
+                    cont.resume(throwing: WhisperError.modelNotLoaded)
+                    return
+                }
+                var params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY)
+
+                // Set language — keep NSString alive through whisper_full via withExtendedLifetime
+                let langNS = language == "auto" ? nil : (language as NSString)
+                if let langNS {
+                    params.language = langNS.utf8String!
+                    params.detect_language = false
+                } else {
+                    params.language = "auto"
+                    params.detect_language = true
+                }
+
+                // Tuning for real-time use
+                params.n_threads = Int32(max(1, ProcessInfo.processInfo.activeProcessorCount / 2))
+                params.print_realtime = false
+                params.print_progress = false
+                params.print_timestamps = false
+                params.print_special = false
+                params.translate = false
+                params.single_segment = false
+                params.no_timestamps = true
+
+                // Run inference — keep langNS alive so params.language pointer stays valid
+                let result = withExtendedLifetime(langNS) {
+                    whisper_full(ctx, params, audio, Int32(audio.count))
+                }
+                guard result == 0 else {
+                    cont.resume(throwing: WhisperError.inferenceFailed(result))
+                    return
+                }
+
+                // Extract text
+                let nSegments = whisper_full_n_segments(ctx)
+                var text = ""
+                for i in 0..<nSegments {
+                    if let cStr = whisper_full_get_segment_text(ctx, i) {
+                        text += String(cString: cStr)
+                    }
+                }
+
+                cont.resume(returning: text.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+    }
+
+    deinit {
+        // Safety net: shutdown() should already have been called.
+        // No queue dispatch here — by the time deinit runs, no external
+        // strong references exist, so no transcribe closures can be queued.
+        if let ctx {
+            whisper_free(ctx)
+        }
+    }
+}
+
+enum WhisperError: LocalizedError {
+    case modelLoadFailed(String)
+    case modelNotLoaded
+    case inferenceFailed(Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .modelLoadFailed(let path): return "Failed to load model at \(path)"
+        case .modelNotLoaded: return "No model loaded"
+        case .inferenceFailed(let code): return "Whisper inference failed (code \(code))"
+        }
+    }
+}

--- a/voice/Sources/CodeyVoice/main.swift
+++ b/voice/Sources/CodeyVoice/main.swift
@@ -1,0 +1,33 @@
+import Cocoa
+
+/// Resolve gateway port: CLI arg > env var > UserDefaults > default.
+func resolveGatewayPort() -> Int {
+    let args = CommandLine.arguments
+    if let idx = args.firstIndex(of: "--gateway-port"), idx + 1 < args.count, let port = Int(args[idx + 1]) {
+        UserDefaults.standard.set(port, forKey: "gatewayPort")
+        return port
+    }
+    if let envStr = ProcessInfo.processInfo.environment["CODEY_GATEWAY_PORT"], let port = Int(envStr) {
+        UserDefaults.standard.set(port, forKey: "gatewayPort")
+        return port
+    }
+    let saved = UserDefaults.standard.integer(forKey: "gatewayPort")
+    return saved > 0 ? saved : 3001
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory) // menu bar only, no dock icon
+
+let port = resolveGatewayPort()
+let coordinator = VoiceCoordinator(gatewayPort: port)
+coordinator.start()
+
+NotificationCenter.default.addObserver(
+    forName: NSApplication.willTerminateNotification,
+    object: nil,
+    queue: .main
+) { _ in
+    coordinator.applicationWillTerminate()
+}
+
+app.run()

--- a/voice/Sources/WhisperBridge/include/module.modulemap
+++ b/voice/Sources/WhisperBridge/include/module.modulemap
@@ -1,0 +1,4 @@
+module WhisperBridge {
+    header "shim.h"
+    export *
+}

--- a/voice/Sources/WhisperBridge/include/shim.h
+++ b/voice/Sources/WhisperBridge/include/shim.h
@@ -1,0 +1,8 @@
+#ifndef WHISPER_BRIDGE_SHIM_H
+#define WHISPER_BRIDGE_SHIM_H
+
+// Re-export the whisper.cpp C API for Swift.
+// whisper.h is a pure-C header (extern "C" guarded) and can be imported directly.
+#include "whisper.h"
+
+#endif


### PR DESCRIPTION
## Summary

- **Native macOS Swift helper** (`voice/`) with system-wide global hotkey (F5 toggle) for voice recording, whisper.cpp integration for speech-to-text, and CGEvent/Accessibility text injection that works in any app
- **Multilingual tiny model** (~78MB) by default, configurable model path for larger models
- **Gateway endpoints** — `GET/PUT /voice/config`, `GET/POST /voice/status` with 501 platform guard on non-macOS
- **Settings UI** — Voice input section in SettingsTab (enabled toggle, hotkey, language, injection mode, model path)
- **Security & memory safety** — weak self in WhisperEngine, explicit shutdown teardown, secure text field guard, modelPath validation, CORS restriction for /voice/* routes
- **Cross-platform ready** — `voice.enabled` defaults to `false`; Windows/Linux deployments unaffected

## Test plan

- [ ] `npm run build` — gateway TypeScript compiles clean
- [ ] `npx tsc --project codey-mac/tsconfig.json --noEmit` — SettingsTab type-checks
- [ ] Gateway: `GET /voice/status` returns 501 on non-macOS, returns config state on macOS
- [ ] Gateway: `PUT /voice/config` validates modelPath (rejects non-.bin, non-absolute, out-of-scope paths)
- [ ] Settings UI: Voice section renders, fields save on change, "Saved" indicator appears
- [ ] macOS helper: `make build && make run` — menu bar icon appears, F5 toggles recording
- [ ] Text injection: transcribed text pastes at cursor in any app; secure text fields are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)