### PR TITLE
Flow canvas: decision diamonds, worker self-loops + editor upgrades

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -988,11 +988,11 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
           const isSelected = !isUser && msg.id === selectedTurnId && panelOpen
           return (
             <div key={msg.id}
-              onClick={isUser ? undefined : () => {
+              onDoubleClick={isUser ? undefined : () => {
                 setSelectedTurnIdState(msg.id)
                 setFollowLatest(false)
-                // If the context panel is closed, open it on the turn-detail
-                // tab so clicking a message reveals that turn's own detail.
+                // Only a double-click reveals the right panel; open it on the
+                // turn-detail tab so it shows that turn's own detail.
                 if (!panelOpen) {
                   setContextPanelOpen(chat.id, true)
                   setPanelTab('current')
@@ -1011,7 +1011,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
               <div style={{
                 maxWidth: '72%', padding: '10px 14px',
                 borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-                background: isUser ? C.userBg : C.aiBg,
+                background: isUser ? C.userBg : C.codeBg,
                 color: isUser ? C.onAccent : C.fg, fontSize: 13, lineHeight: 1.55, wordBreak: 'break-word',
                 boxShadow: isUser
                   ? 'none'
@@ -1090,7 +1090,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
                 && msg.userQuestion.options.length > 0
                 && (
                   msg.userQuestion.multiSelect ? (
-                    <div style={styles.choiceRow}>
+                    <div style={styles.choiceRow} onDoubleClick={e => e.stopPropagation()}>
                       {msg.userQuestion.options.map((opt, i) => {
                         const picked = multiChoice.includes(opt.label)
                         return (
@@ -1128,7 +1128,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
                       </button>
                     </div>
                   ) : (
-                    <div style={styles.choiceRow}>
+                    <div style={styles.choiceRow} onDoubleClick={e => e.stopPropagation()}>
                       {msg.userQuestion.options.map((opt, i) => (
                         <button
                           key={i}

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import {
   ReactFlow, Background, Controls, addEdge, applyNodeChanges, applyEdgeChanges,
+  ReactFlowProvider, useReactFlow,
   Handle, Position,
   type Node, type Edge, type Connection, type NodeProps,
 } from '@xyflow/react'
@@ -75,7 +76,7 @@ interface Props {
   onClose: () => void
 }
 
-export default function FlowEditor({ teamName, workerNames, workerRoles = {}, graph, onSave, onClose }: Props) {
+function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSave, onClose }: Props) {
   const withTypes = (ns: Node[]): Node[] => ns.map(n => {
     const t = (n.data as any).type
     const rfType = t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'
@@ -104,10 +105,29 @@ export default function FlowEditor({ teamName, workerNames, workerRoles = {}, gr
       data: {},
     } as any, es)), [])
 
+  const rf = useReactFlow()
   const addWorker = (worker: string) => {
     const id = newNodeId(nodes.map(n => n.id))
-    setNodes(ns => [...ns, { id, position: { x: 200, y: 60 + ns.length * 70 }, data: { label: worker, type: 'worker', worker } } as any])
+    setNodes(ns => [...ns, { id, type: 'workerNode', position: { x: 200, y: 60 + ns.length * 70 }, data: { label: worker, type: 'worker', worker, role: workerRoles[worker] } } as any])
   }
+  const addCondition = () => {
+    const id = newNodeId(nodes.map(n => n.id))
+    setNodes(ns => [...ns, { id, type: 'conditionNode', position: { x: 260, y: 60 + ns.length * 70 }, data: { label: 'condition', type: 'condition' } } as any])
+  }
+  const onDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    const raw = e.dataTransfer.getData('application/codey-node')
+    if (!raw) return
+    const payload = JSON.parse(raw) as { kind: 'worker' | 'condition'; worker?: string }
+    const position = rf.screenToFlowPosition({ x: e.clientX, y: e.clientY })
+    const id = newNodeId(nodes.map(n => n.id))
+    if (payload.kind === 'condition') {
+      setNodes(ns => [...ns, { id, type: 'conditionNode', position, data: { label: 'condition', type: 'condition' } } as any])
+    } else {
+      setNodes(ns => [...ns, { id, type: 'workerNode', position, data: { label: payload.worker, type: 'worker', worker: payload.worker, role: workerRoles[payload.worker!] } } as any])
+    }
+  }, [nodes, rf, workerRoles])
+  const onDragOver = useCallback((e: React.DragEvent) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move' }, [])
   const updateEdge = (id: string, patch: any) =>
     setEdges(es => es.map(e => e.id === id ? { ...e, data: { ...(e as any).data, ...patch }, label: patch.isDefault ? 'default' : patch.condition ?? (e as any).data?.condition } : e))
 
@@ -140,14 +160,24 @@ export default function FlowEditor({ teamName, workerNames, workerRoles = {}, gr
             <div style={{ width: 160, borderRight: `1px solid ${C.border}`, padding: 10, overflowY: 'auto' }}>
               <div style={{ fontSize: 11, color: C.fg3, marginBottom: 6 }}>Workers</div>
               {workerNames.map(w => (
-                <button key={w} onClick={() => addWorker(w)} style={{ display: 'block', width: '100%', textAlign: 'left', marginBottom: 4, fontSize: 12, padding: '4px 6px', background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 6, cursor: 'pointer' }}>+ {w}</button>
+                <button key={w} draggable
+                  onDragStart={e => e.dataTransfer.setData('application/codey-node', JSON.stringify({ kind: 'worker', worker: w }))}
+                  onClick={() => addWorker(w)}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', marginBottom: 4, fontSize: 12, padding: '8px 8px', minHeight: 40, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 6, cursor: 'pointer' }}>
+                  <div style={{ fontWeight: 600 }}>+ {w}</div>
+                  {workerRoles[w] && <div style={{ fontSize: 10, color: C.fg3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{workerRoles[w]}</div>}
+                </button>
               ))}
+              <button draggable
+                onDragStart={e => e.dataTransfer.setData('application/codey-node', JSON.stringify({ kind: 'condition' }))}
+                onClick={() => addCondition()}
+                style={{ display: 'block', width: '100%', marginTop: 8, fontSize: 12, padding: '6px', background: C.surface2, border: `1px dashed ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>◇ + Condition</button>
             </div>
           )}
           {showRaw ? (
             <pre style={{ flex: 1, margin: 0, padding: 14, overflow: 'auto', fontSize: 12, color: C.fg }}>{JSON.stringify(current(), null, 2)}</pre>
           ) : (
-            <div style={{ flex: 1, position: 'relative' }}>
+            <div style={{ flex: 1, position: 'relative' }} onDrop={onDrop} onDragOver={onDragOver}>
               <ReactFlow nodes={nodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => setSelEdge(e.id)} nodeTypes={nodeTypes} fitView>
                 <Background />
                 <Controls />
@@ -167,4 +197,8 @@ export default function FlowEditor({ teamName, workerNames, workerRoles = {}, gr
       </div>
     </div>
   )
+}
+
+export default function FlowEditor(props: Props) {
+  return <ReactFlowProvider><FlowEditorInner {...props} /></ReactFlowProvider>
 }

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -107,26 +107,37 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
 
   const rf = useReactFlow()
   const addWorker = (worker: string) => {
-    const id = newNodeId(nodes.map(n => n.id))
-    setNodes(ns => [...ns, { id, type: 'workerNode', position: { x: 200, y: 60 + ns.length * 70 }, data: { label: worker, type: 'worker', worker, role: workerRoles[worker] } } as any])
+    setNodes(ns => {
+      const id = newNodeId(ns.map(n => n.id))
+      return [...ns, { id, type: 'workerNode', position: { x: 200, y: 60 + ns.length * 70 }, data: { label: worker, type: 'worker', worker, role: workerRoles[worker] } } as any]
+    })
   }
   const addCondition = () => {
-    const id = newNodeId(nodes.map(n => n.id))
-    setNodes(ns => [...ns, { id, type: 'conditionNode', position: { x: 260, y: 60 + ns.length * 70 }, data: { label: 'condition', type: 'condition' } } as any])
+    setNodes(ns => {
+      const id = newNodeId(ns.map(n => n.id))
+      return [...ns, { id, type: 'conditionNode', position: { x: 260, y: 60 + ns.length * 70 }, data: { label: 'condition', type: 'condition' } } as any]
+    })
   }
   const onDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault()
     const raw = e.dataTransfer.getData('application/codey-node')
     if (!raw) return
-    const payload = JSON.parse(raw) as { kind: 'worker' | 'condition'; worker?: string }
+    let payload: { kind: 'worker' | 'condition'; worker?: string }
+    try { payload = JSON.parse(raw) } catch { return }
     const position = rf.screenToFlowPosition({ x: e.clientX, y: e.clientY })
-    const id = newNodeId(nodes.map(n => n.id))
     if (payload.kind === 'condition') {
-      setNodes(ns => [...ns, { id, type: 'conditionNode', position, data: { label: 'condition', type: 'condition' } } as any])
+      setNodes(ns => {
+        const id = newNodeId(ns.map(n => n.id))
+        return [...ns, { id, type: 'conditionNode', position, data: { label: 'condition', type: 'condition' } } as any]
+      })
     } else {
-      setNodes(ns => [...ns, { id, type: 'workerNode', position, data: { label: payload.worker, type: 'worker', worker: payload.worker, role: workerRoles[payload.worker!] } } as any])
+      if (!payload.worker) return
+      setNodes(ns => {
+        const id = newNodeId(ns.map(n => n.id))
+        return [...ns, { id, type: 'workerNode', position, data: { label: payload.worker, type: 'worker', worker: payload.worker, role: workerRoles[payload.worker!] } } as any]
+      })
     }
-  }, [nodes, rf, workerRoles])
+  }, [rf, workerRoles])
   const onDragOver = useCallback((e: React.DragEvent) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move' }, [])
   const updateEdge = (id: string, patch: any) =>
     setEdges(es => es.map(e => e.id === id ? { ...e, data: { ...(e as any).data, ...patch }, label: patch.isDefault ? 'default' : patch.condition ?? (e as any).data?.condition } : e))

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -204,7 +204,7 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
             <pre style={{ flex: 1, margin: 0, padding: 14, overflow: 'auto', fontSize: 12, color: C.fg }}>{JSON.stringify(current(), null, 2)}</pre>
           ) : (
             <div style={{ flex: 1, position: 'relative' }} onDrop={onDrop} onDragOver={onDragOver}>
-              <ReactFlow nodes={nodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }} onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }} nodeTypes={nodeTypes} fitView>
+              <ReactFlow nodes={nodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }} onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }} onNodesDelete={(ns) => { if (ns.some(n => n.id === selNode)) setSelNode(null) }} onEdgesDelete={(es) => { if (es.some(e => e.id === selEdge)) setSelEdge(null) }} nodeTypes={nodeTypes} fitView>
                 <Background />
                 <Controls />
               </ReactFlow>

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -89,6 +89,7 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   const [edges, setEdges] = useState<Edge[]>(initial.edges as unknown as Edge[])
   const [maxHops, setMaxHops] = useState(graph.maxHops)
   const [selEdge, setSelEdge] = useState<string | null>(null)
+  const [selNode, setSelNode] = useState<string | null>(null)
   const [showRaw, setShowRaw] = useState(false)
 
   const current = (): TeamGraph =>
@@ -98,12 +99,22 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   const onNodesChange = useCallback((cs: any) => setNodes(ns => applyNodeChanges(cs, ns)), [])
   const onEdgesChange = useCallback((cs: any) => setEdges(es => applyEdgeChanges(cs, es)), [])
   const onConnect = useCallback((c: Connection) =>
-    setEdges(es => addEdge({
-      ...c, id: `e_${Date.now()}`,
-      sourceHandle: c.sourceHandle ?? undefined,
-      targetHandle: c.targetHandle ?? undefined,
-      data: {},
-    } as any, es)), [])
+    setEdges(es => {
+      const fromNode = nodes.find(n => n.id === c.source)
+      let data: any = {}
+      if ((fromNode?.data as any)?.type === 'condition') {
+        const existing = es.filter(e => e.source === c.source)
+        if (existing.length >= 2) return es // a diamond has exactly two outcomes
+        data = { branch: existing.some(e => (e as any).data?.branch === 'yes') ? 'no' : 'yes' }
+      }
+      return addEdge({
+        ...c, id: `e_${Date.now()}`,
+        sourceHandle: c.sourceHandle ?? undefined,
+        targetHandle: c.targetHandle ?? undefined,
+        label: data.branch,
+        data,
+      } as any, es)
+    }), [nodes])
 
   const rf = useReactFlow()
   const addWorker = (worker: string) => {
@@ -141,6 +152,8 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   const onDragOver = useCallback((e: React.DragEvent) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move' }, [])
   const updateEdge = (id: string, patch: any) =>
     setEdges(es => es.map(e => e.id === id ? { ...e, data: { ...(e as any).data, ...patch }, label: patch.isDefault ? 'default' : patch.condition ?? (e as any).data?.condition } : e))
+  const updateNodeData = (id: string, patch: any) =>
+    setNodes(ns => ns.map(n => n.id === id ? { ...n, data: { ...n.data, ...patch } } : n))
 
   const colors = useMemo(() => branchColors(nodes as any, edges as any), [nodes, edges])
   const styledEdges = useMemo(() => edges.map(e => ({
@@ -152,6 +165,8 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   const save = () => onSave(current())
 
   const sel = edges.find(e => e.id === selEdge) as any
+  const selN = nodes.find(n => n.id === selNode) as any
+  const selfLoops = selN ? edges.some(e => e.source === selN.id && e.target === selN.id) : false
 
   return (
     <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -189,13 +204,41 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
             <pre style={{ flex: 1, margin: 0, padding: 14, overflow: 'auto', fontSize: 12, color: C.fg }}>{JSON.stringify(current(), null, 2)}</pre>
           ) : (
             <div style={{ flex: 1, position: 'relative' }} onDrop={onDrop} onDragOver={onDragOver}>
-              <ReactFlow nodes={nodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => setSelEdge(e.id)} nodeTypes={nodeTypes} fitView>
+              <ReactFlow nodes={nodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }} onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }} nodeTypes={nodeTypes} fitView>
                 <Background />
                 <Controls />
               </ReactFlow>
             </div>
           )}
-          {!showRaw && sel && (
+          {!showRaw && selN && (selN.data?.type === 'worker' || selN.data?.type === 'condition') && (
+            <div style={{ width: 240, borderLeft: `1px solid ${C.border}`, padding: 10, overflowY: 'auto' }}>
+              {selN.data?.type === 'worker' ? (
+                <>
+                  <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{selN.data.worker}</div>
+                  <div style={{ fontSize: 11, color: C.fg3, marginBottom: 10, whiteSpace: 'pre-wrap' }}>
+                    {workerRoles[selN.data.worker] || 'No description.'}
+                  </div>
+                  {selfLoops && (
+                    <label style={{ fontSize: 12, display: 'block' }}>
+                      Max self-loops
+                      <input type="number" min={1} value={selN.data.maxCalls ?? ''} placeholder="∞"
+                        onChange={e => updateNodeData(selN.id, { maxCalls: e.target.value === '' ? undefined : Math.max(1, Number(e.target.value) || 1) })}
+                        style={{ width: 64, marginLeft: 6 }} />
+                    </label>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div style={{ fontSize: 11, color: C.fg3, marginBottom: 6 }}>Decision</div>
+                  <textarea value={selN.data.condition ?? ''} placeholder='e.g. "Did the tests pass?"'
+                    onChange={e => updateNodeData(selN.id, { condition: e.target.value })}
+                    style={{ width: '100%', minHeight: 70, fontSize: 12, padding: 6, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6 }} />
+                  <div style={{ fontSize: 10, color: C.fg3, marginTop: 6 }}>Yes edge → green · No edge → red</div>
+                </>
+              )}
+            </div>
+          )}
+          {!showRaw && !selN && sel && (sel.data?.branch === undefined) && (
             <div style={{ width: 220, borderLeft: `1px solid ${C.border}`, padding: 10 }}>
               <div style={{ fontSize: 11, color: C.fg3, marginBottom: 6 }}>Edge condition</div>
               <textarea value={sel.data?.condition ?? ''} onChange={e => updateEdge(sel.id, { condition: e.target.value, isDefault: false })} placeholder='e.g. "tests pass"' style={{ width: '100%', minHeight: 70, fontSize: 12, padding: 6, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6 }} />

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import {
   ReactFlow, Background, Controls, addEdge, applyNodeChanges, applyEdgeChanges,
   ReactFlowProvider, useReactFlow,
-  Handle, Position,
+  Handle, Position, NodeResizer,
   type Node, type Edge, type Connection, type NodeProps,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
@@ -30,12 +30,13 @@ function NodeHandles() {
   )
 }
 
-function WorkerNodeView({ data }: NodeProps) {
+function WorkerNodeView({ data, selected, width, height }: NodeProps) {
   const d = data as { label: string; role?: string }
   return (
-    <div style={{ minWidth: 150, padding: '8px 10px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}`, color: C.fg }}>
+    <div style={{ width: width ?? undefined, height: height ?? undefined, minWidth: 120, padding: '8px 10px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}`, color: C.fg, boxSizing: 'border-box' }}>
+      <NodeResizer isVisible={selected} minWidth={120} minHeight={48} />
       <div style={{ fontSize: 13, fontWeight: 600 }}>{d.label}</div>
-      {d.role && <div style={{ fontSize: 11, color: C.fg3, marginTop: 2, maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
+      {d.role && <div style={{ fontSize: 11, color: C.fg3, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
       <NodeHandles />
     </div>
   )

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -1,24 +1,90 @@
 import { useCallback, useMemo, useState } from 'react'
 import {
   ReactFlow, Background, Controls, addEdge, applyNodeChanges, applyEdgeChanges,
-  type Node, type Edge, type Connection,
+  Handle, Position,
+  type Node, type Edge, type Connection, type NodeProps,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { TeamGraph, validateGraph } from '../../../packages/core/src/team-graph'
 import { toFlow, fromFlow, newNodeId } from './flowEditorModel'
 import { C } from '../theme'
 
+// ---------------------------------------------------------------------------
+// Custom node components
+// ---------------------------------------------------------------------------
+
+const HANDLE_IDS = ['t', 'r', 'b', 'l'] as const
+const HANDLE_POS = { t: Position.Top, r: Position.Right, b: Position.Bottom, l: Position.Left }
+
+function NodeHandles() {
+  return (
+    <>
+      {HANDLE_IDS.map(id => (
+        <Handle key={`s-${id}`} type="source" id={id} position={HANDLE_POS[id]} style={{ background: C.accent }} />
+      ))}
+      {HANDLE_IDS.map(id => (
+        <Handle key={`tg-${id}`} type="target" id={id} position={HANDLE_POS[id]} style={{ background: C.fg3 }} />
+      ))}
+    </>
+  )
+}
+
+function WorkerNodeView({ data }: NodeProps) {
+  const d = data as { label: string; role?: string }
+  return (
+    <div style={{ minWidth: 150, padding: '8px 10px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}`, color: C.fg }}>
+      <div style={{ fontSize: 13, fontWeight: 600 }}>{d.label}</div>
+      {d.role && <div style={{ fontSize: 11, color: C.fg3, marginTop: 2, maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
+      <NodeHandles />
+    </div>
+  )
+}
+
+function ConditionNodeView() {
+  return (
+    <div style={{ width: 90, height: 90, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+      <div style={{ width: 64, height: 64, transform: 'rotate(45deg)', background: C.surface2, border: `1px solid ${C.accent}`, borderRadius: 8 }} />
+      <span style={{ position: 'absolute', fontSize: 11, color: C.fg3 }}>?</span>
+      <NodeHandles />
+    </div>
+  )
+}
+
+function TerminalNodeView({ data }: NodeProps) {
+  const d = data as { label: string }
+  return (
+    <div style={{ padding: '6px 14px', borderRadius: 999, background: C.bg, border: `1px solid ${C.border}`, color: C.fg, fontSize: 12 }}>
+      {d.label}
+      <NodeHandles />
+    </div>
+  )
+}
+
+const nodeTypes = { workerNode: WorkerNodeView, conditionNode: ConditionNodeView, terminalNode: TerminalNodeView }
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
 interface Props {
   teamName: string
   workerNames: string[]
+  workerRoles?: Record<string, string>
   graph: TeamGraph
   onSave: (graph: TeamGraph) => void
   onClose: () => void
 }
 
-export default function FlowEditor({ teamName, workerNames, graph, onSave, onClose }: Props) {
+export default function FlowEditor({ teamName, workerNames, workerRoles = {}, graph, onSave, onClose }: Props) {
+  const withTypes = (ns: Node[]): Node[] => ns.map(n => {
+    const t = (n.data as any).type
+    const rfType = t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'
+    const role = t === 'worker' ? workerRoles[(n.data as any).worker] : undefined
+    return { ...n, type: rfType, data: { ...n.data, role } }
+  })
+
   const initial = useMemo(() => toFlow(graph), [])
-  const [nodes, setNodes] = useState<Node[]>(initial.nodes as unknown as Node[])
+  const [nodes, setNodes] = useState<Node[]>(withTypes(initial.nodes as unknown as Node[]))
   const [edges, setEdges] = useState<Edge[]>(initial.edges as unknown as Edge[])
   const [maxHops, setMaxHops] = useState(graph.maxHops)
   const [selEdge, setSelEdge] = useState<string | null>(null)
@@ -70,7 +136,7 @@ export default function FlowEditor({ teamName, workerNames, graph, onSave, onClo
             <pre style={{ flex: 1, margin: 0, padding: 14, overflow: 'auto', fontSize: 12, color: C.fg }}>{JSON.stringify(current(), null, 2)}</pre>
           ) : (
             <div style={{ flex: 1, position: 'relative' }}>
-              <ReactFlow nodes={nodes} edges={edges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => setSelEdge(e.id)} fitView>
+              <ReactFlow nodes={nodes} edges={edges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => setSelEdge(e.id)} nodeTypes={nodeTypes} fitView>
                 <Background />
                 <Controls />
               </ReactFlow>

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -6,7 +6,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { TeamGraph, validateGraph } from '../../../packages/core/src/team-graph'
-import { toFlow, fromFlow, newNodeId } from './flowEditorModel'
+import { toFlow, fromFlow, newNodeId, branchColors } from './flowEditorModel'
 import { C } from '../theme'
 
 // ---------------------------------------------------------------------------
@@ -97,7 +97,12 @@ export default function FlowEditor({ teamName, workerNames, workerRoles = {}, gr
   const onNodesChange = useCallback((cs: any) => setNodes(ns => applyNodeChanges(cs, ns)), [])
   const onEdgesChange = useCallback((cs: any) => setEdges(es => applyEdgeChanges(cs, es)), [])
   const onConnect = useCallback((c: Connection) =>
-    setEdges(es => addEdge({ ...c, id: `e_${Date.now()}`, data: {} } as any, es)), [])
+    setEdges(es => addEdge({
+      ...c, id: `e_${Date.now()}`,
+      sourceHandle: c.sourceHandle ?? undefined,
+      targetHandle: c.targetHandle ?? undefined,
+      data: {},
+    } as any, es)), [])
 
   const addWorker = (worker: string) => {
     const id = newNodeId(nodes.map(n => n.id))
@@ -105,6 +110,13 @@ export default function FlowEditor({ teamName, workerNames, workerRoles = {}, gr
   }
   const updateEdge = (id: string, patch: any) =>
     setEdges(es => es.map(e => e.id === id ? { ...e, data: { ...(e as any).data, ...patch }, label: patch.isDefault ? 'default' : patch.condition ?? (e as any).data?.condition } : e))
+
+  const colors = useMemo(() => branchColors(nodes as any, edges as any), [nodes, edges])
+  const styledEdges = useMemo(() => edges.map(e => ({
+    ...e,
+    animated: true,
+    style: { ...(e as any).style, stroke: colors[e.id] ?? C.fg3 },
+  })), [edges, colors])
 
   const save = () => onSave(current())
 
@@ -136,7 +148,7 @@ export default function FlowEditor({ teamName, workerNames, workerRoles = {}, gr
             <pre style={{ flex: 1, margin: 0, padding: 14, overflow: 'auto', fontSize: 12, color: C.fg }}>{JSON.stringify(current(), null, 2)}</pre>
           ) : (
             <div style={{ flex: 1, position: 'relative' }}>
-              <ReactFlow nodes={nodes} edges={edges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => setSelEdge(e.id)} nodeTypes={nodeTypes} fitView>
+              <ReactFlow nodes={nodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => setSelEdge(e.id)} nodeTypes={nodeTypes} fitView>
                 <Background />
                 <Controls />
               </ReactFlow>

--- a/codey-mac/src/components/GlobalTeamsSection.tsx
+++ b/codey-mac/src/components/GlobalTeamsSection.tsx
@@ -234,6 +234,7 @@ export default function GlobalTeamsSection() {
         <FlowEditor
           teamName={editingFlow}
           workerNames={workers.map(w => w.name)}
+          workerRoles={Object.fromEntries(workers.map(w => [w.name, w.personality.role]))}
           graph={teams[editingFlow].graph ?? emptyGraph()}
           onSave={(graph) => { queueSave({ ...teams, [editingFlow]: { ...teams[editingFlow], graph } }) }}
           onClose={() => setEditingFlow(null)}

--- a/codey-mac/src/components/flowEditorModel.test.ts
+++ b/codey-mac/src/components/flowEditorModel.test.ts
@@ -82,3 +82,39 @@ describe('branchColors', () => {
     expect(colors['only']).toBeUndefined()
   })
 })
+
+describe('flowEditorModel diamond + maxCalls round-trip', () => {
+  const g: TeamGraph = {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 3, width: 220, height: 90, x: 1, y: 0 },
+      { id: 'd1', type: 'condition', condition: 'tests pass?', x: 2, y: 0 },
+      { id: 'end', type: 'end', x: 3, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'd1' },
+      { id: 'e2', from: 'd1', to: 'end', branch: 'yes' },
+      { id: 'e3', from: 'd1', to: 'w1', branch: 'no' },
+    ],
+  };
+
+  it('round-trips condition, maxCalls, width/height, and branch', () => {
+    const flow = toFlow(g);
+    const back = fromFlow(flow.nodes, flow.edges, g.entry, g.maxHops);
+    expect(back).toEqual(g);
+  });
+});
+
+describe('branchColors diamond colors', () => {
+  it('colors a diamond yes green and no red', () => {
+    const nodes = [{ id: 'd1', position: { x: 0, y: 0 }, data: { label: 'd1', type: 'condition' } }] as any;
+    const colors = branchColors(nodes, [
+      { id: 'y', source: 'd1', data: { branch: 'yes' } },
+      { id: 'n', source: 'd1', data: { branch: 'no' } },
+    ] as any);
+    expect(colors['y']).toBe('#22c55e');
+    expect(colors['n']).toBe('#ef4444');
+  });
+});

--- a/codey-mac/src/components/flowEditorModel.test.ts
+++ b/codey-mac/src/components/flowEditorModel.test.ts
@@ -34,3 +34,32 @@ describe('flowEditorModel', () => {
     expect(newNodeId(['n_1', 'n_2'])).not.toBe('n_1')
   })
 })
+
+const gHandles: TeamGraph = {
+  entry: 'start', maxHops: 20,
+  nodes: [
+    { id: 'start', type: 'start', x: 0, y: 0 },
+    { id: 'w1', type: 'worker', worker: 'coder', x: 100, y: 0 },
+    { id: 'c1', type: 'condition', x: 200, y: 0 },
+    { id: 'end', type: 'end', x: 300, y: 0 },
+  ],
+  edges: [
+    { id: 'e0', from: 'start', to: 'w1' },
+    { id: 'e1', from: 'w1', to: 'c1', sourceHandle: 'r', targetHandle: 'l' },
+    { id: 'e2', from: 'c1', to: 'end', isDefault: true },
+  ],
+}
+
+describe('flowEditorModel condition + handles round-trip', () => {
+  it('preserves condition node type and edge handles', () => {
+    const flow = toFlow(gHandles)
+    const cNode = flow.nodes.find(n => n.id === 'c1')!
+    expect(cNode.data.type).toBe('condition')
+
+    const back = fromFlow(flow.nodes, flow.edges, gHandles.entry, gHandles.maxHops)
+    expect(back.nodes.find(n => n.id === 'c1')!.type).toBe('condition')
+    const e1 = back.edges.find(e => e.id === 'e1')!
+    expect(e1.sourceHandle).toBe('r')
+    expect(e1.targetHandle).toBe('l')
+  })
+})

--- a/codey-mac/src/components/flowEditorModel.test.ts
+++ b/codey-mac/src/components/flowEditorModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { toFlow, fromFlow, newNodeId, emptyGraph } from './flowEditorModel'
+import { toFlow, fromFlow, newNodeId, emptyGraph, branchColors } from './flowEditorModel'
 import type { TeamGraph } from '../../../packages/core/src/team-graph'
 
 const g: TeamGraph = {
@@ -61,5 +61,24 @@ describe('flowEditorModel condition + handles round-trip', () => {
     const e1 = back.edges.find(e => e.id === 'e1')!
     expect(e1.sourceHandle).toBe('r')
     expect(e1.targetHandle).toBe('l')
+  })
+})
+
+describe('branchColors', () => {
+  it('colors non-default branch edges distinctly and default gray', () => {
+    const colors = branchColors([] as any, [
+      { id: 'e2a', source: 'c1', data: { isDefault: false } },
+      { id: 'e2b', source: 'c1', data: { isDefault: true } },
+    ] as any)
+    expect(colors['e2a']).toBeTruthy()
+    expect(colors['e2b']).toBe('#888')
+    expect(colors['e2a']).not.toBe('#888')
+  })
+
+  it('does not color edges out of a single-output node', () => {
+    const colors = branchColors([] as any, [
+      { id: 'only', source: 'w1', data: {} },
+    ] as any)
+    expect(colors['only']).toBeUndefined()
   })
 })

--- a/codey-mac/src/components/flowEditorModel.ts
+++ b/codey-mac/src/components/flowEditorModel.ts
@@ -51,3 +51,27 @@ export function emptyGraph(): TeamGraph {
     edges: [],
   }
 }
+
+const BRANCH_PALETTE = ['#3b82f6', '#22c55e', '#f59e0b', '#a855f7', '#ec4899', '#14b8a6']
+
+/**
+ * Map edge id -> color for edges leaving a branch node (a node with >1 outgoing
+ * edge). Non-default edges get distinct palette colors by index; the default
+ * (else) edge is gray. Edges from single-output nodes are left uncolored.
+ */
+export function branchColors(_nodes: FlowNode[], edges: FlowEdge[]): Record<string, string> {
+  const bySource = new Map<string, FlowEdge[]>()
+  for (const e of edges) {
+    if (!bySource.has(e.source)) bySource.set(e.source, [])
+    bySource.get(e.source)!.push(e)
+  }
+  const out: Record<string, string> = {}
+  for (const group of bySource.values()) {
+    if (group.length < 2) continue
+    let i = 0
+    for (const e of group) {
+      out[e.id] = e.data?.isDefault ? '#888' : BRANCH_PALETTE[i++ % BRANCH_PALETTE.length]
+    }
+  }
+  return out
+}

--- a/codey-mac/src/components/flowEditorModel.ts
+++ b/codey-mac/src/components/flowEditorModel.ts
@@ -1,19 +1,21 @@
 import type { TeamGraph, TeamGraphNode, TeamGraphEdge } from '../../../packages/core/src/team-graph'
 
-export interface FlowNode { id: string; position: { x: number; y: number }; data: { label: string; type: TeamGraphNode['type']; worker?: string }; type?: string }
-export interface FlowEdge { id: string; source: string; target: string; sourceHandle?: string; targetHandle?: string; label?: string; data: { condition?: string; isDefault?: boolean } }
+export interface FlowNode { id: string; position: { x: number; y: number }; data: { label: string; type: TeamGraphNode['type']; worker?: string; condition?: string; maxCalls?: number }; type?: string; width?: number; height?: number }
+export interface FlowEdge { id: string; source: string; target: string; sourceHandle?: string; targetHandle?: string; label?: string; data: { condition?: string; isDefault?: boolean; branch?: 'yes' | 'no' } }
 
 export function toFlow(g: TeamGraph): { nodes: FlowNode[]; edges: FlowEdge[] } {
   const nodes = g.nodes.map(n => ({
     id: n.id,
     position: { x: n.x, y: n.y },
-    data: { label: n.type === 'worker' ? (n.worker ?? '?') : n.type, type: n.type, worker: n.worker },
+    data: { label: n.type === 'worker' ? (n.worker ?? '?') : n.type, type: n.type, worker: n.worker, condition: n.condition, maxCalls: n.maxCalls },
+    ...(n.width !== undefined ? { width: n.width } : {}),
+    ...(n.height !== undefined ? { height: n.height } : {}),
   }))
   const edges = g.edges.map(e => ({
     id: e.id, source: e.from, target: e.to,
     sourceHandle: e.sourceHandle, targetHandle: e.targetHandle,
-    label: e.isDefault ? 'default' : e.condition,
-    data: { condition: e.condition, isDefault: e.isDefault },
+    label: e.isDefault ? 'default' : e.branch ?? e.condition,
+    data: { condition: e.condition, isDefault: e.isDefault, branch: e.branch },
   }))
   return { nodes, edges }
 }
@@ -22,12 +24,17 @@ export function fromFlow(nodes: FlowNode[], edges: FlowEdge[], entry: string, ma
   const gNodes: TeamGraphNode[] = nodes.map(n => {
     const node: TeamGraphNode = { id: n.id, type: n.data.type, x: Math.round(n.position.x), y: Math.round(n.position.y) }
     if (n.data.worker !== undefined) node.worker = n.data.worker
+    if (n.data.condition !== undefined) node.condition = n.data.condition
+    if (n.data.maxCalls !== undefined) node.maxCalls = n.data.maxCalls
+    if (n.width !== undefined) node.width = n.width
+    if (n.height !== undefined) node.height = n.height
     return node
   })
   const gEdges: TeamGraphEdge[] = edges.map(e => {
     const edge: TeamGraphEdge = { id: e.id, from: e.source, to: e.target }
     if (e.data.condition !== undefined) edge.condition = e.data.condition
     if (e.data.isDefault !== undefined) edge.isDefault = e.data.isDefault
+    if (e.data.branch !== undefined) edge.branch = e.data.branch
     if (e.sourceHandle) edge.sourceHandle = e.sourceHandle
     if (e.targetHandle) edge.targetHandle = e.targetHandle
     return edge
@@ -59,14 +66,19 @@ const BRANCH_PALETTE = ['#3b82f6', '#22c55e', '#f59e0b', '#a855f7', '#ec4899', '
  * edge). Non-default edges get distinct palette colors by index; the default
  * (else) edge is gray. Edges from single-output nodes are left uncolored.
  */
-export function branchColors(_nodes: FlowNode[], edges: FlowEdge[]): Record<string, string> {
+export function branchColors(nodes: FlowNode[], edges: FlowEdge[]): Record<string, string> {
+  const typeById = new Map(nodes.map(n => [n.id, n.data?.type]))
   const bySource = new Map<string, FlowEdge[]>()
   for (const e of edges) {
     if (!bySource.has(e.source)) bySource.set(e.source, [])
     bySource.get(e.source)!.push(e)
   }
   const out: Record<string, string> = {}
-  for (const group of bySource.values()) {
+  for (const [source, group] of bySource) {
+    if (typeById.get(source) === 'condition') {
+      for (const e of group) out[e.id] = e.data?.branch === 'no' ? '#ef4444' : '#22c55e'
+      continue
+    }
     if (group.length < 2) continue
     let i = 0
     for (const e of group) {

--- a/codey-mac/src/components/flowEditorModel.ts
+++ b/codey-mac/src/components/flowEditorModel.ts
@@ -1,7 +1,7 @@
 import type { TeamGraph, TeamGraphNode, TeamGraphEdge } from '../../../packages/core/src/team-graph'
 
 export interface FlowNode { id: string; position: { x: number; y: number }; data: { label: string; type: TeamGraphNode['type']; worker?: string }; type?: string }
-export interface FlowEdge { id: string; source: string; target: string; label?: string; data: { condition?: string; isDefault?: boolean } }
+export interface FlowEdge { id: string; source: string; target: string; sourceHandle?: string; targetHandle?: string; label?: string; data: { condition?: string; isDefault?: boolean } }
 
 export function toFlow(g: TeamGraph): { nodes: FlowNode[]; edges: FlowEdge[] } {
   const nodes = g.nodes.map(n => ({
@@ -11,6 +11,7 @@ export function toFlow(g: TeamGraph): { nodes: FlowNode[]; edges: FlowEdge[] } {
   }))
   const edges = g.edges.map(e => ({
     id: e.id, source: e.from, target: e.to,
+    sourceHandle: e.sourceHandle, targetHandle: e.targetHandle,
     label: e.isDefault ? 'default' : e.condition,
     data: { condition: e.condition, isDefault: e.isDefault },
   }))
@@ -27,6 +28,8 @@ export function fromFlow(nodes: FlowNode[], edges: FlowEdge[], entry: string, ma
     const edge: TeamGraphEdge = { id: e.id, from: e.source, to: e.target }
     if (e.data.condition !== undefined) edge.condition = e.data.condition
     if (e.data.isDefault !== undefined) edge.isDefault = e.data.isDefault
+    if (e.sourceHandle) edge.sourceHandle = e.sourceHandle
+    if (e.targetHandle) edge.targetHandle = e.targetHandle
     return edge
   })
   return { entry, maxHops, nodes: gNodes, edges: gEdges }

--- a/docs/superpowers/plans/2026-06-15-flow-canvas-decision-nodes.md
+++ b/docs/superpowers/plans/2026-06-15-flow-canvas-decision-nodes.md
@@ -1,0 +1,813 @@
+# Flow Canvas Decision Nodes + Editor Upgrades Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a real diamond decision node to the Sequential flow graph (model + judge-driven runtime) and four editor upgrades — multiple connection handles, always-on animated/colored edges, drag-to-canvas, and bigger worker cards with a role description.
+
+**Architecture:** A new `condition` node type is a *branch point with no worker*: the existing judge LLM evaluates its outgoing edges using the last worker's output, exactly as it does for worker edges today. `settle()` stops at condition nodes; the gateway run loop branches on node type and threads `lastWorkerOutput`. The editor moves to custom React Flow node components, persists per-edge handle ids, animates edges, and supports palette drag-drop.
+
+**Tech Stack:** TypeScript (ES2020/CommonJS, strict), `@xyflow/react` (React Flow) in the Electron/Vite `codey-mac` app, Vitest for `@codey/core` and `codey-mac`. The gateway has no test runner.
+
+**Prerequisite for every test/build command below:** use Node v22.17.1 (`nvm use 22.17.1`). The repo's default Node v16 cannot run vitest/tsc. Spec: `docs/superpowers/specs/2026-06-15-flow-canvas-decision-nodes-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `packages/core/src/team-graph.ts` | Graph types, `settle`/`advance`, `validateGraph` | add `condition` type, edge handle fields, settle + validate rules |
+| `packages/core/src/team-graph.test.ts` | Core unit tests | settle/advance/validate coverage for condition nodes |
+| `packages/gateway/src/gateway.ts` | Flow run loop (2 variants) | node-type branching + `lastWorkerOutput` threading (manual verify) |
+| `codey-mac/src/components/flowEditorModel.ts` | React Flow ↔ TeamGraph mapping | handle fields, condition mapping, branch-color helper |
+| `codey-mac/src/components/flowEditorModel.test.ts` | Model round-trip tests | condition + handle round-trip, color helper |
+| `codey-mac/src/components/FlowEditor.tsx` | Canvas editor | custom nodes, handles, animation, drag-drop, palette |
+| `codey-mac/src/components/GlobalTeamsSection.tsx` | Team library UI | pass worker role lookup into `FlowEditor` |
+
+---
+
+## Task 1: Core — add `condition` node type and edge handle fields
+
+**Files:**
+- Modify: `packages/core/src/team-graph.ts:1-27`
+
+- [ ] **Step 1: Add `condition` to the node type union and handle fields to the edge**
+
+In `packages/core/src/team-graph.ts`, change the type union and edge interface:
+
+```ts
+export type TeamGraphNodeType = 'start' | 'worker' | 'condition' | 'end';
+```
+
+In `interface TeamGraphEdge`, after the `isDefault?` field, add:
+
+```ts
+  /** Presentation-only: React Flow source handle id. Ignored by the runtime. */
+  sourceHandle?: string;
+  /** Presentation-only: React Flow target handle id. Ignored by the runtime. */
+  targetHandle?: string;
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd packages/core && npx tsc --noEmit`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/team-graph.ts
+git commit -m "feat(core): add condition node type and edge handle fields"
+```
+
+---
+
+## Task 2: Core — `settle()` stops at condition nodes
+
+**Files:**
+- Modify: `packages/core/src/team-graph.ts:116-135`
+- Test: `packages/core/src/team-graph.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/team-graph.test.ts` (import helpers already used by the file; match its existing import style):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { startRun, advance, type TeamGraph } from './team-graph';
+
+function graphWithCondition(): TeamGraph {
+  return {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', x: 100, y: 0 },
+      { id: 'c1', type: 'condition', x: 200, y: 0 },
+      { id: 'w2', type: 'worker', worker: 'reviewer', x: 300, y: 0 },
+      { id: 'end', type: 'end', x: 400, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'c1' },
+      { id: 'e2', from: 'c1', to: 'w2', condition: 'needs review' },
+      { id: 'e3', from: 'c1', to: 'end', isDefault: true },
+    ],
+  };
+}
+
+describe('condition node settle', () => {
+  it('settles onto a condition node without recording it in visited', () => {
+    const g = graphWithCondition();
+    let s = startRun(g);            // start -> w1
+    expect(s.currentNodeId).toBe('w1');
+    s = advance(g, s, 'e1');        // w1 -> c1
+    expect(s.currentNodeId).toBe('c1');
+    expect(s.status).toBe('running');
+    expect(s.visited).toEqual(['w1']); // condition NOT in visited
+  });
+
+  it('advances from a condition node to the next worker', () => {
+    const g = graphWithCondition();
+    let s = startRun(g);
+    s = advance(g, s, 'e1');        // at c1
+    s = advance(g, s, 'e2');        // c1 -> w2
+    expect(s.currentNodeId).toBe('w2');
+    expect(s.visited).toEqual(['w1', 'w2']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts -t "condition node settle"`
+Expected: FAIL — current `settle()` records `c1` in `visited` (treats it like a worker).
+
+- [ ] **Step 3: Update `settle()` to handle condition nodes**
+
+In `packages/core/src/team-graph.ts`, in `settle()` (currently lines ~117-135), after the `start`-walk loop and the `end` check, add a `condition` branch BEFORE the final worker return:
+
+```ts
+  const node = nodes.get(cur);
+  if (!node) return { ...state, currentNodeId: cur, status: 'stuck' };
+  if (node.type === 'end') return { ...state, currentNodeId: cur, status: 'done' };
+  if (node.type === 'condition') {
+    // Branch point: stop here so the orchestrator can run the judge. Do not
+    // record it in `visited` (worker-only history).
+    return { ...state, currentNodeId: cur, status: 'running' };
+  }
+  return {
+    ...state,
+    currentNodeId: cur,
+    status: 'running',
+    visited: [...state.visited, cur],
+  };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts -t "condition node settle"`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Run the full core suite to check no regressions**
+
+Run: `cd packages/core && npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/team-graph.ts packages/core/src/team-graph.test.ts
+git commit -m "feat(core): settle stops at condition nodes without recording history"
+```
+
+---
+
+## Task 3: Core — `validateGraph` rules for condition nodes
+
+**Files:**
+- Modify: `packages/core/src/team-graph.ts:36-96`
+- Test: `packages/core/src/team-graph.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/team-graph.test.ts`:
+
+```ts
+import { validateGraph } from './team-graph';
+
+describe('condition node validation', () => {
+  const workers = ['coder', 'reviewer'];
+
+  it('rejects a condition node that carries a worker', () => {
+    const g = graphWithCondition();
+    (g.nodes.find(n => n.id === 'c1') as any).worker = 'coder';
+    const problems = validateGraph(g, workers);
+    expect(problems.some(p => p.includes('c1') && p.includes('worker'))).toBe(true);
+  });
+
+  it('rejects a condition node with no default outgoing edge', () => {
+    const g = graphWithCondition();
+    // drop the default flag from e3
+    g.edges = g.edges.map(e => e.id === 'e3' ? { ...e, isDefault: false } : e);
+    const problems = validateGraph(g, workers);
+    expect(problems.some(p => p.includes('c1') && p.includes('default'))).toBe(true);
+  });
+
+  it('accepts a well-formed condition node', () => {
+    expect(validateGraph(graphWithCondition(), workers)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts -t "condition node validation"`
+Expected: FAIL — no condition-specific rules yet.
+
+- [ ] **Step 3: Add condition rules to `validateGraph`**
+
+In `packages/core/src/team-graph.ts`, inside the `for (const node of graph.nodes)` loop that currently checks `node.type === 'worker'` (lines ~45-53), add an `else if`:
+
+```ts
+    } else if (node.type === 'condition') {
+      if (node.worker) {
+        problems.push(`condition node "${node.id}" must not reference a worker`);
+      }
+      const outs = graph.edges.filter(e => e.from === node.id);
+      if (!outs.some(e => e.isDefault)) {
+        problems.push(`condition node "${node.id}" needs a default outgoing edge`);
+      }
+    }
+```
+
+Then extend the "has no outgoing edge" rule (lines ~67-73) so condition nodes are included:
+
+```ts
+  for (const node of graph.nodes) {
+    const hasOut = (outgoing.get(node.id)?.length ?? 0) > 0;
+    if ((node.type === 'worker' || node.type === 'start' || node.type === 'condition') && !hasOut) {
+      const label = node.type === 'start' ? 'start node' : node.type === 'condition' ? 'condition node' : 'worker node';
+      problems.push(`${label} "${node.id}" has no outgoing edge`);
+    }
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts -t "condition node validation"`
+Expected: PASS (all three cases).
+
+- [ ] **Step 5: Run the full core suite**
+
+Run: `cd packages/core && npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/team-graph.ts packages/core/src/team-graph.test.ts
+git commit -m "feat(core): validate condition nodes (no worker, require default edge)"
+```
+
+---
+
+## Task 4: Editor model — handle fields + condition round-trip
+
+**Files:**
+- Modify: `codey-mac/src/components/flowEditorModel.ts:1-50`
+- Test: `codey-mac/src/components/flowEditorModel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `codey-mac/src/components/flowEditorModel.test.ts` (match its existing import style; it imports from `./flowEditorModel`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { toFlow, fromFlow } from './flowEditorModel';
+import type { TeamGraph } from '../../../packages/core/src/team-graph';
+
+const g: TeamGraph = {
+  entry: 'start', maxHops: 20,
+  nodes: [
+    { id: 'start', type: 'start', x: 0, y: 0 },
+    { id: 'w1', type: 'worker', worker: 'coder', x: 100, y: 0 },
+    { id: 'c1', type: 'condition', x: 200, y: 0 },
+    { id: 'end', type: 'end', x: 300, y: 0 },
+  ],
+  edges: [
+    { id: 'e0', from: 'start', to: 'w1' },
+    { id: 'e1', from: 'w1', to: 'c1', sourceHandle: 'r', targetHandle: 'l' },
+    { id: 'e2', from: 'c1', to: 'end', isDefault: true },
+  ],
+};
+
+describe('flowEditorModel condition + handles round-trip', () => {
+  it('preserves condition node type and edge handles', () => {
+    const flow = toFlow(g);
+    const cNode = flow.nodes.find(n => n.id === 'c1')!;
+    expect(cNode.data.type).toBe('condition');
+
+    const back = fromFlow(flow.nodes, flow.edges, g.entry, g.maxHops);
+    expect(back.nodes.find(n => n.id === 'c1')!.type).toBe('condition');
+    const e1 = back.edges.find(e => e.id === 'e1')!;
+    expect(e1.sourceHandle).toBe('r');
+    expect(e1.targetHandle).toBe('l');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts -t "condition + handles"`
+Expected: FAIL — handles are dropped by `fromFlow`/`toFlow`.
+
+- [ ] **Step 3: Thread handle fields through the model**
+
+In `codey-mac/src/components/flowEditorModel.ts`:
+
+Extend `FlowEdge.data` (line ~4) to carry handles, and add top-level handle fields React Flow uses:
+
+```ts
+export interface FlowEdge { id: string; source: string; target: string; sourceHandle?: string; targetHandle?: string; label?: string; data: { condition?: string; isDefault?: boolean } }
+```
+
+In `toFlow`, map handles onto each edge:
+
+```ts
+  const edges = g.edges.map(e => ({
+    id: e.id, source: e.from, target: e.to,
+    sourceHandle: e.sourceHandle, targetHandle: e.targetHandle,
+    label: e.isDefault ? 'default' : e.condition,
+    data: { condition: e.condition, isDefault: e.isDefault },
+  }))
+```
+
+In `fromFlow`, write handles back onto the `TeamGraphEdge`:
+
+```ts
+  const gEdges: TeamGraphEdge[] = edges.map(e => {
+    const edge: TeamGraphEdge = { id: e.id, from: e.source, to: e.target }
+    if (e.data.condition !== undefined) edge.condition = e.data.condition
+    if (e.data.isDefault !== undefined) edge.isDefault = e.data.isDefault
+    if (e.sourceHandle) edge.sourceHandle = e.sourceHandle
+    if (e.targetHandle) edge.targetHandle = e.targetHandle
+    return edge
+  })
+```
+
+Note: `toFlow`'s node `label` for a `condition` node falls through to `n.type` (i.e. `'condition'`) via the existing `n.type === 'worker' ? ... : n.type` expression — no change needed there.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts -t "condition + handles"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full model test file**
+
+Run: `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/src/components/flowEditorModel.ts codey-mac/src/components/flowEditorModel.test.ts
+git commit -m "feat(codey-mac): round-trip condition nodes and edge handles in flow model"
+```
+
+---
+
+## Task 5: Editor model — branch color helper
+
+**Files:**
+- Modify: `codey-mac/src/components/flowEditorModel.ts`
+- Test: `codey-mac/src/components/flowEditorModel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `codey-mac/src/components/flowEditorModel.test.ts`:
+
+```ts
+import { branchColors } from './flowEditorModel';
+
+describe('branchColors', () => {
+  it('colors non-default branch edges distinctly and default gray', () => {
+    const colors = branchColors(g.nodes.map(n => ({ id: n.id })) as any, [
+      { id: 'e2a', source: 'c1', data: { isDefault: false } },
+      { id: 'e2b', source: 'c1', data: { isDefault: true } },
+    ] as any);
+    expect(colors['e2a']).toBeTruthy();
+    expect(colors['e2b']).toBe('#888');     // default = gray
+    expect(colors['e2a']).not.toBe('#888');
+  });
+
+  it('does not color edges out of a single-output node', () => {
+    const colors = branchColors([{ id: 'w1' }] as any, [
+      { id: 'only', source: 'w1', data: {} },
+    ] as any);
+    expect(colors['only']).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts -t "branchColors"`
+Expected: FAIL — `branchColors` not exported.
+
+- [ ] **Step 3: Implement `branchColors`**
+
+Add to `codey-mac/src/components/flowEditorModel.ts`:
+
+```ts
+const BRANCH_PALETTE = ['#3b82f6', '#22c55e', '#f59e0b', '#a855f7', '#ec4899', '#14b8a6']
+
+/**
+ * Map edge id -> color for edges leaving a branch node (a node with >1 outgoing
+ * edge). Non-default edges get distinct palette colors by index; the default
+ * (else) edge is gray. Edges from single-output nodes are left uncolored.
+ */
+export function branchColors(_nodes: FlowNode[], edges: FlowEdge[]): Record<string, string> {
+  const bySource = new Map<string, FlowEdge[]>()
+  for (const e of edges) {
+    if (!bySource.has(e.source)) bySource.set(e.source, [])
+    bySource.get(e.source)!.push(e)
+  }
+  const out: Record<string, string> = {}
+  for (const group of bySource.values()) {
+    if (group.length < 2) continue
+    let i = 0
+    for (const e of group) {
+      out[e.id] = e.data?.isDefault ? '#888' : BRANCH_PALETTE[i++ % BRANCH_PALETTE.length]
+    }
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts -t "branchColors"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/flowEditorModel.ts codey-mac/src/components/flowEditorModel.test.ts
+git commit -m "feat(codey-mac): branchColors helper for edge coloring"
+```
+
+---
+
+## Task 6: Gateway — run loop branches on node type
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts:2966-3044` (`continueGraphRun`)
+- Modify: `packages/gateway/src/gateway.ts` (the `runSequentialGraphForChatSink` loop, ~3052+)
+
+> The gateway has no unit-test runner. Verify with a TypeScript build and a manual run (Step 4/5). Make the SAME change in both loop variants.
+
+- [ ] **Step 1: Thread `lastWorkerOutput` and branch on node type in `continueGraphRun`**
+
+In `continueGraphRun`, before the `while (state.status === 'running')` loop, add:
+
+```ts
+    let lastWorkerOutput = ''
+    let lastWorkerName = ''
+```
+
+Inside the loop, replace the current body that assumes a worker node. At the top of the loop, after `const node = nodeById.get(state.currentNodeId)!`, branch:
+
+```ts
+      if (node.type === 'condition') {
+        // Branch point: no worker runs. Judge picks among the diamond's edges
+        // using the last worker's output.
+        const { decision, edge } = await this.pickNextGraphEdge(
+          graph, nodeById, state.currentNodeId, task, lastWorkerName,
+          lastWorkerOutput, blackboard.renderForUser() || '',
+        )
+        if (!edge) {
+          await emitter.status(`🏁 Flow stopped at a decision point (no matching branch).`)
+          break
+        }
+        await emitter.status(`↪️ ${decision.fallback ? '(default) ' : ''}${decision.reason || 'branch'}`)
+        state = advance(graph, state, edge.id)
+        continue
+      }
+```
+
+Keep the existing worker logic below this branch. In the worker path, after `const ingested = blackboard.ingest(...)`, set:
+
+```ts
+      lastWorkerOutput = ingested.stripped
+      lastWorkerName = workerName
+```
+
+(The existing `pickNextGraphEdge` call for the worker path stays as-is — workers may still carry their own conditioned edges.)
+
+- [ ] **Step 2: Apply the identical branch to `runSequentialGraphForChatSink`**
+
+Find the sink variant's `while (state.status === 'running')` loop (after line ~3052). Add the same `let lastWorkerOutput = ''` / `let lastWorkerName = ''` before the loop, the same `if (node.type === 'condition') { ... continue }` block at the top, and the same `lastWorkerOutput`/`lastWorkerName` assignment after the worker's `ingest`. Use the sink variant's existing emit/status helpers (mirror its current worker-path style rather than copying `emitter.status` verbatim if it differs).
+
+- [ ] **Step 3: Type-check the gateway**
+
+Run: `cd packages/gateway && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Build core + gateway**
+
+Run: `cd /Users/jackou/Documents/projects/codey && npm run build:core && npm run build:gateway`
+Expected: both build with no errors.
+
+- [ ] **Step 5: Manual smoke (document result in the commit body)**
+
+Construct a tiny team graph in a scratch `gateway.json` (or reuse a test workspace) with `coder → diamond → {reviewer if "needs review", end default}` and run a `/team` task. Confirm: the diamond does not run a worker, a `↪️` branch status appears, and the flow reaches `reviewer` or `end`. If a full run isn't feasible in this environment, note that and rely on the core tests (Task 2/3) for the settle/advance/validate guarantees the loop depends on.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): flow loop runs the judge at condition nodes"
+```
+
+---
+
+## Task 7: Editor — custom node components (worker card, diamond, terminal)
+
+**Files:**
+- Modify: `codey-mac/src/components/FlowEditor.tsx`
+
+> Visual change, no unit test. Verify by `vite build` (Step 3) and manual open.
+
+- [ ] **Step 1: Extend `FlowEditor` props to receive worker roles**
+
+In `codey-mac/src/components/FlowEditor.tsx`, change the `Props` interface to add a role lookup:
+
+```ts
+interface Props {
+  teamName: string
+  workerNames: string[]
+  workerRoles?: Record<string, string>   // name -> personality.role (one-liner)
+  graph: TeamGraph
+  onSave: (graph: TeamGraph) => void
+  onClose: () => void
+}
+```
+
+Destructure `workerRoles = {}` in the component signature.
+
+- [ ] **Step 2: Define custom node components and `nodeTypes`**
+
+Add, above the `FlowEditor` component, custom node renderers using `Handle`/`Position` from `@xyflow/react`. Each interactive node exposes four handles (top/right/bottom/left) that act as both source and target so edges can attach at distinct points:
+
+```tsx
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+
+const HANDLE_IDS = ['t', 'r', 'b', 'l'] as const
+const HANDLE_POS = { t: Position.Top, r: Position.Right, b: Position.Bottom, l: Position.Left }
+
+function NodeHandles() {
+  return (
+    <>
+      {HANDLE_IDS.map(id => (
+        <Handle key={`s-${id}`} type="source" id={id} position={HANDLE_POS[id]} style={{ background: C.accent }} />
+      ))}
+      {HANDLE_IDS.map(id => (
+        <Handle key={`tg-${id}`} type="target" id={id} position={HANDLE_POS[id]} style={{ background: C.fg3 }} />
+      ))}
+    </>
+  )
+}
+
+function WorkerNodeView({ data }: NodeProps) {
+  const d = data as { label: string; role?: string }
+  return (
+    <div style={{ minWidth: 150, padding: '8px 10px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}`, color: C.fg }}>
+      <div style={{ fontSize: 13, fontWeight: 600 }}>{d.label}</div>
+      {d.role && <div style={{ fontSize: 11, color: C.fg3, marginTop: 2, maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
+      <NodeHandles />
+    </div>
+  )
+}
+
+function ConditionNodeView() {
+  return (
+    <div style={{ width: 90, height: 90, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ width: 64, height: 64, transform: 'rotate(45deg)', background: C.surface2, border: `1px solid ${C.accent}`, borderRadius: 8 }} />
+      <span style={{ position: 'absolute', fontSize: 11, color: C.fg3 }}>?</span>
+      <NodeHandles />
+    </div>
+  )
+}
+
+function TerminalNodeView({ data }: NodeProps) {
+  const d = data as { label: string }
+  return (
+    <div style={{ padding: '6px 14px', borderRadius: 999, background: C.bg, border: `1px solid ${C.border}`, color: C.fg, fontSize: 12 }}>
+      {d.label}
+      <NodeHandles />
+    </div>
+  )
+}
+
+const nodeTypes = { workerNode: WorkerNodeView, conditionNode: ConditionNodeView, terminalNode: TerminalNodeView }
+```
+
+- [ ] **Step 3: Assign `type` to nodes and pass `role` into worker node data**
+
+When building the initial nodes (the `toFlow` result at line ~20), set each React Flow node's `type` field and inject `role`. Add a mapper after `const initial = useMemo(...)`:
+
+```ts
+  const withTypes = (ns: Node[]): Node[] => ns.map(n => {
+    const t = (n.data as any).type
+    const rfType = t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'
+    const role = t === 'worker' ? workerRoles[(n.data as any).worker] : undefined
+    return { ...n, type: rfType, data: { ...n.data, role } }
+  })
+```
+
+Initialize state with it: `useState<Node[]>(withTypes(initial.nodes as unknown as Node[]))`.
+
+Pass `nodeTypes` to `<ReactFlow ... nodeTypes={nodeTypes}>`.
+
+- [ ] **Step 4: Build to verify**
+
+Run: `cd codey-mac && npx vite build`
+Expected: build succeeds (TypeScript + bundling).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/FlowEditor.tsx
+git commit -m "feat(codey-mac): custom flow nodes (worker card with role, diamond, terminal)"
+```
+
+---
+
+## Task 8: Editor — persist handles on connect + animated/colored edges
+
+**Files:**
+- Modify: `codey-mac/src/components/FlowEditor.tsx`
+
+- [ ] **Step 1: Capture handles in `onConnect`**
+
+Replace the `onConnect` callback (line ~33) so it records the handles React Flow reports:
+
+```ts
+  const onConnect = useCallback((c: Connection) =>
+    setEdges(es => addEdge({
+      ...c, id: `e_${Date.now()}`,
+      sourceHandle: c.sourceHandle ?? undefined,
+      targetHandle: c.targetHandle ?? undefined,
+      data: {},
+    } as any, es)), [])
+```
+
+- [ ] **Step 2: Derive styled edges (animated + branch colors) for rendering**
+
+Add, before the `return`:
+
+```ts
+  const colors = useMemo(() => branchColors(nodes as any, edges as any), [nodes, edges])
+  const styledEdges = useMemo(() => edges.map(e => ({
+    ...e,
+    animated: true,
+    style: { ...(e as any).style, stroke: colors[e.id] ?? C.fg3 },
+  })), [edges, colors])
+```
+
+Import `branchColors` from `./flowEditorModel` (extend the existing import on line 8).
+
+- [ ] **Step 3: Render `styledEdges` instead of `edges`**
+
+In the `<ReactFlow>` element, change `edges={edges}` to `edges={styledEdges}`. Keep `onEdgesChange`/`onConnect`/`onEdgeClick` bound to the real `edges` state (they operate by id, so styling is render-only).
+
+- [ ] **Step 4: Build to verify**
+
+Run: `cd codey-mac && npx vite build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/FlowEditor.tsx
+git commit -m "feat(codey-mac): persist edge handles, animate + color branch edges"
+```
+
+---
+
+## Task 9: Editor — drag workers/condition onto the canvas
+
+**Files:**
+- Modify: `codey-mac/src/components/FlowEditor.tsx`
+
+- [ ] **Step 1: Wrap the canvas in `ReactFlowProvider`**
+
+Import `ReactFlowProvider, useReactFlow` from `@xyflow/react`. The default export becomes a thin wrapper; rename the current component to `FlowEditorInner` and add:
+
+```tsx
+export default function FlowEditor(props: Props) {
+  return <ReactFlowProvider><FlowEditorInner {...props} /></ReactFlowProvider>
+}
+```
+
+- [ ] **Step 2: Add drag source to palette items**
+
+In the Workers palette (lines ~62-67), make each button draggable and add a Condition button:
+
+```tsx
+{workerNames.map(w => (
+  <button key={w} draggable
+    onDragStart={e => e.dataTransfer.setData('application/codey-node', JSON.stringify({ kind: 'worker', worker: w }))}
+    onClick={() => addWorker(w)}
+    style={{ /* keep existing styles, enlarge: padding '8px 8px', minHeight 40 */ }}>
+    <div style={{ fontWeight: 600 }}>+ {w}</div>
+    {workerRoles[w] && <div style={{ fontSize: 10, color: C.fg3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{workerRoles[w]}</div>}
+  </button>
+))}
+<button draggable
+  onDragStart={e => e.dataTransfer.setData('application/codey-node', JSON.stringify({ kind: 'condition' }))}
+  onClick={() => addCondition()}
+  style={{ display: 'block', width: '100%', marginTop: 8, fontSize: 12, padding: '6px', background: C.surface2, border: `1px dashed ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>◇ + Condition</button>
+```
+
+- [ ] **Step 3: Add `addCondition` and drop handling**
+
+Add near `addWorker`:
+
+```ts
+  const rf = useReactFlow()
+  const addCondition = () => {
+    const id = newNodeId(nodes.map(n => n.id))
+    setNodes(ns => [...ns, { id, type: 'conditionNode', position: { x: 260, y: 60 + ns.length * 70 }, data: { label: 'condition', type: 'condition' } } as any])
+  }
+  const onDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    const raw = e.dataTransfer.getData('application/codey-node')
+    if (!raw) return
+    const payload = JSON.parse(raw) as { kind: 'worker' | 'condition'; worker?: string }
+    const position = rf.screenToFlowPosition({ x: e.clientX, y: e.clientY })
+    const id = newNodeId(nodes.map(n => n.id))
+    if (payload.kind === 'condition') {
+      setNodes(ns => [...ns, { id, type: 'conditionNode', position, data: { label: 'condition', type: 'condition' } } as any])
+    } else {
+      setNodes(ns => [...ns, { id, type: 'workerNode', position, data: { label: payload.worker, type: 'worker', worker: payload.worker, role: workerRoles[payload.worker!] } } as any])
+    }
+  }, [nodes, rf, workerRoles])
+  const onDragOver = useCallback((e: React.DragEvent) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move' }, [])
+```
+
+Update `addWorker` so its node also carries `type: 'workerNode'` and `role`, matching the drop path (so click-add and drag-add produce identical nodes).
+
+- [ ] **Step 4: Wire drop onto the canvas wrapper**
+
+Put `onDrop={onDrop}` and `onDragOver={onDragOver}` on the `<div style={{ flex: 1, position: 'relative' }}>` that wraps `<ReactFlow>` (line ~72).
+
+- [ ] **Step 5: Build to verify**
+
+Run: `cd codey-mac && npx vite build`
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/src/components/FlowEditor.tsx
+git commit -m "feat(codey-mac): drag workers and condition nodes onto the flow canvas"
+```
+
+---
+
+## Task 10: Wire worker roles from `GlobalTeamsSection` into `FlowEditor`
+
+**Files:**
+- Modify: `codey-mac/src/components/GlobalTeamsSection.tsx:234-239`
+
+- [ ] **Step 1: Build a `name → role` map and pass it as a prop**
+
+In `GlobalTeamsSection.tsx`, where `<FlowEditor ... />` is rendered (line ~234), add a `workerRoles` prop derived from the existing `workers` state:
+
+```tsx
+<FlowEditor
+  teamName={editingFlow}
+  workerNames={teams[editingFlow].members}
+  workerRoles={Object.fromEntries(workers.map(w => [w.name, w.personality.role]))}
+  graph={teams[editingFlow].graph ?? emptyGraph()}
+  onSave={(graph) => { queueSave({ ...teams, [editingFlow]: { ...teams[editingFlow], graph } }) }}
+  onClose={() => setEditingFlow(null)}
+/>
+```
+
+(Confirm the exact existing prop lines while editing; keep `onSave`/`onClose` exactly as they are.)
+
+- [ ] **Step 2: Build to verify**
+
+Run: `cd codey-mac && npx vite build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Manual check (Mac app)**
+
+Run the app (`cd codey-mac && npm run dev`), open a Sequential team's flow editor, and verify: worker palette cards show the role line; dragging a worker drops it at the cursor; the "◇ + Condition" control drops a diamond; wiring `worker → diamond → {conditioned, default}` shows animated, colored edges; Save → reopen → toggle "Raw config" shows the `condition` node and `sourceHandle`/`targetHandle` on edges.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add codey-mac/src/components/GlobalTeamsSection.tsx
+git commit -m "feat(codey-mac): pass worker roles into the flow editor"
+```
+
+---
+
+## Final verification
+
+- [ ] **Core tests:** `cd packages/core && npx vitest run` → PASS
+- [ ] **Editor model tests:** `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts` → PASS
+- [ ] **Builds:** `npm run build:core && npm run build:gateway` and `cd codey-mac && npx vite build` → all succeed
+- [ ] **Lint:** `npm run lint` (non-English character check) → PASS
+- [ ] **Manual:** the Task 10 Step 3 checklist passes end-to-end in the Mac app.
+
+---
+
+## Self-review notes (resolved)
+
+- **Spec coverage:** #1 handles → Tasks 4, 7, 8; #2 diamond → Tasks 1–3 (model), 6 (runtime), 7/9 (editor); #3 animation/colors → Tasks 5, 8; #4 drag → Task 9; #5 card+role → Tasks 7, 9, 10. All five covered.
+- **Type consistency:** `condition` node type, `sourceHandle`/`targetHandle` edge fields, `workerRoles` prop, and `branchColors` signature are defined once (Tasks 1, 4, 5, 7) and reused consistently downstream.
+- **Gateway no-test caveat:** Task 6 relies on Task 2/3 core tests for the settle/advance/validate guarantees plus a build + manual smoke, since the gateway has no unit runner.

--- a/docs/superpowers/plans/2026-06-16-decision-diamonds-and-worker-loops.md
+++ b/docs/superpowers/plans/2026-06-16-decision-diamonds-and-worker-loops.md
@@ -1,0 +1,1002 @@
+# Decision Diamonds & Worker Self-Loops Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make decision diamonds carry their condition (yes/no question) with two labeled outcome edges, add bounded worker self-loops, a node inspector (worker description, diamond question, max-self-loops), and resizable worker cards.
+
+**Architecture:** Core graph model gains node `condition`/`maxCalls`/`width`/`height` and edge `branch` fields; `GraphRunState` gains a `runStreak` counter; a new `eligibleEdges` helper drops a worker's self-edge once `maxCalls` is hit; the judge learns an optional `question`. The gateway's single `continueGraphRun` loop threads `runStreak` and the diamond question. The Mac editor adds a node-aware inspector, auto-labeled yes/no diamond edges, self-loop handles, and `NodeResizer`.
+
+**Tech Stack:** TypeScript (ES2020/CommonJS), vitest (core + codey-mac), React + @xyflow/react (Mac app). Node v22.17.1 via nvm (v16 default cannot run vitest/tsc).
+
+---
+
+## File structure
+
+- `packages/core/src/team-graph.ts` — model fields, `validateGraph` rules, `GraphRunState.runStreak`, `settle`, `eligibleEdges`, `resolveEdge` diamond fallback.
+- `packages/core/src/team-graph.test.ts` — vitest for the above.
+- `packages/core/src/judge.ts` — `JudgeInput.question` + `buildJudgePrompt` decision section.
+- `packages/core/src/judge.test.ts` — vitest for the prompt.
+- `packages/gateway/src/gateway.ts` — `buildJudgeEdges`/`pickNextGraphEdge` use eligible edges + question; loop increments `runStreak`; resume persists/restores it. (No unit runner: build + manual.)
+- `codey-mac/src/components/flowEditorModel.ts` — round-trip new fields; `branchColors` diamond colors.
+- `codey-mac/src/components/flowEditorModel.test.ts` — vitest for the above.
+- `codey-mac/src/components/FlowEditor.tsx` — node inspector, yes/no diamond edges, self-loop, `NodeResizer`. (No unit runner: build + manual.)
+
+**Environment setup (run once before any task):**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+```
+
+---
+
+## Task 1: Core model fields + `validateGraph` rules
+
+**Files:**
+- Modify: `packages/core/src/team-graph.ts:3-24` (interfaces), `:49-65` (validate worker/condition blocks)
+- Test: `packages/core/src/team-graph.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/src/team-graph.test.ts` (reuse the existing `import { validateGraph, ... }` line; if `validateGraph` is not already imported, add it):
+
+```ts
+describe('validateGraph — diamonds carry conditions', () => {
+  const base = (over: Partial<import('./team-graph').TeamGraph> = {}) => ({
+    entry: 'start', maxHops: 10,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', x: 1, y: 0 },
+      { id: 'd1', type: 'condition', condition: 'tests pass?', x: 2, y: 0 },
+      { id: 'end', type: 'end', x: 3, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'd1' },
+      { id: 'e2', from: 'd1', to: 'end', branch: 'yes' },
+      { id: 'e3', from: 'd1', to: 'w1', branch: 'no' },
+    ],
+    ...over,
+  } as import('./team-graph').TeamGraph);
+
+  it('accepts a diamond with a question and one yes + one no edge', () => {
+    expect(validateGraph(base(), ['coder'])).toEqual([]);
+  });
+
+  it('rejects a diamond with no question', () => {
+    const g = base();
+    g.nodes.find(n => n.id === 'd1')!.condition = '';
+    expect(validateGraph(g, ['coder']).some(p => p.includes('needs a question'))).toBe(true);
+  });
+
+  it('rejects a diamond without exactly one yes and one no edge', () => {
+    const g = base();
+    g.edges.find(e => e.id === 'e3')!.branch = 'yes';
+    expect(validateGraph(g, ['coder']).some(p => p.includes('one yes and one no'))).toBe(true);
+  });
+});
+
+describe('validateGraph — worker self-loops', () => {
+  it('rejects a worker self-loop with no exit edge', () => {
+    const g: import('./team-graph').TeamGraph = {
+      entry: 'start', maxHops: 10,
+      nodes: [
+        { id: 'start', type: 'start', x: 0, y: 0 },
+        { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 3, x: 1, y: 0 },
+      ],
+      edges: [
+        { id: 'e0', from: 'start', to: 'w1' },
+        { id: 'e1', from: 'w1', to: 'w1' },
+      ],
+    };
+    expect(validateGraph(g, ['coder']).some(p => p.includes('self-loops with no exit'))).toBe(true);
+  });
+
+  it('rejects maxCalls < 1', () => {
+    const g: import('./team-graph').TeamGraph = {
+      entry: 'start', maxHops: 10,
+      nodes: [
+        { id: 'start', type: 'start', x: 0, y: 0 },
+        { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 0, x: 1, y: 0 },
+        { id: 'end', type: 'end', x: 2, y: 0 },
+      ],
+      edges: [
+        { id: 'e0', from: 'start', to: 'w1' },
+        { id: 'e1', from: 'w1', to: 'end' },
+      ],
+    };
+    expect(validateGraph(g, ['coder']).some(p => p.includes('maxCalls must be >= 1'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: FAIL — the diamond test fails on the old "needs a default outgoing edge" rule; `branch`/`maxCalls` are not yet on the types so it may also fail to compile.
+
+- [ ] **Step 3: Add the model fields**
+
+In `packages/core/src/team-graph.ts`, replace the `TeamGraphNode` interface (lines 3-10) with:
+
+```ts
+export interface TeamGraphNode {
+  id: string;
+  type: TeamGraphNodeType;
+  /** Worker name; required when type === 'worker'. */
+  worker?: string;
+  /** Decision question the judge evaluates; used when type === 'condition'. */
+  condition?: string;
+  /** Max consecutive runs of this (self-looping) worker before a forced exit. */
+  maxCalls?: number;
+  x: number;
+  y: number;
+  /** Presentation-only: editor card size. Ignored by the runtime. */
+  width?: number;
+  height?: number;
+}
+```
+
+In the `TeamGraphEdge` interface, add after the `isDefault` field (after line 19):
+
+```ts
+  /** Outcome of a diamond's decision. Only set on edges leaving a 'condition' node. */
+  branch?: 'yes' | 'no';
+```
+
+- [ ] **Step 4: Update the `condition`-node validation block**
+
+Replace the `else if (node.type === 'condition') { ... }` block (lines 56-64) with:
+
+```ts
+    } else if (node.type === 'condition') {
+      if (node.worker) {
+        problems.push(`condition node "${node.id}" must not reference a worker`);
+      }
+      if (!node.condition || !node.condition.trim()) {
+        problems.push(`condition node "${node.id}" needs a question`);
+      }
+      const outs = graph.edges.filter(e => e.from === node.id);
+      const yes = outs.filter(e => e.branch === 'yes').length;
+      const no = outs.filter(e => e.branch === 'no').length;
+      if (outs.length !== 2 || yes !== 1 || no !== 1) {
+        problems.push(`condition node "${node.id}" needs exactly one yes and one no outgoing edge`);
+      }
+    }
+```
+
+- [ ] **Step 5: Add the worker self-loop + maxCalls checks**
+
+In the `if (node.type === 'worker') { ... }` block (lines 50-56), add these statements just before its closing `}` (after the unknown-worker check):
+
+```ts
+      const outs = graph.edges.filter(e => e.from === node.id);
+      if (outs.some(e => e.to === node.id) && !outs.some(e => e.to !== node.id)) {
+        problems.push(`worker node "${node.id}" self-loops with no exit edge`);
+      }
+      if (node.maxCalls !== undefined && (!Number.isInteger(node.maxCalls) || node.maxCalls < 1)) {
+        problems.push(`worker node "${node.id}" maxCalls must be >= 1`);
+      }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: PASS (all existing + new tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/team-graph.ts packages/core/src/team-graph.test.ts
+git commit -m "feat(core): diamonds carry conditions; validate yes/no edges + worker self-loops"
+```
+
+---
+
+## Task 2: `runStreak` on `GraphRunState` + `settle` reset
+
+**Files:**
+- Modify: `packages/core/src/team-graph.ts:110-154` (`GraphRunState`, `settle`, `startRun`)
+- Test: `packages/core/src/team-graph.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/src/team-graph.test.ts`:
+
+```ts
+import { startRun, advance } from './team-graph';
+
+describe('runStreak', () => {
+  const g: import('./team-graph').TeamGraph = {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 2, x: 1, y: 0 },
+      { id: 'w2', type: 'worker', worker: 'reviewer', x: 2, y: 0 },
+      { id: 'end', type: 'end', x: 3, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'w1' },   // self-loop
+      { id: 'e2', from: 'w1', to: 'w2' },   // exit
+      { id: 'e3', from: 'w2', to: 'end' },
+    ],
+  };
+
+  it('starts at 0', () => {
+    expect(startRun(g).runStreak).toBe(0);
+  });
+
+  it('carries the streak when looping onto the same node', () => {
+    const s0 = { ...startRun(g), runStreak: 5 };
+    const s1 = advance(g, s0, 'e1'); // w1 -> w1
+    expect(s1.currentNodeId).toBe('w1');
+    expect(s1.runStreak).toBe(5);
+  });
+
+  it('resets the streak when moving to a different node', () => {
+    const s0 = { ...startRun(g), runStreak: 5 };
+    const s1 = advance(g, s0, 'e2'); // w1 -> w2
+    expect(s1.currentNodeId).toBe('w2');
+    expect(s1.runStreak).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: FAIL — `runStreak` is `undefined` on the returned state.
+
+- [ ] **Step 3: Add `runStreak` to `GraphRunState`**
+
+In `packages/core/src/team-graph.ts`, add to the `GraphRunState` interface (after the `visited` field, ~line 117):
+
+```ts
+  /** Consecutive runs of currentNodeId; resets when settling onto a different node. */
+  runStreak: number;
+```
+
+- [ ] **Step 4: Reset/carry `runStreak` in `settle`; init in `startRun`**
+
+In `settle` (lines 129-150), after the final `cur`/`node` are resolved (just before `if (node.type === 'end')`), add:
+
+```ts
+  const runStreak = state.currentNodeId === cur ? state.runStreak : 0;
+```
+
+Then add `runStreak,` to each of the three terminal returns in `settle` — the `end` return, the `condition` return, and the final worker return. For example the worker return becomes:
+
+```ts
+  return {
+    ...state,
+    currentNodeId: cur,
+    status: 'running',
+    visited: [...state.visited, cur],
+    runStreak,
+  };
+```
+
+In `startRun` (line 152-154), add `runStreak: 0` to the initial state object:
+
+```ts
+export function startRun(graph: TeamGraph): GraphRunState {
+  return settle(graph, graph.entry, { currentNodeId: graph.entry, hops: 0, status: 'running', visited: [], runStreak: 0 });
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/team-graph.ts packages/core/src/team-graph.test.ts
+git commit -m "feat(core): track consecutive worker run streak in GraphRunState"
+```
+
+---
+
+## Task 3: `eligibleEdges` helper
+
+**Files:**
+- Modify: `packages/core/src/team-graph.ts` (add helper near `outgoingEdges`, ~line 126)
+- Test: `packages/core/src/team-graph.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/team-graph.test.ts`:
+
+```ts
+import { eligibleEdges } from './team-graph';
+
+describe('eligibleEdges', () => {
+  const g: import('./team-graph').TeamGraph = {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 2, x: 1, y: 0 },
+      { id: 'w2', type: 'worker', worker: 'reviewer', x: 2, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'w1' },
+      { id: 'e2', from: 'w1', to: 'w2' },
+    ],
+  };
+
+  it('keeps the self-edge below maxCalls', () => {
+    const ids = eligibleEdges(g, { ...startRun(g), currentNodeId: 'w1', runStreak: 1 }, 'w1').map(e => e.id);
+    expect(ids).toContain('e1');
+    expect(ids).toContain('e2');
+  });
+
+  it('drops the self-edge at/after maxCalls', () => {
+    const ids = eligibleEdges(g, { ...startRun(g), currentNodeId: 'w1', runStreak: 2 }, 'w1').map(e => e.id);
+    expect(ids).not.toContain('e1');
+    expect(ids).toContain('e2');
+  });
+
+  it('ignores nodes without maxCalls', () => {
+    const ids = eligibleEdges(g, { ...startRun(g), currentNodeId: 'w2', runStreak: 99 }, 'w2').map(e => e.id);
+    expect(ids).toEqual([]); // w2 has no outgoing in this fixture
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: FAIL — `eligibleEdges` is not exported.
+
+- [ ] **Step 3: Add the helper**
+
+In `packages/core/src/team-graph.ts`, add immediately after `outgoingEdges` (after line 126):
+
+```ts
+/**
+ * Outgoing edges the judge may choose from. Drops a worker's self-edge once its
+ * consecutive-run streak has reached the node's maxCalls, forcing an exit. For
+ * nodes without maxCalls (or non-worker nodes) this equals outgoingEdges.
+ */
+export function eligibleEdges(graph: TeamGraph, state: GraphRunState, nodeId: string): TeamGraphEdge[] {
+  const edges = outgoingEdges(graph, nodeId);
+  const node = nodeMap(graph).get(nodeId);
+  if (node?.type === 'worker' && node.maxCalls !== undefined && state.runStreak >= node.maxCalls) {
+    return edges.filter(e => e.to !== nodeId);
+  }
+  return edges;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/team-graph.ts packages/core/src/team-graph.test.ts
+git commit -m "feat(core): eligibleEdges drops worker self-edge at maxCalls"
+```
+
+---
+
+## Task 4: `resolveEdge` diamond fallback to the `no` edge
+
+**Files:**
+- Modify: `packages/core/src/team-graph.ts:175-181` (`resolveEdge`)
+- Test: `packages/core/src/team-graph.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/team-graph.test.ts`:
+
+```ts
+import { resolveEdge } from './team-graph';
+
+describe('resolveEdge diamond fallback', () => {
+  const g: import('./team-graph').TeamGraph = {
+    entry: 'start', maxHops: 10,
+    nodes: [
+      { id: 'd1', type: 'condition', condition: 'ok?', x: 0, y: 0 },
+      { id: 'a', type: 'worker', worker: 'a', x: 1, y: 0 },
+      { id: 'b', type: 'worker', worker: 'b', x: 2, y: 0 },
+    ],
+    edges: [
+      { id: 'yes', from: 'd1', to: 'a', branch: 'yes' },
+      { id: 'no', from: 'd1', to: 'b', branch: 'no' },
+    ],
+  };
+
+  it('falls back to the no edge on a null choice', () => {
+    expect(resolveEdge(g, 'd1', null)?.id).toBe('no');
+  });
+
+  it('falls back to the no edge on an unknown choice', () => {
+    expect(resolveEdge(g, 'd1', 'bogus')?.id).toBe('no');
+  });
+
+  it('honors a valid choice', () => {
+    expect(resolveEdge(g, 'd1', 'yes')?.id).toBe('yes');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: FAIL — current `resolveEdge` falls back via `isDefault`, returns `null` for a diamond.
+
+- [ ] **Step 3: Update `resolveEdge`**
+
+Replace `resolveEdge` (lines 175-181) with:
+
+```ts
+export function resolveEdge(graph: TeamGraph, nodeId: string, chosenEdgeId: string | null): TeamGraphEdge | null {
+  const edges = outgoingEdges(graph, nodeId);
+  if (edges.length === 0) return null;
+  const chosen = chosenEdgeId ? edges.find(e => e.id === chosenEdgeId) : undefined;
+  if (chosen) return chosen;
+  const node = nodeMap(graph).get(nodeId);
+  if (node?.type === 'condition') {
+    return edges.find(e => e.branch === 'no') ?? null;
+  }
+  return edges.find(e => e.isDefault) ?? null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/core && npx vitest run src/team-graph.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/team-graph.ts packages/core/src/team-graph.test.ts
+git commit -m "feat(core): resolveEdge falls back to the no branch for diamonds"
+```
+
+---
+
+## Task 5: Judge `question` for diamond decisions
+
+**Files:**
+- Modify: `packages/core/src/judge.ts:11-17` (`JudgeInput`), `:38-65` (`buildJudgePrompt`)
+- Test: `packages/core/src/judge.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/judge.test.ts` (reuse the existing `import { buildJudgePrompt } from './judge'`; add it if absent):
+
+```ts
+describe('buildJudgePrompt — decision question', () => {
+  it('renders the decision question and yes/no edges', () => {
+    const prompt = buildJudgePrompt({
+      task: 'ship it',
+      worker: 'coder',
+      workerOutput: 'all green',
+      blackboardSummary: '',
+      question: 'Did the tests pass?',
+      edges: [
+        { id: 'yes', condition: 'yes', targetWorker: '(end)' },
+        { id: 'no', condition: 'no', targetWorker: 'coder' },
+      ],
+    });
+    expect(prompt).toContain('Did the tests pass?');
+    expect(prompt).toContain('id="yes"');
+    expect(prompt).toContain('id="no"');
+  });
+
+  it('omits the decision section when no question is given', () => {
+    const prompt = buildJudgePrompt({
+      task: 't', worker: 'w', workerOutput: 'o', blackboardSummary: '',
+      edges: [{ id: 'e1', condition: 'tests pass', targetWorker: 'reviewer' }],
+    });
+    expect(prompt).not.toContain('## Decision');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/judge.test.ts`
+Expected: FAIL — `question` is not on `JudgeInput` (compile error) and no `## Decision` section exists.
+
+- [ ] **Step 3: Add `question` to `JudgeInput`**
+
+In `packages/core/src/judge.ts`, add to the `JudgeInput` interface (after `blackboardSummary`, ~line 15):
+
+```ts
+  /** Diamond decision question; when set, the judge answers it yes/no over the edges. */
+  question?: string;
+```
+
+- [ ] **Step 4: Render the decision section in `buildJudgePrompt`**
+
+In `buildJudgePrompt`, insert just before the `## Outgoing edges` block (before line 58 `lines.push('## Outgoing edges (choose one)');`):
+
+```ts
+  if (input.question && input.question.trim()) {
+    lines.push('## Decision');
+    lines.push(`Answer this yes/no question about the latest output, then pick the matching edge: ${input.question.trim()}`);
+  }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd packages/core && npx vitest run src/judge.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/judge.ts packages/core/src/judge.test.ts
+git commit -m "feat(core): judge renders an optional decision question"
+```
+
+---
+
+## Task 6: Gateway loop — eligible edges, diamond question, runStreak persistence
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts` — `buildJudgeEdges` (~2861), `pickNextGraphEdge` (~2878), the two `pickNextGraphEdge` call sites (~2981, ~3045), the worker-run body (~3023), the `[ASK_USER]` persist (~3032), the resume reconstruction (~2648).
+- Also: the `PendingTeamState.graphState` type (find it: `grep -rn "graphState" packages/core/src` — it lives on `PendingTeamState` in core).
+
+No unit runner for the gateway — verify via build + the core tests + manual smoke.
+
+- [ ] **Step 1: Add `runStreak` to the persisted graph state type**
+
+Run `grep -rn "currentNodeId" packages/core/src` to find the `PendingTeamState.graphState` shape. Add an optional field to that inline type:
+
+```ts
+    runStreak?: number;
+```
+
+(It sits alongside `currentNodeId`, `hops`, `visited`.)
+
+- [ ] **Step 2: Make `buildJudgeEdges` use eligible edges + branch labels**
+
+Replace the body of `buildJudgeEdges` (lines 2861-2871). Add a `state: GraphRunState` parameter and import `eligibleEdges`:
+
+In the `@codey/core` import (line 3), add `eligibleEdges` to the named imports.
+
+```ts
+  private buildJudgeEdges(
+    graph: TeamGraph,
+    nodeById: Map<string, TeamGraph['nodes'][number]>,
+    nodeId: string,
+    state: GraphRunState,
+  ): JudgeInput['edges'] {
+    const node = nodeById.get(nodeId);
+    return eligibleEdges(graph, state, nodeId).map(e => ({
+      id: e.id,
+      condition: node?.type === 'condition' ? e.branch : e.condition,
+      targetWorker: nodeById.get(e.to)?.type === 'end' ? '(end)' : (nodeById.get(e.to)?.worker ?? e.to),
+    }));
+  }
+```
+
+- [ ] **Step 3: Pass `state` + diamond `question` through `pickNextGraphEdge`**
+
+Replace `pickNextGraphEdge` (lines 2878-2896). Add a `state: GraphRunState` parameter and thread the question:
+
+```ts
+  private async pickNextGraphEdge(
+    graph: TeamGraph,
+    nodeById: Map<string, TeamGraph['nodes'][number]>,
+    currentNodeId: string,
+    state: GraphRunState,
+    task: string,
+    workerName: string,
+    workerOutput: string,
+    blackboardSummary: string,
+    signal?: AbortSignal,
+  ): Promise<{ decision: JudgeDecision; edge: TeamGraphEdge | null }> {
+    const edges = this.buildJudgeEdges(graph, nodeById, currentNodeId, state);
+    const node = nodeById.get(currentNodeId);
+    const { agent, model } = this.getAdvisorAgentAndModel();
+    const decision = await runJudge(
+      { task, worker: workerName, workerOutput, blackboardSummary, edges,
+        question: node?.type === 'condition' ? node.condition : undefined },
+      { agent, model, runner: this.advisorRunner, signal },
+    );
+    const edge = resolveEdge(graph, currentNodeId, decision.edgeId);
+    return { decision, edge };
+  }
+```
+
+- [ ] **Step 4: Update the two call sites to pass `state`**
+
+In the condition-node branch (line ~2981), change the call to insert `state` after `state.currentNodeId`:
+
+```ts
+        const { decision, edge } = await this.pickNextGraphEdge(
+          graph, nodeById, state.currentNodeId, state, task, lastWorkerName,
+          lastWorkerOutput, blackboard.renderForUser() || '',
+        );
+```
+
+In the post-worker branch (line ~3045), likewise:
+
+```ts
+      const { decision, edge } = await this.pickNextGraphEdge(
+        graph, nodeById, state.currentNodeId, state, task, workerName,
+        ingested.stripped, blackboard.renderForUser() || '',
+      );
+```
+
+- [ ] **Step 5: Increment `runStreak` when a worker runs**
+
+In `continueGraphRun`, after `lastWorkerName = workerName;` (line ~3024) and **before** the `[ASK_USER]` pause check, add:
+
+```ts
+      state = { ...state, runStreak: state.runStreak + 1 };
+```
+
+- [ ] **Step 6: Persist + restore `runStreak`**
+
+In the `[ASK_USER]` `persistPendingTeam` call (line ~3032), add `runStreak` to `graphState`:
+
+```ts
+          graphState: { currentNodeId: state.currentNodeId, hops: state.hops, visited: state.visited, runStreak: state.runStreak },
+```
+
+In the resume reconstruction (line ~2648), add `runStreak`:
+
+```ts
+      const state: GraphRunState = { currentNodeId: pending.graphState.currentNodeId, hops: pending.graphState.hops, status: 'running', visited: pending.graphState.visited, runStreak: pending.graphState.runStreak ?? 0 };
+```
+
+- [ ] **Step 7: Build to verify**
+
+Run: `npm run build:core && npm run build:gateway`
+Expected: both succeed with no type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): flow loop bounds worker self-loops and asks the diamond question"
+```
+
+---
+
+## Task 7: Editor model — round-trip new fields + diamond colors
+
+**Files:**
+- Modify: `codey-mac/src/components/flowEditorModel.ts`
+- Test: `codey-mac/src/components/flowEditorModel.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `codey-mac/src/components/flowEditorModel.test.ts`:
+
+```ts
+describe('flowEditorModel diamond + maxCalls round-trip', () => {
+  const g: TeamGraph = {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 3, width: 220, height: 90, x: 1, y: 0 },
+      { id: 'd1', type: 'condition', condition: 'tests pass?', x: 2, y: 0 },
+      { id: 'end', type: 'end', x: 3, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'd1' },
+      { id: 'e2', from: 'd1', to: 'end', branch: 'yes' },
+      { id: 'e3', from: 'd1', to: 'w1', branch: 'no' },
+    ],
+  };
+
+  it('round-trips condition, maxCalls, width/height, and branch', () => {
+    const flow = toFlow(g);
+    const back = fromFlow(flow.nodes, flow.edges, g.entry, g.maxHops);
+    expect(back).toEqual(g);
+  });
+});
+
+describe('branchColors diamond colors', () => {
+  it('colors a diamond yes green and no red', () => {
+    const nodes = [{ id: 'd1', position: { x: 0, y: 0 }, data: { label: 'd1', type: 'condition' } }] as any;
+    const colors = branchColors(nodes, [
+      { id: 'y', source: 'd1', data: { branch: 'yes' } },
+      { id: 'n', source: 'd1', data: { branch: 'no' } },
+    ] as any);
+    expect(colors['y']).toBe('#22c55e');
+    expect(colors['n']).toBe('#ef4444');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts`
+Expected: FAIL — new fields are dropped by `toFlow`/`fromFlow`; diamond colors not implemented.
+
+- [ ] **Step 3: Extend the `FlowNode`/`FlowEdge` types**
+
+In `codey-mac/src/components/flowEditorModel.ts`, replace lines 3-4 with:
+
+```ts
+export interface FlowNode { id: string; position: { x: number; y: number }; data: { label: string; type: TeamGraphNode['type']; worker?: string; condition?: string; maxCalls?: number }; type?: string; width?: number; height?: number }
+export interface FlowEdge { id: string; source: string; target: string; sourceHandle?: string; targetHandle?: string; label?: string; data: { condition?: string; isDefault?: boolean; branch?: 'yes' | 'no' } }
+```
+
+- [ ] **Step 4: Round-trip the new fields**
+
+Replace `toFlow` (lines 6-19) with:
+
+```ts
+export function toFlow(g: TeamGraph): { nodes: FlowNode[]; edges: FlowEdge[] } {
+  const nodes = g.nodes.map(n => ({
+    id: n.id,
+    position: { x: n.x, y: n.y },
+    data: { label: n.type === 'worker' ? (n.worker ?? '?') : n.type, type: n.type, worker: n.worker, condition: n.condition, maxCalls: n.maxCalls },
+    ...(n.width !== undefined ? { width: n.width } : {}),
+    ...(n.height !== undefined ? { height: n.height } : {}),
+  }))
+  const edges = g.edges.map(e => ({
+    id: e.id, source: e.from, target: e.to,
+    sourceHandle: e.sourceHandle, targetHandle: e.targetHandle,
+    label: e.isDefault ? 'default' : e.branch ?? e.condition,
+    data: { condition: e.condition, isDefault: e.isDefault, branch: e.branch },
+  }))
+  return { nodes, edges }
+}
+```
+
+In `fromFlow`, extend the node mapping (after `if (n.data.worker !== undefined) node.worker = n.data.worker`):
+
+```ts
+    if (n.data.condition !== undefined) node.condition = n.data.condition
+    if (n.data.maxCalls !== undefined) node.maxCalls = n.data.maxCalls
+    if (n.width !== undefined) node.width = n.width
+    if (n.height !== undefined) node.height = n.height
+```
+
+and the edge mapping (after `if (e.data.isDefault !== undefined) edge.isDefault = e.data.isDefault`):
+
+```ts
+    if (e.data.branch !== undefined) edge.branch = e.data.branch
+```
+
+- [ ] **Step 5: Add diamond colors to `branchColors`**
+
+Replace `branchColors` (lines 62-77) with:
+
+```ts
+export function branchColors(nodes: FlowNode[], edges: FlowEdge[]): Record<string, string> {
+  const typeById = new Map(nodes.map(n => [n.id, n.data?.type]))
+  const bySource = new Map<string, FlowEdge[]>()
+  for (const e of edges) {
+    if (!bySource.has(e.source)) bySource.set(e.source, [])
+    bySource.get(e.source)!.push(e)
+  }
+  const out: Record<string, string> = {}
+  for (const [source, group] of bySource) {
+    if (typeById.get(source) === 'condition') {
+      for (const e of group) out[e.id] = e.data?.branch === 'no' ? '#ef4444' : '#22c55e'
+      continue
+    }
+    if (group.length < 2) continue
+    let i = 0
+    for (const e of group) {
+      out[e.id] = e.data?.isDefault ? '#888' : BRANCH_PALETTE[i++ % BRANCH_PALETTE.length]
+    }
+  }
+  return out
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts`
+Expected: PASS (existing + new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add codey-mac/src/components/flowEditorModel.ts codey-mac/src/components/flowEditorModel.test.ts
+git commit -m "feat(codey-mac): round-trip diamond/maxCalls/size fields and color diamond edges"
+```
+
+---
+
+## Task 8: Editor — node inspector, yes/no diamond edges, self-loop
+
+**Files:**
+- Modify: `codey-mac/src/components/FlowEditor.tsx`
+
+No unit runner — verify via `npx vite build` + manual.
+
+- [ ] **Step 1: Track a selected node and auto-label diamond edges on connect**
+
+In `FlowEditorInner`, add state next to `selEdge` (line 91):
+
+```ts
+  const [selNode, setSelNode] = useState<string | null>(null)
+```
+
+Replace `onConnect` (lines 100-106) so an edge leaving a diamond is auto-assigned `branch: 'yes'` (first) then `'no'` (second):
+
+```ts
+  const onConnect = useCallback((c: Connection) =>
+    setEdges(es => {
+      const fromNode = nodes.find(n => n.id === c.source)
+      let data: any = {}
+      if ((fromNode?.data as any)?.type === 'condition') {
+        const existing = es.filter(e => e.source === c.source)
+        data = { branch: existing.some(e => (e as any).data?.branch === 'yes') ? 'no' : 'yes' }
+        if (existing.length >= 2) return es // a diamond has exactly two outcomes
+      }
+      return addEdge({
+        ...c, id: `e_${Date.now()}`,
+        sourceHandle: c.sourceHandle ?? undefined,
+        targetHandle: c.targetHandle ?? undefined,
+        label: data.branch,
+        data,
+      } as any, es)
+    }), [nodes])
+```
+
+- [ ] **Step 2: Add node-update helpers and wire `onNodeClick`**
+
+Add near `updateEdge` (line 142):
+
+```ts
+  const updateNodeData = (id: string, patch: any) =>
+    setNodes(ns => ns.map(n => n.id === id ? { ...n, data: { ...n.data, ...patch } } : n))
+```
+
+On the `<ReactFlow>` element (line 192), add an `onNodeClick` handler and clear the edge selection:
+
+```tsx
+                onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }}
+```
+
+- [ ] **Step 3: Render the node inspector**
+
+Add a `selN` lookup next to `sel` (line 154):
+
+```ts
+  const selN = nodes.find(n => n.id === selNode) as any
+  const selfLoops = selN ? edges.some(e => e.source === selN.id && e.target === selN.id) : false
+```
+
+Replace the edge-condition panel block (lines 198-206) with a combined inspector. The edge panel now only opens for **worker** edges; diamond edges are read-only labels:
+
+```tsx
+          {!showRaw && selN && (selN.data?.type === 'worker' || selN.data?.type === 'condition') && (
+            <div style={{ width: 240, borderLeft: `1px solid ${C.border}`, padding: 10, overflowY: 'auto' }}>
+              {selN.data?.type === 'worker' ? (
+                <>
+                  <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{selN.data.worker}</div>
+                  <div style={{ fontSize: 11, color: C.fg3, marginBottom: 10, whiteSpace: 'pre-wrap' }}>
+                    {workerRoles[selN.data.worker] || 'No description.'}
+                  </div>
+                  {selfLoops && (
+                    <label style={{ fontSize: 12, display: 'block' }}>
+                      Max self-loops
+                      <input type="number" min={1} value={selN.data.maxCalls ?? ''} placeholder="∞"
+                        onChange={e => updateNodeData(selN.id, { maxCalls: e.target.value === '' ? undefined : Math.max(1, Number(e.target.value) || 1) })}
+                        style={{ width: 64, marginLeft: 6 }} />
+                    </label>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div style={{ fontSize: 11, color: C.fg3, marginBottom: 6 }}>Decision</div>
+                  <textarea value={selN.data.condition ?? ''} placeholder='e.g. "Did the tests pass?"'
+                    onChange={e => updateNodeData(selN.id, { condition: e.target.value })}
+                    style={{ width: '100%', minHeight: 70, fontSize: 12, padding: 6, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6 }} />
+                  <div style={{ fontSize: 10, color: C.fg3, marginTop: 6 }}>Yes edge → green · No edge → red</div>
+                </>
+              )}
+            </div>
+          )}
+          {!showRaw && !selN && sel && (sel.data?.branch === undefined) && (
+            <div style={{ width: 220, borderLeft: `1px solid ${C.border}`, padding: 10 }}>
+              <div style={{ fontSize: 11, color: C.fg3, marginBottom: 6 }}>Edge condition</div>
+              <textarea value={sel.data?.condition ?? ''} onChange={e => updateEdge(sel.id, { condition: e.target.value, isDefault: false })} placeholder='e.g. "tests pass"' style={{ width: '100%', minHeight: 70, fontSize: 12, padding: 6, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6 }} />
+              <label style={{ fontSize: 12, display: 'block', marginTop: 8 }}>
+                <input type="checkbox" checked={!!sel.data?.isDefault} onChange={e => updateEdge(sel.id, { isDefault: e.target.checked, condition: e.target.checked ? undefined : sel.data?.condition })} /> default (else) edge
+              </label>
+            </div>
+          )}
+```
+
+(`onEdgeClick` already sets `selEdge`; also clear `selNode` there so the panels don't fight — update line 192's `onEdgeClick` to `onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }}`.)
+
+- [ ] **Step 4: Build to verify**
+
+Run: `cd codey-mac && npx vite build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Manual smoke**
+
+Run the app (`cd codey-mac && npm run dev`). Open a Sequential team's flow editor and verify: tapping a diamond opens the Decision textarea and typing persists; drawing two edges out of the diamond labels them yes (green) / no (red); a third edge out of the diamond is rejected; tapping a worker shows its full description; drawing a worker→itself edge then tapping the worker shows the Max self-loops field.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/src/components/FlowEditor.tsx
+git commit -m "feat(codey-mac): node inspector with diamond question, worker description, and self-loop cap"
+```
+
+---
+
+## Task 9: Editor — resizable worker cards
+
+**Files:**
+- Modify: `codey-mac/src/components/FlowEditor.tsx`
+
+No unit runner — verify via `npx vite build` + manual.
+
+- [ ] **Step 1: Import `NodeResizer` and persist size on resize**
+
+In the `@xyflow/react` import (lines 2-7), add `NodeResizer`:
+
+```ts
+  NodeResizer,
+```
+
+(`NodeResizer`'s styles ship with `@xyflow/react/dist/style.css`, already imported.)
+
+- [ ] **Step 2: Make the worker card resizable**
+
+Replace `WorkerNodeView` (lines 33-42) with:
+
+```tsx
+function WorkerNodeView({ data, selected, width, height }: NodeProps) {
+  const d = data as { label: string; role?: string }
+  return (
+    <div style={{ width: width ?? undefined, height: height ?? undefined, minWidth: 120, padding: '8px 10px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}`, color: C.fg, boxSizing: 'border-box' }}>
+      <NodeResizer isVisible={selected} minWidth={120} minHeight={48} />
+      <div style={{ fontSize: 13, fontWeight: 600 }}>{d.label}</div>
+      {d.role && <div style={{ fontSize: 11, color: C.fg3, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
+      <NodeHandles />
+    </div>
+  )
+}
+```
+
+(React Flow writes the dragged size into each node's `width`/`height` via `onNodesChange`, which `flowEditorModel.fromFlow` already persists — Task 7. `ConditionNodeView` and `TerminalNodeView` are left unchanged, so start/end/diamond stay fixed-size.)
+
+- [ ] **Step 3: Build to verify**
+
+Run: `cd codey-mac && npx vite build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual smoke**
+
+Run the app, select a worker card, drag a resize handle, then Save → reopen → toggle Raw config and confirm the node shows `width`/`height`. Confirm start/end pills and the diamond are not resizable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/FlowEditor.tsx
+git commit -m "feat(codey-mac): resizable worker cards via NodeResizer"
+```
+
+---
+
+## Final verification
+
+- [ ] **Core tests:** `cd packages/core && npx vitest run` → PASS
+- [ ] **Editor model tests:** `cd codey-mac && npx vitest run src/components/flowEditorModel.test.ts` → PASS
+- [ ] **Builds:** `npm run build:core && npm run build:gateway` and `cd codey-mac && npx vite build` → all succeed
+- [ ] **Lint:** `npm run lint` (non-English character check) → PASS
+- [ ] **Manual (Mac app):** diamond holds a yes/no question with green/no-red edges; worker inspector shows full description + max-self-loops; a worker self-loop runs `maxCalls` times then exits; worker cards resize and the size survives Save → reopen.
+
+---
+
+## Self-review notes (resolved)
+
+- **Spec coverage:** diamond carries condition → Tasks 1, 5, 6, 8; yes/no edges → Tasks 1, 7, 8; worker branching kept → unchanged (validation only *adds* self-loop rules); worker self-loop + maxCalls → Tasks 1, 2, 3, 6, 8; node inspector → Task 8; resizable worker cards → Tasks 7, 9; back-compat fields presentation-only → Tasks 1, 7.
+- **Type consistency:** `condition`/`maxCalls`/`width`/`height` (node) and `branch: 'yes'|'no'` (edge) are defined once in Task 1 and reused identically in `flowEditorModel` (Task 7), `eligibleEdges` (Task 3), `resolveEdge` (Task 4), and the gateway (Task 6). `runStreak` is added to `GraphRunState` in Task 2 and consumed in Tasks 3 and 6. `buildJudgeEdges`/`pickNextGraphEdge` gain a `state` parameter in Task 6 at both call sites.
+- **Gateway no-test caveat:** Task 6 has no unit runner; it relies on the Task 1-5 core tests for validate/streak/eligible/resolve/judge guarantees plus a build + manual smoke.

--- a/docs/superpowers/specs/2026-06-15-flow-canvas-decision-nodes-design.md
+++ b/docs/superpowers/specs/2026-06-15-flow-canvas-decision-nodes-design.md
@@ -1,0 +1,189 @@
+# Flow Canvas Upgrades — Decision Nodes, Drag-to-Canvas, Animated Edges
+
+**Date:** 2026-06-15
+**Status:** Approved design
+**Surface:** Sequential-mode flow graph editor (`codey-mac` `FlowEditor.tsx`) + flow-graph runtime (`packages/core`, `packages/gateway`)
+
+## Summary
+
+Five upgrades to the Sequential team flow canvas. One is a model/runtime change (a real
+**decision node** rendered as a diamond); the other four are editor-only (multiple connection
+handles, animated edges, drag-to-canvas, bigger worker cards with a description).
+
+All changes are back-compatible: existing graphs in `gateway.json` (conditions placed directly
+on worker outgoing edges) keep working unchanged. Diamonds are purely additive.
+
+## Goals
+
+1. Edges attach at distinct points on a node so parallel/loop-back edges don't overlap.
+2. A real diamond **decision node** users can drop, where the judge picks a branch.
+3. Always-on animated edges (a moving dot) that visualize flow direction; branch edges get
+   distinct colors, the `default` (else) edge styled neutrally.
+4. Drag workers from the palette onto the canvas, placed where dropped.
+5. Bigger worker cards showing a one-line description sourced from `personality.role`.
+
+## Non-Goals
+
+- No run-simulation / playback engine. The animated dot is decorative styling only.
+- No change to the judge prompt or judge decision contract.
+- No change to `auto` / `parallel` dispatch modes.
+
+---
+
+## A. Decision (diamond) node — model + runtime
+
+### Model
+
+`TeamGraphNodeType` (`packages/core/src/team-graph.ts`) gains a third interactive type:
+
+```ts
+export type TeamGraphNodeType = 'start' | 'worker' | 'condition' | 'end';
+```
+
+- A `condition` node carries **no** `worker`.
+- Branching happens on its **outgoing edges**, each with a natural-language `condition`; exactly
+  one outgoing edge is `isDefault` (the else branch).
+
+`TeamGraphEdge` gains two optional, presentation-only fields (ignored by the runtime/judge):
+
+```ts
+sourceHandle?: string;
+targetHandle?: string;
+```
+
+### Semantics
+
+A diamond is a **branch point with no worker**. Flow reaches it (e.g. `worker → diamond`), and the
+**judge evaluates the diamond's outgoing edges** using the *last worker's output* + blackboard —
+exactly the mechanism used today for a worker's outgoing edges. The judge (`judge.ts`) needs **no
+change**: it already operates on a generic edge list (`buildJudgeEdges` / `runJudge`).
+
+### Runtime changes
+
+**`packages/core/src/team-graph.ts`:**
+- `settle()` walks through `start` nodes (as today) and **stops at `condition` nodes**. It does
+  **not** push `condition` nodes to `state.visited` (which remains worker-only history).
+- `advance()` is unchanged structurally (still increments hops, enforces `maxHops`, calls
+  `settle`), but because `settle` now stops at condition nodes, the loop regains control at a
+  diamond.
+
+**`packages/gateway/src/gateway.ts` run loop** (`continueGraphRun` and the sink variant
+`runSequentialGraphForChatSink`): branch on the settled node's type.
+- The loop threads a `lastWorkerOutput` string across iterations (seeded empty).
+- **worker node:** run worker, ingest, `[ASK_USER]` check (unchanged), set
+  `lastWorkerOutput = ingested.stripped`, then `pickNextGraphEdge` (judge over this node's edges),
+  `resolveEdge`, `advance`.
+- **condition node:** no worker run. Call `pickNextGraphEdge` with `workerName` = the last worker
+  that ran (for prompt context) and `workerOutput = lastWorkerOutput`, then `resolveEdge`,
+  `advance`. Emit a status line for the chosen branch (reuse the existing `↪️ reason` emit).
+- `pickNextGraphEdge` / `buildJudgeEdges` are unchanged — they already operate on
+  `outgoingEdges(graph, nodeId)` for any node id.
+
+### Validation (`validateGraph`)
+
+For a `condition` node:
+- must carry **no** `worker` (error if present),
+- must have **≥1 incoming** edge and **≥1 outgoing** edge,
+- **must have a `default` outgoing edge** (so it can never get stuck on an unmatched branch),
+- existing reachability + "outgoing edge required" checks extend to it (treat `condition` like
+  `worker`/`start` for the "has outgoing edge" rule).
+
+An invalid graph falls back to plain linear Sequential via the existing `validateGraph` gate in
+`gateway.ts` (`fallbackTeam.graph` only set when `problems.length === 0`).
+
+### Pause / resume
+
+`[ASK_USER]` pauses happen only at **worker** nodes (diamonds run no worker), so the existing
+`PendingTeamState.graphState` (`currentNodeId`, `hops`, `visited`) is sufficient. On resume the
+re-issued worker produces fresh output, which becomes `lastWorkerOutput` for the subsequent judge
+step. No new persisted fields are required.
+
+---
+
+## B. Editor changes (`codey-mac`, frontend-only)
+
+### B1. Custom React Flow node components
+
+Introduce custom node types (needed for B2/B5/diamond rendering):
+- `workerNode` — card with name + one-line description (B5).
+- `conditionNode` — diamond shape.
+- `terminalNode` — `start` / `end` pill.
+
+Registered via React Flow `nodeTypes`. `flowEditorModel.ts` `toFlow`/`fromFlow` map
+`condition` nodes through unchanged (they already pass `type` and have no `worker`).
+
+### B2. Multiple connection handles (#1)
+
+Each node renders **multiple source/target handles** (left/right/top/bottom). New edges record the
+handle they connect from/to; these persist as `sourceHandle`/`targetHandle` on `TeamGraphEdge`
+(presentation-only). `onConnect` captures `c.sourceHandle` / `c.targetHandle` and stores them in
+edge data → `fromFlow` writes them onto the `TeamGraphEdge`. Result: parallel edges and loop-backs
+attach at distinct points instead of overlapping.
+
+### B3. Animated edges (#3)
+
+- All edges set `animated: true` (React Flow's built-in moving dash → moving-dot effect).
+- **Branch coloring:** for any node with >1 outgoing edge (a worker-with-branches or a diamond),
+  assign each non-default outgoing edge a distinct color from a small fixed palette (by index);
+  the `default` edge renders neutral gray. Colors are computed at render time from the current
+  `edges`/`nodes` (no persistence). Edge label keeps showing the condition text / `default`.
+
+### B4. Drag workers onto canvas (#4)
+
+- Palette worker items + the "+ Condition" button become `draggable` (`onDragStart` sets a
+  `dataTransfer` payload identifying the node kind + worker name).
+- The React Flow pane (wrapped in `ReactFlowProvider`) handles `onDragOver`/`onDrop`; `onDrop` uses
+  `useReactFlow().screenToFlowPosition` to place the node at the cursor.
+- Click-to-add is kept as a fallback (drops at a default offset, current behavior).
+
+### B5. Bigger worker card + description (#5)
+
+- Palette and on-canvas `workerNode` cards are enlarged.
+- Each shows the worker name + a one-line description from `WorkerDto.personality.role`
+  (truncated). `role` is already loaded via `apiService.listWorkers()` / passed into the editor;
+  pass a `workers: WorkerDto[]` (or a `name → role` map) into `FlowEditor` so cards can look up the
+  role. (Today `FlowEditor` only receives `workerNames: string[]`; extend it to also receive the
+  role lookup, sourced from `GlobalTeamsSection`'s existing `workers` state.)
+- Add a **"+ Condition"** palette control to drop a diamond node.
+
+---
+
+## Data-model summary
+
+| Type | Change |
+|------|--------|
+| `TeamGraphNodeType` | add `'condition'` |
+| `TeamGraphNode` | no shape change (`condition` uses existing optional `worker` left unset) |
+| `TeamGraphEdge` | add optional `sourceHandle?`, `targetHandle?` (presentation-only) |
+| `gateway.json` graphs | remain valid; new fields optional |
+
+## Files touched
+
+- `packages/core/src/team-graph.ts` — node type, `settle`, `validateGraph`, edge fields.
+- `packages/core/src/team-graph.test.ts` — coverage for condition settle/validate.
+- `packages/gateway/src/gateway.ts` — `continueGraphRun` + `runSequentialGraphForChatSink` node-type
+  branching, `lastWorkerOutput` threading.
+- `codey-mac/src/components/FlowEditor.tsx` — custom nodes, handles, animation, drag-drop, palette.
+- `codey-mac/src/components/flowEditorModel.ts` — handle fields, condition node mapping; helpers.
+- `codey-mac/src/components/flowEditorModel.test.ts` — round-trip coverage incl. condition + handles.
+- `codey-mac/src/components/GlobalTeamsSection.tsx` — pass worker role lookup into `FlowEditor`.
+
+## Testing
+
+- **Core unit tests:** `settle` stops at a condition node without recording it in `visited`;
+  `advance` through `worker → condition → worker`; `validateGraph` flags a condition node missing a
+  default edge / carrying a worker / lacking in/out edges; existing linear-fallback still triggers
+  on invalid graphs.
+- **Editor unit tests (`flowEditorModel.test.ts`):** `toFlow`/`fromFlow` round-trip a graph
+  containing a condition node and edges with `sourceHandle`/`targetHandle`.
+- **Manual (Mac app):** drop a worker via drag; drop a diamond; wire `worker → diamond → {A,B}`
+  with conditions + a default; confirm animated edges + branch colors; Save → reopen → Raw config
+  shows the `condition` node and handle fields.
+
+## Risks
+
+- Run-loop refactor in `gateway.ts` is the highest-risk change (two variants must stay in sync).
+  Mitigate by threading `lastWorkerOutput` in one shared spot and covering `worker→condition→worker`
+  in core tests before wiring the gateway.
+- React Flow custom nodes + multiple handles require correct handle `id`s for edge persistence;
+  cover with the model round-trip test.

--- a/docs/superpowers/specs/2026-06-16-decision-diamonds-and-worker-loops-design.md
+++ b/docs/superpowers/specs/2026-06-16-decision-diamonds-and-worker-loops-design.md
@@ -1,0 +1,185 @@
+# Decision diamonds, worker self-loops, and the node inspector
+
+**Date:** 2026-06-16
+**Branch:** `flow-canvas-decision-nodes`
+**Status:** Design — approved, ready for plan
+
+## Background
+
+The Flow canvas (Mac app `codey-mac` `FlowEditor.tsx`, core `packages/core/src/team-graph.ts` + `judge.ts`) already supports a `condition` (diamond) node type, multi-handle edges, animated/colored branch edges, drag-to-canvas, and worker cards with a role line. In that first cut, **conditions lived on edges**: a diamond was a judge-evaluated branch point and each *outgoing edge* carried a natural-language condition, with one edge marked `isDefault`.
+
+User feedback after using it:
+
+1. Tapping a diamond does nothing — there is no way to type the condition into it. Conditions should live **on the diamond**, with the edges representing the **yes/no** outcomes.
+2. A worker's description is only a truncated line on the card; there is no way to read the whole thing.
+3. Worker cards are fixed-size and too large relative to the start/end terminals; they should be resizable.
+4. (New capability) A worker should be able to **loop on itself to self-improve**, with a **maximum number of calls** before it is forced to pass to the next node.
+
+This spec revises the decision model to match canonical flowchart conventions (a decision diamond *holds* the condition and emits labeled outcome edges), adds bounded worker self-loops, and adds a node inspector + resizable worker cards.
+
+## Goals
+
+- Diamonds carry the condition (a yes/no question); each diamond has **exactly two** outgoing edges — one `yes`, one `no`.
+- Worker nodes keep their existing multi-edge conditional branching + `isDefault` fallback (back-compatible — "diamonds only" for the new binary model).
+- A worker node may have a **self-loop** edge (`from === to`) with a **per-worker call cap** (`maxCalls`) that forces an exit once reached, independent of the global `maxHops`.
+- A node inspector: tap a worker to see its full description and (when it self-loops) edit `maxCalls`; tap a diamond to edit its question and flip which edge is yes/no.
+- Worker cards are resizable; start/end terminals stay fixed-size.
+
+## Non-goals
+
+- Multiway (>2 exit) decisions. Binary yes/no only; nest diamonds for multiway. (Deliberate house-style simplification.)
+- Forbidding worker branching (strict-flowchart "process boxes have one exit" form). Rejected in favor of back-compat.
+- Any change to `auto` / `parallel` dispatch modes.
+- Changing the `[ASK_USER]` pause/resume path.
+
+## Flowchart-convention alignment
+
+The revised model maps to ANSI/ISO 5807 flowchart symbols: **decision = diamond holding the condition with labeled yes/no exits** (exhaustive + mutually exclusive, so a decision can never dead-end), **process = worker rectangle**, **terminator = start/end pills**, **directed labeled flow lines**. The one intentional deviation from strict form is that worker (process) nodes may still branch; this is kept for flexibility and back-compatibility.
+
+## Design
+
+### A. Data model — `packages/core/src/team-graph.ts`
+
+`TeamGraphNode` gains two optional fields:
+
+```ts
+export interface TeamGraphNode {
+  id: string;
+  type: TeamGraphNodeType;            // 'start' | 'worker' | 'condition' | 'end'
+  worker?: string;                    // required when type === 'worker'
+  /** Decision question the judge evaluates; used when type === 'condition'. */
+  condition?: string;
+  /** Max consecutive runs of this worker (with a self-edge) before a forced exit. */
+  maxCalls?: number;
+  x: number;
+  y: number;
+  /** Presentation-only: editor card size. Ignored by the runtime. */
+  width?: number;
+  height?: number;
+}
+```
+
+`TeamGraphEdge` gains one optional field:
+
+```ts
+export interface TeamGraphEdge {
+  id: string;
+  from: string;
+  to: string;
+  condition?: string;                 // worker-edge condition (unchanged)
+  isDefault?: boolean;                // worker-edge fallback (unchanged)
+  /** Outcome of a diamond's decision. Only set on edges leaving a 'condition' node. */
+  branch?: 'yes' | 'no';
+  sourceHandle?: string;              // presentation-only (unchanged)
+  targetHandle?: string;              // presentation-only (unchanged)
+}
+```
+
+- `condition` (node) is the diamond's question, e.g. *"Did the tests pass?"*
+- `branch` distinguishes the two diamond exits. A self-loop is just an ordinary worker edge where `from === to`; it carries a normal `condition` (the "keep looping" criterion), not a `branch`.
+- `width`/`height` are presentation-only and ignored by the runtime, like `sourceHandle`/`targetHandle`.
+
+This is additive — existing graphs (worker conditions on edges, diamonds with edge conditions + default) keep validating until re-authored; see migration note below.
+
+### B. Validation — `validateGraph`
+
+Replace the current `condition`-node rule ("needs a default outgoing edge") with:
+
+For each `condition` node:
+- must **not** reference a worker (unchanged),
+- must have a non-empty `condition` (the question) → else `condition node "<id>" needs a question`,
+- must have **exactly two** outgoing edges, one `branch: 'yes'` and one `branch: 'no'` → else `condition node "<id>" needs exactly one yes and one no outgoing edge`.
+
+For each `worker` node:
+- existing checks unchanged (has a worker, worker is known, has ≥1 outgoing edge),
+- if it has a self-edge (`from === to`), it must also have **≥1 non-self outgoing edge** → else `worker node "<id>" self-loops with no exit edge`,
+- if `maxCalls` is set, it must be an integer `≥ 1` → else `worker node "<id>" maxCalls must be >= 1`.
+
+Reachability and edge-endpoint checks are unchanged. As today, any problem makes the gateway fall back to plain linear Sequential.
+
+### C. Runtime — `GraphRunState`, `settle`/`advance`, gateway loop, `judge.ts`
+
+**Per-worker consecutive-run count.** `GraphRunState` gains:
+
+```ts
+export interface GraphRunState {
+  currentNodeId: string;
+  hops: number;
+  status: GraphRunStatus;
+  visited: string[];
+  /** Consecutive runs of currentNodeId; resets when the flow settles onto a different node. */
+  runStreak: number;
+}
+```
+
+- `startRun` initializes `runStreak: 0`.
+- `settle()` is unchanged except it sets `runStreak` to `0` when the settled node id differs from the previous `currentNodeId`, and otherwise carries it forward. (settle already stops at `condition` nodes without recording history — unchanged.)
+- The gateway loop increments `runStreak` each time it actually runs the current worker.
+
+**Eligible edges (the cap).** New helper:
+
+```ts
+export function eligibleEdges(graph: TeamGraph, state: GraphRunState, nodeId: string): TeamGraphEdge[]
+```
+
+Returns `outgoingEdges(graph, nodeId)`, but **drops the self-edge** (`e.to === nodeId`) when the node has a `maxCalls` and `state.runStreak >= maxCalls`. The gateway passes `eligibleEdges(...)` (not raw `outgoingEdges`) to the judge, so once the cap is hit the judge can only choose an exit edge. Global `maxHops` remains the outer backstop via `advance`.
+
+**Diamond decisions in the judge.** `JudgeInput` gains optional `question?: string`. `buildJudgePrompt` renders it as a `## Decision` section when present, and frames the edges as outcomes. The gateway loop:
+
+- **worker node:** run worker, ingest output, `[ASK_USER]` check, then `runJudge` over `eligibleEdges` (edges carry `condition`/`isDefault` as today).
+- **condition node:** no worker run; call `runJudge` with `question = node.condition`, `workerOutput = lastWorkerOutput` (already threaded), and the two edges presented as `yes` / `no`. The judge returns the chosen edge id.
+
+`resolveEdge` gains a diamond-aware fallback: for a `condition` node, when the judge's choice is absent/invalid, fall back to the **`no`** edge (conservative — don't loop/advance on an unreadable decision). For worker nodes, the existing `isDefault` fallback is unchanged.
+
+### D. Editor — `codey-mac/src/components/FlowEditor.tsx`
+
+**Node inspector (replaces the edge-only panel as the primary inspector).** Add `onNodeClick`; track `selNode`. The right panel becomes node-type-aware:
+
+- **worker node:** shows the worker name and **full role/description** (not truncated). When the worker has a self-edge, shows a **"Max self-loops"** numeric input bound to `node.maxCalls` (empty = unbounded).
+- **condition (diamond) node:** shows a **"Decision"** textarea bound to `node.condition` (the question), and a control to **flip** which outgoing edge is `yes` vs `no`.
+- The existing **edge** panel (condition textarea + default checkbox) still opens on `onEdgeClick` for **worker** edges. Edges leaving a diamond are not freely edited there; they show a read-only `yes`/`no` label.
+
+**Diamond edges auto-assigned.** When an edge is connected out of a diamond: the first becomes `branch: 'yes'`, the second `branch: 'no'`; connecting a third is rejected (validation will already flag >2). Edge labels render `yes` (green) / `no` (red); `branchColors` is extended so a diamond's yes edge is green and no edge is red, while worker branch edges keep their existing per-edge palette.
+
+**Self-loop rendering.** Connecting a worker's source handle to one of its *own* target handles creates the self-edge (`from === to`); distinct source/target handles make React Flow draw a visible loop arc.
+
+**Resizable worker cards.** Wrap `WorkerNodeView` with React Flow's `NodeResizer` (visible on selection). Persist the resulting size into the node's `width`/`height` via `onNodesChange`. `ConditionNodeView` and `TerminalNodeView` are **not** resizable.
+
+### E. Editor model — `codey-mac/src/components/flowEditorModel.ts`
+
+- `toFlow` / `fromFlow` round-trip the new fields: node `condition`, `maxCalls`, `width`, `height`; edge `branch`. `width`/`height` map to the React Flow node's `style.width`/`height` (or `node.width/height`).
+- `branchColors` extended: for a `condition` source node, color its `yes` edge green and `no` edge red; worker-source branch edges unchanged.
+
+### F. Wiring — `codey-mac/src/components/GlobalTeamsSection.tsx`
+
+No new props. `workerRoles` (added previously) already supplies the description text the inspector shows in full.
+
+## Migration / back-compat
+
+- New fields are all optional; the runtime ignores `width`/`height`. Existing `gateway.json` graphs continue to validate and run **until a diamond is re-opened in the editor**.
+- A pre-existing diamond authored under the old model (conditions on edges + `isDefault`, no node `condition`) will now fail the stricter `validateGraph` and fall back to linear Sequential — the same safe fallback already in place. Re-authoring the diamond in the editor (type a question, mark yes/no) upgrades it. This is acceptable because the diamond feature shipped this same session and is not yet relied upon in saved configs.
+
+## Testing
+
+Core (`packages/core`, vitest):
+- `validateGraph`: diamond needs a question; diamond needs exactly one yes + one no; worker self-edge needs an exit; `maxCalls >= 1`.
+- `settle`/`startRun`: `runStreak` resets on node change, carries within the same node.
+- `eligibleEdges`: drops the self-edge at/after `maxCalls`; keeps it below; ignores nodes without `maxCalls`.
+- `resolveEdge`: diamond falls back to the `no` edge on null/invalid choice; worker fallback unchanged.
+- `buildJudgePrompt`: renders the `## Decision` question and yes/no edges when `question` is set.
+
+Editor model (`codey-mac`, vitest):
+- `toFlow`/`fromFlow` round-trip `condition`, `maxCalls`, `width`/`height`, and edge `branch`.
+- `branchColors`: diamond yes=green / no=red; worker branches unchanged.
+
+Gateway (no unit runner): build + manual smoke; relies on the core tests for settle/eligible/validate/resolve guarantees.
+
+Manual (Mac app): tap a diamond → type question, edges show yes/no with green/red; tap a worker → full description + (with a self-edge) max-self-loops field; draw a worker self-edge and confirm a bounded loop runs `maxCalls` times then exits; resize a worker card and confirm size persists across Save → reopen → Raw config (shows `condition`, `maxCalls`, `branch`, `width`/`height`).
+
+## Files touched
+
+- `packages/core/src/team-graph.ts` — node/edge fields, `validateGraph` rules, `GraphRunState.runStreak`, `settle`, `eligibleEdges`, `resolveEdge` diamond fallback.
+- `packages/core/src/judge.ts` — `JudgeInput.question`, `buildJudgePrompt` decision section.
+- `src/gateway.ts` — loop branches on node type; uses `eligibleEdges`; increments `runStreak`; passes `question` for diamonds.
+- `codey-mac/src/components/FlowEditor.tsx` — node inspector, diamond yes/no edges, self-loop, `NodeResizer`.
+- `codey-mac/src/components/flowEditorModel.ts` — round-trip new fields; `branchColors` for diamonds.

--- a/packages/core/src/judge.test.ts
+++ b/packages/core/src/judge.test.ts
@@ -24,6 +24,33 @@ describe('buildJudgePrompt', () => {
   });
 });
 
+describe('buildJudgePrompt — decision question', () => {
+  it('renders the decision question and yes/no edges', () => {
+    const prompt = buildJudgePrompt({
+      task: 'ship it',
+      worker: 'coder',
+      workerOutput: 'all green',
+      blackboardSummary: '',
+      question: 'Did the tests pass?',
+      edges: [
+        { id: 'yes', condition: 'yes', targetWorker: '(end)' },
+        { id: 'no', condition: 'no', targetWorker: 'coder' },
+      ],
+    });
+    expect(prompt).toContain('Did the tests pass?');
+    expect(prompt).toContain('id="yes"');
+    expect(prompt).toContain('id="no"');
+  });
+
+  it('omits the decision section when no question is given', () => {
+    const prompt = buildJudgePrompt({
+      task: 't', worker: 'w', workerOutput: 'o', blackboardSummary: '',
+      edges: [{ id: 'e1', condition: 'tests pass', targetWorker: 'reviewer' }],
+    });
+    expect(prompt).not.toContain('## Decision');
+  });
+});
+
 describe('runJudge', () => {
   it('returns the chosen edge id and reason from JSON output', async () => {
     const runner = async (): Promise<AgentResponse> =>

--- a/packages/core/src/judge.ts
+++ b/packages/core/src/judge.ts
@@ -13,6 +13,8 @@ export interface JudgeInput {
   worker: string;
   workerOutput: string;
   blackboardSummary: string;
+  /** Diamond decision question; when set, the judge answers it yes/no over the edges. */
+  question?: string;
   edges: JudgeEdge[];
 }
 
@@ -55,6 +57,10 @@ export function buildJudgePrompt(input: JudgeInput): string {
   lines.push(`## Worker just finished: ${input.worker}`);
   lines.push('## Worker output');
   lines.push(input.workerOutput || '(empty)');
+  if (input.question && input.question.trim()) {
+    lines.push('## Decision');
+    lines.push(`Answer this yes/no question about the latest output, then pick the matching edge: ${input.question.trim()}`);
+  }
   lines.push('## Outgoing edges (choose one)');
   for (const e of input.edges) {
     lines.push(`- id="${e.id}" → ${e.targetWorker}: ${e.condition ? `if ${e.condition}` : '(default)'}`);

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -108,3 +108,43 @@ describe('step machine', () => {
     expect(state.status).toBe('capped');
   });
 });
+
+function graphWithCondition(): TeamGraph {
+  return {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', x: 100, y: 0 },
+      { id: 'c1', type: 'condition', x: 200, y: 0 },
+      { id: 'w2', type: 'worker', worker: 'reviewer', x: 300, y: 0 },
+      { id: 'end', type: 'end', x: 400, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'c1' },
+      { id: 'e2', from: 'c1', to: 'w2', condition: 'needs review' },
+      { id: 'e3', from: 'c1', to: 'end', isDefault: true },
+    ],
+  };
+}
+
+describe('condition node settle', () => {
+  it('settles onto a condition node without recording it in visited', () => {
+    const g = graphWithCondition();
+    let s = startRun(g);
+    expect(s.currentNodeId).toBe('w1');
+    s = advance(g, s, 'e1');
+    expect(s.currentNodeId).toBe('c1');
+    expect(s.status).toBe('running');
+    expect(s.visited).toEqual(['w1']);
+  });
+
+  it('advances from a condition node to the next worker', () => {
+    const g = graphWithCondition();
+    let s = startRun(g);
+    s = advance(g, s, 'e1');
+    s = advance(g, s, 'e2');
+    expect(s.currentNodeId).toBe('w2');
+    expect(s.visited).toEqual(['w1', 'w2']);
+  });
+});

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateGraph, TeamGraph, startRun, advance, outgoingEdges } from './team-graph';
+import { validateGraph, TeamGraph, startRun, advance, outgoingEdges, eligibleEdges } from './team-graph';
 
 function baseGraph(): TeamGraph {
   return {
@@ -306,5 +306,38 @@ describe('runStreak', () => {
     const s1 = advance(g, s0, 'e2'); // w1 -> w2
     expect(s1.currentNodeId).toBe('w2');
     expect(s1.runStreak).toBe(0);
+  });
+});
+
+describe('eligibleEdges', () => {
+  const g: import('./team-graph').TeamGraph = {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 2, x: 1, y: 0 },
+      { id: 'w2', type: 'worker', worker: 'reviewer', x: 2, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'w1' },
+      { id: 'e2', from: 'w1', to: 'w2' },
+    ],
+  };
+
+  it('keeps the self-edge below maxCalls', () => {
+    const ids = eligibleEdges(g, { ...startRun(g), currentNodeId: 'w1', runStreak: 1 }, 'w1').map(e => e.id);
+    expect(ids).toContain('e1');
+    expect(ids).toContain('e2');
+  });
+
+  it('drops the self-edge at/after maxCalls', () => {
+    const ids = eligibleEdges(g, { ...startRun(g), currentNodeId: 'w1', runStreak: 2 }, 'w1').map(e => e.id);
+    expect(ids).not.toContain('e1');
+    expect(ids).toContain('e2');
+  });
+
+  it('ignores nodes without maxCalls', () => {
+    const ids = eligibleEdges(g, { ...startRun(g), currentNodeId: 'w2', runStreak: 99 }, 'w2').map(e => e.id);
+    expect(ids).toEqual([]); // w2 has no outgoing in this fixture
   });
 });

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -238,4 +238,37 @@ describe('validateGraph — worker self-loops', () => {
     };
     expect(validateGraph(g, ['coder']).some(p => p.includes('maxCalls must be >= 1'))).toBe(true);
   });
+
+  it('rejects non-integer maxCalls', () => {
+    const g: import('./team-graph').TeamGraph = {
+      entry: 'start', maxHops: 10,
+      nodes: [
+        { id: 'start', type: 'start', x: 0, y: 0 },
+        { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 1.5, x: 1, y: 0 },
+        { id: 'end', type: 'end', x: 2, y: 0 },
+      ],
+      edges: [
+        { id: 'e0', from: 'start', to: 'w1' },
+        { id: 'e1', from: 'w1', to: 'end' },
+      ],
+    };
+    expect(validateGraph(g, ['coder']).some(p => p.includes('maxCalls must be >= 1'))).toBe(true);
+  });
+
+  it('accepts a worker with both a self-edge and an exit edge', () => {
+    const g: import('./team-graph').TeamGraph = {
+      entry: 'start', maxHops: 10,
+      nodes: [
+        { id: 'start', type: 'start', x: 0, y: 0 },
+        { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 3, x: 1, y: 0 },
+        { id: 'end', type: 'end', x: 2, y: 0 },
+      ],
+      edges: [
+        { id: 'e0', from: 'start', to: 'w1' },
+        { id: 'e1', from: 'w1', to: 'w1' },
+        { id: 'e2', from: 'w1', to: 'end' },
+      ],
+    };
+    expect(validateGraph(g, ['coder'])).toEqual([]);
+  });
 });

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -272,3 +272,39 @@ describe('validateGraph — worker self-loops', () => {
     expect(validateGraph(g, ['coder'])).toEqual([]);
   });
 });
+
+describe('runStreak', () => {
+  const g: import('./team-graph').TeamGraph = {
+    entry: 'start', maxHops: 20,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 2, x: 1, y: 0 },
+      { id: 'w2', type: 'worker', worker: 'reviewer', x: 2, y: 0 },
+      { id: 'end', type: 'end', x: 3, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'w1' },   // self-loop
+      { id: 'e2', from: 'w1', to: 'w2' },   // exit
+      { id: 'e3', from: 'w2', to: 'end' },
+    ],
+  };
+
+  it('starts at 0', () => {
+    expect(startRun(g).runStreak).toBe(0);
+  });
+
+  it('carries the streak when looping onto the same node', () => {
+    const s0 = { ...startRun(g), runStreak: 5 };
+    const s1 = advance(g, s0, 'e1'); // w1 -> w1
+    expect(s1.currentNodeId).toBe('w1');
+    expect(s1.runStreak).toBe(5);
+  });
+
+  it('resets the streak when moving to a different node', () => {
+    const s0 = { ...startRun(g), runStreak: 5 };
+    const s1 = advance(g, s0, 'e2'); // w1 -> w2
+    expect(s1.currentNodeId).toBe('w2');
+    expect(s1.runStreak).toBe(0);
+  });
+});

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateGraph, TeamGraph, startRun, advance, outgoingEdges, eligibleEdges } from './team-graph';
+import { validateGraph, TeamGraph, startRun, advance, outgoingEdges, eligibleEdges, resolveEdge } from './team-graph';
 
 function baseGraph(): TeamGraph {
   return {
@@ -342,5 +342,32 @@ describe('eligibleEdges', () => {
     const ids = eligibleEdges(g2, { ...startRun(g2), currentNodeId: 'w2', runStreak: 99 }, 'w2').map(e => e.id);
     expect(ids).toContain('e3'); // self-edge kept
     expect(ids).toContain('e4');
+  });
+});
+
+describe('resolveEdge diamond fallback', () => {
+  const g: import('./team-graph').TeamGraph = {
+    entry: 'start', maxHops: 10,
+    nodes: [
+      { id: 'd1', type: 'condition', condition: 'ok?', x: 0, y: 0 },
+      { id: 'a', type: 'worker', worker: 'a', x: 1, y: 0 },
+      { id: 'b', type: 'worker', worker: 'b', x: 2, y: 0 },
+    ],
+    edges: [
+      { id: 'yes', from: 'd1', to: 'a', branch: 'yes' },
+      { id: 'no', from: 'd1', to: 'b', branch: 'no' },
+    ],
+  };
+
+  it('falls back to the no edge on a null choice', () => {
+    expect(resolveEdge(g, 'd1', null)?.id).toBe('no');
+  });
+
+  it('falls back to the no edge on an unknown choice', () => {
+    expect(resolveEdge(g, 'd1', 'bogus')?.id).toBe('no');
+  });
+
+  it('honors a valid choice', () => {
+    expect(resolveEdge(g, 'd1', 'yes')?.id).toBe('yes');
   });
 });

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -115,15 +115,15 @@ function graphWithCondition(): TeamGraph {
     nodes: [
       { id: 'start', type: 'start', x: 0, y: 0 },
       { id: 'w1', type: 'worker', worker: 'coder', x: 100, y: 0 },
-      { id: 'c1', type: 'condition', x: 200, y: 0 },
+      { id: 'c1', type: 'condition', condition: 'needs review?', x: 200, y: 0 },
       { id: 'w2', type: 'worker', worker: 'reviewer', x: 300, y: 0 },
       { id: 'end', type: 'end', x: 400, y: 0 },
     ],
     edges: [
       { id: 'e0', from: 'start', to: 'w1' },
       { id: 'e1', from: 'w1', to: 'c1' },
-      { id: 'e2', from: 'c1', to: 'w2', condition: 'needs review' },
-      { id: 'e3', from: 'c1', to: 'end', isDefault: true },
+      { id: 'e2', from: 'c1', to: 'w2', branch: 'yes' },
+      { id: 'e3', from: 'c1', to: 'end', branch: 'no' },
       { id: 'e4', from: 'w2', to: 'end', isDefault: true },
     ],
   };
@@ -160,14 +160,82 @@ describe('condition node validation', () => {
     expect(problems.some(p => p.includes('c1') && p.includes('worker'))).toBe(true);
   });
 
-  it('rejects a condition node with no default outgoing edge', () => {
+  it('rejects a condition node missing a yes or no branch edge', () => {
     const g = graphWithCondition();
-    g.edges = g.edges.map(e => e.id === 'e3' ? { ...e, isDefault: false } : e);
+    g.edges = g.edges.map(e => e.id === 'e3' ? { ...e, branch: undefined } : e);
     const problems = validateGraph(g, workers);
-    expect(problems.some(p => p.includes('c1') && p.includes('default'))).toBe(true);
+    expect(problems.some(p => p.includes('c1') && p.includes('one yes and one no'))).toBe(true);
   });
 
   it('accepts a well-formed condition node', () => {
     expect(validateGraph(graphWithCondition(), workers)).toEqual([]);
+  });
+});
+
+describe('validateGraph — diamonds carry conditions', () => {
+  const base = (over: Partial<import('./team-graph').TeamGraph> = {}) => ({
+    entry: 'start', maxHops: 10,
+    nodes: [
+      { id: 'start', type: 'start', x: 0, y: 0 },
+      { id: 'w1', type: 'worker', worker: 'coder', x: 1, y: 0 },
+      { id: 'd1', type: 'condition', condition: 'tests pass?', x: 2, y: 0 },
+      { id: 'end', type: 'end', x: 3, y: 0 },
+    ],
+    edges: [
+      { id: 'e0', from: 'start', to: 'w1' },
+      { id: 'e1', from: 'w1', to: 'd1' },
+      { id: 'e2', from: 'd1', to: 'end', branch: 'yes' },
+      { id: 'e3', from: 'd1', to: 'w1', branch: 'no' },
+    ],
+    ...over,
+  } as import('./team-graph').TeamGraph);
+
+  it('accepts a diamond with a question and one yes + one no edge', () => {
+    expect(validateGraph(base(), ['coder'])).toEqual([]);
+  });
+
+  it('rejects a diamond with no question', () => {
+    const g = base();
+    g.nodes.find(n => n.id === 'd1')!.condition = '';
+    expect(validateGraph(g, ['coder']).some(p => p.includes('needs a question'))).toBe(true);
+  });
+
+  it('rejects a diamond without exactly one yes and one no edge', () => {
+    const g = base();
+    g.edges.find(e => e.id === 'e3')!.branch = 'yes';
+    expect(validateGraph(g, ['coder']).some(p => p.includes('one yes and one no'))).toBe(true);
+  });
+});
+
+describe('validateGraph — worker self-loops', () => {
+  it('rejects a worker self-loop with no exit edge', () => {
+    const g: import('./team-graph').TeamGraph = {
+      entry: 'start', maxHops: 10,
+      nodes: [
+        { id: 'start', type: 'start', x: 0, y: 0 },
+        { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 3, x: 1, y: 0 },
+      ],
+      edges: [
+        { id: 'e0', from: 'start', to: 'w1' },
+        { id: 'e1', from: 'w1', to: 'w1' },
+      ],
+    };
+    expect(validateGraph(g, ['coder']).some(p => p.includes('self-loops with no exit'))).toBe(true);
+  });
+
+  it('rejects maxCalls < 1', () => {
+    const g: import('./team-graph').TeamGraph = {
+      entry: 'start', maxHops: 10,
+      nodes: [
+        { id: 'start', type: 'start', x: 0, y: 0 },
+        { id: 'w1', type: 'worker', worker: 'coder', maxCalls: 0, x: 1, y: 0 },
+        { id: 'end', type: 'end', x: 2, y: 0 },
+      ],
+      edges: [
+        { id: 'e0', from: 'start', to: 'w1' },
+        { id: 'e1', from: 'w1', to: 'end' },
+      ],
+    };
+    expect(validateGraph(g, ['coder']).some(p => p.includes('maxCalls must be >= 1'))).toBe(true);
   });
 });

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -124,6 +124,7 @@ function graphWithCondition(): TeamGraph {
       { id: 'e1', from: 'w1', to: 'c1' },
       { id: 'e2', from: 'c1', to: 'w2', condition: 'needs review' },
       { id: 'e3', from: 'c1', to: 'end', isDefault: true },
+      { id: 'e4', from: 'w2', to: 'end', isDefault: true },
     ],
   };
 }
@@ -146,5 +147,27 @@ describe('condition node settle', () => {
     s = advance(g, s, 'e2');
     expect(s.currentNodeId).toBe('w2');
     expect(s.visited).toEqual(['w1', 'w2']);
+  });
+});
+
+describe('condition node validation', () => {
+  const workers = ['coder', 'reviewer'];
+
+  it('rejects a condition node that carries a worker', () => {
+    const g = graphWithCondition();
+    (g.nodes.find(n => n.id === 'c1') as any).worker = 'coder';
+    const problems = validateGraph(g, workers);
+    expect(problems.some(p => p.includes('c1') && p.includes('worker'))).toBe(true);
+  });
+
+  it('rejects a condition node with no default outgoing edge', () => {
+    const g = graphWithCondition();
+    g.edges = g.edges.map(e => e.id === 'e3' ? { ...e, isDefault: false } : e);
+    const problems = validateGraph(g, workers);
+    expect(problems.some(p => p.includes('c1') && p.includes('default'))).toBe(true);
+  });
+
+  it('accepts a well-formed condition node', () => {
+    expect(validateGraph(graphWithCondition(), workers)).toEqual([]);
   });
 });

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -336,8 +336,11 @@ describe('eligibleEdges', () => {
     expect(ids).toContain('e2');
   });
 
-  it('ignores nodes without maxCalls', () => {
-    const ids = eligibleEdges(g, { ...startRun(g), currentNodeId: 'w2', runStreak: 99 }, 'w2').map(e => e.id);
-    expect(ids).toEqual([]); // w2 has no outgoing in this fixture
+  it('ignores nodes without maxCalls (keeps every edge, including a self-edge)', () => {
+    // w2 has no maxCalls; even a huge runStreak must not drop any edge.
+    const g2 = { ...g, edges: [...g.edges, { id: 'e3', from: 'w2', to: 'w2' }, { id: 'e4', from: 'w2', to: 'w1' }] };
+    const ids = eligibleEdges(g2, { ...startRun(g2), currentNodeId: 'w2', runStreak: 99 }, 'w2').map(e => e.id);
+    expect(ids).toContain('e3'); // self-edge kept
+    expect(ids).toContain('e4');
   });
 });

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -1,4 +1,4 @@
-export type TeamGraphNodeType = 'start' | 'worker' | 'end';
+export type TeamGraphNodeType = 'start' | 'worker' | 'condition' | 'end';
 
 export interface TeamGraphNode {
   id: string;
@@ -17,6 +17,10 @@ export interface TeamGraphEdge {
   condition?: string;
   /** Fallback edge taken when no conditioned edge matches. */
   isDefault?: boolean;
+  /** Presentation-only: React Flow source handle id. Ignored by the runtime. */
+  sourceHandle?: string;
+  /** Presentation-only: React Flow target handle id. Ignored by the runtime. */
+  targetHandle?: string;
 }
 
 export interface TeamGraph {

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -136,6 +136,8 @@ export interface GraphRunState {
   status: GraphRunStatus;
   /** Node ids visited in order (worker nodes only), for progress/history. */
   visited: string[];
+  /** Consecutive runs of currentNodeId; resets when settling onto a different node. */
+  runStreak: number;
 }
 
 function nodeMap(graph: TeamGraph): Map<string, TeamGraphNode> {
@@ -158,20 +160,22 @@ function settle(graph: TeamGraph, nodeId: string, state: GraphRunState): GraphRu
   }
   const node = nodes.get(cur);
   if (!node) return { ...state, currentNodeId: cur, status: 'stuck' };
-  if (node.type === 'end') return { ...state, currentNodeId: cur, status: 'done' };
+  const runStreak = state.currentNodeId === cur ? state.runStreak : 0;
+  if (node.type === 'end') return { ...state, currentNodeId: cur, status: 'done', runStreak };
   if (node.type === 'condition') {
-    return { ...state, currentNodeId: cur, status: 'running' };
+    return { ...state, currentNodeId: cur, status: 'running', runStreak };
   }
   return {
     ...state,
     currentNodeId: cur,
     status: 'running',
     visited: [...state.visited, cur],
+    runStreak,
   };
 }
 
 export function startRun(graph: TeamGraph): GraphRunState {
-  return settle(graph, graph.entry, { currentNodeId: graph.entry, hops: 0, status: 'running', visited: [] });
+  return settle(graph, graph.entry, { currentNodeId: graph.entry, hops: 0, status: 'running', visited: [], runStreak: 0 });
 }
 
 /**

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -216,5 +216,9 @@ export function resolveEdge(graph: TeamGraph, nodeId: string, chosenEdgeId: stri
   if (edges.length === 0) return null;
   const chosen = chosenEdgeId ? edges.find(e => e.id === chosenEdgeId) : undefined;
   if (chosen) return chosen;
+  const node = nodeMap(graph).get(nodeId);
+  if (node?.type === 'condition') {
+    return edges.find(e => e.branch === 'no') ?? null;
+  }
   return edges.find(e => e.isDefault) ?? null;
 }

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -5,8 +5,15 @@ export interface TeamGraphNode {
   type: TeamGraphNodeType;
   /** Worker name; required when type === 'worker'. */
   worker?: string;
+  /** Decision question the judge evaluates; used when type === 'condition'. */
+  condition?: string;
+  /** Max consecutive runs of this (self-looping) worker before a forced exit. */
+  maxCalls?: number;
   x: number;
   y: number;
+  /** Presentation-only: editor card size. Ignored by the runtime. */
+  width?: number;
+  height?: number;
 }
 
 export interface TeamGraphEdge {
@@ -17,6 +24,8 @@ export interface TeamGraphEdge {
   condition?: string;
   /** Fallback edge taken when no conditioned edge matches. */
   isDefault?: boolean;
+  /** Outcome of a diamond's decision. Only set on edges leaving a 'condition' node. */
+  branch?: 'yes' | 'no';
   /** Presentation-only: React Flow source handle id. Ignored by the runtime. */
   sourceHandle?: string;
   /** Presentation-only: React Flow target handle id. Ignored by the runtime. */
@@ -53,13 +62,25 @@ export function validateGraph(graph: TeamGraph, knownWorkers: string[]): string[
       } else if (!known.has(node.worker.toLowerCase())) {
         problems.push(`node "${node.id}" references unknown worker "${node.worker}"`);
       }
+      const outs = graph.edges.filter(e => e.from === node.id);
+      if (outs.some(e => e.to === node.id) && !outs.some(e => e.to !== node.id)) {
+        problems.push(`worker node "${node.id}" self-loops with no exit edge`);
+      }
+      if (node.maxCalls !== undefined && (!Number.isInteger(node.maxCalls) || node.maxCalls < 1)) {
+        problems.push(`worker node "${node.id}" maxCalls must be >= 1`);
+      }
     } else if (node.type === 'condition') {
       if (node.worker) {
         problems.push(`condition node "${node.id}" must not reference a worker`);
       }
+      if (!node.condition || !node.condition.trim()) {
+        problems.push(`condition node "${node.id}" needs a question`);
+      }
       const outs = graph.edges.filter(e => e.from === node.id);
-      if (!outs.some(e => e.isDefault)) {
-        problems.push(`condition node "${node.id}" needs a default outgoing edge`);
+      const yes = outs.filter(e => e.branch === 'yes').length;
+      const no = outs.filter(e => e.branch === 'no').length;
+      if (outs.length !== 2 || yes !== 1 || no !== 1) {
+        problems.push(`condition node "${node.id}" needs exactly one yes and one no outgoing edge`);
       }
     }
   }

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -53,6 +53,14 @@ export function validateGraph(graph: TeamGraph, knownWorkers: string[]): string[
       } else if (!known.has(node.worker.toLowerCase())) {
         problems.push(`node "${node.id}" references unknown worker "${node.worker}"`);
       }
+    } else if (node.type === 'condition') {
+      if (node.worker) {
+        problems.push(`condition node "${node.id}" must not reference a worker`);
+      }
+      const outs = graph.edges.filter(e => e.from === node.id);
+      if (!outs.some(e => e.isDefault)) {
+        problems.push(`condition node "${node.id}" needs a default outgoing edge`);
+      }
     }
   }
 
@@ -70,8 +78,8 @@ export function validateGraph(graph: TeamGraph, knownWorkers: string[]): string[
 
   for (const node of graph.nodes) {
     const hasOut = (outgoing.get(node.id)?.length ?? 0) > 0;
-    if ((node.type === 'worker' || node.type === 'start') && !hasOut) {
-      const label = node.type === 'start' ? 'start node' : 'worker node';
+    if ((node.type === 'worker' || node.type === 'start' || node.type === 'condition') && !hasOut) {
+      const label = node.type === 'start' ? 'start node' : node.type === 'condition' ? 'condition node' : 'worker node';
       problems.push(`${label} "${node.id}" has no outgoing edge`);
     }
   }

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -148,6 +148,20 @@ export function outgoingEdges(graph: TeamGraph, nodeId: string): TeamGraphEdge[]
   return graph.edges.filter(e => e.from === nodeId);
 }
 
+/**
+ * Outgoing edges the judge may choose from. Drops a worker's self-edge once its
+ * consecutive-run streak has reached the node's maxCalls, forcing an exit. For
+ * nodes without maxCalls (or non-worker nodes) this equals outgoingEdges.
+ */
+export function eligibleEdges(graph: TeamGraph, state: GraphRunState, nodeId: string): TeamGraphEdge[] {
+  const edges = outgoingEdges(graph, nodeId);
+  const node = nodeMap(graph).get(nodeId);
+  if (node?.type === 'worker' && node.maxCalls !== undefined && state.runStreak >= node.maxCalls) {
+    return edges.filter(e => e.to !== nodeId);
+  }
+  return edges;
+}
+
 /** Follow non-worker nodes (start) forward to the first worker/end node. */
 function settle(graph: TeamGraph, nodeId: string, state: GraphRunState): GraphRunState {
   const nodes = nodeMap(graph);

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -130,6 +130,9 @@ function settle(graph: TeamGraph, nodeId: string, state: GraphRunState): GraphRu
   const node = nodes.get(cur);
   if (!node) return { ...state, currentNodeId: cur, status: 'stuck' };
   if (node.type === 'end') return { ...state, currentNodeId: cur, status: 'done' };
+  if (node.type === 'condition') {
+    return { ...state, currentNodeId: cur, status: 'running' };
+  }
   return {
     ...state,
     currentNodeId: cur,

--- a/packages/core/src/types/pending-team.ts
+++ b/packages/core/src/types/pending-team.ts
@@ -51,7 +51,7 @@ export type PendingTeamState =
       teamName: string;
       task: string;
       mode: 'graph';
-      graphState: { currentNodeId: string; hops: number; visited: string[] };
+      graphState: { currentNodeId: string; hops: number; visited: string[]; runStreak?: number };
       results: string[];
       askingWorker: string;
       question: string;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3027,7 +3027,6 @@ Example: /model gpt-4.1 write a Python script`;
       results.push(`**${worker.name}**:\n${ingested.stripped}`);
       lastWorkerOutput = ingested.stripped;
       lastWorkerName = workerName;
-      state = { ...state, runStreak: state.runStreak + 1 };
 
       // Pause if this worker asked the user a question.
       const ask = parseAskUser(ingested.stripped);
@@ -3046,6 +3045,9 @@ Example: /model gpt-4.1 write a Python script`;
         await emitter.notify(rendered.text, rendered.choices);
         return emitter.transcript;
       }
+
+      // Count this completed (non-paused) run toward the worker's self-loop cap.
+      state = { ...state, runStreak: state.runStreak + 1 };
 
       // Judge picks the next edge.
       const { decision, edge } = await this.pickNextGraphEdge(

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2968,10 +2968,29 @@ Example: /model gpt-4.1 write a Python script`;
     const nodeById = new Map(graph.nodes.map(n => [n.id, n]));
     let resumeInfo = opts?.resume;
 
+    let lastWorkerOutput = '';
+    let lastWorkerName = '';
     let stepIndex = 0;
     while (state.status === 'running') {
       if (opts?.signal?.aborted) break;
       const node = nodeById.get(state.currentNodeId)!;
+
+      if (node.type === 'condition') {
+        // Branch point: no worker runs. The judge picks among the diamond's
+        // outgoing edges using the last worker's output for context.
+        const { decision, edge } = await this.pickNextGraphEdge(
+          graph, nodeById, state.currentNodeId, task, lastWorkerName,
+          lastWorkerOutput, blackboard.renderForUser() || '',
+        );
+        if (!edge) {
+          await emitter.status(`🏁 Flow stopped at a decision point (no matching branch).`);
+          break;
+        }
+        await emitter.status(`↪️ ${decision.fallback ? '(default) ' : ''}${decision.reason || 'branch'}`);
+        state = advance(graph, state, edge.id);
+        continue;
+      }
+
       // safe: team.graph is only set after validateGraph guarantees every worker node has a worker
       const workerName = node.worker!;
       const worker = wm.getWorker(workerName);
@@ -3001,6 +3020,8 @@ Example: /model gpt-4.1 write a Python script`;
 
       const ingested = blackboard.ingest(workerName, stepIndex, resp.output);
       results.push(`**${worker.name}**:\n${ingested.stripped}`);
+      lastWorkerOutput = ingested.stripped;
+      lastWorkerName = workerName;
 
       // Pause if this worker asked the user a question.
       const ask = parseAskUser(ingested.stripped);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
@@ -2645,7 +2645,7 @@ Example: /model gpt-4.1 write a Python script`;
         await emitter.notify(`Team \`${pending.teamName}\` no longer has a flow graph; the paused run was dropped.`);
         return emitter.transcript;
       }
-      const state: GraphRunState = { currentNodeId: pending.graphState.currentNodeId, hops: pending.graphState.hops, status: 'running', visited: pending.graphState.visited };
+      const state: GraphRunState = { currentNodeId: pending.graphState.currentNodeId, hops: pending.graphState.hops, status: 'running', visited: pending.graphState.visited, runStreak: pending.graphState.runStreak ?? 0 };
       const blackboard = TeamBlackboard.fromJSON(pending.blackboard);
       await this.continueGraphRun(
         emitter, chatId, convBase,
@@ -2862,10 +2862,12 @@ Example: /model gpt-4.1 write a Python script`;
     graph: TeamGraph,
     nodeById: Map<string, TeamGraph['nodes'][number]>,
     nodeId: string,
+    state: GraphRunState,
   ): JudgeInput['edges'] {
-    return outgoingEdges(graph, nodeId).map(e => ({
+    const node = nodeById.get(nodeId);
+    return eligibleEdges(graph, state, nodeId).map(e => ({
       id: e.id,
-      condition: e.condition,
+      condition: node?.type === 'condition' ? e.branch : e.condition,
       targetWorker: nodeById.get(e.to)?.type === 'end' ? '(end)' : (nodeById.get(e.to)?.worker ?? e.to),
     }));
   }
@@ -2879,16 +2881,19 @@ Example: /model gpt-4.1 write a Python script`;
     graph: TeamGraph,
     nodeById: Map<string, TeamGraph['nodes'][number]>,
     currentNodeId: string,
+    state: GraphRunState,
     task: string,
     workerName: string,
     workerOutput: string,
     blackboardSummary: string,
     signal?: AbortSignal,
   ): Promise<{ decision: JudgeDecision; edge: TeamGraphEdge | null }> {
-    const edges = this.buildJudgeEdges(graph, nodeById, currentNodeId);
+    const edges = this.buildJudgeEdges(graph, nodeById, currentNodeId, state);
+    const node = nodeById.get(currentNodeId);
     const { agent, model } = this.getAdvisorAgentAndModel();
     const decision = await runJudge(
-      { task, worker: workerName, workerOutput, blackboardSummary, edges },
+      { task, worker: workerName, workerOutput, blackboardSummary, edges,
+        question: node?.type === 'condition' ? node.condition : undefined },
       { agent, model, runner: this.advisorRunner, signal },
     );
     const edge = resolveEdge(graph, currentNodeId, decision.edgeId);
@@ -2979,7 +2984,7 @@ Example: /model gpt-4.1 write a Python script`;
         // Branch point: no worker runs. The judge picks among the diamond's
         // outgoing edges using the last worker's output for context.
         const { decision, edge } = await this.pickNextGraphEdge(
-          graph, nodeById, state.currentNodeId, task, lastWorkerName,
+          graph, nodeById, state.currentNodeId, state, task, lastWorkerName,
           lastWorkerOutput, blackboard.renderForUser() || '',
         );
         if (!edge) {
@@ -3022,6 +3027,7 @@ Example: /model gpt-4.1 write a Python script`;
       results.push(`**${worker.name}**:\n${ingested.stripped}`);
       lastWorkerOutput = ingested.stripped;
       lastWorkerName = workerName;
+      state = { ...state, runStreak: state.runStreak + 1 };
 
       // Pause if this worker asked the user a question.
       const ask = parseAskUser(ingested.stripped);
@@ -3029,7 +3035,7 @@ Example: /model gpt-4.1 write a Python script`;
         const teamConv = this.workerConversationId(convBase, { team: teamName });
         this.persistPendingTeam(chatId, {
           mode: 'graph', teamName, task,
-          graphState: { currentNodeId: state.currentNodeId, hops: state.hops, visited: state.visited },
+          graphState: { currentNodeId: state.currentNodeId, hops: state.hops, visited: state.visited, runStreak: state.runStreak },
           results,
           askingWorker: workerName, question: ask.question, options: ask.options,
           askedAt: Date.now(), blackboard: blackboard.toJSON(),
@@ -3043,7 +3049,7 @@ Example: /model gpt-4.1 write a Python script`;
 
       // Judge picks the next edge.
       const { decision, edge } = await this.pickNextGraphEdge(
-        graph, nodeById, state.currentNodeId, task, workerName,
+        graph, nodeById, state.currentNodeId, state, task, workerName,
         ingested.stripped, blackboard.renderForUser() || '',
       );
       if (!edge) {


### PR DESCRIPTION
## Summary

Adds a real flowchart-style decision model to Sequential team flow graphs, plus several Flow-canvas editor improvements (and a chat-panel double-click fix).

**Core / runtime**
- New `condition` (diamond) node type. Diamonds **carry the condition** (a yes/no question) and emit exactly two `branch: yes|no` exit edges — standards-aligned (ANSI/ISO 5807). The judge evaluates the diamond's question against the last worker's output; unparseable answers fall back to the `no` edge.
- Worker branching kept (back-compatible) and **bounded worker self-loops**: a worker may self-edge to "self-improve," capped by a per-worker `maxCalls`. A new `eligibleEdges` helper drops the self-edge once the consecutive `runStreak` hits the cap, composing with the global `maxHops` backstop. `runStreak` is counted only on completed (non-paused) runs, so an `[ASK_USER]` pause/resume counts as one iteration.
- `validateGraph` enforces the new rules; invalid graphs fall back to linear Sequential. Presentation-only fields (`sourceHandle`/`targetHandle`, `width`/`height`) are ignored by the runtime.

**Editor (codey-mac FlowEditor)**
- Custom nodes: worker card (with role/description), diamond, terminal.
- Node inspector: tap a diamond to author its yes/no question; tap a worker to read its full description and set Max self-loops (when it self-loops).
- Auto-labeled yes (green) / no (red) diamond edges; animated + colored branch edges; multi-handle connect with persisted handles.
- Drag workers/condition nodes onto the canvas; resizable worker cards via `NodeResizer` (size persists). Selection clears on delete to avoid a stale inspector.
- Chat context panel now opens on double-click only.

## Test Plan
- [x] Core: 104/104 vitest pass
- [x] Editor model: 8/8 vitest pass
- [x] Builds: `build:core`, `build:gateway`, codey-mac vite build all succeed
- [x] Lint (non-English check) passes
- [ ] Manual GUI smoke: open a Sequential team's flow editor — diamond holds a yes/no question with green/red edges and rejects a 3rd exit; worker inspector shows full description + Max self-loops; a worker self-loop runs `maxCalls` times then exits; worker cards resize and size survives Save → reopen → Raw config

🤖 Generated with [Claude Code](https://claude.com/claude-code)