### PR TITLE
Real thinking fold: capture & render model extended-thinking

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -14,6 +14,7 @@ import { parseTeamMessage } from './teamMessageFormat'
 import { isTaskBriefStale } from './taskHudView'
 import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
+import { defaultThinkingExpanded } from './thinkingState'
 
 interface Props {
   chatId: string
@@ -98,9 +99,6 @@ const AGENT_API_TYPE: Record<string, 'anthropic' | 'openai'> = {
 }
 type ModelEntry = { apiType: 'anthropic' | 'openai'; model: string }
 
-const splitParagraphs = (text: string): string[] =>
-  text.split(/\n\s*\n/).map(p => p.trim()).filter(Boolean)
-
 const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }> = ({ toolCalls }) => {
   const [expanded, setExpanded] = useState(false)
   if (!toolCalls || toolCalls.length === 0) return null
@@ -144,37 +142,25 @@ const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }>
   )
 }
 
-const StepBody: React.FC<{
-  output: string
-  bodyKey: string
-  expanded: Set<string>
-  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
-}> = ({ output, bodyKey, expanded, setExpanded }) => {
-  const paragraphs = splitParagraphs(output)
-  const showAll = expanded.has(bodyKey)
-  if (paragraphs.length <= 1) {
-    return <Markdown variant="assistant">{output}</Markdown>
-  }
-  const last = paragraphs[paragraphs.length - 1]
-  const earlierCount = paragraphs.length - 1
-  const toggle = () => setExpanded(prev => {
-    const next = new Set(prev)
-    if (next.has(bodyKey)) next.delete(bodyKey)
-    else next.add(bodyKey)
-    return next
-  })
+const ThinkingBlock: React.FC<{
+  thinking: string
+  hasAnswer: boolean
+  isComplete: boolean
+}> = ({ thinking, hasAnswer, isComplete }) => {
+  const [userToggled, setUserToggled] = useState<boolean | null>(null)
+  if (!thinking.trim()) return null
+  const expanded = userToggled ?? defaultThinkingExpanded({ hasAnswer, isComplete })
   return (
     <div>
-      <div style={styles.thinkingToggle} onClick={toggle}>
-        <span style={{ ...styles.teamStepChevron, transform: showAll ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
-        <span>{showAll ? 'Hide thinking' : `Show thinking (${earlierCount} paragraph${earlierCount === 1 ? '' : 's'})`}</span>
+      <div style={styles.thinkingToggle} onClick={() => setUserToggled(!expanded)}>
+        <span style={{ ...styles.teamStepChevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+        <span>{expanded ? 'Hide thinking' : 'Show thinking'}</span>
       </div>
-      {showAll && (
+      {expanded && (
         <div style={styles.thinkingBody}>
-          <Markdown variant="assistant">{paragraphs.slice(0, -1).join('\n\n')}</Markdown>
+          <Markdown variant="assistant">{thinking}</Markdown>
         </div>
       )}
-      <Markdown variant="assistant">{last}</Markdown>
     </div>
   )
 }
@@ -185,9 +171,11 @@ const TeamMessage: React.FC<{
   messageId: string
   parsed: NonNullable<ReturnType<typeof parseTeamMessage>>
   isStreaming: boolean
+  isComplete: boolean
+  thinkingByStep?: Record<number, string>
   expanded: Set<string>
   setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>
-}> = ({ messageId, parsed, isStreaming, expanded, setExpanded }) => {
+}> = ({ messageId, parsed, isStreaming, isComplete, thinkingByStep, expanded, setExpanded }) => {
   const lastIdx = parsed.steps.length - 1
   return (
     <div>
@@ -211,7 +199,16 @@ const TeamMessage: React.FC<{
               {isLastDuringStream ? (
                 <Markdown variant="assistant">{s.output || '…'}</Markdown>
               ) : (
-                <StepBody output={s.output} bodyKey={bodyKey} expanded={expanded} setExpanded={setExpanded} />
+                <div>
+                  {thinkingByStep?.[s.step] && (
+                    <ThinkingBlock
+                      thinking={thinkingByStep[s.step]}
+                      hasAnswer={!!s.output.trim()}
+                      isComplete={isComplete}
+                    />
+                  )}
+                  <Markdown variant="assistant">{s.output}</Markdown>
+                </div>
               )}
             </div>
           </div>
@@ -935,13 +932,26 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                   if (isUser) return <Markdown variant="user">{msg.content}</Markdown>
                   const text = msg.content || msg.userQuestion?.question || ''
                   const parsed = parseTeamMessage(text)
-                  if (!parsed) return <Markdown variant="assistant">{text}</Markdown>
                   const isStreaming = !!flight && msg === lastMsg
+                  if (!parsed) return (
+                    <div>
+                      {msg.thinking && (
+                        <ThinkingBlock
+                          thinking={msg.thinking}
+                          hasAnswer={!!text.trim()}
+                          isComplete={msg.isComplete ?? false}
+                        />
+                      )}
+                      <Markdown variant="assistant">{text}</Markdown>
+                    </div>
+                  )
                   return (
                     <TeamMessage
                       messageId={msg.id}
                       parsed={parsed}
                       isStreaming={isStreaming}
+                      isComplete={msg.isComplete ?? false}
+                      thinkingByStep={msg.thinkingByStep}
                       expanded={expandedSteps}
                       setExpanded={setExpandedSteps}
                     />

--- a/codey-mac/src/components/thinkingState.test.ts
+++ b/codey-mac/src/components/thinkingState.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { defaultThinkingExpanded } from './thinkingState'
+
+describe('defaultThinkingExpanded', () => {
+  it('expands while thinking and no answer yet', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: false, isComplete: false })).toBe(true)
+  })
+  it('collapses once answer text has started', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: true, isComplete: false })).toBe(false)
+  })
+  it('collapses when the message is complete', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: true, isComplete: true })).toBe(false)
+  })
+  it('collapses a completed message even if answer was empty', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: false, isComplete: true })).toBe(false)
+  })
+})

--- a/codey-mac/src/components/thinkingState.ts
+++ b/codey-mac/src/components/thinkingState.ts
@@ -1,0 +1,6 @@
+/** Default expanded state for a ThinkingBlock (user toggle overrides this). */
+export function defaultThinkingExpanded(args: { hasAnswer: boolean; isComplete: boolean }): boolean {
+  // Live thinking is visible; the moment answer text starts (or the turn ends),
+  // collapse it so the answer is what the eye lands on.
+  return !args.hasAnswer && !args.isComplete
+}

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -8,6 +8,8 @@ interface InFlight {
   userMessageId: string
   agentStatus: 'idle' | 'thinking' | 'working' | 'writing'
   queuedPosition?: number
+  thinking?: string
+  thinkingByStep?: Record<number, string>
 }
 
 interface State {
@@ -33,6 +35,7 @@ type Action =
   | { type: 'toggleWorkspace'; workspaceName: string }
   | { type: 'startSend'; chatId: string; userMessage: ChatMessage; assistantMessageId: string }
   | { type: 'streamToken'; chatId: string; token: string }
+  | { type: 'thinkingToken'; chatId: string; token: string; step?: number }
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: 'working' | 'writing' }
   | { type: 'queued'; chatId: string; position: number }
   | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion'] }
@@ -146,6 +149,27 @@ function reducer(state: State, action: Action): State {
             agentStatus: 'thinking',
           },
         },
