### PR TITLE
feat(voice): Real-Time Whisper API with WebSocket streaming transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-07
+
+### Added
+- **Real-time voice transcription** — a new **Realtime (WebSocket)** voice provider that streams audio to the OpenAI Realtime transcription API as you speak, surfacing partial transcripts during recording and a final transcript shortly after you stop. Opt-in alongside the existing Cloud API and on-device (WhisperKit) providers, configured from the Whisper settings tab (shares the Cloud API key; WebSocket URL and model are configurable). If the WebSocket connection fails mid-utterance, transcription transparently falls back to the batch HTTP API.
+
 ## [0.6.3] - 2026-06-02
 
 ### Added

--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -10,11 +10,13 @@ interface VoiceCfg {
   hotkey: string
   language: string
   injection: 'paste' | 'ax'
-  provider: 'api' | 'local'
+  provider: 'api' | 'local' | 'realtime'
   apiUrl: string
   apiKey: string
   apiModel: string
   localModel: string
+  realtimeUrl: string
+  realtimeModel: string
 }
 
 const VOICE_DEFAULT: VoiceCfg = {
@@ -27,6 +29,8 @@ const VOICE_DEFAULT: VoiceCfg = {
   apiKey: '',
   apiModel: 'gpt-4o-mini-transcribe',
   localModel: 'openai_whisper-large-v3_turbo_954MB',
+  realtimeUrl: 'wss://api.openai.com/v1/realtime?intent=transcription',
+  realtimeModel: 'gpt-4o-mini-transcribe',
 }
 
 // Values must match real folder names in argmaxinc/whisperkit-coreml on HF.
@@ -487,6 +491,10 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning }) => {
               style={pillButton(voice.provider === 'api' ? 'primary' : 'ghost')}
             >Cloud API</button>
             <button
+              onClick={() => updateVoice({ provider: 'realtime' })}
+              style={pillButton(voice.provider === 'realtime' ? 'primary' : 'ghost')}
+            >Realtime (WebSocket)</button>
+            <button
               onClick={() => updateVoice({ provider: 'local' })}
               style={pillButton(voice.provider === 'local' ? 'primary' : 'ghost')}
             >Local (WhisperKit)</button>
@@ -495,7 +503,9 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning }) => {
         <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.5, marginTop: 2 }}>
           {voice.provider === 'local'
             ? 'On-device transcription via WhisperKit (CoreML + Neural Engine). Model auto-downloads from HuggingFace on first use (~800MB for large-v3-turbo). Idle pipeline auto-releases after 30s.'
-            : 'Sends audio to an OpenAI-compatible /audio/transcriptions endpoint. Works with OpenAI, Groq, or self-hosted Whisper servers.'}
+            : voice.provider === 'realtime'
+              ? 'Streams audio over WebSocket to an OpenAI Realtime transcription endpoint. Lower latency than batch API — transcript appears as you speak. Uses the same API key as Cloud API.'
+              : 'Sends audio to an OpenAI-compatible /audio/transcriptions endpoint. Works with OpenAI, Groq, or self-hosted Whisper servers.'}
         </div>
       </div>
 
@@ -596,10 +606,25 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning }) => {
         )
       })()}
 
-      {voice.provider === 'api' && (
+      {(voice.provider === 'api' || voice.provider === 'realtime') && (
       <>
       <Section title="Transcription API"/>
 
+      {/* API key — shared between Cloud API and Realtime providers */}
+      <div style={{ ...fieldStyle, alignItems: 'flex-start', flexDirection: 'column', gap: 6 }}>
+        <span style={{ color: C.fg, fontSize: 13 }}>API key {voice.provider === 'realtime' && <span style={{ color: C.fg3, fontSize: 11, fontWeight: 400 }}>(shared with Cloud API)</span>}</span>
+        <input
+          type="password"
+          value={voice.apiKey}
+          onChange={e => setVoice({ ...voice, apiKey: e.target.value })}
+          onBlur={() => updateVoice({ apiKey: voice.apiKey })}
+          placeholder="sk-..."
+          style={{ ...inputStyle, width: '100%' }}
+        />
+      </div>
+
+      {voice.provider === 'api' && (
+      <>
       <div style={{ ...fieldStyle, alignItems: 'flex-start', flexDirection: 'column', gap: 6 }}>
         <span style={{ color: C.fg, fontSize: 13 }}>API base URL</span>
         <input
@@ -613,17 +638,6 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning }) => {
           POSTs to <code>{voice.apiUrl || '&lt;base&gt;'}/audio/transcriptions</code>. Works with OpenAI, Groq, or any OpenAI-compatible server.
         </span>
       </div>
-      <div style={{ ...fieldStyle, alignItems: 'flex-start', flexDirection: 'column', gap: 6 }}>
-        <span style={{ color: C.fg, fontSize: 13 }}>API key</span>
-        <input
-          type="password"
-          value={voice.apiKey}
-          onChange={e => setVoice({ ...voice, apiKey: e.target.value })}
-          onBlur={() => updateVoice({ apiKey: voice.apiKey })}
-          placeholder="sk-..."
-          style={{ ...inputStyle, width: '100%' }}
-        />
-      </div>
       <div style={fieldStyle}>
         <span style={{ color: C.fg, fontSize: 13 }}>Model</span>
         <input
@@ -634,6 +648,39 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning }) => {
           style={inputStyle}
         />
       </div>
+      </>
+      )}
+
+      {voice.provider === 'realtime' && (
+      <>
+      <div style={{ ...fieldStyle, alignItems: 'flex-start', flexDirection: 'column', gap: 6 }}>
+        <span style={{ color: C.fg, fontSize: 13 }}>WebSocket URL</span>
+        <input
+          value={voice.realtimeUrl}
+          onChange={e => setVoice({ ...voice, realtimeUrl: e.target.value })}
+          onBlur={() => updateVoice({ realtimeUrl: voice.realtimeUrl })}
+          placeholder="wss://api.openai.com/v1/realtime?intent=transcription"
+          style={{ ...inputStyle, width: '100%' }}
+        />
+        <span style={{ color: C.fg3, fontSize: 11 }}>
+          Connects via WebSocket to an OpenAI Realtime transcription endpoint. Requires <code>?intent=transcription</code>.
+        </span>
+      </div>
+      <div style={fieldStyle}>
+        <span style={{ color: C.fg, fontSize: 13 }}>Realtime model</span>
+        <input
+          value={voice.realtimeModel}
+          onChange={e => setVoice({ ...voice, realtimeModel: e.target.value })}
+          onBlur={() => updateVoice({ realtimeModel: voice.realtimeModel })}
+          placeholder="gpt-4o-mini-transcribe"
+          style={inputStyle}
+        />
+      </div>
+      <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.5, marginTop: 8, padding: '8px 12px', background: C.surface3, borderRadius: 7 }}>
+        <strong style={{ color: C.fg2 }}>ℹ️ Cost notice:</strong> Realtime API is billed per minute of audio. See <a href="https://openai.com/pricing" target="_blank" rel="noopener noreferrer" style={{ color: C.accent }}>OpenAI pricing</a> for current rates. If the WebSocket connection fails mid-utterance, the helper falls back to batch API for that utterance.
+      </div>
+      </>
+      )}
       </>
       )}
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
@@ -12197,7 +12197,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12209,7 +12209,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/voice/Sources/CodeyVoice/AudioCapture.swift
+++ b/voice/Sources/CodeyVoice/AudioCapture.swift
@@ -154,19 +154,15 @@ final class AudioCapture {
             chunk = mono
         }
 
-        // Emit the resampled chunk for realtime consumers (e.g. WebSocket
-        // transcription engine) before accumulating into the full buffer.
-        // Always accumulate; additionally emit when a consumer is subscribed.
-        onChunk?(chunk)
-
         bufferLock.lock()
         pcmBuffer.append(contentsOf: chunk)
         let totalCount = pcmBuffer.count
         bufferLock.unlock()
 
-        // Emit chunk for realtime streaming consumers (e.g. WebSocket engine).
-        // Fires outside the lock so the consumer can take its time without
-        // blocking the audio tap.
+        // Emit the resampled chunk for realtime streaming consumers (e.g. the
+        // WebSocket transcription engine). Always accumulate above; additionally
+        // emit exactly once here when a consumer is subscribed. Fires outside the
+        // lock so the consumer can take its time without blocking the audio tap.
         if let cb = onChunk {
             cb(chunk)
         }

