### PR TITLE
feat: parallel team dispatch (Manager-moderated roundtable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ When prompted, analyze requirements and provide...
   - Optional `dispatchHint` on each worker's `config.json` improves routing accuracy.
   - The dispatcher's agent/model is configured under `gateway.json` `dispatcher.{agent, model}`,
     defaulting to the gateway's default agent/model.
+  - Teams configured with `dispatch: 'parallel'` run as a **Manager-moderated roundtable**:
+    all workers run concurrently as long-lived agent sessions, sharing opinion files in
+    `chats/<chatId>/discussion/`. A Manager loop evaluates progress, maintains a summary,
+    and decides when to ask the user, continue, or terminate.
+    Optional settings under `parallel: { maxDurationMs, idleTimeoutMs, managerPollMs }`.
+    See [design spec](docs/superpowers/specs/2026-05-24-team-parallel-mode-design.md).
 
 ### Workspaces
 | Command | Description |

--- a/codey-mac/src/components/GlobalTeamsSection.tsx
+++ b/codey-mac/src/components/GlobalTeamsSection.tsx
@@ -6,18 +6,20 @@ import { C } from '../theme'
 // Mirrors TeamsSection's editor, but operates on the global team library
 // stored in gateway.json. Workspaces opt into these teams by name.
 
-type DispatchMode = 'all' | 'auto'
+type DispatchMode = 'all' | 'auto' | 'parallel'
 interface TeamState { members: string[]; dispatch: DispatchMode }
 type TeamsState = Record<string, TeamState>
 
 function fromRaw(raw: TeamConfigRaw): TeamState {
   if (Array.isArray(raw)) return { members: raw, dispatch: 'all' }
-  const dispatch: DispatchMode = raw?.dispatch === 'auto' ? 'auto' : 'all'
+  const d = raw?.dispatch
+  const dispatch: DispatchMode = d === 'auto' ? 'auto' : d === 'parallel' ? 'parallel' : 'all'
   return { members: Array.isArray(raw?.members) ? raw.members : [], dispatch }
 }
 
 function toRaw(t: TeamState): TeamConfigRaw {
-  return t.dispatch === 'all' ? t.members : { members: t.members, dispatch: 'auto' }
+  if (t.dispatch === 'all') return t.members
+  return { members: t.members, dispatch: t.dispatch }
 }
 
 function normalizeAll(raw: Record<string, TeamConfigRaw>): TeamsState {
@@ -131,7 +133,7 @@ export default function GlobalTeamsSection() {
             <select
               value={team.dispatch}
               onChange={e => setDispatch(name, e.target.value as DispatchMode)}
-              title="Sequential: members run in order, output passed forward. Auto: the advisor picks the relevant subset."
+              title="Sequential: members run in order, output passed forward. Auto: the advisor picks the relevant subset. Parallel: all members discuss concurrently as a Manager-moderated roundtable."
               style={{
                 background: C.surface2, color: C.fg, border: `1px solid ${C.border}`,
                 borderRadius: 6, padding: '3px 8px', fontSize: 11, cursor: 'pointer',
@@ -139,7 +141,7 @@ export default function GlobalTeamsSection() {
             >
               <option value="all">Sequential</option>
               <option value="auto">Auto</option>
-              <option value="parallel" disabled>Parallel (coming soon)</option>
+              <option value="parallel">Parallel</option>
             </select>
             <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: C.dangerFg, border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
           </div>

--- a/codey-mac/src/components/TeamsSection.tsx
+++ b/codey-mac/src/components/TeamsSection.tsx
@@ -10,14 +10,15 @@ import { C } from '../theme'
 interface TeamSummary {
   name: string
   members: string[]
-  dispatch: 'all' | 'auto'
+  dispatch: 'all' | 'auto' | 'parallel'
 }
 
 function summarize(raw: Record<string, TeamConfigRaw>): TeamSummary[] {
   return Object.entries(raw).map(([name, v]) => {
     if (Array.isArray(v)) return { name, members: v, dispatch: 'all' as const }
     const members = Array.isArray(v?.members) ? v.members : []
-    const dispatch: 'all' | 'auto' = v?.dispatch === 'auto' ? 'auto' : 'all'
+    const d = v?.dispatch
+    const dispatch: TeamSummary['dispatch'] = d === 'auto' ? 'auto' : d === 'parallel' ? 'parallel' : 'all'
     return { name, members, dispatch }
   })
 }
@@ -92,7 +93,7 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
               <div style={{ fontSize: 13, fontWeight: 600 }}>
                 {t.name}
                 <span style={{ marginLeft: 8, color: C.fg3, fontWeight: 400, fontSize: 11 }}>
-                  {t.dispatch === 'auto' ? '[auto]' : '[sequential]'}
+                  {t.dispatch === 'parallel' ? '[parallel]' : t.dispatch === 'auto' ? '[auto]' : '[sequential]'}
                 </span>
               </div>
               <div style={{ fontSize: 11, color: C.fg3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "undici": "^5.28.0"

--- a/packages/core/src/discussion/control.test.ts
+++ b/packages/core/src/discussion/control.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseControl,
+  serializeControl,
+  readControl,
+  writeControl,
+  ControlFile,
+} from './control';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ctrl-'));
+}
+
+describe('parseControl', () => {
+  it('parses a running control file', () => {
+    const text = `---
+status: running
+revision: 3
+updated_at: 2026-01-01T00:00:00.000Z
+---
+
+## Directive
+
+Investigate the bug.
+`;
+    const c = parseControl(text);
+    expect(c.status).toBe('running');
+    expect(c.revision).toBe(3);
+    expect(c.directive).toBe('Investigate the bug.');
+    expect(c.userQuestion).toBeUndefined();
+  });
+
+  it('parses paused + free-text User Question', () => {
+    const text = `---
+status: paused
+revision: 5
+updated_at: 2026-01-01T00:00:00.000Z
+---
+
+## Directive
+
+Pick an approach.
+
+## User Question
+
+Which database should we use for this workload?
+`;
+    const c = parseControl(text);
+    expect(c.status).toBe('paused');
+    expect(c.userQuestion).toBe('Which database should we use for this workload?');
+    expect(c.userQuestionChoices).toBeUndefined();
+  });
+
+  it('parses User Question with bulleted choices', () => {
+    const text = `---
+status: paused
+revision: 7
+updated_at: 2026-01-01T00:00:00.000Z
+---
+
+## Directive
+
+Pick one.
+
+## User Question
+
+Which database?
+- Postgres
+- SQLite
+- MySQL
+`;
+    const c = parseControl(text);
+    expect(c.userQuestion).toBe('Which database?');
+    expect(c.userQuestionChoices).toEqual(['Postgres', 'SQLite', 'MySQL']);
+  });
+});
+
+describe('roundtrip', () => {
+  it('parseControl(serializeControl(c)) deep-equals c', () => {
+    const c: ControlFile = {
+      status: 'paused',
+      revision: 42,
+      updatedAt: '2026-05-24T12:34:56.000Z',
+      directive: 'Do the thing.\n\nWith care.',
+      userQuestion: 'Which one?',
+      userQuestionChoices: ['A', 'B'],
+      resumeNote: 'Resuming after user picked A.',
+    };
+    const round = parseControl(serializeControl(c));
+    expect(round).toEqual(c);
+  });
+});
+
+describe('writeControl', () => {
+  it('bumps revision on success', async () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'control.md');
+    const initial: ControlFile = {
+      status: 'running',
+      revision: 1,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      directive: 'Initial directive.',
+    };
+    fs.writeFileSync(file, serializeControl(initial), 'utf8');
+    const after = await writeControl(file, (prev) => ({
+      status: prev.status,
+      directive: 'Updated directive.',
+    }));
+    expect(after.revision).toBe(2);
+    expect(after.directive).toBe('Updated directive.');
+    const disk = await readControl(file);
+    expect(disk?.revision).toBe(2);
+  });
+
+  it('throws stale error when expectedRevision does not match', async () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'control.md');
+    const initial: ControlFile = {
+      status: 'running',
+      revision: 5,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      directive: 'X',
+    };
+    fs.writeFileSync(file, serializeControl(initial), 'utf8');
+    await expect(
+      writeControl(
+        file,
+        (prev) => ({ status: prev.status, directive: prev.directive }),
+        { expectedRevision: 1 },
+      ),
+    ).rejects.toThrow(/stale/);
+  });
+
+  it('readControl returns null when file is missing', async () => {
+    const dir = tmpDir();
+    const result = await readControl(path.join(dir, 'nope.md'));
+    expect(result).toBeNull();
+  });
+
+  it('serializes concurrent writes — revisions strictly monotonic', async () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'control.md');
+    const initial: ControlFile = {
+      status: 'running',
+      revision: 10,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      directive: 'Start.',
+    };
+    fs.writeFileSync(file, serializeControl(initial), 'utf8');
+    const [a, b] = await Promise.all([
+      writeControl(file, (prev) => ({ status: prev.status, directive: prev.directive + ' A' })),
+      writeControl(file, (prev) => ({ status: prev.status, directive: prev.directive + ' B' })),
+    ]);
+    const revs = [a.revision, b.revision].sort((x, y) => x - y);
+    expect(revs).toEqual([11, 12]);
+    const disk = await readControl(file);
+    expect(disk?.revision).toBe(12);
+  });
+});

