### PR TITLE
feat(mac): right-click menus for workspaces & chats + channel link picker

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -756,6 +756,32 @@ app.whenReady().then(async () => {
     })
   )
 
+  ipcMain.handle('workspaces:rename', async (_e, oldName: string, newName: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      await workspaceManager.renameWorkspace(oldName, newName)
+      inProcessGateway?.getChatManager().cascadeRenameWorkspace(oldName, newName.trim())
+    })
+  )
+
+  ipcMain.handle('workspaces:reveal', async (_e, name: string) =>
+    wrap(async () => {
+      if (!workspaceManager) throw new Error('Workspace manager not ready')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const root = workspaceManager.getWorkspacesRoot()
+      const wsDir = pathMod.join(root, name)
+      let target = wsDir
+      try {
+        const cfg = JSON.parse(fsMod.readFileSync(pathMod.join(wsDir, 'workspace.json'), 'utf8'))
+        if (cfg && typeof cfg.workingDir === 'string' && fsMod.existsSync(cfg.workingDir)) {
+          target = cfg.workingDir
+        }
+      } catch {}
+      shell.showItemInFolder(target)
+    })
+  )
+
   ipcMain.handle('dialog:pickDirectory', async () =>
     wrap(async () => {
       const result = await dialog.showOpenDialog(mainWindow ?? undefined as any, {

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -18,6 +18,8 @@ contextBridge.exposeInMainWorld('codey', {
     setMemory: (name: string, content: string) => ipcRenderer.invoke('workspaces:memory:set', name, content),
     create: (dir: string) => ipcRenderer.invoke('workspaces:create', dir),
     delete: (name: string) => ipcRenderer.invoke('workspaces:delete', name),
+    rename: (oldName: string, newName: string) => ipcRenderer.invoke('workspaces:rename', oldName, newName),
+    reveal: (name: string) => ipcRenderer.invoke('workspaces:reveal', name),
   },
   dialog: {
     pickDirectory: () => ipcRenderer.invoke('dialog:pickDirectory'),

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -19,6 +19,7 @@ const Shell: React.FC = () => {
   const { isRunning } = useGateway()
   const { state, createChat, selectChat, refreshWorkspaces } = useChats()
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [settingsTab, setSettingsTab] = useState<string | undefined>(undefined)
 
   const activeChat = state.selectedChatId ? state.chats[state.selectedChatId] : null
 
@@ -77,7 +78,7 @@ const Shell: React.FC = () => {
       </div>
       <div style={styles.body}>
         <ChatListPanel
-          onOpenSettings={() => setSettingsOpen(true)}
+          onOpenSettings={(tab) => { setSettingsTab(tab); setSettingsOpen(true) }}
           activeChatId={state.selectedChatId}
         />
         <div style={styles.content}>
@@ -97,7 +98,7 @@ const Shell: React.FC = () => {
             </div>
           )}
         </div>
-        {settingsOpen && <SettingsOverlay onClose={() => { setSettingsOpen(false); refreshWorkspaces() }} />}
+        {settingsOpen && <SettingsOverlay initialTab={settingsTab} onClose={() => { setSettingsOpen(false); setSettingsTab(undefined); refreshWorkspaces() }} />}
         <VoiceRecorder />
       </div>
       <style>{`

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -31,6 +31,8 @@ declare global {
         setMemory: (name: string, content: string) => Promise<IpcResult<void>>
         create: (dir: string) => Promise<IpcResult<string>>
         delete: (name: string) => Promise<IpcResult<void>>
+        rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
+        reveal: (name: string) => Promise<IpcResult<void>>
       }
       dialog: {
         pickDirectory: () => Promise<IpcResult<string | null>>

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -6,8 +6,14 @@ import { C } from '../theme'
 import { RouteIcons } from './RouteIcons'
 
 interface Props {
-  onOpenSettings: () => void
+  onOpenSettings: (tab?: string) => void
   activeChatId: string | null
+}
+
+interface WsMenuState {
+  workspace: string
+  x: number
+  y: number
 }
 
 export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId }) => {
@@ -18,6 +24,11 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
   const [gatewayWorkspace, setGatewayWorkspace] = useState<string>('')
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
+  const [wsMenu, setWsMenu] = useState<WsMenuState | null>(null)
+  const [renamingWs, setRenamingWs] = useState<string | null>(null)
+  const [wsRenameValue, setWsRenameValue] = useState('')
+  const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
+  const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
   // Shrink the panel on narrow windows so the conversation column keeps
   // breathing room. Matches the threshold used in ChatTab for the context panel.
   const [narrow, setNarrow] = useState<boolean>(() => window.innerWidth < 600)
@@ -61,6 +72,92 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
     const chat = await createChat(target)
     setLastWorkspace(chat.workspaceName)
   }
+
+  const closeWsMenu = () => setWsMenu(null)
+
+  const beginRenameWs = (ws: string) => {
+    closeWsMenu()
+    if (ws === 'default') {
+      alert('The "default" workspace is protected and cannot be renamed.')
+      return
+    }
+    setRenamingWs(ws)
+    setWsRenameValue(ws)
+  }
+
+  const commitRenameWs = async () => {
+    const oldName = renamingWs
+    const newName = wsRenameValue.trim()
+    setRenamingWs(null)
+    if (!oldName || !newName || newName === oldName) return
+    try {
+      await apiService.renameWorkspace(oldName, newName)
+      const fresh = await apiService.getWorkspaces()
+      setWorkspaces(fresh)
+      await refreshWorkspaces()
+      if (lastWorkspace === oldName) setLastWorkspace(newName)
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to rename workspace')
+    }
+  }
+
+  const deleteWs = async (ws: string) => {
+    closeWsMenu()
+    if (ws === 'default') {
+      alert('The "default" workspace is protected and cannot be deleted.')
+      return
+    }
+    if (!confirm(`Delete workspace "${ws}" and all its chats?`)) return
+    try {
+      await apiService.deleteWorkspace(ws)
+      const fresh = await apiService.getWorkspaces()
+      setWorkspaces(fresh)
+      await refreshWorkspaces()
+      if (lastWorkspace === ws) setLastWorkspace(fresh[0] ?? '')
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to delete workspace')
+    }
+  }
+
+  const setAsGateway = async (ws: string) => {
+    closeWsMenu()
+    try {
+      await apiService.switchWorkspace(ws)
+      const w = await apiService.getCurrentWorkspace()
+      setGatewayWorkspace(w)
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to switch workspace')
+    }
+  }
+
+  const revealWs = async (ws: string) => {
+    closeWsMenu()
+    try {
+      await apiService.revealWorkspace(ws)
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to reveal workspace')
+    }
+  }
+
+  const editMemoryWs = (ws: string) => {
+    closeWsMenu()
+    setLastWorkspace(ws)
+    onOpenSettings('workspaces')
+  }
+
+  useEffect(() => {
+    if (!wsMenu && !chatMenu) return
+    const onClick = () => { setWsMenu(null); setChatMenu(null) }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { setWsMenu(null); setChatMenu(null) }
+    }
+    window.addEventListener('mousedown', onClick)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onClick)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [wsMenu, chatMenu])
 
   const handleAddWorkspace = async () => {
     if (addingWorkspace) return
@@ -112,9 +209,31 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
           const collapsed = !!state.collapsedWorkspaces[ws]
           return (
             <div key={ws}>
-              <div style={styles.groupHeader} onClick={() => toggleWorkspace(ws)}>
-                <span style={{ ...styles.chevron, transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)' }}>▸</span>
-                <span style={styles.groupName}>{ws}</span>
+              <div
+                style={styles.groupHeader}
+                onClick={() => renamingWs === ws ? null : toggleWorkspace(ws)}
+                onContextMenu={(e) => {
+                  e.preventDefault()
+                  setWsMenu({ workspace: ws, x: e.clientX, y: e.clientY })
+                }}
+              >
+                <span style={styles.chevron}>{collapsed ? '📁︎' : '📂︎'}</span>
+                {renamingWs === ws ? (
+                  <input
+                    autoFocus
+                    value={wsRenameValue}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={e => setWsRenameValue(e.target.value)}
+                    onBlur={commitRenameWs}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                      else if (e.key === 'Escape') { setRenamingWs(null) }
+                    }}
+                    style={styles.renameInput}
+                  />
+                ) : (
+                  <span style={styles.groupName}>{ws}</span>
+                )}
                 {ws === gatewayWorkspace && (
                   <span style={styles.gatewayBadge} title="Gateway default workspace — receives messages from chat platforms"/>
                 )}
@@ -139,6 +258,12 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
                       e.stopPropagation()
                       setRenamingId(chat.id)
                       setRenameValue(chat.title)
+                    }}
+                    onContextMenu={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      setChatMenuView('main')
+                      setChatMenu({ chat, x: e.clientX, y: e.clientY })
                     }}
                   >
                     {isRenaming ? (
@@ -192,8 +317,102 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
           disabled={addingWorkspace}
           title="Pick a folder and create a new workspace + chat"
         >{addingWorkspace ? 'Picking…' : '+ Add Workspace'}</button>
-        <button style={styles.settingsBtn} onClick={onOpenSettings}>⚙ Settings</button>
+        <button style={styles.settingsBtn} onClick={() => onOpenSettings()}>⚙ Settings</button>
       </div>
+      {wsMenu && (
+        <div
+          style={{ ...styles.menu, top: wsMenu.y, left: wsMenu.x }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div style={styles.menuHeader}>{wsMenu.workspace}</div>
+          <button style={styles.menuItem} onClick={() => handleNewChat(wsMenu.workspace).then(closeWsMenu)}>＋ New chat</button>
+          <button
+            style={{ ...styles.menuItem, opacity: wsMenu.workspace === 'default' ? 0.4 : 1 }}
+            disabled={wsMenu.workspace === 'default'}
+            onClick={() => beginRenameWs(wsMenu.workspace)}
+          >✎ Rename…</button>
+          <button
+            style={styles.menuItem}
+            onClick={() => setAsGateway(wsMenu.workspace)}
+            disabled={wsMenu.workspace === gatewayWorkspace}
+          >★ Set as Gateway default</button>
+          <button style={styles.menuItem} onClick={() => revealWs(wsMenu.workspace)}>↗ Reveal in Finder</button>
+          <button style={styles.menuItem} onClick={() => editMemoryWs(wsMenu.workspace)}>✦ Edit memory…</button>
+          <div style={styles.menuSep} />
+          <button
+            style={{ ...styles.menuItem, color: C.red, opacity: wsMenu.workspace === 'default' ? 0.4 : 1 }}
+            disabled={wsMenu.workspace === 'default'}
+            onClick={() => deleteWs(wsMenu.workspace)}
+          >✕ Delete workspace</button>
+        </div>
+      )}
+      {chatMenu && (
+        <div
+          style={{ ...styles.menu, top: chatMenu.y, left: chatMenu.x }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div style={styles.menuHeader}>{chatMenu.chat.title}</div>
+          {chatMenuView === 'main' ? (
+            <>
+              <button
+                style={styles.menuItem}
+                onClick={() => setChatMenuView('connect')}
+              >🔗 Connect to channel ▸</button>
+              <button
+                style={styles.menuItem}
+                onClick={() => {
+                  const c = chatMenu.chat
+                  setChatMenu(null)
+                  setRenamingId(c.id)
+                  setRenameValue(c.title)
+                }}
+              >✎ Rename…</button>
+              <button
+                style={styles.menuItem}
+                onClick={() => { handleNewChat(chatMenu.chat.workspaceName); setChatMenu(null) }}
+              >＋ New chat in {chatMenu.chat.workspaceName}</button>
+              <button
+                style={styles.menuItem}
+                onClick={async () => {
+                  try { await navigator.clipboard.writeText(chatMenu.chat.id) } catch {}
+                  setChatMenu(null)
+                }}
+              >⧉ Copy chat ID</button>
+              <div style={styles.menuSep} />
+              <button
+                style={{ ...styles.menuItem, color: C.red }}
+                onClick={async () => {
+                  const c = chatMenu.chat
+                  setChatMenu(null)
+                  if (confirm(`Delete chat "${c.title}"?`)) {
+                    await deleteChat(c.id)
+                  }
+                }}
+              >✕ Delete chat</button>
+            </>
+          ) : (
+            <>
+              <button style={styles.menuItem} onClick={() => setChatMenuView('main')}>◂ Back</button>
+              {(['telegram', 'discord', 'imessage'] as const).map(ch => (
+                <button
+                  key={ch}
+                  style={styles.menuItem}
+                  onClick={() => {
+                    const c = chatMenu.chat
+                    setChatMenu(null)
+                    selectChat(c.id)
+                    window.dispatchEvent(new CustomEvent('codey:open-pairing', {
+                      detail: { chatId: c.id, channel: ch },
+                    }))
+                  }}
+                >{ch === 'telegram' ? '✈ Telegram' : ch === 'discord' ? '◈ Discord' : '◐ iMessage'}</button>
+              ))}
+            </>
+          )}
+        </div>
+      )}
       <style>{`
         @keyframes codey-pulse-dot {
           0%, 100% { opacity: 1; transform: scale(1); }
@@ -263,4 +482,24 @@ const styles: Record<string, React.CSSProperties> = {
     background: 'transparent', color: C.fg2, cursor: 'pointer',
     textAlign: 'left', borderRadius: 6, fontSize: 13,
   },
+  menu: {
+    position: 'fixed', zIndex: 1000,
+    minWidth: 180, padding: 4,
+    background: C.surface2 ?? C.surface,
+    border: `1px solid ${C.border2}`,
+    borderRadius: 8,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+    display: 'flex', flexDirection: 'column',
+  },
+  menuHeader: {
+    padding: '4px 10px 6px', fontSize: 11, color: C.fg3,
+    borderBottom: `1px solid ${C.border}`, marginBottom: 4,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  menuItem: {
+    background: 'transparent', border: 'none', textAlign: 'left',
+    padding: '6px 10px', borderRadius: 4, color: C.fg2,
+    fontSize: 12, cursor: 'pointer',
+  },
+  menuSep: { height: 1, background: C.border, margin: '4px 0' },
 }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -218,6 +218,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [pairings, setPairings] = useState<Array<{ channel: 'telegram'|'discord'|'imessage'; channelUserId: string }>>([])
   const [pairingModal, setPairingModal] = useState<null | 'telegram' | 'discord' | 'imessage'>(null)
+  const [linkMenuOpen, setLinkMenuOpen] = useState(false)
   const [followLatest, setFollowLatest] = useState(true)
   const [selectedTurnIdState, setSelectedTurnIdState] = useState<string | null>(null)
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set())
@@ -319,6 +320,17 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     window.addEventListener('keydown', h)
     return () => window.removeEventListener('keydown', h)
   }, [chat?.id, chat?.contextPanelOpen])
+
+  useEffect(() => {
+    const onOpenPairing = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { chatId?: string; channel?: 'telegram'|'discord'|'imessage' } | undefined
+      if (!detail?.channel) return
+      if (detail.chatId && detail.chatId !== chatId) return
+      setPairingModal(detail.channel)
+    }
+    window.addEventListener('codey:open-pairing', onOpenPairing as EventListener)
+    return () => window.removeEventListener('codey:open-pairing', onOpenPairing as EventListener)
+  }, [chatId])
 
   if (!chat) return null
 
@@ -585,13 +597,68 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
           <PanelRightIcon color={C.fg} filled={panelOpen} />
         </button>
         <RouteIcons routes={chat.routes} />
-        <button
-          onClick={onLinkButton}
-          style={styles.linkBtn}
-          title={chat.routes?.length ? 'Manage channel links' : 'Link to a channel'}
-        >
-          {chat.routes?.length ? '🔗' : '🔗+'}
-        </button>
+        <div style={{ position: 'relative' }}>
+          <button
+            onClick={() => setLinkMenuOpen(o => !o)}
+            style={styles.linkBtn}
+            title={chat.routes?.length ? 'Manage channel links' : 'Link to a channel'}
+          >
+            {chat.routes?.length ? '🔗' : '🔗+'}
+          </button>
+          {linkMenuOpen && (
+            <>
+              <div
+                onClick={() => setLinkMenuOpen(false)}
+                style={{ position: 'fixed', inset: 0, zIndex: 999 }}
+              />
+              <div style={styles.linkMenu} onClick={e => e.stopPropagation()}>
+                {(['telegram', 'discord', 'imessage'] as const).map(ch => {
+                  const linked = chat.routes?.find(r => r.channel === ch)
+                  const label = ch === 'telegram' ? '✈ Telegram' : ch === 'discord' ? '◈ Discord' : '◐ iMessage'
+                  return (
+                    <button
+                      key={ch}
+                      style={{
+                        ...styles.linkMenuItem,
+                        background: linked ? C.red + '22' : 'transparent',
+                        border: linked ? `1px solid ${C.red}55` : '1px solid transparent',
+                        color: linked ? C.red : C.fg2,
+                      }}
+                      onClick={async () => {
+                        setLinkMenuOpen(false)
+                        if (linked) {
+                          await unlinkChannel(chat.id, linked.channel, linked.channelUserId)
+                        } else {
+                          setPairingModal(ch)
+                        }
+                      }}
+                      title={linked
+                        ? `Disconnect ${ch} (${linked.channelUserId})`
+                        : `Connect ${ch}`}
+                    >
+                      <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <span
+                          style={{
+                            width: 6, height: 6, borderRadius: '50%',
+                            background: linked ? C.green : C.fg3,
+                            boxShadow: linked ? `0 0 6px ${C.green}` : 'none',
+                          }}
+                        />
+                        {label}
+                      </span>
+                      <span style={{
+                        fontSize: 11, fontWeight: 600,
+                        color: linked ? C.red : C.accent,
+                      }}>
+                        {linked ? '✕ Disconnect' : '+ Connect'}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </>
+          )}
+        </div>
       </div>
 
       <div
@@ -1018,6 +1085,21 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer',
     fontSize: 12,
     color: C.fg,
+  },
+  linkMenu: {
+    position: 'absolute', top: 'calc(100% + 4px)', right: 0, zIndex: 1000,
+    minWidth: 180, padding: 4,
+    background: C.surface2 ?? C.surface,
+    border: `1px solid ${C.border2}`,
+    borderRadius: 8,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+    display: 'flex', flexDirection: 'column',
+  },
+  linkMenuItem: {
+    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+    gap: 12, background: 'transparent', border: 'none',
+    padding: '6px 10px', borderRadius: 4, color: C.fg2,
+    fontSize: 12, cursor: 'pointer', textAlign: 'left',
   },
   teamSummary: {
     fontSize: 13, fontWeight: 600, color: C.accent,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -647,10 +647,10 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                         {label}
                       </span>
                       <span style={{
-                        fontSize: 11, fontWeight: 600,
+                        fontSize: 14, fontWeight: 600,
                         color: linked ? C.red : C.accent,
                       }}>
-                        {linked ? '✕ Disconnect' : '+ Connect'}
+                        {linked ? '✕' : '+'}
                       </span>
                     </button>
                   )

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -20,10 +20,12 @@ const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
   { key: 'status',     label: 'Gateway',    icon: '◉', description: 'Server status & logs' },
 ]
 
-interface Props { onClose: () => void }
+interface Props { onClose: () => void; initialTab?: string }
 
-export const SettingsOverlay: React.FC<Props> = ({ onClose }) => {
-  const [tab, setTab] = useState<Tab>('settings')
+export const SettingsOverlay: React.FC<Props> = ({ onClose, initialTab }) => {
+  const [tab, setTab] = useState<Tab>(
+    (initialTab && TABS.some(t => t.key === initialTab)) ? (initialTab as Tab) : 'settings'
+  )
   const { isRunning, status, logs } = useGateway()
 
   useEffect(() => {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -77,6 +77,12 @@ export const apiService = {
   deleteWorkspace: async (name: string): Promise<void> =>
     unwrap(await window.codey.workspaces.delete(name)),
 
+  renameWorkspace: async (oldName: string, newName: string): Promise<void> =>
+    unwrap(await window.codey.workspaces.rename(oldName, newName)),
+
+  revealWorkspace: async (name: string): Promise<void> =>
+    unwrap(await window.codey.workspaces.reveal(name)),
+
   pickDirectory: async (): Promise<string | null> =>
     unwrap(await window.codey.dialog.pickDirectory()),
 

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -232,6 +232,33 @@ export class WorkspaceManager {
     return fs.existsSync(memoryPath) ? fs.readFileSync(memoryPath, 'utf-8') : '';
   }
 
+  async renameWorkspace(oldName: string, newName: string): Promise<void> {
+    if (oldName === 'default') {
+      throw new Error('The "default" workspace is protected and cannot be renamed.');
+    }
+    const trimmed = newName.trim();
+    if (!trimmed) throw new Error('New workspace name is required');
+    if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+      throw new Error('Workspace name may only contain letters, numbers, dot, underscore and hyphen');
+    }
+    if (trimmed === oldName) return;
+    const src = path.join(this.workspacesDir, oldName);
+    const dst = path.join(this.workspacesDir, trimmed);
+    if (!fs.existsSync(src)) throw new Error(`Workspace "${oldName}" does not exist`);
+    if (fs.existsSync(dst)) throw new Error(`Workspace "${trimmed}" already exists`);
+    const root = path.resolve(this.workspacesDir);
+    if (!path.resolve(src).startsWith(root + path.sep) ||
+        !path.resolve(dst).startsWith(root + path.sep)) {
+      throw new Error('Refusing to rename outside of workspaces root');
+    }
+    await fs.promises.rename(src, dst);
+    this.logger.info(`[Workspace] Renamed workspace: ${oldName} -> ${trimmed}`);
+    if (this.currentWorkspace === oldName) {
+      this.currentWorkspace = trimmed;
+      this.memoryStore = new MemoryStore(this.getWorkspacePath());
+    }
+  }
+
   async deleteWorkspace(name: string): Promise<void> {
     if (name === 'default') {
       throw new Error('The "default" workspace is protected and cannot be deleted.');

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -236,6 +236,21 @@ export class ChatManager {
     return chat;
   }
 
+  /**
+   * Update the `workspaceName` field on every chat that referenced `oldName`
+   * after the workspace folder has been renamed on disk. The chat files
+   * themselves move with the folder; this just rewrites the in-memory cache
+   * and re-persists each chat under its new path.
+   */
+  cascadeRenameWorkspace(oldName: string, newName: string): void {
+    this.ensureLoaded();
+    for (const chat of this.cache.values()) {
+      if (chat.workspaceName !== oldName) continue;
+      chat.workspaceName = newName;
+      this.persist(chat);
+    }
+  }
+
   /** Remove all chat files for a deleted workspace. */
   cascadeDeleteWorkspace(workspaceName: string): void {
     this.ensureLoaded();


### PR DESCRIPTION
## Summary
- Adds **right-click context menus** to workspace headers and chat rows in the Mac app's chat list panel.
- Adds an inline **channel link picker** to the chat header (replaces the prompt-based toggle), with clear connect / disconnect states.
- Adds backend support for **renaming a workspace** (folder + cascading chat refs) and **revealing it in Finder**.

## Workspace context menu
Right-click a workspace header:
- ＋ New chat
- ✎ Rename… *(inline editor; `default` workspace protected)*
- ★ Set as Gateway default
- ↗ Reveal in Finder *(prefers `workingDir`, falls back to workspace dir)*
- ✦ Edit memory… *(opens Settings → Workspaces)*
- ✕ Delete workspace *(`default` protected)*

## Chat context menu
Right-click a chat row:
- 🔗 Connect to channel ▸ submenu (Telegram / Discord / iMessage). Selecting a channel opens the pairing modal via a `codey:open-pairing` window event picked up by `ChatTab`.
- ✎ Rename… / ＋ New chat in same workspace / ⧉ Copy chat ID / ✕ Delete chat

## Channel link button (ChatTab)
- Replaces the `window.prompt` channel picker with a small dropdown listing all three channels and their current link state.
- Linked rows tint red with `✕ Disconnect`; unlinked rows show `+ Connect` in accent color and a green/grey status dot.

## Backend additions
- `WorkspaceManager.renameWorkspace` — validates name, protects `default`, renames the folder, keeps `currentWorkspace` consistent.
- `ChatManager.cascadeRenameWorkspace` — rewrites the `workspaceName` field on every chat in the renamed workspace (the chat files move with the folder).
- New IPC: `workspaces:rename`, `workspaces:reveal` (+ preload / `codey-api.d.ts` / `apiService` entries).
- `SettingsOverlay` now accepts `initialTab` so the workspace menu can deep-link to the Workspaces tab.

## Minor polish
- Workspace headers in the chat list now use 📁︎ / 📂︎ glyphs instead of a rotating triangle to read as a folder.

## Test plan
- [ ] Right-click workspace header → each menu item works; `default` cannot be renamed/deleted
- [ ] Rename a workspace with chats → folder renamed on disk, chats still grouped under new name
- [ ] Reveal in Finder opens the correct project folder
- [ ] Right-click a chat → Connect to channel ▸ Telegram opens the pairing modal for the active chat
- [ ] Channel dropdown in ChatTab: connect shows pairing modal; disconnect unlinks immediately
- [ ] Linked vs unlinked rows render with the expected highlight colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)