### PR TITLE
feat(team): condense Auto (Manager) dispatch display

### DIFF
--- a/packages/core/src/team-blackboard.ts
+++ b/packages/core/src/team-blackboard.ts
@@ -36,7 +36,11 @@ export interface ParseResult {
   stripped: string;
 }
 
-const MARKER_RE = /^\s*\[(FACT|DECISION|OPEN|HANDOFF(?:\s*:\s*[^\]]+)?)\]\s*:\s*(.+?)\s*$/i;
+// Workers often emit markers as list items (`- [DECISION]: …`, `1. [FACT]: …`)
+// rather than at the start of the line. Tolerate an optional leading bullet so
+// the tag never leaks into the user-visible prose. The required `]: <body>`
+// shape excludes real markdown checkboxes like `- [ ]` / `- [x]`.
+const MARKER_RE = /^\s*(?:[-*•]\s+|\d+[.)]\s+)?\[(FACT|DECISION|OPEN|HANDOFF(?:\s*:\s*[^\]]+)?)\]\s*:\s*(.+?)\s*$/i;
 
 /**
  * Pull `[FACT]:`, `[DECISION]:`, `[OPEN]:`, `[HANDOFF: name]:` markers out

--- a/packages/core/src/team-display.test.ts
+++ b/packages/core/src/team-display.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkers } from './team-blackboard';
+import { lastParagraphPreview } from './utils/format';
+
+describe('parseMarkers — bullet/list-prefixed markers', () => {
+  it('strips a plain line-start marker (existing behaviour)', () => {
+    const { markers, stripped } = parseMarkers('hello\n[DECISION]: use X\nworld');
+    expect(markers).toEqual([{ kind: 'decision', text: 'use X' }]);
+    expect(stripped).toBe('hello\nworld');
+  });
+
+  it('strips a marker behind a "- " bullet and records it', () => {
+    const { markers, stripped } = parseMarkers('intro\n- [DECISION]: use X because Y\nrest');
+    expect(markers).toEqual([{ kind: 'decision', text: 'use X because Y' }]);
+    expect(stripped).toBe('intro\nrest');
+  });
+
+  it('strips "* " and "• " bullets and numbered list markers', () => {
+    const input = [
+      '* [FACT]: db is postgres',
+      '• [OPEN]: who owns deploy',
+      '1. [HANDOFF: bob]: pick up the API',
+    ].join('\n');
+    const { markers, stripped } = parseMarkers(input);
+    expect(stripped).toBe('');
+    expect(markers).toEqual([
+      { kind: 'fact', text: 'db is postgres' },
+      { kind: 'open', text: 'who owns deploy' },
+      { kind: 'handoff', to: 'bob', text: 'pick up the API' },
+    ]);
+  });
+
+  it('does not treat a real markdown checkbox/list item as a marker', () => {
+    const input = '- [ ] todo item\n- [x] done item';
+    const { markers, stripped } = parseMarkers(input);
+    expect(markers).toEqual([]);
+    expect(stripped).toBe(input);
+  });
+});
+
+describe('lastParagraphPreview', () => {
+  it('returns the last paragraph when under the cap', () => {
+    expect(lastParagraphPreview('first para\n\nsecond para', 200)).toBe('second para');
+  });
+
+  it('caps long paragraphs with an ellipsis', () => {
+    const long = 'x'.repeat(300);
+    const out = lastParagraphPreview(long, 200);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(201);
+  });
+
+  it('returns empty string for blank input', () => {
+    expect(lastParagraphPreview('   \n  ', 200)).toBe('');
+  });
+
+  it('ignores trailing blank paragraphs', () => {
+    expect(lastParagraphPreview('real content\n\n\n   ', 200)).toBe('real content');
+  });
+});

--- a/packages/core/src/utils/format.ts
+++ b/packages/core/src/utils/format.ts
@@ -13,3 +13,20 @@ export function formatBytes(bytes: number, decimals = 2): string {
 
   return `${parseFloat(value.toFixed(decimals))} ${units[i]}`;
 }
+
+/**
+ * Condense a block of worker output to a short preview: the last non-empty
+ * paragraph, truncated to `maxChars` with a trailing ellipsis. Used to keep
+ * per-step team output compact in chat surfaces. Returns '' for blank input.
+ */
+export function lastParagraphPreview(output: string, maxChars = 200): string {
+  const trimmed = (output ?? '').trim();
+  if (!trimmed) return '';
+  const paragraphs = trimmed
+    .split(/\n\s*\n/)
+    .map(p => p.trim())
+    .filter(Boolean);
+  const last = paragraphs[paragraphs.length - 1] ?? trimmed;
+  if (last.length <= maxChars) return last;
+  return last.slice(0, maxChars).trimEnd() + '…';
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     include: [
       'src/workspace.test.ts',
       'src/workers.test.ts',
+      'src/team-display.test.ts',
       'src/discussion/files.test.ts',
       'src/discussion/control.test.ts',
       'src/discussion/parallel-advisor.test.ts',

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -2268,13 +2268,15 @@ Example: /model gpt-4.1 write a Python script`;
   private formatManagerParts(
     parts: Array<{ step: number; worker: string; output: string; isRevision: boolean }>,
     finalSummary: string,
-    truncatePerStep?: number,
+    previewChars?: number,
   ): string {
     const head = finalSummary ? `🧭 Manager summary: ${finalSummary}\n\n` : '';
     const body = parts
       .map(p => {
         const label = p.isRevision ? `${p.worker} (revision)` : p.worker;
-        const out = truncatePerStep ? p.output.substring(0, truncatePerStep) : p.output;
+        // Condense each step to its last paragraph (~previewChars) so the run
+        // reads as a tight summary instead of a wall of per-step output.
+        const out = previewChars ? lastParagraphPreview(p.output, previewChars) : p.output;
         return `### Step ${p.step}: ${label}\n\n${out}`;
       })
       .join('\n\n---\n\n');
