### PR TITLE
feat(codey-mac): in-app auto-update from GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release codey-mac
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: build & publish (macos)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build core
+        run: npm run build -w @codey/core
+
+      - name: Build gateway
+        run: npm run build -w @codey/gateway
+
+      - name: Build & publish codey-mac
+        working-directory: codey-mac
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: npx vite build && npx electron-builder --mac --publish always

--- a/README.md
+++ b/README.md
@@ -315,3 +315,24 @@ workspaces/              # Per-workspace config, memory, and workers
 ## License
 
 [MIT](LICENSE)
+
+## Releasing (maintainers)
+
+codey-mac auto-updates via electron-updater from GitHub Releases.
+
+**Required repo secrets** (Settings → Secrets and variables → Actions):
+- `CSC_LINK` — base64 of the Apple Developer ID `.p12` certificate
+- `CSC_KEY_PASSWORD` — password for that `.p12`
+- `APPLE_ID` — Apple ID email used for notarization
+- `APPLE_APP_SPECIFIC_PASSWORD` — app-specific password for that Apple ID
+- `APPLE_TEAM_ID` — Apple developer team ID (`N59NN58KB2`)
+
+(`GITHUB_TOKEN` is provided automatically.)
+
+**To ship a release:**
+1. Bump the version in `package.json` and `codey-mac/package.json`.
+2. Commit, then tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+3. The `Release codey-mac` workflow builds, signs, notarizes, and publishes the
+   dmg + zip + `latest-mac.yml` to the GitHub Release.
+4. Installed apps detect the new version on next launch (or within ~4h) and show
+   the update button in the sidebar footer.

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, shell, dialog, pr
 import { join } from 'path'
 import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
