### PR TITLE
fix: render AskUserQuestion text when assistant content is empty

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -842,10 +842,11 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 {!isUser && !!flight && msg === lastMsg && (
                   <LiveActivity toolCalls={msg.toolCalls} />
                 )}
-                {msg.content && (() => {
+                {(msg.content || (!isUser && msg.userQuestion?.question)) && (() => {
                   if (isUser) return <Markdown variant="user">{msg.content}</Markdown>
-                  const parsed = parseTeamMessage(msg.content)
-                  if (!parsed) return <Markdown variant="assistant">{msg.content}</Markdown>
+                  const text = msg.content || msg.userQuestion?.question || ''
+                  const parsed = parseTeamMessage(text)
+                  if (!parsed) return <Markdown variant="assistant">{text}</Markdown>
                   const isStreaming = !!flight && msg === lastMsg
                   return (
                     <TeamMessage

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -353,7 +353,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         }
 
         if (userQuestion) {
-          const resp = this.createResponse(output || '', true, tokens, finalDuration, statusUpdates, states);
+          const resp = this.createResponse(output || userQuestion.question, true, tokens, finalDuration, statusUpdates, states);
           resp.userQuestion = userQuestion;
           safeResolve(resp);
         } else if (code === 0 && output) {


### PR DESCRIPTION
## Summary
- When the agent calls `AskUserQuestion` without any preceding streamed text, the assistant message ends up with empty content. The Mac UI rendered only an empty bubble (and never showed the question text — it only renders option buttons), so the user saw nothing.
- Fall back to `userQuestion.question` as the response output in `claude-code.ts` so channel surfaces also see the prompt.
- In `ChatTab.tsx`, render `msg.userQuestion.question` as the bubble content when `msg.content` is empty.

## Test plan
- [ ] Trigger an agent flow that calls `AskUserQuestion` with no prior text — confirm the bubble shows the question and option buttons.
- [ ] Confirm normal assistant replies (no `userQuestion`) still render unchanged.
- [ ] Confirm Telegram/Discord channel surfaces also receive the question text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)