### PR TITLE
fix(mac): inline permission prompts and AskUserQuestion rendering

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1664,13 +1664,34 @@ app.whenReady().then(async () => {
   )
 
   // ── Permissions IPC ──────────────────────────────────────────────
-  ipcMain.handle('permissions:addAllowed', async (_e, toolNames: string[]) =>
+  ipcMain.handle('permissions:addAllowed', async (_e, toolNames: string[], chatId?: string) =>
     wrap(async () => {
       const fsMod = await import('fs')
       const pathMod = await import('path')
       if (!workspaceManager) throw new Error('Workspace manager not ready')
-      const root = workspaceManager.getWorkspacesRoot()
-      const settingsDir = pathMod.join(pathMod.dirname(root), '.claude')
+
+      // Resolve the project workingDir from the chat so we write to the
+      // correct .claude/settings.local.json that Claude Code actually reads.
+      let workingDir: string | undefined
+      if (chatId && inProcessGateway) {
+        try {
+          const chat = inProcessGateway.getChatManager().get(chatId)
+          if (!chat) throw new Error('Chat not found')
+          const wsConfigPath = pathMod.join(
+            workspaceManager.getWorkspacesRoot(),
+            chat.workspaceName,
+            'workspace.json',
+          )
+          if (fsMod.existsSync(wsConfigPath)) {
+            const wsConfig = JSON.parse(fsMod.readFileSync(wsConfigPath, 'utf-8'))
+            if (wsConfig.workingDir) workingDir = wsConfig.workingDir
+          }
+        } catch { /* fall through to default */ }
+      }
+
+      const settingsDir = workingDir
+        ? pathMod.join(workingDir, '.claude')
+        : pathMod.join(pathMod.dirname(workspaceManager.getWorkspacesRoot()), '.claude')
       const settingsFile = pathMod.join(settingsDir, 'settings.local.json')
       let cfg: any = { permissions: { allow: [] } }
       if (fsMod.existsSync(settingsFile)) {

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -118,7 +118,7 @@ contextBridge.exposeInMainWorld('codey', {
     },
   },
   permissions: {
-    addAllowed: (toolNames: string[]) => ipcRenderer.invoke('permissions:addAllowed', toolNames),
+    addAllowed: (toolNames: string[], chatId?: string) => ipcRenderer.invoke('permissions:addAllowed', toolNames, chatId),
   },
   pairing: {
     start: (channel: 'telegram' | 'discord' | 'imessage') => ipcRenderer.invoke('pairing:start', channel),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -106,7 +106,7 @@ declare global {
         updateContextPanelOpen: (id: string, open: boolean | null) => Promise<IpcResult<Chat>>
       }
       permissions: {
-        addAllowed: (toolNames: string[]) => Promise<IpcResult<{ added: number }>>
+        addAllowed: (toolNames: string[], chatId?: string) => Promise<IpcResult<{ added: number }>>
       }
       pairing: {
         start: (channel: 'telegram' | 'discord' | 'imessage') => Promise<IpcResult<string>>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -218,7 +218,7 @@ const TeamMessage: React.FC<{
 }
 
 export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
-  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, renameChat, setContextPanelOpen, linkChannel, unlinkChannel } = useChats()
+  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, renameChat, setContextPanelOpen, linkChannel, unlinkChannel, resolvePermission } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -888,6 +888,28 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 )}
               </div>
               {msg.role === 'assistant'
+                && idx === chat.messages.length - 1
+                && chat.messages[chat.messages.length - 1]?.role !== 'user'
+                && msg.userQuestion
+                && msg.userQuestion.options.length > 0
+                && (
+                  <div style={styles.choiceRow}>
+                    {msg.userQuestion.options.map((opt, i) => (
+                      <button
+                        key={i}
+                        style={styles.choiceButton}
+                        disabled={isSending || !!flight}
+                        onClick={() => { void sendMessage(chat.id, opt.label) }}
+                      >
+                        <span style={styles.choiceLabel}>{opt.label}</span>
+                        {opt.description && <span style={styles.choiceDesc}>{opt.description}</span>}
+                      </button>
+                    ))}
+                  </div>
+                )
+              }
+              {msg.role === 'assistant'
+                && !msg.userQuestion
                 && msg.choices
                 && msg.choices.length > 0
                 && idx === chat.messages.length - 1
@@ -904,6 +926,21 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                         {label}
                       </button>
                     ))}
+                  </div>
+                )
+              }
+              {msg.role === 'assistant'
+                && idx === chat.messages.length - 1
+                && state.pendingPermissions[chatId]
+                && (
+                  <div style={styles.permissionBanner}>
+                    <span style={styles.permissionText}>
+                      Needs permission: {state.pendingPermissions[chatId].join(', ')}
+                    </span>
+                    <div style={styles.permissionActions}>
+                      <button style={styles.permissionAllow} onClick={() => resolvePermission(chatId, true)}>Allow</button>
+                      <button style={styles.permissionDeny} onClick={() => resolvePermission(chatId, false)}>Deny</button>
+                    </div>
                   </div>
                 )
               }
