### PR TITLE
fix(codey-mac): voice hotkey with Space produces valid accelerator

### DIFF
--- a/codey-mac/electron/capture.test.ts
+++ b/codey-mac/electron/capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { captureAccelerator, resolveCaptureSubmit, DEFAULT_CAPTURE_HOTKEY } from './capture'
+import { captureAccelerator, resolveCaptureSubmit, normalizeAccelerator, DEFAULT_CAPTURE_HOTKEY } from './capture'
 
 describe('captureAccelerator', () => {
   it('defaults to Alt+Space when unset', () => {
@@ -22,6 +22,18 @@ describe('captureAccelerator', () => {
   it('rejects Fn (not bindable via globalShortcut)', () => {
     expect(captureAccelerator('Fn')).toBeNull()
     expect(captureAccelerator(' fn ')).toBeNull()
+  })
+})
+
+// Shared with main.ts's toElectronAccelerator (voice global hotkey). Space is
+// recorded by HotkeyRecorder as e.key === ' ', so a stored hotkey like "Meta+ "
+// must survive trim() and still normalize to a real Space accelerator rather
+// than dropping the part and yielding an invalid "CommandOrControl+".
+describe('normalizeAccelerator (voice hotkey)', () => {
+  it('keeps a space part recorded as " " (not dropped after trim)', () => {
+    expect(normalizeAccelerator('Meta+ ')).toBe('CommandOrControl+Space')
+    expect(normalizeAccelerator('Meta+Shift+ ')).toBe('CommandOrControl+Shift+Space')
+    expect(normalizeAccelerator('Control+space')).toBe('Control+Space')
   })
 })
 

--- a/codey-mac/electron/capture.ts
+++ b/codey-mac/electron/capture.ts
@@ -3,9 +3,11 @@
 
 export const DEFAULT_CAPTURE_HOTKEY = 'Alt+Space'
 
-// Same normalization as main.ts's toElectronAccelerator (WhisperTab format →
-// Electron accelerator), kept pure here for testability.
-function normalizeAccelerator(hotkey: string): string {
+// Shared normalization (WhisperTab format → Electron accelerator), kept pure
+// here for testability. Reused by main.ts's toElectronAccelerator so the voice
+// and quick-capture hotkeys stay in lockstep. The `low === ''` branch matters:
+// HotkeyRecorder stores Space as e.key === ' ', which becomes '' after trim().
+export function normalizeAccelerator(hotkey: string): string {
   return hotkey
     .split('+')
     .map(p => p.trim())

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, shell, dialog, protocol, net, globalShortcut, clipboard, Notification, systemPreferences, screen } from 'electron'
 import { join } from 'path'
-import { captureAccelerator, resolveCaptureSubmit } from './capture'
+import { captureAccelerator, resolveCaptureSubmit, normalizeAccelerator } from './capture'
 import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
 import { initAutoUpdater, registerUpdaterIpc } from './updater'
@@ -714,19 +714,11 @@ async function bootInProcessCore() {
 // accelerator string. Returns null if the binding is empty/disabled.
 function toElectronAccelerator(hotkey: string | undefined): string | null {
   if (!hotkey) return null
-  return hotkey
-    .split('+')
-    .map(p => p.trim())
-    .map(p => {
-      const low = p.toLowerCase()
-      if (low === 'meta' || low === 'cmd' || low === 'command') return 'CommandOrControl'
-      if (low === 'control' || low === 'ctrl') return 'Control'
-      if (low === 'alt' || low === 'option') return 'Alt'
-      if (low === 'shift') return 'Shift'
-      if (low === ' ' || low === 'space') return 'Space'
-      return p.length === 1 ? p.toUpperCase() : p
-    })
-    .join('+')
+  // Delegate to the shared, pure normalizer in capture.ts. Its `low === ''`
+  // check handles Space recorded as ' ' (which trim() collapses to ''); the
+  // old inline copy checked `low === ' '` *after* trim and so dropped the part,
+  // producing invalid accelerators like "CommandOrControl+".
+  return normalizeAccelerator(hotkey)
 }
 
 let currentVoiceAccelerator: string | null = null


### PR DESCRIPTION
## Problem

`toElectronAccelerator` in `electron/main.ts` ran `.map(p => p.trim())` **before** checking `if (low === ' ' || low === 'space')`. After trim, a Space part — which `HotkeyRecorder` stores as `e.key === ' '` — became `''`, so the `' '` branch was unreachable. The empty part then fell through to `p.length === 1 ? p.toUpperCase() : p` and returned `''`.

Result: a recorded voice hotkey like `"Meta+ "` produced the invalid Electron accelerator `"CommandOrControl+"`, which fails to register via `globalShortcut`.

The quick-capture module (`electron/capture.ts`) already had a corrected pure copy that checks `low === ''`.

## Fix

- Export the correct pure `normalizeAccelerator` from `capture.ts` and reuse it in `main.ts`'s `toElectronAccelerator` (keeping the `if (!hotkey) return null` guard). Voice and quick-capture hotkeys now share one normalizer, eliminating the divergent inline copy.
- Add vitest coverage for space-containing voice hotkeys (`"Meta+ "` → `"CommandOrControl+Space"`, plus shift/lowercase variants).

## Verification (Node 22.17.1)

- `npx tsc -p tsconfig.electron.json --noEmit` — clean
- `npx vitest run` — **85 passed (11 files)**, including the new assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)