### PR TITLE
fix: stop fallback banner leaking into chat titles; add fallback badge

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1088,18 +1088,28 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
               }
               <div style={styles.tsLabel}>
                 <span>{fmtTime(msg.timestamp)}</span>
-                {(() => {
-                  const tokStr = msg.tokens != null ? formatTokens(msg.tokens) : null
-                  const durStr = msg.durationSec != null && Number.isFinite(msg.durationSec) ? `${msg.durationSec}s` : null
-                  if (!tokStr && !durStr) return null
-                  return (
-                    <span style={styles.tsMeta}>
-                      {tokStr && `${tokStr} tok`}
-                      {tokStr && durStr && ' · '}
-                      {durStr}
+                <span style={styles.tsRight}>
+                  {msg.fallback && (
+                    <span
+                      style={styles.fallbackBadge}
+                      title={`Primary ${msg.fallback.from} failed — answered by fallback ${msg.fallback.to}`}
+                    >
+                      ⤷ {msg.fallback.to}
                     </span>
-                  )
-                })()}
+                  )}
+                  {(() => {
+                    const tokStr = msg.tokens != null ? formatTokens(msg.tokens) : null
+                    const durStr = msg.durationSec != null && Number.isFinite(msg.durationSec) ? `${msg.durationSec}s` : null
+                    if (!tokStr && !durStr) return null
+                    return (
+                      <span style={styles.tsMeta}>
+                        {tokStr && `${tokStr} tok`}
+                        {tokStr && durStr && ' · '}
+                        {durStr}
+                      </span>
+                    )
+                  })()}
+                </span>
               </div>
             </div>
           )
@@ -1320,6 +1330,12 @@ const styles: Record<string, React.CSSProperties> = {
   typingRow: { display: 'flex', alignItems: 'center', gap: 8, color: C.fg3, fontSize: 13, marginBottom: 12 },
   tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, paddingLeft: 4, paddingRight: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
   tsMeta: { color: C.fg3, opacity: 0.55, fontVariantNumeric: 'tabular-nums' },
+  tsRight: { display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 },
+  fallbackBadge: {
+    color: C.warningFg, background: C.warningBg,
+    borderRadius: 6, padding: '1px 6px', fontSize: 10,
+    maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
   inputContainer: { padding: '10px 14px 12px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 6, flexShrink: 0 },
   composer: {
     background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 12,

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -38,7 +38,7 @@ type Action =
   | { type: 'thinkingToken'; chatId: string; token: string; step?: number }
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: 'working' | 'writing' }
   | { type: 'queued'; chatId: string; position: number }
-  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion'] }
+  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion']; fallback?: ChatMessage['fallback'] }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
   | { type: 'stoppedSend'; chatId: string; text: string }
   | { type: 'clearRestore'; chatId: string }
@@ -213,7 +213,7 @@ function reducer(state: State, action: Action): State {
       if (!chat) return state
       const messages = chat.messages.map(m =>
         m.id === action.assistantMessageId
-          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true, choices: action.choices, userQuestion: action.userQuestion }
+          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true, choices: action.choices, userQuestion: action.userQuestion, fallback: action.fallback }
           : m
       )
       const updatedChat: Chat = { ...chat, messages, updatedAt: Date.now() }
@@ -397,6 +397,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               title: ev.title,
               choices: ev.choices,
               userQuestion: ev.userQuestion,
+              fallback: ev.fallback,
             })
             delete pendingAssistantId.current[ev.chatId]
           } else {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -11,7 +11,7 @@ export type ChatStreamEvent =
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
   | { type: 'thinking'; chatId: string; token: string; step?: number }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string } }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/core/src/aide-tasks.ts
