### PR TITLE
feat(mac): slash command autocomplete with dynamic agent discovery

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -212,6 +212,73 @@ async function detectInstalledAgents(): Promise<Record<string, { installed: bool
   return result
 }
 
+interface SlashCommand {
+  name: string
+  description: string
+  source: 'agent' | 'gateway'
+}
+
+const slashCommandCache = new Map<string, { commands: SlashCommand[]; ts: number }>()
+const SLASH_CACHE_TTL = 5 * 60_000
+
+async function discoverSlashCommands(agent: string): Promise<SlashCommand[]> {
+  const cached = slashCommandCache.get(agent)
+  if (cached && Date.now() - cached.ts < SLASH_CACHE_TTL) return cached.commands
+
+  const { spawn } = await import('child_process')
+  const shell = process.env.SHELL || '/bin/zsh'
+  const binaries: Record<string, string> = {
+    'claude-code': 'claude',
+    'opencode': 'opencode',
+    'codex': 'codex',
+  }
+  const bin = binaries[agent]
+  if (!bin) return []
+
+  const commands: SlashCommand[] = []
+
+  const run = (cmd: string) => new Promise<string>(resolve => {
+    const p = spawn(shell, ['-i', '-c', cmd], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    })
+    let out = ''
+    p.stdout.on('data', (d: Buffer) => { out += d.toString() })
+    const timer = setTimeout(() => { try { p.kill() } catch {} resolve('') }, 15_000)
+    p.on('close', () => { clearTimeout(timer); resolve(out) })
+    p.on('error', () => { clearTimeout(timer); resolve('') })
+  })
+
+  if (agent === 'claude-code') {
+    const raw = await run(`${bin} -p "List every slash command available to you. Output ONLY lines in this exact format, one per line: /name — description. No headers, no grouping, no extra text." --output-format json --max-budget-usd 0.05 2>/dev/null`)
+    try {
+      const parsed = JSON.parse(raw)
+      const text: string = parsed.result || ''
+      for (const line of text.split('\n')) {
+        const m = line.match(/^\s*[-*]?\s*`?\/?(\w[\w-]*)(?:\s+<[^>]*>)?`?\s*[—–-]+\s*(.+)/)
+        if (m) commands.push({ name: m[1], description: m[2].trim(), source: 'agent' })
+      }
+    } catch { /* parse failed */ }
+  } else if (agent === 'opencode') {
+    const raw = await run(`${bin} --help 2>&1`)
+    for (const line of raw.split('\n')) {
+      const m = line.match(/^\s+opencode\s+(\w[\w-]*)\s+(.+)/)
+      if (m) commands.push({ name: m[1], description: m[2].trim(), source: 'agent' })
+    }
+  } else if (agent === 'codex') {
+    const raw = await run(`${bin} --help 2>&1`)
+    for (const line of raw.split('\n')) {
+      const m = line.match(/^\s+(\w[\w-]*)\s{2,}(.+)/)
+      if (m && !['help', 'Options:'].includes(m[1])) {
+        commands.push({ name: m[1], description: m[2].trim(), source: 'agent' })
+      }
+    }
+  }
+
+  slashCommandCache.set(agent, { commands, ts: Date.now() })
+  return commands
+}
+
 function buildRuntimeConfig(json: any): any {
   // Flatten the on-disk GatewayConfigJson into the runtime GatewayConfig
   // the Codey class expects. Default agent + per-agent default model now
@@ -1305,6 +1372,10 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('agents:checkInstalled', async () =>
     wrap(async () => detectInstalledAgents())
+  )
+
+  ipcMain.handle('agents:slashCommands', async (_e, agent: string) =>
+    wrap(async () => discoverSlashCommands(agent))
   )
 
   // ── Conversations IPC ─────────────────────────────────────────────

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -87,6 +87,7 @@ contextBridge.exposeInMainWorld('codey', {
     get: () => ipcRenderer.invoke('agents:get'),
     set: (updates: any) => ipcRenderer.invoke('agents:set', updates),
     checkInstalled: () => ipcRenderer.invoke('agents:checkInstalled'),
+    slashCommands: (agent: string) => ipcRenderer.invoke('agents:slashCommands', agent),
   },
   chats: {
     upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -86,6 +86,7 @@ declare global {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; env?: Record<string, string> }>>>
         set: (updates: Record<string, { enabled?: boolean; defaultModel?: string; env?: Record<string, string> }>) => Promise<IpcResult<void>>
         checkInstalled: () => Promise<IpcResult<Record<string, { installed: boolean; path?: string }>>>
+        slashCommands: (agent: string) => Promise<IpcResult<Array<{ name: string; description: string; source: 'agent' | 'gateway' }>>>
       }
       chats: {
         upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -233,6 +233,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const [titleDraft, setTitleDraft] = useState('')
   const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>([])
   const [isDragging, setIsDragging] = useState(false)
+  const [slashCommands, setSlashCommands] = useState<Array<{ name: string; description: string; source: 'agent' | 'gateway' }>>([])
+  const [slashIdx, setSlashIdx] = useState(0)
+  const slashMenuRef = useRef<HTMLDivElement>(null)
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [pairings, setPairings] = useState<Array<{ channel: 'telegram'|'discord'|'imessage'; channelUserId: string }>>([])
   const [pairingModal, setPairingModal] = useState<null | 'telegram' | 'discord' | 'imessage'>(null)
@@ -458,6 +461,27 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const apiTypeForAgent = AGENT_API_TYPE[effectiveAgent]
   const modelsForAgent = models.filter(m => m.apiType === apiTypeForAgent)
 
+  useEffect(() => {
+    let stale = false
+    window.codey.agents.slashCommands(effectiveAgent).then(r => {
+      if (stale) return
+      if (r.ok) setSlashCommands(r.data)
+    })
+    return () => { stale = true }
+  }, [effectiveAgent])
+
+  useEffect(() => { setSlashIdx(0) }, [input])
+  useEffect(() => {
+    const el = slashMenuRef.current?.children[slashIdx] as HTMLElement | undefined
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [slashIdx])
+  const slashQuery = input.match(/^\/(\S*)$/)?.[1]?.toLowerCase() ?? null
+  const filteredSlash = slashQuery !== null
+    ? slashCommands.filter(c => c.name.toLowerCase().includes(slashQuery)).slice(0, 12)
+    : []
+  const slashLoading = slashQuery !== null && slashCommands.length === 0
+  const showSlashMenu = filteredSlash.length > 0 || slashLoading
+
   const onAgentChange = async (v: string) => {
     const nextAgent = v === '' ? null : v
     // Clear the model override when switching agents — the previous model id
@@ -556,6 +580,29 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   }
 
   const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (showSlashMenu) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSlashIdx(i => Math.min(i + 1, filteredSlash.length - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSlashIdx(i => Math.max(i - 1, 0))
+        return
+      }
+      if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+        e.preventDefault()
+        const cmd = filteredSlash[slashIdx]
+        if (cmd) setInput(`/${cmd.name} `)
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setInput('')
+        return
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       send()
@@ -893,7 +940,24 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
           Workspace "{chat.workspaceName}" no longer exists. Sending is disabled.
         </div>
       )}
-      <div style={styles.inputContainer}>
+      <div style={{ ...styles.inputContainer, position: 'relative' as const }}>
+        {showSlashMenu && (
+          <div ref={slashMenuRef} style={styles.slashMenu}>
+            {slashLoading ? (
+              <div style={{ ...styles.slashMenuItem, color: C.fg3 }}>Loading commands…</div>
+            ) : filteredSlash.map((cmd, i) => (
+              <div
+                key={cmd.name}
+                style={{ ...styles.slashMenuItem, ...(i === slashIdx ? styles.slashMenuItemActive : {}) }}
+                onMouseDown={e => { e.preventDefault(); setInput(`/${cmd.name} `) }}
+                onMouseEnter={() => setSlashIdx(i)}
+              >
+                <span style={styles.slashCmdName}>/{cmd.name}</span>
+                <span style={styles.slashCmdDesc}>{cmd.description}</span>
+              </div>
+            ))}
+          </div>
+        )}
         {uploadError && (
           <div style={styles.uploadError}>{uploadError}</div>
         )}
@@ -1257,5 +1321,28 @@ const styles: Record<string, React.CSSProperties> = {
     marginTop: 4, marginBottom: 6,
     padding: 8, background: 'rgba(0,0,0,0.25)', borderRadius: 4,
     border: `1px solid ${C.border}`,
+  },
+  slashMenu: {
+    position: 'absolute' as const, bottom: '100%', left: 0, right: 0,
+    maxHeight: 260, overflowY: 'auto' as const, zIndex: 100,
+    background: C.surface2, border: `1px solid ${C.border2}`,
+    borderRadius: 10, padding: 4, marginBottom: 4,
+    boxShadow: '0 -4px 20px rgba(0,0,0,0.35)',
+  },
+  slashMenuItem: {
+    display: 'flex', alignItems: 'center', gap: 10,
+    padding: '6px 10px', borderRadius: 6, cursor: 'pointer',
+    fontSize: 12,
+  },
+  slashMenuItemActive: {
+    background: 'rgba(106,176,243,0.15)',
+  },
+  slashCmdName: {
+    color: C.accent, fontWeight: 600, flexShrink: 0,
+    fontFamily: 'SF Mono, Menlo, monospace', fontSize: 12,
+  },
+  slashCmdDesc: {
+    color: C.fg3, overflow: 'hidden' as const,
+    textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
   },
 }


### PR DESCRIPTION
## Summary
- Dynamically discover slash commands from each agent CLI (Claude Code, OpenCode, Codex) with 5-minute caching
- Show autocomplete dropdown above the chat input when user types `/`
- Keyboard navigation (arrow keys, Tab/Enter to select, Esc to dismiss) and mouse support
- Filters commands as the user types (e.g. `/he` narrows to `/help`)

## Test plan
- [ ] Type `/` in chat input — dropdown should appear with agent's commands
- [ ] Type `/he` — should filter to matching commands (e.g. `/help`)
- [ ] Arrow up/down to navigate, Tab or Enter to select a command
- [ ] Esc to dismiss the dropdown
- [ ] Switch agents — commands should refresh for the new agent
- [ ] Verify no conflicts with existing gateway slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)