### PR TITLE
fix(core): restore parallel managerPollMs default to 30s

### DIFF
--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -21,7 +21,7 @@ export interface ParallelSettings {
 export const DEFAULT_PARALLEL_SETTINGS: ParallelSettings = {
   maxDurationMs: 600_000,
   idleTimeoutMs: 60_000,
-  managerPollMs: 15_000,
+  managerPollMs: 30_000,
 };
 
 /** Raw team value as it can appear in workspace.json. */


### PR DESCRIPTION
## Summary
- Restores `DEFAULT_PARALLEL_SETTINGS.managerPollMs` from `15_000` back to `30_000`.
- The default was changed at some point without updating `workspace.test.ts:47`, which kept asserting `30_000`. The new CI workflow caught it on the first run.
- Should turn `main` green and exercise the new required status check end-to-end.

## Test plan
- [x] `vitest run src/workspace.test.ts` passes locally
- [ ] CI green on this PR
- [ ] Required-check gate visible on the PR ("build & test (ubuntu)" required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)