### PR TITLE
Shared API keys: store credentials once, bind to multiple models

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1180,6 +1180,37 @@ app.whenReady().then(async () => {
     })
   )
 
+  // ── APIs IPC ──────────────────────────────────────────────────────
+  ipcMain.handle('apis:list', async () =>
+    wrap(async () => coreConfigManager?.listApis() ?? [])
+  )
+
+  ipcMain.handle('apis:save', async (_e, entry: any) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      if (!entry?.name?.trim()) throw new Error('API name is required')
+      if (entry.apiType !== 'anthropic' && entry.apiType !== 'openai') {
+        throw new Error('API apiType must be "anthropic" or "openai"')
+      }
+      if (!entry.apiKey?.trim()) throw new Error('API key is required')
+      coreConfigManager.saveApi(entry)
+    })
+  )
+
+  ipcMain.handle('apis:delete', async (_e, name: string) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      coreConfigManager.deleteApi(name)
+    })
+  )
+
+  ipcMain.handle('apis:rename', async (_e, oldName: string, newName: string) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      coreConfigManager.renameApi(oldName, newName)
+    })
+  )
+
   // ── Advisor (formerly Dispatcher) IPC ─────────────────────────────
   // The advisor block selects the agent + model that decides which workers
   // a `dispatch: 'auto'` team uses, and runs the /team manager. Empty values

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1189,9 +1189,6 @@ app.whenReady().then(async () => {
     wrap(async () => {
       if (!coreConfigManager) throw new Error('Config manager not initialized')
       if (!entry?.name?.trim()) throw new Error('API name is required')
-      if (entry.apiType !== 'anthropic' && entry.apiType !== 'openai') {
-        throw new Error('API apiType must be "anthropic" or "openai"')
-      }
       if (!entry.apiKey?.trim()) throw new Error('API key is required')
       coreConfigManager.saveApiKey(entry)
     })

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1180,12 +1180,12 @@ app.whenReady().then(async () => {
     })
   )
 
-  // ── APIs IPC ──────────────────────────────────────────────────────
-  ipcMain.handle('apis:list', async () =>
-    wrap(async () => coreConfigManager?.listApis() ?? [])
+  // ── API Keys IPC ──────────────────────────────────────────────────
+  ipcMain.handle('apiKeys:list', async () =>
+    wrap(async () => coreConfigManager?.listApiKeys() ?? [])
   )
 
-  ipcMain.handle('apis:save', async (_e, entry: any) =>
+  ipcMain.handle('apiKeys:save', async (_e, entry: any) =>
     wrap(async () => {
       if (!coreConfigManager) throw new Error('Config manager not initialized')
       if (!entry?.name?.trim()) throw new Error('API name is required')
@@ -1193,21 +1193,21 @@ app.whenReady().then(async () => {
         throw new Error('API apiType must be "anthropic" or "openai"')
       }
       if (!entry.apiKey?.trim()) throw new Error('API key is required')
-      coreConfigManager.saveApi(entry)
+      coreConfigManager.saveApiKey(entry)
     })
   )
 
-  ipcMain.handle('apis:delete', async (_e, name: string) =>
+  ipcMain.handle('apiKeys:delete', async (_e, name: string) =>
     wrap(async () => {
       if (!coreConfigManager) throw new Error('Config manager not initialized')
-      coreConfigManager.deleteApi(name)
+      coreConfigManager.deleteApiKey(name)
     })
   )
 
-  ipcMain.handle('apis:rename', async (_e, oldName: string, newName: string) =>
+  ipcMain.handle('apiKeys:rename', async (_e, oldName: string, newName: string) =>
     wrap(async () => {
       if (!coreConfigManager) throw new Error('Config manager not initialized')
-      coreConfigManager.renameApi(oldName, newName)
+      coreConfigManager.renameApiKey(oldName, newName)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -65,11 +65,11 @@ contextBridge.exposeInMainWorld('codey', {
     delete: (name: string) => ipcRenderer.invoke('models:delete', name),
     rename: (oldName: string, newName: string) => ipcRenderer.invoke('models:rename', oldName, newName),
   },
-  apis: {
-    list: () => ipcRenderer.invoke('apis:list'),
-    save: (entry: any) => ipcRenderer.invoke('apis:save', entry),
-    delete: (name: string) => ipcRenderer.invoke('apis:delete', name),
-    rename: (oldName: string, newName: string) => ipcRenderer.invoke('apis:rename', oldName, newName),
+  apiKeys: {
+    list: () => ipcRenderer.invoke('apiKeys:list'),
+    save: (entry: any) => ipcRenderer.invoke('apiKeys:save', entry),
+    delete: (name: string) => ipcRenderer.invoke('apiKeys:delete', name),
+    rename: (oldName: string, newName: string) => ipcRenderer.invoke('apiKeys:rename', oldName, newName),
   },
   fallback: {
     get: () => ipcRenderer.invoke('fallback:get'),

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -65,6 +65,12 @@ contextBridge.exposeInMainWorld('codey', {
     delete: (name: string) => ipcRenderer.invoke('models:delete', name),
     rename: (oldName: string, newName: string) => ipcRenderer.invoke('models:rename', oldName, newName),
   },
+  apis: {
+    list: () => ipcRenderer.invoke('apis:list'),
+    save: (entry: any) => ipcRenderer.invoke('apis:save', entry),
+    delete: (name: string) => ipcRenderer.invoke('apis:delete', name),
+    rename: (oldName: string, newName: string) => ipcRenderer.invoke('apis:rename', oldName, newName),
+  },
   fallback: {
     get: () => ipcRenderer.invoke('fallback:get'),
     set: (fb: any) => ipcRenderer.invoke('fallback:set', fb),

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -1,6 +1,7 @@
 import type { Chat, ChatSelection } from '../../packages/core/src/types/chat'
 import type { ChatStreamEvent } from '../../packages/gateway/src/chat-runner'
 import type { TeamConfigRaw } from '../../packages/core/src/workspace'
+import type { ApiEntry } from '../../packages/core/src/types/index'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
@@ -61,6 +62,12 @@ declare global {
       models: {
         list: () => Promise<IpcResult<ModelEntry[]>>
         save: (entry: ModelEntry) => Promise<IpcResult<void>>
+        delete: (name: string) => Promise<IpcResult<void>>
+        rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
+      }
+      apis: {
+        list: () => Promise<IpcResult<ApiEntry[]>>
+        save: (entry: ApiEntry) => Promise<IpcResult<void>>
         delete: (name: string) => Promise<IpcResult<void>>
         rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
       }

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -1,14 +1,14 @@
 import type { Chat, ChatSelection } from '../../packages/core/src/types/chat'
 import type { ChatStreamEvent } from '../../packages/gateway/src/chat-runner'
 import type { TeamConfigRaw } from '../../packages/core/src/workspace'
-import type { ApiEntry } from '../../packages/core/src/types/index'
+import type { ApiKeyEntry } from '../../packages/core/src/types/index'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
 export interface ModelEntry {
   apiType: 'anthropic' | 'openai'
   model: string
-  apiRef?: string
+  apiKeyRef?: string
   provider?: string
 }
 
@@ -64,9 +64,9 @@ declare global {
         delete: (name: string) => Promise<IpcResult<void>>
         rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
       }
-      apis: {
-        list: () => Promise<IpcResult<ApiEntry[]>>
-        save: (entry: ApiEntry) => Promise<IpcResult<void>>
+      apiKeys: {
+        list: () => Promise<IpcResult<ApiKeyEntry[]>>
+        save: (entry: ApiKeyEntry) => Promise<IpcResult<void>>
         delete: (name: string) => Promise<IpcResult<void>>
         rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
       }

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -8,8 +8,7 @@ type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 export interface ModelEntry {
   apiType: 'anthropic' | 'openai'
   model: string
-  baseUrl?: string
-  apiKey?: string
+  apiRef?: string
   provider?: string
 }
 

--- a/codey-mac/src/components/ApiKeysTab.tsx
+++ b/codey-mac/src/components/ApiKeysTab.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
 import {
-  inputStyle, pillButton, Section, unwrap,
+  inputStyle, pillButton, unwrap,
 } from './settingsAtoms'
 
 interface ApiKeyEntry { name: string; apiKey: string; anthropicBaseUrl?: string; openaiBaseUrl?: string }
@@ -144,11 +144,11 @@ export const ApiKeysTab: React.FC<Props> = ({ isGatewayRunning }) => {
     <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
       {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
 
-      <Section title="API Keys" right={
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 8 }}>
+        <div style={{ color: C.fg3, fontSize: 11, flex: 1 }}>
+          Saved API keys &amp; endpoints. A single key can be bound from many models in the AI Models tab. Each key can carry separate base URL overrides for anthropic-typed and openai-typed models.
+        </div>
         <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
-      } />
-      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
-        Saved API keys &amp; endpoints. A single key can be bound from many models in the AI Models tab. Each key can carry separate base URL overrides for anthropic-typed and openai-typed models.
       </div>
       {creating && (
         <ApiRow

--- a/codey-mac/src/components/ApiKeysTab.tsx
+++ b/codey-mac/src/components/ApiKeysTab.tsx
@@ -5,19 +5,19 @@ import {
 } from './settingsAtoms'
 
 type ApiType = 'anthropic' | 'openai'
-interface ApiEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
+interface ApiKeyEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
 
 interface Props { isGatewayRunning: boolean }
 
 const ApiRow: React.FC<{
-  entry: ApiEntry
+  entry: ApiKeyEntry
   isNew?: boolean
-  onSave: (draft: ApiEntry, previousName: string) => Promise<void>
+  onSave: (draft: ApiKeyEntry, previousName: string) => Promise<void>
   onDelete?: (name: string) => Promise<void>
   onCancel?: () => void
 }> = ({ entry, isNew, onSave, onDelete, onCancel }) => {
   const [editing, setEditing] = useState(!!isNew)
-  const [draft, setDraft] = useState<ApiEntry>(entry)
+  const [draft, setDraft] = useState<ApiKeyEntry>(entry)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
 
@@ -75,7 +75,7 @@ const ApiRow: React.FC<{
           placeholder="(optional) override endpoint" style={{ ...inputStyle, width: '100%' }} />
         <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
         <input type="password" value={draft.apiKey} onChange={e => setDraft({ ...draft, apiKey: e.target.value })}
-          placeholder="credentials" style={{ ...inputStyle, width: '100%' }} />
+          placeholder="API key" style={{ ...inputStyle, width: '100%' }} />
       </div>
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
@@ -88,14 +88,14 @@ const ApiRow: React.FC<{
   )
 }
 
-export const ApisTab: React.FC<Props> = ({ isGatewayRunning }) => {
-  const [apis, setApis] = useState<ApiEntry[]>([])
+export const ApiKeysTab: React.FC<Props> = ({ isGatewayRunning }) => {
+  const [apiKeys, setApiKeys] = useState<ApiKeyEntry[]>([])
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const reload = useCallback(async () => {
     setError(null)
-    try { setApis(unwrap(await window.codey.apis.list())) }
+    try { setApiKeys(unwrap(await window.codey.apiKeys.list())) }
     catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
@@ -109,17 +109,17 @@ export const ApisTab: React.FC<Props> = ({ isGatewayRunning }) => {
     )
   }
 
-  const saveApi = async (entry: ApiEntry, previousName: string) => {
+  const saveApiKey = async (entry: ApiKeyEntry, previousName: string) => {
     if (previousName && previousName !== entry.name) {
-      await unwrap(await window.codey.apis.rename(previousName, entry.name))
+      await unwrap(await window.codey.apiKeys.rename(previousName, entry.name))
     }
-    await unwrap(await window.codey.apis.save(entry))
+    await unwrap(await window.codey.apiKeys.save(entry))
     await reload()
     setCreating(false)
   }
-  const deleteApi = async (name: string) => {
-    if (!confirm(`Delete API "${name}"?`)) return
-    try { await unwrap(await window.codey.apis.delete(name)); await reload() }
+  const deleteApiKey = async (name: string) => {
+    if (!confirm(`Delete API key "${name}"?`)) return
+    try { await unwrap(await window.codey.apiKeys.delete(name)); await reload() }
     catch (e: any) { setError(e?.message ?? String(e)) }
   }
 
@@ -127,26 +127,26 @@ export const ApisTab: React.FC<Props> = ({ isGatewayRunning }) => {
     <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
       {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
 
-      <Section title="APIs" right={
+      <Section title="API Keys" right={
         <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
       } />
       <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
-        Saved credentials &amp; endpoints. A single API can be bound from many models in the AI Models tab.
+        Saved API keys &amp; endpoints. A single key can be bound from many models in the AI Models tab.
       </div>
       {creating && (
         <ApiRow
           entry={{ name: '', apiType: 'anthropic', baseUrl: '', apiKey: '' }}
           isNew
-          onSave={saveApi}
+          onSave={saveApiKey}
           onCancel={() => setCreating(false)}
         />
       )}
-      {apis.length === 0 && !creating && (
-        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0' }}>No APIs yet. Click + Add to create one.</div>
+      {apiKeys.length === 0 && !creating && (
+        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0' }}>No API keys yet. Click + Add to create one.</div>
       )}
-      {[...apis]
+      {[...apiKeys]
         .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.name.localeCompare(b.name))
-        .map(a => <ApiRow key={a.name} entry={a} onSave={saveApi} onDelete={deleteApi} />)}
+        .map(a => <ApiRow key={a.name} entry={a} onSave={saveApiKey} onDelete={deleteApiKey} />)}
     </div>
   )
 }

--- a/codey-mac/src/components/ApiKeysTab.tsx
+++ b/codey-mac/src/components/ApiKeysTab.tsx
@@ -33,25 +33,39 @@ const ApiRow: React.FC<{
   if (!editing) {
     const hasAnthropicUrl = !!entry.anthropicBaseUrl
     const hasOpenaiUrl = !!entry.openaiBaseUrl
-    const urlSummary = hasAnthropicUrl || hasOpenaiUrl
-      ? [
-          hasAnthropicUrl ? `anthropic: ${entry.anthropicBaseUrl}` : null,
-          hasOpenaiUrl    ? `openai: ${entry.openaiBaseUrl}`       : null,
-        ].filter(Boolean).join(' · ')
-      : 'default endpoints'
+    const hasAnyUrl = hasAnthropicUrl || hasOpenaiUrl
+    const urlLineStyle: React.CSSProperties = {
+      color: C.fg3, fontSize: 11,
+      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    }
+    const labelStyle: React.CSSProperties = { color: C.fg3, opacity: 0.7, marginRight: 4 }
     return (
       <div style={{
         padding: '12px 14px', borderRadius: 10, border: `1px solid ${C.border}`,
         background: C.surface2, marginBottom: 8,
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
+        display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 10,
       }}>
-        <div style={{ minWidth: 0 }}>
+        <div style={{ minWidth: 0, flex: 1 }}>
           <div style={{ fontWeight: 600, fontSize: 13 }}>
             {entry.name}
           </div>
-          <div style={{ color: C.fg3, fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-            🔑 · {urlSummary}
-          </div>
+          <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>🔑</div>
+          {hasAnyUrl ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 1, marginTop: 2 }}>
+              {hasAnthropicUrl && (
+                <div style={urlLineStyle} title={entry.anthropicBaseUrl}>
+                  <span style={labelStyle}>anthropic:</span>{entry.anthropicBaseUrl}
+                </div>
+              )}
+              {hasOpenaiUrl && (
+                <div style={urlLineStyle} title={entry.openaiBaseUrl}>
+                  <span style={labelStyle}>openai:</span>{entry.openaiBaseUrl}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div style={{ ...urlLineStyle, marginTop: 2 }}>default endpoints</div>
+          )}
         </div>
         <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
           <button onClick={() => setEditing(true)} style={pillButton('ghost')}>Edit</button>

--- a/codey-mac/src/components/ApiKeysTab.tsx
+++ b/codey-mac/src/components/ApiKeysTab.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
 import {
-  inputStyle, selectStyle, pillButton, Section, unwrap,
+  inputStyle, pillButton, Section, unwrap,
 } from './settingsAtoms'
 
-type ApiType = 'anthropic' | 'openai'
-interface ApiKeyEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
+interface ApiKeyEntry { name: string; apiKey: string; anthropicBaseUrl?: string; openaiBaseUrl?: string }
 
 interface Props { isGatewayRunning: boolean }
 
@@ -32,6 +31,14 @@ const ApiRow: React.FC<{
   }
 
   if (!editing) {
+    const hasAnthropicUrl = !!entry.anthropicBaseUrl
+    const hasOpenaiUrl = !!entry.openaiBaseUrl
+    const urlSummary = hasAnthropicUrl || hasOpenaiUrl
+      ? [
+          hasAnthropicUrl ? `anthropic: ${entry.anthropicBaseUrl}` : null,
+          hasOpenaiUrl    ? `openai: ${entry.openaiBaseUrl}`       : null,
+        ].filter(Boolean).join(' · ')
+      : 'default endpoints'
     return (
       <div style={{
         padding: '12px 14px', borderRadius: 10, border: `1px solid ${C.border}`,
@@ -41,10 +48,9 @@ const ApiRow: React.FC<{
         <div style={{ minWidth: 0 }}>
           <div style={{ fontWeight: 600, fontSize: 13 }}>
             {entry.name}
-            <span style={{ color: C.fg3, fontWeight: 400, fontSize: 11, marginLeft: 6 }}>[{entry.apiType}]</span>
           </div>
           <div style={{ color: C.fg3, fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-            {entry.baseUrl || '(default url)'} · 🔑
+            🔑 · {urlSummary}
           </div>
         </div>
         <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
@@ -60,22 +66,19 @@ const ApiRow: React.FC<{
       padding: 12, borderRadius: 10, border: `1px solid ${C.border2}`,
       background: C.surface2, marginBottom: 8,
     }}>
-      <div style={{ display: 'grid', gridTemplateColumns: '100px 1fr', gap: 8, alignItems: 'center' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '140px 1fr', gap: 8, alignItems: 'center' }}>
         <label style={{ color: C.fg3, fontSize: 12 }}>Name</label>
         <input value={draft.name} onChange={e => setDraft({ ...draft, name: e.target.value })}
-          placeholder="e.g. anthropic-personal" style={{ ...inputStyle, width: '100%' }} />
-        <label style={{ color: C.fg3, fontSize: 12 }}>API Type</label>
-        <select value={draft.apiType} onChange={e => setDraft({ ...draft, apiType: e.target.value as ApiType })}
-          style={{ ...selectStyle, width: '100%' }}>
-          <option value="anthropic">anthropic (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN)</option>
-          <option value="openai">openai (OPENAI_BASE_URL + OPENAI_API_KEY)</option>
-        </select>
-        <label style={{ color: C.fg3, fontSize: 12 }}>Base URL</label>
-        <input value={draft.baseUrl ?? ''} onChange={e => setDraft({ ...draft, baseUrl: e.target.value || undefined })}
-          placeholder="(optional) override endpoint" style={{ ...inputStyle, width: '100%' }} />
+          placeholder="e.g. my-proxy" style={{ ...inputStyle, width: '100%' }} />
         <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
         <input type="password" value={draft.apiKey} onChange={e => setDraft({ ...draft, apiKey: e.target.value })}
           placeholder="API key" style={{ ...inputStyle, width: '100%' }} />
+        <label style={{ color: C.fg3, fontSize: 12 }}>Anthropic Base URL</label>
+        <input value={draft.anthropicBaseUrl ?? ''} onChange={e => setDraft({ ...draft, anthropicBaseUrl: e.target.value || undefined })}
+          placeholder="(optional) override anthropic endpoint" style={{ ...inputStyle, width: '100%' }} />
+        <label style={{ color: C.fg3, fontSize: 12 }}>OpenAI Base URL</label>
+        <input value={draft.openaiBaseUrl ?? ''} onChange={e => setDraft({ ...draft, openaiBaseUrl: e.target.value || undefined })}
+          placeholder="(optional) override openai endpoint" style={{ ...inputStyle, width: '100%' }} />
       </div>
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
@@ -131,11 +134,11 @@ export const ApiKeysTab: React.FC<Props> = ({ isGatewayRunning }) => {
         <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
       } />
       <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
-        Saved API keys &amp; endpoints. A single key can be bound from many models in the AI Models tab.
+        Saved API keys &amp; endpoints. A single key can be bound from many models in the AI Models tab. Each key can carry separate base URL overrides for anthropic-typed and openai-typed models.
       </div>
       {creating && (
         <ApiRow
-          entry={{ name: '', apiType: 'anthropic', baseUrl: '', apiKey: '' }}
+          entry={{ name: '', apiKey: '', anthropicBaseUrl: '', openaiBaseUrl: '' }}
           isNew
           onSave={saveApiKey}
           onCancel={() => setCreating(false)}
@@ -145,7 +148,7 @@ export const ApiKeysTab: React.FC<Props> = ({ isGatewayRunning }) => {
         <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0' }}>No API keys yet. Click + Add to create one.</div>
       )}
       {[...apiKeys]
-        .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.name.localeCompare(b.name))
+        .sort((a, b) => a.name.localeCompare(b.name))
         .map(a => <ApiRow key={a.name} entry={a} onSave={saveApiKey} onDelete={deleteApiKey} />)}
     </div>
   )

--- a/codey-mac/src/components/ApisTab.tsx
+++ b/codey-mac/src/components/ApisTab.tsx
@@ -1,0 +1,152 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { C } from '../theme'
+import {
+  inputStyle, selectStyle, pillButton, Section, unwrap,
+} from './settingsAtoms'
+
+type ApiType = 'anthropic' | 'openai'
+interface ApiEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
+
+interface Props { isGatewayRunning: boolean }
+
+const ApiRow: React.FC<{
+  entry: ApiEntry
+  isNew?: boolean
+  onSave: (draft: ApiEntry, previousName: string) => Promise<void>
+  onDelete?: (name: string) => Promise<void>
+  onCancel?: () => void
+}> = ({ entry, isNew, onSave, onDelete, onCancel }) => {
+  const [editing, setEditing] = useState(!!isNew)
+  const [draft, setDraft] = useState<ApiEntry>(entry)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => { if (!editing) setDraft(entry) }, [entry.name, editing])
+
+  const save = async () => {
+    if (!draft.name.trim() || !draft.apiKey.trim()) return
+    setBusy(true); setErr(null)
+    try { await onSave(draft, entry.name); setEditing(false) }
+    catch (e: any) { setErr(e?.message ?? String(e)) }
+    finally { setBusy(false) }
+  }
+
+  if (!editing) {
+    return (
+      <div style={{
+        padding: '12px 14px', borderRadius: 10, border: `1px solid ${C.border}`,
+        background: C.surface2, marginBottom: 8,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
+      }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontWeight: 600, fontSize: 13 }}>
+            {entry.name}
+            <span style={{ color: C.fg3, fontWeight: 400, fontSize: 11, marginLeft: 6 }}>[{entry.apiType}]</span>
+          </div>
+          <div style={{ color: C.fg3, fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {entry.baseUrl || '(default url)'} · 🔑
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+          <button onClick={() => setEditing(true)} style={pillButton('ghost')}>Edit</button>
+          {onDelete && <button onClick={() => onDelete(entry.name)} style={pillButton('danger')}>Delete</button>}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{
+      padding: 12, borderRadius: 10, border: `1px solid ${C.border2}`,
+      background: C.surface2, marginBottom: 8,
+    }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '100px 1fr', gap: 8, alignItems: 'center' }}>
+        <label style={{ color: C.fg3, fontSize: 12 }}>Name</label>
+        <input value={draft.name} onChange={e => setDraft({ ...draft, name: e.target.value })}
+          placeholder="e.g. anthropic-personal" style={{ ...inputStyle, width: '100%' }} />
+        <label style={{ color: C.fg3, fontSize: 12 }}>API Type</label>
+        <select value={draft.apiType} onChange={e => setDraft({ ...draft, apiType: e.target.value as ApiType })}
+          style={{ ...selectStyle, width: '100%' }}>
+          <option value="anthropic">anthropic (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN)</option>
+          <option value="openai">openai (OPENAI_BASE_URL + OPENAI_API_KEY)</option>
+        </select>
+        <label style={{ color: C.fg3, fontSize: 12 }}>Base URL</label>
+        <input value={draft.baseUrl ?? ''} onChange={e => setDraft({ ...draft, baseUrl: e.target.value || undefined })}
+          placeholder="(optional) override endpoint" style={{ ...inputStyle, width: '100%' }} />
+        <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
+        <input type="password" value={draft.apiKey} onChange={e => setDraft({ ...draft, apiKey: e.target.value })}
+          placeholder="credentials" style={{ ...inputStyle, width: '100%' }} />
+      </div>
+      {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
+      <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
+        <button onClick={() => { setEditing(false); setDraft(entry); setErr(null); onCancel?.() }} style={pillButton('ghost')} disabled={busy}>Cancel</button>
+        <button onClick={save} style={pillButton('primary')} disabled={busy || !draft.name.trim() || !draft.apiKey.trim()}>
+          {busy ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export const ApisTab: React.FC<Props> = ({ isGatewayRunning }) => {
+  const [apis, setApis] = useState<ApiEntry[]>([])
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setError(null)
+    try { setApis(unwrap(await window.codey.apis.list())) }
+    catch (e: any) { setError(e?.message ?? String(e)) }
+  }, [])
+
+  useEffect(() => { if (isGatewayRunning) reload() }, [isGatewayRunning, reload])
+
+  if (!isGatewayRunning) {
+    return (
+      <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
+        <div style={{ marginTop: 40, textAlign: 'center', color: C.fg3, fontSize: 13 }}>Gateway not available</div>
+      </div>
+    )
+  }
+
+  const saveApi = async (entry: ApiEntry, previousName: string) => {
+    if (previousName && previousName !== entry.name) {
+      await unwrap(await window.codey.apis.rename(previousName, entry.name))
+    }
+    await unwrap(await window.codey.apis.save(entry))
+    await reload()
+    setCreating(false)
+  }
+  const deleteApi = async (name: string) => {
+    if (!confirm(`Delete API "${name}"?`)) return
+    try { await unwrap(await window.codey.apis.delete(name)); await reload() }
+    catch (e: any) { setError(e?.message ?? String(e)) }
+  }
+
+  return (
+    <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
+      {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
+
+      <Section title="APIs" right={
+        <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
+      } />
+      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
+        Saved credentials &amp; endpoints. A single API can be bound from many models in the AI Models tab.
+      </div>
+      {creating && (
+        <ApiRow
+          entry={{ name: '', apiType: 'anthropic', baseUrl: '', apiKey: '' }}
+          isNew
+          onSave={saveApi}
+          onCancel={() => setCreating(false)}
+        />
+      )}
+      {apis.length === 0 && !creating && (
+        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0' }}>No APIs yet. Click + Add to create one.</div>
+      )}
+      {[...apis]
+        .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.name.localeCompare(b.name))
+        .map(a => <ApiRow key={a.name} entry={a} onSave={saveApi} onDelete={deleteApi} />)}
+    </div>
+  )
+}

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -8,10 +8,12 @@ import { useGateway } from '../hooks/useGateway'
 import { C } from '../theme'
 import { AppearanceTab } from './AppearanceTab'
 import { WhisperTab } from './WhisperTab'
+import { ApisTab } from './ApisTab'
 
-type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'whisper'
+type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'whisper' | 'apis'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
   { key: 'general',    label: 'General',    icon: '⚙', description: 'Theme & visual options' },
+  { key: 'apis',       label: 'APIs',       icon: '🔑', description: 'Shared credentials' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'whisper',    label: 'Whisper',    icon: '◐', description: 'Voice input & hotkey' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
@@ -73,6 +75,7 @@ export const SettingsOverlay: React.FC<Props> = ({ onClose, initialTab }) => {
             <div style={styles.mainHeader}>{activeTab.label}</div>
             <div style={styles.mainContent}>
               {tab === 'general'    && <AppearanceTab />}
+              {tab === 'apis'       && <ApisTab isGatewayRunning={isRunning} />}
               {tab === 'status'     && <StatusTab status={status} logs={logs} isRunning={isRunning} />}
               {tab === 'workspaces' && <WorkspacesTab isGatewayRunning={isRunning} />}
               {tab === 'workers'    && <WorkersTab />}

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -13,7 +13,7 @@ import { ApiKeysTab } from './ApiKeysTab'
 type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'whisper' | 'apiKeys'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
   { key: 'general',    label: 'General',    icon: '⚙', description: 'Theme & visual options' },
-  { key: 'apiKeys',    label: 'API Keys',   icon: '🔑', description: 'Shared API keys' },
+  { key: 'apiKeys',    label: 'API Keys',   icon: '⚿', description: 'Shared API keys' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'whisper',    label: 'Whisper',    icon: '◐', description: 'Voice input & hotkey' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -8,12 +8,12 @@ import { useGateway } from '../hooks/useGateway'
 import { C } from '../theme'
 import { AppearanceTab } from './AppearanceTab'
 import { WhisperTab } from './WhisperTab'
-import { ApisTab } from './ApisTab'
+import { ApiKeysTab } from './ApiKeysTab'
 
-type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'whisper' | 'apis'
+type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'whisper' | 'apiKeys'
 const TABS: { key: Tab; label: string; icon: string; description: string }[] = [
   { key: 'general',    label: 'General',    icon: '⚙', description: 'Theme & visual options' },
-  { key: 'apis',       label: 'APIs',       icon: '🔑', description: 'Shared credentials' },
+  { key: 'apiKeys',    label: 'API Keys',   icon: '🔑', description: 'Shared API keys' },
   { key: 'settings',   label: 'AI Models',  icon: '✦', description: 'Default agent & model' },
   { key: 'whisper',    label: 'Whisper',    icon: '◐', description: 'Voice input & hotkey' },
   { key: 'workspaces', label: 'Workspaces', icon: '◫', description: 'Project directories' },
@@ -75,7 +75,7 @@ export const SettingsOverlay: React.FC<Props> = ({ onClose, initialTab }) => {
             <div style={styles.mainHeader}>{activeTab.label}</div>
             <div style={styles.mainContent}>
               {tab === 'general'    && <AppearanceTab />}
-              {tab === 'apis'       && <ApisTab isGatewayRunning={isRunning} />}
+              {tab === 'apiKeys'    && <ApiKeysTab isGatewayRunning={isRunning} />}
               {tab === 'status'     && <StatusTab status={status} logs={logs} isRunning={isRunning} />}
               {tab === 'workspaces' && <WorkspacesTab isGatewayRunning={isRunning} />}
               {tab === 'workers'    && <WorkersTab />}

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -144,12 +144,14 @@ const ModelRow: React.FC<{
           <div style={{ fontWeight: 600, fontSize: 13 }}>
             {entry.model} <span style={{ color: C.fg3, fontWeight: 400, fontSize: 11, marginLeft: 6 }}>[{entry.apiType}]</span>
           </div>
-          <div style={{
-            color: C.fg3,
-            fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-          }}>
-            {entry.apiKeyRef ? `🔑 ${entry.apiKeyRef}` : '(default key)'}
-          </div>
+          {entry.apiKeyRef && (
+            <div style={{
+              color: C.fg3,
+              fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+            }}>
+              🔑 {entry.apiKeyRef}
+            </div>
+          )}
         </div>
         <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
           <button onClick={() => setEditing(true)} style={pillButton('ghost')}>Edit</button>

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -125,7 +125,7 @@ const ModelRow: React.FC<{
   useEffect(() => { if (!editing) setDraft(entry) }, [entry.model, editing])
 
   const save = async () => {
-    if (!draft.model.trim()) return
+    if (!draft.model.trim() || !draft.apiRef) return
     setBusy(true)
     setErr(null)
     try { await onSave(draft, entry.model); setEditing(false) }
@@ -159,6 +159,9 @@ const ModelRow: React.FC<{
     )
   }
 
+  const matchingApis = apis
+    .filter(a => a.apiType === draft.apiType)
+    .sort((a, b) => a.name.localeCompare(b.name))
   return (
     <div style={{
       padding: 12, borderRadius: 10, border: `1px solid ${C.border2}`,
@@ -169,7 +172,13 @@ const ModelRow: React.FC<{
         <input value={draft.model} onChange={e => setDraft({ ...draft, model: e.target.value })}
           placeholder="e.g. claude-sonnet-4-5" style={{ ...inputStyle, width: '100%' }}/>
         <label style={{ color: C.fg3, fontSize: 12 }}>API Type</label>
-        <select value={draft.apiType} onChange={e => setDraft({ ...draft, apiType: e.target.value as ApiType })}
+        <select value={draft.apiType} onChange={e => {
+          const nextType = e.target.value as ApiType
+          // If the currently-bound API isn't of the new apiType, drop the binding
+          // so we don't save a model pointing at an incompatible API.
+          const stillValid = apis.some(a => a.name === draft.apiRef && a.apiType === nextType)
+          setDraft({ ...draft, apiType: nextType, apiRef: stillValid ? draft.apiRef : undefined })
+        }}
           style={{ ...selectStyle, width: '100%' }}>
           <option value="anthropic">anthropic (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN)</option>
           <option value="openai">openai (OPENAI_BASE_URL + OPENAI_API_KEY)</option>
@@ -181,15 +190,13 @@ const ModelRow: React.FC<{
           style={{ ...selectStyle, width: '100%' }}
         >
           <option value="">Select an API…</option>
-          {apis
-            .filter(a => a.apiType === draft.apiType)
-            .map(a => (
+          {matchingApis.map(a => (
               <option key={a.name} value={a.name}>
                 {a.name}{a.baseUrl ? ` (${a.baseUrl})` : ''}
               </option>
             ))}
         </select>
-        {apis.filter(a => a.apiType === draft.apiType).length === 0 && (
+        {matchingApis.length === 0 && (
           <div style={{ gridColumn: '1 / span 2', color: C.fg3, fontSize: 11, marginTop: -4 }}>
             No {draft.apiType} APIs yet — add one in the APIs tab.
           </div>
@@ -198,7 +205,7 @@ const ModelRow: React.FC<{
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
         <button onClick={() => { setEditing(false); setDraft(entry); setErr(null); onCancel?.() }} style={pillButton('ghost')} disabled={busy}>Cancel</button>
-        <button onClick={save} style={pillButton('primary')} disabled={busy || !draft.model.trim()}>
+        <button onClick={save} style={pillButton('primary')} disabled={busy || !draft.model.trim() || !draft.apiRef}>
           {busy ? 'Saving…' : 'Save'}
         </button>
       </div>

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -8,7 +8,7 @@ interface SettingsTabProps {
 }
 
 type ApiType = 'anthropic' | 'openai'
-interface ApiKeyEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
+interface ApiKeyEntry { name: string; apiKey: string; anthropicBaseUrl?: string; openaiBaseUrl?: string }
 interface ModelEntry {
   apiType: ApiType
   model: string
@@ -159,9 +159,6 @@ const ModelRow: React.FC<{
     )
   }
 
-  const matchingApis = apis
-    .filter(a => a.apiType === draft.apiType)
-    .sort((a, b) => a.name.localeCompare(b.name))
   return (
     <div style={{
       padding: 12, borderRadius: 10, border: `1px solid ${C.border2}`,
@@ -173,11 +170,7 @@ const ModelRow: React.FC<{
           placeholder="e.g. claude-sonnet-4-5" style={{ ...inputStyle, width: '100%' }}/>
         <label style={{ color: C.fg3, fontSize: 12 }}>API Type</label>
         <select value={draft.apiType} onChange={e => {
-          const nextType = e.target.value as ApiType
-          // If the currently-bound API key isn't of the new apiType, drop the binding
-          // so we don't save a model pointing at an incompatible API key.
-          const stillValid = apis.some(a => a.name === draft.apiKeyRef && a.apiType === nextType)
-          setDraft({ ...draft, apiType: nextType, apiKeyRef: stillValid ? draft.apiKeyRef : undefined })
+          setDraft({ ...draft, apiType: e.target.value as ApiType })
         }}
           style={{ ...selectStyle, width: '100%' }}>
           <option value="anthropic">anthropic (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN)</option>
@@ -190,17 +183,10 @@ const ModelRow: React.FC<{
           style={{ ...selectStyle, width: '100%' }}
         >
           <option value="">(use default — env vars)</option>
-          {matchingApis.map(a => (
-              <option key={a.name} value={a.name}>
-                {a.name}{a.baseUrl ? ` (${a.baseUrl})` : ''}
-              </option>
-            ))}
+          {[...apis].sort((a, b) => a.name.localeCompare(b.name)).map(a => (
+            <option key={a.name} value={a.name}>{a.name}</option>
+          ))}
         </select>
-        {matchingApis.length === 0 && (
-          <div style={{ gridColumn: '1 / span 2', color: C.fg3, fontSize: 11, marginTop: -4 }}>
-            No {draft.apiType} API keys yet — add one in the API Keys tab.
-          </div>
-        )}
       </div>
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -8,11 +8,11 @@ interface SettingsTabProps {
 }
 
 type ApiType = 'anthropic' | 'openai'
+interface ApiEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
 interface ModelEntry {
   apiType: ApiType
   model: string
-  baseUrl?: string
-  apiKey?: string
+  apiRef?: string
   provider?: string
 }
 interface AgentSlot { enabled?: boolean }
@@ -107,11 +107,12 @@ const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on,
 
 const ModelRow: React.FC<{
   entry: ModelEntry
+  apis: ApiEntry[]
   isNew?: boolean
   onSave: (draft: ModelEntry, previousId: string) => Promise<void>
   onDelete?: (modelId: string) => Promise<void>
   onCancel?: () => void
-}> = ({ entry, isNew, onSave, onDelete, onCancel }) => {
+}> = ({ entry, apis, isNew, onSave, onDelete, onCancel }) => {
   const [editing, setEditing] = useState(!!isNew)
   const [draft, setDraft] = useState<ModelEntry>(entry)
   const [busy, setBusy] = useState(false)
@@ -143,8 +144,11 @@ const ModelRow: React.FC<{
           <div style={{ fontWeight: 600, fontSize: 13 }}>
             {entry.model} <span style={{ color: C.fg3, fontWeight: 400, fontSize: 11, marginLeft: 6 }}>[{entry.apiType}]</span>
           </div>
-          <div style={{ color: C.fg3, fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-            {entry.baseUrl || '(default url)'}{entry.apiKey ? ' · 🔑' : ''}
+          <div style={{
+            color: entry.apiRef ? C.fg3 : C.warningFg,
+            fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>
+            {entry.apiRef ? `→ ${entry.apiRef}` : '(no API bound)'}
           </div>
         </div>
         <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
@@ -170,12 +174,26 @@ const ModelRow: React.FC<{
           <option value="anthropic">anthropic (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN)</option>
           <option value="openai">openai (OPENAI_BASE_URL + OPENAI_API_KEY)</option>
         </select>
-        <label style={{ color: C.fg3, fontSize: 12 }}>Base URL</label>
-        <input value={draft.baseUrl ?? ''} onChange={e => setDraft({ ...draft, baseUrl: e.target.value || undefined })}
-          placeholder="(optional) override endpoint" style={{ ...inputStyle, width: '100%' }}/>
-        <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
-        <input type="password" value={draft.apiKey ?? ''} onChange={e => setDraft({ ...draft, apiKey: e.target.value || undefined })}
-          placeholder="(optional) credentials" style={{ ...inputStyle, width: '100%' }}/>
+        <label style={{ color: C.fg3, fontSize: 12 }}>API</label>
+        <select
+          value={draft.apiRef ?? ''}
+          onChange={e => setDraft({ ...draft, apiRef: e.target.value || undefined })}
+          style={{ ...selectStyle, width: '100%' }}
+        >
+          <option value="">Select an API…</option>
+          {apis
+            .filter(a => a.apiType === draft.apiType)
+            .map(a => (
+              <option key={a.name} value={a.name}>
+                {a.name}{a.baseUrl ? ` (${a.baseUrl})` : ''}
+              </option>
+            ))}
+        </select>
+        {apis.filter(a => a.apiType === draft.apiType).length === 0 && (
+          <div style={{ gridColumn: '1 / span 2', color: C.fg3, fontSize: 11, marginTop: -4 }}>
+            No {draft.apiType} APIs yet — add one in the APIs tab.
+          </div>
+        )}
       </div>
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
@@ -327,6 +345,7 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const [models, setModels] = useState<ModelEntry[]>([])
   const [fallback, setFallback] = useState<FallbackCfg>({ enabled: true, order: [] })
   const [advisor, setAdvisor] = useState<{ agent: string; model: string }>({ agent: '', model: '' })
+  const [apis, setApis] = useState<ApiEntry[]>([])
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Probe runs async after the rest of the panel paints — the chip flips from
@@ -347,13 +366,15 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const reload = useCallback(async () => {
     setError(null)
     try {
-      const [m, f, d] = await Promise.all([
+      const [m, f, d, a] = await Promise.all([
         unwrap(await window.codey.models.list()),
         unwrap(await window.codey.fallback.get()),
         unwrap(await window.codey.dispatcher.get()),
+        unwrap(await window.codey.apis.list()),
       ])
       setModels(m); setFallback(f as FallbackCfg)
       setAdvisor({ agent: d.agent ?? '', model: d.model ?? '' })
+      setApis(a as ApiEntry[])
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
@@ -421,7 +442,8 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
       }/>
       {creating && (
         <ModelRow
-          entry={{ apiType: 'anthropic', model: '', baseUrl: '', apiKey: '' }}
+          entry={{ apiType: 'anthropic', model: '' }}
+          apis={apis}
           isNew
           onSave={saveModel}
           onCancel={() => setCreating(false)}
@@ -432,7 +454,7 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
       )}
       {[...models]
         .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.model.localeCompare(b.model))
-        .map(m => <ModelRow key={m.model} entry={m} onSave={saveModel} onDelete={deleteModel}/>)}
+        .map(m => <ModelRow key={m.model} entry={m} apis={apis} onSave={saveModel} onDelete={deleteModel}/>)}
 
       <Section title="Agents" right={
         <button onClick={refreshInstallStatus} style={pillButton('ghost')} disabled={checkingInstalls} title="Re-check whether each agent's CLI is installed">

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { apiService } from '../services/api'
 import { C } from '../theme'
+import { sectionStyle, fieldStyle, inputStyle, selectStyle, pillButton, Section, unwrap } from './settingsAtoms'
 
 interface SettingsTabProps {
   isGatewayRunning: boolean
@@ -35,36 +36,7 @@ const AGENT_INSTALL_URL: Record<string, string> = {
   'codex':       'https://github.com/openai/codex',
 }
 
-// ── Shared style atoms ───────────────────────────────────────────────
-
-const sectionStyle: React.CSSProperties = {
-  color: C.fg3, fontSize: 11, fontWeight: 600, letterSpacing: 0.5,
-  textTransform: 'uppercase', marginTop: 22, marginBottom: 8,
-}
-const fieldStyle: React.CSSProperties = {
-  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-  padding: '10px 0', borderBottom: `1px solid ${C.border}`,
-}
-const inputStyle: React.CSSProperties = {
-  background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 7,
-  color: C.fg, fontSize: 13, padding: '6px 10px', outline: 'none', width: 180,
-}
-const selectStyle: React.CSSProperties = { ...inputStyle, cursor: 'pointer' }
-const pillButton = (variant: 'primary' | 'danger' | 'ghost'): React.CSSProperties => ({
-  padding: '6px 12px', borderRadius: 7, fontSize: 12, fontWeight: 600,
-  border: 'none', cursor: 'pointer',
-  background: variant === 'primary' ? C.accent : variant === 'danger' ? C.red + '22' : C.surface3,
-  color: variant === 'primary' ? '#fff' : variant === 'danger' ? C.red : C.fg2,
-})
-
 // ── Small helpers ────────────────────────────────────────────────────
-
-const Section: React.FC<{ title: string; right?: React.ReactNode }> = ({ title, right }) => (
-  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', ...sectionStyle }}>
-    <span>{title}</span>
-    {right}
-  </div>
-)
 
 // One of three states: probe in flight, installed, not installed. We render
 // the green pill with the resolved path as a tooltip so power users can see
@@ -548,9 +520,4 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
       </div>
     </div>
   )
-}
-
-function unwrap<T>(r: { ok: true; data: T } | { ok: false; error: string }): T {
-  if (r.ok) return r.data
-  throw new Error(r.error)
 }

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -8,11 +8,11 @@ interface SettingsTabProps {
 }
 
 type ApiType = 'anthropic' | 'openai'
-interface ApiEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
+interface ApiKeyEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
 interface ModelEntry {
   apiType: ApiType
   model: string
-  apiRef?: string
+  apiKeyRef?: string
   provider?: string
 }
 interface AgentSlot { enabled?: boolean }
@@ -107,7 +107,7 @@ const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on,
 
 const ModelRow: React.FC<{
   entry: ModelEntry
-  apis: ApiEntry[]
+  apis: ApiKeyEntry[]
   isNew?: boolean
   onSave: (draft: ModelEntry, previousId: string) => Promise<void>
   onDelete?: (modelId: string) => Promise<void>
@@ -125,7 +125,7 @@ const ModelRow: React.FC<{
   useEffect(() => { if (!editing) setDraft(entry) }, [entry.model, editing])
 
   const save = async () => {
-    if (!draft.model.trim() || !draft.apiRef) return
+    if (!draft.model.trim()) return
     setBusy(true)
     setErr(null)
     try { await onSave(draft, entry.model); setEditing(false) }
@@ -145,10 +145,10 @@ const ModelRow: React.FC<{
             {entry.model} <span style={{ color: C.fg3, fontWeight: 400, fontSize: 11, marginLeft: 6 }}>[{entry.apiType}]</span>
           </div>
           <div style={{
-            color: entry.apiRef ? C.fg3 : C.warningFg,
+            color: C.fg3,
             fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
           }}>
-            {entry.apiRef ? `→ ${entry.apiRef}` : '(no API bound)'}
+            {entry.apiKeyRef ? `🔑 ${entry.apiKeyRef}` : '(default key)'}
           </div>
         </div>
         <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
@@ -174,22 +174,22 @@ const ModelRow: React.FC<{
         <label style={{ color: C.fg3, fontSize: 12 }}>API Type</label>
         <select value={draft.apiType} onChange={e => {
           const nextType = e.target.value as ApiType
-          // If the currently-bound API isn't of the new apiType, drop the binding
-          // so we don't save a model pointing at an incompatible API.
-          const stillValid = apis.some(a => a.name === draft.apiRef && a.apiType === nextType)
-          setDraft({ ...draft, apiType: nextType, apiRef: stillValid ? draft.apiRef : undefined })
+          // If the currently-bound API key isn't of the new apiType, drop the binding
+          // so we don't save a model pointing at an incompatible API key.
+          const stillValid = apis.some(a => a.name === draft.apiKeyRef && a.apiType === nextType)
+          setDraft({ ...draft, apiType: nextType, apiKeyRef: stillValid ? draft.apiKeyRef : undefined })
         }}
           style={{ ...selectStyle, width: '100%' }}>
           <option value="anthropic">anthropic (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN)</option>
           <option value="openai">openai (OPENAI_BASE_URL + OPENAI_API_KEY)</option>
         </select>
-        <label style={{ color: C.fg3, fontSize: 12 }}>API</label>
+        <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
         <select
-          value={draft.apiRef ?? ''}
-          onChange={e => setDraft({ ...draft, apiRef: e.target.value || undefined })}
+          value={draft.apiKeyRef ?? ''}
+          onChange={e => setDraft({ ...draft, apiKeyRef: e.target.value || undefined })}
           style={{ ...selectStyle, width: '100%' }}
         >
-          <option value="">Select an API…</option>
+          <option value="">(use default — env vars)</option>
           {matchingApis.map(a => (
               <option key={a.name} value={a.name}>
                 {a.name}{a.baseUrl ? ` (${a.baseUrl})` : ''}
@@ -198,14 +198,14 @@ const ModelRow: React.FC<{
         </select>
         {matchingApis.length === 0 && (
           <div style={{ gridColumn: '1 / span 2', color: C.fg3, fontSize: 11, marginTop: -4 }}>
-            No {draft.apiType} APIs yet — add one in the APIs tab.
+            No {draft.apiType} API keys yet — add one in the API Keys tab.
           </div>
         )}
       </div>
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
         <button onClick={() => { setEditing(false); setDraft(entry); setErr(null); onCancel?.() }} style={pillButton('ghost')} disabled={busy}>Cancel</button>
-        <button onClick={save} style={pillButton('primary')} disabled={busy || !draft.model.trim() || !draft.apiRef}>
+        <button onClick={save} style={pillButton('primary')} disabled={busy || !draft.model.trim()}>
           {busy ? 'Saving…' : 'Save'}
         </button>
       </div>
@@ -352,7 +352,7 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
   const [models, setModels] = useState<ModelEntry[]>([])
   const [fallback, setFallback] = useState<FallbackCfg>({ enabled: true, order: [] })
   const [advisor, setAdvisor] = useState<{ agent: string; model: string }>({ agent: '', model: '' })
-  const [apis, setApis] = useState<ApiEntry[]>([])
+  const [apis, setApis] = useState<ApiKeyEntry[]>([])
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Probe runs async after the rest of the panel paints — the chip flips from
@@ -377,11 +377,11 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
         unwrap(await window.codey.models.list()),
         unwrap(await window.codey.fallback.get()),
         unwrap(await window.codey.dispatcher.get()),
-        unwrap(await window.codey.apis.list()),
+        unwrap(await window.codey.apiKeys.list()),
       ])
       setModels(m); setFallback(f as FallbackCfg)
       setAdvisor({ agent: d.agent ?? '', model: d.model ?? '' })
-      setApis(a as ApiEntry[])
+      setApis(a as ApiKeyEntry[])
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 

--- a/codey-mac/src/components/settingsAtoms.tsx
+++ b/codey-mac/src/components/settingsAtoms.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { C } from '../theme'
+
+export const sectionStyle: React.CSSProperties = {
+  color: C.fg3, fontSize: 11, fontWeight: 600, letterSpacing: 0.5,
+  textTransform: 'uppercase', marginTop: 22, marginBottom: 8,
+}
+export const fieldStyle: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+  padding: '10px 0', borderBottom: `1px solid ${C.border}`,
+}
+export const inputStyle: React.CSSProperties = {
+  background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 7,
+  color: C.fg, fontSize: 13, padding: '6px 10px', outline: 'none', width: 180,
+}
+export const selectStyle: React.CSSProperties = { ...inputStyle, cursor: 'pointer' }
+
+export const pillButton = (variant: 'primary' | 'danger' | 'ghost'): React.CSSProperties => ({
+  padding: '6px 12px', borderRadius: 7, fontSize: 12, fontWeight: 600,
+  border: 'none', cursor: 'pointer',
+  background: variant === 'primary' ? C.accent : variant === 'danger' ? C.red + '22' : C.surface3,
+  color: variant === 'primary' ? '#fff' : variant === 'danger' ? C.red : C.fg2,
+})
+
+export const Section: React.FC<{ title: string; right?: React.ReactNode }> = ({ title, right }) => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', ...sectionStyle }}>
+    <span>{title}</span>
+    {right}
+  </div>
+)
+
+export function unwrap<T>(r: { ok: true; data: T } | { ok: false; error: string }): T {
+  if (r.ok) return r.data
+  throw new Error(r.error)
+}

--- a/docs/superpowers/plans/2026-05-22-shared-api-keys.md
+++ b/docs/superpowers/plans/2026-05-22-shared-api-keys.md
@@ -1,0 +1,1030 @@
+# Shared API Keys Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an "APIs" tab in Mac Settings that stores reusable credentials/endpoints, and refactor `ModelEntry` to reference an API by name instead of carrying inline `apiKey`/`baseUrl`.
+
+**Architecture:** New `ApiEntry` type in `@codey/core` and an `apis: ApiEntry[]` field on `GatewayConfigJson`. `ModelEntry.apiRef` replaces inline credential fields. Gateway resolution walks model → apiRef → API entry to inject creds. UI gets a new `ApisTab.tsx` mirroring the existing models pattern, and `ModelRow` swaps two inputs for a single API dropdown.
+
+**Tech Stack:** TypeScript, Electron IPC, React, vitest (already a dev-dep on `@codey/core`).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-21-shared-api-keys-design.md`
+
+---
+
+## Task 1: Define `ApiEntry` and refactor `ModelEntry`
+
+**Files:**
+- Modify: `packages/core/src/types/index.ts` (lines 37-65)
+
+- [ ] **Step 1: Add `ApiEntry` and update `ModelEntry`**
+
+Edit `packages/core/src/types/index.ts`. Find the existing block at line 37-65 (the section starting with `// Model configuration for agents`). Replace it with:
+
+```ts
+// Model configuration for agents
+export type ApiType = 'anthropic' | 'openai';
+
+/**
+ * A reusable API connection — credentials + endpoint stored once and
+ * referenced from any number of ModelEntry rows by name. Lets a single
+ * key power multiple models without duplication.
+ */
+export interface ApiEntry {
+  name: string;        // unique id, surfaced in the model dropdown
+  apiType: ApiType;
+  baseUrl?: string;    // optional endpoint override
+  apiKey: string;      // required
+}
+
+export interface ModelConfig {
+  provider: string;
+  model: string;
+  apiKey?: string;
+  baseUrl?: string;
+  /**
+   * Which environment-variable style the spawned CLI expects.
+   * anthropic → ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN
+   * openai   → OPENAI_BASE_URL   + OPENAI_API_KEY
+   * Inferred from the referenced ModelEntry in gateway.json.
+   */
+  apiType?: ApiType;
+}
+
+/**
+ * A reusable model definition the user manages in Settings.
+ * The `model` field is both the identifier agent.defaultModel points
+ * at and the string passed to the CLI as --model. `apiRef` names an
+ * ApiEntry that supplies the credentials at run time.
+ */
+export interface ModelEntry {
+  apiType: ApiType;
+  model: string;
+  apiRef?: string;      // name of an ApiEntry in the gateway's apis catalog
+  provider?: string;    // optional human label (anthropic, minimax, openai, …)
+}
+```
+
+- [ ] **Step 2: Build core to catch type breakage**
+
+Run: `npm run build -w @codey/core`
+Expected: errors in any code that still reads `ModelEntry.apiKey` / `ModelEntry.baseUrl`. Note the call sites — they're handled in Task 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/types/index.ts
+git commit -m "feat(core): add ApiEntry type, replace ModelEntry inline creds with apiRef"
+```
+
+---
+
+## Task 2: Add `apis` to gateway config + normalize() drops legacy fields
+
+**Files:**
+- Modify: `packages/gateway/src/config.ts` (interface lines 8-69, normalize at 431-465, default config, ConfigManager methods)
+- Create: `packages/gateway/src/config.test.ts`
+
+- [ ] **Step 1: Add `apis` to the config interface**
+
+In `packages/gateway/src/config.ts`, change the import line 4 from:
+
+```ts
+import { CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
+```
+
+to:
+
+```ts
+import { ApiEntry, CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
+```
+
+In the same file, find the `GatewayConfigJson` interface block. Right after the `models: ModelEntry[];` line (~line 29), insert:
+
+```ts
+  /** Shared API connections referenced by ModelEntry.apiRef. */
+  apis: ApiEntry[];
+```
+
+- [ ] **Step 2: Include `apis: []` in the default config**
+
+Find `getDefaultConfig()` in `packages/gateway/src/config.ts` (search for `function getDefaultConfig`). Add `apis: [],` to the returned object next to `models: [],`.
+
+- [ ] **Step 3: Update `normalize()` to parse `apis` and strip legacy fields off models**
+
+In `packages/gateway/src/config.ts` find `function normalize(` at line 431. Replace the body up through the `out` object construction with:
+
+```ts
+function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: CodingAgent; model?: string }; planner?: { model?: string } }): GatewayConfigJson {
+  const defaults = getDefaultConfig();
+  const rawModels = Array.isArray(raw.models) ? raw.models : defaults.models;
+  // Clean break: drop inline apiKey/baseUrl from any pre-existing model entries.
+  // Users re-bind via the APIs tab. apiRef is left unset until they do.
+  const models: ModelEntry[] = rawModels.map(m => ({
+    apiType: m.apiType,
+    model: m.model,
+    apiRef: (m as any).apiRef,
+    provider: m.provider,
+  }));
+  const apis: ApiEntry[] = Array.isArray(raw.apis)
+    ? raw.apis.filter((a: any) => a && typeof a.name === 'string' && typeof a.apiKey === 'string')
+    : [];
+  const out: GatewayConfigJson = {
+    gateway: { ...defaults.gateway, ...(raw.gateway ?? {}) },
+    channels: raw.channels ?? defaults.channels,
+    agents: { ...defaults.agents, ...(raw.agents ?? {}) },
+    models,
+    apis,
+    fallback: normalizeFallback(raw.fallback, defaults.fallback),
+    dev: raw.dev ?? defaults.dev,
+  };
+```
+
+Leave the rest of `normalize()` (advisor/dispatcher/teams/voice handling) unchanged.
+
+- [ ] **Step 4: Handle `apis` in `ConfigManager.update()`**
+
+In `packages/gateway/src/config.ts` find the `update()` method (around line 151). After the existing `if (partial.models !== undefined) this.config.models = partial.models;` line add:
+
+```ts
+    if (partial.apis !== undefined) this.config.apis = partial.apis;
+```
+
+- [ ] **Step 5: Add API CRUD methods to `ConfigManager`**
+
+In `packages/gateway/src/config.ts`, find the `deleteModel(...)` method (~line 229) and append the following block right after its closing brace:
+
+```ts
+  // ── APIs ───────────────────────────────────────────────────────────
+  listApis(): ApiEntry[] { return this.config.apis ?? []; }
+
+  getApi(name: string): ApiEntry | undefined {
+    return this.config.apis?.find(a => a.name === name);
+  }
+
+  saveApi(entry: ApiEntry): void {
+    if (!entry.name?.trim()) throw new Error('API name is required');
+    if (!entry.apiKey?.trim()) throw new Error('API key is required');
+    const idx = this.config.apis.findIndex(a => a.name === entry.name);
+    if (idx >= 0) this.config.apis[idx] = entry;
+    else this.config.apis.push(entry);
+    this.save();
+  }
+
+  renameApi(oldName: string, newName: string): boolean {
+    if (!newName.trim() || oldName === newName) return false;
+    if (this.config.apis.some(a => a.name === newName)) {
+      throw new Error(`An API with name "${newName}" already exists`);
+    }
+    const idx = this.config.apis.findIndex(a => a.name === oldName);
+    if (idx < 0) return false;
+    this.config.apis[idx] = { ...this.config.apis[idx], name: newName };
+    // Rewrite every model that referenced the old name so apiRef stays valid.
+    for (const m of this.config.models) {
+      if (m.apiRef === oldName) m.apiRef = newName;
+    }
+    this.save();
+    return true;
+  }
+
+  deleteApi(name: string): boolean {
+    const dependents = this.config.models.filter(m => m.apiRef === name).map(m => m.model);
+    if (dependents.length > 0) {
+      throw new Error(`API "${name}" is referenced by: ${dependents.join(', ')}`);
+    }
+    const before = this.config.apis.length;
+    this.config.apis = this.config.apis.filter(a => a.name !== name);
+    if (this.config.apis.length !== before) {
+      this.save();
+      return true;
+    }
+    return false;
+  }
+```
+
+- [ ] **Step 6: Drop the stale comment about `apiKey` preservation in `renameModel`**
+
+In `packages/gateway/src/config.ts`, find the `renameModel` jsdoc block (~line 210-213):
+
+```ts
+  /**
+   * Change a model entry's identifier and rewrite every fallback entry that
+   * pointed at it. Content (apiType, baseUrl, apiKey) is preserved.
+   */
+```
+
+Replace with:
+
+```ts
+  /**
+   * Change a model entry's identifier and rewrite every fallback entry that
+   * pointed at it. Content (apiType, apiRef, provider) is preserved.
+   */
+```
+
+- [ ] **Step 7: Write a test for normalize() and the API CRUD**
+
+Create `packages/gateway/src/config.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ConfigManager } from './config';
+
+function withTempConfig(initial: any, fn: (cm: ConfigManager, p: string) => void) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-cfg-'));
+  const p = path.join(dir, 'gateway.json');
+  fs.writeFileSync(p, JSON.stringify(initial));
+  const cm = new ConfigManager(p);
+  try { fn(cm, p); } finally { cm.stop(); fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+describe('config normalize', () => {
+  it('strips legacy apiKey/baseUrl from existing ModelEntry rows', () => {
+    withTempConfig({
+      models: [{ model: 'm1', apiType: 'anthropic', apiKey: 'sk-old', baseUrl: 'https://old' }],
+    }, cm => {
+      const m = cm.listModels()[0];
+      expect(m.model).toBe('m1');
+      expect((m as any).apiKey).toBeUndefined();
+      expect((m as any).baseUrl).toBeUndefined();
+    });
+  });
+
+  it('parses apis array and preserves valid entries', () => {
+    withTempConfig({
+      apis: [
+        { name: 'main', apiType: 'anthropic', baseUrl: 'https://api', apiKey: 'sk-1' },
+        { name: '', apiType: 'anthropic', apiKey: 'sk-bad' },     // dropped: empty name
+        { name: 'noKey', apiType: 'openai' },                     // dropped: missing apiKey
+      ],
+    }, cm => {
+      const apis = cm.listApis();
+      expect(apis).toHaveLength(1);
+      expect(apis[0].name).toBe('main');
+    });
+  });
+
+  it('defaults apis to [] when missing', () => {
+    withTempConfig({}, cm => {
+      expect(cm.listApis()).toEqual([]);
+    });
+  });
+});
+
+describe('api CRUD', () => {
+  it('saveApi rejects missing name or key', () => {
+    withTempConfig({}, cm => {
+      expect(() => cm.saveApi({ name: '', apiType: 'openai', apiKey: 'k' } as any)).toThrow();
+      expect(() => cm.saveApi({ name: 'x', apiType: 'openai', apiKey: '' } as any)).toThrow();
+    });
+  });
+
+  it('renameApi rewrites apiRef on dependent models', () => {
+    withTempConfig({
+      apis: [{ name: 'old', apiType: 'anthropic', apiKey: 'sk' }],
+      models: [{ model: 'm1', apiType: 'anthropic', apiRef: 'old' }],
+    }, cm => {
+      expect(cm.renameApi('old', 'new')).toBe(true);
+      expect(cm.listApis()[0].name).toBe('new');
+      expect(cm.listModels()[0].apiRef).toBe('new');
+    });
+  });
+
+  it('deleteApi refuses when models still reference it', () => {
+    withTempConfig({
+      apis: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+      models: [{ model: 'm1', apiType: 'anthropic', apiRef: 'a' }],
+    }, cm => {
+      expect(() => cm.deleteApi('a')).toThrow(/m1/);
+    });
+  });
+
+  it('deleteApi succeeds with no dependents', () => {
+    withTempConfig({
+      apis: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+    }, cm => {
+      expect(cm.deleteApi('a')).toBe(true);
+      expect(cm.listApis()).toHaveLength(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 8: Add vitest run script + run the test**
+
+In `packages/gateway/package.json` scripts block, add (next to `"build"`):
+
+```json
+    "test": "vitest run",
+```
+
+If `vitest` is not already in `packages/gateway/package.json` devDependencies, add it: `cd packages/gateway && npm i -D vitest@^4.1.5`. (It's a hoisted dep through `@codey/core`, so this may be unnecessary — run the test first.)
+
+Run: `npm run test -w @codey/gateway`
+Expected: all 6 tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core packages/gateway/src/config.ts packages/gateway/src/config.test.ts packages/gateway/package.json
+git commit -m "feat(gateway): apis catalog in config + drop legacy inline creds on load"
+```
+
+---
+
+## Task 3: Gateway model resolution reads creds via apiRef
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts:2611-2622`
+
+- [ ] **Step 1: Update `getModelConfig` to resolve via `apiRef`**
+
+In `packages/gateway/src/gateway.ts` find `getModelConfig` (~line 2611). Replace the catalog-hit branch (lines 2612-2622) with:
+
+```ts
+    // 1. Check the global model catalog (apiRef points at the credentials)
+    const catalogEntry = this.configManager?.getModel(modelName);
+    if (catalogEntry) {
+      const api = catalogEntry.apiRef
+        ? this.configManager?.getApi(catalogEntry.apiRef)
+        : undefined;
+      if (!api) {
+        throw new Error(
+          `Model "${catalogEntry.model}" has no API bound. Open Settings → APIs to add one, then bind it from the Models tab.`
+        );
+      }
+      if (api.apiType !== catalogEntry.apiType) {
+        throw new Error(
+          `Model "${catalogEntry.model}" expects apiType "${catalogEntry.apiType}" but API "${api.name}" is "${api.apiType}".`
+        );
+      }
+      return {
+        provider: catalogEntry.provider ?? (catalogEntry.apiType === 'anthropic' ? 'anthropic' : 'openai'),
+        model: catalogEntry.model,
+        apiKey: api.apiKey,
+        baseUrl: api.baseUrl,
+        apiType: catalogEntry.apiType,
+      };
+    }
+```
+
+- [ ] **Step 2: Build the gateway**
+
+Run: `npm run build -w @codey/gateway`
+Expected: clean compile. If any other call site still reads `.apiKey` / `.baseUrl` off a `ModelEntry`, fix it the same way (route via `apiRef`).
+
+- [ ] **Step 3: Audit other call sites**
+
+Run: `grep -rn "\\.apiKey\\|\\.baseUrl" packages/gateway/src/ packages/core/src/`
+Expected: every match is either inside a `ModelConfig` (the runtime shape — keep), inside `ApiEntry` (keep), or inside legacy `voice.apiKey` (unrelated — keep). No `ModelEntry.apiKey` / `ModelEntry.baseUrl` reads should remain.
+
+If `packages/gateway/src/cli.ts` or any other file still prints `m.apiKey` / `m.baseUrl` on a model row (search for `keyHint`, `urlHint`), replace it with `m.apiRef ? ` → ${m.apiRef}` : '(no API)' ` or similar — see `config.ts:347-349` for the existing display.
+
+- [ ] **Step 4: Update the CLI model listing**
+
+In `packages/gateway/src/config.ts` find the display formatting near line 347-349:
+
+```ts
+      const keyHint = m.apiKey ? ' 🔑' : '';
+      const urlHint = m.baseUrl ? ` @ ${m.baseUrl}` : '';
+```
+
+Replace with:
+
+```ts
+      const keyHint = m.apiRef ? ` → ${m.apiRef}` : ' (no API bound)';
+      const urlHint = '';
+```
+
+- [ ] **Step 5: Rebuild + commit**
+
+Run: `npm run build -w @codey/gateway`
+Expected: clean.
+
+```bash
+git add packages/gateway/src/gateway.ts packages/gateway/src/config.ts
+git commit -m "feat(gateway): resolve model creds via apiRef instead of inline fields"
+```
+
+---
+
+## Task 4: Electron IPC + preload + TypeScript surface for APIs
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts:1153-1181`
+- Modify: `codey-mac/electron/preload.ts:62-67`
+- Modify: `codey-mac/src/codey-api.d.ts:61-66`
+
+- [ ] **Step 1: Add IPC handlers in `main.ts`**
+
+In `codey-mac/electron/main.ts` find the `// ── Models IPC ──` block (~line 1153). After the existing `models:rename` handler (~line 1181), insert:
+
+```ts
+  // ── APIs IPC ──────────────────────────────────────────────────────
+  ipcMain.handle('apis:list', async () =>
+    wrap(async () => coreConfigManager?.listApis() ?? [])
+  )
+
+  ipcMain.handle('apis:save', async (_e, entry: any) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      if (!entry?.name?.trim()) throw new Error('API name is required')
+      if (entry.apiType !== 'anthropic' && entry.apiType !== 'openai') {
+        throw new Error('API apiType must be "anthropic" or "openai"')
+      }
+      if (!entry.apiKey?.trim()) throw new Error('API key is required')
+      coreConfigManager.saveApi(entry)
+    })
+  )
+
+  ipcMain.handle('apis:delete', async (_e, name: string) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      coreConfigManager.deleteApi(name)
+    })
+  )
+
+  ipcMain.handle('apis:rename', async (_e, oldName: string, newName: string) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      coreConfigManager.renameApi(oldName, newName)
+    })
+  )
+```
+
+- [ ] **Step 2: Expose the channels through `preload.ts`**
+
+In `codey-mac/electron/preload.ts` find the `models:` block (lines 62-67). After it insert:
+
+```ts
+  apis: {
+    list: () => ipcRenderer.invoke('apis:list'),
+    save: (entry: any) => ipcRenderer.invoke('apis:save', entry),
+    delete: (name: string) => ipcRenderer.invoke('apis:delete', name),
+    rename: (oldName: string, newName: string) => ipcRenderer.invoke('apis:rename', oldName, newName),
+  },
+```
+
+- [ ] **Step 3: Add the TypeScript surface in `codey-api.d.ts`**
+
+In `codey-mac/src/codey-api.d.ts` find the `ModelEntry` import / declaration at the top of the file. Add `ApiEntry` to the imports from `@codey/core`. Then find the `models: { ... }` block (~line 61-66). After it insert:
+
+```ts
+      apis: {
+        list: () => Promise<IpcResult<ApiEntry[]>>
+        save: (entry: ApiEntry) => Promise<IpcResult<void>>
+        delete: (name: string) => Promise<IpcResult<void>>
+        rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
+      }
+```
+
+- [ ] **Step 4: Build the renderer to confirm types compile**
+
+Run: `cd codey-mac && npm run build`
+Expected: clean. Any remaining errors about `ModelEntry.apiKey` come from Task 5 — leave them for now.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/electron/main.ts codey-mac/electron/preload.ts codey-mac/src/codey-api.d.ts
+git commit -m "feat(mac): IPC channels for apis:list/save/delete/rename"
+```
+
+---
+
+## Task 5: Extract shared Settings UI atoms
+
+**Files:**
+- Create: `codey-mac/src/components/settingsAtoms.ts`
+- Modify: `codey-mac/src/components/SettingsTab.tsx` (lines 40-67)
+
+The Models row and the new APIs tab share button / input / section styles. Pulling them into one file keeps both tabs visually identical and avoids divergence.
+
+- [ ] **Step 1: Create the shared atoms file**
+
+Create `codey-mac/src/components/settingsAtoms.ts`:
+
+```ts
+import React from 'react'
+import { C } from '../theme'
+
+export const sectionStyle: React.CSSProperties = {
+  color: C.fg3, fontSize: 11, fontWeight: 600, letterSpacing: 0.5,
+  textTransform: 'uppercase', marginTop: 22, marginBottom: 8,
+}
+export const fieldStyle: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+  padding: '10px 0', borderBottom: `1px solid ${C.border}`,
+}
+export const inputStyle: React.CSSProperties = {
+  background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 7,
+  color: C.fg, fontSize: 13, padding: '6px 10px', outline: 'none', width: 180,
+}
+export const selectStyle: React.CSSProperties = { ...inputStyle, cursor: 'pointer' }
+
+export const pillButton = (variant: 'primary' | 'danger' | 'ghost'): React.CSSProperties => ({
+  padding: '6px 12px', borderRadius: 7, fontSize: 12, fontWeight: 600,
+  border: 'none', cursor: 'pointer',
+  background: variant === 'primary' ? C.accent : variant === 'danger' ? C.red + '22' : C.surface3,
+  color: variant === 'primary' ? '#fff' : variant === 'danger' ? C.red : C.fg2,
+})
+
+export const Section: React.FC<{ title: string; right?: React.ReactNode }> = ({ title, right }) => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', ...sectionStyle }}>
+    <span>{title}</span>
+    {right}
+  </div>
+)
+
+export function unwrap<T>(r: { ok: true; data: T } | { ok: false; error: string }): T {
+  if (r.ok) return r.data
+  throw new Error(r.error)
+}
+```
+
+- [ ] **Step 2: Replace the inline declarations in `SettingsTab.tsx`**
+
+In `codey-mac/src/components/SettingsTab.tsx`:
+
+Delete the inline declarations lines 40-67 (the `sectionStyle`, `fieldStyle`, `inputStyle`, `selectStyle`, `pillButton`, `Section` block).
+
+Also delete the `unwrap` function at the bottom of the file (lines 553-556).
+
+Add a new import below the existing `import { C } from '../theme'` line:
+
+```ts
+import { sectionStyle, fieldStyle, inputStyle, selectStyle, pillButton, Section, unwrap } from './settingsAtoms'
+```
+
+- [ ] **Step 3: Build the renderer**
+
+Run: `cd codey-mac && npm run build`
+Expected: existing `ModelEntry.apiKey`/`baseUrl` errors only — atoms refactor itself compiles cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add codey-mac/src/components/settingsAtoms.ts codey-mac/src/components/SettingsTab.tsx
+git commit -m "refactor(mac): extract shared Settings UI atoms into one module"
+```
+
+---
+
+## Task 6: Build the new APIs tab
+
+**Files:**
+- Create: `codey-mac/src/components/ApisTab.tsx`
+- Modify: `codey-mac/src/components/SettingsOverlay.tsx`
+
+- [ ] **Step 1: Create `ApisTab.tsx`**
+
+Create `codey-mac/src/components/ApisTab.tsx`:
+
+```tsx
+import React, { useCallback, useEffect, useState } from 'react'
+import { C } from '../theme'
+import {
+  inputStyle, selectStyle, pillButton, Section, unwrap,
+} from './settingsAtoms'
+
+type ApiType = 'anthropic' | 'openai'
+interface ApiEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
+
+interface Props { isGatewayRunning: boolean }
+
+const ApiRow: React.FC<{
+  entry: ApiEntry
+  isNew?: boolean
+  onSave: (draft: ApiEntry, previousName: string) => Promise<void>
+  onDelete?: (name: string) => Promise<void>
+  onCancel?: () => void
+}> = ({ entry, isNew, onSave, onDelete, onCancel }) => {
+  const [editing, setEditing] = useState(!!isNew)
+  const [draft, setDraft] = useState<ApiEntry>(entry)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => { if (!editing) setDraft(entry) }, [entry.name, editing])
+
+  const save = async () => {
+    if (!draft.name.trim() || !draft.apiKey.trim()) return
+    setBusy(true); setErr(null)
+    try { await onSave(draft, entry.name); setEditing(false) }
+    catch (e: any) { setErr(e?.message ?? String(e)) }
+    finally { setBusy(false) }
+  }
+
+  if (!editing) {
+    return (
+      <div style={{
+        padding: '12px 14px', borderRadius: 10, border: `1px solid ${C.border}`,
+        background: C.surface2, marginBottom: 8,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
+      }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontWeight: 600, fontSize: 13 }}>
+            {entry.name}
+            <span style={{ color: C.fg3, fontWeight: 400, fontSize: 11, marginLeft: 6 }}>[{entry.apiType}]</span>
+          </div>
+          <div style={{ color: C.fg3, fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {entry.baseUrl || '(default url)'} · 🔑
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+          <button onClick={() => setEditing(true)} style={pillButton('ghost')}>Edit</button>
+          {onDelete && <button onClick={() => onDelete(entry.name)} style={pillButton('danger')}>Delete</button>}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{
+      padding: 12, borderRadius: 10, border: `1px solid ${C.border2}`,
+      background: C.surface2, marginBottom: 8,
+    }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '100px 1fr', gap: 8, alignItems: 'center' }}>
+        <label style={{ color: C.fg3, fontSize: 12 }}>Name</label>
+        <input value={draft.name} onChange={e => setDraft({ ...draft, name: e.target.value })}
+          placeholder="e.g. anthropic-personal" style={{ ...inputStyle, width: '100%' }} />
+        <label style={{ color: C.fg3, fontSize: 12 }}>API Type</label>
+        <select value={draft.apiType} onChange={e => setDraft({ ...draft, apiType: e.target.value as ApiType })}
+          style={{ ...selectStyle, width: '100%' }}>
+          <option value="anthropic">anthropic (ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN)</option>
+          <option value="openai">openai (OPENAI_BASE_URL + OPENAI_API_KEY)</option>
+        </select>
+        <label style={{ color: C.fg3, fontSize: 12 }}>Base URL</label>
+        <input value={draft.baseUrl ?? ''} onChange={e => setDraft({ ...draft, baseUrl: e.target.value || undefined })}
+          placeholder="(optional) override endpoint" style={{ ...inputStyle, width: '100%' }} />
+        <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
+        <input type="password" value={draft.apiKey} onChange={e => setDraft({ ...draft, apiKey: e.target.value })}
+          placeholder="credentials" style={{ ...inputStyle, width: '100%' }} />
+      </div>
+      {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
+      <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
+        <button onClick={() => { setEditing(false); setDraft(entry); setErr(null); onCancel?.() }} style={pillButton('ghost')} disabled={busy}>Cancel</button>
+        <button onClick={save} style={pillButton('primary')} disabled={busy || !draft.name.trim() || !draft.apiKey.trim()}>
+          {busy ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export const ApisTab: React.FC<Props> = ({ isGatewayRunning }) => {
+  const [apis, setApis] = useState<ApiEntry[]>([])
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setError(null)
+    try { setApis(unwrap(await window.codey.apis.list())) }
+    catch (e: any) { setError(e?.message ?? String(e)) }
+  }, [])
+
+  useEffect(() => { if (isGatewayRunning) reload() }, [isGatewayRunning, reload])
+
+  if (!isGatewayRunning) {
+    return (
+      <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
+        <div style={{ marginTop: 40, textAlign: 'center', color: C.fg3, fontSize: 13 }}>Gateway not available</div>
+      </div>
+    )
+  }
+
+  const saveApi = async (entry: ApiEntry, previousName: string) => {
+    if (previousName && previousName !== entry.name) {
+      await unwrap(await window.codey.apis.rename(previousName, entry.name))
+    }
+    await unwrap(await window.codey.apis.save(entry))
+    await reload()
+    setCreating(false)
+  }
+  const deleteApi = async (name: string) => {
+    if (!confirm(`Delete API "${name}"?`)) return
+    try { await unwrap(await window.codey.apis.delete(name)); await reload() }
+    catch (e: any) { setError(e?.message ?? String(e)) }
+  }
+
+  return (
+    <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
+      {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
+
+      <Section title="APIs" right={
+        <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
+      } />
+      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
+        Saved credentials & endpoints. A single API can be bound from many models in the AI Models tab.
+      </div>
+      {creating && (
+        <ApiRow
+          entry={{ name: '', apiType: 'anthropic', baseUrl: '', apiKey: '' }}
+          isNew
+          onSave={saveApi}
+          onCancel={() => setCreating(false)}
+        />
+      )}
+      {apis.length === 0 && !creating && (
+        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0' }}>No APIs yet. Click + Add to create one.</div>
+      )}
+      {[...apis]
+        .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.name.localeCompare(b.name))
+        .map(a => <ApiRow key={a.name} entry={a} onSave={saveApi} onDelete={deleteApi} />)}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Register the tab in `SettingsOverlay.tsx`**
+
+In `codey-mac/src/components/SettingsOverlay.tsx`:
+
+Add at the top with other tab imports:
+
+```ts
+import { ApisTab } from './ApisTab'
+```
+
+Change the `Tab` union (line 12) to include `'apis'`:
+
+```ts
+type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'whisper' | 'apis'
+```
+
+In the `TABS` array (lines 13-21), insert a new entry right after the `general` row, *before* `settings`:
+
+```ts
+  { key: 'apis',       label: 'APIs',       icon: '🔑', description: 'Shared credentials' },
+```
+
+In the main content switch (lines 75-81), add:
+
+```ts
+              {tab === 'apis'       && <ApisTab isGatewayRunning={isRunning} />}
+```
+
+- [ ] **Step 3: Build the renderer**
+
+Run: `cd codey-mac && npm run build`
+Expected: existing `SettingsTab.tsx` errors about `apiKey`/`baseUrl` only — `ApisTab` itself compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add codey-mac/src/components/ApisTab.tsx codey-mac/src/components/SettingsOverlay.tsx
+git commit -m "feat(mac): add APIs settings tab for shared credentials"
+```
+
+---
+
+## Task 7: Refactor `ModelRow` to bind an API
+
+**Files:**
+- Modify: `codey-mac/src/components/SettingsTab.tsx` (ModelEntry interface + ModelRow render)
+
+- [ ] **Step 1: Update the `ModelEntry` interface in the file**
+
+In `codey-mac/src/components/SettingsTab.tsx` near line 9-16:
+
+```ts
+interface ModelEntry {
+  apiType: ApiType
+  model: string
+  baseUrl?: string
+  apiKey?: string
+  provider?: string
+}
+```
+
+Replace with:
+
+```ts
+interface ApiEntry { name: string; apiType: ApiType; baseUrl?: string; apiKey: string }
+interface ModelEntry {
+  apiType: ApiType
+  model: string
+  apiRef?: string
+  provider?: string
+}
+```
+
+- [ ] **Step 2: Pass available APIs into `ModelRow`**
+
+Change the `ModelRow` props (~line 136):
+
+```ts
+const ModelRow: React.FC<{
+  entry: ModelEntry
+  isNew?: boolean
+  onSave: (draft: ModelEntry, previousId: string) => Promise<void>
+  onDelete?: (modelId: string) => Promise<void>
+  onCancel?: () => void
+}>
+```
+
+to:
+
+```ts
+const ModelRow: React.FC<{
+  entry: ModelEntry
+  apis: ApiEntry[]
+  isNew?: boolean
+  onSave: (draft: ModelEntry, previousId: string) => Promise<void>
+  onDelete?: (modelId: string) => Promise<void>
+  onCancel?: () => void
+}>
+```
+
+Destructure `apis` in the component signature on the same line.
+
+- [ ] **Step 3: Replace the collapsed-row "url · 🔑" hint**
+
+In `ModelRow`'s `!editing` return (~lines 174-176):
+
+```tsx
+          <div style={{ color: C.fg3, fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {entry.baseUrl || '(default url)'}{entry.apiKey ? ' · 🔑' : ''}
+          </div>
+```
+
+Replace with:
+
+```tsx
+          <div style={{
+            color: entry.apiRef ? C.fg3 : C.warningFg,
+            fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>
+            {entry.apiRef ? `→ ${entry.apiRef}` : '(no API bound)'}
+          </div>
+```
+
+- [ ] **Step 4: Replace the Base URL + API Key edit inputs with an API dropdown**
+
+In `ModelRow`'s editing return (~lines 201-206):
+
+```tsx
+        <label style={{ color: C.fg3, fontSize: 12 }}>Base URL</label>
+        <input value={draft.baseUrl ?? ''} onChange={e => setDraft({ ...draft, baseUrl: e.target.value || undefined })}
+          placeholder="(optional) override endpoint" style={{ ...inputStyle, width: '100%' }}/>
+        <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
+        <input type="password" value={draft.apiKey ?? ''} onChange={e => setDraft({ ...draft, apiKey: e.target.value || undefined })}
+          placeholder="(optional) credentials" style={{ ...inputStyle, width: '100%' }}/>
+```
+
+Replace with:
+
+```tsx
+        <label style={{ color: C.fg3, fontSize: 12 }}>API</label>
+        <select
+          value={draft.apiRef ?? ''}
+          onChange={e => setDraft({ ...draft, apiRef: e.target.value || undefined })}
+          style={{ ...selectStyle, width: '100%' }}
+        >
+          <option value="">Select an API…</option>
+          {apis
+            .filter(a => a.apiType === draft.apiType)
+            .map(a => (
+              <option key={a.name} value={a.name}>
+                {a.name}{a.baseUrl ? ` (${a.baseUrl})` : ''}
+              </option>
+            ))}
+        </select>
+        {apis.filter(a => a.apiType === draft.apiType).length === 0 && (
+          <span />
+        )}
+        {apis.filter(a => a.apiType === draft.apiType).length === 0 && (
+          <div style={{ gridColumn: '1 / span 2', color: C.fg3, fontSize: 11, marginTop: -4 }}>
+            No {draft.apiType} APIs yet — add one in the APIs tab.
+          </div>
+        )}
+```
+
+- [ ] **Step 5: Load APIs in `SettingsTab` and pass them down**
+
+In `SettingsTab` (~line 354 onward), add an `apis` state and reload alongside models. Replace the `reload` callback (~line 375-386) with:
+
+```ts
+  const [apis, setApis] = useState<ApiEntry[]>([])
+
+  const reload = useCallback(async () => {
+    setError(null)
+    try {
+      const [m, f, d, a] = await Promise.all([
+        unwrap(await window.codey.models.list()),
+        unwrap(await window.codey.fallback.get()),
+        unwrap(await window.codey.dispatcher.get()),
+        unwrap(await window.codey.apis.list()),
+      ])
+      setModels(m); setFallback(f as FallbackCfg)
+      setAdvisor({ agent: d.agent ?? '', model: d.model ?? '' })
+      setApis(a as ApiEntry[])
+    } catch (e: any) { setError(e?.message ?? String(e)) }
+  }, [])
+```
+
+Then update the two `ModelRow` usages (the `creating` one and the `.map(m => <ModelRow ...>)`) to pass `apis={apis}`:
+
+```tsx
+      {creating && (
+        <ModelRow
+          entry={{ apiType: 'anthropic', model: '' }}
+          apis={apis}
+          isNew
+          onSave={saveModel}
+          onCancel={() => setCreating(false)}
+        />
+      )}
+```
+
+and:
+
+```tsx
+        .map(m => <ModelRow key={m.model} entry={m} apis={apis} onSave={saveModel} onDelete={deleteModel}/>)}
+```
+
+(Note: the `creating` entry's initial object also drops `baseUrl: ''` and `apiKey: ''`.)
+
+- [ ] **Step 6: Build the renderer**
+
+Run: `cd codey-mac && npm run build`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add codey-mac/src/components/SettingsTab.tsx
+git commit -m "feat(mac): Model row binds an API instead of inline key/url"
+```
+
+---
+
+## Task 8: Full-stack manual verification
+
+This task has no code changes — it validates the feature end-to-end. Required because the gateway has no automated integration tests for the renderer path.
+
+- [ ] **Step 1: Start the gateway + Mac app fresh**
+
+Pre-flight: back up your `gateway.json` (`cp ~/.codey/gateway.json ~/.codey/gateway.json.bak` or whatever path the app uses), and confirm it currently contains at least one model with an inline `apiKey`.
+
+Run: from the project root, launch the Mac app the way you normally do (`cd codey-mac && npm run dev` or the packaged binary).
+
+Expected: gateway boots, app opens. On startup the gateway's `normalize()` rewrites `gateway.json` — open it and confirm `models[*].apiKey` and `models[*].baseUrl` are gone and an `apis: []` field exists.
+
+- [ ] **Step 2: Verify the warning badge appears on existing models**
+
+Open Settings → AI Models.
+Expected: existing model rows show "(no API bound)" in the warning color where the URL + 🔑 hint used to be.
+
+- [ ] **Step 3: Add an API entry**
+
+Click the new APIs tab. Click "+ Add". Fill in name (e.g. "main"), apiType anthropic, optionally baseUrl, paste a real Anthropic API key. Save.
+Expected: the row collapses, shows `main [anthropic] (default url) · 🔑`.
+
+- [ ] **Step 4: Bind the API to a model**
+
+Go to AI Models. Edit a `claude-code`-compatible (anthropic) model. The new "API" dropdown lists `main`. Pick it. Save.
+Expected: collapsed row now shows `→ main` in the muted color.
+
+- [ ] **Step 5: Run a chat and verify it works**
+
+In the main chat UI, send a prompt to that model.
+Expected: model responds successfully. No "no API bound" error.
+
+- [ ] **Step 6: Test rename propagation**
+
+Settings → APIs → edit "main", rename to "main2". Save. Switch to AI Models.
+Expected: the bound model now reads `→ main2`. Send another chat prompt — still works.
+
+- [ ] **Step 7: Test delete protection**
+
+Settings → APIs → delete "main2".
+Expected: confirm modal; on confirm an error toast appears listing the dependent model — entry stays.
+
+Now unbind by editing the model and selecting "Select an API…". Save. Try delete again.
+Expected: succeeds; row disappears.
+
+- [ ] **Step 8: Test type mismatch error path**
+
+Manually edit `gateway.json` to bind an anthropic-typed model to an openai-typed API. Restart the app, send a prompt.
+Expected: error in chat reads "Model X expects apiType anthropic but API Y is openai".
+
+- [ ] **Step 9: Restore your real keys**
+
+Re-bind models to your real APIs (or restore `gateway.json.bak` and re-run normalize once — the migration is idempotent).
+
+- [ ] **Step 10: Commit the verification log (optional)**
+
+If you took screenshots or notes worth keeping, drop them in `docs/superpowers/notes/2026-05-22-shared-api-keys-verification.md` and commit. Otherwise skip.
+
+---
+
+## Self-review notes
+
+- Spec coverage: ApiEntry (Task 1), config storage + normalize migration (Task 2), backend resolution (Task 3), IPC (Task 4), atoms refactor + UI (Tasks 5-7), manual verification (Task 8). ✓
+- The spec's mention of an inline "no APIs yet" hint in the Model edit dropdown is in Task 7 Step 4. ✓
+- The spec's "renaming an API rewrites all model apiRef atomically" is implemented in Task 2 Step 5's `renameApi`. ✓
+- The spec's "delete refuses when models still reference" is in Task 2 Step 5 and tested in Task 2 Step 7. ✓
+- No placeholders: every step has the actual code or command. ✓

--- a/docs/superpowers/specs/2026-05-21-shared-api-keys-design.md
+++ b/docs/superpowers/specs/2026-05-21-shared-api-keys-design.md
@@ -1,0 +1,165 @@
+# Shared API Keys (APIs Tab in Settings)
+
+## Problem
+
+Today every `ModelEntry` carries its own inline `apiKey` and `baseUrl`. If a user
+has one OpenAI-compatible key that works across `gpt-5`, `gpt-5-mini`, and a
+custom OpenRouter alias, they must paste the same key into each model row
+separately, and rotate it in three places. There is no way to share credentials
+across models or agents.
+
+## Goal
+
+Introduce a first-class **API** entity that stores credentials + endpoint once,
+and have each `ModelEntry` reference an API by name. A new **APIs** tab in
+Settings manages these entries.
+
+## Non-goals
+
+- Per-agent custom env vars / timeouts (out of scope, kept for future).
+- Model name patterns / wildcards on the API entry — each model is still its
+  own row in the catalog; the API just supplies credentials.
+- Automatic migration of existing inline keys — old `apiKey` / `baseUrl` fields
+  on models are dropped on load. Users re-configure in the new tab.
+
+## Data model
+
+### `packages/core/src/types/index.ts`
+
+Add:
+
+```ts
+export interface ApiEntry {
+  name: string;          // unique id, surfaced in the model dropdown
+  apiType: ApiType;      // 'anthropic' | 'openai'
+  baseUrl?: string;      // optional endpoint override
+  apiKey: string;        // required — the whole point of this entry
+}
+```
+
+Modify `ModelEntry`:
+
+```ts
+export interface ModelEntry {
+  apiType: ApiType;      // kept for filtering (must match referenced API)
+  model: string;
+  apiRef?: string;       // name of an ApiEntry; required for the model to run
+  provider?: string;
+  // REMOVED: apiKey, baseUrl
+}
+```
+
+`apiRef` is `?` only so a freshly-created model can be saved before binding,
+but the gateway rejects requests for a model whose `apiRef` doesn't resolve
+to an existing API entry of the same `apiType`.
+
+### `packages/gateway/src/config.ts`
+
+Add `apis: ApiEntry[]` to `GatewayConfigJson`. Default to `[]`. Include it in
+the `update()` merge logic and `normalize()` so existing `gateway.json` files
+load cleanly. During `normalize()`, strip `apiKey` and `baseUrl` from every
+`ModelEntry` (clean break — user re-configures).
+
+## Backend
+
+### Resolution (`packages/gateway/src/gateway.ts` ~2615)
+
+Where the gateway currently reads `catalogEntry.apiKey` / `catalogEntry.baseUrl`:
+
+```ts
+const api = config.apis.find(a => a.name === catalogEntry.apiRef);
+if (!api) throw new Error(`Model "${catalogEntry.model}" has no API bound`);
+if (api.apiType !== catalogEntry.apiType) {
+  throw new Error(`API "${api.name}" is ${api.apiType}, model expects ${catalogEntry.apiType}`);
+}
+modelConfig = {
+  provider, model: catalogEntry.model,
+  apiType: catalogEntry.apiType,
+  apiKey: api.apiKey,
+  baseUrl: api.baseUrl,
+};
+```
+
+Error surfaces back through the existing agent-run error path; the renderer
+shows it in chat the same way other run failures do.
+
+### IPC handlers
+
+New methods on the `window.codey.apis` namespace, mirroring `models`:
+
+- `apis.list()` → `ApiEntry[]`
+- `apis.save(entry)` → upsert by `name`
+- `apis.delete(name)` → fail if any model still references it
+- `apis.rename(oldName, newName)` → update all models' `apiRef` atomically
+
+Wired through `codey-mac/electron/main.ts` IPC bridge, declared in
+`codey-mac/electron/preload.ts` and `codey-mac/src/codey-api.d.ts`, and
+implemented in `packages/gateway/src/chats.ts` (or wherever the existing
+`models.*` handlers live — match the file).
+
+## UI
+
+### `SettingsOverlay.tsx`
+
+Insert a new tab before `settings` (AI Models):
+
+```ts
+{ key: 'apis', label: 'APIs', icon: '🔑', description: 'Shared credentials & endpoints' },
+```
+
+Wire `{tab === 'apis' && <ApisTab isGatewayRunning={isRunning} />}` into the
+main content switch.
+
+### `components/ApisTab.tsx` (new)
+
+Style-for-style sibling of `SettingsTab`'s Models section. Reuses the same
+`pillButton`, `inputStyle`, `Section` atoms — extract them into a small
+shared module (`components/settingsAtoms.ts`) so both tabs import from one
+place instead of duplicating.
+
+Row fields:
+- **Name** (text, required, unique)
+- **API Type** (select: anthropic / openai)
+- **Base URL** (text, optional)
+- **API Key** (password, required)
+
+List, Add, Edit, Delete behave like `ModelRow`. Deleting an API that's still
+referenced surfaces a confirm with the list of bound models and refuses on the
+backend side as well.
+
+### `components/SettingsTab.tsx`
+
+In `ModelRow` edit view:
+- Remove the Base URL and API Key inputs.
+- Add an "API" select that lists APIs of matching `apiType`. If the list is
+  empty, show inline link text "No APIs yet — add one in the APIs tab" (no
+  navigation — user opens the tab themselves).
+
+In `ModelRow` collapsed view:
+- Replace the `(default url)` / `🔑` hint with: `→ {apiRef || '(no API bound)'}`.
+  Models with no bound API render the badge in `C.warningFg`.
+
+`saveModel` keeps working as-is — it just passes `apiRef` instead of
+`apiKey`/`baseUrl`.
+
+## Migration
+
+On gateway load, `normalize()` discards `apiKey` and `baseUrl` from every
+`ModelEntry`. Existing models keep their `model` id, `apiType`, `provider` —
+they simply have no `apiRef` until the user binds one. The Models tab makes
+that state visible via the warning badge described above.
+
+No prompt, no toast, no auto-import. Per the user's call: clean break.
+
+## Testing
+
+Manual test plan (matches the project's no-test-runner reality):
+
+1. Start gateway with an existing `gateway.json` that has inline-keyed models.
+2. Verify models load with no `apiKey`/`baseUrl` and show the "no API bound"
+   warning.
+3. Open the new **APIs** tab, add an anthropic entry with a real key.
+4. Edit a claude-code model, bind the new API, save. Run a prompt — it works.
+5. Rename the API — model still works (apiRef updated atomically).
+6. Try to delete the API — refused with a list of bound models.
+7. Unbind the model, delete the API — succeeds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -38,11 +38,11 @@ export type CodingAgent = 'claude-code' | 'opencode' | 'codex';
 export type ApiType = 'anthropic' | 'openai';
 
 /**
- * A reusable API connection — credentials + endpoint stored once and
+ * A reusable API key entry — credentials + endpoint stored once and
  * referenced from any number of ModelEntry rows by name. Lets a single
  * key power multiple models without duplication.
  */
-export interface ApiEntry {
+export interface ApiKeyEntry {
   name: string;        // unique id, surfaced in the model dropdown
   apiType: ApiType;
   baseUrl?: string;    // optional endpoint override
@@ -66,13 +66,14 @@ export interface ModelConfig {
 /**
  * A reusable model definition the user manages in Settings.
  * The `model` field is both the identifier agent.defaultModel points
- * at and the string passed to the CLI as --model. `apiRef` names an
- * ApiEntry that supplies the credentials at run time.
+ * at and the string passed to the CLI as --model. `apiKeyRef` names an
+ * ApiKeyEntry that supplies the credentials at run time. When unset, the
+ * adapter falls back to its default environment variables.
  */
 export interface ModelEntry {
   apiType: ApiType;
   model: string;
-  apiRef?: string;      // name of an ApiEntry in the gateway's apis catalog
+  apiKeyRef?: string;   // name of an ApiKeyEntry in the gateway's apiKeys catalog
   provider?: string;    // optional human label (anthropic, minimax, openai, …)
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -38,15 +38,21 @@ export type CodingAgent = 'claude-code' | 'opencode' | 'codex';
 export type ApiType = 'anthropic' | 'openai';
 
 /**
- * A reusable API key entry — credentials + endpoint stored once and
+ * A reusable API key entry — credentials + endpoints stored once and
  * referenced from any number of ModelEntry rows by name. Lets a single
  * key power multiple models without duplication.
+ *
+ * A single entry can hold both an Anthropic-style and an OpenAI-style
+ * endpoint with the same bearer token (useful for proxy services and
+ * hybrid setups that expose both protocol variants). The resolver picks
+ * `anthropicBaseUrl` or `openaiBaseUrl` based on the *model's* apiType,
+ * so one key can service any model regardless of its protocol.
  */
 export interface ApiKeyEntry {
-  name: string;        // unique id, surfaced in the model dropdown
-  apiType: ApiType;
-  baseUrl?: string;    // optional endpoint override
-  apiKey: string;      // required
+  name: string;                  // unique id, surfaced in the model dropdown
+  apiKey: string;                // required — shared bearer token
+  anthropicBaseUrl?: string;     // optional override for anthropic-typed models
+  openaiBaseUrl?: string;        // optional override for openai-typed models
 }
 
 export interface ModelConfig {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -37,6 +37,18 @@ export type CodingAgent = 'claude-code' | 'opencode' | 'codex';
 // Model configuration for agents
 export type ApiType = 'anthropic' | 'openai';
 
+/**
+ * A reusable API connection — credentials + endpoint stored once and
+ * referenced from any number of ModelEntry rows by name. Lets a single
+ * key power multiple models without duplication.
+ */
+export interface ApiEntry {
+  name: string;        // unique id, surfaced in the model dropdown
+  apiType: ApiType;
+  baseUrl?: string;    // optional endpoint override
+  apiKey: string;      // required
+}
+
 export interface ModelConfig {
   provider: string;
   model: string;
@@ -54,14 +66,14 @@ export interface ModelConfig {
 /**
  * A reusable model definition the user manages in Settings.
  * The `model` field is both the identifier agent.defaultModel points
- * at and the string passed to the CLI as --model.
+ * at and the string passed to the CLI as --model. `apiRef` names an
+ * ApiEntry that supplies the credentials at run time.
  */
 export interface ModelEntry {
   apiType: ApiType;
   model: string;
-  baseUrl?: string;       // optional endpoint override
-  apiKey?: string;        // credential for this model
-  provider?: string;      // optional human label (anthropic, minimax, openai, …)
+  apiRef?: string;      // name of an ApiEntry in the gateway's apis catalog
+  provider?: string;    // optional human label (anthropic, minimax, openai, …)
 }
 
 export interface FallbackEntry {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "start": "cd ../.. && node packages/gateway/dist/index.js",
     "dev": "cd ../.. && ts-node packages/gateway/src/index.ts",
     "watch": "tsc --watch",

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -27,9 +27,9 @@ describe('config normalize', () => {
   it('parses apiKeys array and preserves valid entries', () => {
     withTempConfig({
       apiKeys: [
-        { name: 'main', apiType: 'anthropic', baseUrl: 'https://api', apiKey: 'sk-1' },
-        { name: '', apiType: 'anthropic', apiKey: 'sk-bad' },
-        { name: 'noKey', apiType: 'openai' },
+        { name: 'main', apiKey: 'sk-1', anthropicBaseUrl: 'https://anthropic.example', openaiBaseUrl: 'https://openai.example' },
+        { name: '', apiKey: 'sk-bad' },
+        { name: 'noKey' },
       ],
     }, cm => {
       const apiKeys = cm.listApiKeys();
@@ -48,14 +48,28 @@ describe('config normalize', () => {
 describe('api key CRUD', () => {
   it('saveApiKey rejects missing name or key', () => {
     withTempConfig({}, cm => {
-      expect(() => cm.saveApiKey({ name: '', apiType: 'openai', apiKey: 'k' } as any)).toThrow();
-      expect(() => cm.saveApiKey({ name: 'x', apiType: 'openai', apiKey: '' } as any)).toThrow();
+      expect(() => cm.saveApiKey({ name: '', apiKey: 'k' })).toThrow();
+      expect(() => cm.saveApiKey({ name: 'x', apiKey: '' })).toThrow();
+    });
+  });
+
+  it('saveApiKey round-trips both base URLs', () => {
+    withTempConfig({}, cm => {
+      cm.saveApiKey({
+        name: 'proxy',
+        apiKey: 'sk-proxy',
+        anthropicBaseUrl: 'https://proxy.example/anthropic',
+        openaiBaseUrl: 'https://proxy.example/openai',
+      });
+      const saved = cm.getApiKey('proxy');
+      expect(saved?.anthropicBaseUrl).toBe('https://proxy.example/anthropic');
+      expect(saved?.openaiBaseUrl).toBe('https://proxy.example/openai');
     });
   });
 
   it('renameApiKey rewrites apiKeyRef on dependent models', () => {
     withTempConfig({
-      apiKeys: [{ name: 'old', apiType: 'anthropic', apiKey: 'sk' }],
+      apiKeys: [{ name: 'old', apiKey: 'sk' }],
       models: [{ model: 'm1', apiType: 'anthropic', apiKeyRef: 'old' }],
     }, cm => {
       expect(cm.renameApiKey('old', 'new')).toBe(true);
@@ -66,7 +80,7 @@ describe('api key CRUD', () => {
 
   it('deleteApiKey refuses when models still reference it', () => {
     withTempConfig({
-      apiKeys: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+      apiKeys: [{ name: 'a', apiKey: 'sk' }],
       models: [{ model: 'm1', apiType: 'anthropic', apiKeyRef: 'a' }],
     }, cm => {
       expect(() => cm.deleteApiKey('a')).toThrow(/m1/);
@@ -75,7 +89,7 @@ describe('api key CRUD', () => {
 
   it('deleteApiKey succeeds with no dependents', () => {
     withTempConfig({
-      apiKeys: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+      apiKeys: [{ name: 'a', apiKey: 'sk' }],
     }, cm => {
       expect(cm.deleteApiKey('a')).toBe(true);
       expect(cm.listApiKeys()).toHaveLength(0);

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -24,61 +24,61 @@ describe('config normalize', () => {
     });
   });
 
-  it('parses apis array and preserves valid entries', () => {
+  it('parses apiKeys array and preserves valid entries', () => {
     withTempConfig({
-      apis: [
+      apiKeys: [
         { name: 'main', apiType: 'anthropic', baseUrl: 'https://api', apiKey: 'sk-1' },
         { name: '', apiType: 'anthropic', apiKey: 'sk-bad' },
         { name: 'noKey', apiType: 'openai' },
       ],
     }, cm => {
-      const apis = cm.listApis();
-      expect(apis).toHaveLength(1);
-      expect(apis[0].name).toBe('main');
+      const apiKeys = cm.listApiKeys();
+      expect(apiKeys).toHaveLength(1);
+      expect(apiKeys[0].name).toBe('main');
     });
   });
 
-  it('defaults apis to [] when missing', () => {
+  it('defaults apiKeys to [] when missing', () => {
     withTempConfig({}, cm => {
-      expect(cm.listApis()).toEqual([]);
+      expect(cm.listApiKeys()).toEqual([]);
     });
   });
 });
 
-describe('api CRUD', () => {
-  it('saveApi rejects missing name or key', () => {
+describe('api key CRUD', () => {
+  it('saveApiKey rejects missing name or key', () => {
     withTempConfig({}, cm => {
-      expect(() => cm.saveApi({ name: '', apiType: 'openai', apiKey: 'k' } as any)).toThrow();
-      expect(() => cm.saveApi({ name: 'x', apiType: 'openai', apiKey: '' } as any)).toThrow();
+      expect(() => cm.saveApiKey({ name: '', apiType: 'openai', apiKey: 'k' } as any)).toThrow();
+      expect(() => cm.saveApiKey({ name: 'x', apiType: 'openai', apiKey: '' } as any)).toThrow();
     });
   });
 
-  it('renameApi rewrites apiRef on dependent models', () => {
+  it('renameApiKey rewrites apiKeyRef on dependent models', () => {
     withTempConfig({
-      apis: [{ name: 'old', apiType: 'anthropic', apiKey: 'sk' }],
-      models: [{ model: 'm1', apiType: 'anthropic', apiRef: 'old' }],
+      apiKeys: [{ name: 'old', apiType: 'anthropic', apiKey: 'sk' }],
+      models: [{ model: 'm1', apiType: 'anthropic', apiKeyRef: 'old' }],
     }, cm => {
-      expect(cm.renameApi('old', 'new')).toBe(true);
-      expect(cm.listApis()[0].name).toBe('new');
-      expect(cm.listModels()[0].apiRef).toBe('new');
+      expect(cm.renameApiKey('old', 'new')).toBe(true);
+      expect(cm.listApiKeys()[0].name).toBe('new');
+      expect(cm.listModels()[0].apiKeyRef).toBe('new');
     });
   });
 
-  it('deleteApi refuses when models still reference it', () => {
+  it('deleteApiKey refuses when models still reference it', () => {
     withTempConfig({
-      apis: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
-      models: [{ model: 'm1', apiType: 'anthropic', apiRef: 'a' }],
+      apiKeys: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+      models: [{ model: 'm1', apiType: 'anthropic', apiKeyRef: 'a' }],
     }, cm => {
-      expect(() => cm.deleteApi('a')).toThrow(/m1/);
+      expect(() => cm.deleteApiKey('a')).toThrow(/m1/);
     });
   });
 
-  it('deleteApi succeeds with no dependents', () => {
+  it('deleteApiKey succeeds with no dependents', () => {
     withTempConfig({
-      apis: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+      apiKeys: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
     }, cm => {
-      expect(cm.deleteApi('a')).toBe(true);
-      expect(cm.listApis()).toHaveLength(0);
+      expect(cm.deleteApiKey('a')).toBe(true);
+      expect(cm.listApiKeys()).toHaveLength(0);
     });
   });
 });

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ConfigManager } from './config';
+
+function withTempConfig(initial: any, fn: (cm: ConfigManager, p: string) => void) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-cfg-'));
+  const p = path.join(dir, 'gateway.json');
+  fs.writeFileSync(p, JSON.stringify(initial));
+  const cm = new ConfigManager(p);
+  try { fn(cm, p); } finally { cm.stop(); fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+describe('config normalize', () => {
+  it('strips legacy apiKey/baseUrl from existing ModelEntry rows', () => {
+    withTempConfig({
+      models: [{ model: 'm1', apiType: 'anthropic', apiKey: 'sk-old', baseUrl: 'https://old' }],
+    }, cm => {
+      const m = cm.listModels()[0];
+      expect(m.model).toBe('m1');
+      expect((m as any).apiKey).toBeUndefined();
+      expect((m as any).baseUrl).toBeUndefined();
+    });
+  });
+
+  it('parses apis array and preserves valid entries', () => {
+    withTempConfig({
+      apis: [
+        { name: 'main', apiType: 'anthropic', baseUrl: 'https://api', apiKey: 'sk-1' },
+        { name: '', apiType: 'anthropic', apiKey: 'sk-bad' },
+        { name: 'noKey', apiType: 'openai' },
+      ],
+    }, cm => {
+      const apis = cm.listApis();
+      expect(apis).toHaveLength(1);
+      expect(apis[0].name).toBe('main');
+    });
+  });
+
+  it('defaults apis to [] when missing', () => {
+    withTempConfig({}, cm => {
+      expect(cm.listApis()).toEqual([]);
+    });
+  });
+});
+
+describe('api CRUD', () => {
+  it('saveApi rejects missing name or key', () => {
+    withTempConfig({}, cm => {
+      expect(() => cm.saveApi({ name: '', apiType: 'openai', apiKey: 'k' } as any)).toThrow();
+      expect(() => cm.saveApi({ name: 'x', apiType: 'openai', apiKey: '' } as any)).toThrow();
+    });
+  });
+
+  it('renameApi rewrites apiRef on dependent models', () => {
+    withTempConfig({
+      apis: [{ name: 'old', apiType: 'anthropic', apiKey: 'sk' }],
+      models: [{ model: 'm1', apiType: 'anthropic', apiRef: 'old' }],
+    }, cm => {
+      expect(cm.renameApi('old', 'new')).toBe(true);
+      expect(cm.listApis()[0].name).toBe('new');
+      expect(cm.listModels()[0].apiRef).toBe('new');
+    });
+  });
+
+  it('deleteApi refuses when models still reference it', () => {
+    withTempConfig({
+      apis: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+      models: [{ model: 'm1', apiType: 'anthropic', apiRef: 'a' }],
+    }, cm => {
+      expect(() => cm.deleteApi('a')).toThrow(/m1/);
+    });
+  });
+
+  it('deleteApi succeeds with no dependents', () => {
+    withTempConfig({
+      apis: [{ name: 'a', apiType: 'anthropic', apiKey: 'sk' }],
+    }, cm => {
+      expect(cm.deleteApi('a')).toBe(true);
+      expect(cm.listApis()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { EventEmitter } from 'events';
-import { ApiEntry, CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
+import { ApiKeyEntry, CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
 
 // ── Configuration types ─────────────────────────────────────────────
 
@@ -27,8 +27,8 @@ export interface GatewayConfigJson {
   };
   /** Global, reusable model catalog. Each agent references an entry by name. */
   models: ModelEntry[];
-  /** Shared API connections referenced by ModelEntry.apiRef. */
-  apis: ApiEntry[];
+  /** Shared API key entries referenced by ModelEntry.apiKeyRef. */
+  apiKeys: ApiKeyEntry[];
   /**
    * Ordered priority list. `order[0]` is the canonical default agent+model;
    * subsequent entries are tried only when an earlier one fails (and only if
@@ -156,7 +156,7 @@ export class ConfigManager extends EventEmitter {
     if (partial.agents) Object.assign(this.config.agents, partial.agents);
     if (partial.dev) Object.assign(this.config.dev, partial.dev);
     if (partial.models !== undefined) this.config.models = partial.models;
-    if (partial.apis !== undefined) this.config.apis = partial.apis;
+    if (partial.apiKeys !== undefined) this.config.apiKeys = partial.apiKeys;
     if (partial.fallback !== undefined) this.config.fallback = partial.fallback;
     if (partial.advisor !== undefined) this.config.advisor = partial.advisor;
     if (partial.teams !== undefined) this.config.teams = partial.teams;
@@ -212,7 +212,7 @@ export class ConfigManager extends EventEmitter {
 
   /**
    * Change a model entry's identifier and rewrite every fallback entry that
-   * pointed at it. Content (apiType, apiRef, provider) is preserved.
+   * pointed at it. Content (apiType, apiKeyRef, provider) is preserved.
    */
   renameModel(oldId: string, newId: string): boolean {
     if (!newId.trim() || oldId === newId) return false;
@@ -242,52 +242,52 @@ export class ConfigManager extends EventEmitter {
     return false;
   }
 
-  // ── APIs ───────────────────────────────────────────────────────────
-  listApis(): ApiEntry[] { return this.config.apis ?? []; }
+  // ── API Keys ───────────────────────────────────────────────────────
+  listApiKeys(): ApiKeyEntry[] { return this.config.apiKeys ?? []; }
 
-  getApi(name: string): ApiEntry | undefined {
-    return this.config.apis?.find(a => a.name === name);
+  getApiKey(name: string): ApiKeyEntry | undefined {
+    return this.config.apiKeys?.find(a => a.name === name);
   }
 
   /**
-   * Upsert an API entry **by name** — `name` is the identity key. To change
-   * the name of an existing entry, call `renameApi` instead, otherwise the
-   * old entry is left in place and every `ModelEntry.apiRef` that pointed
+   * Upsert an API key entry **by name** — `name` is the identity key. To change
+   * the name of an existing entry, call `renameApiKey` instead, otherwise the
+   * old entry is left in place and every `ModelEntry.apiKeyRef` that pointed
    * at it is silently orphaned.
    */
-  saveApi(entry: ApiEntry): void {
+  saveApiKey(entry: ApiKeyEntry): void {
     if (!entry.name?.trim()) throw new Error('API name is required');
     if (!entry.apiKey?.trim()) throw new Error('API key is required');
-    const idx = this.config.apis.findIndex(a => a.name === entry.name);
-    if (idx >= 0) this.config.apis[idx] = entry;
-    else this.config.apis.push(entry);
+    const idx = this.config.apiKeys.findIndex(a => a.name === entry.name);
+    if (idx >= 0) this.config.apiKeys[idx] = entry;
+    else this.config.apiKeys.push(entry);
     this.save();
   }
 
-  renameApi(oldName: string, newName: string): boolean {
+  renameApiKey(oldName: string, newName: string): boolean {
     if (!newName.trim() || oldName === newName) return false;
-    if (this.config.apis.some(a => a.name === newName)) {
-      throw new Error(`An API with name "${newName}" already exists`);
+    if (this.config.apiKeys.some(a => a.name === newName)) {
+      throw new Error(`An API key with name "${newName}" already exists`);
     }
-    const idx = this.config.apis.findIndex(a => a.name === oldName);
+    const idx = this.config.apiKeys.findIndex(a => a.name === oldName);
     if (idx < 0) return false;
-    this.config.apis[idx] = { ...this.config.apis[idx], name: newName };
-    // Rewrite every model that referenced the old name so apiRef stays valid.
+    this.config.apiKeys[idx] = { ...this.config.apiKeys[idx], name: newName };
+    // Rewrite every model that referenced the old name so apiKeyRef stays valid.
     for (const m of this.config.models) {
-      if (m.apiRef === oldName) m.apiRef = newName;
+      if (m.apiKeyRef === oldName) m.apiKeyRef = newName;
     }
     this.save();
     return true;
   }
 
-  deleteApi(name: string): boolean {
-    const dependents = this.config.models.filter(m => m.apiRef === name).map(m => m.model);
+  deleteApiKey(name: string): boolean {
+    const dependents = this.config.models.filter(m => m.apiKeyRef === name).map(m => m.model);
     if (dependents.length > 0) {
-      throw new Error(`API "${name}" is referenced by: ${dependents.join(', ')}`);
+      throw new Error(`API key "${name}" is referenced by: ${dependents.join(', ')}`);
     }
-    const before = this.config.apis.length;
-    this.config.apis = this.config.apis.filter(a => a.name !== name);
-    if (this.config.apis.length !== before) {
+    const before = this.config.apiKeys.length;
+    this.config.apiKeys = this.config.apiKeys.filter(a => a.name !== name);
+    if (this.config.apiKeys.length !== before) {
       this.save();
       return true;
     }
@@ -400,7 +400,7 @@ export class ConfigManager extends EventEmitter {
     console.log(`  iMessage: ${this.config.channels.imessage?.enabled ? '✅' : '❌'}`);
     console.log(`\nModels (${this.config.models.length}):`);
     for (const m of this.config.models) {
-      const keyHint = m.apiRef ? ` → ${m.apiRef}` : ' (no API bound)';
+      const keyHint = m.apiKeyRef ? ` 🔑 ${m.apiKeyRef}` : ' (default)';
       console.log(`  • ${m.model} [${m.apiType}]${keyHint}`);
     }
     console.log(`\nAgents:`);
@@ -469,7 +469,7 @@ function getDefaultConfig(): GatewayConfigJson {
       { apiType: 'anthropic', model: 'claude-haiku-4-5',  provider: 'anthropic' },
       { apiType: 'openai',    model: 'gpt-5',             provider: 'openai' },
     ],
-    apis: [],
+    apiKeys: [],
     fallback: {
       enabled: true,
       order: [
@@ -487,22 +487,22 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
   const defaults = getDefaultConfig();
   const rawModels = Array.isArray(raw.models) ? raw.models : defaults.models;
   // Clean break: drop inline apiKey/baseUrl from any pre-existing model entries.
-  // Users re-bind via the APIs tab. apiRef is left unset until they do.
+  // Users re-bind via the API Keys tab. apiKeyRef is left unset until they do.
   const models: ModelEntry[] = rawModels.map(m => ({
     apiType: m.apiType,
     model: m.model,
-    apiRef: (m as any).apiRef,
+    apiKeyRef: (m as any).apiKeyRef,
     provider: m.provider,
   }));
-  const apis: ApiEntry[] = Array.isArray(raw.apis)
-    ? raw.apis.filter((a: any) => a && typeof a.name === 'string' && a.name.trim() && typeof a.apiKey === 'string' && a.apiKey.trim())
+  const apiKeys: ApiKeyEntry[] = Array.isArray(raw.apiKeys)
+    ? raw.apiKeys.filter((a: any) => a && typeof a.name === 'string' && a.name.trim() && typeof a.apiKey === 'string' && a.apiKey.trim())
     : [];
   const out: GatewayConfigJson = {
     gateway: { ...defaults.gateway, ...(raw.gateway ?? {}) },
     channels: raw.channels ?? defaults.channels,
     agents: { ...defaults.agents, ...(raw.agents ?? {}) },
     models,
-    apis,
+    apiKeys,
     fallback: normalizeFallback(raw.fallback, defaults.fallback),
     dev: raw.dev ?? defaults.dev,
   };

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -401,8 +401,7 @@ export class ConfigManager extends EventEmitter {
     console.log(`\nModels (${this.config.models.length}):`);
     for (const m of this.config.models) {
       const keyHint = m.apiRef ? ` → ${m.apiRef}` : ' (no API bound)';
-      const urlHint = '';
-      console.log(`  • ${m.model} [${m.apiType}]${urlHint}${keyHint}`);
+      console.log(`  • ${m.model} [${m.apiType}]${keyHint}`);
     }
     console.log(`\nAgents:`);
     const inOrder = new Set(this.config.fallback.order.map(e => e.agent));

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { EventEmitter } from 'events';
-import { CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
+import { ApiEntry, CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
 
 // ── Configuration types ─────────────────────────────────────────────
 
@@ -27,6 +27,8 @@ export interface GatewayConfigJson {
   };
   /** Global, reusable model catalog. Each agent references an entry by name. */
   models: ModelEntry[];
+  /** Shared API connections referenced by ModelEntry.apiRef. */
+  apis: ApiEntry[];
   /**
    * Ordered priority list. `order[0]` is the canonical default agent+model;
    * subsequent entries are tried only when an earlier one fails (and only if
@@ -154,6 +156,7 @@ export class ConfigManager extends EventEmitter {
     if (partial.agents) Object.assign(this.config.agents, partial.agents);
     if (partial.dev) Object.assign(this.config.dev, partial.dev);
     if (partial.models !== undefined) this.config.models = partial.models;
+    if (partial.apis !== undefined) this.config.apis = partial.apis;
     if (partial.fallback !== undefined) this.config.fallback = partial.fallback;
     if (partial.advisor !== undefined) this.config.advisor = partial.advisor;
     if (partial.teams !== undefined) this.config.teams = partial.teams;
@@ -209,7 +212,7 @@ export class ConfigManager extends EventEmitter {
 
   /**
    * Change a model entry's identifier and rewrite every fallback entry that
-   * pointed at it. Content (apiType, baseUrl, apiKey) is preserved.
+   * pointed at it. Content (apiType, apiRef, provider) is preserved.
    */
   renameModel(oldId: string, newId: string): boolean {
     if (!newId.trim() || oldId === newId) return false;
@@ -233,6 +236,52 @@ export class ConfigManager extends EventEmitter {
       if (entry.model === modelId) entry.model = undefined;
     }
     if (this.config.models.length !== before) {
+      this.save();
+      return true;
+    }
+    return false;
+  }
+
+  // ── APIs ───────────────────────────────────────────────────────────
+  listApis(): ApiEntry[] { return this.config.apis ?? []; }
+
+  getApi(name: string): ApiEntry | undefined {
+    return this.config.apis?.find(a => a.name === name);
+  }
+
+  saveApi(entry: ApiEntry): void {
+    if (!entry.name?.trim()) throw new Error('API name is required');
+    if (!entry.apiKey?.trim()) throw new Error('API key is required');
+    const idx = this.config.apis.findIndex(a => a.name === entry.name);
+    if (idx >= 0) this.config.apis[idx] = entry;
+    else this.config.apis.push(entry);
+    this.save();
+  }
+
+  renameApi(oldName: string, newName: string): boolean {
+    if (!newName.trim() || oldName === newName) return false;
+    if (this.config.apis.some(a => a.name === newName)) {
+      throw new Error(`An API with name "${newName}" already exists`);
+    }
+    const idx = this.config.apis.findIndex(a => a.name === oldName);
+    if (idx < 0) return false;
+    this.config.apis[idx] = { ...this.config.apis[idx], name: newName };
+    // Rewrite every model that referenced the old name so apiRef stays valid.
+    for (const m of this.config.models) {
+      if (m.apiRef === oldName) m.apiRef = newName;
+    }
+    this.save();
+    return true;
+  }
+
+  deleteApi(name: string): boolean {
+    const dependents = this.config.models.filter(m => m.apiRef === name).map(m => m.model);
+    if (dependents.length > 0) {
+      throw new Error(`API "${name}" is referenced by: ${dependents.join(', ')}`);
+    }
+    const before = this.config.apis.length;
+    this.config.apis = this.config.apis.filter(a => a.name !== name);
+    if (this.config.apis.length !== before) {
       this.save();
       return true;
     }
@@ -345,8 +394,8 @@ export class ConfigManager extends EventEmitter {
     console.log(`  iMessage: ${this.config.channels.imessage?.enabled ? '✅' : '❌'}`);
     console.log(`\nModels (${this.config.models.length}):`);
     for (const m of this.config.models) {
-      const keyHint = m.apiKey ? ' 🔑' : '';
-      const urlHint = m.baseUrl ? ` @ ${m.baseUrl}` : '';
+      const keyHint = m.apiRef ? ` → ${m.apiRef}` : ' (no API bound)';
+      const urlHint = '';
       console.log(`  • ${m.model} [${m.apiType}]${urlHint}${keyHint}`);
     }
     console.log(`\nAgents:`);
@@ -415,6 +464,7 @@ function getDefaultConfig(): GatewayConfigJson {
       { apiType: 'anthropic', model: 'claude-haiku-4-5',  provider: 'anthropic' },
       { apiType: 'openai',    model: 'gpt-5',             provider: 'openai' },
     ],
+    apis: [],
     fallback: {
       enabled: true,
       order: [
@@ -430,11 +480,24 @@ function getDefaultConfig(): GatewayConfigJson {
 /** Fill in any missing top-level fields with defaults so downstream code can assume shape. */
 function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: CodingAgent; model?: string }; planner?: { model?: string } }): GatewayConfigJson {
   const defaults = getDefaultConfig();
+  const rawModels = Array.isArray(raw.models) ? raw.models : defaults.models;
+  // Clean break: drop inline apiKey/baseUrl from any pre-existing model entries.
+  // Users re-bind via the APIs tab. apiRef is left unset until they do.
+  const models: ModelEntry[] = rawModels.map(m => ({
+    apiType: m.apiType,
+    model: m.model,
+    apiRef: (m as any).apiRef,
+    provider: m.provider,
+  }));
+  const apis: ApiEntry[] = Array.isArray(raw.apis)
+    ? raw.apis.filter((a: any) => a && typeof a.name === 'string' && a.name.trim() && typeof a.apiKey === 'string' && a.apiKey.trim())
+    : [];
   const out: GatewayConfigJson = {
     gateway: { ...defaults.gateway, ...(raw.gateway ?? {}) },
     channels: raw.channels ?? defaults.channels,
     agents: { ...defaults.agents, ...(raw.agents ?? {}) },
-    models: Array.isArray(raw.models) ? raw.models : defaults.models,
+    models,
+    apis,
     fallback: normalizeFallback(raw.fallback, defaults.fallback),
     dev: raw.dev ?? defaults.dev,
   };

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -249,6 +249,12 @@ export class ConfigManager extends EventEmitter {
     return this.config.apis?.find(a => a.name === name);
   }
 
+  /**
+   * Upsert an API entry **by name** — `name` is the identity key. To change
+   * the name of an existing entry, call `renameApi` instead, otherwise the
+   * old entry is left in place and every `ModelEntry.apiRef` that pointed
+   * at it is silently orphaned.
+   */
   saveApi(entry: ApiEntry): void {
     if (!entry.name?.trim()) throw new Error('API name is required');
     if (!entry.apiKey?.trim()) throw new Error('API key is required');

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2609,14 +2609,28 @@ Example: /model gpt-4.1 write a Python script`;
   }
 
   getModelConfig(agent: CodingAgent, modelName: string): ModelConfig | undefined {
-    // 1. Check the global model catalog (has credentials + full config)
+    // 1. Check the global model catalog. Credentials live on the referenced
+    //    ApiEntry, not on the model itself — walk apiRef to load them.
     const catalogEntry = this.configManager?.getModel(modelName);
     if (catalogEntry) {
+      const api = catalogEntry.apiRef
+        ? this.configManager?.getApi(catalogEntry.apiRef)
+        : undefined;
+      if (!api) {
+        throw new Error(
+          `Model "${catalogEntry.model}" has no API bound. Open Settings → APIs to add one, then bind it from the Models tab.`
+        );
+      }
+      if (api.apiType !== catalogEntry.apiType) {
+        throw new Error(
+          `Model "${catalogEntry.model}" expects apiType "${catalogEntry.apiType}" but API "${api.name}" is "${api.apiType}".`
+        );
+      }
       return {
         provider: catalogEntry.provider ?? (catalogEntry.apiType === 'anthropic' ? 'anthropic' : 'openai'),
         model: catalogEntry.model,
-        apiKey: catalogEntry.apiKey,
-        baseUrl: catalogEntry.baseUrl,
+        apiKey: api.apiKey,
+        baseUrl: api.baseUrl,
         apiType: catalogEntry.apiType,
       };
     }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2634,16 +2634,14 @@ Example: /model gpt-4.1 write a Python script`;
           `Model "${catalogEntry.model}" references API key "${catalogEntry.apiKeyRef}" which no longer exists. Open Settings → API Keys to add it, or rebind the model.`
         );
       }
-      if (apiKey && apiKey.apiType !== catalogEntry.apiType) {
-        throw new Error(
-          `Model "${catalogEntry.model}" expects apiType "${catalogEntry.apiType}" but API key "${apiKey.name}" is "${apiKey.apiType}".`
-        );
-      }
+      const baseUrl = apiKey
+        ? (catalogEntry.apiType === 'anthropic' ? apiKey.anthropicBaseUrl : apiKey.openaiBaseUrl)
+        : undefined;
       return {
         provider: catalogEntry.provider ?? (catalogEntry.apiType === 'anthropic' ? 'anthropic' : 'openai'),
         model: catalogEntry.model,
         apiKey: apiKey?.apiKey,
-        baseUrl: apiKey?.baseUrl,
+        baseUrl,
         apiType: catalogEntry.apiType,
       };
     }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2566,7 +2566,16 @@ Example: /model gpt-4.1 write a Python script`;
       // Agents are now considered "enabled" iff they appear in fallback.order,
       // and `rawOrder` is sourced from fallback.order — so every entry here is
       // by definition enabled. No additional skip needed.
-      const resolvedModel = this.resolveFallbackModel(entry);
+      let resolvedModel: ModelConfig | undefined;
+      try {
+        resolvedModel = this.resolveFallbackModel(entry);
+      } catch (err) {
+        // getModelConfig may throw for misconfigured catalog entries (no API
+        // bound, apiType mismatch). Don't let one bad fallback entry abort
+        // the whole chain — log it and try the next.
+        this.logger.warn(`Skipping fallback ${entry.agent}${entry.model ? `(${entry.model})` : ''}: ${(err as Error).message}`);
+        continue;
+      }
       if (!resolvedModel) {
         this.logger.warn(`Skipping fallback ${entry.agent}${entry.model ? `(${entry.model})` : ''}: no usable model config`);
         continue;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2900,9 +2900,19 @@ Example: /model gpt-4.1 write a Python script`;
 
     // Per-chat override takes precedence over the gateway default.
     const agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
-    const model = chat.model
-      ? this.getModelConfig(agent, chat.model)
-      : this.getDefaultModelConfig(agent);
+    let model: ModelConfig | undefined;
+    try {
+      model = chat.model
+        ? this.getModelConfig(agent, chat.model)
+        : this.getDefaultModelConfig(agent);
+    } catch (err) {
+      // getModelConfig throws when a model's apiRef is missing or its API isn't
+      // bound — surface that as a chat error rather than leaking the semaphore.
+      this.chatSemaphore.release();
+      const msg = (err as Error).message;
+      sink({ type: 'error', chatId, message: msg });
+      throw err;
+    }
 
     // Decide whether this turn resumes a warm CLI session or bootstraps a
     // new one. Resume mode skips the full history dump and uses the agent's

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2619,27 +2619,31 @@ Example: /model gpt-4.1 write a Python script`;
 
   getModelConfig(agent: CodingAgent, modelName: string): ModelConfig | undefined {
     // 1. Check the global model catalog. Credentials live on the referenced
-    //    ApiEntry, not on the model itself — walk apiRef to load them.
+    //    ApiKeyEntry, not on the model itself — walk apiKeyRef to load them.
+    //    apiKeyRef is optional; when unset, the adapter falls back to its
+    //    default environment variables (ANTHROPIC_API_KEY / OPENAI_API_KEY).
     const catalogEntry = this.configManager?.getModel(modelName);
     if (catalogEntry) {
-      const api = catalogEntry.apiRef
-        ? this.configManager?.getApi(catalogEntry.apiRef)
+      const apiKey = catalogEntry.apiKeyRef
+        ? this.configManager?.getApiKey(catalogEntry.apiKeyRef)
         : undefined;
-      if (!api) {
+      // apiKeyRef set but the referenced key is gone: surface the broken
+      // binding so the user can fix it instead of silently falling back.
+      if (catalogEntry.apiKeyRef && !apiKey) {
         throw new Error(
-          `Model "${catalogEntry.model}" has no API bound. Open Settings → APIs to add one, then bind it from the Models tab.`
+          `Model "${catalogEntry.model}" references API key "${catalogEntry.apiKeyRef}" which no longer exists. Open Settings → API Keys to add it, or rebind the model.`
         );
       }
-      if (api.apiType !== catalogEntry.apiType) {
+      if (apiKey && apiKey.apiType !== catalogEntry.apiType) {
         throw new Error(
-          `Model "${catalogEntry.model}" expects apiType "${catalogEntry.apiType}" but API "${api.name}" is "${api.apiType}".`
+          `Model "${catalogEntry.model}" expects apiType "${catalogEntry.apiType}" but API key "${apiKey.name}" is "${apiKey.apiType}".`
         );
       }
       return {
         provider: catalogEntry.provider ?? (catalogEntry.apiType === 'anthropic' ? 'anthropic' : 'openai'),
         model: catalogEntry.model,
-        apiKey: api.apiKey,
-        baseUrl: api.baseUrl,
+        apiKey: apiKey?.apiKey,
+        baseUrl: apiKey?.baseUrl,
         apiType: catalogEntry.apiType,
       };
     }
@@ -2906,8 +2910,8 @@ Example: /model gpt-4.1 write a Python script`;
         ? this.getModelConfig(agent, chat.model)
         : this.getDefaultModelConfig(agent);
     } catch (err) {
-      // getModelConfig throws when a model's apiRef is missing or its API isn't
-      // bound — surface that as a chat error rather than leaking the semaphore.
+      // getModelConfig throws when a model's apiKeyRef references a missing key
+      // or an apiType mismatch — surface that as a chat error rather than leaking the semaphore.
       this.chatSemaphore.release();
       const msg = (err as Error).message;
       sink({ type: 'error', chatId, message: msg });

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -2,11 +2,11 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    // Explicit allowlist of files that use vitest (describe/it/expect).
-    // Other .test.ts files in this package are legacy `npx ts-node` scripts
-    // that use node:assert with no describe/it blocks — they crash vitest's
-    // discovery. Compiled dist/ artifacts are also excluded.
-    // To add a new vitest test, append its path here.
+    // Explicit allowlist of vitest test files. The other `*.test.ts` files in
+    // src/ (chats, pairings, turn-queue) are legacy scripts run via
+    // `npx ts-node ...` — some use node:test, some use top-level IIFE patterns
+    // — and they crash vitest's collection phase. New vitest tests must be
+    // added to this list.
     include: [
       'src/config.test.ts',
       'src/digit-mapping.test.ts',

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Explicit allowlist of files that use vitest (describe/it/expect).
+    // Other .test.ts files in this package are legacy `npx ts-node` scripts
+    // that use node:assert with no describe/it blocks — they crash vitest's
+    // discovery. Compiled dist/ artifacts are also excluded.
+    // To add a new vitest test, append its path here.
+    include: [
+      'src/config.test.ts',
+      'src/digit-mapping.test.ts',
+      'src/team-pause.test.ts',
+    ],
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+})


### PR DESCRIPTION
## Summary

Adds a new **API Keys** tab in Settings so a user can save a credential once (token + optional Anthropic base URL + optional OpenAI base URL) and bind it to any number of models. Replaces the previous shape where every `ModelEntry` carried its own inline `apiKey` / `baseUrl`.

Key behaviors:
- One key entry, both protocols. A single token can supply both `anthropicBaseUrl` and `openaiBaseUrl` for use with anthropic-typed and openai-typed models respectively.
- Binding is optional. A model with no `apiKeyRef` falls back to environment defaults (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`). The gateway no longer hard-fails on unbound models.
- Renames cascade. Renaming an API key rewrites every model's `apiKeyRef` atomically.
- Delete protection. The gateway refuses to delete a key while any model still references it; the error names the bound models.
- Fallback chain hardened. A misconfigured model in the fallback list logs and skips rather than aborting the chain.

## ⚠️ Destructive migration

First launch rewrites `gateway.json`: every existing model loses its inline `apiKey` / `baseUrl`. Users will see no warning UI — models simply run with default env vars until they add API keys via the new tab and bind them. Back up your `gateway.json` before upgrading if you rely on inline overrides.

## Test plan

- [ ] Back up `~/.codey/gateway.json`, launch the app
- [ ] Confirm `gateway.json` now has `apiKeys: []` and no `apiKey`/`baseUrl` on model rows
- [ ] Add an anthropic-style API key with a custom `anthropicBaseUrl` in Settings → API Keys
- [ ] Bind it to a model in AI Models; send a prompt — works
- [ ] Rename the key — bound model still works (apiKeyRef updated)
- [ ] Try to delete the key while bound — refused with error naming the model
- [ ] Unbind, delete — succeeds
- [ ] Unbind a model and confirm it still works via env-var fallback (assuming `ANTHROPIC_API_KEY` is set)

## Implementation notes

- New types in `@codey/core`: `ApiKeyEntry { name, apiKey, anthropicBaseUrl?, openaiBaseUrl? }`. `ModelEntry` loses `apiKey`/`baseUrl`, gains `apiKeyRef?`.
- Gateway: `ConfigManager` gains `listApiKeys`/`getApiKey`/`saveApiKey`/`renameApiKey`/`deleteApiKey`. `getModelConfig` walks `apiKeyRef` and picks the protocol-appropriate baseUrl.
- IPC: new `apiKeys:list/save/delete/rename` channels mirroring `models:*`.
- UI: new `ApiKeysTab.tsx`; `SettingsTab.tsx`'s `ModelRow` swaps two inputs for one API Key dropdown (no apiType filter — any key can bind to any model).
- Tests: 16 vitest tests in `packages/gateway/src/config.test.ts` cover normalize migration, key CRUD, rename cascade, delete refusal.
- Spec: `docs/superpowers/specs/2026-05-21-shared-api-keys-design.md`
- Plan: `docs/superpowers/plans/2026-05-22-shared-api-keys.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)