### PR TITLE
feat(codey-mac): live Status refresh on turn boundaries + multi-select AskUserQuestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ voice/*.bin
 
 # Stray compiled output that shouldn't sit at repo root
 /gateway.js
+
+.superpowers/

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -251,6 +251,9 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
   const pendingLinkChannelRef = useRef<null | 'telegram' | 'discord' | 'imessage'>(null)
   const [linkMenuOpen, setLinkMenuOpen] = useState(false)
   const [followLatest, setFollowLatest] = useState(true)
+  // Selected option labels for the active multi-select AskUserQuestion. Reset
+  // whenever a new message arrives (the prompt is always the last message).
+  const [multiChoice, setMultiChoice] = useState<string[]>([])
   const [selectedTurnIdState, setSelectedTurnIdState] = useState<string | null>(null)
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set())
   const [taskBriefLoading, setTaskBriefLoading] = useState(false)
@@ -374,6 +377,8 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     })()
   }, [isGatewayRunning])
   const lastMsg = chat?.messages?.[chat.messages.length - 1]
+  // A fresh prompt clears any pending multi-select picks from a prior question.
+  useEffect(() => { setMultiChoice([]) }, [chatId, lastMsg?.id])
   const prevChatIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (!followLatest) return
@@ -388,6 +393,21 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [flight, chatId])
+  // Refresh the Status task brief on each turn boundary — when a turn is sent
+  // and again when it completes — while the Status tab is open, so it reflects
+  // the live history. The tab-switch trigger alone misses these: nothing
+  // re-fires during a run, and a completed assistant message keeps its
+  // send-time timestamp so the staleness check can't see the finished turn.
+  // Key off the boolean (not `flight` itself, which churns every token).
+  const turnActive = !!flight
+  const prevTurnActiveRef = useRef(turnActive)
+  useEffect(() => {
+    const toggled = prevTurnActiveRef.current !== turnActive
+    prevTurnActiveRef.current = turnActive
+    if (!toggled || panelTab !== 'task' || !chat) return
+    setTaskBriefLoading(true)
+    generateTaskBrief(chat.id).finally(() => setTaskBriefLoading(false))
+  }, [turnActive, panelTab, chatId])
   // When a turn is interrupted, lift the original prompt back into the input
   // and focus the textarea so the user can edit/resend without retyping.
   const restoreText = state.pendingRestores[chatId]
@@ -963,19 +983,59 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 && msg.userQuestion
                 && msg.userQuestion.options.length > 0
                 && (
-                  <div style={styles.choiceRow}>
-                    {msg.userQuestion.options.map((opt, i) => (
+                  msg.userQuestion.multiSelect ? (
+                    <div style={styles.choiceRow}>
+                      {msg.userQuestion.options.map((opt, i) => {
+                        const picked = multiChoice.includes(opt.label)
+                        return (
+                          <button
+                            key={i}
+                            style={{
+                              ...styles.choiceButton,
+                              ...(picked ? styles.choiceButtonPicked : null),
+                            }}
+                            disabled={isSending || !!flight}
+                            onClick={() => setMultiChoice(prev =>
+                              prev.includes(opt.label)
+                                ? prev.filter(l => l !== opt.label)
+                                : [...prev, opt.label]
+                            )}
+                          >
+                            <span style={styles.choiceLabel}>
+                              <span style={styles.choiceCheck}>{picked ? '☑' : '☐'}</span>
+                              {opt.label}
+                            </span>
+                            {opt.description && <span style={styles.choiceDesc}>{opt.description}</span>}
+                          </button>
+                        )
+                      })}
                       <button
-                        key={i}
-                        style={styles.choiceButton}
-                        disabled={isSending || !!flight}
-                        onClick={() => { void sendMessage(chat.id, opt.label) }}
+                        style={{
+                          ...styles.choiceSubmit,
+                          opacity: multiChoice.length === 0 ? 0.5 : 1,
+                          cursor: multiChoice.length === 0 ? 'default' : 'pointer',
+                        }}
+                        disabled={isSending || !!flight || multiChoice.length === 0}
+                        onClick={() => { void sendMessage(chat.id, multiChoice.join(', ')) }}
                       >
-                        <span style={styles.choiceLabel}>{opt.label}</span>
-                        {opt.description && <span style={styles.choiceDesc}>{opt.description}</span>}
+                        Submit{multiChoice.length > 0 ? ` (${multiChoice.length})` : ''}
                       </button>
-                    ))}
-                  </div>
+                    </div>
+                  ) : (
+                    <div style={styles.choiceRow}>
+                      {msg.userQuestion.options.map((opt, i) => (
+                        <button
+                          key={i}
+                          style={styles.choiceButton}
+                          disabled={isSending || !!flight}
+                          onClick={() => { void sendMessage(chat.id, opt.label) }}
+                        >
+                          <span style={styles.choiceLabel}>{opt.label}</span>
+                          {opt.description && <span style={styles.choiceDesc}>{opt.description}</span>}
+                        </button>
+                      ))}
+                    </div>
+                  )
                 )
               }
               {msg.role === 'assistant'
@@ -1379,8 +1439,28 @@ const styles: Record<string, React.CSSProperties> = {
     flexDirection: 'column' as const,
     gap: 2,
   },
+  choiceButtonPicked: {
+    border: `1px solid ${C.accent}`,
+    background: C.accentDim,
+  },
+  choiceSubmit: {
+    alignSelf: 'flex-start' as const,
+    padding: '6px 16px',
+    borderRadius: 6,
+    border: 'none',
+    background: C.accent,
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: 600 as const,
+  },
   choiceLabel: {
     fontWeight: 500 as const,
+    display: 'flex',
+    alignItems: 'center' as const,
+    gap: 6,
+  },
+  choiceCheck: {
+    fontSize: 13,
   },
   choiceDesc: {
     fontSize: 11,

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -197,6 +197,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
                   options: q.options
                     .filter((o: any) => o && typeof o.label === 'string')
                     .map((o: any) => ({ label: o.label, description: o.description })),
+                  multiSelect: q.multiSelect === true,
                 };
                 childProcess.kill('SIGTERM');
               }
@@ -226,6 +227,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
                     options: q.options
                       .filter((o: any) => o && typeof o.label === 'string')
                       .map((o: any) => ({ label: o.label, description: o.description })),
+                    multiSelect: q.multiSelect === true,
                   };
                   // Kill the process — it's waiting for interactive input we can't provide.
                   // The gateway will resume the session with the user's answer on the next turn.
@@ -435,6 +437,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
             options: q.options
               .filter((o: any) => o && typeof o.label === 'string')
               .map((o: any) => ({ label: o.label, description: o.description })),
+            multiSelect: q.multiSelect === true,
           };
         }
       } catch { /* keep searching */ }

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -36,6 +36,8 @@ export interface ChatMessage {
   userQuestion?: {
     question: string;
     options: Array<{ label: string; description?: string }>;
+    /** When true, the question allows selecting multiple options at once. */
+    multiSelect?: boolean;
   };
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -192,6 +192,8 @@ export interface AgentResponse {
   userQuestion?: {
     question: string;
     options: Array<{ label: string; description?: string }>;
+    /** When true, the question allows selecting multiple options at once. */
+    multiSelect?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

Two related codey-mac improvements bundled together.

### 1. Live Status (task brief) refresh on turn boundaries
The Status tab's task brief only regenerated on tab-switch, guarded by a staleness check. While a turn was in flight nothing re-triggered it, and once a turn completed the assistant message keeps its **send-time** timestamp — so `isTaskBriefStale` (`lastMsg.timestamp > generatedAt`) returned false and never detected the finished turn.

New effect in `ChatTab.tsx` regenerates the brief from current history on each turn boundary — **on send** and **on completion** — while the Status tab is open:
- Keyed off the `!!flight` boolean (not `flight` itself, which churns every token), so no per-token spam.
- Only runs while the Status tab is open, avoiding wasted Aide calls.
- Requires the Aide model to be configured; otherwise generation still returns `null` ("No task to summarize yet.").

### 2. Multi-select AskUserQuestion
- `claude-code` adapter threads `multiSelect` through the three question-parsing paths.
- `ChatMessage.userQuestion` and `AgentResponse.userQuestion` types carry the `multiSelect` flag.
- Chat UI renders checkbox-style options with a Submit button that sends the joined selection; single-select keeps the existing one-click behavior.

## Testing
- `tsc --noEmit` passes for the renderer.
- Not yet verified live in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)