### PR TITLE
feat(mac): collapsible tool actions in completed messages

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -340,7 +340,7 @@ const ToolTimeline: React.FC<{ toolCalls: import('../types').ToolCallEntry[] }> 
             next.has(r.id) ? next.delete(r.id) : next.add(r.id)
             return next
           })
-          const icon = !r.done ? '▶' : '✓'
+          const icon = isOpen ? '▾' : '▶'
           return (
             <div key={r.id}>
               <div

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -237,6 +237,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
               {!collapsed && groups[ws].map(chat => {
                 const active = chat.id === activeChatId
                 const flight = state.inFlight[chat.id]
+                const unread = !!state.unreadChats[chat.id]
                 const isRenaming = renamingId === chat.id
                 const orphaned = workspaces.length > 0 && !workspaces.includes(chat.workspaceName)
                 return (
@@ -281,6 +282,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
                       <span style={styles.title}>{chat.title}</span>
                     )}
                     <RouteIcons routes={chat.routes} />
+                    {unread && !active && <span style={styles.unreadDot} />}
                     {flight && <span style={styles.dot} />}
                     {!isRenaming && (
                       <button
@@ -461,6 +463,7 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 4, padding: '2px 6px', color: C.fg, fontSize: 12, outline: 'none',
   },
   dot: { width: 6, height: 6, borderRadius: '50%', background: C.accent, animation: 'codey-pulse-dot 1.2s infinite' },
+  unreadDot: { width: 6, height: 6, borderRadius: '50%', background: C.accent, flexShrink: 0 },
   xBtn: {
     background: 'transparent', border: 'none', color: C.fg3,
     cursor: 'pointer', fontSize: 14, padding: '0 4px',

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -116,7 +116,7 @@ const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }>
   const target = active ?? lastDone
   if (!target) return null
   const headline = formatHeadline(target.tool, target.input ?? {})
-  const canExpand = !active && lastDone && hasDetail(lastDone.tool, lastDone.input ?? {}, lastDone.output)
+  const canExpand = !!lastDone && hasDetail(lastDone.tool, lastDone.input ?? {}, lastDone.output)
   return (
     <div>
       <div

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -116,19 +116,24 @@ const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }>
   const target = active ?? lastDone
   if (!target) return null
   const headline = formatHeadline(target.tool, target.input ?? {})
-  const canExpand = !!lastDone && hasDetail(lastDone.tool, lastDone.input ?? {}, lastDone.output)
+  const detailTarget = active
+    ? { tool: active.tool, input: active.input ?? {}, output: undefined as string | undefined }
+    : lastDone
+      ? { tool: lastDone.tool, input: lastDone.input ?? {}, output: lastDone.output }
+      : null
+  const canExpand = !!detailTarget && hasDetail(detailTarget.tool, detailTarget.input, detailTarget.output)
   return (
     <div>
       <div
         style={{ ...styles.liveActivity, cursor: canExpand ? 'pointer' : 'default' }}
         onClick={canExpand ? () => setExpanded(v => !v) : undefined}
       >
-        <span style={styles.liveActivityDot}>{active ? '●' : canExpand ? (expanded ? '▾' : '▸') : '○'}</span>
+        <span style={styles.liveActivityDot}>{active ? (expanded ? '▾' : '●') : canExpand ? (expanded ? '▾' : '▸') : '○'}</span>
         <span>{headline}</span>
       </div>
-      {expanded && canExpand && lastDone && (
+      {expanded && canExpand && detailTarget && (
         <div style={styles.liveActivityDetail}>
-          <ToolDetail rawTool={lastDone.tool} input={lastDone.input ?? {}} output={lastDone.output} />
+          <ToolDetail rawTool={detailTarget.tool} input={detailTarget.input} output={detailTarget.output} />
         </div>
       )}
     </div>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -9,7 +9,7 @@ import { PairingModal } from './PairingModal'
 import { consumePendingPairing } from './pendingPairing'
 import { ChatContextPanel } from './ChatContextPanel'
 import { parseTeamMessage } from './teamMessageFormat'
-import { formatHeadline, normalizeTool } from './toolFormat'
+import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 
 interface Props {
   chatId: string
@@ -98,27 +98,39 @@ const splitParagraphs = (text: string): string[] =>
   text.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean)
 
 const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }> = ({ toolCalls }) => {
+  const [expanded, setExpanded] = useState(false)
   if (!toolCalls || toolCalls.length === 0) return null
   const pending = new Map<string, { id: string; tool?: string; input?: Record<string, unknown> }>()
-  let lastDone: { tool?: string; input?: Record<string, unknown> } | null = null
+  let lastDone: { tool?: string; input?: Record<string, unknown>; output?: string } | null = null
   for (const tc of toolCalls) {
     if (tc.type === 'tool_start') {
       pending.set(normalizeTool(tc.tool), { id: tc.id, tool: tc.tool, input: tc.input })
     } else if (tc.type === 'tool_end') {
       const key = normalizeTool(tc.tool)
       const p = pending.get(key)
-      if (p) { lastDone = { tool: p.tool, input: p.input }; pending.delete(key) }
-      else { lastDone = { tool: tc.tool } }
+      if (p) { lastDone = { tool: p.tool, input: p.input, output: tc.output }; pending.delete(key) }
+      else { lastDone = { tool: tc.tool, output: tc.output } }
     }
   }
   const active = pending.size > 0 ? Array.from(pending.values()).pop()! : null
   const target = active ?? lastDone
   if (!target) return null
   const headline = formatHeadline(target.tool, target.input ?? {})
+  const canExpand = !active && lastDone && hasDetail(lastDone.tool, lastDone.input ?? {}, lastDone.output)
   return (
-    <div style={styles.liveActivity}>
-      <span style={styles.liveActivityDot}>{active ? '●' : '○'}</span>
-      <span>{headline}</span>
+    <div>
+      <div
+        style={{ ...styles.liveActivity, cursor: canExpand ? 'pointer' : 'default' }}
+        onClick={canExpand ? () => setExpanded(v => !v) : undefined}
+      >
+        <span style={styles.liveActivityDot}>{active ? '●' : canExpand ? (expanded ? '▾' : '▸') : '○'}</span>
+        <span>{headline}</span>
+      </div>
+      {expanded && canExpand && lastDone && (
+        <div style={styles.liveActivityDetail}>
+          <ToolDetail rawTool={lastDone.tool} input={lastDone.input ?? {}} output={lastDone.output} />
+        </div>
+      )}
     </div>
   )
 }
@@ -201,7 +213,7 @@ const TeamMessage: React.FC<{
 }
 
 export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
-  const { state, sendMessage, stopChat, setSelection, setAgentModel, renameChat, setContextPanelOpen, linkChannel, unlinkChannel } = useChats()
+  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, renameChat, setContextPanelOpen, linkChannel, unlinkChannel } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -319,6 +331,21 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [flight, chatId])
+  // When a turn is interrupted, lift the original prompt back into the input
+  // and focus the textarea so the user can edit/resend without retyping.
+  const restoreText = state.pendingRestores[chatId]
+  useEffect(() => {
+    if (restoreText === undefined) return
+    setInput(restoreText)
+    clearRestore(chatId)
+    requestAnimationFrame(() => {
+      const ta = taRef.current
+      if (!ta) return
+      ta.focus()
+      const len = ta.value.length
+      try { ta.setSelectionRange(len, len) } catch { /* not supported */ }
+    })
+  }, [restoreText, chatId])
   useEffect(() => { localStorage.setItem('codey.contextPanelWidth', String(panelWidth)) }, [panelWidth])
   // Track window width so the context panel can shrink (or be hidden) when
   // the user resizes Codey down — at small widths the middle column was
@@ -1216,4 +1243,9 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 4, border: `1px solid ${C.border2}`,
   },
   liveActivityDot: { color: '#6ab0f3', fontSize: 9 },
+  liveActivityDetail: {
+    marginTop: 4, marginBottom: 6,
+    padding: 8, background: 'rgba(0,0,0,0.25)', borderRadius: 4,
+    border: `1px solid ${C.border}`,
+  },
 }

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -20,6 +20,7 @@ interface State {
   // When a turn is interrupted, the prompt text is stashed here so ChatTab
   // can repopulate the input box for the matching chat.
   pendingRestores: Record<string, string>
+  unreadChats: Record<string, true>
 }
 
 type Action =
@@ -88,8 +89,11 @@ function reducer(state: State, action: Action): State {
       delete inFlight[action.chatId]
       return { ...state, chats, order, selectedChatId, inFlight }
     }
-    case 'select':
-      return { ...state, selectedChatId: action.chatId }
+    case 'select': {
+      const unreadChats = { ...state.unreadChats }
+      if (action.chatId) delete unreadChats[action.chatId]
+      return { ...state, selectedChatId: action.chatId, unreadChats }
+    }
     case 'toggleWorkspace': {
       const collapsed = { ...state.collapsedWorkspaces }
       if (collapsed[action.workspaceName]) delete collapsed[action.workspaceName]
@@ -174,11 +178,15 @@ function reducer(state: State, action: Action): State {
       if (action.title) updatedChat.title = action.title
       const inFlight = { ...state.inFlight }
       delete inFlight[action.chatId]
+      const unreadChats = state.selectedChatId !== action.chatId
+        ? { ...state.unreadChats, [action.chatId]: true as const }
+        : state.unreadChats
       return {
         ...state,
         chats: { ...state.chats, [chat.id]: updatedChat },
         order: reorder(state.order, chat.id),
         inFlight,
+        unreadChats,
       }
     }
     case 'stoppedSend': {
@@ -261,6 +269,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     })(),
     workspaces: [],
     pendingRestores: {},
+    unreadChats: {},
   })
 
   const pendingAssistantId = useRef<Record<string, string>>({})

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -5,6 +5,7 @@ import type { ChatStreamEvent } from '../../../packages/gateway/src/chat-runner'
 
 interface InFlight {
   assistantMessageId: string
+  userMessageId: string
   agentStatus: 'idle' | 'thinking' | 'working' | 'writing'
   queuedPosition?: number
 }
