### PR TITLE
fix(codey-mac): floating collapsible Status sidecar

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -496,12 +496,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   })()
   const panelOpen: boolean = chat?.contextPanelOpen ?? false
 
-  // The Status sidecar shows in the right slot when the panel is closed and
-  // there's room for it (same width math as the panel block below). It needs
-  // at least one assistant turn to have something to summarize.
+  // The Status sidecar floats over the chat's top-right when the panel is
+  // closed (it's absolutely positioned, so it takes no layout space). Hidden on
+  // narrow windows where it would cover most of the conversation, and only when
+  // there's at least one assistant turn to summarize.
   const SIDECAR_W = 220
-  const sidecarChatListW = windowWidth < 600 ? 180 : 240
-  const sidecarFits = windowWidth - sidecarChatListW - 360 >= SIDECAR_W
+  const sidecarFits = windowWidth >= 720
   const hasAssistantMsg = (chat?.messages ?? []).some(m => m.role === 'assistant')
   const sidecarVisible = !panelOpen && sidecarFits && !!chat && hasAssistantMsg
 

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -500,7 +500,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   // closed (it's absolutely positioned, so it takes no layout space). Hidden on
   // narrow windows where it would cover most of the conversation, and only when
   // there's at least one assistant turn to summarize.
-  const SIDECAR_W = 220
+  const SIDECAR_W = 264
   const sidecarFits = windowWidth >= 720
   const hasAssistantMsg = (chat?.messages ?? []).some(m => m.role === 'assistant')
   const sidecarVisible = !panelOpen && sidecarFits && !!chat && hasAssistantMsg

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -18,8 +18,17 @@ const clamp = (lines: number): React.CSSProperties => ({
   display: '-webkit-box', WebkitLineClamp: lines, WebkitBoxOrient: 'vertical', overflow: 'hidden',
 })
 
+const COLLAPSE_KEY = 'codey.statusSidecarCollapsed'
+
 export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width }) => {
   const sm = statusMeta(view.status)
+  const [collapsed, setCollapsed] = React.useState<boolean>(() => localStorage.getItem(COLLAPSE_KEY) === '1')
+  React.useEffect(() => { localStorage.setItem(COLLAPSE_KEY, collapsed ? '1' : '0') }, [collapsed])
+
+  const pill = (
+    <span style={{ ...styles.pill, color: toneColor(sm.tone), background: `${toneColor(sm.tone)}22` }}>{sm.label}</span>
+  )
+
   return (
     <div
       style={{ ...styles.root, width }}
@@ -31,40 +40,57 @@ export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width })
     >
       <div style={styles.header}>
         <span style={styles.headerLabel}>Status</span>
-        {loading && <span style={styles.headerLoading}>updating…</span>}
-      </div>
-
-      <div style={styles.goal}>{view.goal}</div>
-
-      <div style={styles.statusRow}>
-        <span style={{ ...styles.pill, color: toneColor(sm.tone), background: `${toneColor(sm.tone)}22` }}>{sm.label}</span>
-        <span style={styles.progress}>{view.progress}%</span>
-      </div>
-      <div style={styles.barTrack}>
-        <div style={{ ...styles.barFill, width: `${view.progress}%` }} />
-      </div>
-
-      {view.nextActionText && (
-        <div style={styles.nextBox}>
-          <div style={styles.sectionLabel}>Next</div>
-          <div style={styles.nextText}>{view.nextActionText}</div>
+        <div style={styles.headerRight}>
+          {loading && <span style={styles.headerLoading}>updating…</span>}
+          <button
+            style={styles.collapseBtn}
+            onClick={(e) => { e.stopPropagation(); setCollapsed(v => !v) }}
+            title={collapsed ? 'Expand' : 'Collapse'}
+            aria-label={collapsed ? 'Expand status' : 'Collapse status'}
+          >{collapsed ? '▸' : '▾'}</button>
         </div>
-      )}
+      </div>
 