@@ -1230,6 +1267,55 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer',
     fontSize: 13,
     textAlign: 'left' as const,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 2,
+  },
+  choiceLabel: {
+    fontWeight: 500 as const,
+  },
+  choiceDesc: {
+    fontSize: 11,
+    color: C.fg2,
+    lineHeight: '1.3',
+  },
+  permissionBanner: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 6,
+    marginTop: 8,
+    marginLeft: 12,
+    padding: '8px 12px',
+    borderRadius: 6,
+    border: `1px solid ${C.border2}`,
+    background: C.surface3,
+  },
+  permissionText: {
+    fontSize: 12,
+    color: C.fg2,
+  },
+  permissionActions: {
+    display: 'flex',
+    gap: 8,
+  },
+  permissionAllow: {
+    padding: '4px 12px',
+    borderRadius: 4,
+    border: 'none',
+    background: C.accent,
+    color: '#fff',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontWeight: 500 as const,
+  },
+  permissionDeny: {
+    padding: '4px 12px',
+    borderRadius: 4,
+    border: `1px solid ${C.border2}`,
+    background: 'transparent',
+    color: C.fg2,
+    cursor: 'pointer',
+    fontSize: 12,
   },
   attachButton: {
     width: 32, height: 32, borderRadius: 8, border: 'none',

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -21,6 +21,7 @@ interface State {
   // can repopulate the input box for the matching chat.
   pendingRestores: Record<string, string>
   unreadChats: Record<string, true>
+  pendingPermissions: Record<string, string[]>
 }
 
 type Action =
@@ -34,11 +35,13 @@ type Action =
   | { type: 'streamToken'; chatId: string; token: string }
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: 'working' | 'writing' }
   | { type: 'queued'; chatId: string; position: number }
-  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
+  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion'] }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
   | { type: 'stoppedSend'; chatId: string; text: string }
   | { type: 'clearRestore'; chatId: string }
   | { type: 'patchContextPanelOpen'; chatId: string; open: boolean | null }
+  | { type: 'permissionRequest'; chatId: string; toolNames: string[] }
+  | { type: 'dismissPermission'; chatId: string }
 
 function reorder(order: string[], chatId: string): string[] {
   return [chatId, ...order.filter(id => id !== chatId)]
@@ -79,6 +82,14 @@ function reducer(state: State, action: Action): State {
       if (!chat) return state
       const updated: Chat = { ...chat, contextPanelOpen: action.open ?? undefined }
       return { ...state, chats: { ...state.chats, [chat.id]: updated } }
+    }
+    case 'permissionRequest': {
+      return { ...state, pendingPermissions: { ...state.pendingPermissions, [action.chatId]: action.toolNames } }
+    }
+    case 'dismissPermission': {
+      const pp = { ...state.pendingPermissions }
+      delete pp[action.chatId]
+      return { ...state, pendingPermissions: pp }
     }
     case 'remove': {
       const chats = { ...state.chats }
@@ -171,7 +182,7 @@ function reducer(state: State, action: Action): State {
       if (!chat) return state
       const messages = chat.messages.map(m =>
         m.id === action.assistantMessageId
-          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true, choices: action.choices }
+          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true, choices: action.choices, userQuestion: action.userQuestion }
           : m
       )
       const updatedChat: Chat = { ...chat, messages, updatedAt: Date.now() }
@@ -248,6 +259,7 @@ interface ChatsContextValue {
   unlinkChannel: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<void>
   sendMessage: (chatId: string, text: string, attachments?: FileAttachment[]) => Promise<void>
   stopChat: (chatId: string) => Promise<void>
+  resolvePermission: (chatId: string, allow: boolean) => void
   clearRestore: (chatId: string) => void
   toggleWorkspace: (workspaceName: string) => void
   refreshWorkspaces: () => Promise<void>
@@ -270,6 +282,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     workspaces: [],
     pendingRestores: {},
     unreadChats: {},
+    pendingPermissions: {},
   })
 
   const pendingAssistantId = useRef<Record<string, string>>({})