--- a/packages/core/src/discussion/control.ts
+++ b/packages/core/src/discussion/control.ts
@@ -1,0 +1,202 @@
+import { promises as fsp } from 'fs';
+
+export type ControlStatus = 'running' | 'paused' | 'finalizing' | 'terminated';
+
+export interface ControlFile {
+  status: ControlStatus;
+  revision: number;
+  updatedAt: string;
+  directive: string;
+  userQuestion?: string;
+  userQuestionChoices?: string[];
+  resumeNote?: string;
+}
+
+export interface WriteControlOptions {
+  expectedRevision?: number;
+}
+
+const VALID_STATUSES: ReadonlySet<string> = new Set([
+  'running',
+  'paused',
+  'finalizing',
+  'terminated',
+]);
+
+export function parseControl(text: string): ControlFile {
+  const normalized = text.replace(/\r\n/g, '\n');
+  if (!normalized.startsWith('---\n')) {
+    throw new Error('control.md: missing frontmatter');
+  }
+  const end = normalized.indexOf('\n---', 4);
+  if (end === -1) {
+    throw new Error('control.md: unterminated frontmatter');
+  }
+  const fmBlock = normalized.slice(4, end);
+  const afterFm = normalized.slice(end + 4).replace(/^\n/, '');
+
+  const fm: Record<string, string> = {};
+  for (const rawLine of fmBlock.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const idx = line.indexOf(':');
+    if (idx === -1) {
+      throw new Error(`control.md: invalid frontmatter line: ${line}`);
+    }
+    const key = line.slice(0, idx).trim();
+    let value = line.slice(idx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    fm[key] = value;
+  }
+
+  const status = fm.status;
+  if (!status || !VALID_STATUSES.has(status)) {
+    throw new Error(`control.md: invalid status: ${status}`);
+  }
+  if (!('revision' in fm)) {
+    throw new Error('control.md: missing revision');
+  }
+  const revision = Number(fm.revision);
+  if (!Number.isInteger(revision) || revision < 0) {
+    throw new Error(`control.md: non-numeric revision: ${fm.revision}`);
+  }
+  const updatedAt = fm.updated_at;
+  if (!updatedAt) {
+    throw new Error('control.md: missing updated_at');
+  }
+
+  const sections = splitSections(afterFm);
+  const directive = (sections.get('directive') ?? '').trim();
+  const userQuestionBlock = sections.get('user question');
+  const resumeNote = sections.get('resume note');
+
+  const result: ControlFile = {
+    status: status as ControlStatus,
+    revision,
+    updatedAt,
+    directive,
+  };
+
+  if (userQuestionBlock !== undefined) {
+    const lines = userQuestionBlock
+      .split('\n')
+      .map((l) => l.replace(/\s+$/, ''))
+      .filter((l) => l.length > 0);
+    if (lines.length >= 2 && lines.slice(1).every((l) => l.startsWith('- '))) {
+      result.userQuestion = lines[0];
+      result.userQuestionChoices = lines.slice(1).map((l) => l.slice(2));
+    } else {
+      result.userQuestion = userQuestionBlock.trim();
+    }
+  }
+
+  if (resumeNote !== undefined && resumeNote.trim().length > 0) {
+    result.resumeNote = resumeNote.trim();
+  }
+
+  return result;
+}
+
+function splitSections(body: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const lines = body.split('\n');
+  let currentKey: string | null = null;
+  let buf: string[] = [];
+  const flush = () => {
+    if (currentKey !== null) {
+      map.set(currentKey, buf.join('\n'));
+    }
+  };
+  for (const line of lines) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) {
+      flush();
+      currentKey = m[1].trim().toLowerCase();
+      buf = [];
+    } else if (currentKey !== null) {
+      buf.push(line);
+    }
+  }
+  flush();
+  return map;
+}
+
+export function serializeControl(c: ControlFile): string {
+  let out = '---\n';
+  out += `status: ${c.status}\n`;
+  out += `revision: ${c.revision}\n`;
+  out += `updated_at: ${c.updatedAt}\n`;
+  out += '---\n\n';
+  out += '## Directive\n\n';
+  if (c.directive.length > 0) {
+    out += `${c.directive}\n`;
+  }
+  if (c.userQuestion !== undefined) {
+    out += '\n## User Question\n\n';
+    out += `${c.userQuestion}\n`;
+    if (c.userQuestionChoices && c.userQuestionChoices.length > 0) {
+      for (const choice of c.userQuestionChoices) {
+        out += `- ${choice}\n`;
+      }
+    }
+  }
+  if (c.resumeNote !== undefined) {
+    out += '\n## Resume Note\n\n';
+    out += `${c.resumeNote}\n`;
+  }
+  return out;
+}
+
+export async function readControl(filePath: string): Promise<ControlFile | null> {
+  try {
+    const text = await fsp.readFile(filePath, 'utf8');
+    return parseControl(text);
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+const writeLocks = new Map<string, Promise<unknown>>();
+
+export async function writeControl(
+  filePath: string,
+  update: (prev: ControlFile) => Omit<ControlFile, 'revision' | 'updatedAt'> & {
+    revision?: number;
+    updatedAt?: string;
+  },
+  opts?: WriteControlOptions,
+): Promise<ControlFile> {
+  const prior = writeLocks.get(filePath) ?? Promise.resolve();
+  const run = prior.then(async () => {
+    const current = await readControl(filePath);
+    if (!current) {
+      throw new Error(`control.md: file not found at ${filePath}`);
+    }
+    if (opts?.expectedRevision !== undefined && opts.expectedRevision !== current.revision) {
+      throw new Error(
+        `control.md: stale revision (expected ${opts.expectedRevision}, on-disk ${current.revision})`,
+      );
+    }
+    const next = update(current);
+    const merged: ControlFile = {
+      status: next.status,
+      directive: next.directive,
+      userQuestion: next.userQuestion,
+      userQuestionChoices: next.userQuestionChoices,
+      resumeNote: next.resumeNote,
+      revision: current.revision + 1,
+      updatedAt: new Date().toISOString(),
+    };
+    await fsp.writeFile(filePath, serializeControl(merged), 'utf8');
+    return merged;
+  });
+  const settled = run.catch(() => undefined);
+  writeLocks.set(filePath, settled);
+  return run;
+}

--- a/packages/core/src/discussion/files.test.ts
+++ b/packages/core/src/discussion/files.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  discussionDir,
+  opinionsDir,
+  opinionPath,
+  controlPath,
+  summaryPath,
+  topicPath,
+  transcriptPath,
+  initDiscussionDir,
+  destroyDiscussionDir,
+  listOpinionFiles,
+  appendTranscript,
+} from './files';
+
+let root: string;
+const ws = 'ws1';
+const chat = 'chat1';
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'disc-'));
+});
+
+describe('path helpers', () => {
+  it('return correct paths', () => {
+    expect(discussionDir(root, ws, chat)).toBe(path.join(root, ws, 'chats', chat, 'discussion'));
+    expect(opinionsDir(root, ws, chat)).toBe(path.join(root, ws, 'chats', chat, 'discussion', 'opinions'));
+    expect(opinionPath(root, ws, chat, 'alice')).toBe(path.join(root, ws, 'chats', chat, 'discussion', 'opinions', 'alice.md'));
+    expect(controlPath(root, ws, chat)).toBe(path.join(root, ws, 'chats', chat, 'discussion', 'control.md'));
+    expect(summaryPath(root, ws, chat)).toBe(path.join(root, ws, 'chats', chat, 'discussion', 'summary.md'));
+    expect(topicPath(root, ws, chat)).toBe(path.join(root, ws, 'chats', chat, 'discussion', 'topic.md'));
+    expect(transcriptPath(root, ws, chat)).toBe(path.join(root, ws, 'chats', chat, 'discussion', 'transcript.log'));
+  });
+});
+
+describe('initDiscussionDir', () => {
+  it('first call creates all files', async () => {
+    await initDiscussionDir(root, ws, chat, 'Should we ship?', ['alice', 'bob']);
+    const topic = fs.readFileSync(topicPath(root, ws, chat), 'utf8');
+    expect(topic).toContain('Should we ship?');
+    const control = fs.readFileSync(controlPath(root, ws, chat), 'utf8');
+    expect(control).toContain('status: running');
+    expect(fs.existsSync(summaryPath(root, ws, chat))).toBe(true);
+    expect(fs.existsSync(transcriptPath(root, ws, chat))).toBe(true);
+    expect(fs.readFileSync(opinionPath(root, ws, chat, 'alice'), 'utf8')).toContain("alice's opinion");
+    expect(fs.readFileSync(opinionPath(root, ws, chat, 'bob'), 'utf8')).toContain("bob's opinion");
+  });
+});
+
+describe('listOpinionFiles', () => {
+  it('returns sorted names without .md', async () => {
+    await initDiscussionDir(root, ws, chat, 't', ['charlie', 'alice', 'bob']);
+    const names = await listOpinionFiles(root, ws, chat);
+    expect(names).toEqual(['alice', 'bob', 'charlie']);
+  });
+});
+
+describe('destroyDiscussionDir', () => {
+  it('removes entire dir', async () => {
+    await initDiscussionDir(root, ws, chat, 't', ['alice']);
+    expect(fs.existsSync(discussionDir(root, ws, chat))).toBe(true);
+    await destroyDiscussionDir(root, ws, chat);
+    expect(fs.existsSync(discussionDir(root, ws, chat))).toBe(false);
+  });
+
+  it('is a no-op when missing', async () => {
+    await expect(destroyDiscussionDir(root, ws, chat)).resolves.toBeUndefined();
+  });
+});
+
+describe('resume', () => {
+  it('preserves existing opinions and appends to topic', async () => {
+    await initDiscussionDir(root, ws, chat, 'First topic', ['alice']);
+    const customContent = '# alice opinion\n\nI think yes.\n';
+    fs.writeFileSync(opinionPath(root, ws, chat, 'alice'), customContent);
+
+    await initDiscussionDir(root, ws, chat, 'Second topic', ['alice', 'bob']);
+
+    expect(fs.readFileSync(opinionPath(root, ws, chat, 'alice'), 'utf8')).toBe(customContent);
+    const topic = fs.readFileSync(topicPath(root, ws, chat), 'utf8');
+    expect(topic).toContain('First topic');
+    expect(topic).toContain('## Continuation');
+    expect(topic).toContain('Second topic');
+    expect(fs.readFileSync(opinionPath(root, ws, chat, 'bob'), 'utf8')).toContain("bob's opinion");
+    const control = fs.readFileSync(controlPath(root, ws, chat), 'utf8');
+    expect(control).toContain('status: running');
+    expect(control).toContain('revision: 1');
+  });
+});
+
+describe('appendTranscript', () => {
+  it('appends a line with actor and kind', async () => {
+    await initDiscussionDir(root, ws, chat, 't', ['alice']);
+    await appendTranscript(root, ws, chat, { actor: 'alice', kind: 'spoke', note: 'hello\nworld' });
+    const content = fs.readFileSync(transcriptPath(root, ws, chat), 'utf8');
+    const lines = content.split('\n').filter((l) => l.length > 0);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('alice');
+    expect(lines[0]).toContain('spoke');
+    expect(lines[0]).toContain('hello world');
+    expect(lines[0]).not.toMatch(/hello\nworld/);
+  });
+});

--- a/packages/core/src/discussion/files.ts
+++ b/packages/core/src/discussion/files.ts
@@ -1,0 +1,99 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const fsp = fs.promises;
+
+export function discussionDir(workspacesRoot: string, workspace: string, chatId: string): string {
+  return path.join(workspacesRoot, workspace, 'chats', chatId, 'discussion');
+}
+
+export function opinionsDir(workspacesRoot: string, workspace: string, chatId: string): string {
+  return path.join(discussionDir(workspacesRoot, workspace, chatId), 'opinions');
+}
+
+export function opinionPath(workspacesRoot: string, workspace: string, chatId: string, worker: string): string {
+  return path.join(opinionsDir(workspacesRoot, workspace, chatId), `${worker}.md`);
+}
+
+export function controlPath(workspacesRoot: string, workspace: string, chatId: string): string {
+  return path.join(discussionDir(workspacesRoot, workspace, chatId), 'control.md');
+}
+
+export function summaryPath(workspacesRoot: string, workspace: string, chatId: string): string {
+  return path.join(discussionDir(workspacesRoot, workspace, chatId), 'summary.md');
+}
+
+export function topicPath(workspacesRoot: string, workspace: string, chatId: string): string {
+  return path.join(discussionDir(workspacesRoot, workspace, chatId), 'topic.md');
+}
+
+export function transcriptPath(workspacesRoot: string, workspace: string, chatId: string): string {
+  return path.join(discussionDir(workspacesRoot, workspace, chatId), 'transcript.log');
+}
+
+function controlBlock(): string {
+  return `---\nstatus: running\nrevision: 1\nupdated_at: ${new Date().toISOString()}\n---\n\n## Directive\nStart the discussion. Read the topic, share your initial perspective in your opinion file.\n`;
+}
+
+export async function initDiscussionDir(
+  workspacesRoot: string,
+  workspace: string,
+  chatId: string,
+  topic: string,
+  workers: string[]
+): Promise<void> {
+  const dir = discussionDir(workspacesRoot, workspace, chatId);
+  const opDir = opinionsDir(workspacesRoot, workspace, chatId);
+  const exists = fs.existsSync(dir);
+
+  await fsp.mkdir(opDir, { recursive: true });
+
+  if (!exists) {
+    await fsp.writeFile(topicPath(workspacesRoot, workspace, chatId), `# Topic\n\n${topic}\n`);
+    await fsp.writeFile(controlPath(workspacesRoot, workspace, chatId), controlBlock());
+    await fsp.writeFile(summaryPath(workspacesRoot, workspace, chatId), '# Summary\n\n(pending)\n');
+    await fsp.writeFile(transcriptPath(workspacesRoot, workspace, chatId), '');
+    for (const w of workers) {
+      await fsp.writeFile(opinionPath(workspacesRoot, workspace, chatId, w), `# ${w}'s opinion\n\n(not started)\n`);
+    }
+  } else {
+    await fsp.appendFile(
+      topicPath(workspacesRoot, workspace, chatId),
+      `\n\n## Continuation (${new Date().toISOString()})\n\n${topic}\n`
+    );
+    await fsp.writeFile(controlPath(workspacesRoot, workspace, chatId), controlBlock());
+    for (const w of workers) {
+      const p = opinionPath(workspacesRoot, workspace, chatId, w);
+      if (!fs.existsSync(p)) {
+        await fsp.writeFile(p, `# ${w}'s opinion\n\n(not started)\n`);
+      }
+    }
+  }
+}
+
+export async function destroyDiscussionDir(workspacesRoot: string, workspace: string, chatId: string): Promise<void> {
+  const dir = discussionDir(workspacesRoot, workspace, chatId);
+  await fsp.rm(dir, { recursive: true, force: true });
+}
+
+export async function listOpinionFiles(workspacesRoot: string, workspace: string, chatId: string): Promise<string[]> {
+  const dir = opinionsDir(workspacesRoot, workspace, chatId);
+  if (!fs.existsSync(dir)) return [];
+  const entries = await fsp.readdir(dir);
+  return entries
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.slice(0, -3))
+    .sort();
+}
+
+export async function appendTranscript(
+  workspacesRoot: string,
+  workspace: string,
+  chatId: string,
+  event: { actor: string; kind: string; note?: string }
+): Promise<void> {
+  const ts = new Date().toISOString();
+  const note = event.note ? ` ${event.note.replace(/\r?\n/g, ' ')}` : '';
+  const line = `${ts} ${event.actor} ${event.kind}${note}\n`;
+  await fsp.appendFile(transcriptPath(workspacesRoot, workspace, chatId), line);
+}

