### PR TITLE
test: CI regression coverage for the fallback-title fix (#124)

### DIFF
--- a/packages/core/src/aide-tasks.test.ts
+++ b/packages/core/src/aide-tasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { generateTaskBrief } from './aide-tasks';
+import { generateTaskBrief, generateChatTitle } from './aide-tasks';
 import type { Chat } from './types/chat';
 import type { AideOptions } from './aide';
 
@@ -42,5 +42,21 @@ describe('generateTaskBrief', () => {
     const brief = await generateTaskBrief(makeChat({ title: 'My Task' }), optsReturning('not json'));
     expect(brief.goal).toBe('My Task');
     expect(brief.timeline).toEqual([]);
+  });
+});
+
+describe('generateChatTitle', () => {
+  it('strips a leaked fallback banner so it never becomes the title', async () => {
+    // Regression: the Aide reuses the fallback-routed runner, so a fallback
+    // could prepend "[Fallback: …]\n\n" to its output. sanitizeTitle must not
+    // take that banner line as the title.
+    const banner = '[Fallback: claude-code(opus) → opencode(deepseek)]\n\nRefactor auth module';
+    const title = await generateChatTitle('refactor the auth module', optsReturning(banner));
+    expect(title).toBe('Refactor auth module');
+  });
+
+  it('returns the clean title when no banner is present', async () => {
+    const title = await generateChatTitle('add google login', optsReturning('Add Google login'));
+    expect(title).toBe('Add Google login');
   });
 });

--- a/packages/gateway/src/chats.fallbackHeal.test.ts
+++ b/packages/gateway/src/chats.fallbackHeal.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+
+function tmpRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+  fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+  return root;
+}
+
+function chatFile(root: string, ws: string, id: string): string {
+  return path.join(root, ws, 'chats', `${id}.json`);
+}
+
+// Regression for the fallback-banner-as-title bug. Before the fix, a chat
+// could be persisted with its title set to the leaked "[Fallback: …]" banner.
+// ChatManager must heal such titles on load by re-deriving from the first user
+// message, and persist the repair so it survives subsequent loads.
+describe('ChatManager fallback-title heal', () => {
+  it('re-derives a persisted "[Fallback: …]" title from the first user message', () => {
+    const root = tmpRoot();
+    const mgr = new ChatManager(root);
+    const chat = mgr.create({ workspaceName: 'ws', title: 'placeholder' });
+    mgr.appendMessage(chat.id, {
+      id: 'u1', role: 'user', content: 'Refactor the auth module to use JWT',
+      timestamp: 1, isComplete: true,
+    });
+
+    // Simulate the old on-disk contamination.
+    const file = chatFile(root, 'ws', chat.id);
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf8'));
+    onDisk.title = '[Fallback: claude-code(opus) → opencode(deepseek)]';
+    fs.writeFileSync(file, JSON.stringify(onDisk, null, 2), 'utf8');
+
+    const healed = new ChatManager(root);
+    expect(healed.get(chat.id)?.title).toBe('Refactor the auth module to use JWT');
+
+    // The repair is persisted: a fresh manager also sees the clean title.
+    const reloaded = new ChatManager(root);
+    expect(reloaded.get(chat.id)?.title).toBe('Refactor the auth module to use JWT');
+  });
+
+  it('falls back to "New Chat" when there is no user message to derive from', () => {
+    const root = tmpRoot();
+    const mgr = new ChatManager(root);
+    const chat = mgr.create({ workspaceName: 'ws', title: 'placeholder' });
+
+    const file = chatFile(root, 'ws', chat.id);
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf8'));
+    onDisk.title = '[Fallback: claude-code(opus) → codex(gpt-5)]';
+    fs.writeFileSync(file, JSON.stringify(onDisk, null, 2), 'utf8');
+
+    const healed = new ChatManager(root);
+    expect(healed.get(chat.id)?.title).toBe('New Chat');
+  });
+
+  it('leaves normal titles untouched', () => {
+    const root = tmpRoot();
+    const mgr = new ChatManager(root);
+    const chat = mgr.create({ workspaceName: 'ws', title: 'Implement billing' });
+
+    const reloaded = new ChatManager(root);
+    expect(reloaded.get(chat.id)?.title).toBe('Implement billing');
+  });
+});

