### PR TITLE
fix(codey-mac): refresh chat team dropdown when teams change

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -11,6 +11,7 @@ import { ChatContextPanel } from './ChatContextPanel'
 import type { ContextPanelTab } from './ChatContextPanel'
 import { useQuickQuestion } from '../hooks/useQuickQuestion'
 import { parseTeamMessage } from './teamMessageFormat'
+import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 
 interface Props {
@@ -329,8 +330,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     return off
   }, [chat.id, chat.routes, pairingModal, linkChannel])
   useEffect(() => {
-    if (!chat?.workspaceName) return
-    apiService.getTeams(chat.workspaceName).then(names => setTeamNames(names)).catch(() => setTeamNames([]))
+    const ws = chat?.workspaceName
+    if (!ws) return
+    const refresh = () => apiService.getTeams(ws).then(setTeamNames).catch(() => setTeamNames([]))
+    refresh()
+    // Re-fetch when teams are enabled/edited in the Settings overlay, which
+    // stays mounted alongside this tab so workspaceName never changes.
+    return onTeamsChanged(refresh)
   }, [chat?.workspaceName])
   const [workingDir, setWorkingDir] = useState<string | undefined>(undefined)
   useEffect(() => {

--- a/codey-mac/src/components/TeamsSection.tsx
+++ b/codey-mac/src/components/TeamsSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { apiService } from '../services/api'
 import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
 import { C } from '../theme'
+import { emitTeamsChanged } from './teamsChanged'
 
 // Per-workspace teams editor. Teams are defined globally in Settings →
 // Teams; this component just toggles which of those names are enabled for
@@ -45,7 +46,7 @@ export default function TeamsSection({ workspace }: { workspace: string }) {
     setEnabled(next); setError(null)
     if (saveTimer.current) window.clearTimeout(saveTimer.current)
     saveTimer.current = window.setTimeout(async () => {
-      try { await apiService.setTeams(workspace, [...next]); setSavedAt(Date.now()) }
+      try { await apiService.setTeams(workspace, [...next]); setSavedAt(Date.now()); emitTeamsChanged() }
       catch (err: any) { setError(err.message || String(err)) }
     }, 300)
   }

--- a/codey-mac/src/components/teamsChanged.ts
+++ b/codey-mac/src/components/teamsChanged.ts
@@ -1,0 +1,16 @@
+// Notifies mounted views (e.g. ChatTab's team dropdown) when the set of teams
+// changes. The teams editor lives in the Settings overlay, a sibling tree that
+// stays mounted alongside ChatTab, so ChatTab's one-shot getTeams() effect never
+// re-runs after an edit. Both live in the same renderer and ChatTab is already
+// mounted when a save fires, so a synchronous window event reaches it.
+
+const EVENT = 'codey:teams-changed'
+
+export function emitTeamsChanged(): void {
+  window.dispatchEvent(new Event(EVENT))
+}
+
+export function onTeamsChanged(handler: () => void): () => void {
+  window.addEventListener(EVENT, handler)
+  return () => window.removeEventListener(EVENT, handler)
+}


### PR DESCRIPTION
## Problem

After enabling a team for a workspace, the team did not appear in the chat window's selection dropdown until the whole app was relaunched.

## Root cause

`ChatTab` loads the dropdown's team list once, in an effect keyed only on `chat?.workspaceName`:

```ts
useEffect(() => {
  if (!chat?.workspaceName) return
  apiService.getTeams(chat.workspaceName).then(setTeamNames).catch(() => setTeamNames([]))
}, [chat?.workspaceName])
```

Teams are enabled in `TeamsSection`, which lives in the Settings overlay — a sibling component tree that stays mounted alongside `ChatTab`. Enabling a team never changes `workspaceName`, so the effect never re-ran and the dropdown stayed stale. Only relaunching remounted `ChatTab`, triggering a fresh `getTeams` fetch. No "teams changed" notification existed (only `qq`/`chats`/`pairing` event streams).

## Fix

- **`teamsChanged.ts`** (new) — a tiny window-event bus (`emit` / `on`), matching the existing `pendingPairing.ts` idiom.
- **`TeamsSection.tsx`** — emits `teams-changed` *after* `setTeams` resolves (firing after the save avoids the 300 ms debounce race).
- **`ChatTab.tsx`** — its teams effect subscribes to `onTeamsChanged` and re-fetches `getTeams`, cleaning up the listener on unmount/workspace change.

The chat dropdown now updates immediately when a team is enabled — no relaunch needed.

## Scope

`GlobalTeamsSection` (the global library) is intentionally left untouched: the chat dropdown is driven solely by `getTeams(workspace)`, which only `TeamsSection` mutates.

## Testing

- `npx tsc --noEmit` passes clean.
- Not exercised live in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)