@@ -345,6 +358,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               durationSec: ev.durationSec,
               title: ev.title,
               choices: ev.choices,
+              userQuestion: ev.userQuestion,
             })
             delete pendingAssistantId.current[ev.chatId]
           } else {
@@ -375,12 +389,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         }
         case 'permission_denials': {
           const toolNames = [...new Set(ev.denials.map(d => d.toolName))]
-          const ok = window.confirm(
-            `Claude needs permission to use: ${toolNames.join(', ')}\n\nAdd to allowed tools so future tasks can use them?`
-          )
-          if (ok) {
-            window.codey?.permissions?.addAllowed?.(toolNames).catch(() => {})
-          }
+          dispatch({ type: 'permissionRequest', chatId: ev.chatId, toolNames })
           break
         }
       }
@@ -453,6 +462,13 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     },
     async stopChat(chatId) {
       try { await apiService.chats.stop(chatId) } catch { /* nothing in flight */ }
+    },
+    resolvePermission(chatId, allow) {
+      if (allow) {
+        const toolNames = state.pendingPermissions[chatId]
+        if (toolNames) window.codey?.permissions?.addAllowed?.(toolNames, chatId).catch(() => {})
+      }
+      dispatch({ type: 'dismissPermission', chatId })
     },
     clearRestore(chatId) { dispatch({ type: 'clearRestore', chatId }) },
     toggleWorkspace(workspaceName) { dispatch({ type: 'toggleWorkspace', workspaceName }) },

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -10,7 +10,7 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
+  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -142,6 +142,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       // Track pending tool_use calls by id so we can pair them with tool_result
       const pendingTools = new Map<string, { name: string; input?: Record<string, unknown> }>();
       let permissionDenials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> = [];
