### PR TITLE
fix(imessage): default-deny when allowedSenders is empty

### DIFF
--- a/packages/gateway/src/channels/imessage.ts
+++ b/packages/gateway/src/channels/imessage.ts
@@ -28,10 +28,12 @@ export class IMessageHandler extends BaseChannelHandler {
 
   async start(config: IMessageConfig): Promise<void> {
     const senders = config.allowedSenders ?? [];
-    if (senders.length === 0) {
+    this.allowedSenders = new Set(senders.map(s => s.trim().toLowerCase()).filter(Boolean));
+
+    if (this.allowedSenders.size === 0) {
       console.log('[iMessage] No allowedSenders configured — receive disabled, send-only mode');
+      return;
     }
-    this.allowedSenders = new Set(senders.map(s => s.toLowerCase()));
 
     try {
       this.db = new Database(CHAT_DB_PATH, { readonly: true, fileMustExist: true });
@@ -55,7 +57,7 @@ export class IMessageHandler extends BaseChannelHandler {
     const intervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.pollInterval = setInterval(() => this.poll(), intervalMs);
 
-    console.log(`[iMessage] Handler started — polling every ${intervalMs}ms, ${senders.length} allowed sender(s)`);
+    console.log(`[iMessage] Handler started — polling every ${intervalMs}ms, ${this.allowedSenders.size} allowed sender(s)`);
   }
 
   async stop(): Promise<void> {
@@ -84,7 +86,8 @@ export class IMessageHandler extends BaseChannelHandler {
       for (const row of rows) {
         this.lastSeenRowId = row.ROWID;
 
-        if (this.allowedSenders.size > 0 && !this.allowedSenders.has(row.handle.toLowerCase())) {
+        if (!this.allowedSenders.has(row.handle.trim().toLowerCase())) {
+          console.log(`[iMessage] Dropped message from non-allowed sender: ${row.handle}`);
           continue;
         }
 


### PR DESCRIPTION
## Summary
- `iMessage` poll filter only ran when `allowedSenders.size > 0`, so an empty whitelist let **every** sender through — the opposite of the "receive disabled, send-only mode" the start log claimed. This caused random phone numbers to trigger agent replies.
- `start()` now early-returns (no `chat.db` open, no poll scheduled) when the allowed list is empty, and the poll filter is unconditional.
- Inputs are `trim().toLowerCase()`'d on both the config and the `chat.db` handle side, so stray whitespace can't silently drop into the empty-list path.
- Dropped messages are now logged with the offending handle, so future mismatches (group-chat members, Apple ID emails, short-codes) are debuggable from the daemon log.

## Test plan
- [ ] `npm run build` succeeds.
- [ ] Start daemon with `imessage.enabled=true` and an empty `allowedSenders` → log shows `receive disabled, send-only mode` and no DB/poll is opened.
- [ ] Start daemon with one allowed phone → messages from that number reach the gateway; messages from other numbers produce a `Dropped message from non-allowed sender:` log and never trigger a reply.
- [ ] Sending via `sendToRoute` / `sendMessage` still works in both configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)