### PR TITLE
fix(voice): keep HUD visible when re-triggered during auto-hide fade

### DIFF
--- a/voice/Sources/CodeyVoice/HudOverlay.swift
+++ b/voice/Sources/CodeyVoice/HudOverlay.swift
@@ -25,11 +25,11 @@ final class HudOverlay {
     private var label: NSTextField?
     private var spinner: NSProgressIndicator?
     private var hideWorkItem: DispatchWorkItem?
-    /// Bumped on every `show()`. A hide's fade-out completion captures the value
-    /// at hide time and only `orderOut`s if it still matches — so a `show()` that
-    /// interleaves with an in-flight fade cancels the stale teardown instead of
-    /// having the panel yanked out from under it.
-    private var showGeneration = 0
+    /// The currently desired visibility, set by `show()`/`hide()`. A hide's
+    /// fade-out completion checks this before calling `orderOut`: if a `show()`
+    /// ran during the ~0.18s fade it will have flipped this back to `true`, so the
+    /// stale teardown is skipped instead of yanking the panel out from under us.
+    private var wantVisible = false
 
     private let pillHeight: CGFloat = 44
     private let pillSidePadding: CGFloat = 16
@@ -56,9 +56,9 @@ final class HudOverlay {
 
         hideWorkItem?.cancel()
         hideWorkItem = nil
-        // Invalidate any in-flight hide fade-out so its completion won't orderOut
-        // the panel we're about to (re)show.
-        showGeneration &+= 1
+        // Mark the panel as wanted on-screen so an in-flight hide fade-out's
+        // completion won't orderOut the panel we're about to (re)show.
+        wantVisible = true
 
         switch mode {
         case .recording:
@@ -149,12 +149,13 @@ final class HudOverlay {
         hideWorkItem?.cancel()
         hideWorkItem = nil
         guard let panel = panel, panel.isVisible else { return }
-        let gen = showGeneration
+        wantVisible = false
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.18
             panel.animator().alphaValue = 0
         } completionHandler: { [weak self] in
-            guard let self = self, self.showGeneration == gen else { return }
+            // Skip the teardown if a show() re-asserted visibility mid-fade.
+            guard let self = self, !self.wantVisible else { return }
             self.panel?.orderOut(nil)
         }
     }

--- a/voice/Sources/CodeyVoice/HudOverlay.swift
+++ b/voice/Sources/CodeyVoice/HudOverlay.swift
@@ -25,6 +25,11 @@ final class HudOverlay {
     private var label: NSTextField?
     private var spinner: NSProgressIndicator?
     private var hideWorkItem: DispatchWorkItem?
+    /// Bumped on every `show()`. A hide's fade-out completion captures the value
+    /// at hide time and only `orderOut`s if it still matches — so a `show()` that
+    /// interleaves with an in-flight fade cancels the stale teardown instead of
+    /// having the panel yanked out from under it.
+    private var showGeneration = 0
 
     private let pillHeight: CGFloat = 44
     private let pillSidePadding: CGFloat = 16
@@ -51,6 +56,9 @@ final class HudOverlay {
 
         hideWorkItem?.cancel()
         hideWorkItem = nil
+        // Invalidate any in-flight hide fade-out so its completion won't orderOut
+        // the panel we're about to (re)show.
+        showGeneration &+= 1
 
         switch mode {
         case .recording:
@@ -121,9 +129,15 @@ final class HudOverlay {
             // No scheduled hide — user dismisses by clicking.
         }
 
-        if !panel.isVisible {
-            panel.alphaValue = 0
-            panel.orderFrontRegardless()
+        // Robustly assert top-of-stack visibility. If a previous auto-hide left
+        // the panel mid-fade (visible but alpha < 1), we must cancel that fade by
+        // animating alpha back to 1 — gating only on `!isVisible` would skip that
+        // and let the fade complete, hiding an active HUD.
+        let wasVisible = panel.isVisible
+        let needsFadeIn = !wasVisible || panel.alphaValue < 1.0
+        if !wasVisible { panel.alphaValue = 0 }
+        panel.orderFrontRegardless()
+        if needsFadeIn {
             NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.12
                 panel.animator().alphaValue = 1.0
@@ -135,11 +149,13 @@ final class HudOverlay {
         hideWorkItem?.cancel()
         hideWorkItem = nil
         guard let panel = panel, panel.isVisible else { return }
+        let gen = showGeneration
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.18
             panel.animator().alphaValue = 0
         } completionHandler: { [weak self] in
-            self?.panel?.orderOut(nil)
+            guard let self = self, self.showGeneration == gen else { return }
+            self.panel?.orderOut(nil)
         }
     }
 


### PR DESCRIPTION
## Problem

The voice HUD pill sometimes stayed hidden even though recording/transcription was working normally — intermittent, and most likely right after a previous dictation.

## Root cause

A show/hide animation race in `HudOverlay.swift`:

1. `.success` / `.error` schedules a hide; the hide runs a 0.18s `alphaValue → 0` fade whose completion **unconditionally** calls `panel.orderOut`.
2. If the user re-triggers (Fn) **during that fade**, `show()`'s `hideWorkItem?.cancel()` is a no-op (the work item already fired; the in-flight animation + `orderOut` aren't tracked by it), and the `if !panel.isVisible` guard is **skipped** because `orderOut` hasn't run yet. Alpha keeps animating to 0 and the panel is never re-asserted.
3. The fade's completion handler then `orderOut`s the panel — which is now the **active recording HUD**. Audio works; HUD is invisible.

This is exactly the ~1s auto-hide window where people naturally start their next dictation, which is why it felt random.

## Fix

- **`showGeneration` token**, bumped on every `show()`. The hide fade-out captures the value at hide time and only `orderOut`s if it still matches — so an interleaving `show()` cancels the stale teardown.
- **`show()` now cancels an in-flight fade** by animating alpha back to `1` and re-ordering front whenever the panel isn't already fully opaque, instead of gating solely on `!isVisible`.

## Verification

- `swift build` clean.
- No automated test: the repo has no test runner and this is AppKit animation-completion timing on the main run loop (not unit-testable without a GUI harness). The fix is deterministic by construction; all lifecycle paths (natural hide, auto-hide, re-trigger mid-fade, re-trigger after full hide, Esc-cancel) were traced by hand.

## Not included

A separate, related issue: the HUD is positioned via `NSScreen.main`, so on multi-monitor setups it can appear on a different screen than the active one. Left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)