### PR TITLE
chore: bump version to 0.5.0 across all packages

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.2.2",
+  "version": "0.5.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.2.2",
+  "version": "0.5.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps root, `codey-mac`, `@codey/core`, and `@codey/gateway` to `0.5.0`.
- The internal packages skip from `0.2.2` → `0.5.0` to align the whole monorepo on one version line.

## Test plan
- [x] CI green