### PR TITLE
Quick Question: inline send button + composer image/file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.3] - 2026-06-02
 
 ### Added
-- **Quick Question** — a read-only side-thread in the macOS app that answers questions grounded in the current chat's content without affecting it. It has its own ephemeral history (in-memory, cleared on app restart) and never touches the main chat's messages, CLI session, or channel mirroring, so it can run alongside an active chat. Each turn sees the parent chat (read-only) plus the Quick Question thread's own prior turns. Open it from the new **Quick Question** tab in the right context panel, by typing `/qq <question>`, or by typing a bare `QQ`. Uses the Aide model when configured, otherwise the chat's model, and is restricted to read-only tools.
+- **Quick Question** — a read-only side-thread in the macOS app that answers questions grounded in the current chat's content without affecting it. It has its own ephemeral history (in-memory, cleared on app restart) and never touches the main chat's messages, CLI session, or channel mirroring, so it can run alongside an active chat. Each turn sees the parent chat (read-only) plus the Quick Question thread's own prior turns. Open it from the new **Quick Question** tab in the right context panel, by typing `/qq <question>`, or by typing a bare `QQ`. The composer matches the main chat input (inline send button) and supports image and file attachments via the attach button, paste, or drag-and-drop. Uses the Aide model when configured, otherwise the chat's model, and is restricted to read-only tools.
 
 ## [0.6.2] - 2026-06-01
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1610,13 +1610,13 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('qq:ask', async (_e, payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }> }) =>
+  ipcMain.handle('qq:ask', async (_e, payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }>; attachments?: any[] }) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
       // Stream events to the renderer on a dedicated channel so QQ never
       // collides with the main 'chats:event' stream.
       const sink = (ev: any) => sendToRenderer('qq:event', ev)
-      return inProcessGateway.runQuickQuestion(payload.chatId, payload.question, payload.history ?? [], sink)
+      return inProcessGateway.runQuickQuestion(payload.chatId, payload.question, payload.history ?? [], sink, payload.attachments)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -118,7 +118,7 @@ contextBridge.exposeInMainWorld('codey', {
     },
   },
   qq: {
-    ask: (payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }> }) =>
+    ask: (payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }>; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) =>
       ipcRenderer.invoke('qq:ask', payload),
     stop: (chatId: string) => ipcRenderer.invoke('qq:stop', chatId),
     onEvent: (handler: (ev: any) => void) => {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -106,7 +106,7 @@ declare global {
         updateContextPanelOpen: (id: string, open: boolean | null) => Promise<IpcResult<Chat>>
       }
       qq: {
-        ask: (payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }> }) => Promise<IpcResult<{ response: string; tokens?: number; durationSec?: number }>>
+        ask: (payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }>; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) => Promise<IpcResult<{ response: string; tokens?: number; durationSec?: number }>>
         stop: (chatId: string) => Promise<IpcResult<boolean>>
         onEvent: (handler: (ev: QQStreamEvent) => void) => () => void
       }

--- a/codey-mac/src/components/QuickQuestionView.tsx
+++ b/codey-mac/src/components/QuickQuestionView.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { C } from '../theme'
 import { Markdown } from './Markdown'
 import { useQuickQuestion } from '../hooks/useQuickQuestion'