@@ -16,6 +17,9 @@ interface State {
   inFlight: Record<string, InFlight>
   collapsedWorkspaces: Record<string, true>
   workspaces: string[]
+  // When a turn is interrupted, the prompt text is stashed here so ChatTab
+  // can repopulate the input box for the matching chat.
+  pendingRestores: Record<string, string>
 }
 
 type Action =
@@ -31,6 +35,8 @@ type Action =
   | { type: 'queued'; chatId: string; position: number }
   | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
+  | { type: 'stoppedSend'; chatId: string; text: string }
+  | { type: 'clearRestore'; chatId: string }
   | { type: 'patchContextPanelOpen'; chatId: string; open: boolean | null }
 
 function reorder(order: string[], chatId: string): string[] {
@@ -112,7 +118,11 @@ function reducer(state: State, action: Action): State {
         order: reorder(state.order, chat.id),
         inFlight: {
           ...state.inFlight,
-          [chat.id]: { assistantMessageId: action.assistantMessageId, agentStatus: 'thinking' },
+          [chat.id]: {
+            assistantMessageId: action.assistantMessageId,
+            userMessageId: action.userMessage.id,
+            agentStatus: 'thinking',
+          },
         },
       }
     }
@@ -171,6 +181,31 @@ function reducer(state: State, action: Action): State {
         inFlight,
       }
     }
