### PR TITLE
Context panel UX fixes + updater restart fix (v0.7.2)

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1119,7 +1119,7 @@ app.whenReady().then(async () => {
   createAppMenu()
   createWindow()
   createTray()
-  registerUpdaterIpc(ipcMain, wrap)
+  registerUpdaterIpc(ipcMain, wrap, () => { isQuitting = true })
   initAutoUpdater(
     (payload) => sendToRenderer('updater:state', payload),
     app.isPackaged,
@@ -2282,4 +2282,19 @@ ipcMain.handle('shell:showItemInFolder', async (_event, p: string) => {
   if (typeof p !== 'string' || !p) return false
   shell.showItemInFolder(p)
   return true
+})
+
+// Read a text file so the file-changes viewer can resolve real line numbers for
+// an edit by locating its content in the current file. Capped at 2 MB and
+// returns null on any failure (missing file, binary, too large).
+ipcMain.handle('file:readText', async (_event, p: string): Promise<string | null> => {
+  if (typeof p !== 'string' || !p) return null
+  try {
+    const fs = require('fs') as typeof import('fs')
+    const stat = await fs.promises.stat(p)
+    if (!stat.isFile() || stat.size > 2 * 1024 * 1024) return null
+    return await fs.promises.readFile(p, 'utf-8')
+  } catch {
+    return null
+  }
 })

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -231,6 +231,7 @@ contextBridge.exposeInMainWorld('codey', {
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openPath: (path: string) => ipcRenderer.invoke('shell:openPath', path),
   revealInFolder: (path: string) => ipcRenderer.invoke('shell:showItemInFolder', path),
+  readTextFile: (path: string) => ipcRenderer.invoke('file:readText', path),
   onLog: (handler: (msg: string) => void) => {
     const listener = (_e: Electron.IpcRendererEvent, msg: string) => handler(msg)
     ipcRenderer.on('gateway-log', listener)

--- a/codey-mac/electron/updater.ts
+++ b/codey-mac/electron/updater.ts
@@ -50,10 +50,19 @@ export function initAutoUpdater(notify: Notify, isPackaged: boolean, log: Log): 
 }
 
 /** IPC handlers driven by the renderer button. */
-export function registerUpdaterIpc(ipcMain: IpcMain, wrap: Wrap): void {
+export function registerUpdaterIpc(ipcMain: IpcMain, wrap: Wrap, beforeInstall?: () => void): void {
   ipcMain.handle('updater:check', () => wrap(async () => { await autoUpdater.checkForUpdates() }))
   ipcMain.handle('updater:download', () => wrap(async () => { await autoUpdater.downloadUpdate() }))
-  ipcMain.handle('updater:install', () => wrap(async () => { autoUpdater.quitAndInstall() }))
+  ipcMain.handle('updater:install', () => wrap(async () => {
+    // Mark the app as quitting first. On macOS quitAndInstall() closes every
+    // window via Squirrel and only quits once they have actually closed — but
+    // our mainWindow 'close' handler hides the window (preventDefault) unless
+    // isQuitting is set, so without this the update would just hide the window
+    // instead of restarting. (The Squirrel path fires `before-quit-for-update`,
+    // not the normal `before-quit` that otherwise sets the flag.)
+    beforeInstall?.()
+    autoUpdater.quitAndInstall()
+  }))
   // Backfill: the renderer reads the last known state on mount in case it
   // missed the initial event while React was still mounting.
   ipcMain.handle('updater:lastState', () => wrap(async () => lastState))

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -182,6 +182,7 @@ declare global {
       openExternal: (url: string) => Promise<void>
       openPath: (path: string) => Promise<string>
       revealInFolder: (path: string) => Promise<boolean>
+      readTextFile: (path: string) => Promise<string | null>
       onLog: (handler: (msg: string) => void) => () => void
     }
   }

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type { Chat, ChatMessage } from '../types'
 import { C } from '../theme'
 import { parseTeamMessage } from './teamMessageFormat'
-import { ToolDetail, DiffView, normalizeTool } from './toolFormat'
+import { ToolDetail, CombinedDiffView, normalizeTool } from './toolFormat'
 import { QuickQuestionView } from './QuickQuestionView'
 import { TaskHud } from './TaskHud'
 
@@ -95,7 +95,7 @@ export const ChatContextPanel: React.FC<Props> = ({
     const startX = e.clientX
     const startW = width
     const move = (mv: MouseEvent) => {
-      const next = Math.max(260, Math.min(520, startW + (startX - mv.clientX)))
+      const next = Math.max(260, Math.min(900, startW + (startX - mv.clientX)))
       onResize(next)
     }
     const up = () => {
@@ -160,13 +160,13 @@ export const ChatContextPanel: React.FC<Props> = ({
           aria-selected={tab === 'files'}
           style={{ ...styles.tab, ...(tab === 'files' ? styles.tabActive : null) }}
           onClick={() => setTab('files')}
-        >File changes</button>
+        >Files</button>
         <button
           role="tab"
           aria-selected={tab === 'qq'}
           style={{ ...styles.tab, ...(tab === 'qq' ? styles.tabActive : null) }}
           onClick={() => setTab('qq')}
-        >Quick Question</button>
+        >Q&amp;A</button>
       </div>
 
       <div style={styles.body}>
@@ -618,6 +618,26 @@ const extractChanges = (chat: Chat): FileChange[] => {
   return out
 }
 
+/**
+ * Find the real 1-based line where an edit begins, by locating its content in
+ * the current file. Prefers the post-edit text (present in the current file);
+ * falls back to the pre-edit text, then to the first non-blank line. Returns
+ * undefined when the file is unavailable or the text can't be located (e.g. the
+ * file changed since, or a later edit superseded this one).
+ */
+const locateStartLine = (content: string | null | undefined, oldText: string, newText: string): number | undefined => {
+  if (!content) return undefined
+  const needle = newText && newText.trim() ? newText : oldText
+  if (!needle) return undefined
+  let idx = content.indexOf(needle)
+  if (idx < 0) {
+    const firstLine = needle.split('\n').find(l => l.trim().length > 0)
+    if (firstLine) idx = content.indexOf(firstLine)
+  }
+  if (idx < 0) return undefined
+  return content.slice(0, idx).split('\n').length
+}
+
 const displayPath = (abs: string, workingDir?: string): string => {
   if (workingDir && abs.startsWith(workingDir)) {
     const rel = abs.slice(workingDir.length).replace(/^\/+/, '')
@@ -636,6 +656,26 @@ const FileChangesView: React.FC<{
   const [filter, setFilter] = React.useState<'all' | 'turn'>('all')
   // Files default to expanded; this set tracks the ones the user collapsed.
   const [collapsed, setCollapsed] = React.useState<Set<string>>(() => new Set())
+
+  // Current on-disk text per file, used to resolve real line numbers for each
+  // edit. Loaded lazily and cached; a path we've already fetched is skipped.
+  const [fileText, setFileText] = React.useState<Record<string, string | null>>({})
+  const fetchedRef = React.useRef<Set<string>>(new Set())
+  React.useEffect(() => {
+    let cancelled = false
+    const paths = Array.from(new Set(changes.map(c => c.path)))
+      .filter(p => p && p.startsWith('/') && !fetchedRef.current.has(p))
+    if (paths.length === 0) return
+    ;(async () => {
+      for (const p of paths) {
+        fetchedRef.current.add(p)
+        const content = (await window.codey?.readTextFile?.(p)) ?? null
+        if (cancelled) return
+        setFileText(prev => ({ ...prev, [p]: content }))
+      }
+    })()
+    return () => { cancelled = true }
+  }, [changes])
 
   const visible = filter === 'turn' && selectedTurnId
     ? changes.filter(c => c.msgId === selectedTurnId)
@@ -699,21 +739,29 @@ const FileChangesView: React.FC<{
                 >⤴</button>
               )}
             </div>
-            {!isCollapsed && (
-              <div style={fcStyles.changeBody}>
-                {group.map(c => (
-                  <div key={`${c.msgId}::${c.callId}`} style={fcStyles.changeItem}>
-                    {c.tool === 'Patch' ? (
-                      <pre style={fcStyles.patchPre}>{c.patchText || '(empty patch)'}</pre>
-                    ) : c.tool === 'Write' ? (
-                      <DiffView oldText="" newText={c.newText} />
-                    ) : (
-                      <DiffView oldText={c.oldText} newText={c.newText} />
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
+            {!isCollapsed && (() => {
+              // All Edit/Write/Notebook edits to this file collapse into a
+              // single continuous diff; raw patches keep their own block.
+              const content = fileText[path]
+              const diffHunks = group
+                .filter(c => c.tool !== 'Patch')
+                .map(c => ({
+                  oldText: c.oldText,
+                  newText: c.newText,
+                  startLine: locateStartLine(content, c.oldText, c.newText),
+                }))
+              const patches = group.filter(c => c.tool === 'Patch')
+              return (
+                <div style={fcStyles.changeBody}>
+                  {diffHunks.length > 0 && <CombinedDiffView hunks={diffHunks} />}
+                  {patches.map(c => (
+                    <pre key={`${c.msgId}::${c.callId}`} style={fcStyles.patchPre}>
+                      {c.patchText || '(empty patch)'}
+                    </pre>
+                  ))}
+                </div>
+              )
+            })()}
           </div>
         )
       })}
@@ -757,7 +805,7 @@ const fcStyles: Record<string, React.CSSProperties> = {
     background: 'transparent', border: 'none', color: C.fg3,
     cursor: 'pointer', fontSize: 12, padding: '0 4px', flexShrink: 0,
   },
-  changeBody: { padding: 8, background: 'rgba(0,0,0,0.2)', display: 'flex', flexDirection: 'column', gap: 6 },
+  changeBody: { padding: 8, background: C.bg, display: 'flex', flexDirection: 'column', gap: 6 },
   changeItem: {},
   patchPre: {
     margin: 0, fontSize: 11.5, color: C.fg,
@@ -802,10 +850,12 @@ const styles: Record<string, React.CSSProperties> = {
   },
   tab: {
     flex: 1, minWidth: 0, textAlign: 'center', whiteSpace: 'nowrap',
+    // Clip to ellipsis when the panel is narrow so labels never overlap.
+    overflow: 'hidden', textOverflow: 'ellipsis',
     background: 'transparent', border: 'none',
     color: C.fg3, fontSize: 11, fontWeight: 600,
     letterSpacing: 0.4, textTransform: 'uppercase',
-    padding: '6px 6px', cursor: 'pointer',
+    padding: '6px 4px', cursor: 'pointer',
     // Persistent gray underline under every tab (visible from first open);
     // the active tab overrides the color with the accent.
     borderBottom: `2px solid ${C.border2}`, marginBottom: -1,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -92,6 +92,50 @@ const formatBytes = (n: number): string => {
   return `${(n / (1024 * 1024)).toFixed(n < 10 * 1024 * 1024 ? 1 : 0)} MB`
 }
 
+// A long user message is folded into a small preview by default; the user can
+// expand it on demand so the transcript isn't dominated by one big paste.
+const USER_MSG_COLLAPSE_CHARS = 600
+const USER_MSG_COLLAPSE_LINES = 12
+
+const UserMessageContent: React.FC<{ content: string }> = ({ content }) => {
+  const lineCount = content.split('\n').length
+  const isLong = content.length > USER_MSG_COLLAPSE_CHARS || lineCount > USER_MSG_COLLAPSE_LINES
+  const [expanded, setExpanded] = useState(false)
+
+  if (!isLong) return <Markdown variant="user">{content}</Markdown>
+
+  if (expanded) {
+    return (
+      <div>
+        <Markdown variant="user">{content}</Markdown>
+        <button style={userFoldStyles.btn} onClick={() => setExpanded(false)}>Show less ▲</button>
+      </div>
+    )
+  }
+
+  const preview = content.replace(/\s+/g, ' ').trim().slice(0, 120)
+  return (
+    <div>
+      <div style={userFoldStyles.preview}>{preview}…</div>
+      <button style={userFoldStyles.btn} onClick={() => setExpanded(true)}>
+        Show full message · {lineCount} lines, {content.length.toLocaleString()} chars ▾
+      </button>
+    </div>
+  )
+}
+
+const userFoldStyles: Record<string, React.CSSProperties> = {
+  preview: {
+    opacity: 0.9, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+    maxWidth: '100%', fontStyle: 'italic',
+  },
+  btn: {
+    marginTop: 6, background: 'rgba(255,255,255,0.18)', border: 'none',
+    color: C.onAccent, fontSize: 11, fontWeight: 600,
+    padding: '3px 9px', borderRadius: 8, cursor: 'pointer',
+  },
+}
+
 // Agents that the gateway supports. Mirror of AGENT_NAMES in SettingsTab — kept
 // local so the chat header doesn't depend on the settings module.
 const AGENT_NAMES = ['claude-code', 'opencode', 'codex'] as const
@@ -258,7 +302,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   const [panelWidth, setPanelWidth] = useState<number>(() => {
     const v = localStorage.getItem('codey.contextPanelWidth')
     const n = v ? parseInt(v, 10) : NaN
-    return Number.isFinite(n) ? Math.max(260, Math.min(520, n)) : 340
+    return Number.isFinite(n) ? Math.max(260, Math.min(900, n)) : 340
   })
   // Manual composer height (px). null = auto-grow up to 120px (default
   // behavior). Once the user drags the handle we pin an explicit height so
@@ -857,14 +901,6 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
             </button>
           </>
         )}
-        <button
-          onClick={() => setContextPanelOpen(chat.id, !panelOpen)}
-          style={{ ...styles.linkBtn, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: '4px 6px' }}
-          title={panelOpen ? 'Hide context panel (⌘\\)' : 'Show context panel (⌘\\)'}
-          aria-label={panelOpen ? 'Hide context panel' : 'Show context panel'}
-        >
-          <PanelRightIcon color={C.fg} filled={panelOpen} />
-        </button>
         <RouteIcons routes={chat.routes} />
         <div style={{ position: 'relative' }}>
           <button
@@ -934,6 +970,14 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
             </>
           )}
         </div>
+        <button
+          onClick={() => setContextPanelOpen(chat.id, !panelOpen)}
+          style={{ ...styles.linkBtn, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: '4px 6px' }}
+          title={panelOpen ? 'Hide context panel (⌘\\)' : 'Show context panel (⌘\\)'}
+          aria-label={panelOpen ? 'Hide context panel' : 'Show context panel'}
+        >
+          <PanelRightIcon color={C.fg} filled={panelOpen} />
+        </button>
       </div>
 
       <div
@@ -981,7 +1025,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
                   <LiveActivity toolCalls={msg.toolCalls} />
                 )}
                 {(msg.content || (!isUser && msg.userQuestion?.question)) && (() => {
-                  if (isUser) return <Markdown variant="user">{msg.content}</Markdown>
+                  if (isUser) return <UserMessageContent content={msg.content} />
                   const text = msg.content || msg.userQuestion?.question || ''
                   const parsed = parseTeamMessage(text)
                   const isStreaming = !!flight && msg === lastMsg

--- a/codey-mac/src/components/toolFormat.tsx
+++ b/codey-mac/src/components/toolFormat.tsx
@@ -126,11 +126,16 @@ const lineDiff = (a: string, b: string): DiffLine[] => {
 }
 
 const diffStyles: Record<string, React.CSSProperties> = {
-  wrap: { fontFamily: 'Menlo, Monaco, "Courier New", monospace', fontSize: 11.5, lineHeight: 1.45, borderRadius: 4, overflow: 'hidden', border: `1px solid ${C.border}` },
-  row: { display: 'flex', whiteSpace: 'pre' },
-  add: { background: 'rgba(50,215,75,0.13)', color: C.green },
-  del: { background: 'rgba(255,69,58,0.13)', color: C.dangerFg },
-  eq:  { color: C.fg2 },
+  // overflowX:auto lets long lines scroll horizontally instead of being clipped.
+  wrap: { fontFamily: 'Menlo, Monaco, "Courier New", monospace', fontSize: 11.5, lineHeight: 1.45, borderRadius: 4, overflowX: 'auto', border: `1px solid ${C.border}` },
+  // width:max-content sizes each row to its longest content (so the wrap can
+  // scroll); minWidth:100% keeps the tint spanning the full visible width.
+  row: { display: 'flex', whiteSpace: 'pre', width: 'max-content', minWidth: '100%' },
+  // Code text stays in the readable foreground color in both light and dark
+  // mode; the row tint + colored marker carry the add/delete meaning.
+  add: { background: 'rgba(50,215,75,0.18)' },
+  del: { background: 'rgba(255,69,58,0.16)' },
+  eq:  {},
   // Gutter + marker are not selectable, so line numbers stay out of copied text.
   gutter: {
     flexShrink: 0, textAlign: 'right', padding: '0 6px',
@@ -138,7 +143,64 @@ const diffStyles: Record<string, React.CSSProperties> = {
     minWidth: 30,
   },
   marker: { width: 16, flexShrink: 0, textAlign: 'center', userSelect: 'none', WebkitUserSelect: 'none' },
-  code: { flex: 1, paddingRight: 6 },
+  code: { flexShrink: 0, paddingRight: 12 },
+  // Divider between separate edits to the same file in a combined view.
+  hunkSep: { minWidth: '100%', height: 0, borderTop: `1px dashed ${C.border2}`, margin: '2px 0' },
+}
+
+export type DiffHunk = {
+  oldText: string
+  newText: string
+  /**
+   * Real 1-based line in the current file where this edit begins, resolved by
+   * locating the edit's text on disk. When provided, the gutter numbers this
+   * hunk from its true position; when absent it falls back to continuing from
+   * the previous hunk (or line 1 for the first).
+   */
+  startLine?: number
+}
+
+/**
+ * Renders several edits to the SAME file as one diff. When a hunk's real
+ * startLine is known the gutter shows true file line numbers; otherwise
+ * numbering continues across hunks. A dashed divider marks each edit boundary.
+ */
+export const CombinedDiffView: React.FC<{ hunks: DiffHunk[] }> = ({ hunks }) => {
+  let oldNo = 0
+  let newNo = 0
+  return (
+    <div style={diffStyles.wrap}>
+      {hunks.map((h, hi) => {
+        const lines = lineDiff(h.oldText, h.newText)
+        // Anchor this hunk's gutter to the real file line when we resolved one.
+        if (h.startLine != null && Number.isFinite(h.startLine)) {
+          oldNo = h.startLine - 1
+          newNo = h.startLine - 1
+        }
+        return (
+          <React.Fragment key={hi}>
+            {hi > 0 && <div style={diffStyles.hunkSep} />}
+            {lines.map((l, idx) => {
+              const bg = l.kind === 'add' ? diffStyles.add : l.kind === 'del' ? diffStyles.del : diffStyles.eq
+              const markerColor = l.kind === 'add' ? C.green : l.kind === 'del' ? C.red : C.fg3
+              const codeColor = l.kind === 'eq' ? C.fg2 : C.fg
+              const marker = l.kind === 'add' ? '+' : l.kind === 'del' ? '-' : ' '
+              const oldLabel = l.kind === 'add' ? '' : String(++oldNo)
+              const newLabel = l.kind === 'del' ? '' : String(++newNo)
+              return (
+                <div key={`${hi}:${idx}`} style={{ ...diffStyles.row, ...bg }}>
+                  <span style={diffStyles.gutter}>{oldLabel}</span>
+                  <span style={diffStyles.gutter}>{newLabel}</span>
+                  <span style={{ ...diffStyles.marker, color: markerColor }}>{marker}</span>
+                  <span style={{ ...diffStyles.code, color: codeColor }}>{l.text || ' '}</span>
+                </div>
+              )
+            })}
+          </React.Fragment>
+        )
+      })}
+    </div>
+  )
 }
 
 export const DiffView: React.FC<{ oldText: string; newText: string }> = ({ oldText, newText }) => {
@@ -148,16 +210,18 @@ export const DiffView: React.FC<{ oldText: string; newText: string }> = ({ oldTe
   return (
     <div style={diffStyles.wrap}>
       {lines.map((l, idx) => {
-        const style = l.kind === 'add' ? diffStyles.add : l.kind === 'del' ? diffStyles.del : diffStyles.eq
+        const bg = l.kind === 'add' ? diffStyles.add : l.kind === 'del' ? diffStyles.del : diffStyles.eq
+        const markerColor = l.kind === 'add' ? C.green : l.kind === 'del' ? C.red : C.fg3
+        const codeColor = l.kind === 'eq' ? C.fg2 : C.fg
         const marker = l.kind === 'add' ? '+' : l.kind === 'del' ? '-' : ' '
         const oldLabel = l.kind === 'add' ? '' : String(++oldNo)
         const newLabel = l.kind === 'del' ? '' : String(++newNo)
         return (
-          <div key={idx} style={{ ...diffStyles.row, ...style }}>
+          <div key={idx} style={{ ...diffStyles.row, ...bg }}>
             <span style={diffStyles.gutter}>{oldLabel}</span>
             <span style={diffStyles.gutter}>{newLabel}</span>
-            <span style={diffStyles.marker}>{marker}</span>
-            <span style={diffStyles.code}>{l.text || ' '}</span>
+            <span style={{ ...diffStyles.marker, color: markerColor }}>{marker}</span>
+            <span style={{ ...diffStyles.code, color: codeColor }}>{l.text ||' '}</span>
           </div>
         )
       })}


### PR DESCRIPTION
## Summary
Chat context-panel polish, a macOS updater restart fix, and a version bump to **0.7.2**.

- **Diff viewer**: readable light-mode colors (foreground text + colored `+`/`-` markers); long lines scroll horizontally instead of being clipped.
- **Context panel**: lighter (near-white) file-editor background; tabs no longer overlap when the panel is narrow (shorter labels + ellipsis guard); max drag width raised 520 → 900px.
- **File changes**: all edits to one file are combined into a single diff viewer, and **real file line numbers** are resolved by locating each edit in the current file via a new `file:readText` IPC (graceful fallback to continuous numbering when a line can't be located).
- **Updater**: set `isQuitting` before `quitAndInstall()` so the app actually restarts on macOS instead of just hiding the window (Squirrel fires `before-quit-for-update`, not the normal `before-quit`).
- **Long user messages** fold into a collapsible preview with a show/hide toggle.

## Testing
- `tsc --noEmit` passes for both the renderer (`-p .`) and electron (`-p tsconfig.electron.json`).
- Updater restart + on-disk line resolution require a packaged build to verify end-to-end.

## Release
Tagging `v0.7.2` after merge triggers `release.yml`, which builds/signs/notarizes and publishes the GitHub release the in-app updater consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)