+import { apiService } from '../services/api'
+import type { FileAttachment } from '../types'
 
 interface Props {
   chatId: string
@@ -9,21 +11,129 @@ interface Props {
   inputRef?: React.RefObject<HTMLTextAreaElement>
 }
 
+// Small primitives mirrored from ChatTab's composer so the Quick Question
+// composer matches the main chat input (inline send button, attach, etc.).
+const SendIcon: React.FC<{ color: string }> = ({ color }) => (
+  <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M22 2L11 13M22 2L15 22 11 13 2 9l20-7z" />
+  </svg>
+)
+const StopIcon: React.FC<{ color: string }> = ({ color }) => (
+  <svg width={12} height={12} viewBox="0 0 24 24" fill={color}>
+    <rect x="4" y="4" width="16" height="16" rx="2" />
+  </svg>
+)
+const PaperclipIcon: React.FC<{ color: string }> = ({ color }) => (
+  <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21.44 11.05L12.25 20.24a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 11-2.83-2.83l8.49-8.48" />
+  </svg>
+)
+const FileIcon: React.FC<{ color: string; size?: number }> = ({ color, size = 14 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+    <path d="M14 2v6h6" />
+  </svg>
+)
+
+const assetUrl = (absPath: string): string =>
+  `codey-asset://file/${encodeURIComponent(absPath)}`
+
+const formatBytes = (n: number): string => {
+  if (!Number.isFinite(n) || n < 0) return ''
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)} KB`
+  return `${(n / (1024 * 1024)).toFixed(n < 10 * 1024 * 1024 ? 1 : 0)} MB`
+}
+
+const MAX_SIZE = 10 * 1024 * 1024 // 10MB
+const MAX_ATTACHMENTS = 10
+const ACCEPT = 'image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql'
+
 export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
   const { getThread, ask, stop } = useQuickQuestion()
   const thread = getThread(chatId)
   const [draft, setDraft] = React.useState('')
+  const [pending, setPending] = React.useState<FileAttachment[]>([])
+  const [uploadError, setUploadError] = React.useState<string | null>(null)
+  const [isDragging, setIsDragging] = React.useState(false)
   const listRef = React.useRef<HTMLDivElement>(null)
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
+  const dragDepthRef = React.useRef(0)
 
   React.useEffect(() => {
     listRef.current?.scrollTo({ top: listRef.current.scrollHeight })
   }, [thread.messages, thread.activity])
 
+  const uploadFiles = async (files: FileList | File[]) => {
+    const fileArray = Array.from(files)
+    let count = pending.length
+    const errors: string[] = []
+    for (const file of fileArray) {
+      if (count >= MAX_ATTACHMENTS) { errors.push(`Limit of ${MAX_ATTACHMENTS} attachments reached`); break }
+      if (file.size > MAX_SIZE) { errors.push(`${file.name} exceeds 10 MB`); continue }
+      try {
+        const buffer = await file.arrayBuffer()
+        const att = await apiService.chats.upload(chatId, file.name, file.type || 'application/octet-stream', buffer)
+        setPending(prev => [...prev, att])
+        count++
+      } catch (err) {
+        errors.push(`${file.name}: ${(err as Error).message}`)
+      }
+    }
+    if (errors.length > 0) {
+      setUploadError(errors.join(' · '))
+      window.setTimeout(() => setUploadError(null), 4000)
+    }
+  }
+
+  const removeAttachment = (id: string) => setPending(prev => prev.filter(a => a.id !== id))
+
+  const handleFilePick = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      await uploadFiles(e.target.files)
+      e.target.value = ''
+    }
+  }
+
+  const handlePaste = async (e: React.ClipboardEvent) => {
+    const files = Array.from(e.clipboardData.files)
+    if (files.length > 0) {
+      e.preventDefault()
+      await uploadFiles(files)
+    }
+  }
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault(); e.stopPropagation()
+    if (!e.dataTransfer.types.includes('Files')) return
+    dragDepthRef.current += 1
+    setIsDragging(true)
+  }
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault(); e.stopPropagation()
+    if (e.dataTransfer.types.includes('Files')) e.dataTransfer.dropEffect = 'copy'
+  }
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault(); e.stopPropagation()
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+    if (dragDepthRef.current === 0) setIsDragging(false)
+  }
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault(); e.stopPropagation()
+    dragDepthRef.current = 0
+    setIsDragging(false)
+    if (e.dataTransfer.files.length > 0) await uploadFiles(e.dataTransfer.files)
+  }
+
+  const canSend = (!!draft.trim() || pending.length > 0) && !thread.inFlight
+
   const submit = () => {
-    const q = draft.trim()
-    if (!q || thread.inFlight) return
+    if (!canSend) return
+    const q = draft
+    const atts = pending.length > 0 ? [...pending] : undefined
     setDraft('')
-    void ask(chatId, q)
+    setPending([])
+    void ask(chatId, q, atts)
   }
 
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -34,7 +144,13 @@ export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
   }
 
   return (
-    <div style={qqStyles.root}>
+    <div
+      style={qqStyles.root}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
       <div style={qqStyles.hint}>
         Read-only side-thread. Answers use this chat's content as context but never
         modify the chat or its files.
@@ -50,26 +166,97 @@ export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
               : m.error
                 ? <span style={qqStyles.errText}>{m.content}</span>
                 : <Markdown>{m.content || (m.streaming ? '…' : '')}</Markdown>}
+            {m.attachments && m.attachments.length > 0 && (
+              <div style={qqStyles.msgAttRow}>
+                {m.attachments.map(a => a.mimeType.startsWith('image/') ? (
+                  <img
+                    key={a.id} src={assetUrl(a.path)} alt={a.name} title={a.name}
+                    style={qqStyles.msgAttImg}
+                    onClick={() => window.codey?.openPath?.(a.path)}
+                  />
+                ) : (
+                  <div key={a.id} style={qqStyles.msgAttChip} title={`${a.name} · ${formatBytes(a.size)}`} onClick={() => window.codey?.openPath?.(a.path)}>
+                    <FileIcon color={C.fg2} size={12} />
+                    <span style={qqStyles.msgAttName}>{a.name}</span>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         ))}
         {thread.inFlight && thread.activity && (
           <div style={qqStyles.activity}>{thread.activity}</div>
         )}
       </div>
-      <div style={qqStyles.composer}>
+
+      {uploadError && <div style={qqStyles.uploadError}>{uploadError}</div>}
+
+      {pending.length > 0 && (
+        <div style={qqStyles.pendingRow}>
+          {pending.map(att => att.mimeType.startsWith('image/') ? (
+            <div key={att.id} style={qqStyles.pendingImageWrap} title={`${att.name} · ${formatBytes(att.size)}`}>
+              <img src={assetUrl(att.path)} alt={att.name} style={qqStyles.pendingImage} />
+              <button onClick={() => removeAttachment(att.id)} style={qqStyles.pendingRemoveBtn} aria-label="Remove">×</button>
+            </div>
+          ) : (
+            <div key={att.id} style={qqStyles.pendingFileChip} title={`${att.name} · ${formatBytes(att.size)}`}>
+              <FileIcon color={C.fg2} size={14} />
+              <span style={qqStyles.pendingFileName}>{att.name}</span>
+              <button onClick={() => removeAttachment(att.id)} style={qqStyles.pendingFileRemoveBtn} aria-label="Remove">×</button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div style={{ ...qqStyles.composerRow, ...(isDragging ? qqStyles.composerRowDragging : null) }}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept={ACCEPT}
+          style={{ display: 'none' }}
+          onChange={handleFilePick}
+        />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={thread.inFlight}
+          style={qqStyles.attachBtn}
+          title="Attach file"
+        >
+          <PaperclipIcon color={thread.inFlight ? C.fg3 : C.fg2} />
+        </button>
         <textarea
           ref={inputRef}
           style={qqStyles.textarea}
           value={draft}
-          placeholder="Ask a quick question…"
+          placeholder={isDragging ? 'Drop to attach…' : 'Ask a quick question… (↵ to send)'}
           onChange={e => setDraft(e.target.value)}
           onKeyDown={onKey}
-          rows={2}
+          onPaste={handlePaste}
+          onInput={e => {
+            const el = e.currentTarget
+            el.style.height = 'auto'
+            el.style.height = Math.min(el.scrollHeight, 120) + 'px'
+          }}
+          rows={1}
         />
         {thread.inFlight ? (
-          <button style={qqStyles.stopBtn} onClick={() => void stop(chatId)}>Stop</button>
+          <button
+            style={{ ...qqStyles.sendBtn, background: C.red, cursor: 'pointer' }}
+            onClick={() => void stop(chatId)}
+            title="Stop"
+          >
+            <StopIcon color="#fff" />
+          </button>
         ) : (
-          <button style={qqStyles.sendBtn} onClick={submit} disabled={!draft.trim()}>Ask</button>
+          <button
+            style={{ ...qqStyles.sendBtn, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
+            onClick={submit}
+            disabled={!canSend}
+            title="Ask"
+          >
+            <SendIcon color={canSend ? C.onAccent : C.fg3} />
+          </button>
         )}
       </div>
     </div>
@@ -86,18 +273,53 @@ const qqStyles: Record<string, React.CSSProperties> = {
   asstMsg: { alignSelf: 'flex-start', maxWidth: '100%', fontSize: 12, color: C.fg2, minWidth: 0 },
   errText: { color: C.dangerFg ?? '#e66', fontSize: 12, whiteSpace: 'pre-wrap' },
   activity: { color: C.fg3, fontSize: 10, fontStyle: 'italic' },
-  composer: { display: 'flex', flexDirection: 'column', gap: 6, paddingTop: 8, borderTop: `1px solid ${C.border}` },
+
+  msgAttRow: { display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 },
+  msgAttImg: { width: 64, height: 64, objectFit: 'cover', borderRadius: 6, border: `1px solid ${C.border2}`, cursor: 'pointer' },
+  msgAttChip: {
+    display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer',
+    background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6,
+    padding: '3px 8px', maxWidth: 180,
+  },
+  msgAttName: { color: C.fg2, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+
+  uploadError: { color: C.dangerFg ?? '#e66', fontSize: 11, padding: '4px 2px 0' },
+
+  pendingRow: { display: 'flex', flexWrap: 'wrap', gap: 8, padding: '8px 0 4px' },
+  pendingImageWrap: { position: 'relative', width: 48, height: 48, borderRadius: 8, overflow: 'hidden', border: `1px solid ${C.border2}` },
+  pendingImage: { width: '100%', height: '100%', objectFit: 'cover', display: 'block' },
+  pendingRemoveBtn: {
+    position: 'absolute', top: 2, right: 2, width: 16, height: 16, borderRadius: 8, border: 'none',
+    background: 'rgba(0,0,0,0.7)', color: '#fff', cursor: 'pointer', fontSize: 12, lineHeight: '14px', padding: 0,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+  pendingFileChip: {
+    display: 'flex', alignItems: 'center', gap: 6, background: C.surface2,
+    border: `1px solid ${C.border2}`, borderRadius: 8, padding: '4px 4px 4px 8px', height: 48, boxSizing: 'border-box',
+  },
+  pendingFileName: { color: C.fg, fontSize: 11, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 110 },
+  pendingFileRemoveBtn: {
+    width: 20, height: 20, borderRadius: 10, border: 'none', background: 'transparent', color: C.fg3,
+    cursor: 'pointer', fontSize: 15, lineHeight: 1, padding: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+
+  composerRow: {
+    display: 'flex', gap: 6, alignItems: 'flex-end', paddingTop: 8,
+    borderTop: `1px solid ${C.border}`,
+  },
+  composerRowDragging: { borderTop: `1px solid ${C.accent}` },
+  attachBtn: {
+    width: 32, height: 32, borderRadius: 8, border: 'none', background: 'transparent',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, cursor: 'pointer',
+  },
   textarea: {
-    resize: 'none', width: '100%', background: C.surface3, color: C.fg,
-    border: `1px solid ${C.border2}`, borderRadius: 6, padding: '6px 8px',
-    fontSize: 12, fontFamily: 'inherit', boxSizing: 'border-box',
+    flex: 1, resize: 'none', background: C.surface3, color: C.fg,
+    border: `1px solid ${C.border2}`, borderRadius: 8, padding: '8px 8px',
+    fontSize: 12, fontFamily: 'inherit', lineHeight: 1.5, maxHeight: 120, overflowY: 'auto',
+    outline: 'none', boxSizing: 'border-box',
   },
   sendBtn: {
-    alignSelf: 'flex-end', background: C.accent, color: C.onAccent, border: 'none',
-    borderRadius: 6, fontSize: 11, padding: '4px 12px', cursor: 'pointer',
-  },
-  stopBtn: {
-    alignSelf: 'flex-end', background: 'transparent', color: C.fg2,
-    border: `1px solid ${C.border2}`, borderRadius: 6, fontSize: 11, padding: '4px 12px', cursor: 'pointer',
+    width: 32, height: 32, borderRadius: 8, border: 'none',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, transition: 'background 0.15s',
   },
 }

--- a/codey-mac/src/hooks/useQuickQuestion.tsx
+++ b/codey-mac/src/hooks/useQuickQuestion.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useReducer } from 'react'
 import { apiService } from '../services/api'
 import type { QQStreamEvent } from '../services/api'
+import type { FileAttachment } from '../types'
 
 export interface QQMessage {
   id: string
@@ -8,6 +9,7 @@ export interface QQMessage {
   content: string
   streaming?: boolean
   error?: boolean
+  attachments?: FileAttachment[]
 }
 
 export interface QQThread {
@@ -79,7 +81,7 @@ function reducer(state: State, action: Action): State {
 
 interface QuickQuestionContextValue {
   getThread: (chatId: string) => QQThread
-  ask: (chatId: string, question: string) => Promise<void>
+  ask: (chatId: string, question: string, attachments?: FileAttachment[]) => Promise<void>
   stop: (chatId: string) => Promise<void>
 }
 
@@ -113,9 +115,10 @@ export const QuickQuestionProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const value = useMemo<QuickQuestionContextValue>(() => ({
     getThread: (chatId) => state.threads[chatId] ?? EMPTY,
-    async ask(chatId, question) {
+    async ask(chatId, question, attachments) {
       const q = question.trim()
-      if (!q) return
+      const atts = attachments && attachments.length > 0 ? attachments : undefined
+      if (!q && !atts) return
       const thread = state.threads[chatId] ?? EMPTY
       if (thread.inFlight) return
       const history = thread.messages
@@ -125,11 +128,12 @@ export const QuickQuestionProvider: React.FC<{ children: React.ReactNode }> = ({
         id: `qq-u-${Date.now()}-${Math.random()}`,
         role: 'user',
         content: q,
+        attachments: atts,
       }
       const assistantId = `qq-a-${Date.now()}-${Math.random()}`
       dispatch({ type: 'startAsk', chatId, userMsg, assistantId })
       try {
-        await apiService.qq.ask(chatId, q, history)
+        await apiService.qq.ask(chatId, q, history, atts)
       } catch (err) {
         dispatch({ type: 'error', chatId, message: `Error: ${(err as Error).message}` })
       }

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -50,8 +50,9 @@ export const apiService = {
       chatId: string,
       question: string,
       history: Array<{ role: 'user' | 'assistant'; content: string }>,
+      attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }>,
     ): Promise<{ response: string; tokens?: number; durationSec?: number }> =>
-      unwrap(await window.codey.qq.ask({ chatId, question, history })),
+      unwrap(await window.codey.qq.ask({ chatId, question, history, attachments })),
     stop: async (chatId: string): Promise<boolean> =>
       unwrap(await window.codey.qq.stop(chatId)),
     onEvent: (handler: (ev: QQStreamEvent) => void): (() => void) =>

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -180,9 +180,14 @@ export function buildQuickQuestionPrompt(
   chat: Chat,
   qqHistory: QQHistoryEntry[],
   question: string,
+  attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
 ): string {
   const sections: string[] = [];
+
+  if (attachments && attachments.length > 0) {
+    sections.push(formatAttachmentList(attachments));
+  }
 
   const ctx = renderChatContextSections(chat, windowSize);
   if (ctx.length > 0) {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3483,6 +3483,7 @@ Example: /model gpt-4.1 write a Python script`;
     question: string,
     qqHistory: QQHistoryEntry[],
     sink: (e: QQStreamEvent) => void,
+    attachments?: import('@codey/core').FileAttachment[],
   ): Promise<{ response: string; tokens?: number; durationSec?: number }> {
     const chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
@@ -3527,7 +3528,7 @@ Example: /model gpt-4.1 write a Python script`;
     this.qqAborts.set(chatId, abortController);
 
     const started = Date.now();
-    const prompt = buildQuickQuestionPrompt(chat, qqHistory, question);
+    const prompt = buildQuickQuestionPrompt(chat, qqHistory, question, attachments);
 
     let streamedText = '';
     const onStream = (text: string) => {


### PR DESCRIPTION
## What

Builds on the Quick Question side-thread with composer improvements:

- **Inline send button** in the Quick Question composer.
- **Image/file uploads** from the composer (drag-drop + attachment chips), mirroring the main chat composer.

> Note: the earlier chat UI tweaks (context panel no longer auto-opens; composer is resizable with a top-edge drag handle) already landed on `main` directly, so this PR only adds the commit on top of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)