### PR TITLE
fix(core): detect AskUserQuestion from stream events and text fallback

### DIFF
--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -41,6 +41,7 @@ interface StreamEvent {
   event?: {
     type: string;
     delta?: { type?: string; text?: string };
+    content_block?: { type?: string; name?: string; id?: string };
   };
   // permission_denials in result event
   permission_denials?: Array<{ tool_name: string; tool_input?: Record<string, unknown> }>;
@@ -143,6 +144,8 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       const pendingTools = new Map<string, { name: string; input?: Record<string, unknown> }>();
       let permissionDenials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> = [];
       let userQuestion: AgentResponse['userQuestion'];
+      let askUserInputJson = '';
+      let collectingAskUser = false;
 
       const safeResolve = (response: AgentResponse) => {
         if (!resolved) {
@@ -162,12 +165,38 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
 
         if (event.type === 'system' && event.session_id) {
           this.sessionId = event.session_id;
+        } else if (event.type === 'stream_event' && event.event?.type === 'content_block_start') {
+          const cb = event.event.content_block;
+          if (cb?.type === 'tool_use' && cb.name === 'AskUserQuestion') {
+            collectingAskUser = true;
+            askUserInputJson = '';
+          }
         } else if (event.type === 'stream_event' && event.event?.type === 'content_block_delta') {
           const delta = event.event.delta;
           if (delta?.type === 'text_delta' && delta.text) {
             streamedText += delta.text;
             request.onStream?.(delta.text);
             streamedFromDeltas = true;
+          } else if (collectingAskUser && delta?.type === 'input_json_delta') {
+            askUserInputJson += (delta as any).partial_json ?? (delta as any).text ?? '';
+          }
+        } else if (event.type === 'stream_event' && event.event?.type === 'content_block_stop') {
+          if (collectingAskUser && askUserInputJson) {
+            collectingAskUser = false;
+            try {
+              const inp = JSON.parse(askUserInputJson);
+              const questions = Array.isArray(inp.questions) ? inp.questions : [];
+              const q = questions[0];
+              if (q?.question && Array.isArray(q.options) && q.options.length >= 2) {
+                userQuestion = {
+                  question: q.question,
+                  options: q.options
+                    .filter((o: any) => o && typeof o.label === 'string')
+                    .map((o: any) => ({ label: o.label, description: o.description })),
+                };
+                childProcess.kill('SIGTERM');
+              }
+            } catch { /* ignore parse failure */ }
           }
         } else if (event.type === 'assistant' && event.message?.content) {
           for (const block of event.message.content) {
@@ -315,6 +344,14 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         // Fall back to wall-clock duration if the result event didn't include one
         const finalDuration = durationSec ?? Math.round((Date.now() - startTime) / 1000);
 
+        // Fallback: parse AskUserQuestion JSON from streamed text if the
+        // tool_use block detection didn't fire (e.g. assistant event never
+        // arrived because CLI blocked on interactive input).
+        if (!userQuestion && output) {
+          const parsed = ClaudeCodeAdapter.parseAskUserQuestionFromText(output);
+          if (parsed) userQuestion = parsed;
+        }
+
         if (userQuestion) {
           const resp = this.createResponse(output || '', true, tokens, finalDuration, statusUpdates, states);
           resp.userQuestion = userQuestion;
@@ -372,5 +409,32 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       this.activeProcess.kill('SIGTERM');
       this.activeProcess = undefined;
     }
+  }
+
+  static parseAskUserQuestionFromText(text: string): AgentResponse['userQuestion'] | null {
+    // Match a JSON object containing "questions" with "options" arrays.
+    // The JSON may be embedded in surrounding text.
+    const idx = text.indexOf('"questions"');
+    if (idx === -1) return null;
+    // Walk backwards to find the opening brace
+    let braceStart = text.lastIndexOf('{', idx);
+    if (braceStart === -1) return null;
+    // Try progressively larger substrings to find valid JSON
+    for (let end = text.indexOf('}', idx); end !== -1; end = text.indexOf('}', end + 1)) {
+      try {
+        const obj = JSON.parse(text.substring(braceStart, end + 1));
+        const questions = Array.isArray(obj.questions) ? obj.questions : [];
+        const q = questions[0];
+        if (q?.question && Array.isArray(q.options) && q.options.length >= 2) {
+          return {
+            question: q.question,
+            options: q.options
+              .filter((o: any) => o && typeof o.label === 'string')
+              .map((o: any) => ({ label: o.label, description: o.description })),
+          };
+        }
+      } catch { /* keep searching */ }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- **问题**: `AskUserQuestion` tool call 的 `assistant` event 可能在 CLI 阻塞等待交互输入时永远不会到达，导致选项无法渲染
- **修复**: 添加三层检测机制:
  1. `content_block_start/delta/stop` stream events — 最早检测，在 tool input JSON 流式到达时就捕获
  2. `assistant` event 的 tool_use block — 完整消息事件（如果到达的话）
  3. Close handler 中的文本解析 — 从 streamedText 中解析 AskUserQuestion JSON 作为兜底

## Test plan
- [ ] 触发 AskUserQuestion tool call，确认选项以按钮形式显示
- [ ] 确认进程在检测到 AskUserQuestion 后被 SIGTERM 终止，不会挂起 15 分钟
- [ ] 确认点击选项后下一轮对话正常恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)