@@ -2423,7 +2425,7 @@ Example: /model gpt-4.1 write a Python script`;
         });
       }
 
-      const text = this.formatManagerParts(result.parts, result.finalSummary, /*truncatePerStep*/ 500);
+      const text = this.formatManagerParts(result.parts, result.finalSummary, /*previewChars*/ 200);
       const bbBlock = result.blackboard.renderForUser();
       const body = `📊 Team **${teamName}** results\n\n${text}`;
       await this.sendResponse({
@@ -2624,7 +2626,7 @@ Example: /model gpt-4.1 write a Python script`;
       await this.sendResponse({
         chatId: message.chatId,
         channel: message.channel,
-        text: this.formatManagerParts(pending.partsSoFar, turn.final_summary ?? '', 500),
+        text: this.formatManagerParts(pending.partsSoFar, turn.final_summary ?? '', 200),
       });
       return;
     }
@@ -2712,7 +2714,7 @@ Example: /model gpt-4.1 write a Python script`;
     );
     const finalSummary = closing.fallback ? '' : (closing.final_summary ?? '');
     const resumeBlock = resumeBoard.renderForUser();
-    const resumeFormatted = this.formatManagerParts(newParts, finalSummary, 500);
+    const resumeFormatted = this.formatManagerParts(newParts, finalSummary, 200);
     this.persistBlackboardDecisions(resumeBoard, pending.teamName);
     await this.sendResponse({
       chatId: message.chatId,


### PR DESCRIPTION
## Summary
In team **Auto** (`dispatch: auto`, Manager) mode the chat was a wall of noisy text — every step dumped its first 500 chars, and literal `[DECISION]:` / `[FACT]:` markers leaked into the visible prose. This condenses the per-step display and stops the tag leak. All changes are gateway/core-side, so they apply uniformly to the Mac app, Telegram, Discord, and iMessage.

- **Stop the tag leak** (`packages/core/src/team-blackboard.ts`) — `MARKER_RE` only stripped a marker when it was the entire line, so workers emitting them as list items (`- [DECISION]: …`, `1. [FACT]: …`) leaked into prose. Broadened it to tolerate an optional leading bullet (`-`, `*`, `•`, `N.`/`N)`). Such lines are still recorded into the blackboard and stripped from output; real markdown checkboxes (`- [ ]`, `- [x]`) are left alone.
- **Condense each step** (`packages/core/src/utils/format.ts`, `packages/gateway/src/gateway.ts`) — new `lastParagraphPreview()` replaces the blunt 500-char dump in `formatManagerParts`. Each step now shows just its last paragraph, capped at ~200 chars. Applied at all three call sites (initial run, paused-resume, answer-resume).
- Per-step `📋 Blackboard +…` tickers and the final `🧠 Team blackboard` recap block are kept as-is.

## Test Plan
- [x] `npm test -w packages/core` — 43/43 pass (incl. new `team-display.test.ts`, 8 cases)
- [x] `npm test -w packages/gateway` — 30/30 pass
- [x] `npm run build` clean for both packages
- [ ] Eyeball a live Auto-mode team run in the Mac app to confirm condensed output

🤖 Generated with [Claude Code](https://claude.com/claude-code)