### PR TITLE
feat(memory): harden MemoryStore and wire it into worker/team paths

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -7,6 +7,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { estimateTokens } from './utils/tokens';
 
 // ── Structured turn types ──────────────────────────────────────────
 
@@ -86,13 +87,6 @@ const DEFAULT_CONFIG: ContextConfig = {
   maxTurns: 30,
   ttlMs: 60 * 60 * 1000,
 };
-
-// ── Rough token estimator ──────────────────────────────────────────
-
-function estimateTokens(text: string): number {
-  // ~4 chars per token is a reasonable approximation
-  return Math.ceil(text.length / 4);
-}
 
 // ── Context Manager ────────────────────────────────────────────────
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,4 @@ export * from './aide-tasks';
 export * from './discussion/files';
 export * from './discussion/control';
 export * from './discussion/parallel-advisor';
+export * from './team-blackboard';

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -13,11 +13,25 @@
  *   workspaces/<name>/memory.md  — human-readable summary (legacy, still updated)
  */
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
+import * as crypto from 'crypto';
+import { estimateTokens } from './utils/tokens';
 
 // ── Types ──────────────────────────────────────────────────────────
 
 export type MemoryType = 'fact' | 'preference' | 'lesson' | 'decision' | 'context';
+
+/**
+ * Visibility scope for a memory entry. Controls which agents/workers see this
+ * entry when `buildContext({ forWorker })` filters the candidate set.
+ *
+ *  - `'workspace'` (or undefined) — visible to everyone in the workspace
+ *  - `{ worker: 'alice' }` — only visible when alice is the running worker
+ *    AND to the main chat (the chat is the orchestrator, it sees everything)
+ *  - `{ workers: ['alice', 'bob'] }` — visible when any of those workers run
+ */
+export type MemoryScope = 'workspace' | { worker: string } | { workers: string[] };
 
 export interface MemoryEntry {
   id: string;
@@ -27,14 +41,18 @@ export interface MemoryEntry {
   label: string;
   /** When this memory was created */
   createdAt: number;
-  /** When this memory was last accessed or updated */
+  /** When the memory content was last modified (not bumped on read) */
   updatedAt: number;
+  /** When the memory was last surfaced to a prompt (read-side tracking) */
+  lastAccessedAt?: number;
   /** How many times this memory was included in a prompt */
   accessCount: number;
   /** Tags for filtering */
   tags: string[];
   /** Source that created this memory (e.g. "auto", "user", "planner") */
   source: string;
+  /** Visibility scope; absent = workspace-wide */
+  scope?: MemoryScope;
 }
 
 export interface MemoryIndex {
@@ -51,6 +69,25 @@ export class MemoryStore {
   private legacyPath: string;
   private index: MemoryIndex = { version: 1, entries: [] };
 
+  /** Serialized write queue — every persist chains onto this promise. */
+  private writeChain: Promise<void> = Promise.resolve();
+  /** Set when in-memory state has diverged from disk. */
+  private indexDirty = false;
+  private legacyDirty = false;
+  /** Pending debounced flush handle. */
+  private flushTimer: NodeJS.Timeout | null = null;
+  /** Debounce window for coalescing rapid writes. */
+  private static FLUSH_DEBOUNCE_MS = 50;
+
+  /** Read-side persistence is throttled — counts and timestamp are mutated
+   *  in memory eagerly but only flushed periodically to avoid one disk
+   *  write per chat message. */
+  private pendingAccessFlush = false;
+  private lastAccessFlush = 0;
+  private static ACCESS_FLUSH_INTERVAL_MS = 60_000;
+  private static ACCESS_FLUSH_EVERY_N_READS = 20;
+  private readsSinceFlush = 0;
+
   constructor(workspacePath: string) {
     this.workspacePath = workspacePath;
     this.memoryDir = path.join(workspacePath, 'memory');
@@ -61,37 +98,62 @@ export class MemoryStore {
   // ── Lifecycle ──────────────────────────────────────────────────
 
   async load(): Promise<void> {
-    // Ensure directory exists
     if (!fs.existsSync(this.memoryDir)) {
       fs.mkdirSync(this.memoryDir, { recursive: true });
     }
 
-    // Load index
     if (fs.existsSync(this.indexPath)) {
       try {
         const data = fs.readFileSync(this.indexPath, 'utf-8');
-        this.index = JSON.parse(data);
+        const parsed = JSON.parse(data) as MemoryIndex;
+        if (parsed && parsed.version === 1 && Array.isArray(parsed.entries)) {
+          this.index = parsed;
+        }
       } catch {
         this.index = { version: 1, entries: [] };
       }
     }
 
-    // Migrate from legacy memory.md if index is empty
     if (this.index.entries.length === 0 && fs.existsSync(this.legacyPath)) {
       this.migrateFromLegacy();
+      // Force the migrated entry to disk synchronously-ish — otherwise a
+      // short-lived process (CLI one-shot) would exit before the debounced
+      // unref'd flush timer fires and the migration would be lost.
+      if (this.indexDirty || this.legacyDirty) {
+        await this.flush();
+      }
     }
   }
 
-  private migrateFromLegacy(): void {
-    const content = fs.readFileSync(this.legacyPath, 'utf-8').trim();
-    if (!content || content.startsWith('# ') && content.split('\n').length <= 1) {
-      return; // Empty or just a header
+  /** Wait for all pending writes to drain. Use on shutdown or in tests. */
+  async flush(): Promise<void> {
+    // Fold throttled access updates into the next persist.
+    if (this.pendingAccessFlush) {
+      this.pendingAccessFlush = false;
+      this.lastAccessFlush = Date.now();
+      this.readsSinceFlush = 0;
+      this.markDirty({ index: true, legacy: false });
     }
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+      this.enqueuePersist();
+    }
+    await this.writeChain;
+  }
 
-    // Import the whole legacy file as a single "context" memory
+  private migrateFromLegacy(): void {
+    const raw = fs.readFileSync(this.legacyPath, 'utf-8').trim();
+    if (!raw) return;
+
+    // Skip files that are only a header line (no real content)
+    const lines = raw.split('\n').map(l => l.trim()).filter(Boolean);
+    const hasBodyBeyondHeader = lines.some(l => !l.startsWith('#'));
+    if (!hasBodyBeyondHeader) return;
+
     this.add({
       type: 'context',
-      content,
+      content: raw,
       label: 'Migrated project notes',
       tags: ['migrated'],
       source: 'migration',
@@ -106,22 +168,40 @@ export class MemoryStore {
     label: string;
     tags?: string[];
     source?: string;
+    scope?: MemoryScope;
   }): MemoryEntry {
-    const id = `mem-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+    const now = Date.now();
+
+    // Content-hash dedup: if an entry with the same (type, normalized content)
+    // already exists, treat this as a touch instead of inserting a duplicate.
+    const dedupKey = dedupHash(params.type, params.content);
+    const existing = this.index.entries.find(e => dedupHash(e.type, e.content) === dedupKey);
+    if (existing) {
+      existing.updatedAt = now;
+      // Merge tags (set union, stable order).
+      if (params.tags && params.tags.length > 0) {
+        const seen = new Set(existing.tags);
+        for (const t of params.tags) if (!seen.has(t)) { existing.tags.push(t); seen.add(t); }
+      }
+      this.markDirty({ index: true, legacy: true });
+      return existing;
+    }
+
     const entry: MemoryEntry = {
-      id,
+      id: `mem-${crypto.randomUUID()}`,
       type: params.type,
       content: params.content,
       label: params.label,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
+      createdAt: now,
+      updatedAt: now,
       accessCount: 0,
       tags: params.tags || [],
       source: params.source || 'auto',
+      ...(params.scope ? { scope: params.scope } : {}),
     };
 
     this.index.entries.push(entry);
-    this.persist();
+    this.markDirty({ index: true, legacy: true });
     return entry;
   }
 
@@ -135,7 +215,7 @@ export class MemoryStore {
     if (updates.type !== undefined) entry.type = updates.type;
     entry.updatedAt = Date.now();
 
-    this.persist();
+    this.markDirty({ index: true, legacy: true });
     return true;
   }
 
@@ -144,7 +224,7 @@ export class MemoryStore {
     if (idx === -1) return false;
 
     this.index.entries.splice(idx, 1);
-    this.persist();
+    this.markDirty({ index: true, legacy: true });
     return true;
   }
 
@@ -159,23 +239,84 @@ export class MemoryStore {
   // ── Query ──────────────────────────────────────────────────────
 
   /**
-   * Find memories matching a query string (simple keyword search).
+   * Find memories matching a query string.
+   *
+   * Uses a lightweight BM25 ranking over three fields (label, tags, content)
+   * with field weights — label and tag matches outrank content matches.
+   * IDF is computed across all entries so common tokens stop dominating once
+   * the store has any meaningful size.
    */
-  search(query: string, limit: number = 10): MemoryEntry[] {
-    const keywords = query.toLowerCase().split(/\s+/).filter(Boolean);
-    if (keywords.length === 0) return this.index.entries.slice(0, limit);
+  search(query: string, limit: number = 10, forWorker?: string): MemoryEntry[] {
+    const queryTerms = tokenize(query);
+    const visible = this.index.entries.filter(e => isVisibleTo(e, forWorker));
+    if (queryTerms.length === 0) return visible.slice(0, limit);
 
-    const scored = this.index.entries.map(entry => {
-      const text = `${entry.label} ${entry.content} ${entry.tags.join(' ')}`.toLowerCase();
-      let score = 0;
-      for (const kw of keywords) {
-        if (text.includes(kw)) score++;
+    const entries = visible;
+    if (entries.length === 0) return [];
+
+    // Per-field term frequencies + lengths.
+    const docs = entries.map(e => {
+      const labelTerms = tokenize(e.label);
+      const contentTerms = tokenize(e.content);
+      const tagTerms = tokenize(e.tags.join(' '));
+      return {
+        entry: e,
+        fields: {
+          label: { terms: termFreq(labelTerms), len: labelTerms.length },
+          content: { terms: termFreq(contentTerms), len: contentTerms.length },
+          tags: { terms: termFreq(tagTerms), len: tagTerms.length },
+        },
+      };
+    });
+
+    const avgLen = {
+      label: avg(docs.map(d => d.fields.label.len)),
+      content: avg(docs.map(d => d.fields.content.len)),
+      tags: avg(docs.map(d => d.fields.tags.len)),
+    };
+
+    // Field weights: label and tag hits matter more than content hits.
+    const weights = { label: 3, tags: 2, content: 1 };
+    const k1 = 1.2;
+    const b = 0.75;
+    const N = docs.length;
+
+    // Document frequencies per term across all fields combined.
+    const df = new Map<string, number>();
+    for (const d of docs) {
+      const seen = new Set<string>();
+      for (const f of ['label', 'content', 'tags'] as const) {
+        for (const t of d.fields[f].terms.keys()) seen.add(t);
       }
-      return { entry, score };
+      for (const t of seen) df.set(t, (df.get(t) ?? 0) + 1);
+    }
+
+    const scored = docs.map(d => {
+      let score = 0;
+      let anyHit = false;
+      for (const term of queryTerms) {
+        const dfT = df.get(term);
+        if (!dfT) continue;
+        const idf = Math.log(1 + (N - dfT + 0.5) / (dfT + 0.5));
+        for (const f of ['label', 'content', 'tags'] as const) {
+          const tf = d.fields[f].terms.get(term);
+          if (!tf) continue;
+          anyHit = true;
+          const len = d.fields[f].len;
+          const avgFieldLen = avgLen[f] || 1;
+          const norm = 1 - b + b * (len / avgFieldLen);
+          const fieldScore = (tf * (k1 + 1)) / (tf + k1 * norm);
+          score += weights[f] * idf * fieldScore;
+        }
+      }
+      // Source-aware multiplier: user-curated entries outrank auto-extracted
+      // ones at the same textual relevance.
+      score *= sourceWeight(d.entry.source);
+      return { entry: d.entry, score, anyHit };
     });
 
     return scored
-      .filter(s => s.score > 0)
+      .filter(s => s.anyHit)
       .sort((a, b) => b.score - a.score)
       .slice(0, limit)
       .map(s => s.entry);
@@ -189,10 +330,12 @@ export class MemoryStore {
   }
 
   /**
-   * Get the N most recently updated memories.
+   * Get the N most recently updated memories. Optionally restrict to
+   * entries visible to the given worker (chat/null sees everything).
    */
-  getRecent(limit: number = 10): MemoryEntry[] {
-    return [...this.index.entries]
+  getRecent(limit: number = 10, forWorker?: string): MemoryEntry[] {
+    return this.index.entries
+      .filter(e => isVisibleTo(e, forWorker))
       .sort((a, b) => b.updatedAt - a.updatedAt)
       .slice(0, limit);
   }
@@ -202,36 +345,56 @@ export class MemoryStore {
   /**
    * Build a memory context block to include in agent prompts.
    * Selects the most relevant memories within a token budget.
+   *
+   * Pass `forWorker` when building for a specific worker run — entries scoped
+   * to other workers will be filtered out. Omit for main chat or single-worker
+   * paths (main chat sees everything).
    */
-  buildContext(query?: string, maxTokens: number = 2000): string {
+  buildContext(
+    query?: string,
+    maxTokens: number = 2000,
+    maxTokensPerEntry: number = 200,
+    forWorker?: string,
+  ): string {
     let selected: MemoryEntry[];
 
     if (query) {
-      // Use query-relevant memories + recent important ones
-      const relevant = this.search(query, 8);
-      const recent = this.getRecent(4);
+      const relevant = this.search(query, 8, forWorker);
+      const recent = this.getRecent(4, forWorker);
       const ids = new Set(relevant.map(e => e.id));
       selected = [...relevant, ...recent.filter(e => !ids.has(e.id))];
     } else {
-      // Use most recent memories
-      selected = this.getRecent(12);
+      selected = this.getRecent(12, forWorker);
     }
 
     if (selected.length === 0) return '';
 
-    // Track access
+    // Read-side tracking — does NOT bump updatedAt (which would corrupt
+    // `getRecent` ordering and the prune heuristic). Throttle persistence:
+    // counters mutate in memory immediately, disk flush happens at most
+    // once per ACCESS_FLUSH_INTERVAL_MS or every N reads, whichever first.
+    const now = Date.now();
     for (const entry of selected) {
       entry.accessCount++;
-      entry.updatedAt = Date.now();
+      entry.lastAccessedAt = now;
     }
-    this.persist();
+    this.pendingAccessFlush = true;
+    this.readsSinceFlush++;
+    const due = now - this.lastAccessFlush >= MemoryStore.ACCESS_FLUSH_INTERVAL_MS
+      || this.readsSinceFlush >= MemoryStore.ACCESS_FLUSH_EVERY_N_READS;
+    if (due) {
+      this.pendingAccessFlush = false;
+      this.lastAccessFlush = now;
+      this.readsSinceFlush = 0;
+      this.markDirty({ index: true, legacy: false });
+    }
 
-    // Build context block within token budget
     const lines: string[] = ['## Project Memory'];
     let tokenCount = estimateTokens(lines[0]);
 
     for (const entry of selected) {
-      const line = `- [${entry.type}] ${entry.label}: ${entry.content}`;
+      const content = truncateToTokens(entry.content, maxTokensPerEntry);
+      const line = `- [${entry.type}] ${entry.label}: ${content}`;
       const lineTokens = estimateTokens(line);
       if (tokenCount + lineTokens > maxTokens) break;
       lines.push(line);
@@ -255,41 +418,53 @@ export class MemoryStore {
   }): MemoryEntry[] {
     const created: MemoryEntry[] = [];
 
-    // Remember significant file changes
-    if (params.filesChanged && params.filesChanged.length > 0) {
-      const nonReadChanges = params.filesChanged.filter(f => f.action !== 'read');
-      if (nonReadChanges.length > 0) {
-        const fileList = nonReadChanges.map(f => `${f.action}: ${f.path}`).join(', ');
-        created.push(this.add({
-          type: 'fact',
-          content: `Files modified: ${fileList}`,
-          label: `Changes from: "${params.userPrompt.substring(0, 60)}"`,
-          tags: ['auto', 'file-change'],
-          source: 'auto',
-        }));
-      }
-    }
-
-    // Remember if an error was resolved (user asked about error, agent succeeded)
-    const errorKeywords = ['error', 'bug', 'fix', 'broken', 'fail', 'crash', 'issue'];
+    // Heuristic: only record a "lesson" when the interaction looks like a
+    // genuine fix — i.e. the user described a problem AND the agent
+    // actually mutated code AND nothing errored. File-change lists alone
+    // are not stored (git history already covers that, and storing them
+    // floods the context with noise).
     const promptLower = params.userPrompt.toLowerCase();
-    if (errorKeywords.some(kw => promptLower.includes(kw)) && params.agentOutput.length > 50) {
-      // Extract a short lesson from the fix
-      const outputPreview = params.agentOutput.substring(0, 200);
+    const errorKeywords = ['error', 'bug', 'fix', 'broken', 'fail', 'crash', 'issue', 'regression'];
+    const promptLooksLikeFix = errorKeywords.some(kw =>
+      // Word-boundary match avoids matching "fixture", "issuer", etc.
+      new RegExp(`\\b${kw}\\b`).test(promptLower),
+    );
+
+    const mutatingActions = new Set(['create', 'edit', 'delete']);
+    const editedFiles = (params.filesChanged ?? [])
+      .filter(f => mutatingActions.has(f.action))
+      .map(f => f.path);
+    const hadFailedTools = (params.toolCalls ?? []).some(tc => tc.status === 'error');
+
+    if (
+      promptLooksLikeFix &&
+      editedFiles.length > 0 &&
+      !hadFailedTools &&
+      params.agentOutput.trim().length > 0
+    ) {
+      // Capture the prompt + the touched files. Skip the agent's prose —
+      // the first 200 chars rarely contains the actual insight and tends
+      // to be filler like "I've fixed the issue by...".
+      const filesPart = editedFiles.slice(0, 5).join(', ')
+        + (editedFiles.length > 5 ? `, +${editedFiles.length - 5} more` : '');
+      const promptOneLine = params.userPrompt.replace(/\s+/g, ' ').trim();
       created.push(this.add({
         type: 'lesson',
-        content: `Fixed: "${params.userPrompt.substring(0, 80)}" -> ${outputPreview}`,
-        label: 'Bug fix',
+        content: `Reported: "${truncate(promptOneLine, 160)}". Touched: ${filesPart}.`,
+        label: `Fix: ${truncate(promptOneLine, 60)}`,
         tags: ['auto', 'bugfix'],
         source: 'auto',
       }));
     }
 
-    // Prune auto-memories if we have too many (keep last 50)
+    // Prune auto-memories if we have too many (keep last 50).
+    // Order by accessCount (low first) then createdAt (old first) — using
+    // createdAt avoids the feedback loop where reading a memory would
+    // protect it from prune.
     const autoMemories = this.index.entries.filter(e => e.source === 'auto');
     if (autoMemories.length > 50) {
       const toRemove = autoMemories
-        .sort((a, b) => a.accessCount - b.accessCount || a.updatedAt - b.updatedAt)
+        .sort((a, b) => a.accessCount - b.accessCount || a.createdAt - b.createdAt)
         .slice(0, autoMemories.length - 50);
       for (const entry of toRemove) {
         this.remove(entry.id);
@@ -301,23 +476,58 @@ export class MemoryStore {
 
   // ── Persistence ────────────────────────────────────────────────
 
-  private persist(): void {
+  private markDirty(which: { index?: boolean; legacy?: boolean }): void {
+    if (which.index) this.indexDirty = true;
+    if (which.legacy) this.legacyDirty = true;
+    this.scheduleFlush();
+  }
+
+  /** Chain a persist onto the write queue so writes serialize. */
+  private enqueuePersist(): void {
+    this.writeChain = this.writeChain.then(() => this.doPersist()).catch(() => {
+      // Best-effort: swallow so one failure doesn't break the chain.
+    });
+  }
+
+  private async doPersist(): Promise<void> {
+    if (!this.indexDirty && !this.legacyDirty) return;
+
+    const writeIndex = this.indexDirty;
+    const writeLegacy = this.legacyDirty;
+    // Snapshot serialized payloads under the synchronous tick so concurrent
+    // mutations between now and the await don't see a partially-written state.
+    const indexPayload = writeIndex ? JSON.stringify(this.index, null, 2) : null;
+    const legacyPayload = writeLegacy ? this.renderLegacy() : null;
+    this.indexDirty = false;
+    this.legacyDirty = false;
+
     try {
-      if (!fs.existsSync(this.memoryDir)) {
-        fs.mkdirSync(this.memoryDir, { recursive: true });
+      await fsp.mkdir(this.memoryDir, { recursive: true });
+      if (indexPayload !== null) {
+        await atomicWrite(this.indexPath, indexPayload);
       }
-
-      // Write index
-      fs.writeFileSync(this.indexPath, JSON.stringify(this.index, null, 2));
-
-      // Also update legacy memory.md for human readability
-      this.updateLegacyFile();
+      if (legacyPayload !== null) {
+        await atomicWrite(this.legacyPath, legacyPayload);
+      }
     } catch {
-      // Best-effort persistence
+      // Best-effort persistence; re-mark dirty AND reschedule so retry
+      // doesn't depend on a future mutation to fire.
+      if (writeIndex) this.indexDirty = true;
+      if (writeLegacy) this.legacyDirty = true;
+      this.scheduleFlush();
     }
   }
 
-  private updateLegacyFile(): void {
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.enqueuePersist();
+    }, MemoryStore.FLUSH_DEBOUNCE_MS);
+    if (typeof this.flushTimer.unref === 'function') this.flushTimer.unref();
+  }
+
+  private renderLegacy(): string {
     const workspaceName = path.basename(this.workspacePath);
     const lines: string[] = [`# ${workspaceName} -- Project Memory\n`];
 
@@ -336,18 +546,112 @@ export class MemoryStore {
       context: 'Context',
     };
 
-    for (const [type, entries] of byType) {
+    // Iterate in fixed type order so section ordering is stable across
+    // writes (otherwise diff churn whenever a new type appears first).
+    for (const type of Object.keys(typeLabels) as MemoryType[]) {
+      const entries = byType.get(type);
+      if (!entries || entries.length === 0) continue;
       lines.push(`## ${typeLabels[type]}\n`);
-      for (const entry of entries.slice(-10)) { // Last 10 per type
+      const recent = [...entries].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 10);
+      for (const entry of recent) {
         lines.push(`- ${entry.label}: ${entry.content}`);
       }
       lines.push('');
     }
 
-    fs.writeFileSync(this.legacyPath, lines.join('\n'));
+    return lines.join('\n');
   }
 }
 
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+async function atomicWrite(target: string, contents: string): Promise<void> {
+  const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmp, contents);
+  await fsp.rename(tmp, target);
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function truncateToTokens(text: string, maxTokens: number): string {
+  // ~4 chars per token; leave room for the ellipsis.
+  const maxChars = maxTokens * 4;
+  return truncate(text, maxChars);
+}
+
+// ── Search helpers ─────────────────────────────────────────────────
+
+// Minimal English stop-word list — enough to keep BM25 IDF honest without
+// pulling in a full NLP dep.
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from', 'has',
+  'have', 'in', 'is', 'it', 'its', 'of', 'on', 'or', 'that', 'the', 'to',
+  'was', 'were', 'will', 'with',
+]);
+
+function tokenize(text: string): string[] {
+  if (!text) return [];
+  return text
+    .toLowerCase()
+    // Split on anything that isn't a word/identifier char; keep `_` and `-`
+    // so file paths and kebab/snake identifiers survive as single tokens.
+    .split(/[^a-z0-9_\-]+/i)
+    .filter(t => t.length > 1 && !STOP_WORDS.has(t));
+}
+
+function termFreq(terms: string[]): Map<string, number> {
+  const tf = new Map<string, number>();
+  for (const t of terms) tf.set(t, (tf.get(t) ?? 0) + 1);
+  return tf;
+}
+
+function avg(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  let sum = 0;
+  for (const n of nums) sum += n;
+  return sum / nums.length;
+}
+
+/**
+ * Multiplier applied to BM25 scores during search. Higher = more likely to
+ * be selected for prompt injection.
+ *
+ *  - `user` (explicit /memory add) and `team` (team decisions) are the most
+ *    intentional signals, so they outrank auto-extracted entries.
+ *  - `auto` heuristic extractions are deliberately under-weighted; they're
+ *    cheap to produce and noisy.
+ */
+/**
+ * Visibility predicate. `forWorker === undefined` means main-chat context —
+ * the chat is the orchestrator and is allowed to see every entry. When a
+ * specific worker is running we hide entries scoped to other workers.
+ */
+function isVisibleTo(entry: MemoryEntry, forWorker: string | undefined): boolean {
+  if (forWorker === undefined) return true;
+  const scope = entry.scope;
+  if (!scope || scope === 'workspace') return true;
+  if (typeof scope === 'object') {
+    if ('worker' in scope) return scope.worker === forWorker;
+    if ('workers' in scope) return scope.workers.includes(forWorker);
+  }
+  return true;
+}
+
+function sourceWeight(source: string): number {
+  switch (source) {
+    case 'user-global': return 1.6;
+    case 'user': return 1.5;
+    case 'team': return 1.3;
+    case 'planner': return 1.2;
+    case 'migration': return 1.0;
+    case 'auto': return 0.7;
+    default: return 1.0;
+  }
+}
+
+function dedupHash(type: MemoryType, content: string): string {
+  // Normalize: lowercase + collapse whitespace. Catches near-duplicates
+  // like the same auto-extracted lesson with slightly different spacing.
+  const normalized = content.toLowerCase().replace(/\s+/g, ' ').trim();
+  return crypto.createHash('sha1').update(`${type}:${normalized}`).digest('hex');
 }

--- a/packages/core/src/team-blackboard.ts
+++ b/packages/core/src/team-blackboard.ts
@@ -1,0 +1,211 @@
+/**
+ * Per-team-run shared blackboard.
+ *
+ * Workers emit single-line markers in their output to contribute structured
+ * facts, decisions, handoffs, and open questions. The blackboard collects
+ * them across steps, exposes a compact view for prompt injection on the next
+ * step, and renders a clean summary for the user when the run completes.
+ *
+ * Markers are STRIPPED from the visible output — the user sees prose, the
+ * structured data lives in the blackboard.
+ */
+
+export type MarkerKind = 'fact' | 'decision' | 'handoff' | 'open';
+
+export interface BlackboardEntry {
+  worker: string;
+  step: number;
+  text: string;
+}
+
+export interface HandoffEntry extends BlackboardEntry {
+  /** Target worker name; null means "for whoever runs next". */
+  to: string | null;
+}
+
+export interface Marker {
+  kind: MarkerKind;
+  text: string;
+  /** Only set for HANDOFF. */
+  to?: string | null;
+}
+
+export interface ParseResult {
+  markers: Marker[];
+  /** Output with marker lines removed and surrounding blank lines collapsed. */
+  stripped: string;
+}
+
+const MARKER_RE = /^\s*\[(FACT|DECISION|OPEN|HANDOFF(?:\s*:\s*[^\]]+)?)\]\s*:\s*(.+?)\s*$/i;
+
+/**
+ * Pull `[FACT]:`, `[DECISION]:`, `[OPEN]:`, `[HANDOFF: name]:` markers out
+ * of free-form worker output. Lines that match are removed from the prose.
+ */
+export function parseMarkers(text: string): ParseResult {
+  if (!text) return { markers: [], stripped: text ?? '' };
+  const lines = text.split(/\r?\n/);
+  const markers: Marker[] = [];
+  const kept: string[] = [];
+
+  for (const line of lines) {
+    const m = line.match(MARKER_RE);
+    if (!m) { kept.push(line); continue; }
+
+    const tagRaw = m[1].trim();
+    const body = m[2].trim();
+    const tag = tagRaw.split(/\s*:\s*/, 1)[0].toUpperCase();
+
+    if (tag === 'FACT') markers.push({ kind: 'fact', text: body });
+    else if (tag === 'DECISION') markers.push({ kind: 'decision', text: body });
+    else if (tag === 'OPEN') markers.push({ kind: 'open', text: body });
+    else if (tag === 'HANDOFF') {
+      // Capture optional target after the colon: `HANDOFF: alice`
+      const colonIdx = tagRaw.indexOf(':');
+      const to = colonIdx >= 0 ? tagRaw.slice(colonIdx + 1).trim() || null : null;
+      markers.push({ kind: 'handoff', to, text: body });
+    }
+  }
+
+  // Collapse extra blank lines created by stripped markers.
+  const stripped = kept.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+  return { markers, stripped };
+}
+
+export interface BlackboardSnapshot {
+  facts: BlackboardEntry[];
+  decisions: BlackboardEntry[];
+  handoffs: HandoffEntry[];
+  open: BlackboardEntry[];
+}
+
+export class TeamBlackboard {
+  readonly facts: BlackboardEntry[] = [];
+  readonly decisions: BlackboardEntry[] = [];
+  readonly handoffs: HandoffEntry[] = [];
+  readonly open: BlackboardEntry[] = [];
+
+  /** Serialize to a plain JSON-safe object for persistence. */
+  toJSON(): BlackboardSnapshot {
+    return {
+      facts: [...this.facts],
+      decisions: [...this.decisions],
+      handoffs: [...this.handoffs],
+      open: [...this.open],
+    };
+  }
+
+  /** Rebuild from a previously serialized snapshot. */
+  static fromJSON(snap: BlackboardSnapshot | undefined | null): TeamBlackboard {
+    const bb = new TeamBlackboard();
+    if (!snap) return bb;
+    if (Array.isArray(snap.facts)) bb.facts.push(...snap.facts);
+    if (Array.isArray(snap.decisions)) bb.decisions.push(...snap.decisions);
+    if (Array.isArray(snap.handoffs)) bb.handoffs.push(...snap.handoffs);
+    if (Array.isArray(snap.open)) bb.open.push(...snap.open);
+    return bb;
+  }
+
+  /**
+   * Ingest a worker's raw output. Markers are parsed, recorded, and removed
+   * from the returned `stripped` text — callers should use `stripped` as the
+   * user-visible / next-worker-visible output.
+   */
+  ingest(worker: string, step: number, output: string): {
+    stripped: string;
+    added: { facts: number; decisions: number; handoffs: number; open: number };
+  } {
+    const { markers, stripped } = parseMarkers(output);
+    const added = { facts: 0, decisions: 0, handoffs: 0, open: 0 };
+    for (const m of markers) {
+      if (m.kind === 'fact') { this.facts.push({ worker, step, text: m.text }); added.facts++; }
+      else if (m.kind === 'decision') { this.decisions.push({ worker, step, text: m.text }); added.decisions++; }
+      else if (m.kind === 'open') { this.open.push({ worker, step, text: m.text }); added.open++; }
+      else if (m.kind === 'handoff') {
+        this.handoffs.push({ worker, step, text: m.text, to: m.to ?? null });
+        added.handoffs++;
+      }
+    }
+    return { stripped, added };
+  }
+
+  isEmpty(): boolean {
+    return this.facts.length === 0
+      && this.decisions.length === 0
+      && this.handoffs.length === 0
+      && this.open.length === 0;
+  }
+
+  /**
+   * Compact markdown block to inject into the NEXT worker's prompt.
+   * Handoffs filter to those addressed to this worker (or to anyone).
+   */
+  renderForWorker(workerName: string): string {
+    if (this.isEmpty()) return '';
+    const lines: string[] = ['## Team Blackboard (so far)'];
+
+    if (this.facts.length > 0) {
+      lines.push('', '### Facts');
+      for (const f of this.facts) lines.push(`- (${f.worker}) ${f.text}`);
+    }
+    if (this.decisions.length > 0) {
+      lines.push('', '### Decisions');
+      for (const d of this.decisions) lines.push(`- (${d.worker}) ${d.text}`);
+    }
+    if (this.open.length > 0) {
+      lines.push('', '### Open questions');
+      for (const o of this.open) lines.push(`- (${o.worker}) ${o.text}`);
+    }
+    const myHandoffs = this.handoffs.filter(h => h.to === workerName || h.to === null);
+    if (myHandoffs.length > 0) {
+      lines.push('', '### Handoffs addressed to you');
+      for (const h of myHandoffs) lines.push(`- from ${h.worker}: ${h.text}`);
+    }
+    return lines.join('\n');
+  }
+
+  /**
+   * Markdown summary appended to the user-visible final response.
+   */
+  renderForUser(): string {
+    if (this.isEmpty()) return '';
+    const lines: string[] = ['---', '', '### 🧠 Team blackboard'];
+    if (this.decisions.length > 0) {
+      lines.push('', '**Decisions:**');
+      for (const d of this.decisions) lines.push(`- *${d.worker}* — ${d.text}`);
+    }
+    if (this.facts.length > 0) {
+      lines.push('', '**Facts:**');
+      for (const f of this.facts) lines.push(`- *${f.worker}* — ${f.text}`);
+    }
+    if (this.open.length > 0) {
+      lines.push('', '**Open questions:**');
+      for (const o of this.open) lines.push(`- *${o.worker}* — ${o.text}`);
+    }
+    return lines.join('\n');
+  }
+
+  /** Short one-liner used as a sink/info ticker after each step. */
+  summarizeDelta(added: { facts: number; decisions: number; handoffs: number; open: number }): string {
+    const parts: string[] = [];
+    if (added.decisions) parts.push(`${added.decisions} decision${added.decisions > 1 ? 's' : ''}`);
+    if (added.facts) parts.push(`${added.facts} fact${added.facts > 1 ? 's' : ''}`);
+    if (added.handoffs) parts.push(`${added.handoffs} handoff${added.handoffs > 1 ? 's' : ''}`);
+    if (added.open) parts.push(`${added.open} open question${added.open > 1 ? 's' : ''}`);
+    return parts.length ? `📋 Blackboard +${parts.join(', +')}` : '';
+  }
+}
+
+/**
+ * Prompt fragment that teaches workers about the marker protocol. Kept short
+ * so it doesn't dominate the per-step prompt.
+ */
+export const BLACKBOARD_MARKER_INSTRUCTIONS = [
+  '## Team blackboard markers',
+  'In addition to your normal output, you may surface structured notes for the rest of the team using single-line markers anywhere in your reply. These lines are EXTRACTED and STRIPPED from the user-visible output, so put them on their own line, exactly:',
+  '- `[FACT]: <one line>` — something you discovered that the team should remember',
+  '- `[DECISION]: <one line>` — a decision you made, ideally with a "because" clause',
+  '- `[HANDOFF: <worker-name>]: <one line>` — a specific note for the next worker (omit `: <worker-name>` for "whoever runs next")',
+  '- `[OPEN]: <one line>` — a question or unresolved item the team still needs to address',
+  'Use these sparingly — only for items the next worker or a future run should clearly see. Do NOT use markers to communicate with the user; write prose for that.',
+].join('\n');

--- a/packages/core/src/types/pending-team.ts
+++ b/packages/core/src/types/pending-team.ts
@@ -1,4 +1,5 @@
 import { AdvisorHistoryEntry } from '../advisor';
+import type { BlackboardSnapshot } from '../team-blackboard';
 
 /** Recorded part of a Manager-driven run, kept while the team is paused. */
 export interface PendingPart {
@@ -21,6 +22,7 @@ export type PendingTeamState =
       /** Options when worker emitted [ASK_USER:choice]; absent for free-text questions. */
       options?: string[];
       askedAt: number;
+      blackboard?: BlackboardSnapshot;
     }
   | {
       teamName: string;
@@ -36,4 +38,5 @@ export type PendingTeamState =
       question: string;
       options?: string[];
       askedAt: number;
+      blackboard?: BlackboardSnapshot;
     };

--- a/packages/core/src/utils/tokens.ts
+++ b/packages/core/src/utils/tokens.ts
@@ -1,0 +1,9 @@
+/**
+ * Cheap, dependency-free token estimator.
+ *
+ * ~4 chars per token is a reasonable approximation across English and code.
+ * Used by memory + context managers for budget tracking — not for billing.
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { BLACKBOARD_MARKER_INSTRUCTIONS } from './team-blackboard';
 
 export interface WorkerPersonality {
   role: string;
@@ -226,6 +227,7 @@ export class WorkerManager {
     task: string,
     roster: Array<{ name: string; hint: string }>,
     nextWorker: { name: string; hint: string } | null,
+    blackboardSection?: string,
   ): string {
     const worker = this.getWorker(name);
     if (!worker) return task;
@@ -235,7 +237,7 @@ export class WorkerManager {
     const nextSection = nextWorker
       ? `Next up after you: **${nextWorker.name}** — ${nextWorker.hint || '(no description)'}.\nShape your output so it gives them what they need to do their step well: be explicit about decisions, hand off open questions clearly, and avoid burying important context in passing remarks.`
       : 'You are the last worker in this run. Aim for a complete, polished result.';
-    return [
+    const sections = [
       `# Worker: ${worker.name}`,
       `## Role`,
       worker.personality.role,
@@ -247,12 +249,14 @@ export class WorkerManager {
       rosterLines,
       `## Handoff`,
       nextSection,
+      BLACKBOARD_MARKER_INSTRUCTIONS,
       `## Pause for user input`,
       'If you cannot proceed without information from the user, output a single line `[ASK_USER]: <your question>` and stop. Do not guess.',
       'When the question is yes/no or a pick-one from a small set (≤ 8) of explicit options, prefer `[ASK_USER:choice]: <question> | <option 1> | <option 2>` so the user can answer with a tap. Use the free-text `[ASK_USER]:` form for open-ended questions.',
-      `## Task`,
-      task,
-    ].join('\n\n');
+    ];
+    if (blackboardSection && blackboardSection.trim()) sections.push(blackboardSection);
+    sections.push(`## Task`, task);
+    return sections.join('\n\n');
   }
 
   /**
@@ -266,6 +270,7 @@ export class WorkerManager {
     name: string,
     task: string,
     roster: Array<{ name: string; hint: string; lastDid?: string }>,
+    blackboardSection?: string,
   ): string {
     const worker = this.getWorker(name);
     if (!worker) return task;
@@ -277,7 +282,7 @@ export class WorkerManager {
           })
           .join('\n')
       : '(you are the only worker on this team)';
-    return [
+    const sections = [
       `# Worker: ${worker.name}`,
       `## Role`,
       worker.personality.role,
@@ -287,17 +292,19 @@ export class WorkerManager {
       worker.personality.instructions,
       `## Teammates`,
       rosterLines,
+      BLACKBOARD_MARKER_INSTRUCTIONS,
       `## When you have a question`,
       [
         'If you need information you do not have:',
         '1. First check the Teammates list. If a teammate plausibly knows the answer, output a single line `[ASK: <teammate>]: <your question>` and stop. The team will route the question to that teammate directly.',
         '2. If no teammate could plausibly answer, output a single line `[ASK_USER]: <your question>` and stop. The manager will decide whether to ask the user or route to a teammate.',
         'When the question is yes/no or a pick-one from a small set (≤ 8) of explicit options, prefer `[ASK_USER:choice]: <question> | <option 1> | <option 2>` so the user can answer with a tap. Use the free-text `[ASK_USER]:` form for open-ended questions.',
-        'Use exactly one marker per output. Do not guess. Do not continue the work after emitting a marker.',
+        'Use exactly one ASK marker per output. Do not guess. Do not continue the work after emitting an ASK marker.',
       ].join('\n'),
-      `## Task`,
-      task,
-    ].join('\n\n');
+    ];
+    if (blackboardSection && blackboardSection.trim()) sections.push(blackboardSection);
+    sections.push(`## Task`, task);
+    return sections.join('\n\n');
   }
 
   buildParallelWorkerPrompt(name: string, inputs: ParallelPromptInputs): string {

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { CoreLogger } from './types';
 import { WorkerManager } from './workers';
@@ -57,12 +58,20 @@ export interface WorkspaceJson {
 /** Returns the global team library. Injected so core stays independent of gateway config storage. */
 export type GlobalTeamsProvider = () => Record<string, TeamConfigRaw>;
 
+/** Resolve the on-disk root of the user-global memory store. Overridable via env for tests. */
+export function globalMemoryDir(): string {
+  return process.env.CODEY_GLOBAL_MEMORY_DIR
+    ?? path.join(os.homedir(), '.codey');
+}
+
 export class WorkspaceManager {
   private workspacesDir: string;
   private currentWorkspace: string = '';
   private config: WorkspaceJson | null = null;
   private workerManager: WorkerManager;
   private memoryStore: MemoryStore;
+  /** User-global memory shared across workspaces. Lazily loaded. */
+  private globalMemory: MemoryStore | null = null;
   private teams: Map<string, TeamConfig> = new Map();
   private enabledTeamNames: string[] = [];
   private globalTeamsProvider: GlobalTeamsProvider;
@@ -254,6 +263,21 @@ export class WorkspaceManager {
   getWorkspacesRoot(): string { return this.workspacesDir; }
   getWorkerManager(): WorkerManager { return this.workerManager; }
   getMemoryStore(): MemoryStore { return this.memoryStore; }
+
+  /**
+   * User-global memory store, rooted at `~/.codey/` (override via
+   * `CODEY_GLOBAL_MEMORY_DIR`). Lazily instantiated and survives workspace
+   * switches. Use for cross-workspace preferences ("use pnpm not npm"),
+   * coding conventions, persistent user facts.
+   */
+  getGlobalMemoryStore(): MemoryStore {
+    if (!this.globalMemory) {
+      this.globalMemory = new MemoryStore(globalMemoryDir());
+      // Best-effort eager load so the first buildContext doesn't read empty.
+      void this.globalMemory.load().catch(() => { /* swallow — store is best-effort */ });
+    }
+    return this.globalMemory;
+  }
 
   getMemory(): string {
     const memoryPath = this.getMemoryPath();

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -92,6 +92,117 @@ export class Codey {
 
   private getSkipPermissions(): boolean {
     return this.configManager?.getSkipPermissions() ?? true;
+  }
+
+  /**
+   * Prefix a worker / team prompt with the workspace memory context relevant
+   * to the given query. Used everywhere workers run so they get the same
+   * `## Project Memory` block the main chat path already gets.
+   */
+  /**
+   * Build the combined memory context block (user-global first, then
+   * workspace-scoped). Returns empty string when memory is disabled or
+   * neither store has anything relevant.
+   */
+  private buildMergedMemoryContext(query: string, forWorker?: string): string {
+    if (this.config.memory?.enabled === false) return '';
+    const sections: string[] = [];
+    const globalCtx = this.workspaceManager.getGlobalMemoryStore().buildContext(
+      query, undefined, undefined, forWorker,
+    );
+    if (globalCtx) {
+      // Re-label so the agent can distinguish global vs workspace facts.
+      sections.push(globalCtx.replace(/^## Project Memory/, '## User-Global Memory'));
+    }
+    const workspaceCtx = this.workspaceManager.getMemoryStore().buildContext(
+      query, undefined, undefined, forWorker,
+    );
+    if (workspaceCtx) sections.push(workspaceCtx);
+    return sections.join('\n\n');
+  }
+
+  private wrapPromptWithMemory(prompt: string, query: string, forWorker?: string): string {
+    const ctx = this.buildMergedMemoryContext(query, forWorker);
+    return ctx ? `${ctx}\n\n${prompt}` : prompt;
+  }
+
+  /**
+   * Run the auto-extract heuristic on a worker step's response so insights
+   * from worker runs flow into the same memory store the main chat uses.
+   * Tagged with the worker name so they can be distinguished from chat
+   * extractions later.
+   */
+  /**
+   * Persist a team's accumulated `[DECISION]` markers to the workspace
+   * memory store so future runs can recall what was decided. Skipped when
+   * memory is disabled. Idempotent thanks to MemoryStore dedup.
+   */
+  /**
+   * Persist the Manager's final summary from a parallel discussion as a
+   * `decision` memory entry so future runs on the same topic can recall
+   * what was concluded. Best-effort — skipped when summary is empty.
+   */
+  private persistDiscussionSummary(
+    teamName: string,
+    topic: string,
+    ev: ParallelFinalEvent,
+  ): void {
+    if (this.config.memory?.autoExtract === false) return;
+    const summary = (ev.summary ?? '').replace(/^#\s+Summary\s*/i, '').trim();
+    if (!summary) return;
+    const oneLineTopic = topic.replace(/\s+/g, ' ').trim().slice(0, 80);
+    this.workspaceManager.getMemoryStore().add({
+      type: 'decision',
+      content: summary,
+      label: `Discussion (${teamName}): ${oneLineTopic}`,
+      tags: ['discussion', teamName, `reason:${ev.reason}`],
+      source: 'team',
+    });
+  }
+
+  private persistBlackboardDecisions(
+    blackboard: TeamBlackboard,
+    teamName: string,
+  ): void {
+    if (this.config.memory?.autoExtract === false) return;
+    if (blackboard.decisions.length === 0) return;
+    const store = this.workspaceManager.getMemoryStore();
+    for (const d of blackboard.decisions) {
+      store.add({
+        type: 'decision',
+        content: d.text,
+        label: `Team ${teamName} / ${d.worker}`,
+        tags: ['team', teamName, `worker:${d.worker}`],
+        source: 'team',
+        // Decisions are intentionally workspace-wide: other workers should be
+        // able to see what's been decided. If we ever want per-worker scoping
+        // for decisions, surface it as an opt-in marker.
+      });
+    }
+  }
+
+  private extractWorkerMemories(
+    workerName: string,
+    task: string,
+    agent: CodingAgent,
+    response: AgentResponse,
+  ): void {
+    if (this.config.memory?.autoExtract === false || !response.success) return;
+    const meta = ContextManager.extractMeta(response, agent);
+    this.workspaceManager.getMemoryStore().extractFromInteraction({
+      userPrompt: `[worker:${workerName}] ${task}`,
+      agentOutput: response.output,
+      toolCalls: meta.toolCalls?.map(tc => ({
+        tool: tc.tool,
+        input: tc.input,
+        output: tc.output,
+        status: tc.status,
+      })),
+      filesChanged: meta.filesChanged?.map(fc => ({
+        path: fc.path,
+        action: fc.action,
+      })),
+    });
   }
 
   /**
@@ -733,11 +844,9 @@ export class Codey {
       ?? (codeyChatId ? `chat-${codeyChatId}` : `${message.channel}-${message.chatId}`);
     const ctxWindow = await this.contextManager.getOrCreate(conversationId);
 
-    // Build memory context from workspace memory store
+    // Build memory context — merges user-global + workspace stores.
     const memoryStore = this.workspaceManager.getMemoryStore();
-    const memoryContext = (this.config.memory?.enabled !== false)
-      ? memoryStore.buildContext(parsed.prompt)
-      : undefined;
+    const memoryContext = this.buildMergedMemoryContext(parsed.prompt) || undefined;
 
     // Skip empty prompts
     if (!parsed.prompt.trim()) {
@@ -1298,12 +1407,20 @@ export class Codey {
 
   private async cmdMemory(args: string[], message: UserMessage): Promise<void> {
     const { chatId, channel } = message;
-    const memoryStore = this.workspaceManager.getMemoryStore();
+    // Optional `--global` flag selects the user-global store instead of
+    // the current workspace's store.
+    let useGlobal = false;
+    const rest = [...args];
+    if (rest[0] === '--global') { useGlobal = true; rest.shift(); }
+    const memoryStore = useGlobal
+      ? this.workspaceManager.getGlobalMemoryStore()
+      : this.workspaceManager.getMemoryStore();
+    const scopeLabel = useGlobal ? 'Global' : 'Workspace';
 
-    if (args.length === 0 || args[0] === 'list') {
+    if (rest.length === 0 || rest[0] === 'list') {
       const memories = memoryStore.getRecent(10);
       if (memories.length === 0) {
-        await this.sendResponse({ chatId, channel, text: 'No memories stored for this workspace.' });
+        await this.sendResponse({ chatId, channel, text: `No ${scopeLabel.toLowerCase()} memories stored.` });
         return;
       }
       const lines = memories.map(m =>
@@ -1312,30 +1429,30 @@ export class Codey {
       await this.sendResponse({
         chatId,
         channel,
-        text: `\ud83e\udde0 Workspace Memories (${memories.length})\n\n${lines.join('\n')}`,
+        text: `\ud83e\udde0 ${scopeLabel} Memories (${memories.length})\n\n${lines.join('\n')}`,
       });
-    } else if (args[0] === 'search' && args.length > 1) {
-      const query = args.slice(1).join(' ');
+    } else if (rest[0] === 'search' && rest.length > 1) {
+      const query = rest.slice(1).join(' ');
       const results = memoryStore.search(query);
       if (results.length === 0) {
-        await this.sendResponse({ chatId, channel, text: `No memories matching "${query}".` });
+        await this.sendResponse({ chatId, channel, text: `No ${scopeLabel.toLowerCase()} memories matching "${query}".` });
         return;
       }
       const lines = results.map(m => `- [${m.type}] **${m.label}**: ${m.content.substring(0, 100)}`);
       await this.sendResponse({
         chatId,
         channel,
-        text: `\ud83d\udd0d Memory search: "${query}"\n\n${lines.join('\n')}`,
+        text: `\ud83d\udd0d ${scopeLabel} memory search: "${query}"\n\n${lines.join('\n')}`,
       });
-    } else if (args[0] === 'clear') {
+    } else if (rest[0] === 'clear') {
       const all = memoryStore.getAll();
       for (const m of all) memoryStore.remove(m.id);
-      await this.sendResponse({ chatId, channel, text: '\ud83d\uddd1\ufe0f All workspace memories cleared.' });
+      await this.sendResponse({ chatId, channel, text: `\ud83d\uddd1\ufe0f All ${scopeLabel.toLowerCase()} memories cleared.` });
     } else {
       await this.sendResponse({
         chatId,
         channel,
-        text: 'Usage:\n/memory - List recent memories\n/memory search <query> - Search memories\n/memory clear - Clear all memories\n/remember <text> - Add a memory',
+        text: 'Usage:\n/memory [--global] - List recent memories (workspace or global)\n/memory [--global] search <query> - Search memories\n/memory [--global] clear - Clear all memories in that store\n/remember [--global] [--worker <name>] <text> - Add a memory',
       });
     }
   }
@@ -1346,25 +1463,69 @@ export class Codey {
       await this.sendResponse({
         chatId,
         channel,
-        text: 'Usage: /remember <something to remember>\n\nExample: /remember This project uses PostgreSQL 15 with pgvector',
+        text: 'Usage: /remember [--global] [--worker <name>] <something to remember>\n\nExamples:\n/remember This project uses PostgreSQL 15 with pgvector\n/remember --global prefer pnpm over npm in every workspace\n/remember --worker reviewer prefer explicit error chaining over swallowed exceptions',
       });
       return;
     }
 
-    const content = args.join(' ');
-    const memoryStore = this.workspaceManager.getMemoryStore();
-    const entry = memoryStore.add({
+    // Parse leading flags (--global, --worker NAME, --workers a,b,c). Any
+    // order; consumed from the head until a non-flag token appears.
+    let scope: import('@codey/core').MemoryScope | undefined;
+    let global = false;
+    const rest = [...args];
+    while (rest.length > 0) {
+      if (rest[0] === '--global') {
+        global = true;
+        rest.splice(0, 1);
+        continue;
+      }
+      if (rest[0] === '--worker' && rest[1]) {
+        scope = { worker: rest[1] };
+        rest.splice(0, 2);
+        continue;
+      }
+      if (rest[0] === '--workers' && rest[1]) {
+        const list = rest[1].split(',').map(s => s.trim()).filter(Boolean);
+        if (list.length > 0) scope = { workers: list };
+        rest.splice(0, 2);
+        continue;
+      }
+      break;
+    }
+
+    if (rest.length === 0) {
+      await this.sendResponse({ chatId, channel, text: 'Missing memory text after flag.' });
+      return;
+    }
+
+    const content = rest.join(' ');
+    const tags = ['user'];
+    if (scope && typeof scope === 'object') {
+      if ('worker' in scope) tags.push(`worker:${scope.worker}`);
+      else if ('workers' in scope) for (const w of scope.workers) tags.push(`worker:${w}`);
+    }
+    if (global) tags.push('global');
+
+    const store = global
+      ? this.workspaceManager.getGlobalMemoryStore()
+      : this.workspaceManager.getMemoryStore();
+    const entry = store.add({
       type: 'fact',
       content,
       label: content.substring(0, 60),
-      tags: ['user'],
-      source: 'user',
+      tags,
+      source: global ? 'user-global' : 'user',
+      scope,
     });
 
+    const where = global ? ' (global)' : '';
+    const scopeNote = scope && typeof scope === 'object'
+      ? ('worker' in scope ? ` (worker: ${scope.worker})` : ` (workers: ${scope.workers.join(', ')})`)
+      : '';
     await this.sendResponse({
       chatId,
       channel,
-      text: `\ud83e\udde0 Remembered: ${entry.content}`,
+      text: `\ud83e\udde0 Remembered${where}${scopeNote}: ${entry.content}`,
     });
   }
 
@@ -1615,8 +1776,9 @@ Example: /model gpt-4.1 write a Python script`;
       text: `👷 Running worker: **${worker.name}** (${worker.personality.role})\n\nAgent: ${codingAgent}\nModel: ${model}\nTask: ${task.substring(0, 100)}${task.length > 100 ? '...' : ''}`,
     });
 
-    // Build prompt with worker context
-    const prompt = this.workspaceManager.getWorkerManager().buildWorkerPrompt(workerName, task);
+    // Build prompt with worker context + project memory
+    const basePrompt = this.workspaceManager.getWorkerManager().buildWorkerPrompt(workerName, task);
+    const prompt = this.wrapPromptWithMemory(basePrompt, task, workerName);
 
     // Run with worker's coding agent and model
     const modelConfig = this.getModelConfig(codingAgent, model);
@@ -1633,6 +1795,8 @@ Example: /model gpt-4.1 write a Python script`;
       onStream,
       context: { workingDir: this.workingDir },
     });
+
+    this.extractWorkerMemories(workerName, task, codingAgent, response);
 
     const replyText = response.success
       ? `✅ **${worker.name}** completed:\n\n${response.output}`
@@ -1660,7 +1824,10 @@ Example: /model gpt-4.1 write a Python script`;
     signal: AbortSignal | undefined,
     chatAgent: CodingAgent | undefined,
     chatModel: ModelConfig | undefined,
-    perStep: (msg: { kind: 'route'; step: number; worker: string; reason: string; isRevision: boolean }) => void | Promise<void>,
+    perStep: (msg:
+      | { kind: 'route'; step: number; worker: string; reason: string; isRevision: boolean }
+      | { kind: 'blackboard'; step: number; worker: string; summary: string }
+    ) => void | Promise<void>,
     runWorker: (worker: string, prompt: string, codingAgent: CodingAgent, modelConfig: ModelConfig | undefined) => Promise<{ success: boolean; output: string; error?: string }>,
   ): Promise<
     | { fallback: true; fallbackReason: string }
@@ -1670,6 +1837,7 @@ Example: /model gpt-4.1 write a Python script`;
         parts: Array<{ step: number; worker: string; output: string; isRevision: boolean }>;
         finalSummary: string;
         fallbackMidRun?: { reason: string };
+        blackboard: TeamBlackboard;
       }
     | {
         fallback: false;
@@ -1684,6 +1852,7 @@ Example: /model gpt-4.1 write a Python script`;
           question: string;
           options?: string[];
         };
+        blackboard: TeamBlackboard;
       }
   > {
     const workerManager = this.workspaceManager.getWorkerManager();
@@ -1697,6 +1866,7 @@ Example: /model gpt-4.1 write a Python script`;
     const parts: Array<{ step: number; worker: string; output: string; isRevision: boolean }> = [];
     let finalSummary = '';
     let fallbackMidRun: { reason: string } | undefined;
+    const blackboard = new TeamBlackboard();
 
     const { agent: mAgent, model: mModel } = this.getAdvisorAgentAndModel();
     const seenWorkers = new Set<string>();
@@ -1769,6 +1939,7 @@ Example: /model gpt-4.1 write a Python script`;
               question: pendingArbitration.question,
               options: pendingArbitration.options,
             },
+            blackboard,
           };
         }
         if (turn.done || !turn.next) {
@@ -1802,19 +1973,31 @@ Example: /model gpt-4.1 write a Python script`;
           hint: workerManager.getDispatchHint(n),
           lastDid: lastDidByWorker.get(n),
         }));
-      const prompt = workerManager.buildTeamWorkerPrompt(turnNext, stepTaskBody, teamRoster);
+      const prompt = workerManager.buildTeamWorkerPrompt(
+        turnNext,
+        stepTaskBody,
+        teamRoster,
+        blackboard.renderForWorker(turnNext),
+      );
 
       const response = await runWorker(turnNext, prompt, codingAgent, modelConfig);
       if (!response.success) {
         fallbackMidRun = { reason: `worker ${turnNext} failed: ${response.error ?? 'unknown'}` };
         break;
       }
-      parts.push({ step, worker: turnNext, output: response.output, isRevision });
+      // Pull structured markers out before anything downstream sees the
+      // output — users get clean prose, blackboard collects the structure.
+      const ingested = blackboard.ingest(turnNext, step, response.output);
+      const cleanOutput = ingested.stripped;
+      const deltaSummary = blackboard.summarizeDelta(ingested.added);
+      if (deltaSummary) await perStep({ kind: 'blackboard', step, worker: turnNext, summary: deltaSummary });
+
+      parts.push({ step, worker: turnNext, output: cleanOutput, isRevision });
       seenWorkers.add(turnNext);
       lastWorker = turnNext;
-      lastOutput = response.output;
+      lastOutput = cleanOutput;
 
-      const ask = parseAsk(response.output);
+      const ask = parseAsk(cleanOutput);
       if (!ask) continue;
 
       if (ask.kind === 'team') {
@@ -1859,7 +2042,7 @@ Example: /model gpt-4.1 write a Python script`;
       if (!closing.fallback) finalSummary = closing.final_summary ?? '';
     }
 
-    return { fallback: false, parts, finalSummary, fallbackMidRun };
+    return { fallback: false, parts, finalSummary, fallbackMidRun, blackboard };
   }
 
   private composeStepTask(
@@ -1928,14 +2111,14 @@ Example: /model gpt-4.1 write a Python script`;
     // Helper to run one worker once, used by both the Manager loop and the
     // legacy "all members in input order" fallback.
     const runOneWorker = async (
-      _workerName: string,
+      workerName: string,
       prompt: string,
       codingAgent: CodingAgent,
       modelConfig: ModelConfig | undefined,
     ): Promise<{ success: boolean; output: string; error?: string }> => {
       const onStream = handler?.streamText ? (text: string) => handler.streamText!(text) : undefined;
       const response = await this.runWithFallback(codingAgent, {
-        prompt,
+        prompt: this.wrapPromptWithMemory(prompt, task, workerName),
         agent: codingAgent,
         model: modelConfig,
         interactive: this.tuiMode,
@@ -1943,6 +2126,7 @@ Example: /model gpt-4.1 write a Python script`;
         onStream,
         context: { workingDir: this.workingDir },
       });
+      this.extractWorkerMemories(workerName, task, codingAgent, response);
       return response.success
         ? { success: true, output: response.output }
         : { success: false, output: '', error: response.error };
@@ -1963,12 +2147,16 @@ Example: /model gpt-4.1 write a Python script`;
         undefined,
         undefined,
         undefined,
-        async ({ step, worker, reason, isRevision }) => {
-          await this.sendResponse({
-            chatId,
-            channel,
-            text: `🔄 Step ${step}: **${worker}**${isRevision ? ' (revision)' : ''} — ${reason}`,
-          });
+        async (msg) => {
+          if (msg.kind === 'route') {
+            await this.sendResponse({
+              chatId,
+              channel,
+              text: `🔄 Step ${msg.step}: **${msg.worker}**${msg.isRevision ? ' (revision)' : ''} — ${msg.reason}`,
+            });
+          } else {
+            await this.sendResponse({ chatId, channel, text: msg.summary });
+          }
         },
         runOneWorker,
       );
@@ -2001,6 +2189,7 @@ Example: /model gpt-4.1 write a Python script`;
           question: p.question,
           options: p.options,
           askedAt: Date.now(),
+          blackboard: result.blackboard.toJSON(),
         });
         const rendered1 = renderQuestion(askWorkerName, '', p.question, p.options);
         await this.sendResponse({
@@ -2021,11 +2210,14 @@ Example: /model gpt-4.1 write a Python script`;
       }
 
       const text = this.formatManagerParts(result.parts, result.finalSummary, /*truncatePerStep*/ 500);
+      const bbBlock = result.blackboard.renderForUser();
+      const body = `📊 Team **${teamName}** results\n\n${text}`;
       await this.sendResponse({
         chatId,
         channel,
-        text: `📊 Team **${teamName}** results\n\n${text}`,
+        text: bbBlock ? `${body}\n\n${bbBlock}` : body,
       });
+      this.persistBlackboardDecisions(result.blackboard, teamName);
       return;
     }
 
@@ -2079,14 +2271,14 @@ Example: /model gpt-4.1 write a Python script`;
     }
     const handler = this.handlers.get(message.channel);
     const runOneWorker = async (
-      _workerName: string,
+      workerName: string,
       prompt: string,
       codingAgent: CodingAgent,
       modelConfig: ModelConfig | undefined,
     ): Promise<{ success: boolean; output: string; error?: string }> => {
       const onStream = handler?.streamText ? (text: string) => handler.streamText!(text) : undefined;
       const response = await this.runWithFallback(codingAgent, {
-        prompt,
+        prompt: this.wrapPromptWithMemory(prompt, pending.task, workerName),
         agent: codingAgent,
         model: modelConfig,
         interactive: this.tuiMode,
@@ -2094,6 +2286,7 @@ Example: /model gpt-4.1 write a Python script`;
         onStream,
         context: { workingDir: this.workingDir },
       });
+      this.extractWorkerMemories(workerName, pending.task, codingAgent, response);
       return response.success
         ? { success: true, output: response.output }
         : { success: false, output: '', error: response.error };
@@ -2109,11 +2302,13 @@ Example: /model gpt-4.1 write a Python script`;
       const seqNextWorker = seqNextName
         ? { name: seqNextName, hint: wm.getDispatchHint(seqNextName) }
         : null;
+      const blackboard = TeamBlackboard.fromJSON(pending.blackboard);
       const reprompt = wm.buildSequentialWorkerPrompt(
         memberName,
         `${pending.carry}\n\n[User answer to your question "${pending.question}"]:\n${answer}`,
         seqRoster,
         seqNextWorker,
+        blackboard.renderForWorker(memberName),
       );
       await this.sendResponse({
         chatId: message.chatId,
@@ -2129,6 +2324,12 @@ Example: /model gpt-4.1 write a Python script`;
         });
         return;
       }
+      const ingested = blackboard.ingest(memberName, pending.memberIndex + 1, response.output);
+      response.output = ingested.stripped;
+      const deltaSummary = blackboard.summarizeDelta(ingested.added);
+      if (deltaSummary) {
+        await this.sendResponse({ chatId: message.chatId, channel: message.channel, text: deltaSummary });
+      }
       const ask = parseAskUser(response.output);
       if (ask) {
         this.persistPendingTeam(message.chatId, {
@@ -2141,6 +2342,7 @@ Example: /model gpt-4.1 write a Python script`;
           question: ask.question,
           options: ask.options,
           askedAt: Date.now(),
+          blackboard: blackboard.toJSON(),
         });
         const rendered2 = renderQuestion(memberName, ask.preamble, ask.question, ask.options);
         await this.sendResponse({
@@ -2159,7 +2361,7 @@ Example: /model gpt-4.1 write a Python script`;
         team.members,
         pending.task,
         runOneWorker,
-        { startIndex: pending.memberIndex + 1, startCarry: carryForNext, priorResults },
+        { startIndex: pending.memberIndex + 1, startCarry: carryForNext, priorResults, blackboard },
       );
       return;
     }
@@ -2214,7 +2416,18 @@ Example: /model gpt-4.1 write a Python script`;
       ? this.getModelConfig(codingAgent, workerModelName)
       : this.getDefaultModelConfig(codingAgent);
     const stepTaskBody = this.composeStepTask(pending.task, turn.instruction, pending.lastWorker, pending.lastOutput);
-    const stepPrompt = wm.buildWorkerPrompt(turn.next, stepTaskBody);
+    // Use the team-aware builder so the resumed worker also sees the blackboard
+    // and the marker protocol — keeps post-pause steps consistent with pre-pause.
+    const resumeRoster = team.members
+      .filter(n => n !== turn.next)
+      .map(n => ({ name: n, hint: wm.getDispatchHint(n) }));
+    const resumeBoardForPrompt = TeamBlackboard.fromJSON(pending.blackboard);
+    const stepPrompt = wm.buildTeamWorkerPrompt(
+      turn.next,
+      stepTaskBody,
+      resumeRoster,
+      resumeBoardForPrompt.renderForWorker(turn.next),
+    );
     const response = await runOneWorker(turn.next, stepPrompt, codingAgent, modelConfig);
     if (!response.success) {
       await this.sendResponse({
@@ -2224,6 +2437,11 @@ Example: /model gpt-4.1 write a Python script`;
       });
       return;
     }
+    // Restore the blackboard captured at pause time so resumed step + future
+    // pauses keep accumulating against the same shared state.
+    const resumeBoard = TeamBlackboard.fromJSON(pending.blackboard);
+    const resumeIngest = resumeBoard.ingest(turn.next, pending.step, response.output);
+    response.output = resumeIngest.stripped;
     const ask = parseAskUser(response.output);
     const newParts = [...pending.partsSoFar, { step: pending.step, worker: turn.next, output: response.output, isRevision }];
     const newSeen = Array.from(new Set([...pending.seenWorkers, turn.next]));
@@ -2244,6 +2462,7 @@ Example: /model gpt-4.1 write a Python script`;
         askingWorker: turn.next,
         question: ask.question,
         options: ask.options,
+        blackboard: resumeBoard.toJSON(),
         askedAt: Date.now(),
       });
       const rendered3 = renderQuestion(turn.next, ask.preamble, ask.question, ask.options);
@@ -2267,10 +2486,13 @@ Example: /model gpt-4.1 write a Python script`;
       { agent: mAgent, model: mModel, runner: this.advisorRunner },
     );
     const finalSummary = closing.fallback ? '' : (closing.final_summary ?? '');
+    const resumeBlock = resumeBoard.renderForUser();
+    const resumeFormatted = this.formatManagerParts(newParts, finalSummary, 500);
+    this.persistBlackboardDecisions(resumeBoard, pending.teamName);
     await this.sendResponse({
       chatId: message.chatId,
       channel: message.channel,
-      text: this.formatManagerParts(newParts, finalSummary, 500),
+      text: resumeBlock ? `${resumeFormatted}\n\n${resumeBlock}` : resumeFormatted,
     });
   }
 
@@ -2285,12 +2507,13 @@ Example: /model gpt-4.1 write a Python script`;
       codingAgent: CodingAgent,
       modelConfig: ModelConfig | undefined,
     ) => Promise<{ success: boolean; output: string; error?: string }>,
-    opts: { startIndex?: number; startCarry?: string; priorResults?: string[] } = {},
+    opts: { startIndex?: number; startCarry?: string; priorResults?: string[]; blackboard?: TeamBlackboard } = {},
   ): Promise<void> {
     const { chatId, channel } = message;
     const workerManager = this.workspaceManager.getWorkerManager();
     const results: string[] = opts.priorResults ? [...opts.priorResults] : [];
     let currentTask = opts.startCarry ?? task;
+    const blackboard = opts.blackboard ?? new TeamBlackboard();
 
     for (let i = opts.startIndex ?? 0; i < members.length; i++) {
       const memberName = members[i];
@@ -2316,6 +2539,7 @@ Example: /model gpt-4.1 write a Python script`;
         currentTask,
         roster,
         nextWorker,
+        blackboard.renderForWorker(memberName),
       );
       const modelConfig = this.getModelConfig(codingAgent, model);
       const response = await runOneWorker(memberName, prompt, codingAgent, modelConfig);
