### PR TITLE
feat(codey-mac): Status panel layout polish + persistent tab underline + reorder

### DIFF
--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -145,6 +145,12 @@ export const ChatContextPanel: React.FC<Props> = ({
       <div style={styles.tabs} role="tablist">
         <button
           role="tab"
+          aria-selected={tab === 'task'}
+          style={{ ...styles.tab, ...(tab === 'task' ? styles.tabActive : null) }}
+          onClick={() => setTab('task')}
+        >Status</button>
+        <button
+          role="tab"
           aria-selected={tab === 'current'}
           style={{ ...styles.tab, ...(tab === 'current' ? styles.tabActive : null) }}
           onClick={() => setTab('current')}
@@ -155,12 +161,6 @@ export const ChatContextPanel: React.FC<Props> = ({
           style={{ ...styles.tab, ...(tab === 'files' ? styles.tabActive : null) }}
           onClick={() => setTab('files')}
         >File changes</button>
-        <button
-          role="tab"
-          aria-selected={tab === 'task'}
-          style={{ ...styles.tab, ...(tab === 'task' ? styles.tabActive : null) }}
-          onClick={() => setTab('task')}
-        >Status</button>
         <button
           role="tab"
           aria-selected={tab === 'qq'}
@@ -806,7 +806,9 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.fg3, fontSize: 11, fontWeight: 600,
     letterSpacing: 0.4, textTransform: 'uppercase',
     padding: '6px 6px', cursor: 'pointer',
-    borderBottom: '2px solid transparent', marginBottom: -1,
+    // Persistent gray underline under every tab (visible from first open);
+    // the active tab overrides the color with the accent.
+    borderBottom: `2px solid ${C.border2}`, marginBottom: -1,
   },
   tabActive: {
     color: C.fg, borderBottomColor: C.accent,

--- a/codey-mac/src/components/TaskHud.tsx
+++ b/codey-mac/src/components/TaskHud.tsx
@@ -22,7 +22,7 @@ const clamp = (lines: number): React.CSSProperties => ({
 })
 
 /** History entries shown before the "Show all" toggle kicks in. */
-const TIMELINE_COLLAPSED = 5
+const TIMELINE_COLLAPSED = 3
 
 export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
   const [timelineExpanded, setTimelineExpanded] = React.useState(false)
@@ -44,15 +44,13 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
     <div style={{ fontSize: 13, color: C.fg }}>
       {loading && <div style={{ padding: '6px 16px', fontSize: 11, color: C.fg3 }}>Updating…</div>}
 
-      {/* Goal */}
-      <div style={{ ...sect, borderTop: 'none' }}>
-        {label('Goal')}
+      {/* Goal (no title — the goal text is the panel's heading) */}
+      <div style={{ ...sect, borderTop: 'none', paddingBottom: 12 }}>
         <div style={{ fontSize: 15, fontWeight: 600, lineHeight: 1.4, ...clamp(2) }}>{brief.goal}</div>
       </div>
 
-      {/* Current State */}
-      <div style={sect}>
-        {label('Current State')}
+      {/* Current State (no title — compact progress row) */}
+      <div style={{ ...sect, paddingTop: 10, paddingBottom: 10 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div><b style={{ fontSize: 15 }}>{brief.state.progress}%</b>{brief.state.stepLabel ? ` · ${brief.state.stepLabel}` : ''}</div>
           <span style={{ fontSize: 12, padding: '3px 9px', borderRadius: 6, color: toneColor(sm.tone),
@@ -65,16 +63,16 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
 
       {/* Next Action */}
       {brief.nextAction && (
-        <div style={{ ...sect, background: C.surface2 }}>
+        <div style={{ ...sect, background: C.surface2, padding: '18px 16px' }}>
           {label('Next Action')}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <div style={{ flex: 1 }}>
-              <div style={{ fontWeight: 600, ...clamp(2) }}>{brief.nextAction.text}</div>
-              {brief.nextAction.detail && <div style={{ fontSize: 11, color: C.fg2, marginTop: 3, ...clamp(1) }}>{brief.nextAction.detail}</div>}
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 600, lineHeight: 1.45, ...clamp(3) }}>{brief.nextAction.text}</div>
+              {brief.nextAction.detail && <div style={{ fontSize: 11.5, color: C.fg2, marginTop: 5, lineHeight: 1.45, ...clamp(2) }}>{brief.nextAction.detail}</div>}
             </div>
             <button onClick={() => onAnswer(brief.nextAction?.messageId)}
               style={{ background: C.accent, color: C.onAccent, border: 'none', borderRadius: 7,
-                padding: '7px 14px', fontSize: 13, fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap' }}>
+                padding: '8px 14px', fontSize: 13, fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap', flex: 'none' }}>
               Answer
             </button>
           </div>
@@ -85,16 +83,16 @@ export const TaskHud: React.FC<Props> = ({ brief, loading, onAnswer }) => {
       <div style={sect}>
         {label('Timeline')}
         {head && (
-          <div style={{ background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 8, padding: '9px 10px', marginBottom: 8 }}>
+          <div style={{ background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 8, padding: '12px 13px', marginBottom: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-              <b>Latest</b>
+              <b style={{ fontSize: 13 }}>Latest</b>
               {head.when && <span style={{ fontSize: 10, color: C.accent }}>{formatAgo(head.when)}</span>}
             </div>
             {head.detail?.length ? (
-              <ul style={{ listStyle: 'none', margin: '7px 0 0', padding: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
-                {head.detail.map((d, i) => <li key={i} style={{ fontSize: 12, color: C.fg2, ...clamp(2) }}>· {d}</li>)}
+              <ul style={{ listStyle: 'none', margin: '9px 0 0', padding: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {head.detail.map((d, i) => <li key={i} style={{ fontSize: 12.5, color: C.fg2, lineHeight: 1.45, ...clamp(3) }}>· {d}</li>)}
               </ul>
-            ) : <div style={{ fontSize: 12, color: C.fg2, marginTop: 4, ...clamp(2) }}>{head.text}</div>}
+            ) : <div style={{ fontSize: 12.5, color: C.fg2, marginTop: 6, lineHeight: 1.45, ...clamp(3) }}>{head.text}</div>}
           </div>
         )}
         {shownRest.map((e, i) => (


### PR DESCRIPTION
## Summary

Re-lands the two Status-panel commits that were dropped when #108 merged (the squash captured the earlier commits but not these last two). Rebased fresh onto current `main`.

### Status panel layout
- Drop the **Goal** and **Current State** section titles — the goal text is the panel heading and the progress row is compact.
- Give the **Latest** block more room (padding, larger detail text, up to 3 bullets).
- **Next Action** shows more (headline clamp 2→3, detail 1→2) and is taller, with the Answer button pinned to the top.
- Collapse older timeline steps to **3** by default (was 5) so history extends below the fold behind *Show all*.

### Tabs
- **Persistent gray underline** under every tab from first render (was transparent until active), so the underline shows the first time the panel opens; the active tab swaps it for the accent color.
- **Reorder**: Status · Tools · File changes · Quick Question.

## Test Plan
- [x] Cherry-picked cleanly onto `main`; net diff is the two UI files only
- [x] codey-mac 35 tests green; `tsc` clean; `vite build` succeeds
- [ ] Build `main` (Node ≥20) after merge → relaunch: titles gone, Latest larger, Next Action taller, history collapsed to 3, gray underline on first open, Status tab first

> ⚠️ Merge note: this branch has **2 commits** (`45f3eec`, `54c5af5`). Please merge at the branch's current HEAD so neither is dropped — the previous two PRs each lost their final commit to a stale-merge race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)