### PR TITLE
feat(gateway): iMessage receive via SQLite polling with sender allowlist

### DIFF
--- a/codey-mac/src/components/ChannelsSection.tsx
+++ b/codey-mac/src/components/ChannelsSection.tsx
@@ -6,7 +6,7 @@ import { C } from '../theme'
 interface ChannelsCfg {
   telegram?: { enabled: boolean; botToken: string }
   discord?:  { enabled: boolean; botToken: string }
-  imessage?: { enabled: boolean }
+  imessage?: { enabled: boolean; allowedSenders?: string[]; pollIntervalMs?: number }
 }
 
 const inputStyle: React.CSSProperties = {
@@ -155,7 +155,7 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({ liveStatus, is
     return persist({ ...channels, discord: { ...cur, ...patch } }, 'discord')
   }
   const setIMessage = (patch: Partial<NonNullable<ChannelsCfg['imessage']>>) => {
-    const cur = channels.imessage ?? { enabled: false }
+    const cur = channels.imessage ?? { enabled: false, allowedSenders: [] }
     return persist({ ...channels, imessage: { ...cur, ...patch } }, 'imessage')
   }
 
@@ -207,9 +207,23 @@ export const ChannelsSection: React.FC<ChannelsSectionProps> = ({ liveStatus, is
         label="iMessage"
         enabled={!!channels.imessage?.enabled}
         liveStatus={liveLabel(liveStatus?.imessage)}
-        onToggle={enabled => setIMessage({ enabled })}
-        fields={[]}
-        note="Requires macOS Messages.app and Full Disk Access for the Codey app."
+        onToggle={enabled => {
+          const senders = channels.imessage?.allowedSenders ?? []
+          if (enabled && senders.length === 0) {
+            setError('Add at least one Allowed Sender before enabling iMessage.')
+            return
+          }
+          setError(null)
+          return setIMessage({ enabled })
+        }}
+        fields={[
+          { label: 'Allowed Senders', value: (channels.imessage?.allowedSenders ?? []).join(', '),
+            onChange: v => {
+              const senders = v.split(',').map(s => s.trim()).filter(Boolean)
+              setIMessage({ allowedSenders: senders })
+            } },
+        ]}
+        note="Phone numbers or Apple IDs that can send messages to Codey (comma-separated). Requires Full Disk Access."
       />
     </div>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
@@ -2525,6 +2525,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -3427,7 +3437,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3464,6 +3473,29 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -3549,7 +3581,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4390,7 +4421,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -4406,13 +4436,21 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defer-to-connect": {
@@ -4481,7 +4519,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5350,6 +5387,15 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5463,6 +5509,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -5534,9 +5586,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -5773,6 +5823,12 @@
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -6253,7 +6309,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6286,6 +6341,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -8278,7 +8339,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8341,6 +8401,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8375,6 +8441,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -8748,6 +8844,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -8851,6 +8984,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/react": {
@@ -9678,6 +9826,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -10024,6 +10217,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -10120,13 +10322,39 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-fs/node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10142,9 +10370,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -10155,9 +10381,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -11875,7 +12099,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -11887,10 +12111,11 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
+        "better-sqlite3": "^12.10.0",
         "discord.js": "^14.0.0",
         "dotenv": "^16.0.0",
         "marked": "^15.0.12",
@@ -11902,6 +12127,7 @@
         "codey": "dist/index.js"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node-telegram-bot-api": "^0.64.13",
         "typescript": "^5.9.0"
       }

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@codey/core": "*",
+    "better-sqlite3": "^12.10.0",
     "discord.js": "^14.0.0",
     "dotenv": "^16.0.0",
     "marked": "^15.0.12",
@@ -29,6 +30,7 @@
     "undici": "^5.28.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node-telegram-bot-api": "^0.64.13",
     "typescript": "^5.9.0"
   }

--- a/packages/gateway/src/channels/imessage.ts
+++ b/packages/gateway/src/channels/imessage.ts
@@ -1,35 +1,123 @@
-import { EventEmitter } from 'events';
 import { exec } from 'child_process';
+import Database from 'better-sqlite3';
+import * as os from 'os';
+import * as path from 'path';
 import { BaseChannelHandler, formatChoicesAsText } from './base';
 import { UserMessage, GatewayResponse, ChatRoute } from '@codey/core';
 
-// iMessage handler using macOS AppleScript
-// Note: Requires Mac OS and iMessage enabled
+const CHAT_DB_PATH = path.join(os.homedir(), 'Library', 'Messages', 'chat.db');
+const CORE_DATA_EPOCH_OFFSET = 978307200;
+const DEFAULT_POLL_INTERVAL_MS = 3000;
+
+interface IMessageConfig {
+  enabled: boolean;
+  allowedSenders?: string[];
+  pollIntervalMs?: number;
+}
+
+function coreDataToUnixMs(coreDataTimestamp: number): number {
+  return (coreDataTimestamp / 1e9 + CORE_DATA_EPOCH_OFFSET) * 1000;
+}
+
 export class IMessageHandler extends BaseChannelHandler {
   name = 'imessage';
-  private eventEmitter = new EventEmitter();
+  private db?: Database.Database;
+  private pollInterval?: ReturnType<typeof setInterval>;
+  private lastSeenRowId = 0;
+  private allowedSenders: Set<string> = new Set();
 
-  async start(_config: { enabled: boolean }): Promise<void> {
-    // iMessage polling would require a daemon or external service
-    // For now, we'll support sending via applescript and a simple polling mechanism
-    console.log('[iMessage] Handler started (send-only mode)');
-    
-    // Check for incoming messages via a simple approach
-    // In production, you'd use a service like bluemail or apple-messages-js
+  async start(config: IMessageConfig): Promise<void> {
+    const senders = config.allowedSenders ?? [];
+    if (senders.length === 0) {
+      console.log('[iMessage] No allowedSenders configured — receive disabled, send-only mode');
+    }
+    this.allowedSenders = new Set(senders.map(s => s.toLowerCase()));
+
+    try {
+      this.db = new Database(CHAT_DB_PATH, { readonly: true, fileMustExist: true });
+    } catch (err: any) {
+      if (err.code === 'SQLITE_CANTOPEN' || err.message?.includes('unable to open')) {
+        console.error(
+          '[iMessage] Cannot open chat.db. Grant Full Disk Access to this process:\n' +
+          '  System Settings → Privacy & Security → Full Disk Access\n' +
+          '  Add: Terminal / iTerm / Node.js'
+        );
+      } else {
+        console.error('[iMessage] Failed to open chat.db:', err.message);
+      }
+      console.log('[iMessage] Handler started (send-only mode, database unavailable)');
+      return;
+    }
+
+    const row = this.db.prepare('SELECT MAX(ROWID) AS maxId FROM message').get() as { maxId: number | null } | undefined;
+    this.lastSeenRowId = row?.maxId ?? 0;
+
+    const intervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.pollInterval = setInterval(() => this.poll(), intervalMs);
+
+    console.log(`[iMessage] Handler started — polling every ${intervalMs}ms, ${senders.length} allowed sender(s)`);
   }
 
   async stop(): Promise<void> {
-    // Cleanup if needed
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+      this.pollInterval = undefined;
+    }
+    if (this.db) {
+      this.db.close();
+      this.db = undefined;
+    }
+  }
+
+  private poll(): void {
+    if (!this.db) return;
+
+    try {
+      const rows = this.db.prepare(
+        `SELECT m.ROWID, m.text, m.date, h.id AS handle
+         FROM message m
+         JOIN handle h ON m.handle_id = h.ROWID
+         WHERE m.ROWID > ? AND m.is_from_me = 0 AND m.text IS NOT NULL AND m.text != ''
+         ORDER BY m.ROWID ASC`
+      ).all(this.lastSeenRowId) as Array<{ ROWID: number; text: string; date: number; handle: string }>;
+
+      for (const row of rows) {
+        this.lastSeenRowId = row.ROWID;
+
+        if (this.allowedSenders.size > 0 && !this.allowedSenders.has(row.handle.toLowerCase())) {
+          continue;
+        }
+
+        const message: UserMessage = {
+          id: String(row.ROWID),
+          channel: 'imessage',
+          userId: row.handle,
+          username: row.handle,
+          chatId: row.handle,
+          text: row.text,
+          timestamp: coreDataToUnixMs(row.date),
+        };
+
+        this.emitMessage(message);
+      }
+    } catch (err: any) {
+      console.error('[iMessage] Poll error:', err.message);
+    }
   }
 
   async sendMessage(response: GatewayResponse): Promise<void> {
     const text = formatChoicesAsText(response.text, response.choices);
-    const script = `
-      tell application "Messages"
-        send "${this.escapeString(text)}" to buddy "${response.chatId}"
-      end tell
-    `;
+    await this.runAppleScript(response.chatId, text);
+  }
 
+  async sendToRoute(route: ChatRoute, text: string): Promise<void> {
+    if (route.channel !== 'imessage') return;
+    await this.runAppleScript(route.channelChatId, text);
+  }
+
+  private runAppleScript(recipient: string, text: string): Promise<void> {
+    const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+    const script = `tell application "Messages" to send "${escaped}" to buddy "${recipient}"`;
     return new Promise((resolve, reject) => {
       exec(`osascript -e '${script}'`, (error) => {
         if (error) {
@@ -40,37 +128,5 @@ export class IMessageHandler extends BaseChannelHandler {
         }
       });
     });
-  }
-
-  async sendToRoute(route: ChatRoute, text: string): Promise<void> {
-    if (route.channel !== 'imessage') return;
-    const script = `
-      tell application "Messages"
-        send "${this.escapeString(text)}" to buddy "${route.channelChatId}"
-      end tell
-    `;
-    return new Promise((resolve, reject) => {
-      exec(`osascript -e '${script}'`, (error) => {
-        if (error) {
-          console.error('[iMessage] sendToRoute error:', error.message);
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
-    });
-  }
-
-  onMessage(callback: (message: UserMessage) => Promise<void>): void {
-    this.eventEmitter.on('message', callback);
-  }
-
-  private escapeString(str: string): string {
-    return str.replace(/"/g, '\\"').replace(/\n/g, '\\n');
-  }
-
-  // Method to receive messages (would need external integration)
-  receiveMessage(message: UserMessage): void {
-    this.emitMessage(message);
   }
 }

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -245,6 +245,18 @@ export async function handleCommand(args: string[], config: ConfigManager, logge
       }
       break;
 
+    case 'set-imessage':
+      if (args[1]) {
+        const senders = args.slice(1).join(' ').split(',').map(s => s.trim()).filter(Boolean);
+        config.setIMessageSenders(senders);
+        config.enableChannel('imessage');
+        logger.info(`iMessage configured with ${senders.length} allowed sender(s): ${senders.join(', ')}`);
+      } else {
+        logger.error('Usage: set-imessage <phone-or-email>[,<phone-or-email>,...]');
+        logger.error('Example: set-imessage +8613800138000,someone@icloud.com');
+      }
+      break;
+
     case 'set-loglevel':
       if (args[1]) {
         config.setLogLevel(args[1] as 'debug' | 'info' | 'warn' | 'error');
@@ -295,6 +307,7 @@ function showHelp(): void {
 ║  set-model <name>           Set default model               ║
 ║  set-telegram <token>      Set Telegram bot token          ║
 ║  set-discord <token>       Set Discord bot token           ║
+║  set-imessage <senders>    Set iMessage allowed senders    ║
 ║  set-loglevel <level>      Set log level                   ║
 ║  enable <channel>          Enable a channel                 ║
 ║  disable <channel>         Disable a channel               ║

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -8,11 +8,12 @@ import { ApiKeyEntry, CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, Te
 export interface GatewayConfigJson {
   gateway: {
     port: number;
+    skipPermissions?: boolean;
   };
   channels: {
     telegram?: { enabled: boolean; botToken: string };
     discord?: { enabled: boolean; botToken: string };
-    imessage?: { enabled: boolean };
+    imessage?: { enabled: boolean; allowedSenders?: string[]; pollIntervalMs?: number };
   };
   /**
    * Reserved per-agent settings slot. Currently empty — enablement is derived
@@ -186,6 +187,8 @@ export class ConfigManager extends EventEmitter {
 
   // ── Gateway settings ───────────────────────────────────────────────
   getPort(): number { return this.config.gateway.port; }
+  getSkipPermissions(): boolean { return this.config.gateway.skipPermissions ?? true; }
+  setSkipPermissions(v: boolean): void { this.config.gateway.skipPermissions = v; this.save(); }
 
   /** Canonical default = first entry in fallback.order. */
   getDefaultAgent(): CodingAgent {
@@ -383,10 +386,19 @@ export class ConfigManager extends EventEmitter {
     this.save();
   }
 
+  setIMessageSenders(senders: string[]): void {
+    if (!this.config.channels.imessage) this.config.channels.imessage = { enabled: false, allowedSenders: [] };
+    this.config.channels.imessage.allowedSenders = senders;
+    this.save();
+  }
+
   enableChannel(channel: 'telegram' | 'discord' | 'imessage'): void {
     if (channel === 'telegram' && this.config.channels.telegram) this.config.channels.telegram.enabled = true;
     else if (channel === 'discord' && this.config.channels.discord) this.config.channels.discord.enabled = true;
-    else if (channel === 'imessage') this.config.channels.imessage = { enabled: true };
+    else if (channel === 'imessage') {
+      if (this.config.channels.imessage) this.config.channels.imessage.enabled = true;
+      else this.config.channels.imessage = { enabled: true };
+    }
     this.save();
   }
 
@@ -470,11 +482,11 @@ function normalizeFallback(raw: any, defaults: FallbackConfig): FallbackConfig {
 
 function getDefaultConfig(): GatewayConfigJson {
   return {
-    gateway: { port: 3000 },
+    gateway: { port: 3000, skipPermissions: true },
     channels: {
       telegram: { enabled: false, botToken: '' },
       discord: { enabled: false, botToken: '' },
-      imessage: { enabled: false },
+      imessage: { enabled: false, allowedSenders: [] },
     },
     agents: {
       'claude-code': {},

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -47,7 +47,7 @@ function startGateway(): void {
         botToken: config.channels.telegram.botToken,
       } : undefined,
       discord: config.channels.discord?.enabled ? { botToken: config.channels.discord.botToken } : undefined,
-      imessage: config.channels.imessage?.enabled ? { enabled: true } : undefined,
+      imessage: config.channels.imessage?.enabled ? config.channels.imessage : undefined,
     },
   };
 


### PR DESCRIPTION
Poll ~/Library/Messages/chat.db for incoming messages, filtered by configurable allowedSenders whitelist. Adds set-imessage CLI command and Mac app UI for configuring allowed senders. Requires Full Disk Access; degrades gracefully to send-only when unavailable.