@@ -2323,7 +2547,13 @@ Example: /model gpt-4.1 write a Python script`;
         results.push(`**${worker.name}**: ❌ Failed - ${response.error}`);
         break;
       }
-      const ask = parseAskUser(response.output);
+      const ingested = blackboard.ingest(memberName, i + 1, response.output);
+      const cleanOutput = ingested.stripped;
+      const deltaSummary = blackboard.summarizeDelta(ingested.added);
+      if (deltaSummary) {
+        await this.sendResponse({ chatId, channel, text: deltaSummary });
+      }
+      const ask = parseAskUser(cleanOutput);
       if (ask) {
         const pending: PendingTeamState = {
           mode: 'sequential',
@@ -2335,6 +2565,7 @@ Example: /model gpt-4.1 write a Python script`;
           question: ask.question,
           options: ask.options,
           askedAt: Date.now(),
+          blackboard: blackboard.toJSON(),
         };
         this.persistPendingTeam(chatId, pending);
         const rendered4 = renderQuestion(worker.name, ask.preamble, ask.question, ask.options);
@@ -2346,15 +2577,18 @@ Example: /model gpt-4.1 write a Python script`;
         });
         return;
       }
-      results.push(`**${worker.name}**: ${response.output.substring(0, 500)}`);
-      currentTask = `Previous worker output:\n${response.output}\n\nYour task: ${task}`;
+      results.push(`**${worker.name}**: ${cleanOutput.substring(0, 500)}`);
+      currentTask = `Previous worker output:\n${cleanOutput}\n\nYour task: ${task}`;
     }
 
+    const bbBlock = blackboard.renderForUser();
+    const body = `📊 Team **${teamName}** results\n\n${results.join('\n\n')}`;
     await this.sendResponse({
       chatId,
       channel,
-      text: `📊 Team **${teamName}** results\n\n${results.join('\n\n')}`,
+      text: bbBlock ? `${body}\n\n${bbBlock}` : body,
     });
+    this.persistBlackboardDecisions(blackboard, teamName);
   }
 
   private async runTeamForChat(
@@ -2376,13 +2610,13 @@ Example: /model gpt-4.1 write a Python script`;
     const workerManager = this.workspaceManager.getWorkerManager();
 
     const runOneWorker = async (
-      _workerName: string,
+      workerName: string,
       workerPrompt: string,
       codingAgent: CodingAgent,
       modelConfig: ModelConfig | undefined,
     ): Promise<{ success: boolean; output: string; error?: string }> => {
       const response = await this.runWithFallback(codingAgent, {
-        prompt: workerPrompt,
+        prompt: this.wrapPromptWithMemory(workerPrompt, prompt, workerName),
         agent: codingAgent,
         model: modelConfig,
         context: { workingDir },
@@ -2390,6 +2624,7 @@ Example: /model gpt-4.1 write a Python script`;
         onStatus: (_update: any) => { /* status forwarded via sink elsewhere */ },
         signal,
       });
+      if (response) this.extractWorkerMemories(workerName, prompt, codingAgent, response);
       return response?.success
         ? { success: true, output: this.formatAgentResponse(response) }
         : { success: false, output: '', error: response?.error };
@@ -2476,6 +2711,7 @@ Example: /model gpt-4.1 write a Python script`;
             c.discussion = { teamName, status: 'done', startedAt: c.discussion?.startedAt ?? Date.now(), terminatedReason: ev.reason };
             (c as any).updatedAt = Date.now();
           }
+          this.persistDiscussionSummary(teamName, prompt, ev);
           void sink({ type: 'stream', chatId, token: this.formatParallelFinal(ev, teamName) });
         },
       });
