### PR TITLE
feat(chat): summarize first message into a title via Aide

### DIFF
--- a/packages/core/src/aide-tasks.ts
+++ b/packages/core/src/aide-tasks.ts
@@ -51,3 +51,48 @@ export async function summarizeChatMessages(
 
   return runAide(lines.join('\n'), opts);
 }
+
+/** Upper bound on a generated chat title. Matches the truncation fallback. */
+const MAX_TITLE_CHARS = 40;
+
+/**
+ * Generate a short, human-readable chat title from the opening user message.
+ * Used in place of blindly truncating the first message. Returns a sanitized
+ * single-line title (≤ MAX_TITLE_CHARS), or '' if the Aide produced nothing
+ * usable — the caller should fall back to truncation in that case.
+ */
+export async function generateChatTitle(
+  firstUserMessage: string,
+  opts: AideOptions,
+): Promise<string> {
+  const source = firstUserMessage.trim();
+  if (!source) return '';
+
+  const lines: string[] = [];
+  lines.push('You write concise titles for developer chat threads.');
+  lines.push('Summarize the user message below into a short title.');
+  lines.push('');
+  lines.push('## User message');
+  lines.push(source.length > MAX_MSG_CHARS ? source.slice(0, MAX_MSG_CHARS) + '… [truncated]' : source);
+  lines.push('');
+  lines.push('## Requirements');
+  lines.push('- A noun phrase capturing the topic or intent, not a greeting.');
+  lines.push('- At most 6 words and 40 characters.');
+  lines.push('- Same language as the user message.');
+  lines.push('- No surrounding quotes, no trailing punctuation, no preamble — output only the title.');
+
+  const raw = await runAide(lines.join('\n'), opts);
+  return sanitizeTitle(raw);
+}
+
+/** Collapse whitespace, strip wrapping quotes/markdown, and clamp length. */
+function sanitizeTitle(raw: string): string {
+  let t = raw.trim().split('\n')[0].trim();
+  // Drop a leading "Title:" style label some models prepend.
+  t = t.replace(/^(title|标题)\s*[:：]\s*/i, '');
+  // Strip a single layer of wrapping quotes or backticks.
+  t = t.replace(/^["'`“”]+|["'`“”]+$/g, '').trim();
+  t = t.replace(/\s+/g, ' ');
+  if (t.length > MAX_TITLE_CHARS) t = t.slice(0, MAX_TITLE_CHARS).trim() + '…';
+  return t;
+}

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -412,6 +412,25 @@ export class Codey {
       model: opts.model?.model ?? '(default)',
       updatedAt: Date.now(),
     };
+  }
+
+  /** True when the user has explicitly configured an Aide agent or model. */
+  private isAideConfigured(): boolean {
+    const cfg = this.config.aide;
+    return Boolean(cfg?.agent || cfg?.model);
+  }
+
+  /**
+   * Generate a chat title via the Aide, swallowing any error. Returns '' on
+   * failure so the caller keeps the truncated fallback title.
+   */
+  private async generateChatTitleSafe(firstUserMessage: string): Promise<string> {
+    try {
+      return await generateChatTitle(firstUserMessage, this.getAideOptions());
+    } catch (err) {
+      this.logger.warn(`Aide title generation failed: ${(err as Error).message}`);
+      return '';
+    }
   }
 
   private conversationCleanupInterval?: NodeJS.Timeout;
@@ -3719,7 +3738,17 @@ Example: /model gpt-4.1 write a Python script`;
       isComplete: true,
       attachments: attachments && attachments.length > 0 ? attachments : undefined,
     };
-    this.chatManager.appendMessage(chatId, userMessage);
+    const afterUser = this.chatManager.appendMessage(chatId, userMessage);
+
+    // On the very first message, derive a real title via the Aide instead of
+    // blindly truncating the prompt. Kick it off now so it runs concurrently
+    // with the agent turn; we await it just before the 'done' event. The
+    // truncated title set by appendMessage stays visible until then, and acts
+    // as the fallback if the Aide fails or returns nothing.
+    const titlePromise: Promise<string> | undefined =
+      afterUser.messages.length === 1 && this.isAideConfigured()
+        ? this.generateChatTitleSafe(userText)
+        : undefined;
 
     let streamedText = '';
 
@@ -3889,7 +3918,18 @@ Example: /model gpt-4.1 write a Python script`;
         this.chatManager.setLastAskedOptions(chatId, assistantMessage.id, plainAskOptions);
       }
 
-      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: updated.title, choices: surfacedChoices, userQuestion: agentUserQuestion });
+      // Apply the Aide-generated title (first turn only) before announcing
+      // completion so the sidebar updates in the same 'done' event.
+      let finalTitle = updated.title;
+      if (titlePromise) {
+        const aiTitle = await titlePromise;
+        if (aiTitle && aiTitle !== finalTitle) {
+          this.chatManager.rename(chatId, aiTitle);
+          finalTitle = aiTitle;
+        }
+      }
+
+      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion });
 
       // Mirror this turn to every attached route except the originating one.
       // Mac-origin uses a synthetic '__mac__' channel that matches no real


### PR DESCRIPTION
## Summary

New chats previously took their title by **truncating the first user message**. This generates a short, descriptive title with the **Aide** model instead.

## Changes

- **core (`aide-tasks.ts`)** — add `generateChatTitle()`: prompts the Aide for a concise noun-phrase title (≤6 words / 40 chars, same language as the message), then sanitizes the output (strips wrapping quotes, `Title:`/`标题:` labels, collapses whitespace, clamps length).
- **gateway (`gateway.ts`)** — on the first turn of a chat, kick off title generation *concurrently* with the agent turn and apply it just before the `done` event, so the sidebar updates in the event the UI already consumes (no extra plumbing).

## Fallback behavior

The original truncation (`deriveTitle`) stays as the **instant placeholder** and the **fallback**. The Aide title is only applied when:

- the Aide is **configured** (`aide.agent` or `aide.model` is set) — otherwise generation is skipped entirely; **and**
- generation **succeeds** with usable output — errors/empty results are swallowed and the truncated title stands.

## Testing

- `tsc --noEmit` passes for both `@codey/core` and `@codey/gateway`.
- The repo's vitest/vite toolchain fails to start in this environment due to a Node-version mismatch (`styleText` / `crypto.getRandomValues`), pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)