### PR TITLE
fix(codey-mac): live-update chat list for quick-capture & channel turns

### DIFF
--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { reducer, type State } from './useChats'
+import type { Chat } from '../types'
+
+const emptyState = (): State => ({
+  chats: {}, order: [], selectedChatId: null, inFlight: {},
+  collapsedWorkspaces: {}, workspaces: [], pendingRestores: {},
+  unreadChats: {}, pendingPermissions: {},
+})
+
+// A chat as it exists server-side at turn start: the user message is already
+// persisted (appendMessage in gateway.sendToChat), no assistant message yet.
+const makeChat = (overrides: Partial<Chat> = {}): Chat => ({
+  id: 'c1', title: 'Captured task', workspaceName: 'codey',
+  selection: { type: 'none' }, createdAt: 1, updatedAt: 1,
+  messages: [{ id: 'u1', role: 'user', content: 'do the thing', timestamp: 1, isComplete: true }],
+  ...overrides,
+})
+
+// Regression: quick-capture (and paired-channel) turns are created + run in the
+// main process, so the renderer has no inFlight entry and previously dropped
+// every live event until 'done' — the chat was invisible until refresh and
+// showed no "working" indicator. adoptInFlight is how the renderer adopts such
+// turns on their first live event.
+describe('reducer: adoptInFlight (externally-initiated turns)', () => {
+  it('inserts the chat, appends an assistant stub, and opens an inFlight entry', () => {
+    const chat = makeChat()
+    const next = reducer(emptyState(), { type: 'adoptInFlight', chat, assistantMessageId: 'a1' })
+    expect(next.chats['c1']).toBeDefined()
+    expect(next.order).toContain('c1')
+    const msgs = next.chats['c1'].messages
+    expect(msgs).toHaveLength(2) // persisted user msg + new assistant stub
+    expect(msgs[1]).toMatchObject({ id: 'a1', role: 'assistant', content: '', isComplete: false })
+    expect(next.inFlight['c1']).toMatchObject({ assistantMessageId: 'a1', userMessageId: 'u1', agentStatus: 'thinking' })
+  })
+
+  it('lets subsequent live events render (streamToken appends to the stub)', () => {
+    const chat = makeChat()
+    let s = reducer(emptyState(), { type: 'adoptInFlight', chat, assistantMessageId: 'a1' })
+    s = reducer(s, { type: 'streamToken', chatId: 'c1', token: 'Hello' })
+    const stub = s.chats['c1'].messages.find(m => m.id === 'a1')
+    expect(stub?.content).toBe('Hello')
+    expect(s.inFlight['c1'].agentStatus).toBe('writing')
+  })
+
+  it('is a no-op when the chat is already in flight (no double adopt)', () => {
+    const chat = makeChat()
+    const s1 = reducer(emptyState(), { type: 'adoptInFlight', chat, assistantMessageId: 'a1' })
+    const s2 = reducer(s1, { type: 'adoptInFlight', chat, assistantMessageId: 'a2' })
+    expect(s2).toBe(s1) // unchanged reference
+    expect(s2.chats['c1'].messages).toHaveLength(2) // not a second stub
+  })
+})

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -12,7 +12,7 @@ interface InFlight {
   thinkingByStep?: Record<number, string>
 }
 
