### PR TITLE
feat(codey-mac): drag-reorder workspaces + fix file drop on the composer

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -31,6 +31,19 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
   const [wsRenameValue, setWsRenameValue] = useState('')
   const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
+  // User-defined workspace ordering (drag to reorder). Persisted locally; names
+  // not in the list fall back to alphabetical after the ordered ones.
+  const [wsOrder, setWsOrder] = useState<string[]>(() => {
+    try { const v = JSON.parse(localStorage.getItem('codey.workspaceOrder') || '[]'); return Array.isArray(v) ? v : [] }
+    catch { return [] }
+  })
+  const [draggingWs, setDraggingWs] = useState<string | null>(null)
+  const [dragOverWs, setDragOverWs] = useState<string | null>(null)
+
+  const persistWsOrder = (next: string[]) => {
+    setWsOrder(next)
+    localStorage.setItem('codey.workspaceOrder', JSON.stringify(next))
+  }
   // Shrink the panel on narrow windows so the conversation column keeps
   // breathing room. Matches the threshold used in ChatTab for the context panel.
   const [narrow, setNarrow] = useState<boolean>(() => window.innerWidth < 600)
@@ -189,7 +202,25 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
   for (const ws of workspaces) {
     if (!groups[ws]) groups[ws] = []
   }