-      {view.recent.length > 0 && (
-        <div style={styles.recent}>
-          <div style={styles.sectionLabel}>Recent</div>
-          {view.recent.map((r, i) => (
-            <div key={i} style={styles.recentRow}>
-              <span style={styles.dot} />
-              <span style={styles.recentText}>{r.text}</span>
-              {r.when != null && <span style={styles.recentWhen}>{formatAgo(r.when)}</span>}
+      {collapsed ? (
+        <div style={styles.statusRow}>
+          {pill}
+          <span style={styles.progress}>{view.progress}%</span>
+        </div>
+      ) : (
+        <>
+          <div style={styles.goal}>{view.goal}</div>
+
+          <div style={styles.statusRow}>
+            {pill}
+            <span style={styles.progress}>{view.progress}%</span>
+          </div>
+          <div style={styles.barTrack}>
+            <div style={{ ...styles.barFill, width: `${view.progress}%` }} />
+          </div>
+
+          {view.nextActionText && (
+            <div style={styles.nextBox}>
+              <div style={styles.sectionLabel}>Next</div>
+              <div style={styles.nextText}>{view.nextActionText}</div>
             </div>
-          ))}
-        </div>
-      )}
+          )}
 
-      <div style={styles.footer}>Open panel →</div>
+          {view.recent.length > 0 && (
+            <div style={styles.recent}>
+              <div style={styles.sectionLabel}>Recent</div>
+              {view.recent.map((r, i) => (
+                <div key={i} style={styles.recentRow}>
+                  <span style={styles.dot} />
+                  <span style={styles.recentText}>{r.text}</span>
+                  {r.when != null && <span style={styles.recentWhen}>{formatAgo(r.when)}</span>}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div style={styles.footer}>Open panel →</div>
+        </>
+      )}
     </div>
   )
 }
@@ -79,9 +105,14 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', flexDirection: 'column', gap: 10,
     padding: '12px 13px', overflowY: 'auto', cursor: 'pointer',
   },
-  header: { display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' },
+  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   headerLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.6, textTransform: 'uppercase', color: C.fg3 },
+  headerRight: { display: 'flex', alignItems: 'center', gap: 6 },
   headerLoading: { fontSize: 10, color: C.fg3, fontStyle: 'italic' },
+  collapseBtn: {
+    background: 'transparent', border: 'none', color: C.fg3, cursor: 'pointer',
+    fontSize: 11, lineHeight: 1, padding: '2px 4px', borderRadius: 4,
+  },
   goal: { fontSize: 13, fontWeight: 600, color: C.fg, lineHeight: 1.35, ...clamp(2) },
   statusRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   pill: { fontSize: 11, padding: '2px 7px', borderRadius: 6 },

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -38,16 +38,21 @@ export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width })
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpen() } }}
       title="Open status panel"
     >
-      <div style={styles.header}>
+      <div
+        style={styles.header}
+        onClick={(e) => { e.stopPropagation(); setCollapsed(v => !v) }}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); setCollapsed(v => !v) }
+        }}
+        title={collapsed ? 'Expand status' : 'Collapse status'}
+        aria-expanded={!collapsed}
+      >
         <span style={styles.headerLabel}>Status</span>
         <div style={styles.headerRight}>
           {loading && <span style={styles.headerLoading}>updating…</span>}
-          <button
-            style={styles.collapseBtn}
-            onClick={(e) => { e.stopPropagation(); setCollapsed(v => !v) }}
-            title={collapsed ? 'Expand' : 'Collapse'}
-            aria-label={collapsed ? 'Expand status' : 'Collapse status'}
-          >{collapsed ? '▸' : '▾'}</button>
+          <span style={styles.chevron} aria-hidden>{collapsed ? '▸' : '▾'}</span>
         </div>
       </div>
 
@@ -105,14 +110,16 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', flexDirection: 'column', gap: 10,
     padding: '12px 13px', overflowY: 'auto', cursor: 'pointer',
   },
-  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
-  headerLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.6, textTransform: 'uppercase', color: C.fg3 },
-  headerRight: { display: 'flex', alignItems: 'center', gap: 6 },
-  headerLoading: { fontSize: 10, color: C.fg3, fontStyle: 'italic' },
-  collapseBtn: {
-    background: 'transparent', border: 'none', color: C.fg3, cursor: 'pointer',
-    fontSize: 11, lineHeight: 1, padding: '2px 4px', borderRadius: 4,
+  header: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    cursor: 'pointer', userSelect: 'none',
+    // Stretch the click target across the full card width.
+    margin: '-12px -13px 0', padding: '12px 13px 8px',
   },