+import { initAutoUpdater, registerUpdaterIpc } from './updater'
 
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
@@ -812,6 +813,12 @@ app.whenReady().then(async () => {
   createAppMenu()
   createWindow()
   createTray()
+  registerUpdaterIpc(ipcMain, (m) => sendToRenderer('gateway-log', m))
+  initAutoUpdater(
+    (payload) => sendToRenderer('updater:state', payload),
+    app.isPackaged,
+    (m) => sendToRenderer('gateway-log', m),
+  )
   await bootInProcessCore()
 
   // Check Full Disk Access by probing the iMessage database.

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -813,7 +813,7 @@ app.whenReady().then(async () => {
   createAppMenu()
   createWindow()
   createTray()
-  registerUpdaterIpc(ipcMain, (m) => sendToRenderer('gateway-log', m))
+  registerUpdaterIpc(ipcMain, wrap)
   initAutoUpdater(
     (payload) => sendToRenderer('updater:state', payload),
     app.isPackaged,

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -184,6 +184,7 @@ contextBridge.exposeInMainWorld('codey', {
     check: () => ipcRenderer.invoke('updater:check'),
     download: () => ipcRenderer.invoke('updater:download'),
     install: () => ipcRenderer.invoke('updater:install'),
+    lastState: () => ipcRenderer.invoke('updater:lastState'),
     onState: (handler: (state: any) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, state: any) => handler(state)
       ipcRenderer.on('updater:state', listener)

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -180,6 +180,16 @@ contextBridge.exposeInMainWorld('codey', {
   app: {
     version: () => ipcRenderer.invoke('app:version'),
   },
+  updater: {
+    check: () => ipcRenderer.invoke('updater:check'),
+    download: () => ipcRenderer.invoke('updater:download'),
+    install: () => ipcRenderer.invoke('updater:install'),
+    onState: (handler: (state: any) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, state: any) => handler(state)
+      ipcRenderer.on('updater:state', listener)
+      return () => ipcRenderer.removeListener('updater:state', listener)
+    },
+  },
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openPath: (path: string) => ipcRenderer.invoke('shell:openPath', path),
   revealInFolder: (path: string) => ipcRenderer.invoke('shell:showItemInFolder', path),

--- a/codey-mac/electron/updater.ts
+++ b/codey-mac/electron/updater.ts
@@ -3,6 +3,8 @@ import type { IpcMain } from 'electron'
 
 type Notify = (payload: Record<string, unknown>) => void
 type Log = (message: string) => void
+type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
+type Wrap = <T>(fn: () => Promise<T>) => Promise<IpcResult<T>>
 
 let started = false
 const FOUR_HOURS = 4 * 60 * 60 * 1000
@@ -36,12 +38,8 @@ export function initAutoUpdater(notify: Notify, isPackaged: boolean, log: Log): 
 }
 
 /** IPC handlers driven by the renderer button. */
-export function registerUpdaterIpc(ipcMain: IpcMain, log: Log): void {
-  ipcMain.handle('updater:check', () =>
-    autoUpdater.checkForUpdates().catch((e) => log(`[updater] check failed: ${e?.message ?? e}`)),
-  )
-  ipcMain.handle('updater:download', () =>
-    autoUpdater.downloadUpdate().catch((e) => log(`[updater] download failed: ${e?.message ?? e}`)),
-  )
-  ipcMain.handle('updater:install', () => autoUpdater.quitAndInstall())
+export function registerUpdaterIpc(ipcMain: IpcMain, wrap: Wrap): void {
+  ipcMain.handle('updater:check', () => wrap(async () => { await autoUpdater.checkForUpdates() }))
+  ipcMain.handle('updater:download', () => wrap(async () => { await autoUpdater.downloadUpdate() }))
+  ipcMain.handle('updater:install', () => wrap(async () => { autoUpdater.quitAndInstall() }))
 }

--- a/codey-mac/electron/updater.ts
+++ b/codey-mac/electron/updater.ts
@@ -9,6 +9,13 @@ type Wrap = <T>(fn: () => Promise<T>) => Promise<IpcResult<T>>
 let started = false
 const FOUR_HOURS = 4 * 60 * 60 * 1000
 
+// Last state pushed to the renderer. The initial check fires during
+// app.whenReady(), which can resolve before React mounts and subscribes to
+// `updater:state`; that event would then be dropped. We remember it here so a
+// freshly-mounted renderer can backfill via the `updater:lastState` IPC call —
+// the same pattern the gateway-log ring buffer uses in main.ts.
+let lastState: Record<string, unknown> | null = null
+
 /**
  * Wire electron-updater events to the renderer. No-ops in dev / unpackaged
  * builds, where there is no app-update.yml and autoUpdater would throw.
@@ -20,14 +27,19 @@ export function initAutoUpdater(notify: Notify, isPackaged: boolean, log: Log): 
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = false
 
-  autoUpdater.on('checking-for-update', () => notify({ type: 'checking' }))
-  autoUpdater.on('update-available', (info) => notify({ type: 'available', version: info.version }))
-  autoUpdater.on('update-not-available', () => notify({ type: 'not-available' }))
-  autoUpdater.on('download-progress', (p) => notify({ type: 'progress', percent: Math.round(p.percent) }))
-  autoUpdater.on('update-downloaded', (info) => notify({ type: 'downloaded', version: info.version }))
+  const emit: Notify = (payload) => {
+    lastState = payload
+    notify(payload)
+  }
+
+  autoUpdater.on('checking-for-update', () => emit({ type: 'checking' }))
+  autoUpdater.on('update-available', (info) => emit({ type: 'available', version: info.version }))
+  autoUpdater.on('update-not-available', () => emit({ type: 'not-available' }))
+  autoUpdater.on('download-progress', (p) => emit({ type: 'progress', percent: Math.round(p.percent) }))
+  autoUpdater.on('update-downloaded', (info) => emit({ type: 'downloaded', version: info.version }))
   autoUpdater.on('error', (err) => {
     log(`[updater] error: ${err?.message ?? err}`)
-    notify({ type: 'error' })
+    emit({ type: 'error' })
   })
 
   const check = () => {
@@ -42,4 +54,7 @@ export function registerUpdaterIpc(ipcMain: IpcMain, wrap: Wrap): void {
   ipcMain.handle('updater:check', () => wrap(async () => { await autoUpdater.checkForUpdates() }))
   ipcMain.handle('updater:download', () => wrap(async () => { await autoUpdater.downloadUpdate() }))
   ipcMain.handle('updater:install', () => wrap(async () => { autoUpdater.quitAndInstall() }))
+  // Backfill: the renderer reads the last known state on mount in case it
+  // missed the initial event while React was still mounting.
+  ipcMain.handle('updater:lastState', () => wrap(async () => lastState))
 }

--- a/codey-mac/electron/updater.ts
+++ b/codey-mac/electron/updater.ts
@@ -1,0 +1,47 @@
+import { autoUpdater } from 'electron-updater'
+import type { IpcMain } from 'electron'
+
+type Notify = (payload: Record<string, unknown>) => void
+type Log = (message: string) => void
+
+let started = false
+const FOUR_HOURS = 4 * 60 * 60 * 1000
+
+/**
+ * Wire electron-updater events to the renderer. No-ops in dev / unpackaged
+ * builds, where there is no app-update.yml and autoUpdater would throw.
+ */
+export function initAutoUpdater(notify: Notify, isPackaged: boolean, log: Log): void {
+  if (!isPackaged || started) return
+  started = true
+
+  autoUpdater.autoDownload = false
+  autoUpdater.autoInstallOnAppQuit = false
+
+  autoUpdater.on('checking-for-update', () => notify({ type: 'checking' }))
+  autoUpdater.on('update-available', (info) => notify({ type: 'available', version: info.version }))
+  autoUpdater.on('update-not-available', () => notify({ type: 'not-available' }))
+  autoUpdater.on('download-progress', (p) => notify({ type: 'progress', percent: Math.round(p.percent) }))
+  autoUpdater.on('update-downloaded', (info) => notify({ type: 'downloaded', version: info.version }))
+  autoUpdater.on('error', (err) => {
+    log(`[updater] error: ${err?.message ?? err}`)
+    notify({ type: 'error' })
+  })
+
+  const check = () => {
+    autoUpdater.checkForUpdates().catch((e) => log(`[updater] check failed: ${e?.message ?? e}`))
+  }
+  check()
+  setInterval(check, FOUR_HOURS)
+}
+
+/** IPC handlers driven by the renderer button. */
+export function registerUpdaterIpc(ipcMain: IpcMain, log: Log): void {
+  ipcMain.handle('updater:check', () =>
+    autoUpdater.checkForUpdates().catch((e) => log(`[updater] check failed: ${e?.message ?? e}`)),
+  )
+  ipcMain.handle('updater:download', () =>
+    autoUpdater.downloadUpdate().catch((e) => log(`[updater] download failed: ${e?.message ?? e}`)),
+  )
+  ipcMain.handle('updater:install', () => autoUpdater.quitAndInstall())
+}

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@codey/core": "*",
     "@codey/gateway": "*",
+    "electron-updater": "^6.8.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -56,6 +56,13 @@
             "arm64",
             "x64"
           ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
         }
       ],
       "category": "public.app-category.developer-tools",
@@ -77,6 +84,11 @@
       "dist/**/*",
       "dist-electron/**/*"
     ],
+    "publish": {
+      "provider": "github",
+      "owner": "its-ahoh",
+      "repo": "codey"
+    },
     "extraResources": [
       {
         "from": "build/trayIconTemplate.png",

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -5,6 +5,14 @@ import type { ApiKeyEntry } from '../../packages/core/src/types/index'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
+type UpdaterEvent =
+  | { type: 'checking' }
+  | { type: 'available'; version: string }
+  | { type: 'not-available' }
+  | { type: 'progress'; percent: number }
+  | { type: 'downloaded'; version: string }
+  | { type: 'error' }
+
 export interface ModelEntry {
   apiType: 'anthropic' | 'openai'
   model: string
@@ -149,6 +157,12 @@ declare global {
       }
       app: {
         version: () => Promise<string>
+      }
+      updater: {
+        check: () => Promise<IpcResult<void>>
+        download: () => Promise<IpcResult<void>>
+        install: () => Promise<IpcResult<void>>
+        onState: (handler: (state: UpdaterEvent) => void) => () => void
       }
       openExternal: (url: string) => Promise<void>
       openPath: (path: string) => Promise<string>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -2,16 +2,9 @@ import type { Chat, ChatSelection } from '../../packages/core/src/types/chat'
 import type { ChatStreamEvent, QQStreamEvent } from '../../packages/gateway/src/chat-runner'
 import type { TeamConfigRaw } from '../../packages/core/src/workspace'
 import type { ApiKeyEntry } from '../../packages/core/src/types/index'
+import type { UpdaterEvent } from './hooks/updaterState'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
-
-type UpdaterEvent =
-  | { type: 'checking' }
-  | { type: 'available'; version: string }
-  | { type: 'not-available' }
-  | { type: 'progress'; percent: number }
-  | { type: 'downloaded'; version: string }
-  | { type: 'error' }
 
 export interface ModelEntry {
   apiType: 'anthropic' | 'openai'
@@ -162,6 +155,7 @@ declare global {
         check: () => Promise<IpcResult<void>>
         download: () => Promise<IpcResult<void>>
         install: () => Promise<IpcResult<void>>
+        lastState: () => Promise<IpcResult<UpdaterEvent | null>>
         onState: (handler: (state: UpdaterEvent) => void) => () => void
       }
       openExternal: (url: string) => Promise<void>

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -305,8 +305,8 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
         })}
       </div>
       <div style={styles.footer}>
-          <UpdateButton />
-          <button
+        <UpdateButton />
+        <button
           style={styles.settingsBtn}
           onClick={handleAddWorkspace}
           disabled={addingWorkspace}

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -4,6 +4,7 @@ import { apiService } from '../services/api'
 import type { Chat } from '../types'
 import { C } from '../theme'
 import { RouteIcons } from './RouteIcons'
+import { UpdateButton } from './UpdateButton'
 import { setPendingPairing } from './pendingPairing'
 
 interface Props {
@@ -304,7 +305,8 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
         })}
       </div>
       <div style={styles.footer}>
-        <button
+          <UpdateButton />
+          <button
           style={styles.settingsBtn}
           onClick={handleAddWorkspace}
           disabled={addingWorkspace}

--- a/codey-mac/src/components/UpdateButton.tsx
+++ b/codey-mac/src/components/UpdateButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { C } from '../theme'
+import { useUpdater } from '../hooks/useUpdater'
+
+export const UpdateButton: React.FC = () => {
+  const { state, download, install } = useUpdater()
+
+  if (state.phase === 'idle') return null
+
+  if (state.phase === 'available') {
+    return (
+      <button style={styles.action} onClick={() => download()} title={`Download version ${state.version}`}>
+        ↑ Update to v{state.version}
+      </button>
+    )
+  }
+
+  if (state.phase === 'downloading') {
+    return <div style={styles.progress}>Downloading… {state.percent}%</div>
+  }
+
+  // phase === 'ready'
+  return (
+    <button style={styles.action} onClick={() => install()} title="Restart and install the update">
+      Restart to update
+    </button>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  action: {
+    width: '100%', padding: '8px 10px', border: 'none', marginBottom: 4,
+    background: C.accentDim, color: C.fg, cursor: 'pointer',
+    textAlign: 'left', borderRadius: 6, fontSize: 13, fontWeight: 600,
+  },
+  progress: {
+    width: '100%', padding: '8px 10px', marginBottom: 4,
+    color: C.fg2, fontSize: 13, textAlign: 'left',
+  },
+}

--- a/codey-mac/src/hooks/updaterState.test.ts
+++ b/codey-mac/src/hooks/updaterState.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { updaterReducer, initialUpdaterState, type UpdaterState } from './updaterState'
+
+describe('updaterReducer', () => {
+  it('stays idle on checking and not-available', () => {
+    expect(updaterReducer(initialUpdaterState, { type: 'checking' })).toEqual({ phase: 'idle' })
+    expect(updaterReducer(initialUpdaterState, { type: 'not-available' })).toEqual({ phase: 'idle' })
+  })
+
+  it('moves to available with version', () => {
+    expect(updaterReducer(initialUpdaterState, { type: 'available', version: '0.6.4' }))
+      .toEqual({ phase: 'available', version: '0.6.4' })
+  })
+
+  it('tracks download progress then ready', () => {
+    const downloading = updaterReducer(
+      { phase: 'available', version: '0.6.4' },
+      { type: 'progress', percent: 42 },
+    )
+    expect(downloading).toEqual({ phase: 'downloading', percent: 42 })
+    expect(updaterReducer(downloading, { type: 'downloaded', version: '0.6.4' }))
+      .toEqual({ phase: 'ready', version: '0.6.4' })
+  })
+
+  it('reverts to idle on error', () => {
+    const state: UpdaterState = { phase: 'downloading', percent: 10 }
+    expect(updaterReducer(state, { type: 'error' })).toEqual({ phase: 'idle' })
+  })
+
+  it('leaves an in-progress download untouched on a stray checking event', () => {
+    const state: UpdaterState = { phase: 'downloading', percent: 50 }
+    expect(updaterReducer(state, { type: 'checking' })).toEqual(state)
+  })
+})

--- a/codey-mac/src/hooks/updaterState.test.ts
+++ b/codey-mac/src/hooks/updaterState.test.ts
@@ -31,4 +31,9 @@ describe('updaterReducer', () => {
     const state: UpdaterState = { phase: 'downloading', percent: 50 }
     expect(updaterReducer(state, { type: 'checking' })).toEqual(state)
   })
+
+  it('keeps a shown available button during a periodic re-check', () => {
+    const state: UpdaterState = { phase: 'available', version: '0.6.4' }
+    expect(updaterReducer(state, { type: 'checking' })).toEqual(state)
+  })
 })

--- a/codey-mac/src/hooks/updaterState.ts
+++ b/codey-mac/src/hooks/updaterState.ts
@@ -1,0 +1,33 @@
+export type UpdaterEvent =
+  | { type: 'checking' }
+  | { type: 'available'; version: string }
+  | { type: 'not-available' }
+  | { type: 'progress'; percent: number }
+  | { type: 'downloaded'; version: string }
+  | { type: 'error' }
+
+export type UpdaterState =
+  | { phase: 'idle' }
+  | { phase: 'available'; version: string }
+  | { phase: 'downloading'; percent: number }
+  | { phase: 'ready'; version: string }
+
+export const initialUpdaterState: UpdaterState = { phase: 'idle' }
+
+export function updaterReducer(state: UpdaterState, event: UpdaterEvent): UpdaterState {
+  switch (event.type) {
+    case 'checking':
+      // Don't disturb an in-progress download/ready state on a periodic re-check.
+      return state.phase === 'downloading' || state.phase === 'ready' ? state : { phase: 'idle' }
+    case 'available':
+      return { phase: 'available', version: event.version }
+    case 'not-available':
+      return { phase: 'idle' }
+    case 'progress':
+      return { phase: 'downloading', percent: event.percent }
+    case 'downloaded':
+      return { phase: 'ready', version: event.version }
+    case 'error':
+      return { phase: 'idle' }
+  }
+}

--- a/codey-mac/src/hooks/updaterState.ts
+++ b/codey-mac/src/hooks/updaterState.ts
@@ -17,8 +17,10 @@ export const initialUpdaterState: UpdaterState = { phase: 'idle' }
 export function updaterReducer(state: UpdaterState, event: UpdaterEvent): UpdaterState {
   switch (event.type) {
     case 'checking':
-      // Don't disturb an in-progress download/ready state on a periodic re-check.
-      return state.phase === 'downloading' || state.phase === 'ready' ? state : { phase: 'idle' }
+      // A periodic re-check must not disturb the current phase: the follow-up
+      // available/not-available/error event sets the correct state. Clearing to
+      // idle here would flicker (or permanently drop) a shown update button.
+      return state
     case 'available':
       return { phase: 'available', version: event.version }
     case 'not-available':

--- a/codey-mac/src/hooks/useUpdater.ts
+++ b/codey-mac/src/hooks/useUpdater.ts
@@ -1,0 +1,17 @@
+import { useEffect, useReducer } from 'react'
+import { updaterReducer, initialUpdaterState, type UpdaterEvent } from './updaterState'
+
+export function useUpdater() {
+  const [state, dispatch] = useReducer(updaterReducer, initialUpdaterState)
+
+  useEffect(() => {
+    const unsubscribe = window.codey.updater.onState((event: UpdaterEvent) => dispatch(event))
+    return unsubscribe
+  }, [])
+
+  return {
+    state,
+    download: () => window.codey.updater.download(),
+    install: () => window.codey.updater.install(),
+  }
+}

--- a/codey-mac/src/hooks/useUpdater.ts
+++ b/codey-mac/src/hooks/useUpdater.ts
@@ -5,7 +5,12 @@ export function useUpdater() {
   const [state, dispatch] = useReducer(updaterReducer, initialUpdaterState)
 
   useEffect(() => {
+    // Subscribe first, then backfill the last known state — the initial check
+    // can resolve before this effect runs, so its event may have been missed.
     const unsubscribe = window.codey.updater.onState((event: UpdaterEvent) => dispatch(event))
+    window.codey.updater.lastState().then((result) => {
+      if (result.ok && result.data) dispatch(result.data)
+    })
     return unsubscribe
   }, [])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.6.0",
+      "version": "0.6.3",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,11 +19,12 @@
       }
     },
     "codey-mac": {
-      "version": "0.6.0",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
         "@codey/gateway": "*",
+        "electron-updater": "^6.8.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -3248,7 +3249,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -5075,6 +5075,92 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/electron/node_modules/@types/node": {
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
@@ -5967,7 +6053,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/har-schema": {
@@ -6851,7 +6936,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6956,7 +7040,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream": {
@@ -7256,6 +7339,11 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -7263,6 +7351,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9615,7 +9709,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -10467,6 +10560,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -12099,7 +12197,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.2.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12111,7 +12209,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.2.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",


### PR DESCRIPTION
## Summary
Adds a small update button to the bottom of the codey-mac left sidebar that surfaces newer GitHub releases and lets the user download + install them in-app via `electron-updater`.

- **App side:** `electron-updater` wired into the Electron main process (`autoDownload = false`, no-op in dev), forwarding lifecycle events to the renderer over a buffered `updater:state` IPC channel. A pure `updaterReducer` (unit-tested) maps events → UI state; a small `<UpdateButton />` in the sidebar footer renders idle/available/downloading/ready. IPC handlers route through the existing `wrap()`/`IpcResult` convention.
- **Build:** added a `zip` target (required for macOS auto-install) alongside `dmg`, plus a GitHub `publish` config so `latest-mac.yml` is emitted.
- **Release pipeline:** `.github/workflows/release.yml` builds, signs, notarizes, and publishes dmg + zip + `latest-mac.yml` to GitHub Releases on `v*` tag pushes.
- **Docs:** README "Releasing (maintainers)" section covering the required signing secrets and the tag → release flow.

Built task-by-task with spec + code-quality review per task. Review findings fixed in the final commit: a periodic `checking` event no longer clears a shown update button, the renderer backfills the last updater state on mount (so a fast initial check isn't lost before React subscribes), and `UpdaterEvent` is now defined once.

## Follow-up required before releases work
Add these repo secrets (Settings → Secrets and variables → Actions): `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`. `GITHUB_TOKEN` is automatic.

## Test Plan
- [x] `npx tsc --noEmit` clean (codey-mac)
- [x] `vitest run` — 27 passing (incl. reducer state-machine tests)
- [ ] Manual: install an older signed build, push a newer `vX.Y.Z` tag, confirm the sidebar button appears → downloads → "Restart to update" installs on relaunch
- [ ] Manual: confirm button stays hidden in `npm run dev` (updater disabled when unpackaged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)