### PR TITLE
Fix channel link button state and Mac->channel message sync

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -808,14 +808,14 @@ app.whenReady().then(async () => {
   ipcMain.handle('chats:link', async (_e, chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      await inProcessGateway.linkChat(chatId, channel, channelUserId)
+      return inProcessGateway.linkChat(chatId, channel, channelUserId)
     })
   )
 
   ipcMain.handle('chats:unlink', async (_e, chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      inProcessGateway.unlinkChat(chatId, channel, channelUserId)
+      return inProcessGateway.unlinkChat(chatId, channel, channelUserId)
     })
   )
 

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -88,8 +88,8 @@ declare global {
         send: (payload: { chatId: string; text: string; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) => Promise<IpcResult<{ response: string; chatId: string; tokens?: number; durationSec?: number }>>
         stop: (chatId: string) => Promise<IpcResult<boolean>>
         onEvent: (handler: (ev: ChatStreamEvent) => void) => () => void
-        link: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<void>>
-        unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<void>>
+        link: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<Chat>>
+        unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<Chat>>
         updateContextPanelOpen: (id: string, open: boolean | null) => Promise<IpcResult<Chat>>
       }
       pairing: {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -200,7 +200,7 @@ const TeamMessage: React.FC<{
 }
 
 export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
-  const { state, sendMessage, stopChat, setSelection, setAgentModel, renameChat, setContextPanelOpen } = useChats()
+  const { state, sendMessage, stopChat, setSelection, setAgentModel, renameChat, setContextPanelOpen, linkChannel, unlinkChannel } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -483,9 +483,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     if (pairings.length === 1) {
       const p = pairings[0]
       if (isLinked(p.channel, p.channelUserId)) {
-        await apiService.unlinkChat(chat.id, p.channel, p.channelUserId)
+        await unlinkChannel(chat.id, p.channel, p.channelUserId)
       } else {
-        await apiService.linkChat(chat.id, p.channel, p.channelUserId)
+        await linkChannel(chat.id, p.channel, p.channelUserId)
       }
       return
     }
@@ -494,9 +494,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     if (idx >= 0 && idx < pairings.length) {
       const p = pairings[idx]
       if (isLinked(p.channel, p.channelUserId)) {
-        await apiService.unlinkChat(chat.id, p.channel, p.channelUserId)
+        await unlinkChannel(chat.id, p.channel, p.channelUserId)
       } else {
-        await apiService.linkChat(chat.id, p.channel, p.channelUserId)
+        await linkChannel(chat.id, p.channel, p.channelUserId)
       }
     }
   }

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -201,6 +201,8 @@ interface ChatsContextValue {
   setSelection: (chatId: string, selection: ChatSelection) => Promise<void>
   setAgentModel: (chatId: string, agent: string | null, model: string | null) => Promise<void>
   setContextPanelOpen: (chatId: string, open: boolean | null) => Promise<void>
+  linkChannel: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<void>
+  unlinkChannel: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<void>
   sendMessage: (chatId: string, text: string, attachments?: FileAttachment[]) => Promise<void>
   stopChat: (chatId: string) => Promise<void>
   toggleWorkspace: (workspaceName: string) => void
@@ -356,6 +358,14 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       // The server-side write happens in the background.
       dispatch({ type: 'patchContextPanelOpen', chatId, open })
       try { await apiService.chats.updateContextPanelOpen(chatId, open) } catch { /* swallow */ }
+    },
+    async linkChannel(chatId, channel, channelUserId) {
+      const chat = await apiService.linkChat(chatId, channel, channelUserId)
+      dispatch({ type: 'upsert', chat })
+    },
+    async unlinkChannel(chatId, channel, channelUserId) {
+      const chat = await apiService.unlinkChat(chatId, channel, channelUserId)
+      dispatch({ type: 'upsert', chat })
     },
     async sendMessage(chatId, text, attachments) {
       const assistantMessageId = `asst-${Date.now()}-${Math.random()}`

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -174,16 +174,16 @@ export const apiService = {
       unwrap(await window.codey.chats.stop(chatId)),
     onEvent: (handler: (ev: ChatStreamEvent) => void): (() => void) =>
       window.codey.chats.onEvent(handler),
-    link: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+    link: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<Chat> =>
       unwrap(await window.codey.chats.link(chatId, channel, channelUserId)),
-    unlink: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+    unlink: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<Chat> =>
       unwrap(await window.codey.chats.unlink(chatId, channel, channelUserId)),
   },
 
-  linkChat: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+  linkChat: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<Chat> =>
     unwrap(await window.codey.chats.link(chatId, channel, channelUserId)),
 
-  unlinkChat: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<void> =>
+  unlinkChat: async (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string): Promise<Chat> =>
     unwrap(await window.codey.chats.unlink(chatId, channel, channelUserId)),
 
   startPairing: async (channel: 'telegram' | 'discord' | 'imessage'): Promise<string> =>

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, ChannelKind, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runManager, ManagerTurn, ManagerHistoryEntry, parseAskUser, parseAsk, PendingTeamState } from '@codey/core';
+import { AgentRequest, AgentResponse, ChannelKind, Chat, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runManager, ManagerTurn, ManagerHistoryEntry, parseAskUser, parseAsk, PendingTeamState } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -254,7 +254,7 @@ export class Codey {
    * Mac calls this to attach a channel route to an existing chat.
    * Pushes a one-time summary to the channel after attaching.
    */
-  public async linkChat(chatId: string, channel: ChannelKind, channelUserId: string): Promise<void> {
+  public async linkChat(chatId: string, channel: ChannelKind, channelUserId: string): Promise<Chat> {
     const binding = this.pairingStore.findByChannelUser(channel, channelUserId);
     if (!binding) throw new Error(`No pairing for ${channel}:${channelUserId}`);
 
@@ -262,25 +262,37 @@ export class Codey {
     const channelChatId = channelUserId;
     const route: ChatRoute = { channel, channelUserId, channelChatId, attachedAt: Date.now() };
 
-    this.chatManager.addRoute(chatId, route);
+    // Detect "already linked" before mutating, so we can skip the summary push
+    // on repeat clicks. addRoute is idempotent but unconditionally re-sending
+    // the summary would spam the channel every time the user clicks the link
+    // button while the route is already attached.
+    const existing = this.chatManager.get(chatId);
+    const alreadyLinked = !!existing?.routes?.some(r =>
+      r.channel === channel &&
+      r.channelUserId === channelUserId &&
+      r.channelChatId === channelChatId
+    );
+
+    const updated = this.chatManager.addRoute(chatId, route);
     this.pairingStore.setCurrentChat(channel, channelUserId, chatId);
 
-    const chat = this.chatManager.get(chatId);
-    if (!chat) return;
-    const summary = summarizePriorHistory(chat);
-    const handler = this.handlers.get(channel);
-    if (handler?.sendToRoute) {
-      try {
-        await handler.sendToRoute(route, summary);
-      } catch (err) {
-        this.logger.warn(`linkChat: failed to push summary to ${channel}: ${(err as Error).message}`);
+    if (!alreadyLinked) {
+      const summary = summarizePriorHistory(updated);
+      const handler = this.handlers.get(channel);
+      if (handler?.sendToRoute) {
+        try {
+          await handler.sendToRoute(route, summary);
+        } catch (err) {
+          this.logger.warn(`linkChat: failed to push summary to ${channel}: ${(err as Error).message}`);
+        }
       }
     }
+    return updated;
   }
 
-  public unlinkChat(chatId: string, channel: ChannelKind, channelUserId: string): void {
+  public unlinkChat(chatId: string, channel: ChannelKind, channelUserId: string): Chat {
     const channelChatId = channelUserId;
-    this.chatManager.removeRoute(chatId, channel, channelUserId, channelChatId);
+    return this.chatManager.removeRoute(chatId, channel, channelUserId, channelChatId);
   }
 
   getAgentFactory(): AgentFactory { return this.agentFactory; }
@@ -3145,6 +3157,15 @@ Example: /model gpt-4.1 write a Python script`;
       }
 
       sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title, choices: surfacedChoices });
+
+      // Fan out the Mac-originated turn to every attached channel route so the
+      // other surface (Telegram/Discord/iMessage) sees both the user prompt
+      // and the agent reply. Passing a synthetic origin that no real route
+      // uses ensures every route receives both messages.
+      const MAC_ORIGIN = '__mac__' as unknown as ChannelType;
+      await this.fanOutToOtherRoutes(chatId, MAC_ORIGIN, '', `📱 ${userText}`);
+      await this.fanOutToOtherRoutes(chatId, MAC_ORIGIN, '', output);
+
       return { response: output, chatId, tokens, durationSec };
     } catch (err) {
       const message = `Error: ${(err as Error).message}`;


### PR DESCRIPTION
## Summary
- `linkChat`/`unlinkChat` return the updated `Chat` and skip the summary push when the route is already linked, so repeat clicks don't re-send the summary.
- Mac UI dispatches the returned chat into state via new `linkChannel`/`unlinkChannel` hook methods, so the link button reflects connected state immediately.
- `sendToChat` fans out user input (`📱 <text>`) and agent output to other attached routes via a synthetic `__mac__` origin, mirroring Mac-side conversation into linked channels.

## Test plan
- [ ] Click link button in Mac app: summary posts once, button flips to connected state
- [ ] Click link button again: toggles to unlink (no duplicate summary)
- [ ] Send message from Mac app: linked channel receives both the user input (with 📱 prefix) and the agent response
- [ ] Send message from channel: Mac app still receives the response (no regression on existing fan-out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)