+      }
+    }
+    case 'thinkingToken': {
+      const chat = state.chats[action.chatId]
+      const fl = state.inFlight[action.chatId]
+      if (!chat || !fl) return state
+      const nextFl: InFlight = { ...fl, agentStatus: 'thinking' }
+      if (action.step === undefined) {
+        nextFl.thinking = (fl.thinking ?? '') + action.token
+      } else {
+        nextFl.thinkingByStep = { ...(fl.thinkingByStep ?? {}), [action.step]: (fl.thinkingByStep?.[action.step] ?? '') + action.token }
+      }
+      const messages = chat.messages.map(m =>
+        m.id === fl.assistantMessageId
+          ? { ...m, thinking: nextFl.thinking, thinkingByStep: nextFl.thinkingByStep }
+          : m
+      )
+      return {
+        ...state,
+        chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } },
+        inFlight: { ...state.inFlight, [chat.id]: nextFl },
       }
     }
     case 'streamToken': {
@@ -353,6 +377,9 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           break
         case 'stream':
           dispatch({ type: 'streamToken', chatId: ev.chatId, token: ev.token })
+          break
+        case 'thinking':
+          dispatch({ type: 'thinkingToken', chatId: ev.chatId, token: ev.token, step: ev.step })
           break
         case 'done': {
           const asstId = pendingAssistantId.current[ev.chatId]

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -10,7 +10,8 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
+  | { type: 'thinking'; chatId: string; token: string; step?: number }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/docs/superpowers/plans/2026-06-07-real-thinking-fold.md
+++ b/docs/superpowers/plans/2026-06-07-real-thinking-fold.md
@@ -1,0 +1,812 @@
+# Real Thinking Fold Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the codey-mac fake "show thinking" paragraph fold with a real one driven by the model's actual extended-thinking: capture it from claude-code, transport it on a dedicated stream event, render it live with auto-collapse; when there is no real thinking, show full output unfolded.
+
+**Architecture:** claude-code emits `thinking` content blocks over stream-json; the adapter captures them into a new `onThinking` callback + `AgentResponse.thinking`. The gateway forwards them as a new `ChatStreamEvent { type:'thinking', token, step? }` and persists thinking on the `ChatMessage`. codey-mac accumulates thinking (per-message / per-team-step), renders a `<ThinkingBlock>` that is live while thinking and auto-collapses once answer text starts. The old `StepBody` paragraph heuristic is deleted.
+
+**Tech Stack:** TypeScript (monorepo: `@codey/core`, `@codey/gateway`), React (codey-mac, Electron), vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-real-thinking-fold-design.md`
+
+**Environment (REQUIRED before any test/build):**
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1   # default node v16 cannot run vitest/tsc
+```
+A fresh worktree also needs `npm install` at the repo root and a build of core + gateway before the mac app can import them.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `packages/core/src/types/index.ts` | Agent request/response contract | Add `onThinking` + `AgentResponse.thinking` |
+| `packages/core/src/types/chat.ts` | Persisted `ChatMessage` (shared by gateway + mac) | Add `thinking?` + `thinkingByStep?` |
+| `packages/core/src/agents/thinking-stream.ts` | **NEW** pure classifier for stream-json thinking blocks | Create |
+| `packages/core/src/agents/thinking-stream.test.ts` | **NEW** unit tests for the classifier | Create |
+| `packages/core/src/agents/claude-code.ts` | claude-code adapter | Capture thinking, emit `onThinking`, return `thinking` |
+| `packages/gateway/src/chat-runner.ts` | Stream event protocol | Add `thinking` event + `done.thinking` |
+| `packages/gateway/src/gateway.ts` | Chat + team orchestration | Wire `onThinking`, persist thinking, emit on `done` |
+| `codey-mac/src/components/thinkingState.ts` | **NEW** pure collapse-decision helper | Create |
+| `codey-mac/src/components/thinkingState.test.ts` | **NEW** unit tests | Create |
+| `codey-mac/src/hooks/useChats.tsx` | Stream → state reducer | Accumulate thinking, persist on complete |
+| `codey-mac/src/components/ChatTab.tsx` | Message rendering | Add `<ThinkingBlock>`, delete `StepBody` fake fold |
+
+---
+
+## Task 1: Thinking contract on the agent types
+
+**Files:**
+- Modify: `packages/core/src/types/index.ts` (AgentRequest ~line 109, AgentResponse ~line 165)
+- Modify: `packages/core/src/types/chat.ts` (ChatMessage ~line 21-42)
+
+- [ ] **Step 1: Add `onThinking` to `AgentRequest`**
+
+In `packages/core/src/types/index.ts`, directly under the existing `onStream` line:
+
+```typescript
+  onStream?: (text: string) => void;
+  /** Streamed extended-thinking text (model reasoning), separate from the answer. */
+  onThinking?: (text: string) => void;
+  onStatus?: (update: StatusUpdate) => void;
+```
+
+- [ ] **Step 2: Add `thinking` to `AgentResponse`**
+
+In the same file, inside `AgentResponse` (next to `output`):
+
+```typescript
+export interface AgentResponse {
+  success: boolean;
+  output: string;
+  /** Full extended-thinking text captured this run, if the model emitted any. */
+  thinking?: string;
+  error?: string;
+```
+
+- [ ] **Step 3: Add thinking fields to `ChatMessage`**
+
+In `packages/core/src/types/chat.ts`, inside `ChatMessage`, after `durationSec`:
+
+```typescript
+  /** Extended-thinking for a single-agent assistant message (collapsed in UI). */
+  thinking?: string;
+  /** Per-team-step extended-thinking, keyed by step number. */
+  thinkingByStep?: Record<number, string>;
+```
+
+- [ ] **Step 4: Typecheck core**
+
+Run:
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+cd packages/core && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/types/index.ts packages/core/src/types/chat.ts
+git commit -m "feat(core): add thinking fields to agent + chat message types"
+```
+
+---
+
+## Task 2: Pure thinking-stream classifier (TDD)
+
+The adapter's event handling is a closure inside `run()` and hard to test directly. Extract the thinking decision into a pure, exported function and unit-test it. The shape mirrors the `StreamEvent` already declared in `claude-code.ts` (`event.event.type`, `event.event.content_block.type`, `event.event.delta`).
+
+**Files:**
+- Create: `packages/core/src/agents/thinking-stream.ts`
+- Test: `packages/core/src/agents/thinking-stream.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/core/src/agents/thinking-stream.test.ts
+import { describe, it, expect } from 'vitest';
+import { thinkingDeltaFrom, isThinkingBlockStart } from './thinking-stream';
+
+describe('thinkingDeltaFrom', () => {
+  it('extracts text from a thinking_delta', () => {
+    expect(thinkingDeltaFrom({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'hm ' } },
+    })).toBe('hm ');
+  });
+
+  it('returns null for a text_delta', () => {
+    expect(thinkingDeltaFrom({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'answer' } },
+    })).toBeNull();
+  });
+
+  it('returns null for non-delta events', () => {
+    expect(thinkingDeltaFrom({ type: 'assistant' })).toBeNull();
+  });
+});
+
+describe('isThinkingBlockStart', () => {
+  it('is true for a thinking content_block_start', () => {
+    expect(isThinkingBlockStart({
+      type: 'stream_event',
+      event: { type: 'content_block_start', content_block: { type: 'thinking' } },
+    })).toBe(true);
+  });
+
+  it('is false for a tool_use start', () => {
+    expect(isThinkingBlockStart({
+      type: 'stream_event',
+      event: { type: 'content_block_start', content_block: { type: 'tool_use', name: 'Read' } },
+    })).toBe(false);
+  });
+
+  it('ignores redacted_thinking (no plaintext to show)', () => {
+    expect(isThinkingBlockStart({
+      type: 'stream_event',
+      event: { type: 'content_block_start', content_block: { type: 'redacted_thinking' } },
+    })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd packages/core && npx vitest run src/agents/thinking-stream.test.ts
+```
+Expected: FAIL — `Cannot find module './thinking-stream'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// packages/core/src/agents/thinking-stream.ts
+
+/** Minimal shape of a claude-code stream-json event we inspect for thinking. */
+export interface ThinkingProbe {
+  type?: string;
+  event?: {
+    type?: string;
+    delta?: { type?: string; thinking?: string; text?: string };
+    content_block?: { type?: string; name?: string };
+  };
+}
+
+/** Returns the thinking text of a thinking_delta event, or null if not one. */
+export function thinkingDeltaFrom(event: ThinkingProbe): string | null {
+  if (event.type !== 'stream_event') return null;
+  if (event.event?.type !== 'content_block_delta') return null;
+  const delta = event.event.delta;
+  if (delta?.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+    return delta.thinking;
+  }
+  return null;
+}
+
+/** True when this event opens a (non-redacted) thinking content block. */
+export function isThinkingBlockStart(event: ThinkingProbe): boolean {
+  if (event.type !== 'stream_event') return false;
+  if (event.event?.type !== 'content_block_start') return false;
+  return event.event.content_block?.type === 'thinking';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd packages/core && npx vitest run src/agents/thinking-stream.test.ts
+```
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agents/thinking-stream.ts packages/core/src/agents/thinking-stream.test.ts
+git commit -m "feat(core): pure classifier for claude-code thinking stream events"
+```
+
+---
+
+## Task 3: Capture thinking in the claude-code adapter
+
+**Files:**
+- Modify: `packages/core/src/agents/claude-code.ts` (StreamEvent type ~40-45; `processEvent` ~167-212; final resolve where `AgentResponse` is built)
+
+- [ ] **Step 1: Extend the local StreamEvent delta type**
+
+In the `event.delta` field of the `StreamEvent` interface (~line 43), add `thinking`:
+
+```typescript
+    delta?: { type?: string; text?: string; thinking?: string };
+```
+
+- [ ] **Step 2: Import the classifier and add accumulators**
+
+At the top of `claude-code.ts` with the other imports:
+
+```typescript
+import { thinkingDeltaFrom, isThinkingBlockStart } from './thinking-stream';
+```
+
+Inside `run()`, next to `let streamedText = '';` (~line 140):
+
+```typescript
+      let streamedText = '';
+      let thinkingText = '';
+      let streamedThinkingFromDeltas = false;
+```
+
+- [ ] **Step 3: Handle thinking in `processEvent`**
+
+In `processEvent`, extend the `content_block_start` branch (~172) to recognise thinking starts, and the `content_block_delta` branch (~178) to capture thinking deltas. Replace those two branches with:
+
+```typescript
+        } else if (event.type === 'stream_event' && event.event?.type === 'content_block_start') {
+          const cb = event.event.content_block;
+          if (cb?.type === 'tool_use' && cb.name === 'AskUserQuestion') {
+            collectingAskUser = true;
+            askUserInputJson = '';
+          }
+          // thinking blocks need no setup; isThinkingBlockStart kept for symmetry/future use
+          void isThinkingBlockStart;
+        } else if (event.type === 'stream_event' && event.event?.type === 'content_block_delta') {
+          const thinking = thinkingDeltaFrom(event);
+          if (thinking !== null) {
+            thinkingText += thinking;
+            request.onThinking?.(thinking);
+            streamedThinkingFromDeltas = true;
+          }
+          const delta = event.event.delta;
+          if (delta?.type === 'text_delta' && delta.text) {
+            streamedText += delta.text;
+            request.onStream?.(delta.text);
+            streamedFromDeltas = true;
+          } else if (collectingAskUser && delta?.type === 'input_json_delta') {
+            askUserInputJson += (delta as any).partial_json ?? (delta as any).text ?? '';
+          }
+        }
+```
+
+- [ ] **Step 4: Capture thinking from the final `assistant` event (no-delta fallback)**
+
+In the `assistant` event loop (~206), add a `thinking` block branch alongside the existing `text`/`tool_use` branches:
+
+```typescript
+          for (const block of event.message.content) {
+            if (block.type === 'thinking' && (block as any).thinking) {
+              if (!streamedThinkingFromDeltas) {
+                thinkingText += (block as any).thinking;
+              }
+            } else if (block.type === 'text' && block.text) {
+              if (!streamedFromDeltas) {
+                streamedText += block.text;
+                request.onStream?.(block.text);
+              }
+            } else if (block.type === 'tool_use' && block.name) {
+```
+
+(Leave the rest of the `tool_use` branch unchanged.)
+
+- [ ] **Step 5: Return `thinking` on every resolve path**
+
+Find each place that builds the success `AgentResponse` (the object literal passed to `safeResolve`/`resolve` with `output:` and `success: true`). Add:
+
+```typescript
+        thinking: thinkingText.trim() || undefined,
+```
+
+next to `output:`. (There is one primary success resolve in the `result`/`close` handler; add the field there. Error/early resolves that have no output may omit it.)
+
+- [ ] **Step 6: Typecheck core**
+
+Run:
+```bash
+cd packages/core && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 7: Build core (gateway + mac import the compiled output)**
+
+Run:
+```bash
+cd packages/core && npm run build
+```
+Expected: builds to `dist/` with no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/agents/claude-code.ts
+git commit -m "feat(core): capture extended-thinking in claude-code adapter"
+```
+
+---
+
+## Task 4: Add thinking to the gateway stream protocol
+
+**Files:**
+- Modify: `packages/gateway/src/chat-runner.ts` (ChatStreamEvent ~6-15)
+
+- [ ] **Step 1: Add the `thinking` event and `done.thinking`**
+
+In `ChatStreamEvent`, add a new member after the `stream` line and extend `done`:
+
+```typescript
+  | { type: 'stream'; chatId: string; token: string }
+  | { type: 'thinking'; chatId: string; token: string; step?: number }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
+```
+
+- [ ] **Step 2: Typecheck gateway**
+
+Run:
+```bash
+cd packages/gateway && npx tsc --noEmit
+```
+Expected: no errors (consumers don't yet emit/handle the new event; that's fine).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/gateway/src/chat-runner.ts
+git commit -m "feat(gateway): add thinking stream event + done.thinking"
+```
+
+---
+
+## Task 5: Wire thinking for single-agent chats
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts` (single-agent run path ~2860/2910; assistant persist ~3924-3934; done emit ~3953)
+
+- [ ] **Step 1: Forward thinking deltas on the single-agent run**
+
+At the single-agent `onStream` sink site (~2860), add an `onThinking` sibling. It currently reads:
+
+```typescript
+        onStream: (text: string) => sink({ type: 'stream', chatId, token: text }),
+        onStatus: (_update: any) => { /* status forwarded via sink elsewhere */ },
+```
+
+Change to capture thinking both for live streaming and for persistence:
+
+```typescript
+        onStream: (text: string) => sink({ type: 'stream', chatId, token: text }),
+        onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text }),
+        onStatus: (_update: any) => { /* status forwarded via sink elsewhere */ },
+```
+
+Apply the same addition at the second single-agent sink site (~2910).
+
+- [ ] **Step 2: Persist thinking on the assistant message**
+
+Where the assistant `ChatMessage` is built before `appendMessage` (~3924), the run's `AgentResponse` is in scope (the variable holding `response`/`res` with `.output`). Add `thinking` to the message:
+
+```typescript
+        role: 'assistant',
+        content: output,
+        thinking: response.thinking,
+        // ...existing fields (timestamp, isComplete, tokens, etc.)
+```
+
+(Use whatever local name the response has at this site — confirm it is the `AgentResponse` from the single-agent run.)
+
+- [ ] **Step 3: Emit thinking on `done`**
+
+At the `done` sink (~3953):
+
+```typescript
+      sink({ type: 'done', chatId, response: output, thinking: response.thinking, tokens, durationSec, title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion });
+```
+
+- [ ] **Step 4: Build gateway**
+
+Run:
+```bash
+cd packages/gateway && npm run build
+```
+Expected: builds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): stream + persist thinking for single-agent chats"
+```
+
+---
+
+## Task 6: Wire thinking for team steps
+
+Team steps run through `runWorkerStep` (~131) and stream into one combined message. Each step's thinking must be tagged with its step number so the UI can key it.
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts` (`runWorkerStep` request build ~155-160; team step sink sites ~2852, ~3054; team assistant persist path)
+
+- [ ] **Step 1: Thread `onThinking` through `runWorkerStep`**
+
+`runWorkerStep` builds the agent request (~155) with `onStream: opts.onStream` / `onStatus: opts.onStatus`. Add an `onThinking` opt and pass it through:
+
+```typescript
+  private async runWorkerStep(opts: {
+    // ...existing opts
+    onStream?: (text: string) => void;
+    onThinking?: (text: string) => void;
+    onStatus?: (u: StatusUpdate) => void;
+    // ...
+  }): Promise<{ response: AgentResponse }> {
+    // ...
+      onStream: opts.onStream,
+      onThinking: opts.onThinking,
+      onStatus: opts.onStatus,
+```
+
+- [ ] **Step 2: Emit step-tagged thinking at each team step call**
+
+At each `runWorkerStep({ ... })` call inside the team loop that has a `sink` and a current `step`/`stepNum` in scope (~2852, ~3054), add:
+
+```typescript
+        onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text, step: stepNum }),
+```
+
+(Use the loop's actual step variable — `step` or `stepNum` — at each site.)
+
+- [ ] **Step 3: Collect per-step thinking and persist `thinkingByStep`**
+
+In the team assembly that pushes `parts` (~2200, where `{ step, worker, output }` is pushed), also capture the step's `response.thinking`. Build a `thinkingByStep` map as steps complete:
+
+```typescript
+      const thinkingByStep: Record<number, string> = {};
+      // ...inside the per-step loop, after the step's response resolves:
+      if (response.thinking) thinkingByStep[step] = response.thinking;
+```
+
+When the team assistant `ChatMessage` is persisted, attach it:
+
+```typescript
+        role: 'assistant',
+        content: assembledTeamText,
+        thinkingByStep: Object.keys(thinkingByStep).length ? thinkingByStep : undefined,
+```
+
+(If team runs persist via a shared helper with the single-agent path, attach `thinkingByStep` there instead; the field is optional and ignored when empty.)
+
+- [ ] **Step 4: Build gateway**
+
+Run:
+```bash
+cd packages/gateway && npm run build
+```
+Expected: builds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): stream + persist per-step thinking for team runs"
+```
+
+---
+
+## Task 7: Accumulate thinking in the mac reducer
+
+**Files:**
+- Modify: `codey-mac/src/hooks/useChats.tsx` (InFlight ~6-12; Action union ~34-40; reducer cases; `onEvent` switch ~325-365)
+
+- [ ] **Step 1: Extend `InFlight` with thinking buffers**
+
+In the `InFlight` interface:
+
+```typescript
+interface InFlight {
+  assistantMessageId: string
+  userMessageId: string
+  agentStatus: 'idle' | 'thinking' | 'working' | 'writing'
+  queuedPosition?: number
+  thinking?: string
+  thinkingByStep?: Record<number, string>
+  // ...existing fields
+}
+```
+
+- [ ] **Step 2: Add the `thinkingToken` action**
+
+In the Action union (~34):
+
+```typescript
+  | { type: 'thinkingToken'; chatId: string; token: string; step?: number }
+```
+
+- [ ] **Step 3: Handle `thinkingToken` in the reducer**
+
+Add a case (near `streamToken`, ~151). Accumulate into the in-flight buffer and set `agentStatus: 'thinking'`:
+
+```typescript
+    case 'thinkingToken': {
+      const chat = state.chats.find(c => c.id === action.chatId)
+      const fl = chat ? state.inFlight[chat.id] : undefined
+      if (!chat || !fl) return state
+      const next: InFlight = { ...fl, agentStatus: 'thinking' }
+      if (action.step === undefined) {
+        next.thinking = (fl.thinking ?? '') + action.token
+      } else {
+        next.thinkingByStep = { ...(fl.thinkingByStep ?? {}), [action.step]: (fl.thinkingByStep?.[action.step] ?? '') + action.token }
+      }
+      return { ...state, inFlight: { ...state.inFlight, [chat.id]: next } }
+    }
+```
+
+- [ ] **Step 4: Mirror thinking onto the live assistant message**
+
+So `<ThinkingBlock>` can render mid-stream, also write the buffer onto the in-flight assistant `ChatMessage`. In the same case, before returning, map the message (mirror how `streamToken` updates `m.content`):
+
+```typescript
+      const messages = chat.messages.map(m =>
+        m.id === fl.assistantMessageId
+          ? { ...m, thinking: next.thinking, thinkingByStep: next.thinkingByStep }
+          : m
+      )
+      const chats = state.chats.map(c => c.id === chat.id ? { ...c, messages } : c)
+      return { ...state, chats, inFlight: { ...state.inFlight, [chat.id]: next } }
+```
+
+(Replace the simpler return from Step 3 with this fuller one.)
+
+- [ ] **Step 5: Persist thinking in `completeSend`**
+
+The `completeSend` case (~190) sets final fields on the message. The buffered thinking already lives on the message from Step 4; ensure `completeSend` does not clobber it — when it spreads `{ ...m, content: action.content, ... }`, `thinking`/`thinkingByStep` survive because they are not overwritten. No change needed unless `completeSend` rebuilds the message from scratch; if it does, add `thinking: m.thinking, thinkingByStep: m.thinkingByStep`.
+
+- [ ] **Step 6: Dispatch on the `thinking` stream event**
+
+In the `onEvent` switch (~354, next to `case 'stream'`):
+
+```typescript
+        case 'thinking':
+          dispatch({ type: 'thinkingToken', chatId: ev.chatId, token: ev.token, step: ev.step })
+          break
+```
+
+- [ ] **Step 7: Typecheck mac**
+
+Run:
+```bash
+cd codey-mac && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add codey-mac/src/hooks/useChats.tsx
+git commit -m "feat(codey-mac): accumulate streamed thinking into chat state"
+```
+
+---
+
+## Task 8: Pure collapse-decision helper (TDD)
+
+The `<ThinkingBlock>` needs a clear rule for default expand/collapse. Extract it into a pure, tested function.
+
+**Files:**
+- Create: `codey-mac/src/components/thinkingState.ts`
+- Test: `codey-mac/src/components/thinkingState.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// codey-mac/src/components/thinkingState.test.ts
+import { describe, it, expect } from 'vitest'
+import { defaultThinkingExpanded } from './thinkingState'
+
+describe('defaultThinkingExpanded', () => {
+  it('expands while thinking and no answer yet', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: false, isComplete: false })).toBe(true)
+  })
+  it('collapses once answer text has started', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: true, isComplete: false })).toBe(false)
+  })
+  it('collapses when the message is complete', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: true, isComplete: true })).toBe(false)
+  })
+  it('collapses a completed message even if answer was empty', () => {
+    expect(defaultThinkingExpanded({ hasAnswer: false, isComplete: true })).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd codey-mac && npx vitest run src/components/thinkingState.test.ts
+```
+Expected: FAIL — `Cannot find module './thinkingState'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// codey-mac/src/components/thinkingState.ts
+
+/** Default expanded state for a ThinkingBlock (user toggle overrides this). */
+export function defaultThinkingExpanded(args: { hasAnswer: boolean; isComplete: boolean }): boolean {
+  // Live thinking is visible; the moment answer text starts (or the turn ends),
+  // collapse it so the answer is what the eye lands on.
+  return !args.hasAnswer && !args.isComplete
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd codey-mac && npx vitest run src/components/thinkingState.test.ts
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/thinkingState.ts codey-mac/src/components/thinkingState.test.ts
+git commit -m "feat(codey-mac): pure collapse-decision helper for thinking block"
+```
+
+---
+
+## Task 9: Render ThinkingBlock, delete the fake fold
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx` (delete `splitParagraphs` ~101-102 and `StepBody` ~147-180; team render ~210-216; regular assistant render ~934-949; styles ~1574-1583)
+
+- [ ] **Step 1: Add the `ThinkingBlock` component**
+
+Add near the old `StepBody` location. It owns its own expand state, seeded from `defaultThinkingExpanded`, and lets the user toggle:
+
+```tsx
+import { defaultThinkingExpanded } from './thinkingState'
+
+const ThinkingBlock: React.FC<{
+  thinking: string
+  hasAnswer: boolean
+  isComplete: boolean
+}> = ({ thinking, hasAnswer, isComplete }) => {
+  const [userToggled, setUserToggled] = useState<boolean | null>(null)
+  if (!thinking.trim()) return null
+  const expanded = userToggled ?? defaultThinkingExpanded({ hasAnswer, isComplete })
+  return (
+    <div>
+      <div style={styles.thinkingToggle} onClick={() => setUserToggled(!expanded)}>
+        <span style={{ ...styles.teamStepChevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
+        <span>{expanded ? 'Hide thinking' : 'Show thinking'}</span>
+      </div>
+      {expanded && (
+        <div style={styles.thinkingBody}>
+          <Markdown variant="assistant">{thinking}</Markdown>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Delete `StepBody` and `splitParagraphs`**
+
+Remove the `splitParagraphs` const (~101-102) and the entire `StepBody` component (~147-180). They have no other consumers (verified: `splitParagraphs` is only used by `StepBody`).
+
+- [ ] **Step 3: Render thinking + full output for team steps**
+
+`TeamMessage` receives the parsed steps but not thinking. Thread `thinkingByStep` from the message into it. Update the `TeamMessage` props and the call site (~941) to pass `thinkingByStep={msg.thinkingByStep}` and `isComplete={msg.isComplete ?? false}`. Then replace the completed-step body (~213-215, the `StepBody` branch) with:
+
+```tsx
+              {isLastDuringStream ? (
+                <Markdown variant="assistant">{s.output || '…'}</Markdown>
+              ) : (
+                <div>
+                  {thinkingByStep?.[s.step] && (
+                    <ThinkingBlock
+                      thinking={thinkingByStep[s.step]}
+                      hasAnswer={!!s.output.trim()}
+                      isComplete={isComplete}
+                    />
+                  )}
+                  <Markdown variant="assistant">{s.output}</Markdown>
+                </div>
+              )}
+```
+
+Add to `TeamMessage`'s prop type:
+
+```tsx
+  thinkingByStep?: Record<number, string>
+  isComplete: boolean
+```
+
+- [ ] **Step 4: Render thinking for regular assistant messages**
+
+At the non-team render (~938), where it currently returns `<Markdown variant="assistant">{text}</Markdown>`, wrap with a ThinkingBlock when present:
+
+```tsx
+                  if (!parsed) return (
+                    <div>
+                      {msg.thinking && (
+                        <ThinkingBlock
+                          thinking={msg.thinking}
+                          hasAnswer={!!text.trim()}
+                          isComplete={msg.isComplete ?? false}
+                        />
+                      )}
+                      <Markdown variant="assistant">{text}</Markdown>
+                    </div>
+                  )
+```
+
+- [ ] **Step 5: Keep the thinking styles**
+
+`styles.thinkingToggle` and `styles.thinkingBody` already exist (~1574-1583) and are reused by `ThinkingBlock`. Leave them. If tsc flags `teamStepChevron` as unused elsewhere after the `StepBody` deletion, it is still referenced by `ThinkingBlock` — no change.
+
+- [ ] **Step 6: Typecheck + run mac tests**
+
+Run:
+```bash
+cd codey-mac && npx tsc --noEmit && npx vitest run
+```
+Expected: no type errors; all tests pass (including `teamMessageFormat.test.ts` regression and the new `thinkingState.test.ts`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(codey-mac): render real thinking block, drop fake paragraph fold"
+```
+
+---
+
+## Task 10: Full verification
+
+- [ ] **Step 1: Build everything**
+
+Run:
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+npm run build            # repo-root build (compiles core + gateway + mac as configured)
+cd packages/core && npx vitest run && cd ../..
+cd codey-mac && npx vitest run && cd ..
+```
+Expected: builds succeed; all unit tests pass.
+
+- [ ] **Step 2: Manual smoke (single-agent, claude-code)**
+
+Launch the mac app against the gateway, set a chat to a claude-code agent on a model that emits extended thinking, and send a prompt that triggers reasoning. Verify:
+- While the agent thinks, a live "Hide thinking" block streams the reasoning.
+- When the answer starts, the block auto-collapses to "Show thinking" and the full answer renders below, unfolded.
+- Clicking the toggle expands/collapses; the full answer text is never hidden.
+- Reopen the chat from history — the collapsed "Show thinking" is still available (persisted).
+
+- [ ] **Step 3: Manual smoke (team)**
+
+Run a `/team` task whose workers produce multi-paragraph output (e.g. a review + brainstorm). Verify:
+- Each step shows its FULL output (no paragraph is hidden) — the original bug is gone.
+- Steps whose worker emitted thinking show a per-step "Show thinking"; steps without thinking show none.
+
+- [ ] **Step 4: Manual smoke (no-thinking / other agent)**
+
+Send a prompt to an opencode or codex chat (no thinking capture). Verify the message renders full output with no ThinkingBlock ("无则不折").
+
+- [ ] **Step 5: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore: verification fixups for real thinking fold"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** capture (T2–T3) · transport (T4) · single-agent wire+persist (T5) · team wire+persist (T6) · reducer accumulate+persist (T7) · live + auto-collapse render (T8–T9) · delete fake fold (T9) · "无则不折" default (T9 Step 4, T10 Step 4) · persistence (T1 ChatMessage, T5/T6 persist, T10 Step 2) · testing (T2, T8, T9 Step 6, T10).
+- **Known soft spots to confirm during execution (not placeholders):** the exact local variable name for the run's `AgentResponse` at the gateway persist sites (T5 Step 2, T6 Step 3), and the exact team step variable (`step` vs `stepNum`) at each sink (T6 Step 2). These are explicitly flagged because the gateway file is large; confirm by reading the surrounding lines before editing.

--- a/docs/superpowers/specs/2026-06-07-real-thinking-fold-design.md
+++ b/docs/superpowers/specs/2026-06-07-real-thinking-fold-design.md
@@ -1,0 +1,151 @@
+# Real Thinking Fold — Design
+
+**Date:** 2026-06-07
+**Status:** Approved (pending spec review)
+
+## Problem
+
+In the codey-mac chat UI, completed team steps render through `StepBody`
+(`codey-mac/src/components/ChatTab.tsx`), which splits the worker's output by
+paragraph and **shows only the last paragraph by default**, collapsing every
+earlier paragraph behind a "Show thinking (N paragraphs)" toggle.
+
+This heuristic — "last paragraph = answer, everything before = collapsible
+thinking" — is wrong for substantive work. The earlier paragraphs usually carry
+the actual result (what was reviewed, what was decided, what was done), not
+throwaway reasoning. Collapsing them by default hides key information; e.g. a
+worker output ending in "That covers both the review and the brainstorming"
+leaves only that closing line visible and the substance hidden.
+
+There is no real "thinking" signal today: the claude-code adapter only consumes
+`text_delta` events and silently drops the model's actual extended-thinking
+blocks. The UI fakes thinking by paragraph position.
+
+## Goal
+
+Replace fake paragraph-position folding with a real one, governed by one rule:
+
+> **有真用真,无则不折** — if the agent emits real extended-thinking, capture it
+> and fold *that* (answer text never folds); if there is no real thinking signal,
+> do not fold at all.
+
+## Decisions (locked)
+
+- **Signal source:** real model extended-thinking when available; otherwise no
+  fold. Drop the paragraph-position heuristic entirely.
+- **Scope:** unified across all assistant messages (regular + team steps). Real
+  thinking capture is implemented for **claude-code first**; codex/opencode fall
+  to the safe "no signal → no fold" default until later.
+- **Streaming UX:** thinking displays live while the model is thinking, then
+  auto-collapses once answer text begins (matching the official Claude UI).
+- **Persistence:** thinking is persisted on the message record (collapsed), so
+  reopening a chat can still expand it. Accepted cost: slightly larger messages.
+- **Transport:** dedicated `thinking` stream event (not inline-tagged text).
+- **Delivery shape:** two layers.
+  - **L0 (stop the bleeding):** remove the `StepBody` fake fold → team steps show
+    full output. This alone resolves the information-loss complaint.
+  - **L1 (enhancement):** real thinking channel adapter → transport → render.
+
+## Data Flow
+
+```
+claude-code CLI (stream-json: thinking content blocks)
+  → ClaudeCodeAdapter captures thinking_delta
+      → request.onThinking(text)            (live)
+      → AgentResponse.thinking              (final, for persistence)
+  → gateway emits ChatStreamEvent { type:'thinking', token, step? }
+  → codey-mac useChats reducer accumulates (per-message / per-step)
+  → ChatTab <ThinkingBlock> renders: live while thinking, auto-collapse on answer
+  → answer body rendered in full, never folded
+persistence: thinking stored on the message record (collapsed by default)
+```
+
+## Components
+
+### 1. Adapter capture — `packages/core/src/agents/claude-code.ts`
+
+- Extend the local `StreamEvent` type: `event.delta` gains `thinking?: string`
+  (alongside existing `text?`). `content_block.type` already present.
+- In `processEvent`:
+  - `content_block_start` with `cb.type === 'thinking'` → enter thinking-collect
+    state.
+  - `content_block_delta` with `delta.type === 'thinking_delta'` → accumulate
+    `thinkingText += delta.thinking` and call `request.onThinking?.(delta.thinking)`;
+    set `streamedThinkingFromDeltas = true`.
+  - Final `assistant` event: a `block.type === 'thinking'` with `block.thinking`
+    is accumulated only if `!streamedThinkingFromDeltas` (mirrors the existing
+    text de-dup at lines 206–212).
+  - `redacted_thinking` blocks (no plaintext) → skipped, nothing emitted.
+- Return `thinking: thinkingText.trim() || undefined` on `AgentResponse`.
+
+### 2. Type contract — `packages/core/src/types/index.ts`
+
+- `AgentRequest.onThinking?: (text: string) => void`
+- `AgentResponse.thinking?: string`
+
+### 3. Transport — `packages/gateway/src/chat-runner.ts` + `gateway.ts`
+
+- `ChatStreamEvent` gains `| { type: 'thinking'; chatId: string; token: string; step?: number }`.
+- `done` event gains `thinking?: string` (regular single-agent messages).
+- Regular chat paths (`gateway.ts` ~2860 / ~2910): wire
+  `onThinking: (t) => sink({ type:'thinking', chatId, token: t })`.
+- Team path: `runWorkerStep` threads `onThinking` through to the agent request
+  (near `gateway.ts:157`); each step tags its events with `step`:
+  `sink({ type:'thinking', chatId, token: t, step: stepNum })`.
+- Persistence: regular → `done.thinking = response.thinking`. Team → thinking
+  collected per step into `thinkingByStep` and stored with the message.
+  - **Open integration point:** the exact message persistence store was not
+    located during exploration. The first plan task is to find where chat
+    messages are persisted and add the optional thinking field there. The design
+    contract is: "an optional thinking payload hangs off the message record"
+    (string for single-agent, step-keyed map for team).
+
+### 4. Render — `codey-mac/src/hooks/useChats.tsx` + `ChatTab.tsx`
+
+- `ChatMessage` gains `thinking?: string` and `thinkingByStep?: Record<number, string>`.
+- Reducer: new `case 'thinking'` accumulates into in-flight state
+  (regular → `thinking`; team → `thinkingByStep[step]`) and sets
+  `agentStatus: 'thinking'`. The first answer `stream` token flips status to
+  `'writing'` (existing behavior) — this is the **auto-collapse trigger**.
+  `completeSend` writes thinking onto the persisted message.
+- New `<ThinkingBlock>` component:
+  - Thinking phase (streaming, answer not yet started) → expanded, live.
+  - Answer started / message complete → collapsed by default with a
+    "Show thinking" toggle; manual toggle wins (reuse the existing
+    `expandedSteps` Set keyed per block).
+- **Remove the `StepBody` paragraph-split fake fold (L0).** Team steps render
+  `<ThinkingBlock>` (that step's thinking) + full output. `splitParagraphs` is
+  removed (its only consumer is `StepBody`).
+- Regular assistant messages: when `msg.thinking` is present, render
+  `<ThinkingBlock>` above the full `<Markdown>` body.
+
+## Error Handling / Edge Cases
+
+- No thinking emitted (model didn't think, or non-claude-code agent) → field is
+  `undefined` → no fold, full output shown ("无则不折").
+- Thinking present but empty after trim → treated as none.
+- `redacted_thinking` → not displayed.
+- Stream interrupted (stop / error) → accumulated thinking is best-effort
+  retained, consistent with how partial content is handled today.
+- Team run where some workers think and others don't → per-step keyed,
+  independent; absent steps simply show no ThinkingBlock.
+
+## Testing
+
+- **Adapter unit test:** feed synthetic stream-json containing thinking blocks;
+  assert the `onThinking` call sequence and final `AgentResponse.thinking`.
+  Cover: deltas only, final-assistant-only (no deltas), redacted, none.
+- **Reducer unit test:** thinking tokens accumulate; `agentStatus` transitions
+  thinking → writing; `completeSend` persists; team thinking groups by step.
+- **`teamMessageFormat` regression:** body parsing unaffected (thinking is no
+  longer inline).
+- **ThinkingBlock behavior:** auto-collapse on answer start, manual toggle
+  override — component or manual verification.
+- **Environment note:** vitest/tsc require nvm `v22.17.1`; a fresh worktree needs
+  dependency reinstall + build of core and gateway.
+
+## Out of Scope
+
+- Real thinking capture for codex / opencode (they fall to "no fold" for now).
+- Any change to the team message text format / `parseTeamMessage` (thinking is
+  carried out-of-band, not inline).

--- a/docs/superpowers/specs/2026-06-10-resume-streaming-unification-followup.md
+++ b/docs/superpowers/specs/2026-06-10-resume-streaming-unification-followup.md
@@ -1,0 +1,54 @@
+# Resume Streaming Unification — Follow-up Stub
+
+**Date:** 2026-06-10
+**Status:** Not started — captured as follow-up from the real-thinking-fold work.
+
+## Why this exists
+
+The real-thinking-fold feature (`2026-06-07-real-thinking-fold-design.md`) wired
+extended-thinking through the **primary** team path (`runTeamForChat`:
+sequential, manager/auto, parallel) — live step-tagged streaming plus
+`thinkingByStep` persisted on the assistant `ChatMessage`.
+
+It does **not** cover the **pause/resume** path (`resumeTeamFromAnswer` +
+`runAllMembersInOrder` in `packages/gateway/src/gateway.ts`). That path is a
+separate, older mechanism with a different contract:
+
+- Streams via `sendResponse` (channel chunking), not the chat `sink` — so no
+  token-level streaming and no `thinking` stream events.
+- Emits the legacy `📊 Team {name} results\n\n...` format, **not** the
+  `### Step N:` structure that `parseTeamMessage` + the mac `ThinkingBlock`
+  rendering depend on.
+- Truncates each worker's output to 500 chars.
+- Returns `void` and does not build a structured `thinkingByStep`-bearing
+  `ChatMessage`.
+
+Because of this, surfacing thinking on resume is blocked on a larger change:
+**unifying the resume path onto the same sink + structured-message pipeline as
+`runTeamForChat`.** That is a refactor of resume behavior for all surfaces
+(Telegram/Discord included), with its own pause-re-pause state edges — out of
+scope for the thinking feature and deserving its own brainstorm.
+
+## Goal (when picked up)
+
+Make a resumed team run behave like a fresh one from the UI's perspective:
+- stream worker output (and thinking) token-by-token through the chat `sink`,
+- emit the `### Step N:` structured format,
+- stop truncating output,
+- persist a `thinkingByStep`-bearing assistant `ChatMessage` (merging steps
+  completed before the pause with steps run after resume).
+
+## Scope notes / open questions
+
+- Does the resume path need to keep the channel-text behavior for non-mac
+  surfaces, or can all surfaces move to the unified pipeline?
+- How to merge pre-pause steps (currently in `pending.partsSoFar`) with
+  post-resume steps into one structured message + one `thinkingByStep` map.
+- Re-pause during a resumed run (worker asks again) must round-trip the
+  accumulated thinking through `pendingTeam` — which is why the dead
+  `pending.thinkingByStep` field would come back, this time actually read.
+
+## Not doing now
+
+This stub is intentionally not a full design. Start with the
+`superpowers:brainstorming` skill when this is prioritized.

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -2,7 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { AgentRequest, AgentResponse, AgentStateEntry, StatusUpdate } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
-import { thinkingDeltaFrom, isThinkingBlockStart } from './thinking-stream';
+import { thinkingDeltaFrom } from './thinking-stream';
 
 interface StreamEvent {
   type: string;
@@ -26,6 +26,7 @@ interface StreamEvent {
     content: Array<{
       type: string;
       text?: string;
+      thinking?: string;   // thinking block: reasoning text
       name?: string;       // tool_use block: tool name
       id?: string;         // tool_use block: call id
       input?: Record<string, unknown>; // tool_use block: input
@@ -178,8 +179,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
             collectingAskUser = true;
             askUserInputJson = '';
           }
-          // thinking blocks need no setup; isThinkingBlockStart kept for symmetry/future use
-          void isThinkingBlockStart;
+          // thinking blocks need no start-time setup; captured in the delta branch below
         } else if (event.type === 'stream_event' && event.event?.type === 'content_block_delta') {
           const thinking = thinkingDeltaFrom(event);
           if (thinking !== null) {
@@ -216,9 +216,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
           }
         } else if (event.type === 'assistant' && event.message?.content) {
           for (const block of event.message.content) {
-            if (block.type === 'thinking' && (block as any).thinking) {
+            if (block.type === 'thinking' && block.thinking) {
               if (!streamedThinkingFromDeltas) {
-                thinkingText += (block as any).thinking;
+                thinkingText += block.thinking;
               }
             } else if (block.type === 'text' && block.text) {
               if (!streamedFromDeltas) {

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { AgentRequest, AgentResponse, AgentStateEntry, StatusUpdate } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
+import { thinkingDeltaFrom, isThinkingBlockStart } from './thinking-stream';
 
 interface StreamEvent {
   type: string;
@@ -40,7 +41,7 @@ interface StreamEvent {
   // stream_event (emitted with --include-partial-messages)
   event?: {
     type: string;
-    delta?: { type?: string; text?: string };
+    delta?: { type?: string; text?: string; thinking?: string };
     content_block?: { type?: string; name?: string; id?: string };
   };
   // permission_denials in result event
@@ -163,6 +164,8 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       // UI updates token-by-token; the final assistant event then re-emits
       // the same text in one block — skip the onStream call there to avoid
       // double-rendering, but still record blocks (tool_use) and tally.
+      let thinkingText = '';
+      let streamedThinkingFromDeltas = false;
       let streamedFromDeltas = false;
       const processEvent = (event: StreamEvent) => {
         this.debug(`[claude-code] Event: ${event.type} ${event.subtype || ''}`);
@@ -175,7 +178,15 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
             collectingAskUser = true;
             askUserInputJson = '';
           }
+          // thinking blocks need no setup; isThinkingBlockStart kept for symmetry/future use
+          void isThinkingBlockStart;
         } else if (event.type === 'stream_event' && event.event?.type === 'content_block_delta') {
+          const thinking = thinkingDeltaFrom(event);
+          if (thinking !== null) {
+            thinkingText += thinking;
+            request.onThinking?.(thinking);
+            streamedThinkingFromDeltas = true;
+          }
           const delta = event.event.delta;
           if (delta?.type === 'text_delta' && delta.text) {
             streamedText += delta.text;
@@ -205,7 +216,11 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
           }
         } else if (event.type === 'assistant' && event.message?.content) {
           for (const block of event.message.content) {
-            if (block.type === 'text' && block.text) {
+            if (block.type === 'thinking' && (block as any).thinking) {
+              if (!streamedThinkingFromDeltas) {
+                thinkingText += (block as any).thinking;
+              }
+            } else if (block.type === 'text' && block.text) {
               if (!streamedFromDeltas) {
                 streamedText += block.text;
                 request.onStream?.(block.text);
@@ -363,7 +378,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
           resp.userQuestion = userQuestion;
           safeResolve(resp);
         } else if (code === 0 && output) {
-          safeResolve(this.createResponse(output, true, tokens, finalDuration, statusUpdates, states, permissionDenials));
+          const successResp = this.createResponse(output, true, tokens, finalDuration, statusUpdates, states, permissionDenials);
+          successResp.thinking = thinkingText.trim() || undefined;
+          safeResolve(successResp);
         } else {
           // Clear session on failure to avoid "session already in use" errors
           this.sessionId = undefined;

--- a/packages/core/src/agents/thinking-stream.test.ts
+++ b/packages/core/src/agents/thinking-stream.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { thinkingDeltaFrom, isThinkingBlockStart } from './thinking-stream';
+
+describe('thinkingDeltaFrom', () => {
+  it('extracts text from a thinking_delta', () => {
+    expect(thinkingDeltaFrom({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'hm ' } },
+    })).toBe('hm ');
+  });
+
+  it('returns null for a text_delta', () => {
+    expect(thinkingDeltaFrom({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'answer' } },
+    })).toBeNull();
+  });
+
+  it('returns null for non-delta events', () => {
+    expect(thinkingDeltaFrom({ type: 'assistant' })).toBeNull();
+  });
+});
+
+describe('isThinkingBlockStart', () => {
+  it('is true for a thinking content_block_start', () => {
+    expect(isThinkingBlockStart({
+      type: 'stream_event',
+      event: { type: 'content_block_start', content_block: { type: 'thinking' } },
+    })).toBe(true);
+  });
+
+  it('is false for a tool_use start', () => {
+    expect(isThinkingBlockStart({
+      type: 'stream_event',
+      event: { type: 'content_block_start', content_block: { type: 'tool_use', name: 'Read' } },
+    })).toBe(false);
+  });
+
+  it('ignores redacted_thinking (no plaintext to show)', () => {
+    expect(isThinkingBlockStart({
+      type: 'stream_event',
+      event: { type: 'content_block_start', content_block: { type: 'redacted_thinking' } },
+    })).toBe(false);
+  });
+});

--- a/packages/core/src/agents/thinking-stream.ts
+++ b/packages/core/src/agents/thinking-stream.ts
@@ -1,0 +1,27 @@
+/** Minimal shape of a claude-code stream-json event we inspect for thinking. */
+export interface ThinkingProbe {
+  type?: string;
+  event?: {
+    type?: string;
+    delta?: { type?: string; thinking?: string; text?: string };
+    content_block?: { type?: string; name?: string };
+  };
+}
+
+/** Returns the thinking text of a thinking_delta event, or null if not one. */
+export function thinkingDeltaFrom(event: ThinkingProbe): string | null {
+  if (event.type !== 'stream_event') return null;
+  if (event.event?.type !== 'content_block_delta') return null;
+  const delta = event.event.delta;
+  if (delta?.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+    return delta.thinking;
+  }
+  return null;
+}
+
+/** True when this event opens a (non-redacted) thinking content block. */
+export function isThinkingBlockStart(event: ThinkingProbe): boolean {
+  if (event.type !== 'stream_event') return false;
+  if (event.event?.type !== 'content_block_start') return false;
+  return event.event.content_block?.type === 'thinking';
+}

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -30,6 +30,10 @@ export interface ChatMessage {
   tokens?: number;
   /** Wall-clock seconds the agent took to produce the response. */
   durationSec?: number;
+  /** Extended-thinking for a single-agent assistant message (collapsed in UI). */
+  thinking?: string;
+  /** Per-team-step extended-thinking, keyed by step number. */
+  thinkingByStep?: Record<number, string>;
   /** Option labels when this assistant message ended in [ASK_USER:choice]. */
   choices?: string[];
   /** Structured question from AskUserQuestion tool call, with option descriptions. */

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -107,6 +107,8 @@ export interface AgentRequest {
   interactive?: boolean;
   skipPermissions?: boolean;
   onStream?: (text: string) => void;
+  /** Streamed extended-thinking text (model reasoning), separate from the answer. */
+  onThinking?: (text: string) => void;
   onStatus?: (update: StatusUpdate) => void;
   context?: {
     files?: string[];
@@ -165,6 +167,8 @@ export interface AgentStateEntry {
 export interface AgentResponse {
   success: boolean;
   output: string;
+  /** Full extended-thinking text captured this run, if the model emitted any. */
+  thinking?: string;
   error?: string;
   tokens?: {
     total: number;

--- a/packages/core/src/types/pending-team.ts
+++ b/packages/core/src/types/pending-team.ts
@@ -27,6 +27,8 @@ export type PendingTeamState =
       /** Warm worker sessions captured at pause; rehydrated on resume so the
        *  next step's prompt continues `--resume`-ing instead of re-bootstrapping. */
       workerAnchors?: Record<string, WorkerAnchor>;
+      /** Per-step extended-thinking captured before the pause. */
+      thinkingByStep?: Record<number, string>;
     }
   | {
       teamName: string;
@@ -46,4 +48,6 @@ export type PendingTeamState =
       /** Warm worker sessions captured at pause; rehydrated on resume so the
        *  next step's prompt continues `--resume`-ing instead of re-bootstrapping. */
       workerAnchors?: Record<string, WorkerAnchor>;
+      /** Per-step extended-thinking captured before the pause. */
+      thinkingByStep?: Record<number, string>;
     };

--- a/packages/core/src/types/pending-team.ts
+++ b/packages/core/src/types/pending-team.ts
@@ -27,8 +27,6 @@ export type PendingTeamState =
       /** Warm worker sessions captured at pause; rehydrated on resume so the
        *  next step's prompt continues `--resume`-ing instead of re-bootstrapping. */
       workerAnchors?: Record<string, WorkerAnchor>;
-      /** Per-step extended-thinking captured before the pause. */
-      thinkingByStep?: Record<number, string>;
     }
   | {
       teamName: string;
@@ -48,6 +46,4 @@ export type PendingTeamState =
       /** Warm worker sessions captured at pause; rehydrated on resume so the
        *  next step's prompt continues `--resume`-ing instead of re-bootstrapping. */
       workerAnchors?: Record<string, WorkerAnchor>;
-      /** Per-step extended-thinking captured before the pause. */
-      thinkingByStep?: Record<number, string>;
     };

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       'src/discussion/parallel-advisor.test.ts',
       'src/task-brief.test.ts',
       'src/aide-tasks.test.ts',
+      'src/agents/thinking-stream.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -9,7 +9,8 @@ export type ChatStreamEvent =
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string }
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
+  | { type: 'thinking'; chatId: string; token: string; step?: number }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -137,6 +137,7 @@ export class Codey {
     modelConfig: ModelConfig | undefined;
     buildBootstrapPrompt: () => string;
     onStream?: (text: string) => void;
+    onThinking?: (text: string) => void;
     onStatus?: (update: any) => void;
     signal?: AbortSignal;
     workingDir?: string;
@@ -155,6 +156,7 @@ export class Codey {
       model: opts.modelConfig,
       context: { workingDir: opts.workingDir ?? this.workingDir },
       onStream: opts.onStream,
+      onThinking: opts.onThinking,
       onStatus: opts.onStatus,
       signal: opts.signal,
       interactive: opts.interactive,
@@ -2327,7 +2329,8 @@ Example: /model gpt-4.1 write a Python script`;
       codingAgent: CodingAgent,
       modelConfig: ModelConfig | undefined,
       blackboard: TeamBlackboard,
-    ): Promise<{ success: boolean; output: string; error?: string }> => {
+      onThinking?: (text: string) => void,
+    ): Promise<{ success: boolean; output: string; error?: string; thinking?: string }> => {
       const onStream = handler?.streamText ? (text: string) => handler.streamText!(text) : undefined;
       const { response } = await this.runWorkerStep({
         conversationId: teamConv,
@@ -2338,12 +2341,13 @@ Example: /model gpt-4.1 write a Python script`;
         modelConfig,
         buildBootstrapPrompt: () => this.wrapPromptWithMemory(prompt, task, workerName),
         onStream,
+        onThinking,
         interactive: this.tuiMode,
         skipPermissions: !this.tuiMode && this.getSkipPermissions(),
       });
       this.extractWorkerMemories(workerName, task, codingAgent, response);
       return response.success
-        ? { success: true, output: response.output }
+        ? { success: true, output: response.output, thinking: response.thinking || undefined }
         : { success: false, output: '', error: response.error };
     };
 
@@ -2497,7 +2501,8 @@ Example: /model gpt-4.1 write a Python script`;
       codingAgent: CodingAgent,
       modelConfig: ModelConfig | undefined,
       blackboard: TeamBlackboard,
-    ): Promise<{ success: boolean; output: string; error?: string }> => {
+      onThinking?: (text: string) => void,
+    ): Promise<{ success: boolean; output: string; error?: string; thinking?: string }> => {
       const onStream = handler?.streamText ? (text: string) => handler.streamText!(text) : undefined;
       const { response } = await this.runWorkerStep({
         conversationId: teamConv,
@@ -2508,12 +2513,13 @@ Example: /model gpt-4.1 write a Python script`;
         modelConfig,
         buildBootstrapPrompt: () => this.wrapPromptWithMemory(prompt, pending.task, workerName),
         onStream,
+        onThinking,
         interactive: this.tuiMode,
         skipPermissions: !this.tuiMode && this.getSkipPermissions(),
       });
       this.extractWorkerMemories(workerName, pending.task, codingAgent, response);
       return response.success
-        ? { success: true, output: response.output }
+        ? { success: true, output: response.output, thinking: response.thinking || undefined }
         : { success: false, output: '', error: response.error };
     };
 
@@ -2848,7 +2854,8 @@ Example: /model gpt-4.1 write a Python script`;
       codingAgent: CodingAgent,
       modelConfig: ModelConfig | undefined,
       blackboard: TeamBlackboard,
-    ): Promise<{ success: boolean; output: string; error?: string }> => {
+      onThinking?: (text: string) => void,
+    ): Promise<{ success: boolean; output: string; error?: string; thinking?: string }> => {
       const { response } = await this.runWorkerStep({
         conversationId: teamConv,
         workerName,
@@ -2858,13 +2865,14 @@ Example: /model gpt-4.1 write a Python script`;
         modelConfig,
         buildBootstrapPrompt: () => this.wrapPromptWithMemory(workerPrompt, prompt, workerName),
         onStream: (text: string) => sink({ type: 'stream', chatId, token: text }),
+        onThinking,
         onStatus: (_update: any) => { /* status forwarded via sink elsewhere */ },
         signal,
         workingDir,
       });
       if (response) this.extractWorkerMemories(workerName, prompt, codingAgent, response);
       return response?.success
-        ? { success: true, output: this.formatAgentResponse(response) }
+        ? { success: true, output: this.formatAgentResponse(response), thinking: response.thinking || undefined }
         : { success: false, output: '', error: response?.error };
     };
 
@@ -2908,6 +2916,7 @@ Example: /model gpt-4.1 write a Python script`;
           model: chatModel ?? this.getDefaultModelConfig(chatAgent ?? this.getDefaultAgent() as CodingAgent),
           context: { workingDir },
           onStream: (text: string) => sink({ type: 'stream', chatId, token: text }),
+          onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text }),
           onStatus: (_update: any) => { /* status forwarded via sink elsewhere */ },
           signal: req.signal,
         }),
@@ -2919,6 +2928,7 @@ Example: /model gpt-4.1 write a Python script`;
             model: mModel,
             context: { workingDir },
             onStream: () => {},
+            onThinking: () => {},
             onStatus: () => {},
             signal: req.signal,
           });
@@ -3067,7 +3077,8 @@ Example: /model gpt-4.1 write a Python script`;
       const codingAgent = (workerManager.getWorkerCodingAgent(memberName) ?? chatAgent ?? this.getDefaultAgent()) as CodingAgent;
       const workerModel = workerManager.getWorkerModel(memberName);
       const modelConfig = workerModel ? this.getModelConfig(codingAgent, workerModel) : chatModel ?? this.getDefaultModelConfig(codingAgent);
-      const response = await runOneWorker(memberName, stepPrompt, codingAgent, modelConfig, blackboard);
+      const response = await runOneWorker(memberName, stepPrompt, codingAgent, modelConfig, blackboard,
+        (text: string) => sink({ type: 'thinking', chatId, token: text, step: stepNum }));
       if (!response.success) {
         parts.push(`### Step ${stepNum}: ${memberName}\n\n`);
         break;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2061,7 +2061,6 @@ Example: /model gpt-4.1 write a Python script`;
           options?: string[];
         };
         blackboard: TeamBlackboard;
-        thinkingByStep?: Record<number, string>;
       }
   > {
     const workerManager = this.workspaceManager.getWorkerManager();
@@ -2150,7 +2149,6 @@ Example: /model gpt-4.1 write a Python script`;
               options: pendingArbitration.options,
             },
             blackboard,
-            thinkingByStep,
           };
         }
         if (turn.done || !turn.next) {
@@ -2485,6 +2483,12 @@ Example: /model gpt-4.1 write a Python script`;
     pending: PendingTeamState,
     answer: string,
   ): Promise<void> {
+    // NOTE: this resume path streams via sendResponse and emits the legacy
+    // "📊 Team results" format (not the `### Step` structure parsed by the mac
+    // UI), so extended-thinking is intentionally NOT surfaced here. Showing
+    // per-step thinking on resume requires first unifying this path onto the
+    // same sink + structured-message pipeline as runTeamForChat — tracked as a
+    // follow-up (see docs/superpowers/specs/...-resume-streaming-unification).
     const team = this.workspaceManager.getTeam(pending.teamName);
     if (!team) {
       await this.sendResponse({
@@ -3038,7 +3042,6 @@ Example: /model gpt-4.1 write a Python script`;
           blackboard: result.blackboard.toJSON(),
           askedAt: Date.now(),
           workerAnchors: this.snapshotWorkerAnchors(teamConv),
-          thinkingByStep: result.thinkingByStep,
         });
         const rendered5 = renderQuestion(askWorkerName, '', p.question, p.options);
         sink({ type: 'stream', chatId, token: rendered5.text });
@@ -3110,11 +3113,10 @@ Example: /model gpt-4.1 write a Python script`;
           askedAt: Date.now(),
           blackboard: blackboard.toJSON(),
           workerAnchors: this.snapshotWorkerAnchors(teamConv),
-          thinkingByStep,
         });
         const rendered6 = renderQuestion(askWorkerName, ask.preamble, ask.question, ask.options);
         sink({ type: 'stream', chatId, token: rendered6.text });
-        return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + rendered6.text : rendered6.text, choices: rendered6.choices, thinkingByStep };
+        return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + rendered6.text : rendered6.text, choices: rendered6.choices };
       }
       parts.push(`### Step ${stepNum}: ${memberName}\n\n${cleanOutput}`);
       carry = cleanOutput;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2035,7 +2035,7 @@ Example: /model gpt-4.1 write a Python script`;
       | { kind: 'route'; step: number; worker: string; reason: string; isRevision: boolean }
       | { kind: 'blackboard'; step: number; worker: string; summary: string }
     ) => void | Promise<void>,
-    runWorker: (worker: string, prompt: string, codingAgent: CodingAgent, modelConfig: ModelConfig | undefined, blackboard: TeamBlackboard) => Promise<{ success: boolean; output: string; error?: string }>,
+    runWorker: (worker: string, prompt: string, codingAgent: CodingAgent, modelConfig: ModelConfig | undefined, blackboard: TeamBlackboard) => Promise<{ success: boolean; output: string; error?: string; thinking?: string }>,
   ): Promise<
     | { fallback: true; fallbackReason: string }
     | {
@@ -2045,6 +2045,7 @@ Example: /model gpt-4.1 write a Python script`;
         finalSummary: string;
         fallbackMidRun?: { reason: string };
         blackboard: TeamBlackboard;
+        thinkingByStep?: Record<number, string>;
       }
     | {
         fallback: false;
@@ -2060,6 +2061,7 @@ Example: /model gpt-4.1 write a Python script`;
           options?: string[];
         };
         blackboard: TeamBlackboard;
+        thinkingByStep?: Record<number, string>;
       }
   > {
     const workerManager = this.workspaceManager.getWorkerManager();
@@ -2074,6 +2076,7 @@ Example: /model gpt-4.1 write a Python script`;
     let finalSummary = '';
     let fallbackMidRun: { reason: string } | undefined;
     const blackboard = new TeamBlackboard();
+    const thinkingByStep: Record<number, string> = {};
 
     const { agent: mAgent, model: mModel } = this.getAdvisorAgentAndModel();
     const seenWorkers = new Set<string>();
@@ -2147,6 +2150,7 @@ Example: /model gpt-4.1 write a Python script`;
               options: pendingArbitration.options,
             },
             blackboard,
+            thinkingByStep,
           };
         }
         if (turn.done || !turn.next) {
@@ -2192,6 +2196,7 @@ Example: /model gpt-4.1 write a Python script`;
         fallbackMidRun = { reason: `worker ${turnNext} failed: ${response.error ?? 'unknown'}` };
         break;
       }
