### PR TITLE
feat(codey-mac): Task HUD — refresh/timeline/copy refinements + text clamp

### DIFF
--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -160,7 +160,7 @@ export const ChatContextPanel: React.FC<Props> = ({
           aria-selected={tab === 'task'}
           style={{ ...styles.tab, ...(tab === 'task' ? styles.tabActive : null) }}
           onClick={() => setTab('task')}
-        >Task</button>
+        >Status</button>
         <button
           role="tab"
           aria-selected={tab === 'qq'}
@@ -801,10 +801,11 @@ const styles: Record<string, React.CSSProperties> = {
     flexShrink: 0,
   },
   tab: {
+    flex: 1, minWidth: 0, textAlign: 'center', whiteSpace: 'nowrap',
     background: 'transparent', border: 'none',
     color: C.fg3, fontSize: 11, fontWeight: 600,
     letterSpacing: 0.4, textTransform: 'uppercase',
-    padding: '6px 10px', cursor: 'pointer',
+    padding: '6px 6px', cursor: 'pointer',
     borderBottom: '2px solid transparent', marginBottom: -1,
   },
   tabActive: {

--- a/codey-mac/src/components/TaskHud.tsx
+++ b/codey-mac/src/components/TaskHud.tsx
@@ -13,6 +13,14 @@ interface Props {
 const toneColor = (tone: StatusTone): string =>
   tone === 'yellow' ? C.yellow : tone === 'red' ? C.red : tone === 'green' ? C.green : C.accent
 
+/** Multiline ellipsis — a UI backstop so an over-long model string can't blow out the panel. */
+const clamp = (lines: number): React.CSSProperties => ({
+  display: '-webkit-box',
+  WebkitLineClamp: lines,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+})
+
 /** History entries shown before the "Show all" toggle kicks in. */
 const TIMELINE_COLLAPSED = 2
 
@@ -39,7 +47,7 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
       {/* Goal */}
       <div style={{ ...sect, borderTop: 'none' }}>
         {label('Goal')}
-        <div style={{ fontSize: 15, fontWeight: 600, lineHeight: 1.4 }}>{brief.goal}</div>
+        <div style={{ fontSize: 15, fontWeight: 600, lineHeight: 1.4, ...clamp(2) }}>{brief.goal}</div>
       </div>
 
       {/* Current State */}
@@ -61,8 +69,8 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
           {label('Next Action')}
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             <div style={{ flex: 1 }}>
-              <div style={{ fontWeight: 600 }}>{brief.nextAction.text}</div>
-              {brief.nextAction.detail && <div style={{ fontSize: 11, color: C.fg2, marginTop: 3 }}>{brief.nextAction.detail}</div>}
+              <div style={{ fontWeight: 600, ...clamp(2) }}>{brief.nextAction.text}</div>
+              {brief.nextAction.detail && <div style={{ fontSize: 11, color: C.fg2, marginTop: 3, ...clamp(1) }}>{brief.nextAction.detail}</div>}
             </div>
             <button onClick={() => onAnswer(brief.nextAction?.messageId)}
               style={{ background: C.accent, color: C.onAccent, border: 'none', borderRadius: 7,
@@ -84,9 +92,9 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
             </div>
             {head.detail?.length ? (
               <ul style={{ listStyle: 'none', margin: '7px 0 0', padding: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
-                {head.detail.map((d, i) => <li key={i} style={{ fontSize: 12, color: C.fg2 }}>· {d}</li>)}
+                {head.detail.map((d, i) => <li key={i} style={{ fontSize: 12, color: C.fg2, ...clamp(2) }}>· {d}</li>)}
               </ul>
-            ) : <div style={{ fontSize: 12, color: C.fg2, marginTop: 4 }}>{head.text}</div>}
+            ) : <div style={{ fontSize: 12, color: C.fg2, marginTop: 4, ...clamp(2) }}>{head.text}</div>}
           </div>
         )}
         {shownRest.map((e, i) => (
@@ -95,11 +103,11 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
               background: e.kind === 'dropped' ? C.fg3 : e.kind === 'decision' ? C.accent : C.green }} />
             <div style={{ flex: 1 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
-                <span style={{ textDecoration: e.kind === 'dropped' ? 'line-through' : 'none',
-                  color: e.kind === 'dropped' ? C.fg2 : C.fg }}>{e.text}</span>
-                {e.when && <span style={{ color: C.fg3, fontSize: 10, whiteSpace: 'nowrap' }}>{formatAgo(e.when)}</span>}
+                <span style={{ flex: 1, minWidth: 0, textDecoration: e.kind === 'dropped' ? 'line-through' : 'none',
+                  color: e.kind === 'dropped' ? C.fg2 : C.fg, ...clamp(2) }}>{e.text}</span>
+                {e.when && <span style={{ color: C.fg3, fontSize: 10, whiteSpace: 'nowrap', flex: 'none' }}>{formatAgo(e.when)}</span>}
               </div>
-              {e.why && <div style={{ color: C.fg3, fontSize: 11.5, marginTop: 2 }}>{e.why}</div>}
+              {e.why && <div style={{ color: C.fg3, fontSize: 11.5, marginTop: 2, ...clamp(1) }}>{e.why}</div>}
             </div>
           </div>
         ))}

--- a/codey-mac/src/components/TaskHud.tsx
+++ b/codey-mac/src/components/TaskHud.tsx
@@ -22,7 +22,7 @@ const clamp = (lines: number): React.CSSProperties => ({
 })
 
 /** History entries shown before the "Show all" toggle kicks in. */
-const TIMELINE_COLLAPSED = 2
+const TIMELINE_COLLAPSED = 5
 
 export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
   const [timelineExpanded, setTimelineExpanded] = React.useState(false)

--- a/codey-mac/src/components/TaskHud.tsx
+++ b/codey-mac/src/components/TaskHud.tsx
@@ -13,7 +13,12 @@ interface Props {
 const toneColor = (tone: StatusTone): string =>
   tone === 'yellow' ? C.yellow : tone === 'red' ? C.red : tone === 'green' ? C.green : C.accent
 
+/** History entries shown before the "Show all" toggle kicks in. */
+const TIMELINE_COLLAPSED = 2
+
 export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
+  const [timelineExpanded, setTimelineExpanded] = React.useState(false)
+
   if (!brief) {
     return <div style={{ padding: 16, color: C.fg3, fontSize: 13 }}>
       {loading ? 'Generating…' : 'No task to summarize yet.'}
@@ -22,6 +27,7 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
 
   const sm = statusMeta(brief.state.status)
   const { head, rest } = splitTimeline(brief.timeline)
+  const shownRest = timelineExpanded ? rest : rest.slice(0, TIMELINE_COLLAPSED)
 
   const label = (t: string) => <div style={{ fontSize: 11, color: C.fg3, marginBottom: 8, fontWeight: 500 }}>{t}</div>
   const sect: React.CSSProperties = { padding: '14px 16px', borderTop: `1px solid ${C.border}` }
@@ -83,7 +89,7 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
             ) : <div style={{ fontSize: 12, color: C.fg2, marginTop: 4 }}>{head.text}</div>}
           </div>
         )}
-        {rest.map((e, i) => (
+        {shownRest.map((e, i) => (
           <div key={i} style={{ display: 'flex', gap: 9, padding: '6px 0', fontSize: 12.5, lineHeight: 1.5 }}>
             <span style={{ flex: 'none', width: 7, height: 7, borderRadius: '50%', marginTop: 6,
               background: e.kind === 'dropped' ? C.fg3 : e.kind === 'decision' ? C.accent : C.green }} />
@@ -97,6 +103,13 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
             </div>
           </div>
         ))}
+        {rest.length > TIMELINE_COLLAPSED && (
+          <button
+            onClick={() => setTimelineExpanded(v => !v)}
+            style={{ background: 'none', border: 'none', color: C.fg3, fontSize: 11, cursor: 'pointer',
+              padding: '4px 0', marginTop: 2 }}
+          >{timelineExpanded ? 'Show less' : `Show all (${rest.length})`}</button>
+        )}
       </div>
     </div>
   )

--- a/codey-mac/src/components/taskHudView.test.ts
+++ b/codey-mac/src/components/taskHudView.test.ts
@@ -5,6 +5,7 @@ import type { Chat, TaskBrief } from '../types';
 const brief = (over: Partial<TaskBrief> = {}): TaskBrief => ({
   goal: 'g', state: { progress: 0, status: 'working' }, timeline: [], generatedAt: 100, ...over,
 });
+const msg = (timestamp: number): any => ({ id: 'm' + timestamp, role: 'assistant', content: 'x', timestamp });
 const chat = (over: Partial<Chat> = {}): Chat =>
   ({ id: 'c', title: 't', workspaceName: 'w', selection: {} as any, messages: [],
      createdAt: 0, updatedAt: 100, ...over } as Chat);
@@ -13,11 +14,14 @@ describe('isTaskBriefStale', () => {
   it('is stale when there is no brief', () => {
     expect(isTaskBriefStale(chat({ taskBrief: undefined }))).toBe(true);
   });
-  it('is stale when the chat changed after the brief was generated', () => {
-    expect(isTaskBriefStale(chat({ updatedAt: 200, taskBrief: brief({ generatedAt: 100 }) }))).toBe(true);
+  it('is stale when a new message arrived after the brief was generated', () => {
+    expect(isTaskBriefStale(chat({ messages: [msg(200)], taskBrief: brief({ generatedAt: 100 }) }))).toBe(true);
   });
-  it('is fresh when the brief is at least as new as the chat', () => {
-    expect(isTaskBriefStale(chat({ updatedAt: 100, taskBrief: brief({ generatedAt: 100 }) }))).toBe(false);
+  it('is fresh when no message is newer than the brief', () => {
+    expect(isTaskBriefStale(chat({ messages: [msg(100)], taskBrief: brief({ generatedAt: 100 }) }))).toBe(false);
+  });
+  it('is fresh when an unrelated mutation bumped updatedAt but no new message', () => {
+    expect(isTaskBriefStale(chat({ updatedAt: 999, messages: [msg(50)], taskBrief: brief({ generatedAt: 100 }) }))).toBe(false);
   });
 });
 

--- a/codey-mac/src/components/taskHudView.ts
+++ b/codey-mac/src/components/taskHudView.ts
@@ -2,10 +2,15 @@ import type { Chat, TaskBrief, TaskEvent } from '../types';
 
 export type StatusTone = 'accent' | 'green' | 'yellow' | 'red';
 
-/** A brief is stale when missing, or when the chat changed after it was generated. */
+/**
+ * A brief is stale when missing, or when a new message arrived after it was
+ * generated. Keyed off the last message's timestamp (not chat.updatedAt) so
+ * unrelated chat mutations — e.g. toggling the panel — don't trigger a refresh.
+ */
 export function isTaskBriefStale(chat: Chat): boolean {
   if (!chat.taskBrief) return true;
-  return chat.updatedAt > chat.taskBrief.generatedAt;
+  const last = chat.messages[chat.messages.length - 1];
+  return !!last && last.timestamp > chat.taskBrief.generatedAt;
 }
 
 export function statusMeta(status: TaskBrief['state']['status']): { label: string; tone: StatusTone } {

--- a/packages/core/src/aide-tasks.ts
+++ b/packages/core/src/aide-tasks.ts
@@ -139,9 +139,10 @@ export async function generateTaskBrief(chat: Chat, opts: AideOptions): Promise<
   lines.push('}');
   lines.push('');
   lines.push('Rules:');
-  lines.push('- timeline is REVERSE-chronological: newest first. The first entry is the current/most-recent progress; give it 2-4 `detail` bullets summarizing what just happened. Older entries: no detail.');
+  lines.push('- timeline is REVERSE-chronological: newest first. The first entry is the current/most-recent progress; give it AT MOST 3 `detail` bullets summarizing what just happened. Older entries: no detail.');
   lines.push('- "status" is "waiting" if the assistant is blocked on a user decision/answer, "done" if the task is finished, "blocked" if stuck on an external problem, else "working".');
-  lines.push('- Write every string in English, regardless of the chat\'s language. Keep every string short.');
+  lines.push('- Write every string in English, regardless of the chat\'s language.');
+  lines.push('- Be terse — these render in a narrow panel. Hard limits: goal ≤ 8 words; nextAction.text ≤ 10 words; nextAction.detail ≤ 10 words; each timeline.text ≤ 8 words; each why ≤ 10 words; each detail bullet ≤ 10 words. Use fragments, not full sentences. No trailing punctuation.');
   lines.push('- messageId, when: only include if you can ground them in the transcript markers ([role @timestamp], message ids); otherwise omit.');
   lines.push('');
   lines.push('## Chat title');


### PR DESCRIPTION
## Summary

Re-lands the Task HUD refinements that were lost when #107 merged at its English-only commit (the follow-up commit never made it into `main`), plus a UI text-clamp backstop.

### Refinements (re-applied from the orphaned commit)
- **Refresh only on new messages** — `isTaskBriefStale` keys off the last message's timestamp instead of `chat.updatedAt`, so reopening the tab / toggling the panel no longer regenerates the brief when nothing was said.
- **Collapsible timeline** — history collapses to the *Latest* entry + 5 items, with a **Show all (N)** / **Show less** toggle.
- **Terser copy** — the Aide prompt enforces per-field word caps (goal ≤8, next action ≤10, timeline lines ≤8, detail bullets ≤10, max 3 bullets) and prefers fragments over sentences.

### New: UI clamp backstop
- CSS `line-clamp` on goal (2 lines), next-action text (2) / detail (1), timeline entry text (2) / why (1), and Latest bullets (2). A model response that ignores the word caps gets ellipsized instead of blowing out the narrow panel.

## Test Plan
- [x] core 43 / codey-mac 35 green; `tsc` clean; `vite build` succeeds
- [ ] Build `main` (Node ≥20) after merge → relaunch app: timeline collapses with a toggle, reopening the tab with no new messages doesn't regenerate, long strings ellipsize

> Note: please use **Squash or a normal merge that keeps the branch HEAD** — both commits here need to land (the prior race dropped a follow-up commit twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
