### PR TITLE
fix(codey-mac): restore readable assistant bubble background

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1011,7 +1011,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
               <div style={{
                 maxWidth: '72%', padding: '10px 14px',
                 borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-                background: isUser ? C.userBg : C.codeBg,
+                background: isUser ? C.userBg : C.aiBg,
                 color: isUser ? C.onAccent : C.fg, fontSize: 13, lineHeight: 1.55, wordBreak: 'break-word',
                 boxShadow: isUser
                   ? 'none'


### PR DESCRIPTION
## Summary

Assistant message bubbles were rendering with `C.codeBg` (a near-black color in every theme) while their text color stays `C.fg`. In the light/paper theme this is the worst case — bubble goes near-black (`#211E18`) while text stays dark (`#1A1712`), so the message is dark-on-dark and unreadable. The dark themes also lost the bubble's contrast against the page.

The text color `C.fg` is designed to pair with `C.aiBg`, not `C.codeBg`. This reverts the bubble background to `C.aiBg`.

This was an unintended change that rode along in #142 (commit changed `C.aiBg` → `C.codeBg` on the assistant bubble; nothing in that feature called for it).

## Test Plan
- [x] `npx vite build` succeeds
- [ ] Verify assistant messages are readable across all four themes (dark, light/paper, and the two Flexoki variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)