### PR TITLE
refactor(gateway): separate channelUserId and channelChatId

### DIFF
--- a/codey-mac/src/components/ChannelsSection.tsx
+++ b/codey-mac/src/components/ChannelsSection.tsx
@@ -38,7 +38,7 @@ interface ChannelField {
   label: string
   value: string
   secret?: boolean
-  onChange: (next: string) => void
+  onChange: (next: string) => boolean | void
 }
 
 const ChannelEditor: React.FC<{
@@ -96,7 +96,12 @@ const ChannelEditor: React.FC<{
                 type={f.secret ? 'password' : 'text'}
                 value={drafts[i] ?? ''}
                 onChange={e => setDrafts(d => { const n = d.slice(); n[i] = e.target.value; return n })}
-                onBlur={() => { if (drafts[i] !== f.value) f.onChange(drafts[i] ?? '') }}
+                onBlur={() => {
+                  if (drafts[i] !== f.value) {
+                    const result = f.onChange(drafts[i] ?? '')
+                    if (result === false) setDrafts(d => { const n = d.slice(); n[i] = f.value; return n })
+                  }
+                }}
                 style={{ ...inputStyle, width: '100%' }}
               />
             </div>
@@ -174,7 +179,12 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({ liveStatus, is
         }}
         fields={[
           { label: 'Bot Token', value: channels.telegram?.botToken ?? '', secret: true,
-            onChange: v => setTelegram({ botToken: v }) },
+            onChange: v => {
+              if (channels.telegram?.botToken && v !== channels.telegram.botToken) {
+                if (!window.confirm('Changing the Bot Token will disconnect all linked Telegram channels. Users will need to re-pair.\n\nContinue?')) return false
+              }
+              setTelegram({ botToken: v })
+            } },
         ]}
         note={!channels.telegram?.botToken ? 'A Bot Token is required to enable Telegram.' : undefined}
       />
@@ -185,7 +195,12 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({ liveStatus, is
         onToggle={enabled => setDiscord({ enabled })}
         fields={[
           { label: 'Bot Token', value: channels.discord?.botToken ?? '', secret: true,
-            onChange: v => setDiscord({ botToken: v }) },
+            onChange: v => {
+              if (channels.discord?.botToken && v !== channels.discord.botToken) {
+                if (!window.confirm('Changing the Bot Token will disconnect all linked Discord channels. Users will need to re-pair.\n\nContinue?')) return false
+              }
+              setDiscord({ botToken: v })
+            } },
         ]}
       />
       <ChannelEditor

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { Chat, ChatMessage } from '../types'
 import { C } from '../theme'
 import { parseTeamMessage } from './teamMessageFormat'
+import { ToolDetail } from './toolFormat'
 
 interface Props {
   chat: Chat
@@ -352,18 +353,7 @@ const ToolTimeline: React.FC<{ toolCalls: import('../types').ToolCallEntry[] }> 
               </div>
               {hasDetail && isOpen && (
                 <div style={timelineStyles.detail}>
-                  {r.input && (
-                    <>
-                      <div style={timelineStyles.detailLabel}>input</div>
-                      <pre style={timelineStyles.code}>{JSON.stringify(r.input, null, 2)}</pre>
-                    </>
-                  )}
-                  {r.output && (
-                    <>
-                      <div style={timelineStyles.detailLabel}>output</div>
-                      <pre style={timelineStyles.code}>{truncate(r.output, 2048)}</pre>
-                    </>
-                  )}
+                  <ToolDetail rawTool={r.tool} input={r.input ?? {}} output={r.output} />
                   {!r.done && !r.output && (
                     <div style={timelineStyles.detailLabel}>(no result yet)</div>
                   )}
@@ -378,11 +368,6 @@ const ToolTimeline: React.FC<{ toolCalls: import('../types').ToolCallEntry[] }> 
       </div>
     </Section>
   )
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s
-  return s.slice(0, max) + `\n… (${s.length - max} more chars)`
 }
 
 const timelineStyles: Record<string, React.CSSProperties> = {
@@ -408,10 +393,6 @@ const timelineStyles: Record<string, React.CSSProperties> = {
     maxHeight: 280, overflowY: 'auto',
   },
   detailLabel: { color: C.fg3, fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 4 },
-  code: {
-    color: C.fg, fontSize: 11, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-    margin: '4px 0 0 0', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-  },
 }
 
 const AttachmentsSection: React.FC<{ attachments: import('../types').FileAttachment[] }> = ({ attachments }) => {

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -2,12 +2,9 @@ export type ChannelKind = 'telegram' | 'discord' | 'imessage';
 
 export interface ChatRoute {
   channel: ChannelKind;
-  /** Channel-side user identifier (e.g. Telegram user id, Discord user id, iMessage handle). */
+  /** Channel-side user identifier (e.g. Telegram from.id, Discord author.id). Used for route matching. */
   channelUserId: string;
-  /**
-   * Channel-side conversation identifier (e.g. Telegram chat id, Discord channel id).
-   * For 1:1 DM channels this often equals channelUserId; we store both for clarity.
-   */
+  /** Channel-side conversation identifier (e.g. Telegram chat.id, Discord channelId). Used as send target. */
   channelChatId: string;
   /** Unix ms when this route was attached. */
   attachedAt: number;

--- a/packages/gateway/src/channels/discord.ts
+++ b/packages/gateway/src/channels/discord.ts
@@ -106,7 +106,7 @@ export class DiscordHandler extends BaseChannelHandler {
   }
 
   async sendToRoute(route: ChatRoute, text: string): Promise<void> {
-    if (route.channel !== 'discord' || !this.client) return;
+    if (route.channel !== 'discord' || !this.client || !route.channelChatId) return;
     const channel = await this.client.channels.fetch(route.channelChatId).catch(() => null);
     if (channel && channel instanceof TextChannel) {
       await channel.send(text);

--- a/packages/gateway/src/channels/telegram.ts
+++ b/packages/gateway/src/channels/telegram.ts
@@ -92,6 +92,10 @@ export class TelegramHandler extends BaseChannelHandler {
       { command: 'workspace', description: 'Switch workspace' },
       { command: 'worker', description: 'Run a specific worker' },
       { command: 'team', description: 'Run workers in sequence' },
+      { command: 'pair', description: 'Pair with Mac app using 6-digit code' },
+      { command: 'new', description: 'Start a new chat' },
+      { command: 'list', description: 'List linked chats' },
+      { command: 'switch', description: 'Switch to a different chat' },
       { command: 'clear', description: 'Clear conversation history' },
       { command: 'reset', description: 'Start new conversation' },
       { command: 'model', description: 'Show or set model' },
@@ -222,7 +226,7 @@ export class TelegramHandler extends BaseChannelHandler {
   }
 
   async sendToRoute(route: ChatRoute, text: string): Promise<void> {
-    if (route.channel !== 'telegram' || !this.bot) return;
+    if (route.channel !== 'telegram' || !this.bot || !route.channelChatId) return;
     await this.bot.sendMessage(route.channelChatId, text);
   }
 

--- a/packages/gateway/src/chats.test.ts
+++ b/packages/gateway/src/chats.test.ts
@@ -15,37 +15,38 @@ async function run() {
   const r = mgr.addRoute(chat.id, {
     channel: 'telegram',
     channelUserId: 'u1',
-    channelChatId: 'u1',
+    channelChatId: 'c1',
     attachedAt: 1,
   });
   assert.strictEqual(r.routes?.length, 1);
   assert.strictEqual(r.routes?.[0].channel, 'telegram');
+  assert.strictEqual(r.routes?.[0].channelChatId, 'c1');
 
   mgr.addRoute(chat.id, {
     channel: 'telegram',
     channelUserId: 'u1',
-    channelChatId: 'u1',
+    channelChatId: 'c1',
     attachedAt: 2,
   });
   assert.strictEqual(mgr.get(chat.id)?.routes?.length, 1);
 
-  const found = mgr.findByRoute('telegram', 'u1', 'u1');
+  const found = mgr.findByRoute('telegram', 'u1');
   assert.strictEqual(found?.id, chat.id);
-  assert.strictEqual(mgr.findByRoute('telegram', 'u1', 'other'), undefined);
+  assert.strictEqual(mgr.findByRoute('telegram', 'other'), undefined);
 
-  const after = mgr.removeRoute(chat.id, 'telegram', 'u1', 'u1');
+  const after = mgr.removeRoute(chat.id, 'telegram', 'u1');
   assert.strictEqual(after.routes?.length ?? 0, 0);
-  assert.strictEqual(mgr.findByRoute('telegram', 'u1', 'u1'), undefined);
+  assert.strictEqual(mgr.findByRoute('telegram', 'u1'), undefined);
 
   const r2 = mgr.addRoute(chat.id, {
     channel: 'discord',
     channelUserId: 'd1',
-    channelChatId: 'd1',
+    channelChatId: 'dc1',
     attachedAt: 3,
   });
   assert.strictEqual(r2.routes?.length, 1);
   const reloaded = new ChatManager(root);
-  assert.strictEqual(reloaded.findByRoute('discord', 'd1', 'd1')?.id, chat.id);
+  assert.strictEqual(reloaded.findByRoute('discord', 'd1')?.id, chat.id);
 
   // pendingTeam round-trip
   const pending = {

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -344,8 +344,7 @@ export class ChatManager {
     chat.routes ??= [];
     const exists = chat.routes.some(r =>
       r.channel === route.channel &&
-      r.channelUserId === route.channelUserId &&
-      r.channelChatId === route.channelChatId
+      r.channelUserId === route.channelUserId
     );
     if (!exists) {
       chat.routes.push(route);
@@ -355,12 +354,12 @@ export class ChatManager {
     return chat;
   }
 
-  removeRoute(chatId: string, channel: ChannelKind, channelUserId: string, channelChatId: string): Chat {
+  removeRoute(chatId: string, channel: ChannelKind, channelUserId: string): Chat {
     const chat = this.requireChat(chatId);
     if (!chat.routes) return chat;
     const before = chat.routes.length;
     chat.routes = chat.routes.filter(r =>
-      !(r.channel === channel && r.channelUserId === channelUserId && r.channelChatId === channelChatId)
+      !(r.channel === channel && r.channelUserId === channelUserId)
     );
     if (chat.routes.length !== before) {
       chat.updatedAt = Date.now();
@@ -369,15 +368,28 @@ export class ChatManager {
     return chat;
   }
 
-  findByRoute(channel: ChannelKind, channelUserId: string, channelChatId: string): Chat | undefined {
+  clearRoutesForChannel(channel: ChannelKind): number {
+    this.ensureLoaded();
+    let removed = 0;
+    for (const chat of this.cache.values()) {
+      if (!chat.routes?.length) continue;
+      const before = chat.routes.length;
+      chat.routes = chat.routes.filter(r => r.channel !== channel);
+      if (chat.routes.length !== before) {
+        removed += before - chat.routes.length;
+        chat.updatedAt = Date.now();
+        this.persist(chat);
+      }
+    }
+    return removed;
+  }
+
+  findByRoute(channel: ChannelKind, channelUserId: string): Chat | undefined {
     this.ensureLoaded();
     for (const chat of this.cache.values()) {
-      if (chat.routes?.some(r =>
-        r.channel === channel &&
-        r.channelUserId === channelUserId &&
-        r.channelChatId === channelChatId
-      )) {
-        return chat;
+      if (!chat.routes?.length) continue;
+      for (const r of chat.routes) {
+        if (r.channel === channel && r.channelUserId === channelUserId) return chat;
       }
     }
     return undefined;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -256,7 +256,10 @@ export class Codey {
       try { await existing.stop(); }
       catch (e) { this.logger.error(`Failed to stop ${name} handler: ${e}`); }
       this.handlers.delete(name);
-      this.logger.info(`${name} handler stopped`);
+
+      const removedRoutes = this.chatManager.clearRoutesForChannel(name);
+      const removedPairings = this.pairingStore.clearChannel(name);
+      this.logger.info(`${name} handler stopped — cleared ${removedRoutes} route(s), ${removedPairings} pairing(s)`);
     }
 
     if (next) {
@@ -311,27 +314,18 @@ export class Codey {
     const binding = this.pairingStore.findByChannelUser(channel, channelUserId);
     if (!binding) throw new Error(`No pairing for ${channel}:${channelUserId}`);
 
-    // 1:1 DM model — channelChatId equals channelUserId. See spec §Identity.
-    const channelChatId = channelUserId;
-    const route: ChatRoute = { channel, channelUserId, channelChatId, attachedAt: Date.now() };
+    const route: ChatRoute = { channel, channelUserId, channelChatId: binding.channelChatId, attachedAt: Date.now() };
 
-    // Detect "already linked" before mutating, so we can skip the summary push
-    // on repeat clicks. addRoute is idempotent but unconditionally re-sending
-    // the summary would spam the channel every time the user clicks the link
-    // button while the route is already attached.
     const existing = this.chatManager.get(chatId);
     const alreadyLinked = !!existing?.routes?.some(r =>
       r.channel === channel &&
-      r.channelUserId === channelUserId &&
-      r.channelChatId === channelChatId
+      r.channelUserId === channelUserId
     );
 
     const updated = this.chatManager.addRoute(chatId, route);
     this.pairingStore.setCurrentChat(channel, channelUserId, chatId);
 
     if (!alreadyLinked) {
-      // Resolve the chat's effective agent/model — same logic as sendToChat —
-      // so the summary reflects the actual runtime config, not just gateway defaults.
       const effectiveAgent = (updated.agent ?? this.getDefaultAgent()) as CodingAgent;
       const effectiveModel = updated.model
         ?? this.getDefaultModelConfig(effectiveAgent)?.model
@@ -353,8 +347,7 @@ export class Codey {
   }
 
   public unlinkChat(chatId: string, channel: ChannelKind, channelUserId: string): Chat {
-    const channelChatId = channelUserId;
-    return this.chatManager.removeRoute(chatId, channel, channelUserId, channelChatId);
+    return this.chatManager.removeRoute(chatId, channel, channelUserId);
   }
 
   getAgentFactory(): AgentFactory { return this.agentFactory; }
@@ -689,14 +682,21 @@ export class Codey {
     return false;
   }
 
+  /** Resolve which Codey Chat this channel message belongs to. */
+  private resolveChatId(channel: ChannelType, userId: string): string | undefined {
+    if (!this.isPairableChannel(channel)) return undefined;
+    const byRoute = this.chatManager.findByRoute(channel, userId);
+    if (byRoute) return byRoute.id;
+    // 2. Per-user pairing `currentChatId` — multi-Chat /switch shortcut.
+    const binding = this.pairingStore.findByChannelUser(channel, userId);
+    if (binding?.currentChatId) return binding.currentChatId;
+    return undefined;
+  }
+
   private async processPrompt(message: UserMessage, parsed: ParsedCommand): Promise<void> {
     const { userId, chatId, channel } = message;
 
-    let codeyChatId: string | undefined;
-    if (this.isPairableChannel(channel)) {
-      const binding = this.pairingStore.findByChannelUser(channel, userId);
-      if (binding?.currentChatId) codeyChatId = binding.currentChatId;
-    }
+    const codeyChatId = this.resolveChatId(channel as ChannelType, userId);
 
     // Queue key: prefer the Codey chat id; fall back to the channel-derived id
     // so non-paired channels and Mac users still get per-conversation serialization.
@@ -715,25 +715,13 @@ export class Codey {
   private async runOneTurn(message: UserMessage, parsed: ParsedCommand): Promise<void> {
     const { userId, chatId, channel, id: messageId } = message;
 
+    const codeyChatId = this.resolveChatId(channel as ChannelType, userId);
+
     // Channel-side with a linked Codey chat → route through sendToChat so the
     // Codey Chat record is updated and the Mac app sees the events.
-    if (this.isPairableChannel(channel)) {
-      const binding = this.pairingStore.findByChannelUser(channel, userId);
-      if (binding?.currentChatId) {
-        await this.runChannelTurnViaChat(message, parsed, binding.currentChatId);
-        return;
-      }
-    }
-
-    // Channel-side: if this user has a paired binding with a current chat,
-    // use it for Codey-side state (context window, fan-out lookup). Replies
-    // continue to use `chatId` (the channel-side chat id) for routing.
-    let codeyChatId: string | undefined;
-    if (this.isPairableChannel(channel)) {
-      const binding = this.pairingStore.findByChannelUser(channel, userId);
-      if (binding?.currentChatId) {
-        codeyChatId = binding.currentChatId;
-      }
+    if (codeyChatId) {
+      await this.runChannelTurnViaChat(message, parsed, codeyChatId);
+      return;
     }
 
     // Get or create structured context window keyed by conversationId
@@ -1390,7 +1378,7 @@ export class Codey {
       await this.sendResponse({ chatId, channel, text: 'Usage: /pair <6-digit code from the Mac app>' });
       return;
     }
-    const ok = this.pairingStore.completePairing(code, { channel, channelUserId: userId });
+    const ok = this.pairingStore.completePairing(code, { channel, channelUserId: userId, channelChatId: chatId });
     await this.sendResponse({
       chatId,
       channel,
@@ -1425,7 +1413,7 @@ export class Codey {
     this.chatManager.addRoute(chat.id, {
       channel,
       channelUserId: userId,
-      channelChatId: userId,
+      channelChatId: binding.channelChatId,
       attachedAt: Date.now(),
     });
     this.pairingStore.setCurrentChat(channel, userId, chat.id);

--- a/packages/gateway/src/pairings.test.ts
+++ b/packages/gateway/src/pairings.test.ts
@@ -14,13 +14,14 @@ async function run() {
   assert.match(code, /^\d{6}$/);
   assert.strictEqual(store.findByChannelUser('telegram', 'u1'), undefined);
 
-  const ok = store.completePairing(code, { channel: 'telegram', channelUserId: 'u1' });
+  const ok = store.completePairing(code, { channel: 'telegram', channelUserId: 'u1', channelChatId: 'c1' });
   assert.strictEqual(ok, true);
   const binding = store.findByChannelUser('telegram', 'u1');
   assert.ok(binding);
   assert.strictEqual(binding!.channelUserId, 'u1');
+  assert.strictEqual(binding!.channelChatId, 'c1');
 
-  const second = store.completePairing(code, { channel: 'telegram', channelUserId: 'u2' });
+  const second = store.completePairing(code, { channel: 'telegram', channelUserId: 'u2', channelChatId: 'c2' });
   assert.strictEqual(second, false);
 
   store.updatePrefs('telegram', 'u1', { workspace: 'main', agent: 'claude-code', model: 'sonnet-4-6' });
@@ -30,13 +31,13 @@ async function run() {
   assert.strictEqual(b2?.prefs?.agent, 'claude-code');
 
   store.startPairing({ channel: 'telegram' });
-  store.completePairing(store.startPairing({ channel: 'discord' }), { channel: 'discord', channelUserId: 'd1' });
+  store.completePairing(store.startPairing({ channel: 'discord' }), { channel: 'discord', channelUserId: 'd1', channelChatId: 'dc1' });
   const tg = reloaded.listForChannel('telegram');
   assert.strictEqual(tg.length, 1);
 
   const c2 = store.startPairing({ channel: 'telegram', ttlMs: 0 });
   await new Promise(r => setTimeout(r, 5));
-  assert.strictEqual(store.completePairing(c2, { channel: 'telegram', channelUserId: 'u3' }), false);
+  assert.strictEqual(store.completePairing(c2, { channel: 'telegram', channelUserId: 'u3', channelChatId: 'c3' }), false);
 
   fs.rmSync(dir, { recursive: true, force: true });
   console.log('pairings.test ok');

--- a/packages/gateway/src/pairings.ts
+++ b/packages/gateway/src/pairings.ts
@@ -11,6 +11,8 @@ export interface PairingPrefs {
 export interface ChannelBinding {
   channel: ChannelKind;
   channelUserId: string;
+  /** Platform conversation id (e.g. Telegram chat.id, Discord channelId). */
+  channelChatId: string;
   prefs?: PairingPrefs;
   /** Per-binding "current chat" id used for the implicit-routing rule. */
   currentChatId?: string;
@@ -66,7 +68,7 @@ export class PairingStore {
     return code;
   }
 
-  completePairing(code: string, input: { channel: ChannelKind; channelUserId: string }): boolean {
+  completePairing(code: string, input: { channel: ChannelKind; channelUserId: string; channelChatId: string }): boolean {
     const entry = this.pending.get(code);
     if (!entry) return false;
     this.pending.delete(code);
@@ -79,6 +81,7 @@ export class PairingStore {
     this.bindings.push({
       channel: input.channel,
       channelUserId: input.channelUserId,
+      channelChatId: input.channelChatId,
       createdAt: Date.now(),
     });
     this.persist();
@@ -118,5 +121,13 @@ export class PairingStore {
       !(b.channel === channel && b.channelUserId === channelUserId)
     );
     if (this.bindings.length !== before) this.persist();
+  }
+
+  clearChannel(channel: ChannelKind): number {
+    const before = this.bindings.length;
+    this.bindings = this.bindings.filter(b => b.channel !== channel);
+    const removed = before - this.bindings.length;
+    if (removed > 0) this.persist();
+    return removed;
   }
 }


### PR DESCRIPTION
## Summary

- **Split `channelUserId` / `channelChatId` into distinct roles**: `channelUserId` (from `msg.from.id` / `msg.author.id`) for route matching, `channelChatId` (from `msg.chat.id` / `msg.channelId`) as send target — fixes Discord fan-out which was using user ID as channel ID
- **Bot token change clears all routes & pairings**: `reconcileChannel()` calls `clearRoutesForChannel()` + `clearChannel()` when a handler restarts, forcing users to re-pair. Mac app shows confirm dialog before token change
- **Removes catch-all route concept**: explicit `/pair` is always required, no implicit matching
- **Registers `/pair /new /list /switch` in Telegram bot command menu**

## Test plan

- [x] `chats.test.ts` passes
- [x] `pairings.test.ts` passes
- [x] TypeScript type-check passes (core, gateway, codey-mac)
- [ ] Manual: pair Telegram bot, link chat, verify bidirectional messaging
- [ ] Manual: change bot token in Mac app, verify confirm dialog and re-pair requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)