+      if (response.thinking) thinkingByStep[step] = response.thinking;
       // Pull structured markers out before anything downstream sees the
       // output — users get clean prose, blackboard collects the structure.
       const ingested = blackboard.ingest(turnNext, step, response.output);
@@ -2249,7 +2254,7 @@ Example: /model gpt-4.1 write a Python script`;
       if (!closing.fallback) finalSummary = closing.final_summary ?? '';
     }
 
-    return { fallback: false, parts, finalSummary, fallbackMidRun, blackboard };
+    return { fallback: false, parts, finalSummary, fallbackMidRun, blackboard, thinkingByStep };
   }
 
   private composeStepTask(
@@ -2840,7 +2845,7 @@ Example: /model gpt-4.1 write a Python script`;
     opts: { forceAll?: boolean } = {},
     chatAgent?: CodingAgent,
     chatModel?: ModelConfig,
-  ): Promise<{ response: string; tokens?: number; choices?: string[] }> {
+  ): Promise<{ response: string; tokens?: number; choices?: string[]; thinkingByStep?: Record<number, string> }> {
     if (!team || !team.members || team.members.length === 0) {
       throw new Error(`Team not found or empty: ${teamName}`);
     }
@@ -3033,6 +3038,7 @@ Example: /model gpt-4.1 write a Python script`;
           blackboard: result.blackboard.toJSON(),
           askedAt: Date.now(),
           workerAnchors: this.snapshotWorkerAnchors(teamConv),
+          thinkingByStep: result.thinkingByStep,
         });
         const rendered5 = renderQuestion(askWorkerName, '', p.question, p.options);
         sink({ type: 'stream', chatId, token: rendered5.text });
@@ -3047,7 +3053,7 @@ Example: /model gpt-4.1 write a Python script`;
         const bbBlock = result.blackboard.renderForUser();
         const formatted = this.formatManagerParts(result.parts, result.finalSummary);
         this.persistBlackboardDecisions(result.blackboard, teamName);
-        return { response: bbBlock ? `${formatted}\n\n${bbBlock}` : formatted };
+        return { response: bbBlock ? `${formatted}\n\n${bbBlock}` : formatted, thinkingByStep: result.thinkingByStep };
       }
     }
 