--- a/packages/core/src/discussion/parallel-advisor.test.ts
+++ b/packages/core/src/discussion/parallel-advisor.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { buildParallelManagerPrompt, parseParallelManagerTurn } from './parallel-advisor';
+
+describe('buildParallelManagerPrompt', () => {
+  it('includes topic, opinions, pending asks, and the word JSON', () => {
+    const prompt = buildParallelManagerPrompt({
+      topic: 'choose-stack',
+      summary: 'so far we lean rust',
+      opinions: [
+        { name: 'alice', text: 'rust is fast' },
+        { name: 'bob', text: 'go is simple' },
+      ],
+      pendingAsks: [{ worker: 'alice', question: 'what budget?' }],
+      idleMs: 1234,
+      revision: 3,
+    });
+    expect(prompt).toContain('choose-stack');
+    expect(prompt).toContain('rust is fast');
+    expect(prompt).toContain('go is simple');
+    expect(prompt).toContain('what budget?');
+    expect(prompt).toContain('alice');
+    expect(prompt).toContain('JSON');
+  });
+});
+
+describe('parseParallelManagerTurn', () => {
+  it('parses a continue action with summary_update and directive', () => {
+    const out = parseParallelManagerTurn(
+      '{"action":"continue","summary_update":"new sum","directive":"focus on cost","reason":"continuing"}',
+    );
+    expect(out).toEqual({
+      action: 'continue',
+      summary_update: 'new sum',
+      directive: 'focus on cost',
+      reason: 'continuing',
+    });
+  });
+
+  it('parses ask_user with user_question_choices', () => {
+    const out = parseParallelManagerTurn(
+      JSON.stringify({
+        action: 'ask_user',
+        user_question: 'pick one',
+        user_question_choices: ['a', 'b'],
+        reason: 'pending_question',
+      }),
+    );
+    expect(out).toEqual({
+      action: 'ask_user',
+      user_question: 'pick one',
+      user_question_choices: ['a', 'b'],
+      reason: 'pending_question',
+    });
+  });
+
+  it('parses finalize with final_message', () => {
+    const out = parseParallelManagerTurn(
+      '{"action":"finalize","final_message":"we agreed","reason":"consensus"}',
+    );
+    expect(out?.action).toBe('finalize');
+    expect(out?.final_message).toBe('we agreed');
+    expect(out?.reason).toBe('consensus');
+  });
+
+  it('parses terminate with final_message', () => {
+    const out = parseParallelManagerTurn(
+      '{"action":"terminate","final_message":"off topic","reason":"drift"}',
+    );
+    expect(out?.action).toBe('terminate');
+    expect(out?.final_message).toBe('off topic');
+  });
+
+  it('returns null on non-JSON garbage', () => {
+    expect(parseParallelManagerTurn('not json at all')).toBeNull();
+  });
+
+  it('returns null on unknown action', () => {
+    expect(
+      parseParallelManagerTurn('{"action":"explode","reason":"continuing"}'),
+    ).toBeNull();
+  });
+
+  it('returns null when ask_user is missing user_question', () => {
+    expect(
+      parseParallelManagerTurn('{"action":"ask_user","reason":"pending_question"}'),
+    ).toBeNull();
+  });
+
+  it('returns null when terminate is missing final_message', () => {
+    expect(
+      parseParallelManagerTurn('{"action":"terminate","reason":"drift"}'),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/discussion/parallel-advisor.ts
+++ b/packages/core/src/discussion/parallel-advisor.ts
@@ -1,0 +1,128 @@
+import { extractJsonObject } from '../advisor';
+
+export interface ParallelManagerInput {
+  topic: string;
+  summary: string;
+  opinions: Array<{ name: string; text: string }>;
+  pendingAsks: Array<{ worker: string; question: string }>;
+  idleMs: number;
+  revision: number;
+  userAnswer?: { question: string; answer: string };
+}
+
+export type ParallelAction = 'continue' | 'ask_user' | 'finalize' | 'terminate';
+export type ParallelReason = 'continuing' | 'pending_question' | 'consensus' | 'drift' | 'idle' | 'manager_error';
+
+export interface ParallelManagerTurn {
+  action: ParallelAction;
+  summary_update?: string;
+  directive?: string;
+  route_to?: string;
+  user_question?: string;
+  user_question_choices?: string[];
+  final_message?: string;
+  reason: ParallelReason;
+}
+
+const VALID_ACTIONS: readonly ParallelAction[] = ['continue', 'ask_user', 'finalize', 'terminate'];
+const VALID_REASONS: readonly ParallelReason[] = ['continuing', 'pending_question', 'consensus', 'drift', 'idle', 'manager_error'];
+
+export function buildParallelManagerPrompt(input: ParallelManagerInput): string {
+  const lines: string[] = [];
+  lines.push('# Role');
+  lines.push('You are the Manager of a parallel roundtable discussion. Multiple workers are appending opinions in parallel. Read the current state, optionally update the shared summary, and decide what happens next.');
+
+  lines.push('## Topic');
+  lines.push(input.topic);
+
+  lines.push('## Current Summary');
+  lines.push(input.summary || '(empty)');
+
+  lines.push('## Opinions');
+  if (input.opinions.length === 0) {
+    lines.push('(no opinions yet)');
+  } else {
+    for (const op of input.opinions) {
+      lines.push(`### ${op.name}`);
+      lines.push(op.text || '(empty)');
+    }
+  }
+
+  lines.push('## Pending Worker Questions');
+  if (input.pendingAsks.length === 0) {
+    lines.push('(none)');
+  } else {
+    lines.push(input.pendingAsks.map(a => `- ${a.worker}: ${a.question}`).join('\n'));
+  }
+
+  lines.push('## State');
+  lines.push(`- idle_ms: ${input.idleMs}`);
+  lines.push(`- control_revision: ${input.revision}`);
+
+  if (input.userAnswer) {
+    lines.push('## User Just Answered');
+    lines.push(`Question: ${input.userAnswer.question}`);
+    lines.push(`Answer: ${input.userAnswer.answer}`);
+  }
+
+  lines.push('## Decide');
+  lines.push([
+    'Respond with a single JSON object and no prose. Schema:',
+    '{',
+    '  "action": "continue" | "ask_user" | "finalize" | "terminate",',
+    '  "summary_update": "<optional new summary text to replace the shared summary>",',
+    '  "directive": "<optional short steering note for workers on the next loop>",',
+    '  "route_to": "<optional worker name to route a pending question to>",',
+    '  "user_question": "<required when action == ask_user>",',
+    '  "user_question_choices": ["<optional>", "<pick-one>", "<choices>"] ,',
+    '  "final_message": "<required when action == finalize or terminate>",',
+    '  "reason": "continuing" | "pending_question" | "consensus" | "drift" | "idle" | "manager_error"',
+    '}',
+    '',
+    'Guidelines:',
+    '- Use "continue" with reason "continuing" when workers should keep iterating.',
+    '- Use "ask_user" with reason "pending_question" when a worker question requires human input.',
+    '- Use "finalize" with reason "consensus" or "idle" when the discussion has converged or stalled.',
+    '- Use "terminate" with reason "drift" when the discussion has gone off-topic and must be stopped.',
+    '- "manager_error" is reserved for parser-side fallbacks; do not emit it yourself.',
+    '- Output a single JSON object. No markdown fences, no commentary.',
+  ].join('\n'));
+
+  return lines.join('\n\n');
+}
+
+export function parseParallelManagerTurn(raw: string): ParallelManagerTurn | null {
+  const obj = extractJsonObject(raw) as Record<string, unknown> | null;
+  if (!obj || typeof obj !== 'object') return null;
+
+  const action = obj.action;
+  if (typeof action !== 'string' || !VALID_ACTIONS.includes(action as ParallelAction)) return null;
+  const reason = obj.reason;
+  if (typeof reason !== 'string' || !VALID_REASONS.includes(reason as ParallelReason)) return null;
+
+  const strOrUndef = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
+  const user_question = strOrUndef(obj.user_question);
+  const final_message = strOrUndef(obj.final_message);
+
+  if (action === 'ask_user' && !user_question) return null;
+  if ((action === 'finalize' || action === 'terminate') && !final_message) return null;
+
+  const choices = Array.isArray(obj.user_question_choices)
+    ? (obj.user_question_choices.filter(c => typeof c === 'string') as string[])
+    : undefined;
+
+  const turn: ParallelManagerTurn = {
+    action: action as ParallelAction,
+    reason: reason as ParallelReason,
+  };
+  const summary_update = strOrUndef(obj.summary_update);
+  const directive = strOrUndef(obj.directive);
+  const route_to = strOrUndef(obj.route_to);
+  if (summary_update !== undefined) turn.summary_update = summary_update;
+  if (directive !== undefined) turn.directive = directive;
+  if (route_to !== undefined) turn.route_to = route_to;
+  if (user_question !== undefined) turn.user_question = user_question;
+  if (choices !== undefined) turn.user_question_choices = choices;
+  if (final_message !== undefined) turn.final_message = final_message;
+  return turn;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,6 @@ export * from './advisor';
 export * from './advisor-personality';
 export * from './aide';
 export * from './aide-tasks';
+export * from './discussion/files';
+export * from './discussion/control';
+export * from './discussion/parallel-advisor';

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -40,6 +40,22 @@ export type ChatSelection =
   /** `name` identifies which team to run. Optional only for backward compat with chats persisted before per-team selection landed; the UI always sets it. */
   | { type: 'team'; name?: string };
 
+export type DiscussionStatus = 'running' | 'paused' | 'done' | 'terminated';
+export type DiscussionTerminatedReason =
+  | 'consensus'
+  | 'drift'
+  | 'timeout'
+  | 'max_duration'
+  | 'user_cancel'
+  | 'manager_error';
+
+export interface DiscussionMeta {
+  teamName: string;
+  status: DiscussionStatus;
+  startedAt: number;
+  terminatedReason?: DiscussionTerminatedReason;
+}
+
 export interface Chat {
   id: string;
   title: string;
@@ -77,6 +93,8 @@ export interface Chat {
    * crosses a threshold; never blocks a user-visible turn.
    */
   compaction?: ChatCompaction;
+  /** Set when this chat is hosting a parallel-team (roundtable) discussion. */
+  discussion?: DiscussionMeta;
 }
 
 export interface ChatCompaction {

--- a/packages/core/src/workers.test.ts
+++ b/packages/core/src/workers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { WorkerManager } from './workers';
+
+function seedWorkers(workersDir: string, names: string[]) {
+  for (const n of names) {
+    fs.mkdirSync(path.join(workersDir, n), { recursive: true });
+    fs.writeFileSync(
+      path.join(workersDir, n, 'personality.md'),
+      `# ${n}\n## Role\nROLE_OF_${n}\n## Soul\n.\n## Instructions\n.\n`,
+    );
+    fs.writeFileSync(
+      path.join(workersDir, n, 'config.json'),
+      JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }),
+    );
+  }
+}
+
+describe('WorkerManager.buildParallelWorkerPrompt', () => {
+  it('builds a parallel-mode prompt with role, topic, file paths, ASK_MANAGER, and control protocol', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'workers-parallel-'));
+    seedWorkers(root, ['alice', 'bob']);
+    const wm = new WorkerManager(root);
+    await wm.loadWorkers();
+
+    const prompt = wm.buildParallelWorkerPrompt('alice', {
+      topic: 'Pick a database',
+      controlPath: '/tmp/c.md',
+      summaryPath: '/tmp/s.md',
+      ownOpinionPath: '/tmp/alice.md',
+      peerOpinions: [{ name: 'bob', path: '/tmp/bob.md' }],
+    });
+
+    expect(prompt).toContain('ROLE_OF_alice');
+    expect(prompt).toContain('Pick a database');
+    expect(prompt).toContain('/tmp/alice.md');
+    expect(prompt).toContain('/tmp/s.md');
+    expect(prompt).toContain('/tmp/c.md');
+    expect(prompt).toContain('/tmp/bob.md');
+    expect(prompt).toContain('[ASK_MANAGER]');
+    expect(prompt.toLowerCase()).toContain('read control.md');
+  });
+
+  it('returns the topic unchanged for an unknown worker', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'workers-parallel-'));
+    seedWorkers(root, ['alice']);
+    const wm = new WorkerManager(root);
+    await wm.loadWorkers();
+
+    const prompt = wm.buildParallelWorkerPrompt('nobody', {
+      topic: 'just-the-topic',
+      controlPath: 'c',
+      summaryPath: 's',
+      ownOpinionPath: 'o',
+      peerOpinions: [],
+    });
+    expect(prompt).toBe('just-the-topic');
+  });
+});

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -26,6 +26,14 @@ export interface Worker {
   config: WorkerConfig;
 }
 