--- a/packages/gateway/src/chats.test.ts
+++ b/packages/gateway/src/chats.test.ts
@@ -68,25 +68,8 @@ async function run() {
   mgr.setPendingTeam(chat.id, null);
   assert.strictEqual(mgr.get(chat.id)?.pendingTeam, undefined);
 
-  // Fallback-title heal: a chat persisted with a leaked "[Fallback: …]" title
-  // (from before the banner moved to response metadata) is re-derived from the
-  // first user message on the next load.
-  const healChat = mgr.create({ workspaceName: 'main', title: 'placeholder' });
-  mgr.appendMessage(healChat.id, {
-    id: 'u-heal', role: 'user', content: 'Refactor the auth module to use JWT',
-    timestamp: 1, isComplete: true,
-  });
-  // Simulate the old on-disk contamination by writing a banner title directly.
-  const healFile = path.join(root, 'main', 'chats', `${healChat.id}.json`);
-  const onDisk = JSON.parse(fs.readFileSync(healFile, 'utf8'));
-  onDisk.title = '[Fallback: claude-code(opus) → opencode(deepseek)]';
-  fs.writeFileSync(healFile, JSON.stringify(onDisk, null, 2), 'utf8');
-
-  const healed = new ChatManager(root);
-  assert.strictEqual(healed.get(healChat.id)?.title, 'Refactor the auth module to use JWT');
-  // And the heal is persisted, so a second load also sees the clean title.
-  const healedAgain = new ChatManager(root);
-  assert.strictEqual(healedAgain.get(healChat.id)?.title, 'Refactor the auth module to use JWT');
+  // Note: fallback-title heal coverage lives in chats.fallbackHeal.test.ts
+  // (a vitest file that actually runs in CI; this script is ts-node only).
 
   fs.rmSync(root, { recursive: true, force: true });
   console.log('chats.test ok');

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       'src/team-pause.test.ts',
       'src/chats.discussion.test.ts',
       'src/chats.taskBrief.test.ts',
+      'src/chats.fallbackHeal.test.ts',
       'src/parallel-team.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],


### PR DESCRIPTION
## Why

Reviewing what #124 left behind: **the fix had no test that runs in CI.** Both the gateway and core vitest configs use an explicit allowlist, and the heal assertion added in #124 lived in `chats.test.ts` — a legacy `ts-node`-only script that CI never invokes (`npm test` → `vitest run`, which only collects allowlisted files). So the user's exact bug (fallback banner becoming the chat title) had zero automated guard.

Confirmed empirically: `npm test -w @codey/gateway` collected only 6 files / 30 tests despite ~9 `*.test.ts` in `src/` — the `assert`/IIFE scripts are deliberately excluded.

## What

- **core** (`aide-tasks.test.ts`): `generateChatTitle` tests — a leaked `[Fallback: …]` banner is stripped and never becomes the title. Verified to **fail without the fix** (reverting the `sanitizeTitle` strip makes the banner test red), so it's a real regression guard, not a tautology.
- **gateway** (`chats.fallbackHeal.test.ts`, new, added to the vitest allowlist): `ChatManager` re-derives a persisted `[Fallback: …]` title from the first user message, persists the repair, falls back to `New Chat` with no user message, and leaves normal titles untouched.
- Drop the now-redundant heal block from the `ts-node`-only `chats.test.ts` (coverage now lives in the vitest file).

## Verification (Node 22.17.1)
- `npm test -w @codey/core` — 51 passed (9 files), incl. 2 new title tests
- `npm test -w @codey/gateway` — 33 passed (7 files), incl. 3 new heal tests
- Mutation check: removing the `sanitizeTitle` strip turns the banner test red; restoring it passes
- `build:core` + `build:gateway` — clean

## Not covered (intentional, noting for visibility)
- The ephemeral **Quick Question** path runs through fallback but isn't a persisted/footer-rendered message, so it stays unbadged.
- Already-persisted **summaries / task briefs** that captured the banner before the fix aren't healed (titles are). Low impact — internal, and new contamination is stopped at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)