@@ -3055,6 +3061,7 @@ Example: /model gpt-4.1 write a Python script`;
     let carry = prompt;
     const parts: string[] = [];
     const blackboard = new TeamBlackboard();
+    const thinkingByStep: Record<number, string> = {};
     for (let i = 0; i < team.members.length; i++) {
       if (signal?.aborted) break;
       const memberName = team.members[i];
@@ -3083,6 +3090,7 @@ Example: /model gpt-4.1 write a Python script`;
         parts.push(`### Step ${stepNum}: ${memberName}\n\n`);
         break;
       }
+      if (response.thinking) thinkingByStep[stepNum] = response.thinking;
       const ingested = blackboard.ingest(memberName, stepNum, response.output);
       const cleanOutput = ingested.stripped;
       const deltaSummary = blackboard.summarizeDelta(ingested.added);
@@ -3102,10 +3110,11 @@ Example: /model gpt-4.1 write a Python script`;
           askedAt: Date.now(),
           blackboard: blackboard.toJSON(),
           workerAnchors: this.snapshotWorkerAnchors(teamConv),
+          thinkingByStep,
         });
         const rendered6 = renderQuestion(askWorkerName, ask.preamble, ask.question, ask.options);
         sink({ type: 'stream', chatId, token: rendered6.text });
-        return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + rendered6.text : rendered6.text, choices: rendered6.choices };
+        return { response: parts.length ? parts.join('\n\n---\n\n') + '\n\n' + rendered6.text : rendered6.text, choices: rendered6.choices, thinkingByStep };
       }
       parts.push(`### Step ${stepNum}: ${memberName}\n\n${cleanOutput}`);
       carry = cleanOutput;