+export interface ParallelPromptInputs {
+  topic: string;
+  controlPath: string;
+  summaryPath: string;
+  ownOpinionPath: string;
+  peerOpinions: Array<{ name: string; path: string }>;
+}
+
 const VALID_CODING_AGENTS: readonly WorkerConfig['codingAgent'][] = ['claude-code', 'opencode', 'codex'];
 
 export class WorkerManager {
@@ -289,6 +297,47 @@ export class WorkerManager {
       ].join('\n'),
       `## Task`,
       task,
+    ].join('\n\n');
+  }
+
+  buildParallelWorkerPrompt(name: string, inputs: ParallelPromptInputs): string {
+    const worker = this.getWorker(name);
+    if (!worker) return inputs.topic;
+    const peerLines = inputs.peerOpinions.length > 0
+      ? inputs.peerOpinions.map(p => `- ${p.name}'s opinion (read-only): ${p.path}`).join('\n')
+      : '(no peers)';
+    return [
+      `# Worker: ${worker.name} (Parallel/Roundtable Mode)`,
+      `## Role`,
+      worker.personality.role,
+      `## Personality`,
+      worker.personality.soul,
+      `## Instructions`,
+      worker.personality.instructions,
+      `## Topic`,
+      inputs.topic,
+      `## Files (use your Read/Write tools)`,
+      [
+        `- Your opinion file (write): ${inputs.ownOpinionPath}`,
+        `- Shared summary (read-only): ${inputs.summaryPath}`,
+        `- Control file (read-only, check before EVERY write): ${inputs.controlPath}`,
+        peerLines,
+      ].join('\n'),
+      `## Loop Protocol`,
+      [
+        '1. Read control.md. If status is "terminated", exit immediately. If "finalizing", write one consolidating final entry to your opinion file then exit. If "paused", wait and re-read every ~5 seconds until status changes.',
+        '2. Read summary.md and each peer opinion file.',
+        '3. Update YOUR opinion file (append a timestamped section; do not overwrite past entries) with your current position, what you agree/disagree with, and any open question.',
+        '4. If you need information you do not have, append a single line `[ASK_MANAGER]: <question>` at the end of your opinion file. The Manager will route or escalate.',
+        '5. If you have nothing new to add after the most recent peer/summary update, write a short "no further input" note and exit.',
+        '6. Otherwise sleep briefly (the agent may simply continue) and repeat from step 1.',
+      ].join('\n'),
+      `## Important`,
+      [
+        '- Do not touch other workers\' opinion files, the summary, or control.md — those are owned by the Manager and peers.',
+        '- Keep each appended entry concise (a few short paragraphs) so peers can absorb it quickly.',
+        '- Re-read control.md before every write — the Manager may have flipped status to terminated/finalizing/paused since your last check.',
+      ].join('\n'),
     ].join('\n\n');
   }
 

--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -1,69 +1,101 @@
-// Run: npx ts-node packages/core/src/workspace.test.ts
-import * as assert from 'assert';
-import { WorkspaceManager } from './workspace';
-import { WorkerManager } from './workers';
+import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { WorkspaceManager } from './workspace';
+import { WorkerManager } from './workers';
 
 function seedWorkers(workersDir: string, names: string[]) {
   for (const n of names) {
     fs.mkdirSync(path.join(workersDir, n), { recursive: true });
-    fs.writeFileSync(path.join(workersDir, n, 'personality.md'), `# ${n}\n## Role\n${n}\n## Soul\n.\n## Instructions\n.\n`);
-    fs.writeFileSync(path.join(workersDir, n, 'config.json'), JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
+    fs.writeFileSync(
+      path.join(workersDir, n, 'personality.md'),
+      `# ${n}\n## Role\n${n}\n## Soul\n.\n## Instructions\n.\n`,
+    );
+    fs.writeFileSync(
+      path.join(workersDir, n, 'config.json'),
+      JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }),
+    );
   }
 }
 
-async function testNormalizesParallelWithDefaults() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-parallel-'));
-  const wsDir = path.join(root, 'workspaces');
-  const workersDir = path.join(root, 'workers');
-  fs.mkdirSync(path.join(wsDir, 'demo'), { recursive: true });
-  seedWorkers(workersDir, ['a', 'b']);
-  fs.writeFileSync(path.join(wsDir, 'demo', 'workspace.json'), JSON.stringify({ workingDir: root, teams: ['rt'] }));
+describe('WorkspaceManager parallel team config', () => {
+  it('normalizes dispatch: "parallel" with default parallel settings', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-parallel-'));
+    const wsDir = path.join(root, 'workspaces');
+    const workersDir = path.join(root, 'workers');
+    fs.mkdirSync(path.join(wsDir, 'demo'), { recursive: true });
+    seedWorkers(workersDir, ['a', 'b']);
+    fs.writeFileSync(
+      path.join(wsDir, 'demo', 'workspace.json'),
+      JSON.stringify({ workingDir: root, teams: ['rt'] }),
+    );
 
-  const workers = new WorkerManager(workersDir);
-  await workers.loadWorkers();
-  const ws = new WorkspaceManager(workers, wsDir, undefined, () => ({
-    rt: { members: ['a', 'b'], dispatch: 'parallel' },
-  }));
-  await ws.switchWorkspace('demo');
+    const workers = new WorkerManager(workersDir);
+    await workers.loadWorkers();
+    const ws = new WorkspaceManager(workers, wsDir, undefined, () => ({
+      rt: { members: ['a', 'b'], dispatch: 'parallel' },
+    }));
+    await ws.switchWorkspace('demo');
 
-  const team = ws.getTeam('rt');
-  assert.ok(team, 'team should exist');
-  assert.strictEqual(team!.dispatch, 'parallel', 'dispatch should be parallel');
-  assert.deepStrictEqual(team!.parallel, {
-    maxDurationMs: 600_000,
-    idleTimeoutMs: 60_000,
-    managerPollMs: 30_000,
-  }, 'parallel should have default settings');
+    const team = ws.getTeam('rt');
+    expect(team).toBeTruthy();
+    expect(team!.dispatch).toBe('parallel');
+    expect(team!.parallel).toEqual({
+      maxDurationMs: 600_000,
+      idleTimeoutMs: 60_000,
+      managerPollMs: 30_000,
+    });
+  });
 
-  console.log('✓ normalizes dispatch: "parallel" with default parallel settings');
-}
+  it('preserves explicit parallel settings', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-parallel-'));
+    const wsDir = path.join(root, 'workspaces');
+    const workersDir = path.join(root, 'workers');
+    fs.mkdirSync(path.join(wsDir, 'demo'), { recursive: true });
+    seedWorkers(workersDir, ['a']);
+    fs.writeFileSync(
+      path.join(wsDir, 'demo', 'workspace.json'),
+      JSON.stringify({ workingDir: root, teams: ['rt'] }),
+    );
 
-async function testPreservesExplicitParallelSettings() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-parallel-'));
-  const wsDir = path.join(root, 'workspaces');
-  const workersDir = path.join(root, 'workers');
-  fs.mkdirSync(path.join(wsDir, 'demo'), { recursive: true });
-  seedWorkers(workersDir, ['a']);
-  fs.writeFileSync(path.join(wsDir, 'demo', 'workspace.json'), JSON.stringify({ workingDir: root, teams: ['rt'] }));
+    const workers = new WorkerManager(workersDir);
+    await workers.loadWorkers();
+    const ws = new WorkspaceManager(workers, wsDir, undefined, () => ({
+      rt: {
+        members: ['a'],
+        dispatch: 'parallel',
+        parallel: { maxDurationMs: 1000, idleTimeoutMs: 200, managerPollMs: 100 },
+      },
+    }));
+    await ws.switchWorkspace('demo');
 
-  const workers = new WorkerManager(workersDir);
-  await workers.loadWorkers();
-  const ws = new WorkspaceManager(workers, wsDir, undefined, () => ({
-    rt: { members: ['a'], dispatch: 'parallel', parallel: { maxDurationMs: 1000, idleTimeoutMs: 200, managerPollMs: 100 } },
-  }));
-  await ws.switchWorkspace('demo');
+    expect(ws.getTeam('rt')!.parallel).toEqual({
+      maxDurationMs: 1000,
+      idleTimeoutMs: 200,
+      managerPollMs: 100,
+    });
+  });
 
-  assert.deepStrictEqual(ws.getTeam('rt')!.parallel, { maxDurationMs: 1000, idleTimeoutMs: 200, managerPollMs: 100 }, 'parallel should preserve explicit settings');
+  it('falls back to "all" for unknown dispatch values', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-parallel-'));
+    const wsDir = path.join(root, 'workspaces');
+    const workersDir = path.join(root, 'workers');
+    fs.mkdirSync(path.join(wsDir, 'demo'), { recursive: true });
+    seedWorkers(workersDir, ['a']);
+    fs.writeFileSync(
+      path.join(wsDir, 'demo', 'workspace.json'),
+      JSON.stringify({ workingDir: root, teams: ['rt'] }),
+    );
 
-  console.log('✓ preserves explicit parallel settings');
-}
+    const workers = new WorkerManager(workersDir);
+    await workers.loadWorkers();
+    const ws = new WorkspaceManager(workers, wsDir, undefined, () => ({
+      rt: { members: ['a'], dispatch: 'nope' as unknown as 'all' },
+    }));
+    await ws.switchWorkspace('demo');
 