+++ b/packages/core/src/aide-tasks.ts
@@ -88,7 +88,11 @@ export async function generateChatTitle(
 
 /** Collapse whitespace, strip wrapping quotes/markdown, and clamp length. */
 function sanitizeTitle(raw: string): string {
-  let t = raw.trim().split('\n')[0].trim();
+  // Defensive: drop a leading "[Fallback: … → …]" banner line if one ever
+  // reaches here (the banner now travels as response metadata, not text, but
+  // a cached/older output could still carry it — never make it the title).
+  const cleaned = raw.replace(/^\s*\[Fallback:[^\]]*\]\s*/i, '');
+  let t = cleaned.trim().split('\n')[0].trim();
   // Drop a leading "Title:" style label some models prepend.
   t = t.replace(/^(title|标题)\s*[:：]\s*/i, '');
   // Strip a single layer of wrapping quotes or backticks.

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -30,6 +30,12 @@ export interface ChatMessage {
   tokens?: number;
   /** Wall-clock seconds the agent took to produce the response. */
   durationSec?: number;
+  /**
+   * Present when this turn was produced by a fallback agent after the primary
+   * failed. Rendered as a small badge in the message footer. `from`/`to` are
+   * display labels like "claude-code(opus)".
+   */
+  fallback?: { from: string; to: string };
   /** Extended-thinking for a single-agent assistant message (collapsed in UI). */
   thinking?: string;
   /** Per-team-step extended-thinking, keyed by step number. */

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -192,6 +192,13 @@ export interface AgentResponse {
   sessionId?: string;
   /** Tools that were denied due to permission settings (only when skipPermissions is false). */
   permissionDenials?: Array<{ toolName: string; toolInput?: Record<string, unknown> }>;
+  /**
+   * Set when the primary agent failed and a configured fallback produced this
+   * response. Carries the labels (e.g. "claude-code(opus)") so the UI can show
+   * a badge. Kept as structured metadata — never injected into `output` — so
+   * machine-consumed Aide calls (titles, summaries, JSON) stay clean.
+   */
+  fallback?: { from: string; to: string };
   /** Structured question extracted from an AskUserQuestion tool call. */
   userQuestion?: {
     question: string;

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -10,7 +10,7 @@ export type ChatStreamEvent =
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string }
   | { type: 'thinking'; chatId: string; token: string; step?: number }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> } }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string } }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/gateway/src/chats.test.ts