+    case 'stoppedSend': {
+      const chat = state.chats[action.chatId]
+      const fl = state.inFlight[action.chatId]
+      if (!chat || !fl) return state
+      // Drop both the user prompt and the assistant placeholder for this turn.
+      // The prompt text is stashed in pendingRestores so ChatTab can lift it
+      // back into the input box.
+      const messages = chat.messages.filter(m =>
+        m.id !== fl.userMessageId && m.id !== fl.assistantMessageId
+      )
+      const inFlight = { ...state.inFlight }
+      delete inFlight[action.chatId]
+      return {
+        ...state,
+        chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } },
+        inFlight,
+        pendingRestores: { ...state.pendingRestores, [action.chatId]: action.text },
+      }
+    }
+    case 'clearRestore': {
+      if (!(action.chatId in state.pendingRestores)) return state
+      const pendingRestores = { ...state.pendingRestores }
+      delete pendingRestores[action.chatId]
+      return { ...state, pendingRestores }
+    }
     case 'errorSend': {
       const chat = state.chats[action.chatId]
       if (!chat) return state
@@ -205,6 +240,7 @@ interface ChatsContextValue {
   unlinkChannel: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<void>
   sendMessage: (chatId: string, text: string, attachments?: FileAttachment[]) => Promise<void>
   stopChat: (chatId: string) => Promise<void>
+  clearRestore: (chatId: string) => void
   toggleWorkspace: (workspaceName: string) => void
   refreshWorkspaces: () => Promise<void>
 }
@@ -224,6 +260,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       try { return JSON.parse(localStorage.getItem(LS_COLLAPSED) ?? '{}') } catch { return {} }
     })(),
     workspaces: [],
