### PR TITLE
chore: lint to block non-English characters (emoji allowed)

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -377,7 +377,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
           onClick={(e) => e.stopPropagation()}
         >
           <div style={styles.menuHeader}>{wsMenu.workspace}</div>
-          <button style={styles.menuItem} onClick={() => handleNewChat(wsMenu.workspace).then(closeWsMenu)}>＋ New chat</button>
+          <button style={styles.menuItem} onClick={() => handleNewChat(wsMenu.workspace).then(closeWsMenu)}>+ New chat</button>
           <button
             style={{ ...styles.menuItem, opacity: wsMenu.workspace === 'default' ? 0.4 : 1 }}
             disabled={wsMenu.workspace === 'default'}

--- a/codey-mac/src/components/teamMessageFormat.test.ts
+++ b/codey-mac/src/components/teamMessageFormat.test.ts
@@ -72,8 +72,8 @@ describe('extractPreview', () => {
   })
 
   it('handles Chinese full stop', () => {
-    const text = '中间段落\n\n结论一。结论二。'
-    expect(extractPreview(text)).toBe('结论一。')
+    const text = '中间段落\n\n结论一。结论二。' // lint-allow-non-english: Chinese fixture
+    expect(extractPreview(text)).toBe('结论一。') // lint-allow-non-english: Chinese fixture
   })
 
   it('returns whole paragraph when no sentence terminator', () => {

--- a/codey-mac/src/components/teamMessageFormat.ts
+++ b/codey-mac/src/components/teamMessageFormat.ts
@@ -52,7 +52,7 @@ export function extractPreview(output: string): string {
   const westernParts = last.split(/(?<=\w[.!?])\s+/)
   const chunk = westernParts[westernParts.length - 1].trim()
   // Extract the first complete sentence from that chunk
-  const m = chunk.match(/^([^.!?。！？]*[.!?。！？])/)
+  const m = chunk.match(/^([^.!?。！？]*[.!?。！？])/) // lint-allow-non-english: splits on Chinese sentence terminators
   const sentence = (m ? m[1] : chunk).trim()
   if (sentence.length <= MAX_PREVIEW) return sentence
   return sentence.slice(0, MAX_PREVIEW) + '…'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "npm run build -ws --if-present",
+    "lint": "node scripts/check-non-english.mjs",
     "build:core": "npm run build -w @codey/core",
     "build:gateway": "npm run build -w @codey/gateway",
     "dev": "npm run dev -w @codey/gateway",

--- a/packages/core/src/aide-tasks.ts
+++ b/packages/core/src/aide-tasks.ts
@@ -94,7 +94,7 @@ function sanitizeTitle(raw: string): string {
   const cleaned = raw.replace(/^\s*\[Fallback:[^\]]*\]\s*/i, '');
   let t = cleaned.trim().split('\n')[0].trim();
   // Drop a leading "Title:" style label some models prepend.
-  t = t.replace(/^(title|标题)\s*[:：]\s*/i, '');
+  t = t.replace(/^(title|标题)\s*[:：]\s*/i, ''); // lint-allow-non-english: strips Chinese "title:" prefix from model output
   // Strip a single layer of wrapping quotes or backticks.
   t = t.replace(/^["'`“”]+|["'`“”]+$/g, '').trim();
   t = t.replace(/\s+/g, ' ');

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -156,7 +156,7 @@ export interface TaskBrief {
   state: {
     /** 0–100, best-effort. */
     progress: number;
-    /** e.g. "步骤 3 / 5" or a phase name. */
+    /** e.g. "step 3 / 5" or a phase name. */
     stepLabel?: string;
     status: TaskStatus;
   };

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3486,12 +3486,12 @@ Example: /model gpt-4.1 write a Python script`;
     const summaryBody = ev.summary.replace(/^#\s+Summary\s*/i, '').trim();
     return [
       `🪑 Roundtable: **${team}**`,
-      `终止原因: ${ev.reason}`,
+      `Termination reason: ${ev.reason}`,
       '',
-      '## Advisor 总结',
+      '## Advisor Summary',
       summaryBody || '(empty)',
       '',
-      '## 各方观点',
+      '## Viewpoints',
       ...ev.perWorker.map(p => `**${p.name}**: ${p.excerpt || '(empty)'}`),
       '',
       ev.message,

--- a/scripts/check-non-english.mjs
+++ b/scripts/check-non-english.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Lint: flag non-English characters in source code. Emoji are allowed.
+//
+// "Non-English" = any letter outside the Latin script (CJK, Hangul, Kana,
+// Cyrillic, Greek, Arabic, ...) plus CJK/fullwidth punctuation. Emoji and
+// pictographs are symbols (not letters), so they pass; so do ordinary
+// typographic marks like — “ ” → … and accented Latin (é, ü).
+//
+// Opt out on a single line with a trailing `lint-allow-non-english` comment.
+// Run: npm run lint
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, extname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
+
+// Directories to scan (relative to repo root).
+const SCAN_DIRS = [
+  'packages/core/src',
+  'packages/gateway/src',
+  'codey-mac/src',
+  'codey-mac/electron',
+  'scripts',
+];
+
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', 'out', '.git']);
+const ALLOW_MARKER = 'lint-allow-non-english';
+
+// A letter (\p{L}) that is not in the Latin script, excluding emoji/pictographs
+// (e.g. the emoji base "i" in info). Needs the RegExp `v` flag for set
+// subtraction (Node 20+).
+const NON_LATIN_LETTER = /[\p{L}--\p{Script=Latin}--\p{Extended_Pictographic}]/v;
+// CJK symbols & punctuation (U+3000-U+303F) and fullwidth/halfwidth forms
+// (U+FF00-U+FFEF). Written with \u escapes so this file stays pure ASCII.
+const CJK_PUNCTUATION = new RegExp('[\\u3000-\\u303F\\uFF00-\\uFFEF]');
+
+function isOffending(codePoint) {
+  const ch = String.fromCodePoint(codePoint);
+  return NON_LATIN_LETTER.test(ch) || CJK_PUNCTUATION.test(ch);
+}
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return; // directory missing — skip silently
+  }
+  for (const name of entries) {
+    if (SKIP_DIRS.has(name)) continue;
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      yield* walk(full);
+    } else if (EXTENSIONS.has(extname(name))) {
+      yield full;
+    }
+  }
+}
+
+const violations = [];
+
+for (const dir of SCAN_DIRS) {
+  for (const file of walk(join(ROOT, dir))) {
+    const text = readFileSync(file, 'utf8');
+    const lines = text.split(/\r?\n/);
+    lines.forEach((line, i) => {
+      if (line.includes(ALLOW_MARKER)) return;
+      let col = 0;
+      for (const ch of line) {
+        col += 1;
+        if (isOffending(ch.codePointAt(0))) {
+          violations.push({
+            file: relative(ROOT, file),
+            line: i + 1,
+            col,
+            ch,
+            snippet: line.trim().slice(0, 100),
+          });
+        }
+      }
+    });
+  }
+}
+
+if (violations.length === 0) {
+  console.log('✓ No non-English characters found (emoji are allowed).');
+  process.exit(0);
+}
+
+console.error(`✗ Found ${violations.length} non-English character(s):\n`);
+for (const v of violations) {
+  console.error(`  ${v.file}:${v.line}:${v.col}  "${v.ch}"  ${v.snippet}`);
+}
+console.error(
+  '\nUse English only. Emoji are fine. To allow a specific line on purpose, ' +
+    `add a "${ALLOW_MARKER}" comment to it.`,
+);
+process.exit(1);


### PR DESCRIPTION
Adds a dependency-free lint that keeps the codebase English-only, while allowing emoji.

## What it does
- `scripts/check-non-english.mjs`, wired as `npm run lint`.
- Flags **non-Latin letters** (Chinese, Japanese, Korean, Cyrillic, Greek, Arabic, ...) and **CJK/fullwidth punctuation** in source files.
- **Allows** emoji/pictographs (they're symbols, not letters), ordinary typography (— " " → …), and accented Latin (é, ü).
- Scans `packages/*/src`, `codey-mac/src`, `codey-mac/electron`, `scripts` (`.ts/.tsx/.js/.jsx/.mjs/.cjs`); skips `node_modules`/`dist`/`build`.
- Per-line opt-out: add a `lint-allow-non-english` comment.

## Cleanups to make the tree pass
- Translated stray Chinese UI strings/comments to English: the parallel-roundtable headers in `gateway.ts` (now `Termination reason` / `## Advisor Summary` / `## Viewpoints`, matching the surrounding English) and a doc-comment example in `chat.ts`.
- Replaced a fullwidth `＋` with `+` in the new-chat button.
- Marked the genuinely-required Chinese with the opt-out: regexes that parse Chinese model output (`aide-tasks.ts`) and Chinese sentence punctuation (`teamMessageFormat.ts`), plus the Chinese test fixtures in `teamMessageFormat.test.ts`.

## Test Plan
- [x] `npm run lint` — passes (no findings)
- [x] `npm run build:core && npm run build:gateway` — clean
- [x] `npx tsc --noEmit -p codey-mac/tsconfig.json` — clean
- [x] `npm test -w @codey/core` — 81/81; `teamMessageFormat.test.ts` — 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)