@@ -3113,7 +3122,7 @@ Example: /model gpt-4.1 write a Python script`;
     const bbBlock = blackboard.renderForUser();
     this.persistBlackboardDecisions(blackboard, teamName);
     const body = parts.join('\n\n---\n\n');
-    return { response: bbBlock ? `${body}\n\n${bbBlock}` : body };
+    return { response: bbBlock ? `${body}\n\n${bbBlock}` : body, thinkingByStep };
   }
 
   private formatUptime(seconds: number): string {
@@ -3814,6 +3823,7 @@ Example: /model gpt-4.1 write a Python script`;
       let output = '';
       let tokens: number | undefined;
       let teamChoices: string[] | undefined;
+      let teamThinkingByStep: Record<number, string> | undefined;
       let agentUserQuestion: AgentResponse['userQuestion'];
       let singleAgentResponse: AgentResponse | null | undefined;
       if (chat.selection.type === 'team') {
@@ -3848,6 +3858,7 @@ Example: /model gpt-4.1 write a Python script`;
         output = r.response;
         tokens = r.tokens;
         teamChoices = r.choices;
+        teamThinkingByStep = r.thinkingByStep;
       } else {
         let response = await this.runWithFallback(agent, {
           prompt,
@@ -3939,6 +3950,7 @@ Example: /model gpt-4.1 write a Python script`;
         role: 'assistant',
         content: output,
         thinking: singleAgentResponse?.thinking,
+        thinkingByStep: teamThinkingByStep,
         timestamp: Date.now(),
         toolCalls,
         isComplete: true,

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3804,6 +3804,7 @@ Example: /model gpt-4.1 write a Python script`;
       let tokens: number | undefined;
       let teamChoices: string[] | undefined;
       let agentUserQuestion: AgentResponse['userQuestion'];
+      let singleAgentResponse: AgentResponse | null | undefined;
       if (chat.selection.type === 'team') {
         // Resolve the team from the chat's workspace.json (read above), not from
         // the active workspace, so a chat in workspace B uses B's team config
@@ -3844,6 +3845,7 @@ Example: /model gpt-4.1 write a Python script`;
           context: { workingDir },
           skipPermissions: this.getSkipPermissions(),
           onStream,
+          onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text }),
           onStatus,
           signal: abortController.signal,
           resumeSessionId,