+++ b/packages/gateway/src/chats.test.ts
@@ -68,6 +68,26 @@ async function run() {
   mgr.setPendingTeam(chat.id, null);
   assert.strictEqual(mgr.get(chat.id)?.pendingTeam, undefined);
 
+  // Fallback-title heal: a chat persisted with a leaked "[Fallback: …]" title
+  // (from before the banner moved to response metadata) is re-derived from the
+  // first user message on the next load.
+  const healChat = mgr.create({ workspaceName: 'main', title: 'placeholder' });
+  mgr.appendMessage(healChat.id, {
+    id: 'u-heal', role: 'user', content: 'Refactor the auth module to use JWT',
+    timestamp: 1, isComplete: true,
+  });
+  // Simulate the old on-disk contamination by writing a banner title directly.
+  const healFile = path.join(root, 'main', 'chats', `${healChat.id}.json`);
+  const onDisk = JSON.parse(fs.readFileSync(healFile, 'utf8'));
+  onDisk.title = '[Fallback: claude-code(opus) → opencode(deepseek)]';
+  fs.writeFileSync(healFile, JSON.stringify(onDisk, null, 2), 'utf8');
+
+  const healed = new ChatManager(root);
+  assert.strictEqual(healed.get(healChat.id)?.title, 'Refactor the auth module to use JWT');
+  // And the heal is persisted, so a second load also sees the clean title.
+  const healedAgain = new ChatManager(root);
+  assert.strictEqual(healedAgain.get(healChat.id)?.title, 'Refactor the auth module to use JWT');
+
   fs.rmSync(root, { recursive: true, force: true });
   console.log('chats.test ok');
 }

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -65,7 +65,17 @@ export class ChatManager {
           const raw = fs.readFileSync(full, 'utf8');
           const chat = JSON.parse(raw) as Chat;
           if (chat.id && chat.workspaceName) {
-            this.cache.set(chat.id, chat);
+            // Heal titles persisted before the fallback banner was moved out of
+            // the response text: such titles are just the leaked "[Fallback: …]"
+            // line. Re-derive from the first user message and persist once.
+            if (chat.title && /^\[Fallback:/.test(chat.title)) {
+              const firstUser = chat.messages?.find(m => m.role === 'user');
+              chat.title = firstUser ? deriveTitle(firstUser.content) : 'New Chat';
+              this.cache.set(chat.id, chat);
+              this.persist(chat);
+            } else {
+              this.cache.set(chat.id, chat);
+            }
           }
         } catch (err) {
           log.warn(`ChatManager: skipped corrupt chat file ${full}: ${(err as Error).message}`);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3305,7 +3305,11 @@ Example: /model gpt-4.1 write a Python script`;
       });
       if (fallbackResponse.success) {
         const fromLabel = originalModel ? `${agent}(${originalModel})` : agent;
-        fallbackResponse.output = `[Fallback: ${fromLabel} → ${label}]\n\n${fallbackResponse.output}`;
+        // Carry the fallback as structured metadata rather than prepending a
+        // banner to the output text. The Aide reuses this same fallback-routed
+        // runner for housekeeping (title/summary/JSON), and a text banner would
+        // leak into those — e.g. a chat title becoming "[Fallback: …]".
+        fallbackResponse.fallback = { from: fromLabel, to: label };
         return fallbackResponse;
       }
       this.logger.error(`Fallback ${label} also failed: ${fallbackResponse.error || fallbackResponse.output}`);
@@ -3960,6 +3964,7 @@ Example: /model gpt-4.1 write a Python script`;
         durationSec,
         ...(surfacedChoices ? { choices: surfacedChoices } : {}),
         ...(agentUserQuestion ? { userQuestion: agentUserQuestion } : {}),
+        ...(singleAgentResponse?.fallback ? { fallback: singleAgentResponse.fallback } : {}),
       };
       const updated = this.chatManager.appendMessage(chatId, assistantMessage);
 
@@ -3980,7 +3985,7 @@ Example: /model gpt-4.1 write a Python script`;
         }
       }
 
-      sink({ type: 'done', chatId, response: output, thinking: singleAgentResponse?.thinking, tokens, durationSec, title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion });
+      sink({ type: 'done', chatId, response: output, thinking: singleAgentResponse?.thinking, tokens, durationSec, title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion, fallback: singleAgentResponse?.fallback });
 
       // Mirror this turn to every attached route except the originating one.
       // Mac-origin uses a synthetic '__mac__' channel that matches no real


### PR DESCRIPTION
## Problem

Chat titles were showing up as `[Fallback: claude-code(deepseek)…` (see two affected chats below). The fallback "banner" (`[Fallback: from → to]`) was prepended directly into the response **output text** (`gateway.ts` `runFallback`). The Aide reuses the *same fallback-routed runner* for housekeeping, so when title generation itself fell back, `generateChatTitle → sanitizeTitle` took the banner's first line as the chat title. The same leak silently corrupted summaries, task briefs, and JSON classification too.

## Fix — carry the fallback as structured metadata, not text

**1. Title is never the banner**
- `runFallback` now sets `response.fallback = { from, to }` instead of mutating `output`. Aide calls read only `output`, so titles/summaries stay clean.
- `sanitizeTitle` defensively strips a leading `[Fallback: …]` line (guards cached/older output).
- `ChatManager` **auto-heals already-persisted banner titles** on load: a title matching `^\[Fallback:` is re-derived from the first user message and re-persisted. Fixes existing broken chats with no user action.

**2. Show which model answered**
- `AgentResponse` + `ChatMessage` gain `fallback?: { from, to }`.
- The `done` stream event and the persisted assistant message carry it through gateway → `chat-runner` → renderer (`api.ts`, `useChats.tsx`).
- `ChatTab` renders a small amber pill in the message footer (next to tokens/duration): `⤷ opencode(deepseek)`, tooltip `Primary … failed — answered by fallback …`.
- The textual banner is **dropped everywhere** (no more `[Fallback: …]` in Telegram/Discord/iMessage output) — fallback info now lives as metadata + Mac badge.

Out of scope: the ephemeral Quick Question path also uses fallback but isn't a persisted/footer-rendered message, so it's left unbadged.

## Verification (Node 22.17.1)
- `build:core` + `build:gateway` — clean
- renderer `tsc -p tsconfig.json` + electron `tsc -p tsconfig.electron.json` — clean
- `npx vitest run` (codey-mac) — **92 passed (12 files)**
- `packages/gateway/src/chats.test.ts` incl. new fallback-title-heal regression — `chats.test ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)