### PR TITLE
docs(mac): improve settings descriptions for skip permissions and whisper models

### DIFF
--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -80,7 +80,7 @@ export const AppearanceTab: React.FC = () => {
           <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
             <div>Skip permissions</div>
             <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
-              Auto-approve agent actions (--dangerously-skip-permissions)
+              When enabled, agents run shell commands, edit files, and make network requests without asking for confirmation. Disable to review every action before execution.
             </div>
           </div>
           <Toggle on={skipPerms} onChange={toggleSkipPerms}/>

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -32,14 +32,14 @@ const VOICE_DEFAULT: VoiceCfg = {
 // Values must match real folder names in argmaxinc/whisperkit-coreml on HF.
 // The helper strips the `openai_whisper-` prefix before passing to WhisperKit.
 const LOCAL_MODELS: Array<{ value: string; label: string; note: string }> = [
-  { value: 'openai_whisper-large-v3_turbo_954MB', label: 'large-v3 turbo · 954MB (recommended)', note: '量化版, 速度=small, 质量≈large, 多语言' },
-  { value: 'openai_whisper-large-v3_turbo', label: 'large-v3 turbo · ~1.6GB', note: '全精度 turbo, 质量最佳' },
-  { value: 'openai_whisper-large-v3', label: 'large-v3 · ~3GB (full precision)', note: '原版 large-v3, 最准但最慢, 不是 turbo' },
-  { value: 'openai_whisper-large-v3-v20240930_turbo_632MB', label: 'large-v3 turbo · Sep 2024 · 632MB', note: '更小的量化 turbo, 中文略弱' },
-  { value: 'openai_whisper-small_216MB', label: 'small · 216MB', note: '量化版, 中等质量, 中文一般' },
-  { value: 'openai_whisper-small', label: 'small · ~480MB', note: '全精度 small' },
-  { value: 'openai_whisper-base', label: 'base · ~150MB', note: '低质量, 仅作 quick test' },
-  { value: 'openai_whisper-tiny', label: 'tiny · ~75MB', note: '最小, 中文几乎不可用' },
+  { value: 'openai_whisper-large-v3_turbo_954MB', label: 'large-v3 turbo · 954MB (recommended)', note: 'Quantized — near large-v3 quality at small-model speed. Best balance for most users.' },
+  { value: 'openai_whisper-large-v3_turbo', label: 'large-v3 turbo · ~1.6GB', note: 'Full-precision turbo. Highest accuracy, but larger download and slower inference.' },
+  { value: 'openai_whisper-large-v3', label: 'large-v3 · ~3GB (full precision)', note: 'Original large-v3 (non-turbo). Maximum accuracy at the cost of speed and disk space.' },
+  { value: 'openai_whisper-large-v3-v20240930_turbo_632MB', label: 'large-v3 turbo · Sep 2024 · 632MB', note: 'Compact quantized turbo. Lower disk usage but slightly weaker on non-English languages.' },
+  { value: 'openai_whisper-small_216MB', label: 'small · 216MB', note: 'Quantized small. Moderate quality, acceptable for English; weaker on other languages.' },
+  { value: 'openai_whisper-small', label: 'small · ~480MB', note: 'Full-precision small. Mid-range accuracy and speed.' },
+  { value: 'openai_whisper-base', label: 'base · ~150MB', note: 'Minimal footprint. Low accuracy — useful only for quick testing.' },
+  { value: 'openai_whisper-tiny', label: 'tiny · ~75MB', note: 'Smallest model. Very fast but accuracy is poor; not recommended for real use.' },
 ]
 
 const VOICE_LANGUAGES: Array<{ value: string; label: string }> = [


### PR DESCRIPTION
## Summary
Polishes two settings descriptions in the Mac app:

- **Skip permissions toggle** — now explains what actions agents bypass (shell commands, file edits, network requests) and when to disable it, instead of just naming the CLI flag
- **Whisper model dropdown** — rewritten all 8 model descriptions in consistent English with clear quality/speed/size tradeoffs for each model

## Before / After

### Skip permissions
Before: `Auto-approve agent actions (--dangerously-skip-permissions)`
After: `When enabled, agents run shell commands, edit files, and make network requests without asking for confirmation. Disable to review every action before execution.`

### Whisper models (example)
| Model | Before | After |
|---|---|---|
| large-v3 turbo 954MB | 量化版, 速度=small, 质量≈large, 多语言 | Quantized — near large-v3 quality at small-model speed. Best balance for most users. |
| tiny | 最小, 中文几乎不可用 | Smallest model. Very fast but accuracy is poor; not recommended for real use. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)