@@ -2505,16 +2741,20 @@ Example: /model gpt-4.1 write a Python script`;
         signal,
         chatAgent,
         chatModel,
-        ({ step, worker, reason, isRevision }) => {
-          sink({
-            type: 'info',
-            chatId,
-            message: `Step ${step}: ${worker}${isRevision ? ' (revision)' : ''} — ${reason}`,
-          });
-          const label = isRevision ? `${worker} (revision)` : worker;
-          const sep = isFirstStep ? '' : '\n\n---\n\n';
-          sink({ type: 'stream', chatId, token: `${sep}### Step ${step}: ${label}\n\n` });
-          isFirstStep = false;
+        (msg) => {
+          if (msg.kind === 'route') {
+            sink({
+              type: 'info',
+              chatId,
+              message: `Step ${msg.step}: ${msg.worker}${msg.isRevision ? ' (revision)' : ''} — ${msg.reason}`,
+            });
+            const label = msg.isRevision ? `${msg.worker} (revision)` : msg.worker;
+            const sep = isFirstStep ? '' : '\n\n---\n\n';
+            sink({ type: 'stream', chatId, token: `${sep}### Step ${msg.step}: ${label}\n\n` });
+            isFirstStep = false;
+          } else {
+            sink({ type: 'info', chatId, message: msg.summary });
+          }
         },
         runOneWorker,
       );
