### PR TITLE
Per-chat CLI session resume + abort short-circuit

### DIFF
--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -62,4 +62,12 @@ export interface Chat {
   contextPanelOpen?: boolean;
   /** Last unanswered choice question in a non-team chat. Cleared on next user message. */
   lastAskedOptions?: { messageId: string; options: string[] };
+  /**
+   * Warm CLI session for this chat. When set, the next turn for the same
+   * coding agent is sent via `--resume <sessionId>` (only the new user text is
+   * passed to the agent; the agent retrieves prior context from its own
+   * session store). Cleared on agent switch, selection-type change, /clear,
+   * or when a resume attempt fails.
+   */
+  sessionAnchor?: { agent: 'claude-code' | 'opencode' | 'codex'; sessionId: string };
 }

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -36,7 +36,16 @@ function formatAttachmentList(attachments: FileAttachment[]): string {
   ].join('\n');
 }
 
-/** Build the prompt string from the tail of the chat's message history + new user message. */
+/**
+ * Build the prompt string from the tail of the chat's message history + new
+ * user message. Used by paths that don't support session resume (currently
+ * team-mode dispatch and as the bootstrap turn of resume-capable chats).
+ *
+ * History is rendered as a single "Prior conversation" block — NOT as a
+ * "User:/Assistant:" transcript — so the model does not treat the prompt as
+ * a script to continue (which previously caused it to fabricate further
+ * "User:" turns and self-answer).
+ */
 export function buildChatPrompt(
   chat: Chat,
   userText: string,
@@ -44,19 +53,51 @@ export function buildChatPrompt(
   windowSize = CHAT_CONTEXT_WINDOW,
 ): string {
   const tail = chat.messages.slice(-windowSize);
-  const lines: string[] = [];
+  const sections: string[] = [];
 
-  // Prepend attachment context if present
   if (attachments && attachments.length > 0) {
-    lines.push(formatAttachmentList(attachments));
+    sections.push(formatAttachmentList(attachments));
   }
 
-  for (const m of tail) {
-    const tag = m.role === 'user' ? 'User' : 'Assistant';
-    lines.push(`${tag}: ${m.content}`);
+  if (tail.length > 0) {
+    const transcript = tail.map(m => {
+      const tag = m.role === 'user' ? '[user]' : '[assistant]';
+      return `${tag}\n${m.content}`;
+    }).join('\n\n');
+    sections.push(
+      `[Prior conversation — context only; do not continue or fabricate further turns]\n${transcript}`,
+    );
   }
-  lines.push(`User: ${userText}`);
-  return lines.join('\n\n');
+
+  sections.push(`[Respond to this new user message]\n${userText}`);
+  return sections.join('\n\n');
+}
+
+/**
+ * Bootstrap prompt for a chat that is about to start (or restart) a CLI
+ * session. Always includes prior context — used on the FIRST turn of a fresh
+ * session anchor. Subsequent same-agent turns send only userText via resume.
+ */
+export function buildChatBootstrapPrompt(
+  chat: Chat,
+  userText: string,
+  attachments?: FileAttachment[],
+  windowSize = CHAT_CONTEXT_WINDOW,
+): string {
+  return buildChatPrompt(chat, userText, attachments, windowSize);
+}
+
+/** Resume-turn prompt: just the new user text, optionally prefixed by attachments. */
+export function buildChatResumePrompt(
+  userText: string,
+  attachments?: FileAttachment[],
+): string {
+  const parts: string[] = [];
+  if (attachments && attachments.length > 0) {
+    parts.push(formatAttachmentList(attachments));
+  }
+  parts.push(userText);
+  return parts.join('\n\n');
 }
 
 export function assistantPrefixForSelection(chat: Chat): string {

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -131,10 +131,31 @@ export class ChatManager {
 
   updateSelection(chatId: string, selection: ChatSelection): Chat {
     const chat = this.requireChat(chatId);
+    const changedKind = chat.selection.type !== selection.type
+      || (chat.selection.type === selection.type && (chat.selection as { name?: string }).name !== (selection as { name?: string }).name);
     chat.selection = selection;
+    if (changedKind) delete chat.sessionAnchor;
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;
+  }
+
+  /** Persist the warm CLI session for this chat. */
+  setSessionAnchor(chatId: string, anchor: NonNullable<Chat['sessionAnchor']>): void {
+    const chat = this.cache.get(chatId);
+    if (!chat) return;
+    chat.sessionAnchor = anchor;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+  }
+
+  /** Drop the warm CLI session — next turn will bootstrap. */
+  clearSessionAnchor(chatId: string): void {
+    const chat = this.cache.get(chatId);
+    if (!chat || !chat.sessionAnchor) return;
+    delete chat.sessionAnchor;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
   }
 
   /**
@@ -143,10 +164,12 @@ export class ChatManager {
    */
   updateAgentModel(chatId: string, agent?: Chat['agent'] | null, model?: string | null): Chat {
     const chat = this.requireChat(chatId);
+    const prevAgent = chat.agent;
     if (agent === null || agent === undefined) delete chat.agent;
     else chat.agent = agent;
     if (model === null || model === undefined || model === '') delete chat.model;
     else chat.model = model;
+    if (chat.agent !== prevAgent) delete chat.sessionAnchor;
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -14,7 +14,7 @@ import { WorkerManager } from '@codey/core';
 import { ChatManager } from './chats';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
-import { buildChatPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink } from './chat-runner';
+import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
 import { resolveChoiceDigit } from './digit-mapping';
@@ -2657,6 +2657,10 @@ Example: /model gpt-4.1 write a Python script`;
     const response = await this.agentFactory.run(agent, request);
     if (response.success) return response;
 
+    // User-initiated abort — do NOT churn through every fallback agent,
+    // spawning subprocesses the user just asked to cancel.
+    if (request.signal?.aborted) return response;
+
     this.logger.error(`Agent ${agent} failed: ${response.error || response.output}`);
 
     // Fallback is opt-in. When disabled, surface the original failure.
@@ -2688,6 +2692,9 @@ Example: /model gpt-4.1 write a Python script`;
       const key = `${entry.agent}::${resolvedModel.model}`;
       if (seen.has(key)) continue;
       seen.add(key);
+
+      // Bail out mid-loop if the user aborted while a fallback was running.
+      if (request.signal?.aborted) return response;
 
       const label = `${entry.agent}(${resolvedModel.model})`;
       this.logger.warn(`Agent ${agent} failed, trying ${label}...`);
@@ -3021,11 +3028,38 @@ Example: /model gpt-4.1 write a Python script`;
       throw new Error(msg);
     }
 
-    // Build the prompt from the existing chat history + the new user turn,
-    // BEFORE persisting the user message. Persisting first would cause
-    // buildChatPrompt to see the new turn in the tail AND get it appended
-    // again as `User: ${userText}`, doubling the user message in the prompt.
-    const prompt = assistantPrefixForSelection(chat) + buildChatPrompt(chat, userText, attachments);
+    // Per-chat override takes precedence over the gateway default.
+    const agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
+    const model = chat.model
+      ? this.getModelConfig(agent, chat.model)
+      : this.getDefaultModelConfig(agent);
+
+    // Decide whether this turn resumes a warm CLI session or bootstraps a
+    // new one. Resume mode skips the full history dump and uses the agent's
+    // own session memory. Bootstrap mode sends a one-shot "prior conversation"
+    // block. Team mode always uses the legacy bootstrap path (no session
+    // resume) because team dispatch builds worker prompts internally.
+    const selPrefix = assistantPrefixForSelection(chat);
+    const canResume = chat.selection.type !== 'team';
+    const warmAnchor = canResume && chat.sessionAnchor && chat.sessionAnchor.agent === agent
+      ? chat.sessionAnchor
+      : undefined;
+
+    let prompt: string;
+    let resumeSessionId: string | undefined;
+    let newSessionId: string | undefined;
+    if (warmAnchor) {
+      // Resume turn: send only the new user text (+ attachments).
+      prompt = selPrefix + buildChatResumePrompt(userText, attachments);
+      resumeSessionId = warmAnchor.sessionId;
+    } else {
+      // Bootstrap turn: include prior history once. For claude-code, pre-allocate
+      // a session id so we can resume on the next turn without parsing CLI output.
+      prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments);
+      if (canResume && agent === 'claude-code') {
+        newSessionId = randomUUID();
+      }
+    }
 
     const userMessage: ChatMessage = {
       id: randomUUID(),
@@ -3036,12 +3070,6 @@ Example: /model gpt-4.1 write a Python script`;
       attachments: attachments && attachments.length > 0 ? attachments : undefined,
     };
     this.chatManager.appendMessage(chatId, userMessage);
-
-    // Per-chat override takes precedence over the gateway default.
-    const agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
-    const model = chat.model
-      ? this.getModelConfig(agent, chat.model)
-      : this.getDefaultModelConfig(agent);
 
     let streamedText = '';
 
@@ -3104,7 +3132,7 @@ Example: /model gpt-4.1 write a Python script`;
         tokens = r.tokens;
         teamChoices = r.choices;
       } else {
-        const response = await this.runWithFallback(agent, {
+        let response = await this.runWithFallback(agent, {
           prompt,
           agent,
           model,
@@ -3112,9 +3140,39 @@ Example: /model gpt-4.1 write a Python script`;
           onStream,
           onStatus,
           signal: abortController.signal,
+          resumeSessionId,
+          newSessionId,
         });
+        // If resume failed (stale session id on disk, or agent rejected it),
+        // drop the anchor and retry once with a full bootstrap prompt.
+        if (resumeSessionId && !response?.success && !abortController.signal.aborted) {
+          this.logger.warn(`[chat ${chatId}] resume of ${resumeSessionId} failed; bootstrapping`);
+          this.chatManager.clearSessionAnchor(chatId);
+          streamedText = '';
+          resumeSessionId = undefined;
+          newSessionId = canResume && agent === 'claude-code' ? randomUUID() : undefined;
+          prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments);
+          response = await this.runWithFallback(agent, {
+            prompt,
+            agent,
+            model,
+            context: { workingDir },
+            onStream,
+            onStatus,
+            signal: abortController.signal,
+            resumeSessionId: undefined,
+            newSessionId,
+          });
+        }
         output = response?.success ? this.formatAgentResponse(response) : (streamedText || '');
         tokens = (response as any)?.tokens?.total;
+        // Persist the anchor on success for next-turn resume.
+        if (canResume && response?.success) {
+          const anchorId = newSessionId ?? (response as any)?.sessionId;
+          if (anchorId) {
+            this.chatManager.setSessionAnchor(chatId, { agent, sessionId: anchorId });
+          }
+        }
       }
       if (abortController.signal.aborted && !output) {
         output = 'Stopped';


### PR DESCRIPTION
## Summary

- Adds `Chat.sessionAnchor` (agent + sessionId) so long chats reuse the CLI agent's own session store instead of re-shipping full history every turn — big token + latency savings on extended conversations
- Resume failure auto-falls-back: drops the anchor, retries once with a full bootstrap prompt
- Fixes prompt drift bug: history was rendered as a `User:/Assistant:` transcript that the model would occasionally continue with fabricated user turns. Now framed as `[Prior conversation — context only; do not continue or fabricate further turns]`
- Fixes abort regression: hitting Stop mid-turn no longer churns the fallback chain (was spawning N subprocess agents the user just asked to cancel)

## Implementation

| Surface | Change |
|---|---|
| `core/types/chat.ts` | New optional `sessionAnchor: { agent, sessionId }` on `Chat` |
| `gateway/chats.ts` | `setSessionAnchor` / `clearSessionAnchor`; auto-clear on agent or selection change |
| `gateway/chat-runner.ts` | Split into `buildChatBootstrapPrompt` (with history) and `buildChatResumePrompt` (just new text); reformatted history rendering |
| `gateway/gateway.ts` | Choose bootstrap vs resume per turn; pre-allocate UUID for claude-code via `--session-id`; one-shot retry on resume failure; abort short-circuit |

Agent adapters (`claude-code`, `opencode`, `codex`) already accept `resumeSessionId` / `newSessionId` — this is the chat-side consumer that lights up the feature for free-form chats.

## Test plan

- [ ] Send a few turns in a non-team chat. Verify only the first turn includes the full history in the gateway log; subsequent turns send just the user text.
- [ ] Switch agent mid-chat — next turn should bootstrap (anchor cleared).
- [ ] Switch selection (worker → team or team → individual) — same: anchor cleared, bootstrap.
- [ ] `/clear` resets anchor.
- [ ] Manually corrupt the on-disk session id (or wait for claude-code to GC it), send a turn — gateway should log "resume of … failed; bootstrapping" and the turn should still complete.
- [ ] Press Stop while an agent is running — fallback chain should not spawn additional subprocesses.
- [ ] Existing prompt-drift case (Chinese chats where the model used to self-answer fake "用户:" turns) — verify no more fabricated turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)