### PR TITLE
fix(codey-mac): invalidate voice warm marker on macOS build change

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -925,7 +925,28 @@ function warmMarkerPath(): string {
   return path.join(app.getPath('userData'), 'voice-warm.json')
 }
 
-type WarmMarkers = Record<string, { warmedAt: string; loadSeconds: number }>
+// The macOS build (e.g. "23F79") the warm marker was stamped under. CoreML
+// rebuilds its per-machine compiled model cache on an OS update, so a marker
+// written before the bump is stale: the model is still on disk but the next
+// load recompiles from scratch (30-90s, and trips the helper's 10s load
+// timeout). Keying markers on the build lets us downgrade ⚡→✓ after an OS
+// change instead of lying about "instant".
+let _osBuildCache: string | null = null
+function currentOsBuild(): string {
+  if (_osBuildCache !== null) return _osBuildCache
+  try {
+    const cp = require('child_process') as typeof import('child_process')
+    _osBuildCache = cp.execSync('sw_vers -buildVersion', { encoding: 'utf8' }).trim()
+  } catch {
+    // Non-macOS or sw_vers missing — fall back to the Darwin kernel string,
+    // which also bumps on OS updates.
+    const os = require('os') as typeof import('os')
+    _osBuildCache = os.release()
+  }
+  return _osBuildCache || ''
+}
+
+type WarmMarkers = Record<string, { warmedAt: string; loadSeconds: number; osBuild?: string }>
 
 function readWarmMarkers(): WarmMarkers {
   try {
@@ -944,7 +965,7 @@ function writeWarmMarker(model: string, loadSeconds: number) {
     // Store under both forms so lookups work whether UI sends the prefixed
     // (`openai_whisper-...`) or bare (`large-v3...`) variant string.
     const bare = model.startsWith('openai_whisper-') ? model.slice('openai_whisper-'.length) : model
-    const entry = { warmedAt: new Date().toISOString(), loadSeconds }
+    const entry = { warmedAt: new Date().toISOString(), loadSeconds, osBuild: currentOsBuild() }
     cur[model] = entry
     cur[bare] = entry
     cur[`openai_whisper-${bare}`] = entry
@@ -1707,7 +1728,15 @@ app.whenReady().then(async () => {
   )
 
   ipcMain.handle('voice:listWarmedModels', async () =>
-    wrap(async () => Object.keys(readWarmMarkers()))
+    wrap(async () => {
+      // Only report models whose warm marker matches the current OS build.
+      // Entries from a prior build (or pre-osBuild markers, which read as
+      // undefined) are dropped, so the UI shows ✓ instead of ⚡ and
+      // WhisperTab's auto-warm effect re-warms the selected model on boot.
+      const build = currentOsBuild()
+      const markers = readWarmMarkers()
+      return Object.keys(markers).filter(k => markers[k]?.osBuild === build)
+    })
   )
 
   // Lists WhisperKit model folders currently on disk. WhisperKit stores


### PR DESCRIPTION
## Problem

`voice-warm.json` records which WhisperKit variants have completed CoreML's one-time per-machine compile, so the Whisper settings UI can show ⚡ *warmed (instant)* vs ✓ *downloaded (first press = 30–90s compile)*. **Nothing invalidated it on a macOS update.** CoreML rebuilds its compiled model cache on an OS bump, so after an update the marker still claims ⚡ while the real next load recompiles from scratch — 30–90s, which trips the helper's 10s load timeout (`voice/.../WhisperKitEngine.swift` `withLoadTimeout(seconds: 10)`). Result: the UI says "warm", but the first Fn press either times out or hangs.

## Fix — Downgrade + auto re-warm

- **Stamp the OS build.** Added `currentOsBuild()` (`sw_vers -buildVersion`, cached; falls back to `os.release()`), and `writeWarmMarker` now stores `osBuild` on each entry.
- **Downgrade on mismatch.** `voice:listWarmedModels` returns only entries whose `osBuild` matches the current build. Stale entries (and pre-existing markers with no `osBuild`, read as `undefined`) are dropped → the model shows ✓ instead of ⚡, reflecting actual status.
- **Auto re-warm is free.** `WhisperTab.tsx` already has an effect that re-warms the selected model whenever it's `isDownloaded && !isWarmed`. Once the downgrade flips it to ✓, that effect fires on app open, re-warms in the background (with the existing warming UI/elapsed counter), and re-stamps ⚡ under the new build.

## Not included

The underlying 10s load timeout in the Swift helper is untouched — this PR removes the *misleading* warm state, but a genuine cold load on a slow machine could still exceed 10s. A follow-up could give the load path a more realistic budget (e.g. 60s cold / 15s warm).

## Testing

- `npx tsc --noEmit -p tsconfig.electron.json` → clean (node v22.17.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)