-async function run() {
-  await testNormalizesParallelWithDefaults();
-  await testPreservesExplicitParallelSettings();
-}
-
-run().catch((err) => { console.error(err); process.exit(1); });
+    expect(ws.getTeam('rt')!.dispatch).toBe('all');
+    expect(ws.getTeam('rt')!.parallel).toBeUndefined();
+  });
+});

--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -1,0 +1,69 @@
+// Run: npx ts-node packages/core/src/workspace.test.ts
+import * as assert from 'assert';
+import { WorkspaceManager } from './workspace';
+import { WorkerManager } from './workers';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+function seedWorkers(workersDir: string, names: string[]) {
+  for (const n of names) {
+    fs.mkdirSync(path.join(workersDir, n), { recursive: true });
+    fs.writeFileSync(path.join(workersDir, n, 'personality.md'), `# ${n}\n## Role\n${n}\n## Soul\n.\n## Instructions\n.\n`);
+    fs.writeFileSync(path.join(workersDir, n, 'config.json'), JSON.stringify({ codingAgent: 'claude-code', model: 'm', tools: [] }));
+  }
+}
+
+async function testNormalizesParallelWithDefaults() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-parallel-'));
+  const wsDir = path.join(root, 'workspaces');
+  const workersDir = path.join(root, 'workers');
+  fs.mkdirSync(path.join(wsDir, 'demo'), { recursive: true });
+  seedWorkers(workersDir, ['a', 'b']);
+  fs.writeFileSync(path.join(wsDir, 'demo', 'workspace.json'), JSON.stringify({ workingDir: root, teams: ['rt'] }));
+
+  const workers = new WorkerManager(workersDir);
+  await workers.loadWorkers();
+  const ws = new WorkspaceManager(workers, wsDir, undefined, () => ({
+    rt: { members: ['a', 'b'], dispatch: 'parallel' },
+  }));
+  await ws.switchWorkspace('demo');
+
+  const team = ws.getTeam('rt');
+  assert.ok(team, 'team should exist');
+  assert.strictEqual(team!.dispatch, 'parallel', 'dispatch should be parallel');
+  assert.deepStrictEqual(team!.parallel, {
+    maxDurationMs: 600_000,
+    idleTimeoutMs: 60_000,
+    managerPollMs: 30_000,
+  }, 'parallel should have default settings');
+
+  console.log('✓ normalizes dispatch: "parallel" with default parallel settings');
+}
+
+async function testPreservesExplicitParallelSettings() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-parallel-'));
+  const wsDir = path.join(root, 'workspaces');
+  const workersDir = path.join(root, 'workers');
+  fs.mkdirSync(path.join(wsDir, 'demo'), { recursive: true });
+  seedWorkers(workersDir, ['a']);
+  fs.writeFileSync(path.join(wsDir, 'demo', 'workspace.json'), JSON.stringify({ workingDir: root, teams: ['rt'] }));
+
+  const workers = new WorkerManager(workersDir);
+  await workers.loadWorkers();
+  const ws = new WorkspaceManager(workers, wsDir, undefined, () => ({
+    rt: { members: ['a'], dispatch: 'parallel', parallel: { maxDurationMs: 1000, idleTimeoutMs: 200, managerPollMs: 100 } },
+  }));
+  await ws.switchWorkspace('demo');
+
+  assert.deepStrictEqual(ws.getTeam('rt')!.parallel, { maxDurationMs: 1000, idleTimeoutMs: 200, managerPollMs: 100 }, 'parallel should preserve explicit settings');
+
+  console.log('✓ preserves explicit parallel settings');
+}
+
+async function run() {
+  await testNormalizesParallelWithDefaults();
+  await testPreservesExplicitParallelSettings();
+}
+
+run().catch((err) => { console.error(err); process.exit(1); });

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -10,15 +10,35 @@ const defaultLogger: CoreLogger = {
   error: (msg: string) => console.error(msg),
 };
 
-export type TeamDispatchMode = 'all' | 'auto';
+export type TeamDispatchMode = 'all' | 'auto' | 'parallel';
+
+export interface ParallelSettings {
+  maxDurationMs: number;
+  idleTimeoutMs: number;
+  managerPollMs: number;
+}
+
+const DEFAULT_PARALLEL_SETTINGS: ParallelSettings = {
+  maxDurationMs: 600_000,
+  idleTimeoutMs: 60_000,
+  managerPollMs: 30_000,
+};
 
 /** Raw team value as it can appear in workspace.json. */
