### PR TITLE
feat(codey-mac): native macOS notifications for background turns

### DIFF
--- a/codey-mac/electron/chat-notifications.test.ts
+++ b/codey-mac/electron/chat-notifications.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { decideNotification, createTurnTracker, truncate } from './chat-notifications'
+
+const ctx = { focused: false, enabled: true }
+
+describe('decideNotification', () => {
+  it('returns null when disabled or focused', () => {
+    const done = { type: 'done' as const, chatId: 'c1', response: 'hi' }
+    expect(decideNotification(done, { focused: true, enabled: true })).toBeNull()
+    expect(decideNotification(done, { focused: false, enabled: false })).toBeNull()
+  })
+
+  it('plain done → "Codey finished" with response snippet and chat title', () => {
+    const d = decideNotification(
+      { type: 'done', chatId: 'c1', response: 'All tests pass.' },
+      { ...ctx, chatTitle: 'My project' },
+    )
+    expect(d).toEqual({ chatId: 'c1', title: 'Codey finished — My project', body: 'All tests pass.' })
+  })
+
+  it('done without chat title uses bare title', () => {
+    const d = decideNotification({ type: 'done', chatId: 'c1', response: 'ok' }, ctx)
+    expect(d?.title).toBe('Codey finished')
+  })
+
+  it('done with single-select userQuestion → input title + up to 4 action buttons', () => {
+    const d = decideNotification(
+      {
+        type: 'done', chatId: 'c1', response: 'irrelevant',
+        userQuestion: {
+          question: 'Which approach?',
+          options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }, { label: 'E' }],
+        },
+      },
+      { ...ctx, chatTitle: 'My project' },
+    )
+    expect(d?.title).toBe('Codey needs your input — My project')
+    expect(d?.body).toBe('Which approach?')
+    expect(d?.actions).toEqual([{ label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }])
+  })
+
+  it('multi-select userQuestion → notification but NO action buttons', () => {
+    const d = decideNotification(
+      {
+        type: 'done', chatId: 'c1', response: '',
+        userQuestion: { question: 'Pick several', options: [{ label: 'A' }, { label: 'B' }], multiSelect: true },
+      },
+      ctx,
+    )
+    expect(d?.title).toBe('Codey needs your input')
+    expect(d?.actions).toBeUndefined()
+  })
+
+  it('userQuestion with fewer than 1 option falls back to plain done', () => {
+    const d = decideNotification(
+      { type: 'done', chatId: 'c1', response: 'resp', userQuestion: { question: 'q', options: [] } },
+      ctx,
+    )
+    expect(d?.title).toBe('Codey finished')
+  })
+
+  it('error → "Codey hit an error" with message', () => {
+    const d = decideNotification({ type: 'error', chatId: 'c1', message: 'boom' }, ctx)
+    expect(d).toEqual({ chatId: 'c1', title: 'Codey hit an error', body: 'boom' })
+  })
+
+  it('all other event types → null', () => {
+    for (const type of ['queued', 'tool_start', 'tool_end', 'info', 'stream', 'thinking', 'stopped', 'permission_denials']) {
+      expect(decideNotification({ type, chatId: 'c1' } as any, ctx)).toBeNull()
+    }
+  })
+
+  it('bodies are truncated to 180 chars with ellipsis', () => {
+    const long = 'x'.repeat(300)
+    const d = decideNotification({ type: 'done', chatId: 'c1', response: long }, ctx)
+    expect(d?.body.length).toBe(180)
+    expect(d?.body.endsWith('…')).toBe(true)
+  })
+})
+
+describe('truncate', () => {
+  it('leaves short strings alone and trims whitespace', () => {
+    expect(truncate('  hi  ', 10)).toBe('hi')
+  })
+})
+
+describe('createTurnTracker', () => {
+  it('dedupes: second terminal event for the same turn is suppressed', () => {
+    const t = createTurnTracker()
+    t.observe({ type: 'stream', chatId: 'c1' })
+    expect(t.alreadyNotified('c1')).toBe(false)
+    t.markNotified('c1')
+    t.observe({ type: 'done', chatId: 'c1' })
+    expect(t.alreadyNotified('c1')).toBe(true) // duplicate done / error-after-done suppressed
+  })
+
+  it('a new turn resets the notified flag', () => {
+    const t = createTurnTracker()
+    t.markNotified('c1')
+    t.observe({ type: 'queued', chatId: 'c1' }) // new turn begins
+    expect(t.alreadyNotified('c1')).toBe(false)
+  })
+
+  it('tracks in-flight per chat from non-terminal vs terminal events', () => {
+    const t = createTurnTracker()
+    expect(t.isInFlight('c1')).toBe(false)
+    t.observe({ type: 'tool_start', chatId: 'c1' })
+    expect(t.isInFlight('c1')).toBe(true)
+    t.observe({ type: 'done', chatId: 'c1' })
+    expect(t.isInFlight('c1')).toBe(false)
+    t.observe({ type: 'stream', chatId: 'c2' })
+    expect(t.isInFlight('c2')).toBe(true)
+    expect(t.isInFlight('c1')).toBe(false)
+  })
+})