-interface State {
+export interface State {
   chats: Record<string, Chat>
   order: string[]
   selectedChatId: string | null
@@ -30,6 +30,10 @@ type Action =
   | { type: 'loaded'; chats: Chat[] }
   | { type: 'setWorkspaces'; workspaces: string[] }
   | { type: 'upsert'; chat: Chat }
+  // Adopt a turn that was started outside the renderer (quick-capture or a
+  // paired channel): insert the fetched chat, append an assistant stub, and
+  // open an inFlight entry so its live events render. See onEvent adoption.
+  | { type: 'adoptInFlight'; chat: Chat; assistantMessageId: string }
   | { type: 'remove'; chatId: string }
   | { type: 'select'; chatId: string | null }
   | { type: 'toggleWorkspace'; workspaceName: string }
@@ -51,7 +55,7 @@ function reorder(order: string[], chatId: string): string[] {
   return [chatId, ...order.filter(id => id !== chatId)]
 }
 
-function reducer(state: State, action: Action): State {
+export function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'loaded': {
       const chats: Record<string, Chat> = {}
@@ -80,6 +84,38 @@ function reducer(state: State, action: Action): State {
       const chats = { ...state.chats, [action.chat.id]: next }
       const order = state.order.includes(action.chat.id) ? state.order : [action.chat.id, ...state.order]
       return { ...state, chats, order: reorder(order, action.chat.id) }
+    }
+    case 'adoptInFlight': {
+      // Externally-initiated turn (quick-capture / paired channel). The fetched
+      // chat already holds the persisted user message; append an empty assistant
+      // stub for the live turn and open an inFlight entry so streaming/tool
+      // events render and the "working" indicator shows. Idempotent: if a turn
+      // is already tracked for this chat, leave it untouched.
+      if (state.inFlight[action.chat.id]) return state
+      const assistantStub: ChatMessage = {
+        id: action.assistantMessageId,
+        role: 'assistant',
+        content: '',
+        timestamp: Date.now(),
+        toolCalls: [],
+        isComplete: false,
+      }
+      const userMessageId = [...action.chat.messages].reverse().find(m => m.role === 'user')?.id ?? ''
+      const adopted: Chat = {
+        ...action.chat,
+        messages: [...action.chat.messages, assistantStub],
+        updatedAt: Date.now(),
+      }
+      const order = state.order.includes(action.chat.id) ? state.order : [action.chat.id, ...state.order]
+      return {
+        ...state,
+        chats: { ...state.chats, [action.chat.id]: adopted },
+        order: reorder(order, action.chat.id),
+        inFlight: {
+          ...state.inFlight,
+          [action.chat.id]: { assistantMessageId: action.assistantMessageId, userMessageId, agentStatus: 'thinking' },
+        },
+      }
     }
     case 'patchContextPanelOpen': {
       const chat = state.chats[action.chatId]
@@ -321,6 +357,10 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   })
 
   const pendingAssistantId = useRef<Record<string, string>>({})
+  // Chats whose externally-initiated turn we are mid-adopting (chats.get in
+  // flight). Prevents duplicate fetches and lets a fast terminal event cancel
+  // a pending adoption (see onEvent).
+  const adopting = useRef<Set<string>>(new Set())
 
   useEffect(() => {
     ;(async () => {
@@ -350,6 +390,29 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useEffect(() => {
     const off = apiService.chats.onEvent((ev: ChatStreamEvent) => {
+      // Adopt turns started outside the renderer (quick-capture, paired
+      // channels). Such chats have no local inFlight entry, so every live event
+      // below would be dropped until 'done'. On the first live event, fetch the
+      // chat (its user message is already persisted) and open an inFlight entry
+      // so streaming/tool events render and the "working" indicator shows.
+      if (
+        (ev.type === 'tool_start' || ev.type === 'tool_end' || ev.type === 'info' ||
+         ev.type === 'stream' || ev.type === 'thinking') &&
+        !pendingAssistantId.current[ev.chatId] &&
+        !adopting.current.has(ev.chatId)
+      ) {
+        adopting.current.add(ev.chatId)
+        apiService.chats.get(ev.chatId)
+          .then(chat => {
+            // A terminal event may have won the race and cancelled adoption.
+            if (!adopting.current.has(ev.chatId)) return
+            const assistantMessageId = `asst-${Date.now()}-${Math.random()}`
+            pendingAssistantId.current[ev.chatId] = assistantMessageId
+            dispatch({ type: 'adoptInFlight', chat, assistantMessageId })
+          })
+          .catch(() => { adopting.current.delete(ev.chatId) })
+      }
+
       switch (ev.type) {
         case 'queued':
           dispatch({ type: 'queued', chatId: ev.chatId, position: ev.position })
@@ -385,6 +448,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           dispatch({ type: 'thinkingToken', chatId: ev.chatId, token: ev.token, step: ev.step })
           break
         case 'done': {
+          adopting.current.delete(ev.chatId)
           const asstId = pendingAssistantId.current[ev.chatId]
           if (asstId) {
             dispatch({
@@ -409,11 +473,13 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           break
         }
         case 'stopped': {
+          adopting.current.delete(ev.chatId)
           dispatch({ type: 'stoppedSend', chatId: ev.chatId, text: ev.text })
           delete pendingAssistantId.current[ev.chatId]
           break
         }
         case 'error': {
+          adopting.current.delete(ev.chatId)
           const asstId = pendingAssistantId.current[ev.chatId]
           if (asstId) {
             dispatch({ type: 'errorSend', chatId: ev.chatId, assistantMessageId: asstId, error: ev.message })


### PR DESCRIPTION
## Symptoms (reported)
After firing a screenshot/quick-capture: the new chat doesn't appear in the sidebar until you manually refresh Codey, and even once visible you see your own message but no indication that Codey is working on a reply.

## Root cause
Quick-capture creates the chat and runs the entire turn in the **main process** (`capture:submit` → `ChatManager.create()` → `sendToChat`). The renderer's `useChats` only has a `chats[id]` **and** `inFlight[id]` entry for turns it started itself (`send`/`startSend`). The reducer drops every live event unless both exist — e.g. `streamToken`/`toolCall` do `if (!chat || !fl) return state`. So for a capture turn:

- All working-phase events (`tool_start`, `stream`, `thinking`, …) are dropped.
- The chat is only inserted by the `done`/`error` "channel-driven" branch (`chats.get → upsert`) — i.e. **after the turn completes**, hence invisible until then / until a manual `chats.list()` refresh.
- `inFlight[id]` (which drives the Thinking…/Working…/Writing… indicator in `ChatTab` and the sidebar dot) is never created.

Paired-channel turns (Telegram/Discord/iMessage) have the same limitation.

## Fix (renderer-only, `useChats`)
Adopt externally-initiated turns on their **first live event**: fetch the chat once (its user message is already persisted at turn start), append an assistant stub, and open an `inFlight` entry via a new `adoptInFlight` reducer action. Subsequent streaming/tool events then render and the working indicator shows; `done` finalizes the stub via `completeSend`. An `adopting` ref dedupes the fetch and lets a fast terminal event cancel a pending adoption (no empty stub on an already-finished chat). Bonus: channel-driven turns now update live too.

## Tests
Exports the (previously private) pure `reducer` + `State` for unit testing. New `useChats.reducer.test.ts`:
- `adoptInFlight` inserts the chat, appends the assistant stub, opens `inFlight: thinking`
- a subsequent `streamToken` appends to the stub (proves live events render post-adoption)
- idempotent: a second `adoptInFlight` for an already-in-flight chat is a no-op

## Verification
- `vitest run` — 92/92 pass (3 new)
- `tsc --noEmit` (src + electron) — clean
- `vite build` — renderer / main / preload compile

Verified by the reducer unit tests + reasoning through the event flow; not exercised in a running app (the live IPC adoption path isn't unit-testable here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)