### PR TITLE
fix(codey-mac): center capture composer row + one-line placeholder

### DIFF
--- a/codey-mac/src/components/CaptureWindow.tsx
+++ b/codey-mac/src/components/CaptureWindow.tsx
@@ -171,7 +171,7 @@ export const CaptureWindow: React.FC = () => {
               el.style.height = 'auto'
               el.style.height = Math.min(el.scrollHeight, 120) + 'px'
             }}
-            placeholder="What should Codey do? (↵ to send, esc to dismiss)"
+            placeholder="What should Codey do?"
             rows={1}
             autoFocus
             style={styles.input}
@@ -236,7 +236,7 @@ const styles: Record<string, React.CSSProperties> = {
     background: 'none', border: 'none', color: C.fg2, cursor: 'pointer',
     fontSize: 14, lineHeight: 1, padding: '0 2px',
   },
-  composerRow: { display: 'flex', gap: 6, alignItems: 'flex-end', padding: 6 },
+  composerRow: { display: 'flex', gap: 6, alignItems: 'center', padding: 6 },
   attachBtn: {
     width: 34, height: 34, borderRadius: 9, border: 'none', background: 'transparent',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -249,7 +249,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   // Shorter workspace picker so the input gets the room.
   select: {
-    width: 96, height: 34, alignSelf: 'flex-end', background: C.surface3, color: C.fg2,
+    width: 96, height: 34, background: C.surface3, color: C.fg2,
     border: `1px solid ${C.border2}`, borderRadius: 8, padding: '0 6px',
     fontSize: 12, cursor: 'pointer', flexShrink: 0,
   },


### PR DESCRIPTION
Follow-up to #120 — fixes the "weird top padding" / clipped placeholder reported on the new composer.

## Problem
- `composerRow` used `align-items: flex-end`, so the taller (46px) Send button set the row height and the shorter attach button / textarea / workspace select sank to the bottom — leaving an empty band across the top of the input.
- The placeholder `"What should Codey do? (↵ to send, esc to dismiss)"` was long enough to wrap to two lines in the narrowed textarea, and the second line clipped against the one-line textarea height.

## Fix
- `composerRow` `align-items` → `center` (controls sit on a shared baseline, no top gap).
- Drop the now-redundant `alignSelf: flex-end` on the workspace select.
- Shorten the placeholder to `"What should Codey do?"` so it stays on one line.

## Verification
- `tsc --noEmit` (src + electron) — clean
- `vite build` — renderer / main / preload all compile

Visual: reasoned from the reported screenshot + the flex layout; not re-launched in the app (driving the global-hotkey overlay headlessly was unreliable here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)