--- a/codey-mac/electron/chat-notifications.ts
+++ b/codey-mac/electron/chat-notifications.ts
@@ -1,0 +1,91 @@
+// Pure decision logic for native macOS notifications. No Electron imports so
+// it is unit-testable; main.ts supplies context (focus, enabled, chat title)
+// and renders the returned decision with the Notification API.
+
+// Structural subset of ChatStreamEvent — only the fields this module reads.
+export interface NotifyEvent {
+  type: string
+  chatId: string
+  response?: string
+  message?: string
+  userQuestion?: {
+    question: string
+    options: Array<{ label: string; description?: string }>
+    multiSelect?: boolean
+  }
+}
+
+export interface NotifyContext {
+  focused: boolean
+  enabled: boolean
+  chatTitle?: string
+}
+
+export interface NotificationDecision {
+  chatId: string
+  title: string
+  body: string
+  actions?: Array<{ label: string }>
+}
+
+const MAX_BODY = 180
+const MAX_ACTIONS = 4
+
+export function truncate(s: string, max: number): string {
+  const t = s.trim()
+  return t.length <= max ? t : t.slice(0, max - 1) + '…'
+}
+
+function withTitle(base: string, chatTitle?: string): string {
+  return chatTitle ? `${base} — ${chatTitle}` : base
+}
+
+export function decideNotification(ev: NotifyEvent, ctx: NotifyContext): NotificationDecision | null {
+  if (!ctx.enabled || ctx.focused) return null
+  if (ev.type === 'error') {
+    return { chatId: ev.chatId, title: withTitle('Codey hit an error', ctx.chatTitle), body: truncate(ev.message ?? '', MAX_BODY) }
+  }
+  if (ev.type !== 'done') return null
+  const q = ev.userQuestion
+  if (q && q.options.length >= 1) {
+    const decision: NotificationDecision = {
+      chatId: ev.chatId,
+      title: withTitle('Codey needs your input', ctx.chatTitle),
+      body: truncate(q.question, MAX_BODY),
+    }
+    if (!q.multiSelect) decision.actions = q.options.slice(0, MAX_ACTIONS).map(o => ({ label: o.label }))
+    return decision
+  }
+  return { chatId: ev.chatId, title: withTitle('Codey finished', ctx.chatTitle), body: truncate(ev.response ?? '', MAX_BODY) }
+}
+
+const TERMINAL_TYPES = new Set(['done', 'error', 'stopped'])
+
+// Per-chat turn state: dedupes notifications (one per turn) and tells the
+// action-button handler whether a new turn is already running (stale button).
+export interface TurnTracker {
+  observe(ev: { type: string; chatId: string }): void
+  markNotified(chatId: string): void
+  alreadyNotified(chatId: string): boolean
+  isInFlight(chatId: string): boolean
+}
+
+export function createTurnTracker(): TurnTracker {
+  const notified = new Set<string>()
+  const inFlight = new Set<string>()
+  return {
+    observe(ev) {
+      if (TERMINAL_TYPES.has(ev.type)) {
+        inFlight.delete(ev.chatId)
+      } else {
+        // Any non-terminal event means a turn is running; that's a NEW turn,
+        // so clear the previous turn's notified flag.
+        inFlight.add(ev.chatId)
+        notified.delete(ev.chatId)
+      }
+    },
+    markNotified: (chatId) => { notified.add(chatId) },
+    alreadyNotified: (chatId) => notified.has(chatId),
+    isInFlight: (chatId) => inFlight.has(chatId),
+  }
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
 import { initAutoUpdater, registerUpdaterIpc } from './updater'
 import { createCoreStateStore } from './core-state'
+import { decideNotification, createTurnTracker } from './chat-notifications'
 
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
@@ -18,6 +19,7 @@ let tray: Tray | null = null
 let isQuitting = false
 let inProcessGateway: Codey | null = null
 const coreStateStore = createCoreStateStore((s) => sendToRenderer('core:state', s))
+const turnTracker = createTurnTracker()
 let workerManager: WorkerManager | null = null
 let workspaceManager: WorkspaceManager | null = null
 let coreConfigManager: ConfigManager | null = null
@@ -110,6 +112,50 @@ function sendToRenderer(channel: string, ...args: any[]) {
     if (pendingRendererMessages.length > 500) pendingRendererMessages.shift()
   }
 }
