### PR TITLE
ci: add GitHub Actions workflow for build & test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: build & test (ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # Headers for better-sqlite3 in case its prebuilt binary doesn't match
+      # the runner's Node ABI and it has to compile from source.
+      - name: Install native build deps
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
+
+      - run: npm ci
+
+      # Build the two TS packages. This invokes `tsc` which both type-checks
+      # and emits; codey-mac is skipped here because its `build` script runs
+      # electron-builder, which is heavy and only meaningful on macOS.
+      - name: Build core
+        run: npm run build -w @codey/core
+
+      - name: Build gateway
+        run: npm run build -w @codey/gateway
+
+      # Type-check codey-mac without running electron-builder.
+      - name: Type-check codey-mac
+        working-directory: codey-mac
+        run: npx tsc --noEmit
+
+      - name: Test core
+        run: npm test -w @codey/core
+
+      - name: Test gateway
+        run: npm test -w @codey/gateway
+
+      - name: Test codey-mac
+        run: npm test -w codey-mac


### PR DESCRIPTION
## Summary
- Single Ubuntu job: install deps → build core/gateway via `tsc` → type-check `codey-mac` → run vitest in all three workspaces
- Triggers on push to `main` and every PR; concurrent runs on the same branch cancel
- Installs `libsqlite3-dev` as insurance for `better-sqlite3` if a source rebuild is needed
- Skips `codey-mac`'s electron-builder build (mac-only, slow)

Once this lands and shows a green run, you can require it as a status check under *Settings → Branches → main* to gate future PRs.

## Test plan
- [ ] First CI run completes green on this PR
- [ ] If any test hard-imports Mac-only modules (Electron / iMessage SQLite), gate it for `process.platform === 'darwin'`
- [ ] Enable the `build & test (ubuntu)` status check in branch protection after the first green run

🤖 Generated with [Claude Code](https://claude.com/claude-code)