### PR TITLE
Chat menu: clearer arrow glyphs for submenu + back

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -359,7 +359,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
               <button
                 style={styles.menuItem}
                 onClick={() => setChatMenuView('connect')}
-              >🔗 Connect to channel ▸</button>
+              >🔗 Connect to channel...</button>
               <button
                 style={styles.menuItem}
                 onClick={() => {
@@ -394,7 +394,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
             </>
           ) : (
             <>
-              <button style={styles.menuItem} onClick={() => setChatMenuView('main')}>◂ Back</button>
+              <button style={styles.menuItem} onClick={() => setChatMenuView('main')}>⬅ Back</button>
               {(['telegram', 'discord', 'imessage'] as const).map(ch => (
                 <button
                   key={ch}


### PR DESCRIPTION
## Summary

Two small glyph swaps in the chat row's context menu:

- `🔗 Connect to channel ▸` → `🔗 Connect to channel...` — uses the standard ellipsis convention for "opens a sub-menu".
- `◂ Back` → `⬅ Back` — heavier glyph reads more clearly as a back affordance.

Single file, two lines.

## Test plan

- [ ] Right-click a chat row → menu shows `Connect to channel...` (with ellipsis, not `▸`)
- [ ] Click it → submenu opens with `⬅ Back` button at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)