@@ -2542,6 +2782,7 @@ Example: /model gpt-4.1 write a Python script`;
           askingWorker: p.askingWorker,
           question: p.question,
           options: p.options,
+          blackboard: result.blackboard.toJSON(),
           askedAt: Date.now(),
         });
         const rendered5 = renderQuestion(askWorkerName, '', p.question, p.options);
@@ -2554,13 +2795,17 @@ Example: /model gpt-4.1 write a Python script`;
         if (result.fallbackMidRun) {
           sink({ type: 'info', chatId, message: `Manager halted mid-run: ${result.fallbackMidRun.reason}` });
         }
-        return { response: this.formatManagerParts(result.parts, result.finalSummary) };
+        const bbBlock = result.blackboard.renderForUser();
+        const formatted = this.formatManagerParts(result.parts, result.finalSummary);
+        this.persistBlackboardDecisions(result.blackboard, teamName);
+        return { response: bbBlock ? `${formatted}\n\n${bbBlock}` : formatted };
       }
     }
 
     // dispatch === 'all', forceAll, or auto-routing fallback
     let carry = prompt;
     const parts: string[] = [];
+    const blackboard = new TeamBlackboard();
     for (let i = 0; i < team.members.length; i++) {
       if (signal?.aborted) break;
       const memberName = team.members[i];
@@ -2578,6 +2823,7 @@ Example: /model gpt-4.1 write a Python script`;
         carry,
         seqRoster,
         seqNextWorker,
+        blackboard.renderForWorker(memberName),
       );
       const codingAgent = (workerManager.getWorkerCodingAgent(memberName) ?? chatAgent ?? this.getDefaultAgent()) as CodingAgent;
       const workerModel = workerManager.getWorkerModel(memberName);
@@ -2587,7 +2833,11 @@ Example: /model gpt-4.1 write a Python script`;
         parts.push(`### Step ${stepNum}: ${memberName}\n\n`);
         break;
       }