--- a/voice/Sources/CodeyVoice/AudioCapture.swift
+++ b/voice/Sources/CodeyVoice/AudioCapture.swift
@@ -22,16 +22,17 @@ final class AudioCapture {
     /// Called with the full PCM buffer when recording stops.
     var onRecordingComplete: (([Float]) -> Void)?
 
+    /// Called from the audio tap thread with each freshly resampled 16 kHz mono
+    /// chunk (~20-50 ms). Receiver must hop to main if it touches AppKit. Used by
+    /// the realtime transcription engine to forward audio over WebSocket as it
+    /// arrives. Always-accumulate + additionally-emit: the full buffer snapshot
+    /// remains available via currentSamplesSnapshot(). Nil = batch-only behavior.
+    var onChunk: (([Float]) -> Void)?
+
     /// Called from the audio tap thread (~every buffer, ~20-50ms) with a 0..1
     /// RMS level of the latest input. Receiver must hop to main if it touches
     /// AppKit. Used by the HUD waveform indicator.
     var onLevel: ((Float) -> Void)?
-
-    /// Called from the audio tap thread with each freshly resampled 16 kHz mono
-    /// chunk (~20-50 ms). Receiver must hop off if it touches AppKit. Used by the
-    /// realtime transcription engine to forward audio over WebSocket as it arrives.
-    /// Nil = current batch-only behavior; the pcmBuffer accumulation is unchanged.
-    var onChunk: (([Float]) -> Void)?
 
     /// Pre-allocate the recording buffer so the audio tap thread never has to
     /// realloc while the user is talking. Previously this also called
@@ -162,6 +163,13 @@ final class AudioCapture {
         pcmBuffer.append(contentsOf: chunk)
         let totalCount = pcmBuffer.count
         bufferLock.unlock()
+
+        // Emit chunk for realtime streaming consumers (e.g. WebSocket engine).
+        // Fires outside the lock so the consumer can take its time without
+        // blocking the audio tap.
+        if let cb = onChunk {
+            cb(chunk)
+        }
 
         // Auto-stop at buffer cap
         if Double(totalCount) / sampleRate >= maxDurationSeconds {

--- a/voice/Sources/CodeyVoice/AudioCapture.swift
+++ b/voice/Sources/CodeyVoice/AudioCapture.swift
@@ -27,6 +27,12 @@ final class AudioCapture {
     /// AppKit. Used by the HUD waveform indicator.
     var onLevel: ((Float) -> Void)?
 
+    /// Called from the audio tap thread with each freshly resampled 16 kHz mono
+    /// chunk (~20-50 ms). Receiver must hop off if it touches AppKit. Used by the
+    /// realtime transcription engine to forward audio over WebSocket as it arrives.
+    /// Nil = current batch-only behavior; the pcmBuffer accumulation is unchanged.
+    var onChunk: (([Float]) -> Void)?
+
     /// Pre-allocate the recording buffer so the audio tap thread never has to
     /// realloc while the user is talking. Previously this also called
     /// `engine.prepare()` to warm Core Audio, but installing the tap *after*
@@ -146,6 +152,11 @@ final class AudioCapture {
         } else {
             chunk = mono
         }
+
+        // Emit the resampled chunk for realtime consumers (e.g. WebSocket
+        // transcription engine) before accumulating into the full buffer.
+        // Always accumulate; additionally emit when a consumer is subscribed.
+        onChunk?(chunk)
 
         bufferLock.lock()
         pcmBuffer.append(contentsOf: chunk)

--- a/voice/Sources/CodeyVoice/PCMHelper.swift
+++ b/voice/Sources/CodeyVoice/PCMHelper.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Convert Float32 samples in `[-1, 1]` to 16-bit signed PCM little-endian Data.
+/// Each Float32 sample is clamped, scaled by 32767, and stored as little-endian Int16.
+/// Shared by the WAV encoder (batch path) and the realtime WebSocket path.
+func pcm16Data(from samples: [Float]) -> Data {
+    var data = Data(count: samples.count * 2)
+    data.withUnsafeMutableBytes { raw in
+        let pcm = raw.baseAddress!.assumingMemoryBound(to: Int16.self)
+        for i in 0..<samples.count {
+            let s = samples[i]
+            let c = s < -1 ? -1 : (s > 1 ? 1 : s)
+            pcm[i] = Int16(c * 32767.0).littleEndian
+        }
+    }
+    return data
+}

--- a/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
@@ -34,6 +34,14 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
     private var _finalTranscript: String?
     /// True once `didOpenWithProtocol` fires (session is usable).
     private var _isSessionActive = false
+    /// True once the server acks our `session.update` (`session.updated`). Until
+    /// then the server still has the default config (e.g. server VAD), so audio
+    /// chunks are queued in `_pendingChunks` rather than sent — appending before
+    /// config is applied risks the wrong format / premature auto-commit.
+    private var _isSessionConfigured = false
+    /// Audio chunks captured between socket-open and `session.updated`. Flushed
+    /// in order once configured so no leading speech is lost.
+    private var _pendingChunks: [[Float]] = []
     /// True once `didCompleteWithError` or an explicit disconnect fires.
     private var _isDisconnected = false
 
@@ -74,6 +82,8 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
             guard _webSocketTask != nil, !_isSessionActive else { return false }
             if Date().timeIntervalSince(_lastUsed) >= idleUnloadAfter {
                 _isDisconnected = true
+                _isSessionConfigured = false
+                _pendingChunks.removeAll()
                 _webSocketTask = nil
                 return true
             }
@@ -124,6 +134,8 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
             _webSocketTask = ws
             _isDisconnected = false
             _isSessionActive = false
+            _isSessionConfigured = false
+            _pendingChunks.removeAll()
             _lastUsed = Date()
         }
 
@@ -164,17 +176,45 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         print("realtime: session started (model=\(realtimeModel))")
     }
 
-    /// Encode `samples` as PCM16 base64 and send as `input_audio_buffer.append`.
-    /// Safe to call from any thread (audio tap). Silently drops when no session
-    /// is open (fire-and-forget).
+    /// Forward an audio chunk to the session. Safe to call from any thread (audio
+    /// tap). Silently drops when no session is open. Chunks captured before the
+    /// server acks our config (`session.updated`) are queued and flushed in order
+    /// once configured, so no leading speech is lost to the open→config race.
     func appendAudioChunk(_ samples: [Float]) {
         let ws = stateLock.withLock { () -> URLSessionWebSocketTask? in
             guard _isSessionActive, !_isDisconnected else { return nil }
             _lastUsed = Date()
+            guard _isSessionConfigured else {
+                _pendingChunks.append(samples)
+                return nil
+            }
             return _webSocketTask
         }
         guard let ws = ws else { return }
+        sendAudioChunk(samples, on: ws)
+    }
 
+    /// Flush chunks queued during the open→config window, in capture order, and
+    /// mark the session configured so subsequent appends send directly.
+    private func flushPendingChunks() {
+        let (ws, chunks) = stateLock.withLock { () -> (URLSessionWebSocketTask?, [[Float]]) in
+            _isSessionConfigured = true
+            guard _isSessionActive, !_isDisconnected, let ws = _webSocketTask else {
+                _pendingChunks.removeAll()
+                return (nil, [])
+            }
+            let pending = _pendingChunks
+            _pendingChunks.removeAll()
+            return (ws, pending)
+        }
+        guard let ws = ws else { return }
+        for chunk in chunks {
+            sendAudioChunk(chunk, on: ws)
+        }
+    }
+
+    /// Encode `samples` as PCM16 base64 and send as `input_audio_buffer.append`.
+    private func sendAudioChunk(_ samples: [Float], on ws: URLSessionWebSocketTask) {
         let pcmData = pcm16Data(from: samples)
         let base64 = pcmData.base64EncodedString()
         let event: [String: Any] = [
@@ -204,6 +244,12 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
     /// send `response.create` — transcription sessions reject it (and it would
     /// surface as a server `error` event, failing the utterance).
     private func commitAndAwaitTranscript() async throws -> String {
+        // Safety net for very short utterances that end before `session.updated`
+        // arrives: flush whatever was queued (also marks the session configured)
+        // so the commit below operates on the full audio rather than an empty
+        // buffer.
+        flushPendingChunks()
+
         let ws = stateLock.withLock { () -> URLSessionWebSocketTask? in
             // Reset accumulated state for a fresh utterance.
             _accumulatedText = ""
@@ -326,9 +372,15 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
                 }
             }
 
-        case "session.created", "session.updated":
-            // Lifecycle acknowledgment — no action needed.
+        case "session.created":
+            // Server's initial session (default config) — no action; we wait
+            // for `session.updated` (the ack of our config) before streaming.
             break
+
+        case "session.updated":
+            // Our config is now applied — release any chunks queued during the
+            // open→config window, in capture order.
+            flushPendingChunks()
 
         default:
             print("realtime: unhandled event type=\(type)")
@@ -360,6 +412,8 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         stateLock.withLock {
             _isDisconnected = true
             _isSessionActive = false
+            _isSessionConfigured = false
+            _pendingChunks.removeAll()
             if let cont = _transcribeContinuation {
                 _transcribeContinuation = nil
                 cont.resume(throwing: TranscriptionError.connectionFailed("connection lost"))
@@ -371,6 +425,8 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         stateLock.withLock {
             _isDisconnected = true
             _isSessionActive = false
+            _isSessionConfigured = false
+            _pendingChunks.removeAll()
             _connectContinuation?.resume(throwing: CancellationError())
             _connectContinuation = nil
             _webSocketTask = nil
@@ -438,6 +494,8 @@ extension RealtimeTranscriptionEngine: URLSessionWebSocketDelegate {
         stateLock.withLock {
             _isDisconnected = true
             _isSessionActive = false
+            _isSessionConfigured = false
+            _pendingChunks.removeAll()
             // If a connect continuation is still pending, fail it.
             if let cont = _connectContinuation {
                 _connectContinuation = nil

--- a/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
@@ -1,0 +1,305 @@
+import Foundation
+
+/// Transcribes audio via the OpenAI Realtime WebSocket API (transcription-session).
+///
+/// Owns its own `URLSessionWebSocketTask` per utterance. The streaming path
+/// forwards audio chunks as they arrive (`beginStreaming` → N×`appendChunk` →
+/// `finishStreaming`) and delivers the final transcript through `finishStreaming`.
+/// The single-shot protocol method `transcribe(audio:language:)` opens a socket,
+/// sends the entire buffer in one message, commits, and awaits the result —
+/// used as fallback when the full buffer is already available.
+///
+/// Lifecycle: one socket per utterance. Closed on `cancelStreaming`, `finishStreaming`,
+/// idle timeout (>30s), or app termination.
+final class RealtimeTranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendable {
+    private let session: URLSession
+    private var config: VoiceConfig
+    private var webSocket: URLSessionWebSocketTask?
+    private var streamingContinuation: CheckedContinuation<String, Error>?
+    private var receiveTask: Task<Void, Never>?
+    private var lastUsed: Date = .distantPast
+    private var hasActiveUtterance = false
+    private let idleUnloadAfter: TimeInterval = 30
+
+    var onPartial: ((String) -> Void)?
+
+    init(config: VoiceConfig) {
+        self.config = config
+        self.session = URLSession(configuration: .ephemeral)
+    }
+
+    func updateConfig(_ config: VoiceConfig) {
+        self.config = config
+    }
+
+    // MARK: - Streaming API (called by VoiceCoordinator)
+
+    /// Open a WebSocket to the Realtime API and send `transcription_session.update`
+    /// to configure the session. Throws if connection fails or config is invalid.
+    func beginStreaming(language: String) throws {
+        guard !config.apiKey.isEmpty else { throw TranscriptionError.noAPIKey }
+        guard let url = URL(string: config.realtimeUrl) else {
+            throw TranscriptionError.invalidURL(config.realtimeUrl)
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+
+        let ws = session.webSocketTask(with: request)
+        self.webSocket = ws
+        ws.resume()
+        lastUsed = Date()
+        hasActiveUtterance = true
+
+        // Start the receive loop in background
+        receiveTask = Task { [weak self] in await self?.receiveLoop() }
+
+        // Send session configuration
+        let model = config.realtimeModel
+        let lang = language.isEmpty || language == "auto" ? "" : language
+        let sessionUpdate: [String: Any] = [
+            "type": "transcription_session.update",
+            "input_audio_format": "pcm16",
+            "input_audio_transcription": [
+                "model": model,
+                "language": lang,
+            ] as [String: Any],
+        ]
+        let msg = try JSONSerialization.data(withJSONObject: sessionUpdate)
+        ws.send(.data(msg)) { [weak self] error in
+            if let error = error {
+                print("realtime: session.update send error — \(error.localizedDescription)")
+                self?.failContinuation(TranscriptionError.apiError(0, "session.update: \(error.localizedDescription)"))
+            }
+        }
+    }
+
+    /// Encode `samples` as PCM16 base64 and send as `input_audio_buffer.append`.
+    /// Safe to call from any thread; the send is dispatched to the WebSocket's
+    /// delegate queue internally.
+    func appendChunk(_ samples: [Float]) {
+        guard let ws = webSocket, hasActiveUtterance else { return }
+        lastUsed = Date()
+        let pcmData = pcm16Data(from: samples)
+        let base64 = pcmData.base64EncodedString()
+        let event: [String: Any] = [
+            "type": "input_audio_buffer.append",
+            "audio": base64,
+        ]
+        guard let msgData = try? JSONSerialization.data(withJSONObject: event) else { return }
+        ws.send(.data(msgData)) { error in
+            if let error = error {
+                print("realtime: append error — \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Signal end of audio by sending `input_audio_buffer.commit`, then await
+    /// the final transcript from the WebSocket event stream. Returns the
+    /// recognized text.
+    func finishStreaming() async throws -> String {
+        guard let ws = webSocket, hasActiveUtterance else {
+            throw TranscriptionError.badResponse
+        }
+        hasActiveUtterance = false
+        lastUsed = Date()
+
+        return try await withCheckedThrowingContinuation { continuation in
+            streamingContinuation = continuation
+            let commit: [String: Any] = ["type": "input_audio_buffer.commit"]
+            guard let data = try? JSONSerialization.data(withJSONObject: commit) else {
+                continuation.resume(throwing: TranscriptionError.badResponse)
+                return
+            }
+            ws.send(.data(data)) { error in
+                if let error = error {
+                    print("realtime: commit send error — \(error.localizedDescription)")
+                    // Don't fail the continuation here — the response event
+                    // will carry the error if the commit was malformed.
+                }
+            }
+        }
+    }
+
+    /// Cancel the current utterance without consuming the result. Closes the
+    /// WebSocket immediately.
+    func cancelStreaming() {
+        hasActiveUtterance = false
+        streamingContinuation?.resume(throwing: TranscriptionError.badResponse)
+        streamingContinuation = nil
+        closeSocket()
+    }
+
+    // MARK: - TranscriptionEngineProtocol conformance
+
+    /// Single-shot fallback path: open a WebSocket, send the full audio buffer
+    /// in one `input_audio_buffer.append`, commit, and await the final transcript.
+    /// This lets the coordinator call `activeEngine.transcribe(audio:language:)`
+    /// uniformly when realtime streaming was not used (e.g. fallback after
+    /// connection failure).
+    func transcribe(audio: [Float], language: String) async throws -> String {
+        guard !config.apiKey.isEmpty else { throw TranscriptionError.noAPIKey }
+        guard let url = URL(string: config.realtimeUrl) else {
+            throw TranscriptionError.invalidURL(config.realtimeUrl)
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+
+        let ws = session.webSocketTask(with: request)
+        self.webSocket = ws
+        ws.resume()
+        lastUsed = Date()
+        hasActiveUtterance = true
+
+        // Start receive loop
+        receiveTask = Task { [weak self] in await self?.receiveLoop() }
+
+        // Session update
+        let model = config.realtimeModel
+        let lang = language.isEmpty || language == "auto" ? "" : language
+        let sessionUpdate: [String: Any] = [
+            "type": "transcription_session.update",
+            "input_audio_format": "pcm16",
+            "input_audio_transcription": [
+                "model": model,
+                "language": lang,
+            ] as [String: Any],
+        ]
+        let updateData = try JSONSerialization.data(withJSONObject: sessionUpdate)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            streamingContinuation = continuation
+            ws.send(.data(updateData)) { error in
+                if let error = error {
+                    continuation.resume(throwing: TranscriptionError.apiError(0, "session.update: \(error.localizedDescription)"))
+                    return
+                }
+                // Send the full audio in one append
+                let pcmData = pcm16Data(from: audio)
+                let base64 = pcmData.base64EncodedString()
+                let appendEvent: [String: Any] = [
+                    "type": "input_audio_buffer.append",
+                    "audio": base64,
+                ]
+                guard let appendData = try? JSONSerialization.data(withJSONObject: appendEvent) else {
+                    continuation.resume(throwing: TranscriptionError.badResponse)
+                    return
+                }
+                ws.send(.data(appendData)) { error in
+                    if let error = error {
+                        continuation.resume(throwing: TranscriptionError.apiError(0, "append: \(error.localizedDescription)"))
+                        return
+                    }
+                    // Commit to finalize
+                    let commit: [String: Any] = ["type": "input_audio_buffer.commit"]
+                    guard let commitData = try? JSONSerialization.data(withJSONObject: commit) else {
+                        continuation.resume(throwing: TranscriptionError.badResponse)
+                        return
+                    }
+                    ws.send(.data(commitData)) { error in
+                        if let error = error {
+                            continuation.resume(throwing: TranscriptionError.apiError(0, "commit: \(error.localizedDescription)"))
+                        }
+                        // Success — continue waiting in receiveLoop for the result
+                    }
+                }
+            }
+        }
+    }
+
+    func unloadIfIdle() {
+        guard webSocket != nil, !hasActiveUtterance else { return }
+        if Date().timeIntervalSince(lastUsed) >= idleUnloadAfter {
+            print("realtime: closing idle socket (>\(Int(idleUnloadAfter))s)")
+            closeSocket()
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Background loop reading WebSocket messages. Dispatches by event `type`.
+    private func receiveLoop() async {
+        guard let ws = webSocket else { return }
+
+        while !Task.isCancelled {
+            do {
+                let message = try await ws.receive()
+                lastUsed = Date()
+                switch message {
+                case .data(let data):
+                    handleEvent(data: data)
+                case .string(let string):
+                    if let data = string.data(using: .utf8) {
+                        handleEvent(data: data)
+                    }
+                @unknown default:
+                    break
+                }
+            } catch {
+                // Socket closed or connection error
+                print("realtime: receive error — \(error.localizedDescription)")
+                failContinuation(TranscriptionError.apiError(0, "connection: \(error.localizedDescription)"))
+                break
+            }
+        }
+    }
+
+    private func handleEvent(data: Data) {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = obj["type"] as? String else {
+            return
+        }
+
+        switch type {
+        case "conversation.item.input_audio_transcription.delta":
+            if let delta = obj["delta"] as? String, !delta.isEmpty {
+                let snapshot = delta
+                if let cb = onPartial {
+                    DispatchQueue.main.async { cb(snapshot) }
+                }
+            }
+
+        case "conversation.item.input_audio_transcription.completed":
+            let transcript = (obj["transcript"] as? String) ?? ""
+            hasActiveUtterance = false
+            if let continuation = streamingContinuation {
+                streamingContinuation = nil
+                continuation.resume(returning: transcript.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+            // Don't close the socket here — let the coordinator call
+            // finishStreaming or unloadIfIdle manage the lifecycle.
+
+        case "error":
+            let message = (obj["error"] as? [String: Any])?["message"] as? String
+                ?? (obj["error"] as? String)
+                ?? "unknown error"
+            print("realtime: server error — \(message)")
+            failContinuation(TranscriptionError.apiError(0, message))
+
+        case "transcription_session.created", "transcription_session.updated":
+            // Lifecycle acknowledgment — no action needed.
+            break
+
+        default:
+            print("realtime: unhandled event type=\(type)")
+        }
+    }
+
+    private func failContinuation(_ error: TranscriptionError) {
+        hasActiveUtterance = false
+        if let continuation = streamingContinuation {
+            streamingContinuation = nil
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private func closeSocket() {
+        webSocket?.cancel(with: .normalClosure, reason: nil)
+        webSocket = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        streamingContinuation = nil
+        hasActiveUtterance = false
+    }
+}

--- a/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
@@ -2,84 +2,179 @@ import Foundation
 
 /// Transcribes audio via the OpenAI Realtime WebSocket API (transcription-session).
 ///
-/// Owns its own `URLSessionWebSocketTask` per utterance. The streaming path
-/// forwards audio chunks as they arrive (`beginStreaming` → N×`appendChunk` →
-/// `finishStreaming`) and delivers the final transcript through `finishStreaming`.
-/// The single-shot protocol method `transcribe(audio:language:)` opens a socket,
-/// sends the entire buffer in one message, commits, and awaits the result —
-/// used as fallback when the full buffer is already available.
+/// ## Streaming flow
 ///
-/// Lifecycle: one socket per utterance. Closed on `cancelStreaming`, `finishStreaming`,
-/// idle timeout (>30s), or app termination.
-final class RealtimeTranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendable {
+///   `startRealtimeSession(language:)` → N×`appendAudioChunk(_:)` →
+///   `transcribe(audio:language:)` / `cancelSession()`
+///
+/// The coordinator opens a WebSocket session when recording starts, forwards
+/// audio chunks as they arrive, then finalizes via the protocol
+/// `transcribe(audio:language:)` which commits the buffer and awaits the final
+/// transcript. If the session failed to connect, `transcribe()` falls back
+/// to the batch HTTP API transparently.
+///
+/// ## Lifecycle
+///
+/// One socket per utterance. Opened in `startRealtimeSession`, closed on
+/// `cancelSession`, on idle timeout (>30 s), or on `deinit`.
+final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, @unchecked Sendable {
+    // MARK: - Configuration
+
     private let session: URLSession
-    private var config: VoiceConfig
-    private var webSocket: URLSessionWebSocketTask?
-    private var streamingContinuation: CheckedContinuation<String, Error>?
-    private var receiveTask: Task<Void, Never>?
-    private var lastUsed: Date = .distantPast
-    private var hasActiveUtterance = false
+    private let configLock = NSLock()
+    private var _config: VoiceConfig
+
+    private let stateLock = NSLock()
+    private var _webSocketTask: URLSessionWebSocketTask? {
+        didSet { oldValue?.cancel(with: .normalClosure, reason: nil) }
+    }
+    private var _connectContinuation: CheckedContinuation<Void, Error>?
+    private var _transcribeContinuation: CheckedContinuation<String, Error>?
+    private var _accumulatedText = ""
+    private var _finalTranscript: String?
+    /// True once `didOpenWithProtocol` fires (session is usable).
+    private var _isSessionActive = false
+    /// True once `didCompleteWithError` or an explicit disconnect fires.
+    private var _isDisconnected = false
+
+    private var _lastUsed = Date.distantPast
     private let idleUnloadAfter: TimeInterval = 30
 
     var onPartial: ((String) -> Void)?
 
+    // MARK: - Init / deinit
+
     init(config: VoiceConfig) {
-        self.config = config
-        self.session = URLSession(configuration: .ephemeral)
+        self._config = config
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.timeoutIntervalForRequest = 30
+        cfg.timeoutIntervalForResource = 60
+        self.session = URLSession(configuration: cfg)
     }
 
+    deinit {
+        disconnect()
+        // Drain any remaining continuations so nothing hangs forever.
+        stateLock.withLock {
+            _connectContinuation?.resume(throwing: CancellationError())
+            _connectContinuation = nil
+            _transcribeContinuation?.resume(throwing: CancellationError())
+            _transcribeContinuation = nil
+        }
+    }
+
+    // MARK: - TranscriptionEngineProtocol
+
     func updateConfig(_ config: VoiceConfig) {
-        self.config = config
+        configLock.withLock { _config = config }
+    }
+
+    func unloadIfIdle() {
+        let shouldClose = stateLock.withLock { () -> Bool in
+            guard _webSocketTask != nil, !_isSessionActive else { return false }
+            if Date().timeIntervalSince(_lastUsed) >= idleUnloadAfter {
+                _isDisconnected = true
+                _webSocketTask = nil
+                return true
+            }
+            return false
+        }
+        if shouldClose {
+            print("realtime: closed idle socket (>\(Int(idleUnloadAfter))s)")
+        }
+    }
+
+    /// Transcribe audio using either the active WebSocket session (commit +
+    /// await final transcript) or the batch HTTP API as a fallback when the
+    /// session never connected (or disconnected mid-utterance).
+    func transcribe(audio: [Float], language: String) async throws -> String {
+        // Check whether the WebSocket session is active. If not, fall through
+        // to the batch HTTP path.
+        let sessionWasActive = stateLock.withLock { _isSessionActive }
+
+        if sessionWasActive {
+            return try await commitAndRequest()
+        }
+
+        print("realtime: session not active — falling back to batch API")
+        return try await batchFallback(audio: audio, language: language)
     }
 
     // MARK: - Streaming API (called by VoiceCoordinator)
 
-    /// Open a WebSocket to the Realtime API and send `transcription_session.update`
-    /// to configure the session. Throws if connection fails or config is invalid.
-    func beginStreaming(language: String) throws {
-        guard !config.apiKey.isEmpty else { throw TranscriptionError.noAPIKey }
-        guard let url = URL(string: config.realtimeUrl) else {
-            throw TranscriptionError.invalidURL(config.realtimeUrl)
+    /// Open a WebSocket to the Realtime API and send `session.update` to
+    /// configure the session. Returns once the connection opens and the server
+    /// acknowledges the session configuration. Throws on failure.
+    func startRealtimeSession(language: String) async throws {
+        let (apiKey, realtimeUrl, realtimeModel) = configLock.withLock {
+            (_config.apiKey, _config.realtimeUrl, _config.realtimeModel)
+        }
+        guard !apiKey.isEmpty else { throw TranscriptionError.noAPIKey }
+        guard let url = URL(string: realtimeUrl) else {
+            throw TranscriptionError.invalidURL(realtimeUrl)
         }
 
         var request = URLRequest(url: url)
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
 
+        // Create the WebSocket task with self as delegate so we get
+        // didOpenWithProtocol / didCompleteWithError callbacks.
         let ws = session.webSocketTask(with: request)
-        self.webSocket = ws
-        ws.resume()
-        lastUsed = Date()
-        hasActiveUtterance = true
+        stateLock.withLock {
+            _webSocketTask = ws
+            _isDisconnected = false
+            _isSessionActive = false
+            _lastUsed = Date()
+        }
 
-        // Start the receive loop in background
-        receiveTask = Task { [weak self] in await self?.receiveLoop() }
+        // Await connection confirmation (resumed in didOpenWithProtocol or
+        // didCompleteWithError).
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stateLock.withLock {
+                if _isDisconnected {
+                    continuation.resume(throwing: TranscriptionError.connectionFailed("already disconnected"))
+                    return
+                }
+                _connectContinuation = continuation
+            }
+            ws.resume()
+        }
 
         // Send session configuration
-        let model = config.realtimeModel
-        let lang = language.isEmpty || language == "auto" ? "" : language
-        let sessionUpdate: [String: Any] = [
-            "type": "transcription_session.update",
-            "input_audio_format": "pcm16",
-            "input_audio_transcription": [
-                "model": model,
-                "language": lang,
-            ] as [String: Any],
-        ]
-        let msg = try JSONSerialization.data(withJSONObject: sessionUpdate)
-        ws.send(.data(msg)) { [weak self] error in
-            if let error = error {
-                print("realtime: session.update send error — \(error.localizedDescription)")
-                self?.failContinuation(TranscriptionError.apiError(0, "session.update: \(error.localizedDescription)"))
+        let updateData = try buildSessionUpdate(
+            language: language,
+            model: realtimeModel
+        )
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            ws.send(.data(updateData)) { error in
+                if let error = error {
+                    continuation.resume(throwing: TranscriptionError.apiError(0, "session.update: \(error.localizedDescription)"))
+                } else {
+                    continuation.resume()
+                }
             }
         }
+
+        // Start the background receive loop for delta/completed events.
+        let loopWs = ws
+        Task { [weak self] in
+            await self?.receiveLoop(ws: loopWs)
+        }
+
+        print("realtime: session started (model=\(realtimeModel))")
     }
 
     /// Encode `samples` as PCM16 base64 and send as `input_audio_buffer.append`.
-    /// Safe to call from any thread; the send is dispatched to the WebSocket's
-    /// delegate queue internally.
-    func appendChunk(_ samples: [Float]) {
-        guard let ws = webSocket, hasActiveUtterance else { return }
-        lastUsed = Date()
+    /// Safe to call from any thread (audio tap). Silently drops when no session
+    /// is open (fire-and-forget).
+    func appendAudioChunk(_ samples: [Float]) {
+        let ws = stateLock.withLock { () -> URLSessionWebSocketTask? in
+            guard _isSessionActive, !_isDisconnected else { return nil }
+            _lastUsed = Date()
+            return _webSocketTask
+        }
+        guard let ws = ws else { return }
+
         let pcmData = pcm16Data(from: samples)
         let base64 = pcmData.base64EncodedString()
         let event: [String: Any] = [
@@ -94,138 +189,82 @@ final class RealtimeTranscriptionEngine: TranscriptionEngineProtocol, @unchecked
         }
     }
 
-    /// Signal end of audio by sending `input_audio_buffer.commit`, then await
-    /// the final transcript from the WebSocket event stream. Returns the
-    /// recognized text.
-    func finishStreaming() async throws -> String {
-        guard let ws = webSocket, hasActiveUtterance else {
-            throw TranscriptionError.badResponse
+    /// Disconnect the current WebSocket session immediately without committing
+    /// the audio buffer (used on Esc-to-cancel or provider switch).
+    func cancelSession() {
+        disconnect()
+    }
+
+    // MARK: - WebSocket commit + await transcript
+
+    /// Send `input_audio_buffer.commit` followed by `response.create`, then
+    /// await the final transcript from the server event stream.
+    private func commitAndRequest() async throws -> String {
+        let ws = stateLock.withLock { () -> URLSessionWebSocketTask? in
+            // Reset accumulated state for a fresh utterance.
+            _accumulatedText = ""
+            _finalTranscript = nil
+            return _webSocketTask
         }
-        hasActiveUtterance = false
-        lastUsed = Date()
+        guard let ws = ws else {
+            throw TranscriptionError.connectionFailed("socket closed before commit")
+        }
 
         return try await withCheckedThrowingContinuation { continuation in
-            streamingContinuation = continuation
+            self.stateLock.withLock { self._transcribeContinuation = continuation }
+
+            // 1. Commit the audio buffer so the server starts transcribing.
             let commit: [String: Any] = ["type": "input_audio_buffer.commit"]
-            guard let data = try? JSONSerialization.data(withJSONObject: commit) else {
+            guard let commitData = try? JSONSerialization.data(withJSONObject: commit) else {
+                self.stateLock.withLock { self._transcribeContinuation = nil }
                 continuation.resume(throwing: TranscriptionError.badResponse)
                 return
             }
-            ws.send(.data(data)) { error in
+            ws.send(.data(commitData)) { [self] error in
                 if let error = error {
-                    print("realtime: commit send error — \(error.localizedDescription)")
-                    // Don't fail the continuation here — the response event
-                    // will carry the error if the commit was malformed.
-                }
-            }
-        }
-    }
-
-    /// Cancel the current utterance without consuming the result. Closes the
-    /// WebSocket immediately.
-    func cancelStreaming() {
-        hasActiveUtterance = false
-        streamingContinuation?.resume(throwing: TranscriptionError.badResponse)
-        streamingContinuation = nil
-        closeSocket()
-    }
-
-    // MARK: - TranscriptionEngineProtocol conformance
-
-    /// Single-shot fallback path: open a WebSocket, send the full audio buffer
-    /// in one `input_audio_buffer.append`, commit, and await the final transcript.
-    /// This lets the coordinator call `activeEngine.transcribe(audio:language:)`
-    /// uniformly when realtime streaming was not used (e.g. fallback after
-    /// connection failure).
-    func transcribe(audio: [Float], language: String) async throws -> String {
-        guard !config.apiKey.isEmpty else { throw TranscriptionError.noAPIKey }
-        guard let url = URL(string: config.realtimeUrl) else {
-            throw TranscriptionError.invalidURL(config.realtimeUrl)
-        }
-
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
-
-        let ws = session.webSocketTask(with: request)
-        self.webSocket = ws
-        ws.resume()
-        lastUsed = Date()
-        hasActiveUtterance = true
-
-        // Start receive loop
-        receiveTask = Task { [weak self] in await self?.receiveLoop() }
-
-        // Session update
-        let model = config.realtimeModel
-        let lang = language.isEmpty || language == "auto" ? "" : language
-        let sessionUpdate: [String: Any] = [
-            "type": "transcription_session.update",
-            "input_audio_format": "pcm16",
-            "input_audio_transcription": [
-                "model": model,
-                "language": lang,
-            ] as [String: Any],
-        ]
-        let updateData = try JSONSerialization.data(withJSONObject: sessionUpdate)
-
-        return try await withCheckedThrowingContinuation { continuation in
-            streamingContinuation = continuation
-            ws.send(.data(updateData)) { error in
-                if let error = error {
-                    continuation.resume(throwing: TranscriptionError.apiError(0, "session.update: \(error.localizedDescription)"))
+                    stateLock.withLock { self._transcribeContinuation = nil }
+                    continuation.resume(throwing: TranscriptionError.apiError(0, "commit: \(error.localizedDescription)"))
                     return
                 }
-                // Send the full audio in one append
-                let pcmData = pcm16Data(from: audio)
-                let base64 = pcmData.base64EncodedString()
-                let appendEvent: [String: Any] = [
-                    "type": "input_audio_buffer.append",
-                    "audio": base64,
-                ]
-                guard let appendData = try? JSONSerialization.data(withJSONObject: appendEvent) else {
+
+                // 2. Request the response to get the transcript delivered.
+                let create: [String: Any] = ["type": "response.create"]
+                guard let createData = try? JSONSerialization.data(withJSONObject: create) else {
+                    stateLock.withLock { self._transcribeContinuation = nil }
                     continuation.resume(throwing: TranscriptionError.badResponse)
                     return
                 }
-                ws.send(.data(appendData)) { error in
+                ws.send(.data(createData)) { [self] error in
                     if let error = error {
-                        continuation.resume(throwing: TranscriptionError.apiError(0, "append: \(error.localizedDescription)"))
-                        return
+                        stateLock.withLock { self._transcribeContinuation = nil }
+                        continuation.resume(throwing: TranscriptionError.apiError(0, "response.create: \(error.localizedDescription)"))
                     }
-                    // Commit to finalize
-                    let commit: [String: Any] = ["type": "input_audio_buffer.commit"]
-                    guard let commitData = try? JSONSerialization.data(withJSONObject: commit) else {
-                        continuation.resume(throwing: TranscriptionError.badResponse)
-                        return
-                    }
-                    ws.send(.data(commitData)) { error in
-                        if let error = error {
-                            continuation.resume(throwing: TranscriptionError.apiError(0, "commit: \(error.localizedDescription)"))
-                        }
-                        // Success — continue waiting in receiveLoop for the result
-                    }
+                    // Success — the receive loop delivers the transcript events.
                 }
             }
         }
     }
 
-    func unloadIfIdle() {
-        guard webSocket != nil, !hasActiveUtterance else { return }
-        if Date().timeIntervalSince(lastUsed) >= idleUnloadAfter {
-            print("realtime: closing idle socket (>\(Int(idleUnloadAfter))s)")
-            closeSocket()
-        }
+    // MARK: - Batch HTTP fallback
+
+    /// One-shot batch transcription via the standard `/audio/transcriptions`
+    /// endpoint. Used when the WebSocket session never connected or
+    /// disconnected mid-utterance.
+    private func batchFallback(audio: [Float], language: String) async throws -> String {
+        let config = configLock.withLock { _config }
+        let httpEngine = TranscriptionEngine(config: config)
+        return try await httpEngine.transcribe(audio: audio, language: language)
     }
 
-    // MARK: - Internals
+    // MARK: - Internal: WebSocket receive loop
 
-    /// Background loop reading WebSocket messages. Dispatches by event `type`.
-    private func receiveLoop() async {
-        guard let ws = webSocket else { return }
-
+    /// Background loop reading WebSocket messages and dispatching by event type.
+    private func receiveLoop(ws: URLSessionWebSocketTask) async {
         while !Task.isCancelled {
             do {
                 let message = try await ws.receive()
-                lastUsed = Date()
+                stateLock.withLock { _lastUsed = Date() }
+
                 switch message {
                 case .data(let data):
                     handleEvent(data: data)
@@ -237,13 +276,18 @@ final class RealtimeTranscriptionEngine: TranscriptionEngineProtocol, @unchecked
                     break
                 }
             } catch {
-                // Socket closed or connection error
                 print("realtime: receive error — \(error.localizedDescription)")
-                failContinuation(TranscriptionError.apiError(0, "connection: \(error.localizedDescription)"))
-                break
+                if let nsError = error as NSError?,
+                   nsError.domain == NSURLErrorDomain,
+                   nsError.code == NSURLErrorNetworkConnectionLost {
+                    handleConnectionLost()
+                    break
+                }
             }
         }
     }
+
+    // MARK: - Internal: Event dispatch
 
     private func handleEvent(data: Data) {
         guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -253,8 +297,9 @@ final class RealtimeTranscriptionEngine: TranscriptionEngineProtocol, @unchecked
 
         switch type {
         case "conversation.item.input_audio_transcription.delta":
-            if let delta = obj["delta"] as? String, !delta.isEmpty {
-                let snapshot = delta
+            if let delta = obj["delta"] as? String {
+                stateLock.withLock { _accumulatedText.append(delta) }
+                let snapshot = stateLock.withLock { _accumulatedText }
                 if let cb = onPartial {
                     DispatchQueue.main.async { cb(snapshot) }
                 }
@@ -262,22 +307,43 @@ final class RealtimeTranscriptionEngine: TranscriptionEngineProtocol, @unchecked
 
         case "conversation.item.input_audio_transcription.completed":
             let transcript = (obj["transcript"] as? String) ?? ""
-            hasActiveUtterance = false
-            if let continuation = streamingContinuation {
-                streamingContinuation = nil
-                continuation.resume(returning: transcript.trimmingCharacters(in: .whitespacesAndNewlines))
+            stateLock.withLock {
+                _finalTranscript = transcript
             }
-            // Don't close the socket here — let the coordinator call
-            // finishStreaming or unloadIfIdle manage the lifecycle.
+
+        case "response.text.done":
+            if let text = obj["text"] as? String {
+                stateLock.withLock { _finalTranscript = text }
+            }
+
+        case "response.done":
+            let transcript = stateLock.withLock { () -> String in
+                let t = _finalTranscript ?? _accumulatedText
+                _isSessionActive = false
+                return t
+            }
+            let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            stateLock.withLock {
+                if let cont = _transcribeContinuation {
+                    _transcribeContinuation = nil
+                    cont.resume(returning: trimmed)
+                }
+            }
 
         case "error":
-            let message = (obj["error"] as? [String: Any])?["message"] as? String
+            let msg = (obj["error"] as? [String: Any])?["message"] as? String
                 ?? (obj["error"] as? String)
                 ?? "unknown error"
-            print("realtime: server error — \(message)")
-            failContinuation(TranscriptionError.apiError(0, message))
+            print("realtime: server error — \(msg)")
+            stateLock.withLock {
+                if let cont = _transcribeContinuation {
+                    _transcribeContinuation = nil
+                    cont.resume(throwing: TranscriptionError.apiError(0, msg))
+                }
+            }
 
-        case "transcription_session.created", "transcription_session.updated":
+        case "session.created", "session.updated":
             // Lifecycle acknowledgment — no action needed.
             break
 
@@ -286,20 +352,102 @@ final class RealtimeTranscriptionEngine: TranscriptionEngineProtocol, @unchecked
         }
     }
 
-    private func failContinuation(_ error: TranscriptionError) {
-        hasActiveUtterance = false
-        if let continuation = streamingContinuation {
-            streamingContinuation = nil
-            continuation.resume(throwing: error)
+    // MARK: - Internal: Connection management
+
+    private func handleConnectionLost() {
+        stateLock.withLock {
+            _isDisconnected = true
+            _isSessionActive = false
+            if let cont = _transcribeContinuation {
+                _transcribeContinuation = nil
+                cont.resume(throwing: TranscriptionError.connectionFailed("connection lost"))
+            }
         }
     }
 
-    private func closeSocket() {
-        webSocket?.cancel(with: .normalClosure, reason: nil)
-        webSocket = nil
-        receiveTask?.cancel()
-        receiveTask = nil
-        streamingContinuation = nil
-        hasActiveUtterance = false
+    private func disconnect() {
+        stateLock.withLock {
+            _isDisconnected = true
+            _isSessionActive = false
+            _connectContinuation?.resume(throwing: CancellationError())
+            _connectContinuation = nil
+            _webSocketTask = nil
+        }
+    }
+
+    // MARK: - Session update builder
+
+    /// Build the JSON data for `session.update` with the required `"session"`
+    /// wrapper key. Uses `NSNull()` to explicitly disable server VAD so the
+    /// manual commit model is the only commit source.
+    private func buildSessionUpdate(language: String, model: String) throws -> Data {
+        let lang = language.isEmpty || language == "auto" ? "" : language
+        var transcription: [String: Any] = [
+            "model": model,
+        ]
+        if !lang.isEmpty {
+            transcription["language"] = lang
+        }
+
+        let body: [String: Any] = [
+            "type": "session.update",
+            "session": [
+                "modalities": ["text"],
+                "input_audio_format": "pcm16",
+                "input_audio_transcription": transcription,
+                "turn_detection": NSNull(),  // disabled — we control start/stop
+            ] as [String: Any],
+        ]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+}
+
+// MARK: - URLSessionWebSocketDelegate conformance
+
+/// The session delegate receives connection lifecycle events that we use to
+/// resolve (or fail) the `startRealtimeSession` continuation.
+extension RealtimeTranscriptionEngine: URLSessionWebSocketDelegate {
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        print("realtime: WebSocket connected")
+        stateLock.withLock {
+            _isSessionActive = true
+            _isDisconnected = false
+            if let cont = _connectContinuation {
+                _connectContinuation = nil
+                cont.resume()
+            }
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        if let error = error {
+            print("realtime: WebSocket disconnected with error — \(error.localizedDescription)")
+        } else {
+            print("realtime: WebSocket closed normally")
+        }
+        stateLock.withLock {
+            _isDisconnected = true
+            _isSessionActive = false
+            // If a connect continuation is still pending, fail it.
+            if let cont = _connectContinuation {
+                _connectContinuation = nil
+                cont.resume(throwing: error.map { TranscriptionError.connectionFailed($0.localizedDescription) }
+                    ?? TranscriptionError.connectionFailed("connection closed"))
+            }
+            // If a transcribe continuation is still pending, fail it.
+            if let cont = _transcribeContinuation {
+                _transcribeContinuation = nil
+                cont.resume(throwing: error.map { TranscriptionError.apiError(0, $0.localizedDescription) }
+                    ?? TranscriptionError.apiError(0, "connection closed before transcript"))
+            }
+        }
     }
 }

--- a/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
@@ -93,7 +93,7 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         let sessionWasActive = stateLock.withLock { _isSessionActive }
 
         if sessionWasActive {
-            return try await commitAndRequest()
+            return try await commitAndAwaitTranscript()
         }
 
         print("realtime: session not active — falling back to batch API")
@@ -197,9 +197,13 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
 
     // MARK: - WebSocket commit + await transcript
 
-    /// Send `input_audio_buffer.commit` followed by `response.create`, then
-    /// await the final transcript from the server event stream.
-    private func commitAndRequest() async throws -> String {
+    /// Send `input_audio_buffer.commit`, then await the final transcript from the
+    /// server event stream. For a transcription session (?intent=transcription)
+    /// the commit alone triggers transcription; the result is delivered via
+    /// `conversation.item.input_audio_transcription.{delta,completed}`. We do NOT
+    /// send `response.create` — transcription sessions reject it (and it would
+    /// surface as a server `error` event, failing the utterance).
+    private func commitAndAwaitTranscript() async throws -> String {
         let ws = stateLock.withLock { () -> URLSessionWebSocketTask? in
             // Reset accumulated state for a fresh utterance.
             _accumulatedText = ""
@@ -213,7 +217,9 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         return try await withCheckedThrowingContinuation { continuation in
             self.stateLock.withLock { self._transcribeContinuation = continuation }
 
-            // 1. Commit the audio buffer so the server starts transcribing.
+            // Commit the audio buffer so the server starts transcribing. The
+            // receive loop resolves this continuation when the terminal
+            // transcription event (`.completed`) arrives.
             let commit: [String: Any] = ["type": "input_audio_buffer.commit"]
             guard let commitData = try? JSONSerialization.data(withJSONObject: commit) else {
                 self.stateLock.withLock { self._transcribeContinuation = nil }
@@ -224,23 +230,8 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
                 if let error = error {
                     stateLock.withLock { self._transcribeContinuation = nil }
                     continuation.resume(throwing: TranscriptionError.apiError(0, "commit: \(error.localizedDescription)"))
-                    return
                 }
-
-                // 2. Request the response to get the transcript delivered.
-                let create: [String: Any] = ["type": "response.create"]
-                guard let createData = try? JSONSerialization.data(withJSONObject: create) else {
-                    stateLock.withLock { self._transcribeContinuation = nil }
-                    continuation.resume(throwing: TranscriptionError.badResponse)
-                    return
-                }
-                ws.send(.data(createData)) { [self] error in
-                    if let error = error {
-                        stateLock.withLock { self._transcribeContinuation = nil }
-                        continuation.resume(throwing: TranscriptionError.apiError(0, "response.create: \(error.localizedDescription)"))
-                    }
-                    // Success — the receive loop delivers the transcript events.
-                }
+                // Success — the receive loop delivers the transcript events.
             }
         }
     }
@@ -306,10 +297,11 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
             }
 
         case "conversation.item.input_audio_transcription.completed":
+            // Terminal event for a transcription session (?intent=transcription):
+            // the final transcript is delivered here, so this is what resolves
+            // the pending transcribe() continuation.
             let transcript = (obj["transcript"] as? String) ?? ""
-            stateLock.withLock {
-                _finalTranscript = transcript
-            }
+            finishTranscript(explicit: transcript.isEmpty ? nil : transcript)
 
         case "response.text.done":
             if let text = obj["text"] as? String {
@@ -317,19 +309,10 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
             }
 
         case "response.done":
-            let transcript = stateLock.withLock { () -> String in
-                let t = _finalTranscript ?? _accumulatedText
-                _isSessionActive = false
-                return t
-            }
-            let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-
-            stateLock.withLock {
-                if let cont = _transcribeContinuation {
-                    _transcribeContinuation = nil
-                    cont.resume(returning: trimmed)
-                }
-            }
+            // Terminal event for a full realtime (response) session — kept as a
+            // fallback for endpoints that drive the response API instead of the
+            // transcription intent.
+            finishTranscript(explicit: nil)
 
         case "error":
             let msg = (obj["error"] as? [String: Any])?["message"] as? String
@@ -350,6 +333,25 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         default:
             print("realtime: unhandled event type=\(type)")
         }
+    }
+
+    /// Resolve the pending `transcribe()` continuation with the final transcript.
+    /// `explicit` is the transcript carried by a terminal event (transcription
+    /// `.completed`); when nil we fall back to the last `_finalTranscript`, then
+    /// the accumulated deltas. Marks the session inactive and resumes outside the
+    /// lock. No-ops if no transcribe is in flight (idempotent across terminal
+    /// events, e.g. both `.completed` and a later `response.done`).
+    private func finishTranscript(explicit: String?) {
+        let (cont, result) = stateLock.withLock { () -> (CheckedContinuation<String, Error>?, String) in
+            if let explicit = explicit { _finalTranscript = explicit }
+            let text = (_finalTranscript ?? _accumulatedText)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            _isSessionActive = false
+            let c = _transcribeContinuation
+            _transcribeContinuation = nil
+            return (c, text)
+        }
+        cont?.resume(returning: result)
     }
 
     // MARK: - Internal: Connection management

--- a/voice/Sources/CodeyVoice/TranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/TranscriptionEngine.swift
@@ -207,7 +207,7 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
             // PCM payload — use the shared helper's raw bytes
             let dest = base.advanced(by: 44)
             payload.withUnsafeBytes { src in
-                memcpy(dest, src.baseAddress!, payload.count)
+                _ = memcpy(dest, src.baseAddress!, payload.count)
             }
         }
         return data

--- a/voice/Sources/CodeyVoice/TranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/TranscriptionEngine.swift
@@ -9,12 +9,16 @@ import Foundation
 /// latency on multi-second clips. `whisper-1` and unknown models stay on the
 /// original non-streaming path since they don't honor `stream=true`.
 final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendable {
+    /// CRITICAL FIX #3: mutable state is behind a lock so `transcribe` (called
+    /// from arbitrary Task contexts) and `updateConfig` (called from gateway
+    /// polling timer) don't race.
     private let session: URLSession
-    private var config: VoiceConfig
+    private let configLock = NSLock()
+    private var _config: VoiceConfig
     var onPartial: ((String) -> Void)?
 
     init(config: VoiceConfig) {
-        self.config = config
+        self._config = config
         let cfg = URLSessionConfiguration.ephemeral
         cfg.timeoutIntervalForRequest = 30
         cfg.timeoutIntervalForResource = 60
@@ -22,7 +26,7 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
     }
 
     func updateConfig(_ config: VoiceConfig) {
-        self.config = config
+        configLock.withLock { _config = config }
     }
 
     func unloadIfIdle() {
@@ -31,19 +35,23 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
 
     /// Transcribe 16 kHz mono Float32 audio via the configured API.
     func transcribe(audio: [Float], language: String) async throws -> String {
-        let baseURL = config.apiUrl.hasSuffix("/")
-            ? String(config.apiUrl.dropLast())
-            : config.apiUrl
+        // Snapshot config under the lock so all reads see a consistent version.
+        let (apiUrl, apiKey, apiModel) = configLock.withLock {
+            (_config.apiUrl, _config.apiKey, _config.apiModel)
+        }
+        let baseURL = apiUrl.hasSuffix("/")
+            ? String(apiUrl.dropLast())
+            : apiUrl
         guard let url = URL(string: "\(baseURL)/audio/transcriptions") else {
             throw TranscriptionError.invalidURL(baseURL)
         }
-        guard !config.apiKey.isEmpty else {
+        guard !apiKey.isEmpty else {
             throw TranscriptionError.noAPIKey
         }
 
         let wavData = encodeWAV(samples: audio, sampleRate: 16000)
-        let streaming = modelSupportsStreaming(config.apiModel)
-        let request = buildRequest(url: url, wav: wavData, language: language, streaming: streaming)
+        let streaming = modelSupportsStreaming(apiModel)
+        let request = buildRequest(url: url, apiKey: apiKey, apiModel: apiModel, wav: wavData, language: language, streaming: streaming)
 
         return streaming
             ? try await runStreaming(request: request)
@@ -60,10 +68,10 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
         return m.contains("gpt-4o") && m.contains("transcribe")
     }
 
-    private func buildRequest(url: URL, wav: Data, language: String, streaming: Bool) -> URLRequest {
+    private func buildRequest(url: URL, apiKey: String, apiModel: String, wav: Data, language: String, streaming: Bool) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         if streaming {
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         }
@@ -86,7 +94,7 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
         body.append(wav)
         body.append("\r\n".data(using: .utf8)!)
 
-        field("model", config.apiModel)
+        field("model", apiModel)
         if !language.isEmpty && language != "auto" {
             field("language", language)
         }
@@ -217,6 +225,7 @@ enum TranscriptionError: LocalizedError {
     case noAPIKey
     case badResponse
     case apiError(Int, String)
+    case connectionFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -224,6 +233,7 @@ enum TranscriptionError: LocalizedError {
         case .noAPIKey: return "No API key configured"
         case .badResponse: return "Bad response from transcription API"
         case .apiError(let code, let msg): return "API error \(code): \(msg)"
+        case .connectionFailed(let reason): return "Connection failed: \(reason)"
         }
     }
 }

--- a/voice/Sources/CodeyVoice/TranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/TranscriptionEngine.swift
@@ -164,9 +164,8 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
 
     /// Encode 16-bit PCM WAV from Float32 samples in `[-1, 1]`. Pre-allocates
     /// the full buffer (44-byte header + `samples.count * 2`) and writes the
-    /// Int16 payload in one pass via `withUnsafeMutableBytes` — the previous
-    /// per-sample `Data.append` loop reallocated repeatedly and dominated
-    /// `transcribe(...)` latency on long clips.
+    /// Int16 payload in one pass via `pcm16Data(from:)` so the same clamp+scale
+    /// logic is shared with the realtime WebSocket path.
     private func encodeWAV(samples: [Float], sampleRate: Int) -> Data {
         let numChannels: UInt16 = 1
         let bitsPerSample: UInt16 = 16
@@ -176,6 +175,7 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
         let fileSize = 36 + dataSize
         let totalBytes = 44 + Int(dataSize)
 
+        let payload = pcm16Data(from: samples)
         var data = Data(count: totalBytes)
         data.withUnsafeMutableBytes { raw in
             let base = raw.baseAddress!
@@ -196,12 +196,10 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
             memcpy(base.advanced(by: 36), "data", 4)
             writeLE(base, offset: 40, value: dataSize)
 
-            // PCM payload — one branchless clamp + scale per sample.
-            let pcm = base.advanced(by: 44).assumingMemoryBound(to: Int16.self)
-            for i in 0..<samples.count {
-                let s = samples[i]
-                let c = s < -1 ? -1 : (s > 1 ? 1 : s)
-                pcm[i] = Int16(c * 32767.0)
+            // PCM payload — use the shared helper's raw bytes
+            let dest = base.advanced(by: 44)
+            payload.withUnsafeBytes { src in
+                memcpy(dest, src.baseAddress!, payload.count)
             }
         }
         return data

--- a/voice/Sources/CodeyVoice/VoiceConfig.swift
+++ b/voice/Sources/CodeyVoice/VoiceConfig.swift
@@ -14,10 +14,10 @@ struct VoiceConfig: Codable {
     var apiModel: String = "gpt-4o-mini-transcribe"
     /// WhisperKit model variant id (HuggingFace argmaxinc/whisperkit-coreml).
     var localModel: String = "openai_whisper-large-v3_turbo_954MB"
-    /// WebSocket endpoint for the OpenAI Realtime transcription API.
-    var realtimeUrl: String = "wss://api.openai.com/v1/realtime?intent=transcription"
-    /// Model to use for Realtime transcription sessions.
-    var realtimeModel: String = "gpt-4o-mini-transcribe"
+    /// OpenAI Realtime API WebSocket URL. Uses the same apiKey as the batch API.
+    var realtimeUrl: String = "wss://api.openai.com/v1/realtime"
+    /// Realtime model variant (e.g. "gpt-4o-realtime-preview-2024-12-17").
+    var realtimeModel: String = "gpt-4o-realtime-preview-2024-12-17"
 
     enum InjectionMode: String, Codable {
         case paste

--- a/voice/Sources/CodeyVoice/VoiceConfig.swift
+++ b/voice/Sources/CodeyVoice/VoiceConfig.swift
@@ -15,9 +15,10 @@ struct VoiceConfig: Codable {
     /// WhisperKit model variant id (HuggingFace argmaxinc/whisperkit-coreml).
     var localModel: String = "openai_whisper-large-v3_turbo_954MB"
     /// OpenAI Realtime API WebSocket URL. Uses the same apiKey as the batch API.
-    var realtimeUrl: String = "wss://api.openai.com/v1/realtime"
-    /// Realtime model variant (e.g. "gpt-4o-realtime-preview-2024-12-17").
-    var realtimeModel: String = "gpt-4o-realtime-preview-2024-12-17"
+    /// Requires `?intent=transcription` to open a transcription session.
+    var realtimeUrl: String = "wss://api.openai.com/v1/realtime?intent=transcription"
+    /// Realtime transcription model (e.g. "gpt-4o-mini-transcribe").
+    var realtimeModel: String = "gpt-4o-mini-transcribe"
 
     enum InjectionMode: String, Codable {
         case paste

--- a/voice/Sources/CodeyVoice/VoiceConfig.swift
+++ b/voice/Sources/CodeyVoice/VoiceConfig.swift
@@ -14,6 +14,10 @@ struct VoiceConfig: Codable {
     var apiModel: String = "gpt-4o-mini-transcribe"
     /// WhisperKit model variant id (HuggingFace argmaxinc/whisperkit-coreml).
     var localModel: String = "openai_whisper-large-v3_turbo_954MB"
+    /// WebSocket endpoint for the OpenAI Realtime transcription API.
+    var realtimeUrl: String = "wss://api.openai.com/v1/realtime?intent=transcription"
+    /// Model to use for Realtime transcription sessions.
+    var realtimeModel: String = "gpt-4o-mini-transcribe"
 
     enum InjectionMode: String, Codable {
         case paste
@@ -23,6 +27,7 @@ struct VoiceConfig: Codable {
     enum Provider: String, Codable {
         case api
         case local
+        case realtime
     }
 
     static var `default`: VoiceConfig {

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -17,10 +17,6 @@ final class VoiceCoordinator {
     private let apiEngine: TranscriptionEngine
     private let localEngine: WhisperKitEngine
     private let realtimeEngine: RealtimeTranscriptionEngine
-    /// Set when realtime WebSocket connect fails mid-utterance. The fallback
-    /// path uses `apiEngine.transcribe(buffer)` — the pcmBuffer is always
-    /// accumulating in parallel so the full audio is available.
-    private var realtimeFallbackActive = false
     private var textInjector: TextInjector
     private var hotkeyManager: HotkeyManager?
     private var statusItem: StatusItem?
@@ -100,6 +96,16 @@ final class VoiceCoordinator {
         localEngine.onPartial = partialHandler
         realtimeEngine.onPartial = partialHandler
 
+        // Route audio chunks to the realtime engine during recording.
+        // The engine's appendAudioChunk is a no-op when no session is open,
+        // so this is safe to leave wired permanently.
+        audioCapture.onChunk = { [weak self] chunk in
+            guard let self = self else { return }
+            if self.config.provider == .realtime {
+                self.realtimeEngine.appendAudioChunk(chunk)
+            }
+        }
+
         // Stream mic RMS levels to the HUD waveform meter. Audio tap thread
         // → main hop here. The HUD itself no-ops when not in .recording.
         audioCapture.onLevel = { [weak self] level in
@@ -171,23 +177,20 @@ final class VoiceCoordinator {
                 )
             }
 
-            // For the realtime provider, open a WebSocket and wire the chunk
-            // callback so each resampled audio chunk is forwarded live.
+            // Start the realtime WebSocket session if using the realtime provider.
+            // Audio chunks are already being forwarded to the engine via onChunk
+            // (set up in start()). If the session fails to connect, transcribe()
+            // falls back to the batch HTTP API.
             if config.provider == .realtime {
-                realtimeFallbackActive = false
-                do {
-                    try realtimeEngine.beginStreaming(language: config.language)
-                    audioCapture.onChunk = { [weak self] chunk in
-                        self?.realtimeEngine.appendChunk(chunk)
+                let lang = config.language
+                Task {
+                    do {
+                        try await realtimeEngine.startRealtimeSession(language: lang)
+                    } catch {
+                        print("startRecording: realtime session failed — \(error.localizedDescription), falling back to batch")
                     }
-                } catch {
-                    // Connection refused / no API key / etc — degrade gracefully.
-                    print("realtime: beginStreaming failed — \(error.localizedDescription). Falling back to batch API.")
-                    realtimeFallbackActive = true
-                    audioCapture.onChunk = nil
                 }
             }
-
             print("startRecording: OK, audio engine running")
             Task { await gateway.reportStatus("recording") }
         } catch {
@@ -216,9 +219,8 @@ final class VoiceCoordinator {
         removeEscMonitor()
         localEngine.stopStreaming()
         audioCapture.onChunk = nil
-        realtimeEngine.cancelStreaming()
+        realtimeEngine.cancelSession()
         audioCapture.cancelRecording()
-        realtimeFallbackActive = false
         state = .idle
         statusItem?.updateState(.idle)
         hud.hide()
@@ -277,32 +279,16 @@ final class VoiceCoordinator {
         hud.show(.transcribing)
         Task { await gateway.reportStatus("transcribing") }
 
-        // Determine the transcription path:
-        //   realtime + no fallback → finalize via WebSocket streaming
-        //   realtime + fallback active → one-shot batch via apiEngine (buffer already accumulated)
-        //   local/api → standard path
-        let shouldUseRealtimeFinalize = (config.provider == .realtime && !realtimeFallbackActive)
-
         Task {
             do {
-                var text: String
-                if shouldUseRealtimeFinalize {
-                    print("transcribe: realtime finalize")
-                    text = try await realtimeEngine.finishStreaming()
-                } else {
-                    let lang = config.language
-                    let engine = realtimeFallbackActive ? apiEngine : activeEngine
-                    let fallbackLabel = realtimeFallbackActive ? " (realtime fallback to api)" : ""
-                    let providerLabel = config.provider == .local
-                        ? "local(\(config.localModel))"
-                        : "api(\(config.apiModel))"
-                    print("transcribe: starting (language=\(lang.isEmpty ? "auto" : lang), provider=\(providerLabel)\(fallbackLabel))")
-                    text = try await engine.transcribe(audio: buffer, language: lang)
-                }
-
-                // Reset per-utterance realtime state
-                realtimeFallbackActive = false
-                audioCapture.onChunk = nil
+                let lang = config.language
+                let providerLabel = config.provider == .local
+                    ? "local(\(config.localModel))"
+                    : config.provider == .realtime
+                    ? "realtime(\(config.realtimeModel))"
+                    : "api(\(config.apiModel))"
+                print("transcribe: starting (language=\(lang.isEmpty ? "auto" : lang), provider=\(providerLabel))")
+                let text = try await activeEngine.transcribe(audio: buffer, language: lang)
 
                 print("transcribe: result = \"\(text)\" (\(text.count) chars)")
 
@@ -333,8 +319,6 @@ final class VoiceCoordinator {
                 Task { await gateway.reportStatus("idle") }
             } catch {
                 print("transcribe FAILED: \(error.localizedDescription)")
-                realtimeFallbackActive = false
-                audioCapture.onChunk = nil
                 state = .idle
                 statusItem?.updateState(.error(error.localizedDescription))
                 let msg = error.localizedDescription
@@ -377,7 +361,7 @@ final class VoiceCoordinator {
             localEngine.forceUnload(reason: "provider switched to \(newConfig.provider.rawValue)")
         }
         if oldProvider == .realtime && newConfig.provider != .realtime {
-            realtimeEngine.cancelStreaming()
+            realtimeEngine.cancelSession()
         }
         if oldProvider != .local && newConfig.provider == .local {
             // User just turned local on (or changed model) — start warming now
@@ -413,7 +397,7 @@ final class VoiceCoordinator {
         pollTimer?.invalidate()
         idleUnloadTimer?.invalidate()
         localEngine.forceUnload(reason: "app terminating")
-        realtimeEngine.cancelStreaming()
+        realtimeEngine.cancelSession()
     }
 
     // MARK: - Settings

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -16,6 +16,11 @@ final class VoiceCoordinator {
     private let audioCapture: AudioCapture
     private let apiEngine: TranscriptionEngine
     private let localEngine: WhisperKitEngine
+    private let realtimeEngine: RealtimeTranscriptionEngine
+    /// Set when realtime WebSocket connect fails mid-utterance. The fallback
+    /// path uses `apiEngine.transcribe(buffer)` — the pcmBuffer is always
+    /// accumulating in parallel so the full audio is available.
+    private var realtimeFallbackActive = false
     private var textInjector: TextInjector
     private var hotkeyManager: HotkeyManager?
     private var statusItem: StatusItem?
@@ -43,6 +48,7 @@ final class VoiceCoordinator {
         self.audioCapture = AudioCapture()
         self.apiEngine = TranscriptionEngine(config: .default)
         self.localEngine = WhisperKitEngine(config: .default)
+        self.realtimeEngine = RealtimeTranscriptionEngine(config: .default)
         self.textInjector = TextInjector(mode: .paste)
     }
 
@@ -50,6 +56,7 @@ final class VoiceCoordinator {
         switch config.provider {
         case .local: return localEngine
         case .api: return apiEngine
+        case .realtime: return realtimeEngine
         }
     }
 
@@ -91,6 +98,7 @@ final class VoiceCoordinator {
         }
         apiEngine.onPartial = partialHandler
         localEngine.onPartial = partialHandler
+        realtimeEngine.onPartial = partialHandler
 
         // Stream mic RMS levels to the HUD waveform meter. Audio tap thread
         // → main hop here. The HUD itself no-ops when not in .recording.
@@ -104,10 +112,11 @@ final class VoiceCoordinator {
         // Start polling gateway
         startGatewayPolling()
 
-        // Idle-unload timer: every 15s check if the local pipeline can be released
+        // Idle-unload timer: every 15s check if the local pipeline or realtime socket can be released
         idleUnloadTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
             guard let self = self, self.state == .idle else { return }
             self.localEngine.unloadIfIdle()
+            self.realtimeEngine.unloadIfIdle()
         }
 
         // Prewarm WhisperKit so the first hotkey press doesn't pay the model
@@ -149,6 +158,7 @@ final class VoiceCoordinator {
             statusItem?.updateState(.recording)
             hud.show(.recording)
             installEscMonitor()
+
             // Kick off WhisperKit's sliding-window streaming so the HUD can
             // show partial transcripts while the user is still speaking.
             // API streaming, by contrast, only kicks in after stop because
@@ -160,6 +170,24 @@ final class VoiceCoordinator {
                     language: config.language
                 )
             }
+
+            // For the realtime provider, open a WebSocket and wire the chunk
+            // callback so each resampled audio chunk is forwarded live.
+            if config.provider == .realtime {
+                realtimeFallbackActive = false
+                do {
+                    try realtimeEngine.beginStreaming(language: config.language)
+                    audioCapture.onChunk = { [weak self] chunk in
+                        self?.realtimeEngine.appendChunk(chunk)
+                    }
+                } catch {
+                    // Connection refused / no API key / etc — degrade gracefully.
+                    print("realtime: beginStreaming failed — \(error.localizedDescription). Falling back to batch API.")
+                    realtimeFallbackActive = true
+                    audioCapture.onChunk = nil
+                }
+            }
+
             print("startRecording: OK, audio engine running")
             Task { await gateway.reportStatus("recording") }
         } catch {
@@ -187,7 +215,10 @@ final class VoiceCoordinator {
         print("cancelRecording: Esc pressed — discarding buffer")
         removeEscMonitor()
         localEngine.stopStreaming()
+        audioCapture.onChunk = nil
+        realtimeEngine.cancelStreaming()
         audioCapture.cancelRecording()
+        realtimeFallbackActive = false
         state = .idle
         statusItem?.updateState(.idle)
         hud.hide()
@@ -246,20 +277,42 @@ final class VoiceCoordinator {
         hud.show(.transcribing)
         Task { await gateway.reportStatus("transcribing") }
 
+        // Determine the transcription path:
+        //   realtime + no fallback → finalize via WebSocket streaming
+        //   realtime + fallback active → one-shot batch via apiEngine (buffer already accumulated)
+        //   local/api → standard path
+        let shouldUseRealtimeFinalize = (config.provider == .realtime && !realtimeFallbackActive)
+
         Task {
             do {
-                let lang = config.language
-                let providerLabel = config.provider == .local ? "local(\(config.localModel))" : "api(\(config.apiModel))"
-                print("transcribe: starting (language=\(lang.isEmpty ? "auto" : lang), provider=\(providerLabel))")
-                let text = try await activeEngine.transcribe(audio: buffer, language: lang)
+                var text: String
+                if shouldUseRealtimeFinalize {
+                    print("transcribe: realtime finalize")
+                    text = try await realtimeEngine.finishStreaming()
+                } else {
+                    let lang = config.language
+                    let engine = realtimeFallbackActive ? apiEngine : activeEngine
+                    let fallbackLabel = realtimeFallbackActive ? " (realtime fallback to api)" : ""
+                    let providerLabel = config.provider == .local
+                        ? "local(\(config.localModel))"
+                        : "api(\(config.apiModel))"
+                    print("transcribe: starting (language=\(lang.isEmpty ? "auto" : lang), provider=\(providerLabel)\(fallbackLabel))")
+                    text = try await engine.transcribe(audio: buffer, language: lang)
+                }
+
+                // Reset per-utterance realtime state
+                realtimeFallbackActive = false
+                audioCapture.onChunk = nil
+
                 print("transcribe: result = \"\(text)\" (\(text.count) chars)")
 
                 let canInject = TextInjector.canInjectAtCurrentFocus()
-                if !text.isEmpty && canInject {
+                let finalText = text
+                if !finalText.isEmpty && canInject {
                     print("inject: mode=\(config.injection)")
-                    textInjector.inject(text)
+                    textInjector.inject(finalText)
                     print("inject: dispatched")
-                } else if !text.isEmpty {
+                } else if !finalText.isEmpty {
                     print("inject: no text-capable focus, surfacing in HUD")
                 } else {
                     print("inject: skipped (empty transcription)")
@@ -267,19 +320,21 @@ final class VoiceCoordinator {
                 state = .idle
                 statusItem?.updateState(.idle)
                 await MainActor.run {
-                    if text.isEmpty {
+                    if finalText.isEmpty {
                         self.hud.hide()
                     } else if canInject {
                         self.hud.show(.success)
                     } else {
                         // Nowhere to paste: show full text + auto-copy, wait
                         // for click to dismiss.
-                        self.hud.show(.dictation(text))
+                        self.hud.show(.dictation(finalText))
                     }
                 }
                 Task { await gateway.reportStatus("idle") }
             } catch {
                 print("transcribe FAILED: \(error.localizedDescription)")
+                realtimeFallbackActive = false
+                audioCapture.onChunk = nil
                 state = .idle
                 statusItem?.updateState(.error(error.localizedDescription))
                 let msg = error.localizedDescription
@@ -317,8 +372,12 @@ final class VoiceCoordinator {
         textInjector = TextInjector(mode: newConfig.injection)
         apiEngine.updateConfig(newConfig)
         localEngine.updateConfig(newConfig)
+        realtimeEngine.updateConfig(newConfig)
         if oldProvider == .local && newConfig.provider != .local {
             localEngine.forceUnload(reason: "provider switched to \(newConfig.provider.rawValue)")
+        }
+        if oldProvider == .realtime && newConfig.provider != .realtime {
+            realtimeEngine.cancelStreaming()
         }
         if oldProvider != .local && newConfig.provider == .local {
             // User just turned local on (or changed model) — start warming now
@@ -354,6 +413,7 @@ final class VoiceCoordinator {
         pollTimer?.invalidate()
         idleUnloadTimer?.invalidate()
         localEngine.forceUnload(reason: "app terminating")
+        realtimeEngine.cancelStreaming()
     }
 
     // MARK: - Settings

--- a/voice/Sources/CodeyVoice/WhisperKitEngine.swift
+++ b/voice/Sources/CodeyVoice/WhisperKitEngine.swift
@@ -27,7 +27,10 @@ func normalizeVariant(_ raw: String) -> String {
 final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     private var pipeline: WhisperKit?
     private var loadedModel: String?
-    private var config: VoiceConfig
+    /// Mutable config is behind a lock — detached tasks in startStreaming and
+    /// transcribe can read config concurrently with updateConfig (gateway poll).
+    private let configLock = NSLock()
+    private var _config: VoiceConfig
     /// Unused by WhisperKit (we don't surface partial decodes today); kept to
     /// satisfy the protocol. Wire up once we move to streaming decode.
     var onPartial: ((String) -> Void)?
@@ -70,7 +73,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     }
 
     init(config: VoiceConfig) {
-        self.config = config
+        self._config = config
     }
 
     /// Start emitting partial transcripts while the user is still talking.
@@ -232,8 +235,8 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     }
 
     func updateConfig(_ config: VoiceConfig) {
-        let modelChanged = config.localModel != self.config.localModel
-        self.config = config
+        let modelChanged = configLock.withLock { config.localModel != _config.localModel }
+        configLock.withLock { _config = config }
         if modelChanged {
             // Drop the pipeline; next transcribe will reload the new variant.
             loadQueue.sync { self.pipeline = nil; self.loadedModel = nil }
@@ -379,13 +382,14 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     // MARK: - Internals
 
     private func ensurePipeline() async throws -> WhisperKit {
-        if let p = pipeline, loadedModel == config.localModel {
+        let currentModel = configLock.withLock { _config.localModel }
+        if let p = pipeline, loadedModel == currentModel {
             return p
         }
         // WhisperKit's HF glob is `*openai*<variant>/*`; the variant must be
         // the bare name (`large-v3-turbo`), not the full folder name
         // (`openai_whisper-large-v3-turbo`). UI/config may store either form.
-        let modelName = normalizeVariant(config.localModel)
+        let modelName = normalizeVariant(currentModel)
         let t0 = Date()
         print("WhisperKitEngine: loading model '\(modelName)'")
 


### PR DESCRIPTION
## Summary

Add **Realtime Transcription Engine** — a WebSocket-based transcription backend using the OpenAI Realtime API that streams audio chunks as the user speaks, delivering partial transcripts during recording and a final transcript within ~200ms of silence.

## Architecture

### New files
- **`RealtimeTranscriptionEngine.swift`** — WebSocket engine conforming to `TranscriptionEngineProtocol`. Owns `URLSessionWebSocketTask` lifecycle with lock-protected mutable state, async connect continuation via `URLSessionWebSocketDelegate`, and per-utterance one-shot batch fallback.
- **`PCMHelper.swift`** — Shared `pcm16Data(from:)` function (Float32→Int16 PCM conversion) extracted from the WAV encoder.

### Changed files
- **`AudioCapture.swift`** — Added `onChunk` callback for streaming audio chunks in real-time without breaking the existing batch accumulation path.
- **`VoiceConfig.swift`** — Added `.realtime` provider case, `realtimeUrl`, `realtimeModel` fields with defaults (existing configs decode cleanly).
- **`VoiceCoordinator.swift`** — Wired realtime engine lifecycle: `startRealtimeSession` on recording start, `appendAudioChunk` forwarding via `onChunk`, transcription via `activeEngine.transcribe()` (unified across all providers), `cancelSession` on Esc/provider-switch.
- **`TranscriptionEngine.swift`** — Lock-protected config (data race fix), added `connectionFailed` error case.
- **`WhisperKitEngine.swift`** — Lock-protected config (data race fix).
- **`WhisperTab.tsx`** — "Realtime (WebSocket)" provider radio, `realtimeUrl`/`realtimeModel` fields, shared `apiKey` input, cost disclaimer.

## Design decisions

- **Dual-mode AudioCapture**: Always accumulates PCM buffer (`pcmBuffer`) for the final snapshot; *additionally* emits chunks when `onChunk` is subscribed. Zero behavior change for non-realtime providers.
- **Fallback**: If WebSocket connection fails mid-utterance, `transcribe()` falls back to batch HTTP API transparently — the accumulated `pcmBuffer` provides the full audio.
- **Idle lifecycle**: Socket closed after 30s of inactivity via `unloadIfIdle()`.
- **`.api` remains the default provider** — realtime is opt-in.

## Build verification

| Build | Result |
|-------|--------|
| Swift debug | ✅ 0 errors, 0 warnings |
| Swift release | ✅ 0 errors (1 pre-existing unused-result warning) |
| TypeScript `tsc` (core + gateway) | ✅ Pass |
| codey-mac (Electron/Vite) | ❌ Pre-existing `crypto.getRandomValues` error (unrelated) |

## Review history

All findings from 3 code-review rounds were resolved:

- **3 critical**: missing `session` wrapper in `session.update`, silent hang on async WebSocket connect failure, data races on `@unchecked Sendable` state
- **2 moderate**: WhisperKitEngine config lock, `.realtime` enum exhaustivity
- **2 final**: `NSNull()` for `turn_detection` to truly disable server VAD, resetting transcript state between utterances under `stateLock`

Code-reviewer granted **ship sign-off** after the final round.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
