### PR TITLE
feat(codey-mac): gateway failure visibility — offline banner + Relaunch App

### DIFF
--- a/codey-mac/electron/core-state.test.ts
+++ b/codey-mac/electron/core-state.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createCoreStateStore } from './core-state'
+
+describe('createCoreStateStore', () => {
+  it('starts in booting phase without notifying', () => {
+    const notify = vi.fn()
+    const store = createCoreStateStore(notify)
+    expect(store.get()).toEqual({ phase: 'booting' })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('booting → ready notifies with the new state', () => {
+    const notify = vi.fn()
+    const store = createCoreStateStore(notify)
+    store.setReady()
+    expect(store.get()).toEqual({ phase: 'ready' })
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(notify).toHaveBeenCalledWith({ phase: 'ready' })
+  })
+
+  it('booting → failed carries the error message', () => {
+    const notify = vi.fn()
+    const store = createCoreStateStore(notify)
+    store.setFailed('ENOENT: gateway.json missing')
+    expect(store.get()).toEqual({ phase: 'failed', error: 'ENOENT: gateway.json missing' })
+    expect(notify).toHaveBeenCalledWith({ phase: 'failed', error: 'ENOENT: gateway.json missing' })
+  })
+
+  it('setBooting resets state (relaunch path) and notifies', () => {
+    const notify = vi.fn()
+    const store = createCoreStateStore(notify)
+    store.setFailed('boom')
+    store.setBooting()
+    expect(store.get()).toEqual({ phase: 'booting' })
+    expect(notify).toHaveBeenLastCalledWith({ phase: 'booting' })
+  })
+
+  it('a thrown notify callback does not corrupt state', () => {
+    const store = createCoreStateStore(() => { throw new Error('renderer gone') })
+    expect(() => store.setReady()).not.toThrow()
+    expect(store.get()).toEqual({ phase: 'ready' })
+  })
+})

--- a/codey-mac/electron/core-state.ts
+++ b/codey-mac/electron/core-state.ts
@@ -1,0 +1,30 @@
+// Pure state store for the in-process core's lifecycle phase. Kept free of
+// Electron imports so it is unit-testable; main.ts injects the notify
+// callback that forwards transitions to the renderer.
+export type CorePhase = 'booting' | 'ready' | 'failed'
+
+export interface CoreState {
+  phase: CorePhase
+  error?: string
+}
+
+export interface CoreStateStore {
+  get(): CoreState
+  setBooting(): void
+  setReady(): void
+  setFailed(error: string): void
+}
+
+export function createCoreStateStore(notify: (state: CoreState) => void): CoreStateStore {
+  let state: CoreState = { phase: 'booting' }
+  const set = (next: CoreState) => {
+    state = next
+    try { notify(state) } catch { /* renderer gone */ }
+  }
+  return {
+    get: () => state,
+    setBooting: () => set({ phase: 'booting' }),
+    setReady: () => set({ phase: 'ready' }),
+    setFailed: (error: string) => set({ phase: 'failed', error }),
+  }
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -824,6 +824,14 @@ app.whenReady().then(async () => {
     app.isPackaged,
     (m) => sendToRenderer('gateway-log', m),
   )
+  // Must be registered before the boot await: the renderer can mount and
+  // query core state while bootInProcessCore() is still running.
+  ipcMain.handle('core:state', async () =>
+    wrap(async () => coreStateStore.get())
+  )
+  ipcMain.handle('app:relaunch', async () =>
+    wrap(async () => { app.relaunch(); app.quit() })
+  )
   await bootInProcessCore()
 
   // Check Full Disk Access by probing the iMessage database.
@@ -851,12 +859,6 @@ app.whenReady().then(async () => {
   // ── Gateway status IPC ────────────────────────────────────────────
   ipcMain.handle('gateway:status', async () =>
     wrap(async () => inProcessGateway?.getHealthStatus() ?? null)
-  )
-  ipcMain.handle('core:state', async () =>
-    wrap(async () => coreStateStore.get())
-  )
-  ipcMain.handle('app:relaunch', async () =>
-    wrap(async () => { app.relaunch(); app.quit() })
   )
 
   // Renderer mounts after did-finish-load fires, so any logs sent during

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
 import { initAutoUpdater, registerUpdaterIpc } from './updater'
+import { createCoreStateStore } from './core-state'
 
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
@@ -16,6 +17,7 @@ let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let isQuitting = false
 let inProcessGateway: Codey | null = null
+const coreStateStore = createCoreStateStore((s) => sendToRenderer('core:state', s))
 let workerManager: WorkerManager | null = null
 let workspaceManager: WorkspaceManager | null = null
 let coreConfigManager: ConfigManager | null = null
@@ -414,6 +416,7 @@ function buildRuntimeConfig(json: any): any {
 }
 
 async function bootInProcessCore() {
+  coreStateStore.setBooting()
   const root = resolveDataRoot()
   try {
     coreConfigManager = new ConfigManager(join(root, 'gateway.json'))
@@ -502,8 +505,10 @@ async function bootInProcessCore() {
     inProcessGateway.setPairingEventListener((ev: any) => {
       sendToRenderer('pairing:event', ev)
     })
+    coreStateStore.setReady()
   } catch (err: any) {
     sendToRenderer('gateway-log', `[core] Boot failed: ${err?.message ?? err}`)
+    coreStateStore.setFailed(err?.message ?? String(err))
   }
 }
 
@@ -846,6 +851,12 @@ app.whenReady().then(async () => {
   // ── Gateway status IPC ────────────────────────────────────────────
   ipcMain.handle('gateway:status', async () =>
     wrap(async () => inProcessGateway?.getHealthStatus() ?? null)
+  )
+  ipcMain.handle('core:state', async () =>
+    wrap(async () => coreStateStore.get())
+  )
+  ipcMain.handle('app:relaunch', async () =>
+    wrap(async () => { app.relaunch(); app.quit() })
   )
 
   // Renderer mounts after did-finish-load fires, so any logs sent during

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -144,6 +144,15 @@ contextBridge.exposeInMainWorld('codey', {
     status: () => ipcRenderer.invoke('gateway:status'),
     recentLogs: () => ipcRenderer.invoke('gateway:recentLogs'),
   },
+  core: {
+    state: () => ipcRenderer.invoke('core:state'),
+    relaunch: () => ipcRenderer.invoke('app:relaunch'),
+    onState: (handler: (state: { phase: 'booting' | 'ready' | 'failed'; error?: string }) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, state: any) => handler(state)
+      ipcRenderer.on('core:state', listener)
+      return () => ipcRenderer.removeListener('core:state', listener)
+    },
+  },
   voice: {
     onHotkey: (handler: () => void) => {
       const listener = () => handler()

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import type { CoreState } from './core-state'
 
 contextBridge.exposeInMainWorld('codey', {
   workers: {
@@ -147,7 +148,7 @@ contextBridge.exposeInMainWorld('codey', {
   core: {
     state: () => ipcRenderer.invoke('core:state'),
     relaunch: () => ipcRenderer.invoke('app:relaunch'),
-    onState: (handler: (state: { phase: 'booting' | 'ready' | 'failed'; error?: string }) => void) => {
+    onState: (handler: (state: CoreState) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, state: any) => handler(state)
       ipcRenderer.on('core:state', listener)
       return () => ipcRenderer.removeListener('core:state', listener)

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -7,6 +7,7 @@ import { NotificationCenter } from './components/NotificationCenter'
 import { ChatsProvider, useChats } from './hooks/useChats'
 import { QuickQuestionProvider } from './hooks/useQuickQuestion'
 import { useGateway } from './hooks/useGateway'
+import { CoreOfflineBanner } from './components/CoreOfflineBanner'
 import {
   C,
   applyTheme,
@@ -22,7 +23,7 @@ import {
 } from './theme'
 
 const Shell: React.FC = () => {
-  const { isRunning } = useGateway()
+  const { isRunning, coreState, relaunchApp } = useGateway()
   const { state, createChat, selectChat, refreshWorkspaces } = useChats()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<string | undefined>(undefined)
@@ -110,12 +111,13 @@ const Shell: React.FC = () => {
           />
         )}
         <div style={styles.content}>
+          <CoreOfflineBanner state={coreState} onRelaunch={relaunchApp} />
           {activeChat && (
             <div
               key={activeChat.id}
               style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
             >
-              <ChatTab chatId={activeChat.id} isGatewayRunning={isRunning} />
+              <ChatTab chatId={activeChat.id} isGatewayRunning={isRunning} coreFailed={coreState.phase === 'failed'} />
             </div>
           )}
           {!activeChat && (

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -4,6 +4,7 @@ import type { TaskBrief } from '../types'
 import type { TeamConfigRaw } from '../../packages/core/src/workspace'
 import type { ApiKeyEntry } from '../../packages/core/src/types/index'
 import type { UpdaterEvent } from './hooks/updaterState'
+import type { CoreState } from '../electron/core-state'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
@@ -135,6 +136,11 @@ declare global {
           stats: { messagesProcessed: number; activeConversations: number; errors: number }
         } | null>>
         recentLogs: () => Promise<IpcResult<string[]>>
+      }
+      core: {
+        state: () => Promise<IpcResult<CoreState>>
+        relaunch: () => Promise<IpcResult<void>>
+        onState: (handler: (state: CoreState) => void) => () => void
       }
       voice: {
         onHotkey: (handler: () => void) => () => void

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -15,10 +15,12 @@ import { isTaskBriefStale } from './taskHudView'
 import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
+import { composerPlaceholder } from './coreOfflineView'
 
 interface Props {
   chatId: string
   isGatewayRunning: boolean
+  coreFailed?: boolean
 }
 
 const SendIcon: React.FC<{ color: string }> = ({ color }) => (
@@ -218,7 +220,7 @@ const TeamMessage: React.FC<{
   )
 }
 
-export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
+export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed }) => {
   const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, renameChat, setContextPanelOpen, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
@@ -725,7 +727,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
 
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
-  const canSend = isGatewayRunning && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
+  const canSend = isGatewayRunning && !coreFailed && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
   const statusLabel = flight?.queuedPosition
     ? `Queued (#${flight.queuedPosition})`
     : flight?.agentStatus === 'thinking' ? 'Thinking…'
@@ -1185,7 +1187,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
             />
             <button
               onClick={() => fileInputRef.current?.click()}
-              disabled={!isGatewayRunning || isSending}
+              disabled={!isGatewayRunning || !!coreFailed || isSending}
               style={styles.attachButton}
               title="Attach file"
             >
@@ -1202,8 +1204,8 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning }) => {
                 el.style.height = 'auto'
                 el.style.height = Math.min(el.scrollHeight, 120) + 'px'
               }}
-              placeholder={isGatewayRunning ? (isSending ? 'Sending…' : 'Message Codey… (↵ to send)') : 'Start gateway to chat'}
-              disabled={!isGatewayRunning}
+              placeholder={composerPlaceholder({ coreFailed: !!coreFailed, isGatewayRunning, isSending })}
+              disabled={!isGatewayRunning || !!coreFailed}
               rows={1}
               style={composerHeight != null
                 ? { ...styles.input, height: composerHeight, maxHeight: 'none' }

--- a/codey-mac/src/components/CoreOfflineBanner.tsx
+++ b/codey-mac/src/components/CoreOfflineBanner.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { C } from '../theme'
+import { coreBannerText } from './coreOfflineView'
+import type { CoreState } from '../../electron/core-state'
+
+export const CoreOfflineBanner: React.FC<{
+  state: CoreState
+  onRelaunch: () => void
+}> = ({ state, onRelaunch }) => {
+  const text = coreBannerText(state)
+  if (!text) return null
+  return (
+    <div style={styles.banner}>
+      <span style={styles.text} title={text}>⚠️ {text}</span>
+      <button type="button" onClick={onRelaunch} style={styles.button}>
+        Relaunch App
+      </button>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  banner: {
+    display: 'flex', alignItems: 'center', gap: 10,
+    padding: '8px 14px', flexShrink: 0,
+    background: C.dangerBg, borderBottom: `1px solid ${C.dangerBorder}`,
+    color: C.dangerFg, fontSize: 12,
+  },
+  text: {
+    flex: 1, minWidth: 0,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  button: {
+    background: 'transparent', border: `1px solid ${C.dangerBorder}`,
+    color: C.dangerFg, borderRadius: 5, padding: '3px 10px',
+    fontSize: 12, cursor: 'pointer', flexShrink: 0,
+  },
+}

--- a/codey-mac/src/components/coreOfflineView.test.ts
+++ b/codey-mac/src/components/coreOfflineView.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { coreBannerText, composerPlaceholder } from './coreOfflineView'
+
+describe('coreBannerText', () => {
+  it('returns null while booting and when ready', () => {
+    expect(coreBannerText({ phase: 'booting' })).toBeNull()
+    expect(coreBannerText({ phase: 'ready' })).toBeNull()
+  })
+
+  it('returns message with error detail when failed', () => {
+    expect(coreBannerText({ phase: 'failed', error: 'ENOENT: gateway.json' }))
+      .toBe("Codey's core failed to start: ENOENT: gateway.json")
+  })
+
+  it('returns generic message when failed without detail', () => {
+    expect(coreBannerText({ phase: 'failed' })).toBe("Codey's core failed to start.")
+    expect(coreBannerText({ phase: 'failed', error: '  ' })).toBe("Codey's core failed to start.")
+  })
+})
+
+describe('composerPlaceholder', () => {
+  it('core failure wins over everything', () => {
+    expect(composerPlaceholder({ coreFailed: true, isGatewayRunning: false, isSending: false }))
+      .toBe('Core offline — relaunch to continue')
+    expect(composerPlaceholder({ coreFailed: true, isGatewayRunning: true, isSending: true }))
+      .toBe('Core offline — relaunch to continue')
+  })
+
+  it('matches existing placeholders otherwise', () => {
+    expect(composerPlaceholder({ coreFailed: false, isGatewayRunning: false, isSending: false }))
+      .toBe('Start gateway to chat')
+    expect(composerPlaceholder({ coreFailed: false, isGatewayRunning: true, isSending: true }))
+      .toBe('Sending…')
+    expect(composerPlaceholder({ coreFailed: false, isGatewayRunning: true, isSending: false }))
+      .toBe('Message Codey… (↵ to send)')
+  })
+})

--- a/codey-mac/src/components/coreOfflineView.ts
+++ b/codey-mac/src/components/coreOfflineView.ts
@@ -1,0 +1,22 @@
+import type { CoreState } from '../../electron/core-state'
+
+// Pure view logic for the core-offline banner and composer, extracted for
+// unit testing (vitest runs in a node environment with no DOM).
+
+export function coreBannerText(state: CoreState | null | undefined): string | null {
+  if (!state || state.phase !== 'failed') return null
+  const detail = state.error?.trim()
+  return detail
+    ? `Codey's core failed to start: ${detail}`
+    : "Codey's core failed to start."
+}
+
+export function composerPlaceholder(opts: {
+  coreFailed: boolean
+  isGatewayRunning: boolean
+  isSending: boolean
+}): string {
+  if (opts.coreFailed) return 'Core offline — relaunch to continue'
+  if (!opts.isGatewayRunning) return 'Start gateway to chat'
+  return opts.isSending ? 'Sending…' : 'Message Codey… (↵ to send)'
+}

--- a/codey-mac/src/hooks/useGateway.ts
+++ b/codey-mac/src/hooks/useGateway.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import type { CoreState } from '../../electron/core-state'
 
 export interface GatewayStatus {
   status: 'healthy' | 'degraded' | 'stopped' | 'starting'
@@ -20,6 +21,7 @@ export const useGateway = () => {
   const [logs, setLogs] = useState<string[]>(['Gateway running in-process'])
   const [status, setStatus] = useState<GatewayStatus>(EMPTY_STATUS)
   const [isRunning, setIsRunning] = useState(false)
+  const [coreState, setCoreState] = useState<CoreState>({ phase: 'booting' })
 
   useEffect(() => {
     // The renderer subscribes after main has already emitted boot-time logs,
@@ -37,6 +39,17 @@ export const useGateway = () => {
     const off = window.codey.onLog(msg => {
       setLogs(prev => [...prev.slice(-99), msg])
     })
+    return () => { cancelled = true; off() }
+  }, [])
+
+  useEffect(() => {
+    // Same backfill-then-subscribe pattern: boot may have finished (or failed)
+    // before this component mounted.
+    let cancelled = false
+    window.codey.core.state().then(res => {
+      if (!cancelled && res.ok && res.data) setCoreState(res.data)
+    }).catch(() => {})
+    const off = window.codey.core.onState(s => setCoreState(s))
     return () => { cancelled = true; off() }
   }, [])
 
@@ -72,8 +85,7 @@ export const useGateway = () => {
     isRunning,
     status,
     logs,
-    start: async () => {},
-    stop: async () => {},
-    toggle: () => {},
+    coreState,
+    relaunchApp: () => { void window.codey.core.relaunch() },
   }
 }


### PR DESCRIPTION
## Summary

When the in-process core fails to boot, the Mac app currently degrades silently (a single log line in the Status tab). This PR makes the failure impossible to miss and gives a one-click recovery:

- **Danger banner** at the top of the content area showing the real boot error, with a **Relaunch App** button (`app.relaunch()` + quit). Shown with or without an active chat; never flashes during a normal boot.
- **Composer fully gated** while the core is down: textarea, attach, and send disabled with placeholder "Core offline — relaunch to continue".
- **Architecture:** pure unit-tested state store (`electron/core-state.ts`, `booting | ready | failed`) driven by `bootInProcessCore()`, pushed to the renderer via a `core:state` event + backfill getter (same pattern as updater state). IPC handlers register **before** the boot await so a renderer mounting mid-boot can't hit "No handler registered".
- Removes the dead `start`/`stop`/`toggle` no-op stubs from `useGateway`.

## Testing

- 2 new vitest suites (state store + pure view helpers), 49/49 tests green; both tsconfig targets typecheck clean.
- Manually verified in the running app with an injected boot failure: banner + error text render, Relaunch App round-trips (quit → reopen), `core:state` backfill survives a renderer reload, and a healthy boot shows no banner with a fully working composer.

Note for dev: clicking Relaunch App under `npm run dev` orphans the relaunched instance (the vite parent dies with the original process). Packaged builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)