### PR TITLE
fix: show more of the chat title in the app title bar

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -197,7 +197,7 @@ const styles: Record<string, React.CSSProperties> = {
     WebkitAppRegion: 'drag',
   },
   titleBarDragArea: { flex: 1, display: 'flex', alignItems: 'center', height: '100%' },
-  titleCenter: { flex: 1, textAlign: 'center', paddingLeft: 12, paddingRight: 12, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' },
+  titleCenter: { flex: 1, textAlign: 'center', paddingLeft: 4, paddingRight: 4, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' },
   appName: { color: C.fg2, fontSize: 13, fontWeight: 500 },
   sidebarToggle: {
     background: 'transparent', border: 'none', cursor: 'pointer',


### PR DESCRIPTION
## What

The chat title in the app's top title bar (`App.tsx`) truncates with an ellipsis (`…`) sooner than necessary. This trims the `titleCenter` horizontal padding from `12` to `4` per side, reclaiming ~16px so a few more characters of the title show before truncating.

## Why

User feedback: the header title cut off too early. The title element already gets all available width (`flex: 1`); the padding was the only free space to reclaim without restructuring the bar layout.

## Notes

- Style-only, single-line change.
- Bigger gains (e.g. smaller font) were intentionally left out to keep the visual change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)