### PR TITLE
fix(codey-mac): preserve chat drafts and refresh sidebar on workspace removal

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useChats } from '../hooks/useChats'
 import { apiService } from '../services/api'
 import type { Chat } from '../types'
@@ -6,6 +6,7 @@ import { C } from '../theme'
 import { RouteIcons } from './RouteIcons'
 import { UpdateButton } from './UpdateButton'
 import { setPendingPairing } from './pendingPairing'
+import { onWorkspacesChanged } from './workspacesChanged'
 
 interface Props {
   onOpenSettings: (tab?: string) => void
@@ -19,7 +20,7 @@ interface WsMenuState {
 }
 
 export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId }) => {
-  const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace, refreshWorkspaces, linkChannel, unlinkChannel } = useChats()
+  const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace, refreshWorkspaces, refreshChats, linkChannel, unlinkChannel } = useChats()
   const [addingWorkspace, setAddingWorkspace] = useState(false)
   const [workspaces, setWorkspaces] = useState<string[]>([])
   const [lastWorkspace, setLastWorkspace] = useState<string>('')
@@ -53,29 +54,33 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
     return () => window.removeEventListener('resize', onResize)
   }, [])
 
-  useEffect(() => {
-    let cancelled = false
-    const refresh = () => {
-      apiService.getCurrentWorkspace()
-        .then(w => { if (!cancelled) setGatewayWorkspace(w) })
-        .catch(() => {})
-      apiService.getWorkspaces()
-        .then(w => {
-          if (cancelled) return
-          setWorkspaces(w)
-          setLastWorkspace(prev => {
-            if (prev && w.includes(prev)) return prev
-            const stored = localStorage.getItem('codey.lastWorkspace')
-            if (stored && w.includes(stored)) return stored
-            return w[0] ?? ''
-          })
+  const refreshWs = useCallback(() => {
+    apiService.getCurrentWorkspace()
+      .then(setGatewayWorkspace)
+      .catch(() => {})
+    apiService.getWorkspaces()
+      .then(w => {
+        setWorkspaces(w)
+        setLastWorkspace(prev => {
+          if (prev && w.includes(prev)) return prev
+          const stored = localStorage.getItem('codey.lastWorkspace')
+          if (stored && w.includes(stored)) return stored
+          return w[0] ?? ''
         })
-        .catch(() => {})
-    }
-    refresh()
-    const id = setInterval(refresh, 5000)
-    return () => { cancelled = true; clearInterval(id) }
+      })
+      .catch(() => {})
   }, [])
+
+  useEffect(() => {
+    refreshWs()
+    const id = setInterval(refreshWs, 5000)
+    // Refresh immediately when a workspace is added/removed/renamed in the
+    // Settings overlay, instead of waiting up to 5s for the next poll. A delete
+    // also removes that workspace's chats, so reload the chat list too — the
+    // sidebar groups are derived from state.chats, not the workspace array.
+    const off = onWorkspacesChanged(() => { refreshWs(); refreshChats() })
+    return () => { clearInterval(id); off() }
+  }, [refreshWs, refreshChats])
 
   useEffect(() => {
     if (lastWorkspace) localStorage.setItem('codey.lastWorkspace', lastWorkspace)
@@ -110,6 +115,9 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
       const fresh = await apiService.getWorkspaces()
       setWorkspaces(fresh)
       await refreshWorkspaces()
+      // Rename cascades to the chats' workspaceName on the backend; reload them
+      // so they regroup under the new name instead of stranding the old group.
+      await refreshChats()
       if (lastWorkspace === oldName) setLastWorkspace(newName)
     } catch (e) {
       alert(e instanceof Error ? e.message : 'Failed to rename workspace')
@@ -128,6 +136,9 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
       const fresh = await apiService.getWorkspaces()
       setWorkspaces(fresh)
       await refreshWorkspaces()
+      // Deleting a workspace also deletes its chats; drop them from the store so
+      // the group disappears instead of lingering until a reload.
+      await refreshChats()
       if (lastWorkspace === ws) setLastWorkspace(fresh[0] ?? '')
     } catch (e) {
       alert(e instanceof Error ? e.message : 'Failed to delete workspace')

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -17,6 +17,7 @@ import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
 import { composerPlaceholder } from './coreOfflineView'
+import { getDraft, setDraft } from './chatDrafts'
 
 interface Props {
   chatId: string
@@ -281,14 +282,16 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
-  const [input, setInput] = useState('')
+  // Seed from the per-chat draft store so unsent text/attachments survive the
+  // remount that happens when switching chats (App.tsx keys ChatTab by chat id).
+  const [input, setInput] = useState(() => getDraft(chatId).text)
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   const [teamNames, setTeamNames] = useState<string[]>([])
   const [models, setModels] = useState<ModelEntry[]>([])
   const [enabledAgents, setEnabledAgents] = useState<string[]>([...AGENT_NAMES])
   const [defaultAgent, setDefaultAgent] = useState<string | null>(null)
   const [agentDefaultModels, setAgentDefaultModels] = useState<Record<string, string | undefined>>({})
-  const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>([])
+  const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>(() => getDraft(chatId).attachments)
   const [isDragging, setIsDragging] = useState(false)
   const [slashCommands, setSlashCommands] = useState<Array<{ name: string; description: string; source: 'agent' | 'gateway' }>>([])
   const [slashIdx, setSlashIdx] = useState(0)
@@ -461,6 +464,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
     setTaskBriefLoading(true)
     generateTaskBrief(chat.id).finally(() => setTaskBriefLoading(false))
   }, [turnActive, panelTab, chatId])
+  // Keep the per-chat draft store in sync so the current text/attachments are
+  // preserved when ChatTab remounts on a chat switch. setDraft drops the entry
+  // once both are empty (e.g. after send), so this also clears sent drafts.
+  useEffect(() => {
+    setDraft(chatId, { text: input, attachments: pendingAttachments })
+  }, [chatId, input, pendingAttachments])
   // When a turn is interrupted, lift the original prompt back into the input
   // and focus the textarea so the user can edit/resend without retyping.
   const restoreText = state.pendingRestores[chatId]

--- a/codey-mac/src/components/WorkspacesTab.tsx
+++ b/codey-mac/src/components/WorkspacesTab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { apiService } from '../services/api'
 import { C } from '../theme'
 import TeamsSection from './TeamsSection'
+import { emitWorkspacesChanged } from './workspacesChanged'
 
 interface WorkspacesTabProps {
   isGatewayRunning: boolean
@@ -91,6 +92,7 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning }
       if (!dir) return
       await apiService.createWorkspaceFromDir(dir)
       await loadWorkspaces()
+      emitWorkspacesChanged()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create workspace')
     } finally {
@@ -117,6 +119,7 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning }
     try {
       await apiService.deleteWorkspace(name)
       setWorkspaces(prev => prev.filter(w => w !== name))
+      emitWorkspacesChanged()
       setInfoCache(prev => {
         const next = { ...prev }; delete next[name]; return next
       })

--- a/codey-mac/src/components/chatDrafts.test.ts
+++ b/codey-mac/src/components/chatDrafts.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getDraft, setDraft, clearDraft, __resetDrafts } from './chatDrafts'
+import type { FileAttachment } from '../types'
+
+const att = (id: string): FileAttachment => ({
+  id,
+  name: `${id}.png`,
+  path: `/tmp/${id}.png`,
+  mimeType: 'image/png',
+  size: 1,
+})
+
+describe('chatDrafts', () => {
+  beforeEach(() => __resetDrafts())
+
+  it('returns an empty draft for an unknown chat', () => {
+    expect(getDraft('a')).toEqual({ text: '', attachments: [] })
+  })
+
+  it('persists text and attachments for a chat', () => {
+    setDraft('a', { text: 'hello', attachments: [att('x')] })
+    expect(getDraft('a')).toEqual({ text: 'hello', attachments: [att('x')] })
+  })
+
+  it('keeps drafts isolated per chat (switching does not clear)', () => {
+    setDraft('a', { text: 'draft for a', attachments: [att('x')] })
+    setDraft('b', { text: 'draft for b', attachments: [] })
+    // Reading either chat after the other was written must not lose the first.
+    expect(getDraft('a')).toEqual({ text: 'draft for a', attachments: [att('x')] })
+    expect(getDraft('b')).toEqual({ text: 'draft for b', attachments: [] })
+  })
+
+  it('drops the entry when the draft becomes empty', () => {
+    setDraft('a', { text: 'hi', attachments: [] })
+    setDraft('a', { text: '', attachments: [] })
+    expect(getDraft('a')).toEqual({ text: '', attachments: [] })
+  })
+
+  it('clearDraft removes a chat draft', () => {
+    setDraft('a', { text: 'hi', attachments: [att('x')] })
+    clearDraft('a')
+    expect(getDraft('a')).toEqual({ text: '', attachments: [] })
+  })
+})

--- a/codey-mac/src/components/chatDrafts.ts
+++ b/codey-mac/src/components/chatDrafts.ts
@@ -1,0 +1,37 @@
+// Per-chat composer drafts. ChatTab is remounted on every chat switch (App.tsx
+// keys it by chat id), which would otherwise reset its local input/attachment
+// state and lose anything the user typed but hasn't sent. We stash drafts in a
+// module-level store keyed by chat id so they survive that remount: ChatTab
+// seeds its state from getDraft() on mount and writes back with setDraft() on
+// change. Attachments are lightweight metadata (path on disk), so this is cheap.
+import type { FileAttachment } from '../types'
+
+export interface ChatDraft {
+  text: string
+  attachments: FileAttachment[]
+}
+
+const drafts = new Map<string, ChatDraft>()
+
+const EMPTY: ChatDraft = { text: '', attachments: [] }
+
+export function getDraft(chatId: string): ChatDraft {
+  return drafts.get(chatId) ?? { ...EMPTY }
+}
+
+export function setDraft(chatId: string, draft: ChatDraft): void {
+  if (!draft.text && draft.attachments.length === 0) {
+    drafts.delete(chatId)
+    return
+  }
+  drafts.set(chatId, draft)
+}
+
+export function clearDraft(chatId: string): void {
+  drafts.delete(chatId)
+}
+
+// Test-only: reset the store between cases.
+export function __resetDrafts(): void {
+  drafts.clear()
+}

--- a/codey-mac/src/components/workspacesChanged.ts
+++ b/codey-mac/src/components/workspacesChanged.ts
@@ -1,0 +1,17 @@
+// Notifies mounted views (e.g. the chat sidebar's workspace list) when the set
+// of workspaces changes. The workspace editor lives in the Settings overlay, a
+// sibling tree that stays mounted alongside ChatListPanel, which otherwise only
+// re-fetches workspaces on a 5s poll — so a delete/create/rename appears to
+// require a refresh. Both live in the same renderer, so a synchronous window
+// event reaches the sidebar immediately. Mirrors teamsChanged.ts.
+
+const EVENT = 'codey:workspaces-changed'
+
+export function emitWorkspacesChanged(): void {
+  window.dispatchEvent(new Event(EVENT))
+}
+
+export function onWorkspacesChanged(handler: () => void): () => void {
+  window.addEventListener(EVENT, handler)
+  return () => window.removeEventListener(EVENT, handler)
+}

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -342,6 +342,7 @@ interface ChatsContextValue {
   clearRestore: (chatId: string) => void
   toggleWorkspace: (workspaceName: string) => void
   refreshWorkspaces: () => Promise<void>
+  refreshChats: () => Promise<void>
 }
 
 const ChatsContext = createContext<ChatsContextValue | null>(null)
@@ -607,6 +608,14 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     async refreshWorkspaces() {
       const workspaces = await apiService.getWorkspaces()
       dispatch({ type: 'setWorkspaces', workspaces })
+    },
+    // Re-fetch the chat list from the gateway. Used after a workspace is deleted
+    // (which also deletes its chats) so the sidebar groups, which are derived
+    // from state.chats, drop the removed workspace instead of waiting for a
+    // full app reload.
+    async refreshChats() {
+      const chats = await apiService.chats.list()
+      dispatch({ type: 'loaded', chats })
     },
   }), [state])
 


### PR DESCRIPTION
## Summary

Fixes two chat-sidebar bugs in the Mac app:

1. **Unsent drafts lost on chat switch** — `App.tsx` keys `ChatTab` by chat id, so every switch fully remounts it and resets its local `input`/`pendingAttachments` state, wiping anything typed but not yet sent. Added a per-chat draft store (`chatDrafts.ts`) that `ChatTab` seeds from on mount and writes back on change. Drafts (text **and** attachments) now survive the remount and stay isolated per chat; they self-clear on send.

2. **Removed workspace lingers in the sidebar until reload** — the sidebar's workspace groups are derived from `state.chats`, which was only loaded once at startup. Deleting a workspace cascades to deleting its chats backend-side (`cascadeDeleteWorkspace`), but the renderer never re-fetched. Added:
   - a `workspacesChanged` notifier (mirrors the existing `teamsChanged` idiom) so a delete/create in the Settings overlay reaches the sidebar immediately instead of waiting on its 5s poll;
   - a `refreshChats()` on the chats store so the deleted workspace's chats drop out of `state.chats`, removing the group. Rename gets the same refresh so chats regroup under the new name.

## Testing

- `npx tsc --noEmit` clean
- `npx vitest run` — 135/135 pass, including new `chatDrafts.test.ts` (persistence, per-chat isolation, empty-cleanup, clear)

Note: the draft fix is fully provable only in the live UI; logic + types verified via tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)