+  headerLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.6, textTransform: 'uppercase', color: C.fg3 },
+  headerRight: { display: 'flex', alignItems: 'center', gap: 8 },
+  headerLoading: { fontSize: 10, color: C.fg3, fontStyle: 'italic' },
+  chevron: { color: C.fg2, fontSize: 15, lineHeight: 1 },
   goal: { fontSize: 13, fontWeight: 600, color: C.fg, lineHeight: 1.35, ...clamp(2) },
   statusRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   pill: { fontSize: 11, padding: '2px 7px', borderRadius: 6 },

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -52,7 +52,12 @@ export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width })
         <span style={styles.headerLabel}>Status</span>
         <div style={styles.headerRight}>
           {loading && <span style={styles.headerLoading}>updating…</span>}
-          <span style={styles.chevron} aria-hidden>{collapsed ? '▸' : '▾'}</span>
+          <svg
+            style={{ ...styles.chevron, transform: collapsed ? 'rotate(-90deg)' : 'none' }}
+            width="14" height="14" viewBox="0 0 14 14" aria-hidden
+          >
+            <path d="M3.5 5.25 L7 8.75 L10.5 5.25" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
         </div>
       </div>
 
@@ -119,7 +124,7 @@ const styles: Record<string, React.CSSProperties> = {
   headerLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.6, textTransform: 'uppercase', color: C.fg3 },
   headerRight: { display: 'flex', alignItems: 'center', gap: 8 },
   headerLoading: { fontSize: 10, color: C.fg3, fontStyle: 'italic' },
-  chevron: { color: C.fg2, fontSize: 15, lineHeight: 1 },
+  chevron: { color: C.fg2, display: 'block', flex: 'none', transition: 'transform 0.15s ease' },
   goal: { fontSize: 13, fontWeight: 600, color: C.fg, lineHeight: 1.35, ...clamp(2) },
   statusRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   pill: { fontSize: 11, padding: '2px 7px', borderRadius: 6 },

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -71,9 +71,13 @@ export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width })
 
 const styles: Record<string, React.CSSProperties> = {
   root: {
-    height: '100%', background: C.surface2, borderLeft: `1px solid ${C.border}`,
-    flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 10,
-    padding: '12px 12px', overflowY: 'auto', cursor: 'pointer',
+    // Floats over the chat in the top-right corner — does not take layout space.
+    position: 'absolute', top: 52, right: 16, zIndex: 6,
+    maxHeight: 'calc(100% - 68px)',
+    background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 12,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+    display: 'flex', flexDirection: 'column', gap: 10,
+    padding: '12px 13px', overflowY: 'auto', cursor: 'pointer',
   },
   header: { display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' },
   headerLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.6, textTransform: 'uppercase', color: C.fg3 },
@@ -92,5 +96,5 @@ const styles: Record<string, React.CSSProperties> = {
   dot: { flex: 'none', width: 6, height: 6, borderRadius: '50%', background: C.green, marginTop: 5 },
   recentText: { flex: 1, minWidth: 0, fontSize: 12, color: C.fg2, lineHeight: 1.4, ...clamp(2) },
   recentWhen: { flex: 'none', fontSize: 10, color: C.fg3, whiteSpace: 'nowrap' },
-  footer: { marginTop: 'auto', fontSize: 11, color: C.fg3, paddingTop: 8 },
+  footer: { fontSize: 11, color: C.fg3, paddingTop: 2 },
 }


### PR DESCRIPTION
## Summary
Turns the Status sidecar into a floating, collapsible card and polishes its header interaction.

- Float the Status sidecar as a card over the chat (top-right), not taking layout space
- Collapsible with persisted state (`localStorage`); collapsed view shows just status pill + progress
- Wider card for readability
- Whole header bar is the collapse toggle (click / Enter / Space)
- Replace the text triangle (▸/▾) with a geometrically centered **SVG chevron** that aligns cleanly with the STATUS label and rotates -90° when collapsed

## Test plan
- `npx tsc --noEmit` passes
- Verify: open a chat with status, toggle collapse via the header bar, confirm chevron is centered against "STATUS" and rotates on collapse
- Confirm collapsed/expanded state persists across reloads
- Clicking the card body (outside header) opens the full Status panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)