### PR TITLE
fix(codey-mac): float Status sidecar as a card over the chat

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -496,12 +496,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   })()
   const panelOpen: boolean = chat?.contextPanelOpen ?? false
 
-  // The Status sidecar shows in the right slot when the panel is closed and
-  // there's room for it (same width math as the panel block below). It needs
-  // at least one assistant turn to have something to summarize.
+  // The Status sidecar floats over the chat's top-right when the panel is
+  // closed (it's absolutely positioned, so it takes no layout space). Hidden on
+  // narrow windows where it would cover most of the conversation, and only when
+  // there's at least one assistant turn to summarize.
   const SIDECAR_W = 220
-  const sidecarChatListW = windowWidth < 600 ? 180 : 240
-  const sidecarFits = windowWidth - sidecarChatListW - 360 >= SIDECAR_W
+  const sidecarFits = windowWidth >= 720
   const hasAssistantMsg = (chat?.messages ?? []).some(m => m.role === 'assistant')
   const sidecarVisible = !panelOpen && sidecarFits && !!chat && hasAssistantMsg
 

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -500,7 +500,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   // closed (it's absolutely positioned, so it takes no layout space). Hidden on
   // narrow windows where it would cover most of the conversation, and only when
   // there's at least one assistant turn to summarize.
-  const SIDECAR_W = 220
+  const SIDECAR_W = 264
   const sidecarFits = windowWidth >= 720
   const hasAssistantMsg = (chat?.messages ?? []).some(m => m.role === 'assistant')
   const sidecarVisible = !panelOpen && sidecarFits && !!chat && hasAssistantMsg

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -18,8 +18,17 @@ const clamp = (lines: number): React.CSSProperties => ({
   display: '-webkit-box', WebkitLineClamp: lines, WebkitBoxOrient: 'vertical', overflow: 'hidden',
 })
 
+const COLLAPSE_KEY = 'codey.statusSidecarCollapsed'
+
 export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width }) => {
   const sm = statusMeta(view.status)
+  const [collapsed, setCollapsed] = React.useState<boolean>(() => localStorage.getItem(COLLAPSE_KEY) === '1')
+  React.useEffect(() => { localStorage.setItem(COLLAPSE_KEY, collapsed ? '1' : '0') }, [collapsed])
+
+  const pill = (
+    <span style={{ ...styles.pill, color: toneColor(sm.tone), background: `${toneColor(sm.tone)}22` }}>{sm.label}</span>
+  )
+
   return (
     <div
       style={{ ...styles.root, width }}
@@ -31,40 +40,57 @@ export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width })
     >
       <div style={styles.header}>
         <span style={styles.headerLabel}>Status</span>
-        {loading && <span style={styles.headerLoading}>updating…</span>}
-      </div>
-
-      <div style={styles.goal}>{view.goal}</div>
-
-      <div style={styles.statusRow}>
-        <span style={{ ...styles.pill, color: toneColor(sm.tone), background: `${toneColor(sm.tone)}22` }}>{sm.label}</span>
-        <span style={styles.progress}>{view.progress}%</span>
-      </div>
-      <div style={styles.barTrack}>
-        <div style={{ ...styles.barFill, width: `${view.progress}%` }} />
-      </div>
-
-      {view.nextActionText && (
-        <div style={styles.nextBox}>
-          <div style={styles.sectionLabel}>Next</div>
-          <div style={styles.nextText}>{view.nextActionText}</div>
+        <div style={styles.headerRight}>
+          {loading && <span style={styles.headerLoading}>updating…</span>}
+          <button
+            style={styles.collapseBtn}
+            onClick={(e) => { e.stopPropagation(); setCollapsed(v => !v) }}
+            title={collapsed ? 'Expand' : 'Collapse'}
+            aria-label={collapsed ? 'Expand status' : 'Collapse status'}
+          >{collapsed ? '▸' : '▾'}</button>
         </div>
-      )}
+      </div>
 