-export type TeamConfigRaw = string[] | { members: string[]; dispatch?: TeamDispatchMode };
+export type TeamConfigRaw =
+  | string[]
+  | {
+      members: string[];
+      dispatch?: TeamDispatchMode;
+      parallel?: Partial<ParallelSettings>;
+    };
 
 /** Normalized team value used at runtime. */
 export interface TeamConfig {
   members: string[];
   dispatch: TeamDispatchMode;
+  /** Only populated when dispatch === 'parallel'. */
+  parallel?: ParallelSettings;
 }
 
 export interface WorkspaceJson {
@@ -154,15 +174,18 @@ export class WorkspaceManager {
   private normalizeTeam(name: string, raw: TeamConfigRaw): TeamConfig | null {
     let members: string[];
     let dispatch: TeamDispatchMode = 'all';
+    let parallel: Partial<ParallelSettings> | undefined;
 
     if (Array.isArray(raw)) {
       members = raw;
     } else if (raw && typeof raw === 'object' && Array.isArray(raw.members)) {
       members = raw.members;
-      if (raw.dispatch === 'auto' || raw.dispatch === 'all') dispatch = raw.dispatch;
-      else if (raw.dispatch !== undefined) {
+      if (raw.dispatch === 'auto' || raw.dispatch === 'all' || raw.dispatch === 'parallel') {
+        dispatch = raw.dispatch;
+      } else if (raw.dispatch !== undefined) {
         this.logger.warn(`[Workspace] Team "${name}" has invalid dispatch="${raw.dispatch}" — defaulting to "all"`);
       }
+      parallel = raw.parallel;
     } else {
       this.logger.error(`[Workspace] Team "${name}" has invalid shape — skipping`);
       return null;
@@ -173,7 +196,12 @@ export class WorkspaceManager {
       this.logger.error(`[Workspace] Team "${name}" references unknown workers: ${unknown.join(', ')} — skipping`);
       return null;
     }
-    return { members, dispatch };
+
+    const result: TeamConfig = { members, dispatch };
+    if (dispatch === 'parallel') {
+      result.parallel = { ...DEFAULT_PARALLEL_SETTINGS, ...(parallel ?? {}) };
+    }
+    return result;
   }
 
   async switchWorkspace(workspaceId: string): Promise<boolean> {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     // crash vitest's collection phase. New vitest tests must be added here.
     include: [
       'src/workspace.test.ts',
+      'src/discussion/files.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,8 +7,10 @@ export default defineConfig({
     // crash vitest's collection phase. New vitest tests must be added here.
     include: [
       'src/workspace.test.ts',
+      'src/workers.test.ts',
       'src/discussion/files.test.ts',
       'src/discussion/control.test.ts',
+      'src/discussion/parallel-advisor.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,10 +1,13 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Explicit allowlist of vitest test files. Other `*.test.ts` files in src/
+    // (advisor, context, etc.) are legacy ts-node/node:test scripts and would
+    // crash vitest's collection phase. New vitest tests must be added here.
     include: [
       'src/workspace.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },
-})
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     include: [
       'src/workspace.test.ts',
       'src/discussion/files.test.ts',
+      'src/discussion/control.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: [
+      'src/workspace.test.ts',
+    ],
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+})

--- a/packages/gateway/src/chats.discussion.test.ts
+++ b/packages/gateway/src/chats.discussion.test.ts
@@ -45,4 +45,17 @@ describe('Chat.discussion metadata', () => {
 
     fs.rmSync(root, { recursive: true, force: true });
   });
+
+  it('deletes the discussion directory when the chat is deleted', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-del-'));
+    fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
+    const mgr = new ChatManager(root);
+    const chat = mgr.create({ workspaceName: 'demo', title: 't' });
+    const discDir = path.join(root, 'demo', 'chats', chat.id, 'discussion');
+    fs.mkdirSync(discDir, { recursive: true });
+    fs.writeFileSync(path.join(discDir, 'topic.md'), 'x');
+    mgr.delete(chat.id);
+    expect(fs.existsSync(discDir)).toBe(false);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/packages/gateway/src/chats.discussion.test.ts
+++ b/packages/gateway/src/chats.discussion.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { Chat, DiscussionMeta } from '@codey/core';
+import { ChatManager } from './chats';
+
+describe('Chat.discussion metadata', () => {
+  it('roundtrips through persistence', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-discussion-'));
+    fs.mkdirSync(path.join(root, 'main'), { recursive: true });
+
+    const mgr = new ChatManager(root);
+    const chat = mgr.create({ workspaceName: 'main', title: 'roundtable' });
+
+    const discussion: DiscussionMeta = {
+      teamName: 'reviewers',
+      status: 'running',
+      startedAt: 1_700_000_000_000,
+    };
+
+    // ChatManager exposes no public mutator for `discussion` yet; write the
+    // field directly via the on-disk JSON and reload to assert the type
+    // survives the persistence round-trip.
+    const chatFile = path.join(root, 'main', 'chats', `${chat.id}.json`);
+    const raw = JSON.parse(fs.readFileSync(chatFile, 'utf8')) as Chat;
+    raw.discussion = discussion;
+    fs.writeFileSync(chatFile, JSON.stringify(raw, null, 2), 'utf8');
+
+    const reloaded = new ChatManager(root);
+    const got = reloaded.get(chat.id);
+    expect(got?.discussion).toEqual(discussion);
+
+    // Terminated state with reason also roundtrips.
+    const terminated: DiscussionMeta = {
+      teamName: 'reviewers',
+      status: 'terminated',
+      startedAt: 1_700_000_000_000,
+      terminatedReason: 'consensus',
+    };
+    raw.discussion = terminated;
+    fs.writeFileSync(chatFile, JSON.stringify(raw, null, 2), 'utf8');
+    const reloaded2 = new ChatManager(root);
+    expect(reloaded2.get(chat.id)?.discussion).toEqual(terminated);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -243,6 +243,10 @@ export class ChatManager {
     if (!chat) return;
     const file = this.chatFile(chat.workspaceName, chat.id);
     if (fs.existsSync(file)) fs.unlinkSync(file);
+    const chatDir = path.join(this.workspacesRoot, chat.workspaceName, 'chats', chatId);
+    if (fs.existsSync(chatDir)) {
+      fs.rmSync(chatDir, { recursive: true, force: true });
+    }
     this.cache.delete(chatId);
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -17,6 +17,7 @@ import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, assis
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
 import { resolveChoiceDigit } from './digit-mapping';
+import { ParallelTeamRunner, ParallelFinalEvent } from './parallel-team';
 
 interface ParsedCommand {
   command: string;
@@ -46,6 +47,8 @@ export class Codey {
   private configManager?: ConfigManager;
   private chatSemaphore = new RunSemaphore();
   private chatAborts: Map<string, AbortController> = new Map();
+  private parallelResumes = new Map<string, (answer: string) => Promise<void>>();
+  private activeParallelRuns = new Map<string, ParallelTeamRunner>();
   private turnQueue: TurnQueue;
   private chatEventListener: ((ev: any) => void) | undefined;
   private pairingEventListener: ((ev: { type: 'completed'; channel: ChannelKind; channelUserId: string }) => void) | undefined;
@@ -2395,6 +2398,7 @@ Example: /model gpt-4.1 write a Python script`;
     workingDir: string,
     sink: ChatStreamSink,
     chatId: string,
+    chat: Chat,
     signal?: AbortSignal,
     opts: { forceAll?: boolean } = {},
     chatAgent?: CodingAgent,
@@ -2426,6 +2430,83 @@ Example: /model gpt-4.1 write a Python script`;
     };
 
     const useManager = team.dispatch === 'auto' && !opts.forceAll;
+
+    // === parallel dispatch branch ===
+    if (team.dispatch === 'parallel') {
+      if (!team.parallel) {
+        // defensive — normalizer always populates this for parallel teams
+        await sink({ type: 'stream', chatId, token: '⚠️ parallel team is missing settings' });
+        return { response: '' };
+      }
+      const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
+      const runner = new ParallelTeamRunner({
+        workspacesRoot,
+        workspace: chat.workspaceName,
+        chatId: chat.id,
+        teamName: teamName,
+        members: team.members,
+        topic: prompt,
+        settings: team.parallel,
+        workerRunner: async req => this.runWithFallback(chatAgent ?? this.getDefaultAgent() as CodingAgent, {
+          prompt: req.prompt,
+          agent: chatAgent ?? this.getDefaultAgent() as CodingAgent,
+          model: chatModel ?? this.getDefaultModelConfig(chatAgent ?? this.getDefaultAgent() as CodingAgent),
+          context: { workingDir },
+          onStream: (text: string) => sink({ type: 'stream', chatId, token: text }),
+          onStatus: (_update: any) => { /* status forwarded via sink elsewhere */ },
+          signal: req.signal,
+        }),
+        managerRunner: async req => {
+          const { agent: mAgent, model: mModel } = this.getAdvisorAgentAndModel();
+          const advisorResult = await this.runWithFallback(mAgent, {
+            prompt: req.prompt,
+            agent: mAgent,
+            model: mModel,
+            context: { workingDir },
+            onStream: () => {},
+            onStatus: () => {},
+            signal: req.signal,
+          });
+          return advisorResult;
+        },
+        buildWorkerPrompt: (workerName: string) => {
+          const wm = this.workspaceManager.getWorkerManager();
+          return wm.buildParallelWorkerPrompt(workerName, {
+            topic: prompt,
+            controlPath: controlPath(workspacesRoot, chat.workspaceName, chat.id),
+            summaryPath: summaryPath(workspacesRoot, chat.workspaceName, chat.id),
+            ownOpinionPath: opinionPath(workspacesRoot, chat.workspaceName, chat.id, workerName),
+            peerOpinions: team.members
+              .filter(m => m !== workerName)
+              .map(m => ({ name: m, path: opinionPath(workspacesRoot, chat.workspaceName, chat.id, m) })),
+          });
+        },
+        onUserQuestion: q => {
+          this.parallelResumes.set(chat.id, q.resume);
+          const rendered = renderQuestion('Manager', '', q.question, q.choices);
+          sink({ type: 'stream', chatId, token: rendered.text });
+        },
+        onFinal: ev => {
+          this.parallelResumes.delete(chat.id);
+          this.activeParallelRuns.delete(chat.id);
+          const c = this.chatManager.get(chat.id);
+          if (c) {
+            c.discussion = { teamName, status: 'done', startedAt: c.discussion?.startedAt ?? Date.now(), terminatedReason: ev.reason };
+            (c as any).updatedAt = Date.now();
+          }
+          void sink({ type: 'stream', chatId, token: this.formatParallelFinal(ev, teamName) });
+        },
+      });
+      const c0 = this.chatManager.get(chat.id);
+      if (c0) {
+        c0.discussion = { teamName, status: 'running', startedAt: Date.now() };
+        (c0 as any).updatedAt = Date.now();
+      }
+      this.activeParallelRuns.set(chat.id, runner);
+      await runner.start();
+      return { response: '' };
+    }
+    // === end parallel dispatch branch ===
 
     if (useManager) {
       let isFirstStep = true;
@@ -2546,6 +2627,21 @@ Example: /model gpt-4.1 write a Python script`;
     const m = Math.floor((seconds % 3600) / 60);
     const s = seconds % 60;
     return `${h}h ${m}m ${s}s`;
+  }
+
+  private formatParallelFinal(ev: ParallelFinalEvent, team: string): string {
+    return [
+      `🪑 Roundtable: ${team}`,
+      `终止原因: ${ev.reason}`,
+      '',
+      '【Manager 总结】',
+      ev.summary.trim() || '(empty)',
+      '',
+      '【各方观点】',
+      ...ev.perWorker.map(p => `• ${p.name}: ${p.excerpt || '(empty)'}`),
+      '',
+      ev.message,
+    ].join('\n');
   }
 
   private parseCommand(text: string): ParsedCommand {
@@ -3116,7 +3212,7 @@ Example: /model gpt-4.1 write a Python script`;
           members: rawMembers,
           dispatch: (Array.isArray(rawTeam) ? 'all' : (rawTeam?.dispatch ?? 'all')) as TeamConfig['dispatch'],
         };
-        const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, abortController.signal, {}, agent, model);
+        const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, chat, abortController.signal, {}, agent, model);
         output = r.response;
         tokens = r.tokens;
         teamChoices = r.choices;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2390,7 +2390,7 @@ Example: /model gpt-4.1 write a Python script`;
 
   private async runTeamForChat(
     teamName: string,
-    team: { members: string[]; dispatch: 'all' | 'auto' },
+    team: { members: string[]; dispatch: 'all' | 'auto' | 'parallel'; parallel?: any },
     prompt: string,
     workingDir: string,
     sink: ChatStreamSink,

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2432,13 +2432,27 @@ Example: /model gpt-4.1 write a Python script`;
     const useManager = team.dispatch === 'auto' && !opts.forceAll;
 
     // === parallel dispatch branch ===
+    // Check if user is answering a pending question from a paused parallel discussion
+    if (this.parallelResumes.has(chat.id)) {
+      const resume = this.parallelResumes.get(chat.id)!;
+      this.parallelResumes.delete(chat.id);
+      await resume(prompt);
+      return { response: '' };
+    }
+
     if (team.dispatch === 'parallel') {
+      const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
+      // Resume detection: if this chat has a completed/terminated discussion,
+      // re-activate it instead of starting fresh. initDiscussionDir will
+      // append a Continuation header to topic.md and reset control.md.
+      if (chat.discussion && (chat.discussion.status === 'done' || chat.discussion.status === 'terminated')) {
+        await initDiscussionDir(workspacesRoot, chat.workspaceName, chat.id, prompt, team.members);
+      }
       if (!team.parallel) {
         // defensive — normalizer always populates this for parallel teams
         await sink({ type: 'stream', chatId, token: '⚠️ parallel team is missing settings' });
         return { response: '' };
       }
-      const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
       const runner = new ParallelTeamRunner({
         workspacesRoot,
         workspace: chat.workspaceName,
@@ -3342,6 +3356,11 @@ Example: /model gpt-4.1 write a Python script`;
    * Cancel an in-flight chat turn. Returns true if a run was aborted.
    */
   stopChat(chatId: string): boolean {
+    const runner = this.activeParallelRuns.get(chatId);
+    if (runner) {
+      void runner.stop('user_cancel', 'user cancelled the discussion');
+      return true;
+    }
     const controller = this.chatAborts.get(chatId);
     if (!controller) return false;
     controller.abort();

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -8,7 +8,7 @@ import { AgentFactory } from '@codey/core';
 import { Logger } from './logger';
 import { ContextManager, ContextWindow } from '@codey/core';
 import { MemoryStore } from '@codey/core';
-import { WorkspaceManager, TeamConfigRaw } from '@codey/core';
+import { WorkspaceManager, TeamConfigRaw, TeamConfig } from '@codey/core';
 import { WorkerManager } from '@codey/core';
 import { ChatManager } from './chats';
 import { PairingStore, ChannelBinding } from './pairings';
@@ -2390,7 +2390,7 @@ Example: /model gpt-4.1 write a Python script`;
 
   private async runTeamForChat(
     teamName: string,
-    team: { members: string[]; dispatch: 'all' | 'auto' | 'parallel'; parallel?: any },
+    team: TeamConfig,
     prompt: string,
     workingDir: string,
     sink: ChatStreamSink,
@@ -3112,9 +3112,9 @@ Example: /model gpt-4.1 write a Python script`;
         // Prefer the active workspace's normalized team (which carries dispatch mode);
         // fall back to building a TeamConfig inline from the chat's raw config.
         const wsTeam = this.workspaceManager.getTeam(teamName);
-        const team = wsTeam ?? {
+        const team: TeamConfig = wsTeam ?? {
           members: rawMembers,
-          dispatch: (Array.isArray(rawTeam) ? 'all' : (rawTeam?.dispatch ?? 'all')) as 'all' | 'auto',
+          dispatch: (Array.isArray(rawTeam) ? 'all' : (rawTeam?.dispatch ?? 'all')) as TeamConfig['dispatch'],
         };
         const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, abortController.signal, {}, agent, model);
         output = r.response;

--- a/packages/gateway/src/parallel-team.test.ts
+++ b/packages/gateway/src/parallel-team.test.ts
@@ -124,4 +124,11 @@ describe('ParallelTeamRunner', () => {
     await r.waitDone();
     expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ reason: 'timeout' }));
   });
+
+  it('smoke: ParallelTeamRunner can be imported and constructed', () => {
+    // Verify the class is importable and has expected interface
+    expect(ParallelTeamRunner).toBeDefined();
+    const r = makeRunner();
+    expect(r.discussionDir).toBeDefined();
+  });
 });

--- a/packages/gateway/src/parallel-team.test.ts
+++ b/packages/gateway/src/parallel-team.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ParallelTeamRunner } from './parallel-team';
+
+const stubRunner = vi.fn().mockResolvedValue({ success: true, output: '' });
+
+function makeRunner(overrides: Partial<ConstructorParameters<typeof ParallelTeamRunner>[0]> = {}) {
+  const workspacesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pt-'));
+  fs.mkdirSync(path.join(workspacesRoot, 'demo', 'chats', 'c1'), { recursive: true });
+  return new ParallelTeamRunner({
+    workspacesRoot,
+    workspace: 'demo',
+    chatId: 'c1',
+    teamName: 'rt',
+    members: ['a', 'b'],
+    topic: 'Decide X',
+    settings: { maxDurationMs: 1000, idleTimeoutMs: 500, managerPollMs: 200 },
+    workerRunner: stubRunner,
+    managerRunner: vi.fn().mockResolvedValue({ success: true, output: '{"action":"terminate","final_message":"end","reason":"drift"}' }),
+    buildWorkerPrompt: () => 'WORKER',
+    onUserQuestion: vi.fn(),
+    onFinal: vi.fn(),
+    ...overrides,
+  });
+}
+
+describe('ParallelTeamRunner', () => {
+  it('initializes discussion files on start()', async () => {
+    const r = makeRunner();
+    await r.start();
+    expect(fs.existsSync(path.join(r.discussionDir, 'topic.md'))).toBe(true);
+    expect(fs.existsSync(path.join(r.discussionDir, 'control.md'))).toBe(true);
+    expect(fs.existsSync(path.join(r.discussionDir, 'opinions', 'a.md'))).toBe(true);
+    await r.stop('user_cancel');
+  });
+
+  it('emits onFinal with reason after stop()', async () => {
+    const onFinal = vi.fn();
+    const r = makeRunner({ onFinal });
+    await r.start();
+    await r.stop('user_cancel', 'stopped');
+    expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ reason: 'user_cancel', message: 'stopped' }));
+  });
+});

--- a/packages/gateway/src/parallel-team.test.ts
+++ b/packages/gateway/src/parallel-team.test.ts
@@ -131,4 +131,30 @@ describe('ParallelTeamRunner', () => {
     const r = makeRunner();
     expect(r.discussionDir).toBeDefined();
   });
+
+  it('resume: new message into done discussion preserves opinions and appends Continuation', async () => {
+    const { initDiscussionDir, readControl } = await import('@codey/core');
+    const wsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pt-resume-'));
+    fs.mkdirSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'opinions'), { recursive: true });
+    // Seed a prior "done" discussion
+    fs.writeFileSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'topic.md'), '# Topic\n\nfirst round\n');
+    fs.writeFileSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'control.md'),
+      `---\nstatus: terminated\nrevision: 9\nupdated_at: 2026-05-24T00:00:00.000Z\n---\n\n## Directive\nended\n`);
+    fs.writeFileSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'summary.md'), '# Summary\nprior\n');
+    fs.writeFileSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'opinions', 'a.md'), 'prior a opinion');
+
+    // Simulate resume invocation: gateway calls initDiscussionDir with the new topic
+    await initDiscussionDir(wsRoot, 'demo', 'c1', 'second round', ['a', 'b']);
+
+    const topic = fs.readFileSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'topic.md'), 'utf-8');
+    expect(topic).toContain('first round');
+    expect(topic).toMatch(/## Continuation/);
+    expect(topic).toContain('second round');
+    expect(fs.readFileSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'opinions', 'a.md'), 'utf-8')).toContain('prior a opinion');
+    // New worker b gets a fresh opinion file
+    expect(fs.existsSync(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'opinions', 'b.md'))).toBe(true);
+    // Control reset to running with bumped revision
+    const ctrl = await readControl(path.join(wsRoot, 'demo', 'chats', 'c1', 'discussion', 'control.md'));
+    expect(ctrl?.status).toBe('running');
+  });
 });