-  const groupNames = Object.keys(groups).sort()
+  // Order by the user's saved arrangement; unknown names sort alphabetically
+  // after the explicitly-ordered ones.
+  const orderIndex = (name: string) => {
+    const i = wsOrder.indexOf(name)
+    return i === -1 ? Number.MAX_SAFE_INTEGER : i
+  }
+  const groupNames = Object.keys(groups).sort((a, b) => {
+    const ia = orderIndex(a), ib = orderIndex(b)
+    return ia !== ib ? ia - ib : a.localeCompare(b)
+  })
+
+  const reorderWs = (dragged: string, target: string) => {
+    if (dragged === target) return
+    const without = groupNames.filter(n => n !== dragged)
+    const idx = without.indexOf(target)
+    if (idx === -1) return
+    without.splice(idx, 0, dragged)
+    persistWsOrder(without)
+  }
 
   return (
     <div style={{ ...styles.root, width: narrow ? 180 : 240 }}>
@@ -202,12 +233,37 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
           return (
             <div key={ws}>
               <div
-                style={styles.groupHeader}
+                style={{
+                  ...styles.groupHeader,
+                  ...(dragOverWs === ws && draggingWs && draggingWs !== ws ? styles.groupHeaderDropTarget : null),
+                  ...(draggingWs === ws ? styles.groupHeaderDragging : null),
+                }}
+                draggable={renamingWs !== ws}
                 onClick={() => renamingWs === ws ? null : toggleWorkspace(ws)}
                 onContextMenu={(e) => {
                   e.preventDefault()
                   setWsMenu({ workspace: ws, x: e.clientX, y: e.clientY })
                 }}
+                onDragStart={(e) => {
+                  setDraggingWs(ws)
+                  e.dataTransfer.effectAllowed = 'move'
+                  // Some platforms require data to be set for drag to initiate.
+                  try { e.dataTransfer.setData('text/plain', ws) } catch { /* ignore */ }
+                }}
+                onDragOver={(e) => {
+                  if (!draggingWs) return
+                  e.preventDefault()
+                  e.dataTransfer.dropEffect = 'move'
+                  if (dragOverWs !== ws) setDragOverWs(ws)
+                }}
+                onDragLeave={() => { if (dragOverWs === ws) setDragOverWs(null) }}
+                onDrop={(e) => {
+                  e.preventDefault()
+                  if (draggingWs) reorderWs(draggingWs, ws)
+                  setDraggingWs(null)
+                  setDragOverWs(null)
+                }}
+                onDragEnd={() => { setDraggingWs(null); setDragOverWs(null) }}
               >
                 <span style={styles.chevron}>{collapsed ? '📁︎' : '📂︎'}</span>
                 {renamingWs === ws ? (
@@ -451,6 +507,8 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '6px 8px', color: C.fg3, fontSize: 13, fontWeight: 600,
     cursor: 'pointer', userSelect: 'none',
   },
+  groupHeaderDropTarget: { boxShadow: `inset 0 2px 0 ${C.accent}` },
+  groupHeaderDragging: { opacity: 0.45 },
   groupName: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   groupAddBtn: {
     background: 'transparent', border: 'none', color: C.fg3,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -610,6 +610,24 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
     setPendingAttachments(prev => prev.filter(a => a.id !== id))
   }
 
+  // Without this, dropping a file outside the chat's own drop zone (or on the
+  // composer/textarea) makes Electron navigate to file:// and "open" the file.
+  // Swallow file drags window-wide; the chat's onDrop still handles the upload
+  // for drops inside the conversation column.
+  useEffect(() => {
+    const prevent = (e: DragEvent) => {
+      if (e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files')) {
+        e.preventDefault()
+      }
+    }
+    window.addEventListener('dragover', prevent)
+    window.addEventListener('drop', prevent)
+    return () => {
+      window.removeEventListener('dragover', prevent)
+      window.removeEventListener('drop', prevent)
+    }
+  }, [])
+
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -763,7 +781,22 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
 
   return (
     <div style={styles.outer}>
-      <div style={styles.container}>
+      <div
+        style={styles.container}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+      {isDragging && (
+        <div style={styles.dropOverlay}>
+          <div style={styles.dropOverlayCard}>
+            <UploadCloudIcon color={C.accent} size={36} />
+            <div style={styles.dropOverlayTitle}>Drop to attach</div>
+            <div style={styles.dropOverlaySubtitle}>Up to 10 files · max 10 MB each</div>
+          </div>
+        </div>
+      )}
       <div style={styles.header}>
         {editingTitle ? (
           <input
@@ -904,20 +937,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
 
       <div
         style={{ ...styles.messages, position: 'relative' }}
-        onDragEnter={handleDragEnter}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
       >
-        {isDragging && (
-          <div style={styles.dropOverlay}>
-            <div style={styles.dropOverlayCard}>
-              <UploadCloudIcon color={C.accent} size={36} />
-              <div style={styles.dropOverlayTitle}>Drop to attach</div>
-              <div style={styles.dropOverlaySubtitle}>Up to 10 files · max 10 MB each</div>
-            </div>
-          </div>
-        )}
         {chat.messages.map((msg, idx) => {
           const isUser = msg.role === 'user'
           const isSelected = !isUser && msg.id === selectedTurnId && panelOpen
@@ -1355,7 +1375,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
 
 const styles: Record<string, React.CSSProperties> = {
   outer: { display: 'flex', flexDirection: 'row', height: '100%', minHeight: 0, position: 'relative' },
-  container: { display: 'flex', flexDirection: 'column', height: '100%', flex: 1, minWidth: 0 },
+  container: { display: 'flex', flexDirection: 'column', height: '100%', flex: 1, minWidth: 0, position: 'relative' },
   header: {
     padding: '10px 16px', borderBottom: `1px solid ${C.border}`,
     display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0,


### PR DESCRIPTION
## Summary
Two independent UX fixes in the chat window:

1. **Drag-to-reorder workspaces** — workspace group headers in the left panel are now draggable. Drop one onto another to reorder; an accent line marks the drop target and the dragged header dims. The arrangement persists across sessions in `localStorage` (`codey.workspaceOrder`); any workspace not in the saved order falls back to alphabetical after the ordered ones. Renaming a header temporarily disables its drag.

2. **File drop anywhere in the chat** — previously, dragging a file onto the composer/input area made Electron navigate to `file://` and *open* the file instead of attaching it (only the message list was a drop zone). The entire conversation column is now the drop zone, and a window-level guard prevents a stray file drop anywhere from navigating away. Behaves the same as the message-list drop: up to 10 files, 10 MB each.

## Test Plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 96 passing
- [ ] Manual: drag a workspace header above/below another → order changes and survives reload.
- [ ] Manual: drag a file onto the text input → it attaches (no file opens); drag onto the message list → still attaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)