-      {view.recent.length > 0 && (
-        <div style={styles.recent}>
-          <div style={styles.sectionLabel}>Recent</div>
-          {view.recent.map((r, i) => (
-            <div key={i} style={styles.recentRow}>
-              <span style={styles.dot} />
-              <span style={styles.recentText}>{r.text}</span>
-              {r.when != null && <span style={styles.recentWhen}>{formatAgo(r.when)}</span>}
+      {collapsed ? (
+        <div style={styles.statusRow}>
+          {pill}
+          <span style={styles.progress}>{view.progress}%</span>
+        </div>
+      ) : (
+        <>
+          <div style={styles.goal}>{view.goal}</div>
+
+          <div style={styles.statusRow}>
+            {pill}
+            <span style={styles.progress}>{view.progress}%</span>
+          </div>
+          <div style={styles.barTrack}>
+            <div style={{ ...styles.barFill, width: `${view.progress}%` }} />
+          </div>
+
+          {view.nextActionText && (
+            <div style={styles.nextBox}>
+              <div style={styles.sectionLabel}>Next</div>
+              <div style={styles.nextText}>{view.nextActionText}</div>
             </div>
-          ))}
-        </div>
-      )}
+          )}
 
-      <div style={styles.footer}>Open panel →</div>
+          {view.recent.length > 0 && (
+            <div style={styles.recent}>
+              <div style={styles.sectionLabel}>Recent</div>
+              {view.recent.map((r, i) => (
+                <div key={i} style={styles.recentRow}>
+                  <span style={styles.dot} />
+                  <span style={styles.recentText}>{r.text}</span>
+                  {r.when != null && <span style={styles.recentWhen}>{formatAgo(r.when)}</span>}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div style={styles.footer}>Open panel →</div>
+        </>
+      )}
     </div>
   )
 }
@@ -79,9 +105,14 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', flexDirection: 'column', gap: 10,
     padding: '12px 13px', overflowY: 'auto', cursor: 'pointer',
   },
-  header: { display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' },
+  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   headerLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.6, textTransform: 'uppercase', color: C.fg3 },
+  headerRight: { display: 'flex', alignItems: 'center', gap: 6 },
   headerLoading: { fontSize: 10, color: C.fg3, fontStyle: 'italic' },
+  collapseBtn: {
+    background: 'transparent', border: 'none', color: C.fg3, cursor: 'pointer',
+    fontSize: 11, lineHeight: 1, padding: '2px 4px', borderRadius: 4,
+  },
   goal: { fontSize: 13, fontWeight: 600, color: C.fg, lineHeight: 1.35, ...clamp(2) },
   statusRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   pill: { fontSize: 11, padding: '2px 7px', borderRadius: 6 },

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -71,9 +71,13 @@ export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width })
 
 const styles: Record<string, React.CSSProperties> = {
   root: {
-    height: '100%', background: C.surface2, borderLeft: `1px solid ${C.border}`,
-    flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 10,
-    padding: '12px 12px', overflowY: 'auto', cursor: 'pointer',
+    // Floats over the chat in the top-right corner — does not take layout space.
+    position: 'absolute', top: 52, right: 16, zIndex: 6,
+    maxHeight: 'calc(100% - 68px)',
+    background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 12,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+    display: 'flex', flexDirection: 'column', gap: 10,
+    padding: '12px 13px', overflowY: 'auto', cursor: 'pointer',
   },
   header: { display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' },
   headerLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.6, textTransform: 'uppercase', color: C.fg3 },
@@ -92,5 +96,5 @@ const styles: Record<string, React.CSSProperties> = {
   dot: { flex: 'none', width: 6, height: 6, borderRadius: '50%', background: C.green, marginTop: 5 },
   recentText: { flex: 1, minWidth: 0, fontSize: 12, color: C.fg2, lineHeight: 1.4, ...clamp(2) },
   recentWhen: { flex: 'none', fontSize: 10, color: C.fg3, whiteSpace: 'nowrap' },
-  footer: { marginTop: 'auto', fontSize: 11, color: C.fg3, paddingTop: 8 },
+  footer: { fontSize: 11, color: C.fg3, paddingTop: 2 },
 }


### PR DESCRIPTION
## Summary
Follow-up to #127. The Status sidecar was rendering as a full-height layout **column** on the right, shifting the layout. This makes it a small **floating card** absolutely positioned in the chat's top-right that hovers over the conversation and takes no layout space — matching the intended "hovering square" look.

- `StatusSidecar` root: `position: absolute; top: 52; right: 16` with `borderRadius: 12` + drop shadow; removed full-height/`borderLeft`.
- `ChatTab`: relaxed the visibility guard (no longer reserves layout width) — hides only on windows narrower than 720px.

## Test Plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` green
- [ ] Manual: close the right panel on a chat with ≥1 assistant turn → a rounded card floats top-right over the chat (doesn't push content); click opens the Status tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)