+// Native macOS notifications for background chats. Decisions are pure
+// (chat-notifications.ts); this is the impure shell: focus check, config
+// read, Notification construction, click/action routing.
+function maybeNotify(ev: any) {
+  try {
+    if (!ev || typeof ev.chatId !== 'string') return
+    const enabled = ((coreConfigManager?.get() as any)?.notifications?.enabled ?? true) as boolean
+    const focused = mainWindow?.isFocused() ?? false
+    const chatTitle = inProcessGateway?.getChatManager().get(ev.chatId)?.title
+    const decision = decideNotification(ev, { focused, enabled, chatTitle })
+    const isDuplicate = turnTracker.alreadyNotified(ev.chatId)
+    turnTracker.observe(ev)
+    if (!decision || isDuplicate) return
+    turnTracker.markNotified(decision.chatId)
+
+    const openChat = () => {
+      mainWindow?.show()
+      sendToRenderer('notify:openChat', { chatId: decision.chatId })
+    }
+    const notif = new Notification({
+      title: decision.title,
+      body: decision.body,
+      actions: decision.actions?.map(a => ({ type: 'button' as const, text: a.label })),
+    })
+    notif.on('click', openChat)
+    if (decision.actions?.length) {
+      notif.on('action', (_e, index) => {
+        const label = decision.actions?.[index]?.label
+        // Stale button (a new turn already started) or missing gateway:
+        // fall back to focusing the chat instead of sending.
+        if (!label || !inProcessGateway || turnTracker.isInFlight(decision.chatId)) { openChat(); return }
+        const sink = () => { /* no-op: global chatEventListener mirrors to renderer */ }
+        void inProcessGateway.sendToChat(decision.chatId, label, sink).catch((err: any) => {
+          sendToRenderer('gateway-log', `[notify] answer send failed: ${err?.message ?? err}`)
+          openChat()
+        })
+      })
+    }
+    notif.show()
+  } catch (err: any) {
+    try { sendToRenderer('gateway-log', `[notify] notification failed: ${err?.message ?? err}`) } catch { /* renderer gone */ }
+  }
+}
+
 function flushPendingRendererMessages() {
   rendererReady = true
   if (!mainWindow) return
@@ -501,6 +547,7 @@ async function bootInProcessCore() {
     // messages on paired surfaces) to the renderer so the Mac UI stays in sync.
     inProcessGateway.setChatEventListener((ev: any) => {
       sendToRenderer('chats:event', ev)
+      maybeNotify(ev)
     })
     inProcessGateway.setPairingEventListener((ev: any) => {
       sendToRenderer('pairing:event', ev)

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -154,6 +154,13 @@ contextBridge.exposeInMainWorld('codey', {
       return () => ipcRenderer.removeListener('core:state', listener)
     },
   },
+  notify: {
+    onOpenChat: (handler: (msg: { chatId: string }) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, msg: any) => handler(msg)
+      ipcRenderer.on('notify:openChat', listener)
+      return () => ipcRenderer.removeListener('notify:openChat', listener)
+    },
+  },
   voice: {
     onHotkey: (handler: () => void) => {
       const listener = () => handler()

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -142,6 +142,9 @@ declare global {
         relaunch: () => Promise<IpcResult<void>>
         onState: (handler: (state: CoreState) => void) => () => void
       }
+      notify: {
+        onOpenChat: (handler: (msg: { chatId: string }) => void) => () => void
+      }
       voice: {
         onHotkey: (handler: () => void) => () => void
         notifyTranscribed: (text: string) => Promise<IpcResult<void>>

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -34,6 +34,7 @@ export const AppearanceTab: React.FC = () => {
   const effective = useEffectiveTheme()
   const [version, setVersion] = React.useState<string>('')
   const [skipPerms, setSkipPerms] = React.useState<boolean>(true)
+  const [notifyEnabled, setNotifyEnabled] = React.useState<boolean>(true)
   const [loaded, setLoaded] = React.useState(false)
 
   React.useEffect(() => {
@@ -41,6 +42,7 @@ export const AppearanceTab: React.FC = () => {
     window.codey?.config?.get?.().then((res: any) => {
       const cfg = res?.ok ? res.data : res
       setSkipPerms(cfg?.gateway?.skipPermissions ?? true)
+      setNotifyEnabled(cfg?.notifications?.enabled ?? true)
       setLoaded(true)
     }).catch(() => { setLoaded(true) })
   }, [])
@@ -48,6 +50,11 @@ export const AppearanceTab: React.FC = () => {
   const toggleSkipPerms = (v: boolean) => {
     setSkipPerms(v)
     window.codey?.config?.set?.({ gateway: { skipPermissions: v } }).catch(() => { /* ignore */ })
+  }
+
+  const toggleNotify = (v: boolean) => {
+    setNotifyEnabled(v)
+    window.codey?.config?.set?.({ notifications: { enabled: v } }).catch(() => { /* ignore */ })
   }
 
   return (
@@ -101,15 +108,27 @@ export const AppearanceTab: React.FC = () => {
       </div>
 
       {loaded && (
-        <div style={styles.row}>
-          <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
-            <div>Skip permissions</div>
-            <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
-              When enabled, agents run shell commands, edit files, and make network requests without asking for confirmation. Disable to review every action before execution.
+        <>
+          <div style={styles.row}>
+            <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
+              <div>Skip permissions</div>
+              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+                When enabled, agents run shell commands, edit files, and make network requests without asking for confirmation. Disable to review every action before execution.
+              </div>
             </div>
+            <Toggle on={skipPerms} onChange={toggleSkipPerms}/>
           </div>
-          <Toggle on={skipPerms} onChange={toggleSkipPerms}/>
-        </div>
+
+          <div style={styles.row}>
+            <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
+              <div>Background notifications</div>
+              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+                Notify when Codey finishes, errors, or needs your input while the app is in the background.
+              </div>
+            </div>
+            <Toggle on={notifyEnabled} onChange={toggleNotify}/>
+          </div>
+        </>
       )}
 
       <div style={styles.row}>

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -266,10 +266,13 @@ function reducer(state: State, action: Action): State {
       )
       const inFlight = { ...state.inFlight }
       delete inFlight[action.chatId]
+      const unreadChats = { ...state.unreadChats }
+      if (state.selectedChatId !== action.chatId) unreadChats[action.chatId] = true
       return {
         ...state,
         chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } },
         inFlight,
+        unreadChats,
       }
     }
     default:
@@ -428,6 +431,13 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           break
         }
       }
+    })
+    return off
+  }, [])
+
+  useEffect(() => {
+    const off = window.codey.notify.onOpenChat(({ chatId }) => {
+      dispatch({ type: 'select', chatId })
     })
     return off
   }, [])


### PR DESCRIPTION
## Summary

Stacked on #114. When the Codey window is unfocused, the app now posts native macOS notifications:

- **"Codey finished — <chat title>"** with a response snippet on turn completion
- **"Codey needs your input — <chat title>"** when the turn ends in an AskUserQuestion — with **answer buttons** (up to 4, single-select questions only) that send the chosen option straight into the chat from the main process
- **"Codey hit an error"** on turn errors
- Clicking any notification focuses the window and selects that chat (`notify:openChat`)
- Suppressed while the app is focused (the in-app bell covers that case) and behind a new **Settings → General → Background notifications** toggle (`notifications.enabled`, default on)

Also fixes a gap where **background errors never marked a chat unread** in the in-app notification bell.

Architecture: pure decision module (`electron/chat-notifications.ts`, 13 unit tests — event×focus×enabled matrix, multi-select fallback, 4-button cap, per-turn dedupe, stale-button guard) + thin Electron glue tapping the existing global chat-event listener.

## Testing

- 62/62 vitest, both tsconfig targets clean.
- Live runtime evidence (temporary instrumentation, since reverted): focused `done` → `decision=null` (suppressed); unfocused `done` → decision built and `Notification.show()` executed cleanly.
- Known caveats per design spec: action buttons may not render in unsigned dev builds (click-to-focus is the fallback); multi-select questions get no buttons by design. Banner click + buttons worth one manual click in a signed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)