### PR TITLE
Workflow editor UX, team settings refresh, message fade (v0.8.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
 
       - run: npm ci
 
+      # Lint first so style/source violations fail fast, before the heavier
+      # build and test steps.
+      - name: Lint
+        run: npm run lint
+
       # Build the two TS packages. This invokes `tsc` which both type-checks
       # and emits; codey-mac is skipped here because its `build` script runs
       # electron-builder, which is heavy and only meaningful on macOS.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,12 @@ npm run configure      # Interactive config setup
 npm run status         # Show current config
 npm run set-agent      # Set default coding agent
 npm run set-model      # Set default model
+npm test               # Run all workspace unit tests (Vitest)
+npm run lint           # Flag non-English characters in source
 ```
 
-No test runner is configured.
+Tests run on Vitest. `npm test` runs every workspace's suite (`packages/core`,
+`packages/gateway`, `codey-mac`); target one with `npm test -w @codey/core`.
 
 ## Architecture
 

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -108,31 +108,42 @@ const UserMessageContent: React.FC<{ content: string }> = ({ content }) => {
     return (
       <div>
         <Markdown variant="user">{content}</Markdown>
-        <button style={userFoldStyles.btn} onClick={() => setExpanded(false)}>Show less ▲</button>
+        <button style={{ ...userFoldStyles.btn, marginTop: 6 }} onClick={() => setExpanded(false)}>Show less ▲</button>
       </div>
     )
   }
 
-  const preview = content.replace(/\s+/g, ' ').trim().slice(0, 120)
   return (
-    <div>
-      <div style={userFoldStyles.preview}>{preview}…</div>
-      <button style={userFoldStyles.btn} onClick={() => setExpanded(true)}>
-        Show full message · {lineCount} lines, {content.length.toLocaleString()} chars ▾
-      </button>
+    <div style={userFoldStyles.wrap}>
+      <div style={userFoldStyles.clamp}>
+        <Markdown variant="user">{content}</Markdown>
+      </div>
+      <div style={userFoldStyles.fade}>
+        <button style={userFoldStyles.btn} onClick={() => setExpanded(true)} title={`${lineCount} lines · ${content.length.toLocaleString()} chars`}>
+          Show more ▾
+        </button>
+      </div>
     </div>
   )
 }
 
 const userFoldStyles: Record<string, React.CSSProperties> = {
-  preview: {
-    opacity: 0.9, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-    maxWidth: '100%', fontStyle: 'italic',
+  wrap: { position: 'relative' },
+  // Clamp the real message to a few lines; the fade block below hides the cut.
+  clamp: { maxHeight: '7.5em', overflow: 'hidden' },
+  // A short gradient block at the bottom that fades into the bubble and holds
+  // the unfold button. The gradient ignores clicks; the button takes them.
+  fade: {
+    position: 'absolute', left: 0, right: 0, bottom: 0, height: 44,
+    display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
+    background: `linear-gradient(to bottom, transparent, ${C.userBg})`,
+    pointerEvents: 'none',
   },
   btn: {
-    marginTop: 6, background: 'rgba(255,255,255,0.18)', border: 'none',
+    pointerEvents: 'auto', background: 'rgba(255,255,255,0.18)', border: 'none',
     color: C.onAccent, fontSize: 11, fontWeight: 600,
-    padding: '3px 9px', borderRadius: 8, cursor: 'pointer',
+    padding: '2px 10px', borderRadius: 8, cursor: 'pointer',
+    backdropFilter: 'blur(2px)',
   },
 }
 

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -3,12 +3,17 @@ import {
   ReactFlow, Background, Controls, addEdge, applyNodeChanges, applyEdgeChanges,
   ReactFlowProvider, useReactFlow,
   Handle, Position, NodeResizer, ConnectionMode,
-  type Node, type Edge, type Connection, type NodeProps,
+  BaseEdge, EdgeLabelRenderer, getBezierPath, MarkerType,
+  type Node, type Edge, type Connection, type NodeProps, type EdgeProps,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { TeamGraph, validateGraph } from '../../../packages/core/src/team-graph'
-import { toFlow, fromFlow, newNodeId, branchColors } from './flowEditorModel'
+import { toFlow, fromFlow, newNodeId } from './flowEditorModel'
 import { C } from '../theme'
+
+// A single edge color throughout — edges don't encode meaning by color; the
+// branch (yes/no) and conditions are shown as labels instead.
+const EDGE_COLOR = C.accent
 
 // ---------------------------------------------------------------------------
 // Custom node components
@@ -32,13 +37,21 @@ function NodeHandles() {
   )
 }
 
+// A node flagged by validation gets a red border; the selected node gets an
+// accent ring. `bad` is injected per-render from the validation problems.
+function ring(selected?: boolean, bad?: boolean): string | undefined {
+  if (selected) return `0 0 0 3px ${C.accent}, 0 0 14px 2px ${C.accent}`
+  if (bad) return `0 0 0 1px ${C.red}`
+  return undefined
+}
+
 function WorkerNodeView({ data, selected }: NodeProps) {
-  const d = data as { label: string; role?: string }
+  const d = data as { label: string; role?: string; bad?: boolean }
   // Size to content (full name on one line); never clip the name. React Flow
   // applies any user-resized width/height to the node wrapper itself, so we
   // don't bind them here — that previously collapsed the card and clipped text.
   return (
-    <div style={{ minWidth: 100, padding: '8px 12px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}`, color: C.fg, boxSizing: 'border-box' }}>
+    <div style={{ minWidth: 100, padding: '8px 12px', borderRadius: 8, background: C.surface2, border: `1px solid ${d.bad ? C.red : C.border}`, color: C.fg, boxSizing: 'border-box', boxShadow: ring(selected, d.bad) }}>
       <NodeResizer isVisible={selected} minWidth={100} minHeight={44} />
       <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap' }}>{d.label}</div>
       {d.role && <div style={{ fontSize: 11, color: C.fg3, marginTop: 2, maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
@@ -47,20 +60,23 @@ function WorkerNodeView({ data, selected }: NodeProps) {
   )
 }
 
-function ConditionNodeView() {
+function ConditionNodeView({ data, selected }: NodeProps) {
+  const d = data as { condition?: string; bad?: boolean }
+  const text = d.condition?.trim() || 'condition?'
   return (
-    <div style={{ width: 90, height: 90, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
-      <div style={{ width: 64, height: 64, transform: 'rotate(45deg)', background: C.surface2, border: `1px solid ${C.accent}`, borderRadius: 8 }} />
-      <span style={{ position: 'absolute', fontSize: 11, color: C.fg3 }}>?</span>
+    <div style={{ width: 130, height: 130, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+      {/* The diamond is a rotated square behind upright, centered text. */}
+      <div style={{ position: 'absolute', inset: 19, transform: 'rotate(45deg)', background: C.surface2, border: `1px solid ${d.bad ? C.red : C.accent}`, borderRadius: 8, boxShadow: ring(selected, d.bad) }} />
+      <span style={{ position: 'relative', fontSize: 10, lineHeight: 1.25, color: C.fg, width: 78, textAlign: 'center', display: '-webkit-box', WebkitLineClamp: 5, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{text}</span>
       <NodeHandles />
     </div>
   )
 }
 
-function TerminalNodeView({ data }: NodeProps) {
-  const d = data as { label: string }
+function TerminalNodeView({ data, selected }: NodeProps) {
+  const d = data as { label: string; bad?: boolean }
   return (
-    <div style={{ padding: '10px 22px', borderRadius: 999, background: C.bg, border: `1px solid ${C.border}`, color: C.fg, fontSize: 14, fontWeight: 600 }}>
+    <div style={{ padding: '10px 22px', borderRadius: 999, background: C.bg, border: `1px solid ${d.bad ? C.red : C.border}`, color: C.fg, fontSize: 14, fontWeight: 600, boxShadow: ring(selected, d.bad) }}>
       {d.label}
       <NodeHandles />
     </div>
@@ -68,6 +84,39 @@ function TerminalNodeView({ data }: NodeProps) {
 }
 
 const nodeTypes = { workerNode: WorkerNodeView, conditionNode: ConditionNodeView, terminalNode: TerminalNodeView }
+
+// Custom edge: single color, optional label, and — when `data.running` is set
+// (the edge is reachable from the start node) — a dot that travels along the
+// path to visualize flow leaving start.
+function FlowEdgeView({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, label, data, selected }: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition })
+  const running = (data as any)?.running
+  // Edges in the live flow (reachable from start) use the accent color; dangling
+  // edges are greyed. The selected edge is always accent and drawn thicker.
+  const stroke = selected ? C.accent : running ? EDGE_COLOR : C.fg3
+  return (
+    <>
+      {selected && <path d={edgePath} fill="none" stroke={C.accent} strokeWidth={9} strokeLinecap="round" style={{ opacity: 0.25 }} />}
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ stroke, strokeWidth: selected ? 3.5 : 1.5 }} />
+      {running && (
+        <circle r={4} fill={stroke}>
+          <animateMotion dur="1.6s" repeatCount="indefinite" path={edgePath} rotate="auto" />
+        </circle>
+      )}
+      {label != null && label !== '' && (
+        <EdgeLabelRenderer>
+          <div style={{
+            position: 'absolute', transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            background: C.bg, color: C.fg3, fontSize: 10, padding: '1px 5px', borderRadius: 4,
+            border: `1px solid ${C.border}`, pointerEvents: 'none',
+          }}>{String(label)}</div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}
+
+const edgeTypes = { flowEdge: FlowEdgeView }
 
 // ---------------------------------------------------------------------------
 // Props
@@ -97,10 +146,20 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   const [selEdge, setSelEdge] = useState<string | null>(null)
   const [selNode, setSelNode] = useState<string | null>(null)
   const [showRaw, setShowRaw] = useState(false)
+  const [justSaved, setJustSaved] = useState(false)
 
   const current = (): TeamGraph =>
     fromFlow(nodes as any, edges as any, graph.entry, maxHops)
   const problems = validateGraph(current(), workerNames)
+
+  // Which nodes/edges does validation complain about? Problem messages quote the
+  // offending id (e.g. condition node "n_5"), so pull those out and flag them.
+  const badNodes = useMemo(() => {
+    const ids = new Set(nodes.map(n => n.id))
+    const bad = new Set<string>()
+    for (const p of problems) for (const m of p.matchAll(/"([^"]+)"/g)) if (ids.has(m[1])) bad.add(m[1])
+    return bad
+  }, [problems, nodes])
 
   const onNodesChange = useCallback((cs: any) => setNodes(ns => applyNodeChanges(cs, ns)), [])
   const onEdgesChange = useCallback((cs: any) => setEdges(es => applyEdgeChanges(cs, es)), [])
@@ -111,6 +170,8 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
       if ((fromNode?.data as any)?.type === 'condition') {
         const existing = es.filter(e => e.source === c.source)
         if (existing.length >= 2) return es // a diamond has exactly two outcomes
+        // First branch out of a diamond defaults to "yes", the second to "no",
+        // so a freshly-wired diamond is already valid. Flip either in the panel.
         data = { branch: existing.some(e => (e as any).data?.branch === 'yes') ? 'no' : 'yes' }
       }
       return addEdge({
@@ -161,26 +222,74 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   const updateNodeData = (id: string, patch: any) =>
     setNodes(ns => ns.map(n => n.id === id ? { ...n, data: { ...n.data, ...patch } } : n))
 
-  const colors = useMemo(() => branchColors(nodes as any, edges as any), [nodes, edges])
-  const styledEdges = useMemo(() => edges.map(e => ({
-    ...e,
-    animated: true,
-    style: { ...(e as any).style, stroke: colors[e.id] ?? C.fg3 },
-  })), [edges, colors])
+  const updateEdgeBranch = (id: string, branch: 'yes' | 'no') =>
+    setEdges(es => es.map(e => e.id === id ? { ...e, data: { ...(e as any).data, branch }, label: branch } : e))
 
-  const save = () => onSave(current())
+  // Swap an edge's direction. Edges take their direction from the drag, so a
+  // backwards edge (which leaves a node unreachable) is fixed with one click.
+  const reverseEdge = (id: string) =>
+    setEdges(es => es.map(e => e.id === id
+      ? { ...e, source: e.target, target: e.source, sourceHandle: (e as any).targetHandle, targetHandle: (e as any).sourceHandle }
+      : e))
+
+  // Flip every edge at once — rescues a flow drawn the wrong way round (all
+  // arrows pointing back at start), which otherwise reads as "unreachable".
+  const reverseAllEdges = () =>
+    setEdges(es => es.map(e => ({ ...e, source: e.target, target: e.source, sourceHandle: (e as any).targetHandle, targetHandle: (e as any).sourceHandle })))
+
+  // Edges reachable from the start node "run" (carry a travelling dot). Walk the
+  // graph from start so a flow lights up as soon as nodes wire back to it.
+  const runningEdgeIds = useMemo(() => {
+    const startId = nodes.find(n => (n.data as any)?.type === 'start')?.id
+    const active = new Set<string>()
+    if (!startId) return active
+    const seen = new Set<string>([startId])
+    const queue = [startId]
+    while (queue.length) {
+      const cur = queue.shift()!
+      for (const e of edges) {
+        if (e.source !== cur) continue
+        active.add(e.id)
+        if (!seen.has(e.target)) { seen.add(e.target); queue.push(e.target) }
+      }
+    }
+    return active
+  }, [nodes, edges])
+
+  const styledEdges = useMemo(() => edges.map(e => {
+    const running = runningEdgeIds.has(e.id)
+    return {
+      ...e,
+      type: 'flowEdge',
+      markerEnd: { type: MarkerType.ArrowClosed, color: running ? EDGE_COLOR : C.fg3 },
+      data: { ...(e as any).data, running },
+    }
+  }), [edges, runningEdgeIds])
+
+  // Inject the per-node `bad` flag so node views can paint themselves red.
+  const styledNodes = useMemo(() => nodes.map(n => ({
+    ...n, data: { ...n.data, bad: badNodes.has(n.id) },
+  })), [nodes, badNodes])
+
+  const save = () => { onSave(current()); setJustSaved(true); window.setTimeout(() => setJustSaved(false), 1600) }
 
   const sel = edges.find(e => e.id === selEdge) as any
   const selN = nodes.find(n => n.id === selNode) as any
   const selfLoops = selN ? edges.some(e => e.source === selN.id && e.target === selN.id) : false
+  // An edge that leaves a condition node is a branch — it needs a yes/no label,
+  // even if `branch` is currently unset (e.g. it was drawn into the diamond and
+  // then reversed, which never assigned one).
+  const selIsBranch = sel ? (nodes.find(n => n.id === sel.source)?.data as any)?.type === 'condition' : false
 
   return (
     <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
       <div onClick={e => e.stopPropagation()} style={{ width: '90vw', height: '85vh', background: C.bg, border: `1px solid ${C.border}`, borderRadius: 10, display: 'flex', flexDirection: 'column' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', borderBottom: `1px solid ${C.border}` }}>
-          <strong style={{ flex: 1 }}>Flow — {teamName}</strong>
+          <strong style={{ flex: 1 }}>Workflow — {teamName}</strong>
           <label style={{ fontSize: 12, color: C.fg3 }}>max hops <input type="number" min={1} value={maxHops} onChange={e => setMaxHops(Math.max(1, Number(e.target.value) || 1))} style={{ width: 56, marginLeft: 6 }} /></label>
+          <button onClick={reverseAllEdges} title="Flip the direction of every edge" style={{ fontSize: 12 }}>⇄ Reverse all</button>
           <button onClick={() => setShowRaw(s => !s)} style={{ fontSize: 12 }}>{showRaw ? 'Canvas' : 'Raw config'}</button>
+          {justSaved && <span style={{ fontSize: 12, color: C.green }}>Saved ✓</span>}
           <button onClick={save} style={{ fontSize: 12, color: C.onAccent, background: C.accent, border: 'none', borderRadius: 6, padding: '4px 12px' }}>Save</button>
           <button onClick={onClose} style={{ fontSize: 12 }}>Close</button>
         </div>
@@ -210,7 +319,7 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
             <pre style={{ flex: 1, margin: 0, padding: 14, overflow: 'auto', fontSize: 12, color: C.fg }}>{JSON.stringify(current(), null, 2)}</pre>
           ) : (
             <div style={{ flex: 1, position: 'relative' }} onDrop={onDrop} onDragOver={onDragOver}>
-              <ReactFlow nodes={nodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }} onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }} onNodesDelete={(ns) => { if (ns.some(n => n.id === selNode)) setSelNode(null) }} onEdgesDelete={(es) => { if (es.some(e => e.id === selEdge)) setSelEdge(null) }} nodeTypes={nodeTypes} connectionMode={ConnectionMode.Loose} fitView fitViewOptions={{ maxZoom: 1, padding: 0.2 }} minZoom={0.2} maxZoom={1.5}>
+              <ReactFlow nodes={styledNodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }} onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }} onNodesDelete={(ns) => { if (ns.some(n => n.id === selNode)) setSelNode(null) }} onEdgesDelete={(es) => { if (es.some(e => e.id === selEdge)) setSelEdge(null) }} nodeTypes={nodeTypes} edgeTypes={edgeTypes} connectionMode={ConnectionMode.Loose} fitView fitViewOptions={{ maxZoom: 1, padding: 0.2 }} minZoom={0.2} maxZoom={1.5}>
                 <Background />
                 <Controls />
               </ReactFlow>
@@ -239,18 +348,35 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
                   <textarea value={selN.data.condition ?? ''} placeholder='e.g. "Did the tests pass?"'
                     onChange={e => updateNodeData(selN.id, { condition: e.target.value })}
                     style={{ width: '100%', minHeight: 70, fontSize: 12, padding: 6, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6 }} />
-                  <div style={{ fontSize: 10, color: C.fg3, marginTop: 6 }}>Yes edge → green · No edge → red</div>
+                  <div style={{ fontSize: 10, color: C.fg3, marginTop: 6 }}>Draw two edges out — label each yes / no by clicking it.</div>
                 </>
               )}
             </div>
           )}
-          {!showRaw && !selN && sel && (sel.data?.branch === undefined) && (
+          {!showRaw && !selN && sel && selIsBranch && (
+            <div style={{ width: 220, borderLeft: `1px solid ${C.border}`, padding: 10 }}>
+              <div style={{ fontSize: 11, color: C.fg3, marginBottom: 6 }}>Branch</div>
+              <div style={{ display: 'flex', gap: 6 }}>
+                {(['yes', 'no'] as const).map(b => (
+                  <button key={b} onClick={() => updateEdgeBranch(sel.id, b)}
+                    style={{ flex: 1, fontSize: 12, padding: '6px 0', borderRadius: 6, cursor: 'pointer',
+                      background: sel.data?.branch === b ? C.accent : C.surface2,
+                      color: sel.data?.branch === b ? C.onAccent : C.fg,
+                      border: `1px solid ${sel.data?.branch === b ? C.accent : C.border}` }}>{b}</button>
+                ))}
+              </div>
+              {sel.data?.branch === undefined && <div style={{ fontSize: 10, color: C.dangerFg, marginTop: 6 }}>Unlabeled — pick yes or no.</div>}
+              <button onClick={() => reverseEdge(sel.id)} style={{ marginTop: 10, width: '100%', fontSize: 12, padding: '6px 0', borderRadius: 6, cursor: 'pointer', background: C.surface2, color: C.fg, border: `1px solid ${C.border}` }}>⇄ Reverse direction</button>
+            </div>
+          )}
+          {!showRaw && !selN && sel && !selIsBranch && (
             <div style={{ width: 220, borderLeft: `1px solid ${C.border}`, padding: 10 }}>
               <div style={{ fontSize: 11, color: C.fg3, marginBottom: 6 }}>Edge condition</div>
               <textarea value={sel.data?.condition ?? ''} onChange={e => updateEdge(sel.id, { condition: e.target.value, isDefault: false })} placeholder='e.g. "tests pass"' style={{ width: '100%', minHeight: 70, fontSize: 12, padding: 6, background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6 }} />
               <label style={{ fontSize: 12, display: 'block', marginTop: 8 }}>
                 <input type="checkbox" checked={!!sel.data?.isDefault} onChange={e => updateEdge(sel.id, { isDefault: e.target.checked, condition: e.target.checked ? undefined : sel.data?.condition })} /> default (else) edge
               </label>
+              <button onClick={() => reverseEdge(sel.id)} style={{ marginTop: 10, width: '100%', fontSize: 12, padding: '6px 0', borderRadius: 6, cursor: 'pointer', background: C.surface2, color: C.fg, border: `1px solid ${C.border}` }}>⇄ Reverse direction</button>
             </div>
           )}
         </div>

--- a/codey-mac/src/components/GlobalTeamsSection.tsx
+++ b/codey-mac/src/components/GlobalTeamsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react'
+import { useEffect, useState, useCallback, useRef, type CSSProperties } from 'react'
 import { apiService, WorkerDto } from '../services/api'
 import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
 import type { TeamGraph } from '../../../packages/core/src/team-graph'
@@ -12,6 +12,14 @@ import { emptyGraph } from './flowEditorModel'
 type DispatchMode = 'all' | 'auto' | 'parallel'
 interface TeamState { members: string[]; dispatch: DispatchMode; graph?: TeamGraph }
 type TeamsState = Record<string, TeamState>
+
+const DISPATCH: { id: DispatchMode; label: string; desc: string }[] = [
+  { id: 'all', label: 'Sequential', desc: 'Members run in order, each passing its output to the next.' },
+  { id: 'auto', label: 'Auto', desc: 'The advisor picks the relevant subset for each task.' },
+  { id: 'parallel', label: 'Parallel', desc: 'All members discuss concurrently in an advisor-moderated roundtable.' },
+]
+
+const labelStyle: CSSProperties = { fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, color: C.fg3, marginBottom: 6 }
 
 function fromRaw(raw: TeamConfigRaw): TeamState {
   if (Array.isArray(raw)) return { members: raw, dispatch: 'all' }
@@ -131,83 +139,117 @@ export default function GlobalTeamsSection() {
       </div>
       {error && <div style={{ background: C.dangerBg, color: C.dangerFg, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{error}</div>}
       {Object.keys(teams).length === 0 && <div style={{ fontSize: 12, color: C.fg3 }}>No teams yet. Click &quot;+ New team&quot;.</div>}
-      {Object.entries(teams).map(([name, team]) => (
-        <div key={name} style={{ marginBottom: 12, padding: 10, background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-            <input defaultValue={name} onBlur={e => renameTeam(name, e.target.value.trim())}
-              style={{ flex: 1, background: 'transparent', color: C.fg, border: 'none', fontSize: 14, fontWeight: 600 }} />
-            <select
-              value={team.dispatch}
-              onChange={e => setDispatch(name, e.target.value as DispatchMode)}
-              title="Sequential: members run in order, output passed forward. Auto: the advisor picks the relevant subset. Parallel: all members discuss concurrently as a Advisor-moderated roundtable."
-              style={{
-                background: C.surface2, color: C.fg, border: `1px solid ${C.border}`,
-                borderRadius: 6, padding: '3px 8px', fontSize: 11, cursor: 'pointer',
-              }}
-            >
-              <option value="all">Sequential</option>
-              <option value="auto">Auto</option>
-              <option value="parallel">Parallel</option>
-            </select>
-            <button onClick={() => removeTeam(name)} style={{ background: 'transparent', color: C.dangerFg, border: 'none', cursor: 'pointer', fontSize: 12 }}>Delete</button>
+      {Object.entries(teams).map(([name, team]) => {
+        const showOrder = team.dispatch === 'all' && !team.graph
+        return (
+        <div key={name} style={{ marginBottom: 12, background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10, overflow: 'hidden' }}>
+          {/* Header: name · member count · delete */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', borderBottom: `1px solid ${C.border}` }}>
+            <input defaultValue={name} onBlur={e => renameTeam(name, e.target.value.trim())} aria-label="Team name"
+              style={{ flex: 1, background: 'transparent', color: C.fg, border: 'none', fontSize: 15, fontWeight: 700, outline: 'none' }} />
+            <span style={{ fontSize: 11, color: C.fg3 }}>{team.members.length} {team.members.length === 1 ? 'member' : 'members'}</span>
+            <button onClick={() => removeTeam(name)} title="Delete team"
+              style={{ background: 'transparent', color: C.fg3, border: 'none', cursor: 'pointer', fontSize: 11, padding: '2px 4px' }}>Delete</button>
           </div>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
-            {team.members.map((m, i) => {
-              const isDragging = drag?.team === name && drag.idx === i
-              const isOver = dragOver?.team === name && dragOver.idx === i && !isDragging
-              return (
-                <span
-                  key={`${m}-${i}`}
-                  draggable
-                  onDragStart={e => { setDrag({ team: name, idx: i }); e.dataTransfer.effectAllowed = 'move' }}
-                  onDragOver={e => {
-                    if (drag?.team !== name) return
-                    e.preventDefault(); e.dataTransfer.dropEffect = 'move'
-                    if (dragOver?.team !== name || dragOver.idx !== i) setDragOver({ team: name, idx: i })
-                  }}
-                  onDrop={e => {
-                    e.preventDefault()
-                    if (drag?.team === name) reorderMember(name, drag.idx, i)
-                    setDrag(null); setDragOver(null)
-                  }}
-                  onDragEnd={() => { setDrag(null); setDragOver(null) }}
-                  style={{
-                    display: 'inline-flex', alignItems: 'center', gap: 4, padding: '4px 8px',
-                    background: C.surface2, borderRadius: 14, fontSize: 12,
-                    cursor: 'grab', opacity: isDragging ? 0.4 : 1,
-                    border: isOver ? `1px solid ${C.accent}` : '1px solid transparent',
-                  }}
-                >
-                  <span style={{ color: C.fg3, cursor: 'grab' }}>⋮⋮</span>
-                  {m}
-                  <button onClick={() => removeMember(name, i)} style={{ background: 'transparent', color: C.fg3, border: 'none', cursor: 'pointer', padding: 0 }}>×</button>
-                </span>
-              )
-            })}
-            <select value="" onChange={e => {
-                const v = e.target.value
-                if (!v) return
-                if (v === '__create__') { setCreatingFor(name); setCreatePrompt(''); setCreateError(null) }
-                else addMember(name, v)
-                e.target.value = ''
-              }}
-              style={{ background: C.surface2, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 6, padding: '4px 8px', fontSize: 12 }}>
-              <option value="">+ add worker</option>
-              {available(name).map(w => <option key={w.name} value={w.name}>{w.name}</option>)}
-              <option value="__create__">+ Create new worker…</option>
-            </select>
-          </div>
-          {team.dispatch === 'all' && (
-            <div style={{ marginTop: 8 }}>
-              <button onClick={() => setEditingFlow(name)}
-                style={{ padding: '3px 10px', fontSize: 11, background: 'transparent', color: C.accent, border: `1px solid ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>
-                {team.graph ? 'Edit flow ↗' : '+ Add flow ↗'}
-              </button>
-              {team.graph && <span style={{ fontSize: 11, color: C.fg3, marginLeft: 8 }}>{team.graph.nodes.filter(n => n.type === 'worker').length} nodes</span>}
+
+          <div style={{ padding: 12 }}>
+            {/* Dispatch: segmented control + description */}
+            <div style={labelStyle}>Dispatch mode</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 14 }}>
+              <div style={{ display: 'inline-flex', background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8, padding: 2, gap: 2 }}>
+                {DISPATCH.map(d => {
+                  const on = team.dispatch === d.id
+                  return (
+                    <button key={d.id} onClick={() => setDispatch(name, d.id)}
+                      style={{ fontSize: 11, padding: '4px 12px', borderRadius: 6, border: 'none', cursor: 'pointer',
+                        background: on ? C.accent : 'transparent', color: on ? C.onAccent : C.fg2, fontWeight: on ? 600 : 400 }}>
+                      {d.label}
+                    </button>
+                  )
+                })}
+              </div>
+              <span style={{ fontSize: 11, color: C.fg3, flex: 1, minWidth: 180 }}>{DISPATCH.find(d => d.id === team.dispatch)?.desc}</span>
             </div>
-          )}
+
+            {/* Members. Show run-order (numbers + arrows + drag) only for a plain
+                Sequential team — when a flow graph exists it defines the order,
+                so the linear numbering would just be misleading. */}
+            <div style={labelStyle}>
+              {showOrder
+                ? <>Run order <span style={{ textTransform: 'none', letterSpacing: 0, color: C.fg3 }}>· drag to reorder</span></>
+                : 'Members'}
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: showOrder ? 4 : 6, alignItems: 'center' }}>
+              {team.members.length === 0 && <span style={{ fontSize: 12, color: C.fg3 }}>No members yet —</span>}
+              {team.members.map((m, i) => {
+                const isDragging = drag?.team === name && drag.idx === i
+                const isOver = dragOver?.team === name && dragOver.idx === i && !isDragging
+                return (
+                  <span key={`${m}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                    {showOrder && i > 0 && <span style={{ color: C.fg3, fontSize: 13 }}>→</span>}
+                    <span
+                      draggable
+                      onDragStart={e => { setDrag({ team: name, idx: i }); e.dataTransfer.effectAllowed = 'move' }}
+                      onDragOver={e => {
+                        if (drag?.team !== name) return
+                        e.preventDefault(); e.dataTransfer.dropEffect = 'move'
+                        if (dragOver?.team !== name || dragOver.idx !== i) setDragOver({ team: name, idx: i })
+                      }}
+                      onDrop={e => {
+                        e.preventDefault()
+                        if (drag?.team === name) reorderMember(name, drag.idx, i)
+                        setDrag(null); setDragOver(null)
+                      }}
+                      onDragEnd={() => { setDrag(null); setDragOver(null) }}
+                      style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 6, padding: showOrder ? '4px 8px 4px 5px' : '4px 8px 4px 6px',
+                        background: C.surface2, borderRadius: 14, fontSize: 12,
+                        cursor: 'grab', opacity: isDragging ? 0.4 : 1,
+                        border: isOver ? `1px solid ${C.accent}` : `1px solid ${C.border}`,
+                      }}
+                    >
+                      <span style={{ color: C.fg3, cursor: 'grab', fontSize: 10 }}>⋮⋮</span>
+                      {showOrder && (
+                        <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 18, height: 18, borderRadius: 9, background: C.accent, color: C.onAccent, fontSize: 10, fontWeight: 700 }}>{i + 1}</span>
+                      )}
+                      <span>{m}</span>
+                      <button onClick={() => removeMember(name, i)} title="Remove" style={{ background: 'transparent', color: C.fg3, border: 'none', cursor: 'pointer', padding: 0, fontSize: 14, lineHeight: 1 }}>×</button>
+                    </span>
+                  </span>
+                )
+              })}
+              <select value="" onChange={e => {
+                  const v = e.target.value
+                  if (!v) return
+                  if (v === '__create__') { setCreatingFor(name); setCreatePrompt(''); setCreateError(null) }
+                  else addMember(name, v)
+                  e.target.value = ''
+                }}
+                style={{ background: 'transparent', color: C.accent, border: `1px dashed ${C.accent}`, borderRadius: 14, padding: '4px 8px', fontSize: 12, cursor: 'pointer' }}>
+                <option value="">+ add worker</option>
+                {available(name).map(w => <option key={w.name} value={w.name}>{w.name}</option>)}
+                <option value="__create__">+ Create new worker…</option>
+              </select>
+            </div>
+
+            {/* Flow (Sequential only) */}
+            {team.dispatch === 'all' && (
+              <div style={{ marginTop: 14, paddingTop: 12, borderTop: `1px solid ${C.border}`, display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, color: C.fg3 }}>Workflow</span>
+                <button onClick={() => setEditingFlow(name)}
+                  style={{ padding: '4px 12px', fontSize: 11, fontWeight: 600, borderRadius: 6, cursor: 'pointer',
+                    background: team.graph ? C.accent : 'transparent', color: team.graph ? C.onAccent : C.accent, border: `1px solid ${C.accent}` }}>
+                  {team.graph ? '✎ Edit workflow' : '+ Add workflow'}
+                </button>
+                {team.graph
+                  ? <span style={{ fontSize: 11, color: C.fg3 }}>{team.graph.nodes.filter(n => n.type === 'worker').length} worker nodes wired</span>
+                  : <span style={{ fontSize: 11, color: C.fg3 }}>Optional — branch &amp; loop between members on a workflow canvas.</span>}
+              </div>
+            )}
+          </div>
         </div>
-      ))}
+        )
+      })}
       {creatingFor && (
         <div onClick={() => !createBusy && setCreatingFor(null)}
           style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "npm run build -ws --if-present",
+    "test": "npm run test -ws --if-present",
     "lint": "node scripts/check-non-english.mjs",
     "build:core": "npm run build -w @codey/core",
     "build:gateway": "npm run build -w @codey/gateway",


### PR DESCRIPTION
## Summary
A round of UI/UX work on the Mac app, plus a rename and version bump to **0.8.0**.

### Workflow (flow-graph) editor — `FlowEditor.tsx`
- **Single edge color with arrowheads** so direction is always visible; **running dot** travels along every edge reachable from `start`.
- **Validation feedback inline**: nodes with problems turn red; the selected node/edge gets an accent ring + glow.
- **Condition diamonds render their question text** instead of a bare `?`.
- **yes/no branch toggle** for any edge leaving a condition (works even if the branch was unset); first edge out of a diamond defaults to `yes`.
- **Reverse direction** per-edge and a bulk **Reverse all** to fix edges drawn the wrong way.
- **Save** now shows a `Saved ✓` confirmation.

### Team settings — `GlobalTeamsSection.tsx`
- Card layout with a divided header, a **segmented dispatch control** (Sequential/Auto/Parallel) with an inline description.
- **Run-order numbers + arrows** are shown only for plain Sequential teams (hidden when a workflow graph defines the order, since the numbering would mislead).
- Restyled member chips and add-worker control; clearer workflow entry button.

### Chat — `ChatTab.tsx`
- Long user messages now collapse into a **bottom fade block** with a "Show more" button, instead of a one-line italic preview.

### Wording / version
- Renamed user-facing **"flow" → "workflow"**.
- Bumped version to **0.8.0**.

## Testing
- `tsc --noEmit` passes; `vite build` succeeds.
- Not driven in the live Electron app in this session — please sanity-check the workflow editor interactions on a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)