--- a/packages/gateway/src/parallel-team.test.ts
+++ b/packages/gateway/src/parallel-team.test.ts
@@ -36,6 +36,16 @@ describe('ParallelTeamRunner', () => {
     await r.stop('user_cancel');
   });
 
+  it('dispatches each member exactly once via workerRunner with its built prompt', async () => {
+    const workerRunner = vi.fn().mockResolvedValue({ success: true, output: '' });
+    const buildWorkerPrompt = vi.fn((w: string) => `PROMPT-${w}`);
+    const r = makeRunner({ workerRunner, buildWorkerPrompt });
+    await r.start();
+    await r.stop('user_cancel');
+    const calls = workerRunner.mock.calls.map(c => c[0].prompt);
+    expect(calls.sort()).toEqual(['PROMPT-a', 'PROMPT-b']);
+  });
+
   it('emits onFinal with reason after stop()', async () => {
     const onFinal = vi.fn();
     const r = makeRunner({ onFinal });

--- a/packages/gateway/src/parallel-team.test.ts
+++ b/packages/gateway/src/parallel-team.test.ts
@@ -96,4 +96,32 @@ describe('ParallelTeamRunner', () => {
     await r.waitDone();
     expect(fs.readFileSync(path.join(r.discussionDir, 'summary.md'), 'utf-8')).toContain('new sum');
   });
+
+  it('terminates on max_duration when settings.maxDurationMs elapses', async () => {
+    const managerRunner = vi.fn().mockImplementation(() => new Promise(() => {/* never resolves */}));
+    const workerRunner = vi.fn().mockImplementation(() => new Promise(() => {/* never resolves */}));
+    const onFinal = vi.fn();
+    const r = makeRunner({
+      managerRunner,
+      workerRunner,
+      onFinal,
+    }, { maxDurationMs: 200, idleTimeoutMs: 10_000, managerPollMs: 10_000 });
+    await r.start();
+    await r.waitDone();
+    expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ reason: 'max_duration' }));
+  });
+
+  it('terminates on timeout when idleTimeoutMs elapses with no file mtime change', async () => {
+    const managerRunner = vi.fn().mockImplementation(() => new Promise(() => {/* never resolves */}));
+    const workerRunner = vi.fn().mockImplementation(() => new Promise(() => {/* never resolves */}));
+    const onFinal = vi.fn();
+    const r = makeRunner({
+      managerRunner,
+      workerRunner,
+      onFinal,
+    }, { maxDurationMs: 10_000, idleTimeoutMs: 250, managerPollMs: 10_000 });
+    await r.start();
+    await r.waitDone();
+    expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ reason: 'timeout' }));
+  });
 });

--- a/packages/gateway/src/parallel-team.test.ts
+++ b/packages/gateway/src/parallel-team.test.ts
@@ -6,7 +6,7 @@ import { ParallelTeamRunner } from './parallel-team';
 
 const stubRunner = vi.fn().mockResolvedValue({ success: true, output: '' });
 
-function makeRunner(overrides: Partial<ConstructorParameters<typeof ParallelTeamRunner>[0]> = {}) {
+function makeRunner(overrides: Partial<ConstructorParameters<typeof ParallelTeamRunner>[0]> = {}, settingsOverrides: Partial<{ maxDurationMs: number; idleTimeoutMs: number; managerPollMs: number }> = {}) {
   const workspacesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pt-'));
   fs.mkdirSync(path.join(workspacesRoot, 'demo', 'chats', 'c1'), { recursive: true });
   return new ParallelTeamRunner({
@@ -16,7 +16,7 @@ function makeRunner(overrides: Partial<ConstructorParameters<typeof ParallelTeam
     teamName: 'rt',
     members: ['a', 'b'],
     topic: 'Decide X',
-    settings: { maxDurationMs: 1000, idleTimeoutMs: 500, managerPollMs: 200 },
+    settings: { maxDurationMs: 1000, idleTimeoutMs: 500, managerPollMs: 200, ...settingsOverrides },
     workerRunner: stubRunner,
     managerRunner: vi.fn().mockResolvedValue({ success: true, output: '{"action":"terminate","final_message":"end","reason":"drift"}' }),
     buildWorkerPrompt: () => 'WORKER',
@@ -52,5 +52,48 @@ describe('ParallelTeamRunner', () => {
     await r.start();
     await r.stop('user_cancel', 'stopped');
     expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ reason: 'user_cancel', message: 'stopped' }));
+  });
+
+  it('terminates when managerRunner returns action=terminate', async () => {
+    const managerRunner = vi.fn().mockResolvedValue({
+      success: true,
+      output: '{"action":"terminate","final_message":"off topic","reason":"drift"}',
+    });
+    const onFinal = vi.fn();
+    const r = makeRunner({ managerRunner, onFinal }, { managerPollMs: 50 });
+    await r.start();
+    await r.waitDone();
+    expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ reason: 'drift', message: 'off topic' }));
+  });
+
+  it('on ask_user, calls onUserQuestion with a resume function', async () => {
+    const responses = [
+      '{"action":"ask_user","user_question":"Color?","reason":"pending_question"}',
+      '{"action":"terminate","final_message":"done","reason":"consensus"}',
+    ];
+    const managerRunner = vi.fn().mockImplementation(() => Promise.resolve({ success: true, output: responses.shift()! }));
+    const onUserQuestion = vi.fn();
+    const r = makeRunner({ managerRunner, onUserQuestion }, { managerPollMs: 50 });
+    await r.start();
+    // Wait for the ask
+    await new Promise(res => setTimeout(res, 400));
+    expect(onUserQuestion).toHaveBeenCalled();
+    const q = onUserQuestion.mock.calls[0][0];
+    expect(q.question).toBe('Color?');
+    await q.resume('blue');
+    await r.waitDone();
+  });
+
+  it('writes summary_update to summary.md on continue', async () => {
+    let i = 0;
+    const managerRunner = vi.fn().mockImplementation(() => {
+      i++;
+      if (i === 1) return Promise.resolve({ success: true, output: '{"action":"continue","summary_update":"new sum","directive":"focus","reason":"continuing"}' });
+      return Promise.resolve({ success: true, output: '{"action":"terminate","final_message":"end","reason":"consensus"}' });
+    });
+    const r = makeRunner({ managerRunner }, { managerPollMs: 50 });
+    await r.start();
+    await r.waitDone();
+    expect(fs.readFileSync(path.join(r.discussionDir, 'summary.md'), 'utf-8')).toContain('new sum');
   });
 });

--- a/packages/gateway/src/parallel-team.ts
+++ b/packages/gateway/src/parallel-team.ts
@@ -1,0 +1,114 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  initDiscussionDir,
+  discussionDir,
+  controlPath,
+  summaryPath,
+  topicPath,
+  opinionPath,
+  listOpinionFiles,
+  appendTranscript,
+  readControl,
+  writeControl,
+  buildParallelManagerPrompt,
+  parseParallelManagerTurn,
+  type ParallelManagerTurn,
+  type ParallelSettings,
+  type DiscussionTerminatedReason,
+} from '@codey/core';
+import type { AgentRequest, AgentResponse } from '@codey/core';
+
+export type AgentRunner = (req: AgentRequest) => Promise<AgentResponse>;
+
+export interface ParallelFinalEvent {
+  reason: DiscussionTerminatedReason;
+  message: string;
+  summary: string;
+  perWorker: Array<{ name: string; excerpt: string }>;
+}
+
+export interface ParallelUserQuestion {
+  question: string;
+  choices?: string[];
+  /** Caller must invoke this once the user answers. */
+  resume: (answer: string) => Promise<void>;
+}
+
+export interface ParallelTeamRunnerOptions {
+  workspacesRoot: string;
+  workspace: string;
+  chatId: string;
+  teamName: string;
+  members: string[];
+  topic: string;
+  settings: ParallelSettings;
+  workerRunner: AgentRunner;
+  managerRunner: AgentRunner;
+  buildWorkerPrompt: (worker: string) => string;
+  onUserQuestion: (q: ParallelUserQuestion) => void;
+  onFinal: (e: ParallelFinalEvent) => void;
+}
+
+export class ParallelTeamRunner {
+  readonly discussionDir: string;
+  private abort = new AbortController();
+  private workerAborts: AbortController[] = [];
+  private done = false;
+  private donePromise: Promise<void>;
+  private resolveDone!: () => void;
+  private pendingResume: ((answer: string) => void) | null = null;
+  private lastMtimeMs = 0;
+  private startedAt = 0;
+  private idleSince = 0;
+
+  constructor(private opts: ParallelTeamRunnerOptions) {
+    this.discussionDir = discussionDir(opts.workspacesRoot, opts.workspace, opts.chatId);
+    this.donePromise = new Promise<void>(res => { this.resolveDone = res; });
+  }
+
+  async start(): Promise<void> {
+    await initDiscussionDir(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId, this.opts.topic, this.opts.members);
+    this.startedAt = Date.now();
+    this.idleSince = this.startedAt;
+    await appendTranscript(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId, { actor: 'system', kind: 'started' });
+    void this.runManagerLoop();
+    this.spawnWorkers();
+    this.armSupervisors();
+  }
+
+  waitDone(): Promise<void> { return this.donePromise; }
+
+  async stop(reason: DiscussionTerminatedReason, finalMessage = ''): Promise<void> {
+    if (this.done) return;
+    this.done = true;
+    try {
+      await writeControl(controlPath(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId),
+        prev => ({ ...prev, status: 'terminated', directive: 'discussion ended' })).catch(() => undefined);
+    } finally {
+      this.abort.abort();
+      for (const a of this.workerAborts) a.abort();
+      await this.emitFinal(reason, finalMessage);
+      this.resolveDone();
+    }
+  }
+
+  // Worker loops, manager loop, supervisors, emitFinal — added in subsequent tasks.
+  private spawnWorkers(): void { /* Task 9 */ }
+  private async runManagerLoop(): Promise<void> { /* Task 10 */ }
+  private armSupervisors(): void { /* Task 11 */ }
+  private async emitFinal(reason: DiscussionTerminatedReason, message: string): Promise<void> {
+    const summary = safeRead(summaryPath(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId));
+    const perWorker: Array<{ name: string; excerpt: string }> = [];
+    for (const w of this.opts.members) {
+      const text = safeRead(opinionPath(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId, w));
+      const firstLine = text.split('\n').find(l => l.trim().length > 0) || '';
+      perWorker.push({ name: w, excerpt: firstLine.slice(0, 200) });
+    }
+    this.opts.onFinal({ reason, message, summary, perWorker });
+  }
+}
+
+function safeRead(p: string): string {
+  try { return fs.readFileSync(p, 'utf-8'); } catch { return ''; }
+}