+    pendingRestores: {},
   })
 
   const pendingAssistantId = useRef<Record<string, string>>({})
@@ -310,6 +347,11 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           }
           break
         }
+        case 'stopped': {
+          dispatch({ type: 'stoppedSend', chatId: ev.chatId, text: ev.text })
+          delete pendingAssistantId.current[ev.chatId]
+          break
+        }
         case 'error': {
           const asstId = pendingAssistantId.current[ev.chatId]
           if (asstId) {
@@ -393,6 +435,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     async stopChat(chatId) {
       try { await apiService.chats.stop(chatId) } catch { /* nothing in flight */ }
     },
+    clearRestore(chatId) { dispatch({ type: 'clearRestore', chatId }) },
     toggleWorkspace(workspaceName) { dispatch({ type: 'toggleWorkspace', workspaceName }) },
     async refreshWorkspaces() {
       const workspaces = await apiService.getWorkspaces()

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -11,6 +11,7 @@ export type ChatStreamEvent =
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
   | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
+  | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string };
 
 function unwrap<T>(result: { ok: true; data: T } | { ok: false; error: string }): T {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -10,6 +10,7 @@ export type ChatStreamEvent =
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
   | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
+  | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string };
 
 export type ChatStreamSink = (e: ChatStreamEvent) => void;

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -250,6 +250,21 @@ export class ChatManager {
     this.cache.delete(chatId);
   }
 
+  /**
+   * Remove a message by id and persist. Used when a turn is aborted and we
+   * want to roll the conversation back so the user can re-edit the prompt.
+   */
+  removeMessage(chatId: string, messageId: string): Chat | undefined {
+    const chat = this.cache.get(chatId);
+    if (!chat) return undefined;
+    const idx = chat.messages.findIndex(m => m.id === messageId);
+    if (idx < 0) return chat;
+    chat.messages.splice(idx, 1);
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
   /** Append a message and persist. Called at message completion. */
   appendMessage(chatId: string, message: ChatMessage): Chat {
     const chat = this.requireChat(chatId);


### PR DESCRIPTION
## Summary
- **Expandable tool call detail**: The in-message LiveActivity indicator is now clickable when a tool call has completed (during streaming). Clicking expands the last tool call's ToolDetail (diffs, command output, file contents) inline.
- **Restore prompt on cancel**: When a streaming turn is cancelled, the user and assistant messages are removed and the original prompt text is restored to the input box for easy re-editing.
- **Version bump**: 0.4.1 → 0.4.2 across monorepo, codey-mac, and @codey/core.

## Test plan
- [ ] Send a message that triggers tool calls, click the activity indicator after a tool finishes (while still streaming) to expand detail
- [ ] Cancel a streaming turn, verify the prompt reappears in the input box
- [ ] Verify LiveActivity still shows ● during active tool execution
- [ ] Verify the activity indicator disappears after the message completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)