### PR TITLE
ci: fix codey-mac release pipeline (7za + signing preflight + non-draft)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,53 @@ jobs:
 
       - run: npm ci
 
+      # Workaround for an npm extraction bug where 7zip-bin's `7za` binary is
+      # occasionally absent after `npm ci`, which makes electron-builder fail
+      # with: `ENOENT ... chmod '.../node_modules/7zip-bin/mac/arm64/7za'`.
+      # Reinstall the package if the binary is missing, then ensure it's
+      # executable. (Locally the binary is always present; this only bites CI.)
+      - name: Ensure 7zip-bin binary is present
+        run: |
+          if [ ! -f node_modules/7zip-bin/mac/arm64/7za ]; then
+            echo "7za missing after npm ci — reinstalling 7zip-bin"
+            rm -rf node_modules/7zip-bin
+            npm install --no-save 7zip-bin
+          fi
+          chmod -R +x node_modules/7zip-bin/mac 2>/dev/null || true
+
       - name: Build core
         run: npm run build -w @codey/core
 
       - name: Build gateway
         run: npm run build -w @codey/gateway
+
+      # Signing + notarization require these repo secrets (Settings → Secrets and
+      # variables → Actions). Without them electron-builder can't sign/notarize
+      # and the release silently fails late in the build, so fail fast here with
+      # a clear message instead:
+      #   CSC_LINK                     base64 of the Developer ID Application .p12
+      #   CSC_KEY_PASSWORD             password for that .p12
+      #   APPLE_ID                     Apple ID email used for notarization
+      #   APPLE_APP_SPECIFIC_PASSWORD  app-specific password (appleid.apple.com)
+      #   APPLE_TEAM_ID                Apple Developer team id (e.g. N59NN58KB2)
+      - name: Verify signing secrets are configured
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=()
+          [ -z "$CSC_LINK" ] && missing+=("CSC_LINK")
+          [ -z "$CSC_KEY_PASSWORD" ] && missing+=("CSC_KEY_PASSWORD")
+          [ -z "$APPLE_ID" ] && missing+=("APPLE_ID")
+          [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] && missing+=("APPLE_APP_SPECIFIC_PASSWORD")
+          [ -z "$APPLE_TEAM_ID" ] && missing+=("APPLE_TEAM_ID")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required signing secrets: ${missing[*]}. Add them in repo Settings → Secrets and variables → Actions, then re-run."
+            exit 1
+          fi
 
       - name: Build & publish codey-mac
         working-directory: codey-mac

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -88,7 +88,8 @@
     "publish": {
       "provider": "github",
       "owner": "its-ahoh",
-      "repo": "codey"
+      "repo": "codey",
+      "releaseType": "release"
     },
     "extraResources": [
       {


### PR DESCRIPTION
## Why
The `Release codey-mac` workflow has **failed for every recent tag (v0.7.0, v0.7.1, v0.7.2)**, so the in-app updater has had nothing new to fetch. Two distinct failures:

1. **`7za` ENOENT.** electron-builder dies at:
   ```
   ⨯ ENOENT: no such file or directory, chmod '.../node_modules/7zip-bin/mac/arm64/7za'  failedTask=build
   ```
   An npm extraction bug where 7zip-bin's `7za` binary is sometimes missing after `npm ci` on the runner (it's always present locally, which is why local builds work).
2. **No signing secrets.** The `CSC_*` / `APPLE_*` env values come through empty, so signing/notarization fails late with a confusing error.

## What this does
- **Repair step**: reinstalls `7zip-bin` if `7za` is missing, then `chmod +x`.
- **Preflight check**: fails fast with `::error::` listing exactly which signing secrets are missing, instead of a deep electron-builder stack trace.
- **`publish.releaseType: "release"`**: published builds are no longer left as **drafts** — the updater can't see draft releases, so this is required for tag-push releases to actually reach users.

## ⚠️ Required follow-up (cannot be done in a PR)
CI still can't sign/notarize until these repo secrets are added under **Settings → Secrets and variables → Actions**:

| Secret | What |
|---|---|
| `CSC_LINK` | base64 of the Developer ID Application `.p12` |
| `CSC_KEY_PASSWORD` | password for that `.p12` |
| `APPLE_ID` | Apple ID email for notarization |
| `APPLE_APP_SPECIFIC_PASSWORD` | app-specific password (appleid.apple.com) |
| `APPLE_TEAM_ID` | `N59NN58KB2` |

Once added, pushing a `v*` tag will build, sign, notarize, and publish automatically — no more local publishing needed.

## Testing
- `release.yml` validated as well-formed YAML; `package.json` validated as JSON.
- Full verification requires a tag push *after* the secrets are configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)