--- a/packages/gateway/src/parallel-team.ts
+++ b/packages/gateway/src/parallel-team.ts
@@ -94,7 +94,27 @@ export class ParallelTeamRunner {
   }
 
   // Worker loops, manager loop, supervisors, emitFinal — added in subsequent tasks.
-  private spawnWorkers(): void { /* Task 9 */ }
+  private spawnWorkers(): void {
+    for (const w of this.opts.members) {
+      const ac = new AbortController();
+      this.workerAborts.push(ac);
+      const req: AgentRequest = {
+        prompt: this.opts.buildWorkerPrompt(w),
+        signal: ac.signal,
+      } as AgentRequest;
+      void this.opts.workerRunner(req)
+        .then(async res => {
+          await appendTranscript(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId, {
+            actor: w, kind: res.success ? 'worker_done' : 'worker_failed', note: res.error,
+          });
+        })
+        .catch(async err => {
+          await appendTranscript(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId, {
+            actor: w, kind: 'worker_error', note: (err as Error).message,
+          });
+        });
+    }
+  }
   private async runManagerLoop(): Promise<void> { /* Task 10 */ }
   private armSupervisors(): void { /* Task 11 */ }
   private async emitFinal(reason: DiscussionTerminatedReason, message: string): Promise<void> {

--- a/packages/gateway/src/parallel-team.ts
+++ b/packages/gateway/src/parallel-team.ts
@@ -227,7 +227,35 @@ export class ParallelTeamRunner {
     if (watcher) watcher.close();
     if (debounce) clearTimeout(debounce);
   }
-  private armSupervisors(): void { /* Task 11 */ }
+  private armSupervisors(): void {
+    const start = Date.now();
+    const checkMs = Math.min(500, Math.max(50, this.opts.settings.idleTimeoutMs / 4));
+    const interval = setInterval(async () => {
+      if (this.done) { clearInterval(interval); return; }
+      if (Date.now() - start >= this.opts.settings.maxDurationMs) {
+        clearInterval(interval);
+        await this.stop('max_duration', 'discussion exceeded maximum duration');
+        return;
+      }
+      // idle timeout: latest mtime across opinions + summary
+      let latest = 0;
+      try {
+        const files = [summaryPath(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId)];
+        const wnames = await listOpinionFiles(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId);
+        for (const w of wnames) files.push(opinionPath(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId, w));
+        for (const f of files) {
+          try { latest = Math.max(latest, (await fs.promises.stat(f)).mtimeMs); } catch { /* ignore */ }
+        }
+      } catch { /* ignore */ }
+      if (latest > this.lastMtimeMs) {
+        this.lastMtimeMs = latest;
+        this.idleSince = Date.now();
+      } else if (Date.now() - this.idleSince >= this.opts.settings.idleTimeoutMs) {
+        clearInterval(interval);
+        await this.stop('timeout', 'no activity within idle window');
+      }
+    }, checkMs);
+  }
   private async emitFinal(reason: DiscussionTerminatedReason, message: string): Promise<void> {
     const summary = safeRead(summaryPath(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId));
     const perWorker: Array<{ name: string; excerpt: string }> = [];

--- a/packages/gateway/src/parallel-team.ts
+++ b/packages/gateway/src/parallel-team.ts
@@ -115,7 +115,118 @@ export class ParallelTeamRunner {
         });
     }
   }
-  private async runManagerLoop(): Promise<void> { /* Task 10 */ }
+  private async runManagerLoop(): Promise<void> {
+    const dir = this.discussionDir;
+    const wsRoot = this.opts.workspacesRoot;
+    const ws = this.opts.workspace;
+    const chat = this.opts.chatId;
+    const ctrlPath = controlPath(wsRoot, ws, chat);
+    const sumPath = summaryPath(wsRoot, ws, chat);
+    const topPath = topicPath(wsRoot, ws, chat);
+
+    let watcher: fs.FSWatcher | undefined;
+    let debounce: NodeJS.Timeout | null = null;
+    const tickSignal = (() => {
+      let resolveTick: (() => void) | null = null;
+      return {
+        wait: () => new Promise<void>(res => { resolveTick = res; }),
+        poke: () => { if (resolveTick) { const r = resolveTick!; resolveTick = null; r(); } },
+      };
+    })();
+
+    try {
+      watcher = fs.watch(dir, { recursive: false }, () => {
+        if (debounce) clearTimeout(debounce);
+        debounce = setTimeout(() => tickSignal.poke(), 2000);
+      });
+    } catch { /* watch may fail on some FS; poll covers it */ }
+
+    let pendingUserAnswer: { question: string; answer: string } | undefined;
+
+    while (!this.done) {
+      await new Promise<void>(res => setTimeout(res, this.opts.settings.managerPollMs));
+      if (this.done) break;
+
+      const topic = safeRead(topPath);
+      const summary = safeRead(sumPath);
+      const opinions = (await listOpinionFiles(wsRoot, ws, chat)).map(name => ({
+        name,
+        text: safeRead(opinionPath(wsRoot, ws, chat, name)),
+      }));
+      const pendingAsks = extractPendingAsks(opinions);
+      const ctrl = await readControl(ctrlPath);
+      this.idleSince = Date.now();
+
+      const prompt = buildParallelManagerPrompt({
+        topic, summary, opinions, pendingAsks, idleMs: 0,
+        revision: ctrl?.revision ?? 0,
+        userAnswer: pendingUserAnswer,
+      });
+      pendingUserAnswer = undefined;
+
+      let resp: AgentResponse;
+      try {
+        resp = await this.opts.managerRunner({ prompt, signal: this.abort.signal } as AgentRequest);
+      } catch (err) {
+        await appendTranscript(wsRoot, ws, chat, { actor: 'manager', kind: 'error', note: (err as Error).message });
+        continue;
+      }
+      if (!resp.success) {
+        await appendTranscript(wsRoot, ws, chat, { actor: 'manager', kind: 'error', note: resp.error });
+        continue;
+      }
+      const turn = parseParallelManagerTurn(resp.output);
+      if (!turn) {
+        await appendTranscript(wsRoot, ws, chat, { actor: 'manager', kind: 'parse_error' });
+        continue;
+      }
+
+      if (turn.summary_update) {
+        await fs.promises.writeFile(sumPath, `# Summary\n\n${turn.summary_update}\n`, 'utf-8');
+      }
+      if (turn.directive) {
+        await writeControl(ctrlPath, prev => ({ ...prev, status: prev.status, directive: turn.directive! })).catch(() => undefined);
+      }
+
+      if (turn.action === 'continue') {
+        await appendTranscript(wsRoot, ws, chat, { actor: 'manager', kind: 'continue', note: turn.reason });
+        continue;
+      }
+      if (turn.action === 'ask_user') {
+        await writeControl(ctrlPath, prev => ({
+          ...prev,
+          status: 'paused',
+          userQuestion: turn.user_question,
+          userQuestionChoices: turn.user_question_choices,
+        })).catch(() => undefined);
+        const answerPromise = new Promise<string>(res => { this.pendingResume = res; });
+        this.opts.onUserQuestion({
+          question: turn.user_question!,
+          choices: turn.user_question_choices,
+          resume: async (answer: string) => {
+            if (this.pendingResume) { this.pendingResume(answer); this.pendingResume = null; }
+          },
+        });
+        const answer = await answerPromise;
+        pendingUserAnswer = { question: turn.user_question!, answer };
+        await writeControl(ctrlPath, prev => ({
+          ...prev,
+          status: 'running',
+          resumeNote: `User answered: ${answer}`,
+          userQuestion: undefined,
+          userQuestionChoices: undefined,
+        })).catch(() => undefined);
+        continue;
+      }
+      if (turn.action === 'finalize' || turn.action === 'terminate') {
+        const reason: DiscussionTerminatedReason = turn.action === 'finalize' ? 'consensus' : (turn.reason === 'drift' ? 'drift' : 'consensus');
+        await this.stop(reason, turn.final_message || '');
+        break;
+      }
+    }
+    if (watcher) watcher.close();
+    if (debounce) clearTimeout(debounce);
+  }
   private armSupervisors(): void { /* Task 11 */ }
   private async emitFinal(reason: DiscussionTerminatedReason, message: string): Promise<void> {
     const summary = safeRead(summaryPath(this.opts.workspacesRoot, this.opts.workspace, this.opts.chatId));
@@ -131,4 +242,16 @@ export class ParallelTeamRunner {
 
 function safeRead(p: string): string {
   try { return fs.readFileSync(p, 'utf-8'); } catch { return ''; }
+}
+
+function extractPendingAsks(opinions: Array<{ name: string; text: string }>): Array<{ worker: string; question: string }> {
+  const out: Array<{ worker: string; question: string }> = [];
+  for (const o of opinions) {
+    const lines = o.text.split('\n');
+    for (const line of lines) {
+      const m = /^\[ASK_MANAGER\]:\s*(.+)$/.exec(line.trim());
+      if (m) out.push({ worker: o.name, question: m[1] });
+    }
+  }
+  return out;
 }

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       'src/config.test.ts',
       'src/digit-mapping.test.ts',
       'src/team-pause.test.ts',
+      'src/chats.discussion.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       'src/digit-mapping.test.ts',
       'src/team-pause.test.ts',
       'src/chats.discussion.test.ts',
+      'src/parallel-team.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },


### PR DESCRIPTION
## Summary

- Add `dispatch: 'parallel'` mode for teams — all workers run concurrently as long-lived agent sessions, communicating via shared opinion files in `chats/<chatId>/discussion/`
- A Manager loop (`fs.watch` + 30s heartbeat) maintains `summary.md`, evaluates progress, and decides to continue / ask the user / terminate
- Three exit gates: Manager judgment (consensus/drift), max-duration supervisor, idle-timeout supervisor
- Discussions are Chat-linked — resume, deletion cleanup, and listing come for free
- User `/cancel` stops active parallel runs gracefully (soft signal → hard abort)

## New files

- `packages/core/src/discussion/` — file layout helpers, control.md parser/serializer, Manager prompt builder + JSON parser
- `packages/gateway/src/parallel-team.ts` — `ParallelTeamRunner` orchestrator (worker loops + Manager loop + supervisors)

## Modified files

- `packages/core/src/workspace.ts` — accept `dispatch: 'parallel'` + `parallel: { maxDurationMs, idleTimeoutMs, managerPollMs }`
- `packages/core/src/types/chat.ts` — `Chat.discussion?: DiscussionMeta`
- `packages/core/src/workers.ts` — `buildParallelWorkerPrompt()`
- `packages/gateway/src/gateway.ts` — route parallel teams to runner, wire cancel, resume detection
- `packages/gateway/src/chats.ts` — clean up discussion dir on chat delete

## Test plan

- [ ] 29 core tests pass (`packages/core`: workspace config normalization, discussion file helpers, control parser, manager prompt/parser)
- [ ] 28 gateway tests pass (`packages/gateway`: chat discussion metadata, parallel-team runner lifecycle, worker dispatch, manager terminate/ask_user/continue, max-duration supervisor, idle-timeout supervisor, resume)
- [ ] TypeScript strict build clean on both packages
- [ ] Manual: configure a team with `dispatch: 'parallel'`, run `/team <name> <topic>`, verify workers write opinions and Manager produces summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)