@@ -3865,12 +3867,14 @@ Example: /model gpt-4.1 write a Python script`;
             context: { workingDir },
             skipPermissions: this.getSkipPermissions(),
             onStream,
+            onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text }),
             onStatus,
             signal: abortController.signal,
             resumeSessionId: undefined,
             newSessionId,
           });
         }
+        singleAgentResponse = response;
         output = response?.success ? this.formatAgentResponse(response) : (streamedText || '');
         tokens = (response as any)?.tokens?.total;
         // Persist the anchor on success for next-turn resume.
@@ -3923,6 +3927,7 @@ Example: /model gpt-4.1 write a Python script`;
         id: randomUUID(),
         role: 'assistant',
         content: output,
+        thinking: singleAgentResponse?.thinking,
         timestamp: Date.now(),
         toolCalls,
         isComplete: true,
@@ -3950,7 +3955,7 @@ Example: /model gpt-4.1 write a Python script`;
         }
       }
 
-      sink({ type: 'done', chatId, response: output, tokens, durationSec, title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion });
+      sink({ type: 'done', chatId, response: output, thinking: singleAgentResponse?.thinking, tokens, durationSec, title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion });
 
       // Mirror this turn to every attached route except the originating one.
       // Mac-origin uses a synthetic '__mac__' channel that matches no real


### PR DESCRIPTION
## Summary

Replaces codey-mac's fake "show thinking" paragraph fold with a real one driven by the model's actual extended-thinking. Rule: **real thinking → fold it (answer never folds); no thinking signal → no fold.**

- **Core**: capture `thinking`/`thinking_delta` blocks in the claude-code adapter via a pure, tested classifier; new `AgentRequest.onThinking` + `AgentResponse.thinking`; `ChatMessage.thinking`/`thinkingByStep`.
- **Gateway**: new `thinking` stream event; wired for single-agent chats and all primary team modes (sequential, manager/auto, parallel) with step-tagged live streaming and `thinkingByStep` persisted on the assistant message.
- **codey-mac**: reducer accumulates streamed thinking (per-message / per-step); new `ThinkingBlock` renders live then auto-collapses when the answer begins; deleted the old `StepBody` paragraph-position heuristic — team step output now shows in full.

## Not included (documented follow-up)

Pause/resume (`resumeTeamFromAnswer`) is a legacy channel path using a different output format/transport (`📊 Team results`, truncated, `sendResponse` not the sink), so thinking isn't surfaced there. Captured in `docs/superpowers/specs/2026-06-10-resume-streaming-unification-followup.md`.

## Test Plan

- [x] 118 unit tests pass (core 49, gateway 30, mac 39); all packages build & typecheck on node v22.17.1
- [ ] Manual: claude-code chat with extended-thinking — thinking streams live, auto-collapses on answer, toggle works, persists across reload
- [ ] Manual: `/team` run — each step shows full output; per-step "Show thinking" where the worker reasoned
- [ ] Manual: non-claude-code agent — full output, no ThinkingBlock

Design: \`docs/superpowers/specs/2026-06-07-real-thinking-fold-design.md\` · Plan: \`docs/superpowers/plans/2026-06-07-real-thinking-fold.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)