### PR TITLE
fix(codey-mac): space out General settings + image thumbnails in capture

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1157,6 +1157,28 @@ app.whenReady().then(async () => {
       }
     })
   )
+  // Preview helper for the capture window: read-only base64 data URL for an
+  // image at any path. Screenshots live in os.tmpdir() and picked files at
+  // their original location — both outside .codey/uploads/, so the codey-asset
+  // protocol can't serve them. Restricted to image extensions and capped so a
+  // stray huge file can't be slurped into the renderer.
+  ipcMain.handle('capture:thumbnail', async (_e, filePath: string) =>
+    wrap(async () => {
+      const pathMod = await import('path')
+      const fsMod = await import('fs')
+      const ext = pathMod.extname(String(filePath || '')).toLowerCase()
+      const mime: Record<string, string> = {
+        '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif', '.webp': 'image/webp', '.bmp': 'image/bmp',
+        '.heic': 'image/heic', '.heif': 'image/heif', '.svg': 'image/svg+xml',
+      }
+      if (!mime[ext]) throw new Error('not an image')
+      const stat = await fsMod.promises.stat(filePath)
+      if (stat.size > 25 * 1024 * 1024) throw new Error('image too large to preview')
+      const buf = await fsMod.promises.readFile(filePath)
+      return { dataUrl: `data:${mime[ext]};base64,${buf.toString('base64')}` }
+    })
+  )
   ipcMain.handle('capture:submit', async (_e, payload: { workspaceName?: string; text: string; filePaths?: string[] }) =>
     wrap(async () => {
       if (!inProcessGateway || !workspaceManager) throw new Error('Core not ready — open Codey to check its status')

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -169,6 +169,7 @@ contextBridge.exposeInMainWorld('codey', {
   capture: {
     submit: (payload: { workspaceName?: string; text: string; filePaths?: string[] }) => ipcRenderer.invoke('capture:submit', payload),
     pickFiles: () => ipcRenderer.invoke('capture:pickFiles'),
+    thumbnail: (path: string) => ipcRenderer.invoke('capture:thumbnail', path),
     hide: () => ipcRenderer.invoke('capture:hide'),
     setHeight: (height: number) => ipcRenderer.invoke('capture:setHeight', height),
     onShown: (handler: (payload?: { files?: Array<{ path: string; name: string; size: number }> }) => void) => {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -149,6 +149,7 @@ declare global {
       capture: {
         submit: (payload: { workspaceName?: string; text: string; filePaths?: string[] }) => Promise<IpcResult<{ chatId: string }>>
         pickFiles: () => Promise<IpcResult<{ files: Array<{ path: string; name: string; size: number }> }>>
+        thumbnail: (path: string) => Promise<IpcResult<{ dataUrl: string }>>
         hide: () => Promise<IpcResult<void>>
         setHeight: (height: number) => Promise<IpcResult<void>>
         onShown: (handler: (payload?: { files?: Array<{ path: string; name: string; size: number }> }) => void) => () => void

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -138,67 +138,67 @@ export const AppearanceTab: React.FC = () => {
       </div>
 
       {loaded && (
-        <>
-          <div style={styles.row}>
+        <div style={styles.settingsGroup}>
+          <div style={{ ...styles.settingRow, borderTop: 'none' }}>
             <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
               <div>Skip permissions</div>
-              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+              <div style={styles.settingDesc}>
                 When enabled, agents run shell commands, edit files, and make network requests without asking for confirmation. Disable to review every action before execution.
               </div>
             </div>
             <Toggle on={skipPerms} onChange={toggleSkipPerms}/>
           </div>
 
-          <div style={styles.row}>
+          <div style={styles.settingRow}>
             <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
               <div>Background notifications</div>
-              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+              <div style={styles.settingDesc}>
                 Notify when Codey finishes, errors, or needs your input while the app is in the background.
               </div>
             </div>
             <Toggle on={notifyEnabled} onChange={toggleNotify}/>
           </div>
 
-          <div style={styles.row}>
+          <div style={styles.settingRow}>
             <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
               <div>Quick capture hotkey</div>
-              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+              <div style={styles.settingDesc}>
                 Summon a floating composer from anywhere to send Codey a task. Clear to disable.
               </div>
             </div>
             <HotkeyRecorder value={captureHotkey} onChange={changeCaptureHotkey}/>
           </div>
 
-          <div style={styles.row}>
+          <div style={styles.settingRow}>
             <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
               <div>Screenshot to Quick Capture</div>
-              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+              <div style={styles.settingDesc}>
                 Grab a full-screen screenshot and open Quick Capture with it attached. Clear to disable.
               </div>
             </div>
             <HotkeyRecorder value={screenshotHotkey} onChange={changeScreenshotHotkey}/>
           </div>
 
-          <div style={styles.row}>
+          <div style={styles.settingRow}>
             <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
               <div>Launch Codey at login</div>
-              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+              <div style={styles.settingDesc}>
                 Start Codey automatically when you log in, so the gateway and menu bar are always available.
               </div>
             </div>
             <Toggle on={launchAtLogin} onChange={toggleLaunchAtLogin}/>
           </div>
 
-          <div style={styles.row}>
+          <div style={styles.settingRow}>
             <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
               <div>Hide Dock icon (menu bar only)</div>
-              <div style={{ fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 2 }}>
+              <div style={styles.settingDesc}>
                 Run as a menu-bar app with no Dock icon. Codey stays reachable from the menu bar.
               </div>
             </div>
             <Toggle on={dockless} onChange={toggleDockless}/>
           </div>
-        </>
+        </div>
       )}
 
       <div style={styles.row}>
@@ -210,9 +210,21 @@ export const AppearanceTab: React.FC = () => {
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  wrap:  { padding: '20px', display: 'flex', flexDirection: 'column', gap: 10 },
+  wrap:  { padding: '20px', display: 'flex', flexDirection: 'column', gap: 14 },
   row:   { display: 'flex', alignItems: 'center', gap: 16 },
   label: { fontSize: 13, color: C.fg, width: 80 },
+  // Toggle/hotkey settings stacked with dividers so each row's label and
+  // control read as a distinct line instead of a packed block.
+  settingsGroup: {
+    display: 'flex', flexDirection: 'column',
+    border: `1px solid ${C.border}`, borderRadius: 8,
+    background: C.surface2, overflow: 'hidden',
+  },
+  settingRow: {
+    display: 'flex', alignItems: 'center', gap: 16,
+    padding: '14px 14px', borderTop: `1px solid ${C.border}`,
+  },
+  settingDesc: { fontSize: 11, color: C.fg3, fontWeight: 400, marginTop: 3, lineHeight: 1.4 },
   segmented: {
     display: 'inline-flex',
     background: C.surface2,

--- a/codey-mac/src/components/CaptureWindow.tsx
+++ b/codey-mac/src/components/CaptureWindow.tsx
@@ -9,6 +9,11 @@ import {
 // window on success. Escape hides; main also hides on blur.
 type PickedFile = { path: string; name: string; size: number }
 
+// PickedFile carries no mimeType, so fall back to the extension. Screenshots
+// land here as .png and should preview as images, like the chat upload.
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|heic|heif|svg)$/i
+const isImageFile = (name: string): boolean => IMAGE_EXT.test(name)
+
 // Icons mirrored from the chat composer (QuickQuestionView) so the capture
 // input reads like the main chat input: paperclip on the left, send on the right.
 const PaperclipIcon: React.FC<{ color: string }> = ({ color }) => (
@@ -29,6 +34,9 @@ export const CaptureWindow: React.FC = () => {
   const [error, setError] = useState<string | null>(null)
   const [sending, setSending] = useState(false)
   const [files, setFiles] = useState<PickedFile[]>([])
+  // Cache of path → base64 data URL for image previews. Built lazily as image
+  // files appear; the asset:// protocol can't reach tmpdir/picked paths.
+  const [thumbs, setThumbs] = useState<Record<string, string>>({})
   const taRef = useRef<HTMLTextAreaElement>(null)
   const rootRef = useRef<HTMLDivElement>(null)
 
@@ -96,6 +104,22 @@ export const CaptureWindow: React.FC = () => {
     taRef.current?.focus()
   }
 
+  // Load a base64 preview for each image attachment we haven't fetched yet.
+  useEffect(() => {
+    let cancelled = false
+    for (const f of files) {
+      if (!isImageFile(f.name) || thumbs[f.path]) continue
+      window.codey.capture.thumbnail(f.path)
+        .then(res => {
+          if (!cancelled && res.ok && res.data) {
+            setThumbs(prev => ({ ...prev, [f.path]: res.data!.dataUrl }))
+          }
+        })
+        .catch(() => { /* unreadable — falls back to the filename chip */ })
+    }
+    return () => { cancelled = true }
+  }, [files, thumbs])
+
   const removeFile = (path: string) => setFiles(prev => prev.filter(f => f.path !== path))
 
   const submit = async () => {
@@ -139,7 +163,17 @@ export const CaptureWindow: React.FC = () => {
       <div style={styles.composer}>
         {files.length > 0 && (
           <div style={styles.chips}>
-            {files.map(f => (
+            {files.map(f => isImageFile(f.name) && thumbs[f.path] ? (
+              <span key={f.path} style={styles.thumbWrap} title={f.name}>
+                <img src={thumbs[f.path]} alt={f.name} style={styles.thumbImg} />
+                <button
+                  type="button"
+                  onClick={() => removeFile(f.path)}
+                  aria-label={`Remove ${f.name}`}
+                  style={styles.thumbX}
+                >×</button>
+              </span>
+            ) : (
               <span key={f.path} style={styles.chip} title={f.name}>
                 <span style={styles.chipName}>{f.name}</span>
                 <button
@@ -235,6 +269,19 @@ const styles: Record<string, React.CSSProperties> = {
   chipX: {
     background: 'none', border: 'none', color: C.fg2, cursor: 'pointer',
     fontSize: 14, lineHeight: 1, padding: '0 2px',
+  },
+  // Image attachments preview as thumbnails (matching the chat composer) with
+  // an overlaid remove button, instead of a plain filename chip.
+  thumbWrap: {
+    position: 'relative', width: 48, height: 48, borderRadius: 8,
+    overflow: 'hidden', border: `1px solid ${C.border2}`, flexShrink: 0,
+  },
+  thumbImg: { width: '100%', height: '100%', objectFit: 'cover', display: 'block' },
+  thumbX: {
+    position: 'absolute', top: 2, right: 2, width: 16, height: 16, borderRadius: 8,
+    border: 'none', background: 'rgba(0,0,0,0.7)', color: '#fff', cursor: 'pointer',
+    fontSize: 12, lineHeight: '14px', padding: 0,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
   },
   composerRow: { display: 'flex', gap: 6, alignItems: 'center', padding: 6 },
   attachBtn: {

--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { reducer, type State } from './useChats'
+import type { Chat } from '../types'
+
+const emptyState = (): State => ({
+  chats: {}, order: [], selectedChatId: null, inFlight: {},
+  collapsedWorkspaces: {}, workspaces: [], pendingRestores: {},
+  unreadChats: {}, pendingPermissions: {},
+})
+
+// A chat as it exists server-side at turn start: the user message is already
+// persisted (appendMessage in gateway.sendToChat), no assistant message yet.
+const makeChat = (overrides: Partial<Chat> = {}): Chat => ({
+  id: 'c1', title: 'Captured task', workspaceName: 'codey',
+  selection: { type: 'none' }, createdAt: 1, updatedAt: 1,
+  messages: [{ id: 'u1', role: 'user', content: 'do the thing', timestamp: 1, isComplete: true }],
+  ...overrides,
+})
+
+// Regression: quick-capture (and paired-channel) turns are created + run in the
+// main process, so the renderer has no inFlight entry and previously dropped
+// every live event until 'done' — the chat was invisible until refresh and
+// showed no "working" indicator. adoptInFlight is how the renderer adopts such
+// turns on their first live event.
+describe('reducer: adoptInFlight (externally-initiated turns)', () => {
+  it('inserts the chat, appends an assistant stub, and opens an inFlight entry', () => {
+    const chat = makeChat()
+    const next = reducer(emptyState(), { type: 'adoptInFlight', chat, assistantMessageId: 'a1' })
+    expect(next.chats['c1']).toBeDefined()
+    expect(next.order).toContain('c1')
+    const msgs = next.chats['c1'].messages
+    expect(msgs).toHaveLength(2) // persisted user msg + new assistant stub
+    expect(msgs[1]).toMatchObject({ id: 'a1', role: 'assistant', content: '', isComplete: false })
+    expect(next.inFlight['c1']).toMatchObject({ assistantMessageId: 'a1', userMessageId: 'u1', agentStatus: 'thinking' })
+  })
+
+  it('lets subsequent live events render (streamToken appends to the stub)', () => {
+    const chat = makeChat()
+    let s = reducer(emptyState(), { type: 'adoptInFlight', chat, assistantMessageId: 'a1' })
+    s = reducer(s, { type: 'streamToken', chatId: 'c1', token: 'Hello' })
+    const stub = s.chats['c1'].messages.find(m => m.id === 'a1')
+    expect(stub?.content).toBe('Hello')
+    expect(s.inFlight['c1'].agentStatus).toBe('writing')
+  })
+
+  it('is a no-op when the chat is already in flight (no double adopt)', () => {
+    const chat = makeChat()
+    const s1 = reducer(emptyState(), { type: 'adoptInFlight', chat, assistantMessageId: 'a1' })
+    const s2 = reducer(s1, { type: 'adoptInFlight', chat, assistantMessageId: 'a2' })
+    expect(s2).toBe(s1) // unchanged reference
+    expect(s2.chats['c1'].messages).toHaveLength(2) // not a second stub
+  })
+})

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -12,7 +12,7 @@ interface InFlight {
   thinkingByStep?: Record<number, string>
 }
 
-interface State {
+export interface State {
   chats: Record<string, Chat>
   order: string[]
   selectedChatId: string | null
@@ -30,6 +30,10 @@ type Action =
   | { type: 'loaded'; chats: Chat[] }
   | { type: 'setWorkspaces'; workspaces: string[] }
   | { type: 'upsert'; chat: Chat }
+  // Adopt a turn that was started outside the renderer (quick-capture or a
+  // paired channel): insert the fetched chat, append an assistant stub, and
+  // open an inFlight entry so its live events render. See onEvent adoption.
+  | { type: 'adoptInFlight'; chat: Chat; assistantMessageId: string }
   | { type: 'remove'; chatId: string }
   | { type: 'select'; chatId: string | null }
   | { type: 'toggleWorkspace'; workspaceName: string }
@@ -51,7 +55,7 @@ function reorder(order: string[], chatId: string): string[] {
   return [chatId, ...order.filter(id => id !== chatId)]
 }
 
-function reducer(state: State, action: Action): State {
+export function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'loaded': {
       const chats: Record<string, Chat> = {}
@@ -80,6 +84,38 @@ function reducer(state: State, action: Action): State {
       const chats = { ...state.chats, [action.chat.id]: next }
       const order = state.order.includes(action.chat.id) ? state.order : [action.chat.id, ...state.order]
       return { ...state, chats, order: reorder(order, action.chat.id) }
+    }
+    case 'adoptInFlight': {
+      // Externally-initiated turn (quick-capture / paired channel). The fetched
+      // chat already holds the persisted user message; append an empty assistant
+      // stub for the live turn and open an inFlight entry so streaming/tool
+      // events render and the "working" indicator shows. Idempotent: if a turn
+      // is already tracked for this chat, leave it untouched.
+      if (state.inFlight[action.chat.id]) return state
+      const assistantStub: ChatMessage = {
+        id: action.assistantMessageId,
+        role: 'assistant',
+        content: '',
+        timestamp: Date.now(),
+        toolCalls: [],
+        isComplete: false,
+      }
+      const userMessageId = [...action.chat.messages].reverse().find(m => m.role === 'user')?.id ?? ''
+      const adopted: Chat = {
+        ...action.chat,
+        messages: [...action.chat.messages, assistantStub],
+        updatedAt: Date.now(),
+      }
+      const order = state.order.includes(action.chat.id) ? state.order : [action.chat.id, ...state.order]
+      return {
+        ...state,
+        chats: { ...state.chats, [action.chat.id]: adopted },
+        order: reorder(order, action.chat.id),
+        inFlight: {
+          ...state.inFlight,
+          [action.chat.id]: { assistantMessageId: action.assistantMessageId, userMessageId, agentStatus: 'thinking' },
+        },
+      }
     }
     case 'patchContextPanelOpen': {
       const chat = state.chats[action.chatId]
@@ -321,6 +357,10 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   })
 
   const pendingAssistantId = useRef<Record<string, string>>({})
+  // Chats whose externally-initiated turn we are mid-adopting (chats.get in
+  // flight). Prevents duplicate fetches and lets a fast terminal event cancel
+  // a pending adoption (see onEvent).
+  const adopting = useRef<Set<string>>(new Set())
 
   useEffect(() => {
     ;(async () => {
@@ -350,6 +390,29 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useEffect(() => {
     const off = apiService.chats.onEvent((ev: ChatStreamEvent) => {
+      // Adopt turns started outside the renderer (quick-capture, paired
+      // channels). Such chats have no local inFlight entry, so every live event
+      // below would be dropped until 'done'. On the first live event, fetch the
+      // chat (its user message is already persisted) and open an inFlight entry
+      // so streaming/tool events render and the "working" indicator shows.
+      if (
+        (ev.type === 'tool_start' || ev.type === 'tool_end' || ev.type === 'info' ||
+         ev.type === 'stream' || ev.type === 'thinking') &&
+        !pendingAssistantId.current[ev.chatId] &&
+        !adopting.current.has(ev.chatId)
+      ) {
+        adopting.current.add(ev.chatId)
+        apiService.chats.get(ev.chatId)
+          .then(chat => {
+            // A terminal event may have won the race and cancelled adoption.
+            if (!adopting.current.has(ev.chatId)) return
+            const assistantMessageId = `asst-${Date.now()}-${Math.random()}`
+            pendingAssistantId.current[ev.chatId] = assistantMessageId
+            dispatch({ type: 'adoptInFlight', chat, assistantMessageId })
+          })
+          .catch(() => { adopting.current.delete(ev.chatId) })
+      }
+
       switch (ev.type) {
         case 'queued':
           dispatch({ type: 'queued', chatId: ev.chatId, position: ev.position })
@@ -385,6 +448,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           dispatch({ type: 'thinkingToken', chatId: ev.chatId, token: ev.token, step: ev.step })
           break
         case 'done': {
+          adopting.current.delete(ev.chatId)
           const asstId = pendingAssistantId.current[ev.chatId]
           if (asstId) {
             dispatch({
@@ -409,11 +473,13 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           break
         }
         case 'stopped': {
+          adopting.current.delete(ev.chatId)
           dispatch({ type: 'stoppedSend', chatId: ev.chatId, text: ev.text })
           delete pendingAssistantId.current[ev.chatId]
           break
         }
         case 'error': {
+          adopting.current.delete(ev.chatId)
           const asstId = pendingAssistantId.current[ev.chatId]
           if (asstId) {
             dispatch({ type: 'errorSend', chatId: ev.chatId, assistantMessageId: asstId, error: ev.message })


### PR DESCRIPTION
## Summary
Two UX fixes in the macOS app, from screenshot feedback on the Settings → General tab and the Quick Capture window.

### 1. General settings spacing
The toggle/hotkey rows were packed with a flat 10px gap and no visual structure, so the alignment was hard to read. The six settings (Skip permissions → Hide Dock icon) are now grouped into a bordered card with dividers between each row and roomier padding — each label/control pair reads as its own line and the toggles line up cleanly down the right edge.

### 2. Screenshots preview as images, not files
Screenshot (and picked-image) attachments in Quick Capture rendered as plain filename chips. The chat composer previews images via the `codey-asset://` protocol, but that handler only serves files under `.codey/uploads/` — screenshots live in `os.tmpdir()` and picked files at their original path, so that route 403s.

Added a read-only `capture:thumbnail(path)` IPC that returns a base64 data URL (image extensions only, 25 MB cap). Image attachments now render as 48×48 cover-fit tiles with an overlaid × button, matching the chat composer. Non-image files keep the filename chip; an image falls back to the chip if its preview can't be read.

## Files
- `src/components/AppearanceTab.tsx` — grouped/divided setting rows
- `src/components/CaptureWindow.tsx` — image thumbnails + lazy load
- `electron/main.ts` — `capture:thumbnail` handler
- `electron/preload.ts`, `src/codey-api.d.ts` — IPC wiring + types

## Note
Based on `fix/capture-live-chat-adoption` (PR #122), so this stacks on that branch — only the one commit here is new.

## Test plan
- `tsc --noEmit` passes for both renderer (`tsconfig.json`) and electron (`tsconfig.electron.json`).
- Not yet eyeballed in the running app: Settings → General spacing, and screenshot-hotkey → Quick Capture showing a live thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)