-      const ask = parseAskUser(response.output);
+      const ingested = blackboard.ingest(memberName, stepNum, response.output);
+      const cleanOutput = ingested.stripped;
+      const deltaSummary = blackboard.summarizeDelta(ingested.added);
+      if (deltaSummary) sink({ type: 'info', chatId, message: deltaSummary });
+      const ask = parseAskUser(cleanOutput);
       if (ask) {
         const askWorkerName = workerManager.getWorker(memberName)?.name ?? memberName;
         this.persistPendingTeam(chatId, {
@@ -2600,15 +2850,19 @@ Example: /model gpt-4.1 write a Python script`;
           question: ask.question,
           options: ask.options,
           askedAt: Date.now(),
+          blackboard: blackboard.toJSON(),
         });
         const rendered6 = renderQuestion(askWorkerName, ask.preamble, ask.question, ask.options);
         sink({ type: 'stream', chatId, token: rendered6.text });
         return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + rendered6.text : rendered6.text, choices: rendered6.choices };
       }
-      parts.push(`### Step ${stepNum}: ${memberName}\n\n${response.output}`);
-      carry = response.output;
+      parts.push(`### Step ${stepNum}: ${memberName}\n\n${cleanOutput}`);
+      carry = cleanOutput;
     }
-    return { response: parts.join('\n\n---\n\n') };
+    const bbBlock = blackboard.renderForUser();
+    this.persistBlackboardDecisions(blackboard, teamName);
+    const body = parts.join('\n\n---\n\n');
+    return { response: bbBlock ? `${body}\n\n${bbBlock}` : body };
   }
 
   private formatUptime(seconds: number): string {
@@ -2957,11 +3211,9 @@ Example: /model gpt-4.1 write a Python script`;
       sse('conversationId', ctxId);
     }
 
-    // Build memory context
+    // Build memory context — merges user-global + workspace stores.
     const memoryStore = this.workspaceManager.getMemoryStore();
-    const memoryContext = (this.config.memory?.enabled !== false)
-      ? memoryStore.buildContext(prompt)
-      : undefined;
+    const memoryContext = this.buildMergedMemoryContext(prompt) || undefined;
 
     const onStream = sse ? (text: string) => sse('stream', text) : undefined;
     const onStatus = sse ? (update: any) => sse('status', update) : undefined;


### PR DESCRIPTION
## Summary

Workspace memory used to be effectively chat-only — workers and teams bypassed `buildContext`, never wrote back, and the store itself had several persistence/correctness issues. This PR:

- Hardens `MemoryStore` (async/atomic writes, dedup, BM25, scope, throttling).
- Adds a per-team-run **shared blackboard** with structured `[FACT]` / `[DECISION]` / `[HANDOFF]` / `[OPEN]` markers that workers emit and the gateway strips from user-visible output.
- Adds a **user-global memory layer** at `~/.codey/` shared across workspaces.
- Wires memory into every worker / team / parallel-discussion path.

## What changed

### `MemoryStore` (`packages/core/src/memory.ts`)

- Async write queue + debounced flush + atomic `temp+rename` (replaces sync per-mutation `writeFileSync`); failed writes reschedule themselves.
- Read tracking decoupled from `updatedAt`: new `lastAccessedAt`; `buildContext` bumps counters in memory and throttles persistence to ~60s / 20 reads.
- Content-hash dedup in `add()` so repeated `/remember` or auto-extracts merge tags instead of duplicating rows.
- **BM25 search** over `label×3 / tags×2 / content×1` with stop-words and source-aware weighting (`user-global` 1.6, `user` 1.5, `team` 1.3, `planner` 1.2, `auto` 0.7); prune only touches `source: 'auto'`.
- New `MemoryScope = 'workspace' | { worker } | { workers[] }` for per-worker visibility; `buildContext` / `search` / `getRecent` accept optional `forWorker`.
- Per-entry truncation; stable section ordering in legacy `memory.md`; `migrateFromLegacy` null-check fix; `load()` drains after migration so short-lived processes don't lose imported entries.

### Team blackboard (`packages/core/src/team-blackboard.ts`, new)

- `TeamBlackboard` collects `[FACT]` / `[DECISION]` / `[HANDOFF: name]` / `[OPEN]` markers emitted in worker output. `parseMarkers` strips them — the UI sees clean prose.
- `renderForWorker(name)` injects the relevant subset (handoffs filtered to addressee) into the next worker's prompt.
- `renderForUser()` appends a final `### 🧠 Team blackboard` section to the chat response.
- `toJSON` / `fromJSON` snapshot lets pause/resume carry the board across `[ASK_USER]` interrupts via new `PendingTeamState.blackboard`.
- Marker protocol added to `buildTeamWorkerPrompt` and `buildSequentialWorkerPrompt`.

### Global memory layer

- `WorkspaceManager.getGlobalMemoryStore()` — lazy `MemoryStore` rooted at `~/.codey/` (override via `CODEY_GLOBAL_MEMORY_DIR`), survives workspace switches.
- Gateway's `buildMergedMemoryContext` prefixes the global block with `## User-Global Memory` so agents can distinguish global vs workspace facts; chat and worker paths both consume it.

### Gateway wiring

- `wrapPromptWithMemory(prompt, query, forWorker?)` + `extractWorkerMemories(...)` prepend merged context and run the auto-extract heuristic on each worker step's response (tagged `[worker:name]`).
- `runAdvisorLoop`, `runAllMembersInOrder`, `runTeamForChat`: maintain a `TeamBlackboard`, inject it into each step's prompt, ingest+strip markers from each response, emit per-step `📋 Blackboard +1 decision...` info to UI, and persist `[DECISION]` markers as `source: 'team'` memory on completion.
- Pause/resume paths snapshot blackboard to `PendingTeamState` and rehydrate on resume.
- Parallel discussion `onFinal` persists Manager's final summary as a decision memory tagged `['discussion', teamName, 'reason:<...>']`.

### User surface

```
/remember [--global] [--worker NAME | --workers a,b,c] <text>
/memory  [--global] list | search <q> | clear
```

## Test plan

- [ ] `/remember <text>` then `/memory list` shows the entry; restart gateway and the entry survives.
- [ ] `/remember --global pnpm over npm`; switch workspaces and confirm a new chat sees the global block above the workspace block.
- [ ] `/remember --worker reviewer focus on data races` — confirm the entry surfaces when reviewer runs but not for other workers.
- [ ] Run a multi-step team; verify `[FACT]/[DECISION]` markers in worker output are stripped from the UI bubble and surface in the per-step `📋 Blackboard ...` ticker + final `🧠 Team blackboard` block.
- [ ] Pause a team with `[ASK_USER]`, answer it; confirm prior blackboard entries are still visible to the resumed step.
- [ ] Run a parallel discussion to consensus; `/memory search <topic>` returns the auto-saved summary as a `decision`.
- [ ] Same prompt twice in a row produces only one memory entry (dedup).
- [ ] BM25 spot-check: `/memory search` against a populated store ranks label/tag matches above content matches and demotes auto entries below user entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)