+      let userQuestion: AgentResponse['userQuestion'];
 
       const safeResolve = (response: AgentResponse) => {
         if (!resolved) {
@@ -181,6 +182,24 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
               if (block.id) {
                 pendingTools.set(block.id, { name: toolName, input: block.input });
               }
+
+              if (toolName === 'AskUserQuestion' && block.input) {
+                const inp = block.input as any;
+                const questions = Array.isArray(inp.questions) ? inp.questions : [];
+                const q = questions[0];
+                if (q?.question && Array.isArray(q.options)) {
+                  userQuestion = {
+                    question: q.question,
+                    options: q.options
+                      .filter((o: any) => o && typeof o.label === 'string')
+                      .map((o: any) => ({ label: o.label, description: o.description })),
+                  };
+                  // Kill the process — it's waiting for interactive input we can't provide.
+                  // The gateway will resume the session with the user's answer on the next turn.
+                  childProcess.kill('SIGTERM');
+                }
+              }
+
               const inputSummary = block.input
                 ? Object.entries(block.input).map(([k, v]) => {
                     const val = typeof v === 'string' ? v : JSON.stringify(v);
@@ -296,7 +315,11 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         // Fall back to wall-clock duration if the result event didn't include one
         const finalDuration = durationSec ?? Math.round((Date.now() - startTime) / 1000);
 
-        if (code === 0 && output) {
+        if (userQuestion) {
+          const resp = this.createResponse(output || '', true, tokens, finalDuration, statusUpdates, states);
+          resp.userQuestion = userQuestion;
+          safeResolve(resp);
+        } else if (code === 0 && output) {
           safeResolve(this.createResponse(output, true, tokens, finalDuration, statusUpdates, states, permissionDenials));
         } else {
           // Clear session on failure to avoid "session already in use" errors

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -32,6 +32,11 @@ export interface ChatMessage {
   durationSec?: number;
   /** Option labels when this assistant message ended in [ASK_USER:choice]. */
   choices?: string[];
+  /** Structured question from AskUserQuestion tool call, with option descriptions. */
+  userQuestion?: {
+    question: string;
+    options: Array<{ label: string; description?: string }>;
+  };
 }
 
 export type ChatSelection =

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -181,6 +181,11 @@ export interface AgentResponse {
   sessionId?: string;
   /** Tools that were denied due to permission settings (only when skipPermissions is false). */
   permissionDenials?: Array<{ toolName: string; toolInput?: Record<string, unknown> }>;
+  /** Structured question extracted from an AskUserQuestion tool call. */
+  userQuestion?: {
+    question: string;
+    options: Array<{ label: string; description?: string }>;
+  };
 }
 
 // Channel configuration

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -9,7 +9,7 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[] }
+  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3178,6 +3178,7 @@ Example: /model gpt-4.1 write a Python script`;
       let output = '';
       let tokens: number | undefined;
       let teamChoices: string[] | undefined;
+      let agentUserQuestion: AgentResponse['userQuestion'];
       if (chat.selection.type === 'team') {
         // Resolve the team from the chat's workspace.json (read above), not from
         // the active workspace, so a chat in workspace B uses B's team config
@@ -3258,6 +3259,11 @@ Example: /model gpt-4.1 write a Python script`;
         if (response?.permissionDenials && response.permissionDenials.length > 0) {
           sink({ type: 'permission_denials', chatId, denials: response.permissionDenials });
         }
+        // Capture structured AskUserQuestion from the agent so the UI can
+        // render interactive choices instead of raw JSON.
+        if (response?.userQuestion) {
+          agentUserQuestion = response.userQuestion;
+        }
       }
       if (abortController.signal.aborted) {
         // User-initiated stop: roll the prompt back so the client can restore
@@ -3273,9 +3279,12 @@ Example: /model gpt-4.1 write a Python script`;
       // ASK_USER:choice detection. Team flows already stripped the marker into
       // a rendered question via runTeamForChat, so reuse the choices it
       // returned. For non-team chats, parse the worker output for the marker.
+      // Also check for structured AskUserQuestion from the agent adapter.
       let surfacedChoices: string[] | undefined;
       let plainAskOptions: string[] | undefined;
-      if (teamChoices && teamChoices.length >= 2) {
+      if (agentUserQuestion && agentUserQuestion.options.length >= 2) {
+        surfacedChoices = agentUserQuestion.options.map(o => o.label);
+      } else if (teamChoices && teamChoices.length >= 2) {
         surfacedChoices = teamChoices;
       } else {
         const plainAsk = parseAskUser(output);
@@ -3295,6 +3304,7 @@ Example: /model gpt-4.1 write a Python script`;
         tokens,
         durationSec,
         ...(surfacedChoices ? { choices: surfacedChoices } : {}),
+        ...(agentUserQuestion ? { userQuestion: agentUserQuestion } : {}),
       };
       const updated = this.chatManager.appendMessage(chatId, assistantMessage);
 
@@ -3304,7 +3314,7 @@ Example: /model gpt-4.1 write a Python script`;
         this.chatManager.setLastAskedOptions(chatId, assistantMessage.id, plainAskOptions);
       }
 
-      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title, choices: surfacedChoices });
+      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title, choices: surfacedChoices, userQuestion: agentUserQuestion });
 
       // Mirror this turn to every attached route except the originating one.
       // Mac-origin uses a synthetic '__mac__' channel that matches no real


### PR DESCRIPTION
## Summary
- **Permission 弹窗 → 内联 banner**: 用 `window.confirm()` 弹窗改为消息下方的 inline banner，显示 Allow/Deny 按钮，不中断对话流
- **Permission 持久化修复**: `addAllowed` 之前写到 Codey 数据目录的 `.claude/settings.local.json`，Claude Code 根本读不到；现在根据 chatId 解析出 workspace 的 `workingDir`，写入项目目录
- **AskUserQuestion 渲染**: 检测 Claude Code 的 `AskUserQuestion` tool_use block，提取结构化问题（label + description），kill 等待交互输入的进程，在消息下方渲染带描述的选项按钮

## Test plan
- [ ] 在 skipPermissions=false 模式下触发 permission denial，确认 inline banner 出现且不弹窗
- [ ] 点击 Allow 后确认 `.claude/settings.local.json` 写入到项目目录
- [ ] 下一轮对话确认已 allow 的 tool 不再被拒绝
- [ ] 触发 AskUserQuestion tool call，确认选项以带描述的按钮形式显示
- [ ] 点击选项后确认下一轮对话正常恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)