### PR TITLE
fix(codey-mac): open context panel on message click when closed

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -903,6 +903,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
               onClick={isUser ? undefined : () => {
                 setSelectedTurnIdState(msg.id)
                 setFollowLatest(false)
+                // If the context panel is closed, open it on the turn-detail
+                // tab so clicking a message reveals that turn's own detail.
+                if (!panelOpen) {
+                  setContextPanelOpen(chat.id, true)
+                  setPanelTab('current')
+                }
               }}
               style={{
                 display: 'flex', flexDirection: 'column',


### PR DESCRIPTION
## Summary
Clicking an assistant chat message previously set the selected turn internally but did nothing visible when the right-side context panel was closed — so you couldn't see that turn's detail.

Now, clicking a message while the panel is closed opens it on the turn-detail (`current`) tab and shows that message's own detail. Behavior is unchanged when the panel is already open (it just retargets the selection).

## Changes
- `codey-mac/src/components/ChatTab.tsx`: in the assistant-message `onClick`, open the context panel and switch to the `current` tab when it's closed.

## Testing
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)