### PR TITLE
feat: team run flow view + default self-loop cap

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import type { Chat, ChatMessage } from '../types'
 import { C } from '../theme'
 import { parseTeamMessage } from './teamMessageFormat'
-import { ToolDetail, CombinedDiffView, normalizeTool } from './toolFormat'
+import { CombinedDiffView, normalizeTool } from './toolFormat'
+import { ToolCallList } from './ToolCallList'
 import { QuickQuestionView } from './QuickQuestionView'
 import { TaskHud } from './TaskHud'
 import TeamRunFlow from './TeamRunFlow'
@@ -385,114 +386,12 @@ const flowStyles: Record<string, React.CSSProperties> = {
 }
 
 const ToolTimeline: React.FC<{ toolCalls: import('../types').ToolCallEntry[] }> = ({ toolCalls }) => {
-  const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
-
-  type Row =
-    | { kind: 'call'; id: string; tool?: string; input?: Record<string, unknown>; output?: string; done: boolean; message: string }
-    | { kind: 'info'; id: string; message: string }
-  const rows: Row[] = []
-  const startIdxById = new Map<string, number>()
-  for (const tc of toolCalls) {
-    if (tc.type === 'info') {
-      rows.push({ kind: 'info', id: tc.id, message: tc.message })
-      continue
-    }
-    if (tc.type === 'tool_start') {
-      const idx = rows.push({
-        kind: 'call', id: tc.id, tool: tc.tool, input: tc.input,
-        done: false, message: tc.message,
-      }) - 1
-      startIdxById.set(tc.id, idx)
-    } else { // tool_end
-      const idx = startIdxById.get(tc.id)
-      if (idx != null) {
-        const row = rows[idx] as Extract<Row, { kind: 'call' }>
-        row.done = true
-        if (tc.output) row.output = tc.output
-        if (tc.message) row.message = tc.message
-        startIdxById.delete(tc.id)
-      } else {
-        rows.push({
-          kind: 'call', id: tc.id, tool: tc.tool, output: tc.output,
-          done: true, message: tc.message,
-        })
-      }
-    }
-  }
-
-  if (rows.length === 0) return null
+  if (toolCalls.length === 0) return null
   return (
     <Section title="Tool calls">
-      <div style={timelineStyles.list}>
-        {rows.map(r => {
-          if (r.kind === 'info') {
-            return (
-              <div key={r.id} style={timelineStyles.infoRow}>
-                <span style={timelineStyles.iconInfo}>ⓘ</span>
-                <span>{r.message}</span>
-              </div>
-            )
-          }
-          const isOpen = expanded.has(r.id)
-          const hasDetail = !!r.input || !!r.output
-          const toggle = () => setExpanded(prev => {
-            const next = new Set(prev)
-            next.has(r.id) ? next.delete(r.id) : next.add(r.id)
-            return next
-          })
-          const icon = isOpen ? '▾' : '▶'
-          return (
-            <div key={r.id}>
-              <div
-                style={{ ...timelineStyles.callRow, cursor: hasDetail ? 'pointer' : 'default' }}
-                onClick={hasDetail ? toggle : undefined}
-              >
-                <span style={r.done ? timelineStyles.iconDone : timelineStyles.iconRunning}>{icon}</span>
-                <span style={timelineStyles.tool}>{r.tool ?? '(tool)'}</span>
-                <span style={timelineStyles.callMsg}>{r.message}</span>
-              </div>
-              {hasDetail && isOpen && (
-                <div style={timelineStyles.detail}>
-                  <ToolDetail rawTool={r.tool} input={r.input ?? {}} output={r.output} />
-                  {!r.done && !r.output && (
-                    <div style={timelineStyles.detailLabel}>(no result yet)</div>
-                  )}
-                  {r.done && !r.output && !r.input && (
-                    <div style={timelineStyles.detailLabel}>(no result)</div>
-                  )}
-                </div>
-              )}
-            </div>
-          )
-        })}
-      </div>
+      <ToolCallList toolCalls={toolCalls} />
     </Section>
   )
-}
-
-const timelineStyles: Record<string, React.CSSProperties> = {
-  list: { display: 'flex', flexDirection: 'column', gap: 4 },
-  infoRow: {
-    display: 'flex', alignItems: 'flex-start', gap: 6,
-    color: C.fg3, fontSize: 11, fontStyle: 'italic',
-  },
-  callRow: {
-    display: 'flex', alignItems: 'flex-start', gap: 6,
-    fontSize: 12, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-    padding: '2px 0',
-  },
-  tool: { color: C.fg2, flexShrink: 0 },
-  callMsg: { color: C.fg2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
-  iconRunning: { color: C.accent, width: 12, flexShrink: 0 },
-  iconDone: { color: C.green, width: 12, flexShrink: 0 },
-  iconInfo: { color: C.fg3, width: 12, flexShrink: 0 },
-  detail: {
-    marginLeft: 18, marginTop: 4, marginBottom: 6,
-    padding: 8, background: 'rgba(0,0,0,0.3)',
-    border: `1px solid ${C.border}`, borderRadius: 6,
-    maxHeight: 280, overflowY: 'auto',
-  },
-  detailLabel: { color: C.fg3, fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 4 },
 }
 
 const AttachmentsSection: React.FC<{ attachments: import('../types').FileAttachment[] }> = ({ attachments }) => {

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -199,18 +199,12 @@ export const ChatContextPanel: React.FC<Props> = ({
               </div>
             </Section>
 
-            {turn && teamName && (
-              <Section title="Team flow">
-                <button onClick={() => setFlowOpen(true)} style={{ fontSize: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 12px', cursor: 'pointer', marginBottom: 8 }}>
-                  View flow ⤢
-                </button>
-              </Section>
-            )}
             {turn && (
               <TeamFlow
                 turn={turn}
                 isStreaming={isTurnStreaming}
                 onScrollToStep={onScrollToStep}
+                onViewFlow={teamName ? () => setFlowOpen(true) : undefined}
               />
             )}
             {turn && <ToolTimeline toolCalls={turn.toolCalls ?? []} />}
@@ -319,9 +313,12 @@ const TeamFlow: React.FC<{
   turn: ChatMessage
   isStreaming: boolean
   onScrollToStep: (messageId: string, stepNum: number) => void
-}> = ({ turn, isStreaming, onScrollToStep }) => {
+  /** When set, renders a "View flow ⤢" button that opens the run-flow overlay. */
+  onViewFlow?: () => void
+}> = ({ turn, isStreaming, onScrollToStep, onViewFlow }) => {
   const parsed = parseTeamMessage(turn.content)
-  if (!parsed) return null
+  // Nothing to show: no steps to list and no overlay to launch.
+  if (!parsed && !onViewFlow) return null
   const infos = (turn.toolCalls ?? []).filter(tc => tc.type === 'info')
   // Match info messages to steps by step number prefix ("Step N:" or "Step N/M:")
   const reasonByStep = new Map<number, string>()
@@ -330,11 +327,20 @@ const TeamFlow: React.FC<{
     if (!m) continue
     reasonByStep.set(parseInt(m[1], 10), info.message)
   }
-  const lastIdx = parsed.steps.length - 1
+  const steps = parsed?.steps ?? []
+  const lastIdx = steps.length - 1
   return (
-    <Section title={`Team flow (${parsed.steps.length} step${parsed.steps.length === 1 ? '' : 's'})`}>
+    <Section title="Team flow">
+      {onViewFlow && (
+        <button
+          onClick={onViewFlow}
+          style={{ fontSize: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 12px', cursor: 'pointer', marginBottom: steps.length ? 8 : 0 }}
+        >
+          View flow ⤢
+        </button>
+      )}
       <div style={flowStyles.list}>
-        {parsed.steps.map((s, i) => {
+        {steps.map((s, i) => {
           const isRunning = isStreaming && i === lastIdx
           const status: 'done' | 'running' = isRunning ? 'running' : 'done'
           const reason = reasonByStep.get(s.step)

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -5,6 +5,7 @@ import { parseTeamMessage } from './teamMessageFormat'
 import { ToolDetail, CombinedDiffView, normalizeTool } from './toolFormat'
 import { QuickQuestionView } from './QuickQuestionView'
 import { TaskHud } from './TaskHud'
+import TeamRunFlow from './TeamRunFlow'
 
 export type ContextPanelTab = 'current' | 'task' | 'files' | 'qq'
 
@@ -22,6 +23,8 @@ interface Props {
   workerName?: string
   /** Team name actively bound, when chat selection is a team. */
   teamName?: string
+  /** Authored flow graph for the chat's team, if any. */
+  teamGraph?: import('../../../packages/core/src/team-graph').TeamGraph
   /** Working directory of the workspace, used to render relative file paths. */
   workingDir?: string
   width: number
@@ -57,7 +60,7 @@ const formatTokens = (n: number): string | null => {
 
 export const ChatContextPanel: React.FC<Props> = ({
   chat, selectedTurnId, followLatest, selectedTurnIndex,
-  effectiveAgent, effectiveModel, workerName, teamName, workingDir,
+  effectiveAgent, effectiveModel, workerName, teamName, teamGraph, workingDir,
   width, onFollowLatest, onClose, onResize, onRevealFile, onScrollToStep, isTurnStreaming,
   activeTab, onTabChange, qqInputRef,
   onAnswerNextAction, taskBriefLoading, onTaskTabShown,
@@ -65,6 +68,8 @@ export const ChatContextPanel: React.FC<Props> = ({
   const turn: ChatMessage | undefined = selectedTurnId
     ? chat.messages.find(m => m.id === selectedTurnId && m.role === 'assistant')
     : undefined
+
+  const [flowOpen, setFlowOpen] = React.useState(false)
 
   const triggeringUserMsg: ChatMessage | undefined = (() => {
     if (!turn) return undefined
@@ -193,6 +198,13 @@ export const ChatContextPanel: React.FC<Props> = ({
               </div>
             </Section>
 
+            {turn && teamName && (
+              <Section title="Team flow">
+                <button onClick={() => setFlowOpen(true)} style={{ fontSize: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 12px', cursor: 'pointer', marginBottom: 8 }}>
+                  View flow ⤢
+                </button>
+              </Section>
+            )}
             {turn && (
               <TeamFlow
                 turn={turn}
@@ -214,6 +226,15 @@ export const ChatContextPanel: React.FC<Props> = ({
               </Section>
             )}
             {!turn && <div style={styles.emptyHint}>Send a message to see run context.</div>}
+            {flowOpen && turn && (
+              <TeamRunFlow
+                turn={turn}
+                isStreaming={isTurnStreaming}
+                teamGraph={teamGraph}
+                askingWorker={chat.pendingTeam?.askingWorker}
+                onClose={() => setFlowOpen(false)}
+              />
+            )}
           </>
         ) : (
           <FileChangesView

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -831,6 +831,13 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
 
   const panelWorkerName = chat.selection.type === 'worker' ? chat.selection.name : undefined
   const panelTeamName = chat.selection.type === 'team' ? chat.selection.name : undefined
+  const [panelTeamGraph, setPanelTeamGraph] = useState<import('../../../packages/core/src/team-graph').TeamGraph | undefined>(undefined)
+  useEffect(() => {
+    if (!panelTeamName) { setPanelTeamGraph(undefined); return }
+    apiService.getGlobalTeams()
+      .then(teams => setPanelTeamGraph((teams[panelTeamName] as any)?.graph))
+      .catch(() => setPanelTeamGraph(undefined))
+  }, [panelTeamName])
 
   return (
     <div style={styles.outer}>
@@ -1389,6 +1396,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
               effectiveModel={effectiveModel}
               workerName={panelWorkerName}
               teamName={panelTeamName}
+              teamGraph={panelTeamGraph}
               workingDir={workingDir}
               width={effectiveWidth}
               onFollowLatest={() => setFollowLatest(true)}

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -1,127 +1,14 @@
 import { useCallback, useMemo, useState } from 'react'
 import {
   ReactFlow, Background, Controls, addEdge, applyNodeChanges, applyEdgeChanges,
-  ReactFlowProvider, useReactFlow,
-  Handle, Position, NodeResizer, ConnectionMode,
-  BaseEdge, EdgeLabelRenderer, getBezierPath, MarkerType,
-  type Node, type Edge, type Connection, type NodeProps, type EdgeProps,
+  ReactFlowProvider, useReactFlow, ConnectionMode, MarkerType,
+  type Node, type Edge, type Connection,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { TeamGraph, validateGraph } from '../../../packages/core/src/team-graph'
 import { toFlow, fromFlow, newNodeId } from './flowEditorModel'
+import { nodeTypes, edgeTypes, EDGE_COLOR, resolveColor, rfNodeType } from './flowGraph'
 import { C, useEffectiveTheme } from '../theme'
-
-// A single edge color throughout — edges don't encode meaning by color; the
-// branch (yes/no) and conditions are shown as labels instead.
-const EDGE_COLOR = C.accent
-
-// SVG <marker> fill is a presentation attribute — CSS var() references don't
-// resolve there. Read the actual computed hex from the document root instead.
-const resolveColor = (cssVar: string) =>
-  getComputedStyle(document.documentElement).getPropertyValue(cssVar.slice(4, -1)).trim()
-
-// ---------------------------------------------------------------------------
-// Custom node components
-// ---------------------------------------------------------------------------
-
-const HANDLE_IDS = ['t', 'r', 'b', 'l'] as const
-const HANDLE_POS = { t: Position.Top, r: Position.Right, b: Position.Bottom, l: Position.Left }
-
-// One handle per side. With ConnectionMode.Loose (set on <ReactFlow>), a single
-// `source` handle can both start and receive a connection, so a drag can begin
-// from any side. Rendering separate source+target handles per side stacked them
-// on top of each other — the target covered the source, so drags could never
-// start and no edges could be drawn.
-function NodeHandles() {
-  return (
-    <>
-      {HANDLE_IDS.map(id => (
-        <Handle key={id} type="source" id={id} position={HANDLE_POS[id]} style={{ width: 9, height: 9, background: C.accent }} />
-      ))}
-    </>
-  )
-}
-
-// A node flagged by validation gets a red border; the selected node gets an
-// accent ring. `bad` is injected per-render from the validation problems.
-function ring(selected?: boolean, bad?: boolean): string | undefined {
-  if (selected) return `0 0 0 3px ${C.accent}, 0 0 14px 2px ${C.accent}`
-  if (bad) return `0 0 0 1px ${C.red}`
-  return undefined
-}
-
-function WorkerNodeView({ data, selected }: NodeProps) {
-  const d = data as { label: string; role?: string; bad?: boolean }
-  // Size to content (full name on one line); never clip the name. React Flow
-  // applies any user-resized width/height to the node wrapper itself, so we
-  // don't bind them here — that previously collapsed the card and clipped text.
-  return (
-    <div style={{ minWidth: 100, padding: '8px 12px', borderRadius: 8, background: C.surface2, border: `1px solid ${d.bad ? C.red : C.border}`, color: C.fg, boxSizing: 'border-box', boxShadow: ring(selected, d.bad) }}>
-      <NodeResizer isVisible={selected} minWidth={100} minHeight={44} />
-      <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap' }}>{d.label}</div>
-      {d.role && <div style={{ fontSize: 11, color: C.fg2, marginTop: 2, maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
-      <NodeHandles />
-    </div>
-  )
-}
-
-function ConditionNodeView({ data, selected }: NodeProps) {
-  const d = data as { condition?: string; bad?: boolean }
-  const text = d.condition?.trim() || 'condition?'
-  return (
-    <div style={{ width: 130, height: 130, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
-      {/* The diamond is a rotated square behind upright, centered text. */}
-      <div style={{ position: 'absolute', inset: 19, transform: 'rotate(45deg)', background: C.surface2, border: `1px solid ${d.bad ? C.red : C.accent}`, borderRadius: 8, boxShadow: ring(selected, d.bad) }} />
-      <span style={{ position: 'relative', fontSize: 10, lineHeight: 1.25, color: C.fg, width: 78, textAlign: 'center', display: '-webkit-box', WebkitLineClamp: 5, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{text}</span>
-      <NodeHandles />
-    </div>
-  )
-}
-
-function TerminalNodeView({ data, selected }: NodeProps) {
-  const d = data as { label: string; bad?: boolean }
-  return (
-    <div style={{ padding: '10px 22px', borderRadius: 999, background: C.bg, border: `1px solid ${d.bad ? C.red : C.border}`, color: C.fg, fontSize: 14, fontWeight: 600, boxShadow: ring(selected, d.bad) }}>
-      {d.label}
-      <NodeHandles />
-    </div>
-  )
-}
-
-const nodeTypes = { workerNode: WorkerNodeView, conditionNode: ConditionNodeView, terminalNode: TerminalNodeView }
-
-// Custom edge: single color, optional label, and — when `data.running` is set
-// (the edge is reachable from the start node) — a dot that travels along the
-// path to visualize flow leaving start.
-function FlowEdgeView({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, label, data, selected }: EdgeProps) {
-  const [edgePath, labelX, labelY] = getBezierPath({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition })
-  const running = (data as any)?.running
-  // Edges in the live flow (reachable from start) use the accent color; dangling
-  // edges are greyed. The selected edge is always accent and drawn thicker.
-  const stroke = selected ? C.accent : running ? EDGE_COLOR : C.fg2
-  return (
-    <>
-      {selected && <path d={edgePath} fill="none" stroke={C.accent} strokeWidth={9} strokeLinecap="round" style={{ opacity: 0.25 }} />}
-      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ stroke, strokeWidth: selected ? 3.5 : 1.5 }} />
-      {running && (
-        <circle r={4} fill={stroke}>
-          <animateMotion dur="1.6s" repeatCount="indefinite" path={edgePath} rotate="auto" />
-        </circle>
-      )}
-      {label != null && label !== '' && (
-        <EdgeLabelRenderer>
-          <div style={{
-            position: 'absolute', transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-            background: C.bg, color: C.fg2, fontSize: 10, padding: '1px 5px', borderRadius: 4,
-            border: `1px solid ${C.border}`, pointerEvents: 'none',
-          }}>{String(label)}</div>
-        </EdgeLabelRenderer>
-      )}
-    </>
-  )
-}
-
-const edgeTypes = { flowEdge: FlowEdgeView }
 
 // ---------------------------------------------------------------------------
 // Props
@@ -140,7 +27,7 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   const effectiveTheme = useEffectiveTheme()
   const withTypes = (ns: Node[]): Node[] => ns.map(n => {
     const t = (n.data as any).type
-    const rfType = t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'
+    const rfType = rfNodeType(t)
     const role = t === 'worker' ? workerRoles[(n.data as any).worker] : undefined
     return { ...n, type: rfType, data: { ...n.data, role } }
   })

--- a/codey-mac/src/components/FlowEditor.tsx
+++ b/codey-mac/src/components/FlowEditor.tsx
@@ -9,11 +9,16 @@ import {
 import '@xyflow/react/dist/style.css'
 import { TeamGraph, validateGraph } from '../../../packages/core/src/team-graph'
 import { toFlow, fromFlow, newNodeId } from './flowEditorModel'
-import { C } from '../theme'
+import { C, useEffectiveTheme } from '../theme'
 
 // A single edge color throughout — edges don't encode meaning by color; the
 // branch (yes/no) and conditions are shown as labels instead.
 const EDGE_COLOR = C.accent
+
+// SVG <marker> fill is a presentation attribute — CSS var() references don't
+// resolve there. Read the actual computed hex from the document root instead.
+const resolveColor = (cssVar: string) =>
+  getComputedStyle(document.documentElement).getPropertyValue(cssVar.slice(4, -1)).trim()
 
 // ---------------------------------------------------------------------------
 // Custom node components
@@ -54,7 +59,7 @@ function WorkerNodeView({ data, selected }: NodeProps) {
     <div style={{ minWidth: 100, padding: '8px 12px', borderRadius: 8, background: C.surface2, border: `1px solid ${d.bad ? C.red : C.border}`, color: C.fg, boxSizing: 'border-box', boxShadow: ring(selected, d.bad) }}>
       <NodeResizer isVisible={selected} minWidth={100} minHeight={44} />
       <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap' }}>{d.label}</div>
-      {d.role && <div style={{ fontSize: 11, color: C.fg3, marginTop: 2, maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
+      {d.role && <div style={{ fontSize: 11, color: C.fg2, marginTop: 2, maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
       <NodeHandles />
     </div>
   )
@@ -93,7 +98,7 @@ function FlowEdgeView({ id, sourceX, sourceY, targetX, targetY, sourcePosition, 
   const running = (data as any)?.running
   // Edges in the live flow (reachable from start) use the accent color; dangling
   // edges are greyed. The selected edge is always accent and drawn thicker.
-  const stroke = selected ? C.accent : running ? EDGE_COLOR : C.fg3
+  const stroke = selected ? C.accent : running ? EDGE_COLOR : C.fg2
   return (
     <>
       {selected && <path d={edgePath} fill="none" stroke={C.accent} strokeWidth={9} strokeLinecap="round" style={{ opacity: 0.25 }} />}
@@ -107,7 +112,7 @@ function FlowEdgeView({ id, sourceX, sourceY, targetX, targetY, sourcePosition, 
         <EdgeLabelRenderer>
           <div style={{
             position: 'absolute', transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-            background: C.bg, color: C.fg3, fontSize: 10, padding: '1px 5px', borderRadius: 4,
+            background: C.bg, color: C.fg2, fontSize: 10, padding: '1px 5px', borderRadius: 4,
             border: `1px solid ${C.border}`, pointerEvents: 'none',
           }}>{String(label)}</div>
         </EdgeLabelRenderer>
@@ -132,6 +137,7 @@ interface Props {
 }
 
 function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSave, onClose }: Props) {
+  const effectiveTheme = useEffectiveTheme()
   const withTypes = (ns: Node[]): Node[] => ns.map(n => {
     const t = (n.data as any).type
     const rfType = t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'
@@ -258,13 +264,14 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
 
   const styledEdges = useMemo(() => edges.map(e => {
     const running = runningEdgeIds.has(e.id)
+    const markerColor = resolveColor(running || e.selected ? C.accent : C.fg2)
     return {
       ...e,
       type: 'flowEdge',
-      markerEnd: { type: MarkerType.ArrowClosed, color: running ? EDGE_COLOR : C.fg3 },
+      markerEnd: { type: MarkerType.ArrowClosed, color: markerColor },
       data: { ...(e as any).data, running },
     }
-  }), [edges, runningEdgeIds])
+  }), [edges, runningEdgeIds, effectiveTheme])
 
   // Inject the per-node `bad` flag so node views can paint themselves red.
   const styledNodes = useMemo(() => nodes.map(n => ({
@@ -281,17 +288,19 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
   // then reversed, which never assigned one).
   const selIsBranch = sel ? (nodes.find(n => n.id === sel.source)?.data as any)?.type === 'condition' : false
 
+  const secondaryBtn = { fontSize: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 12px', cursor: 'pointer' } as const
+
   return (
     <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
       <div onClick={e => e.stopPropagation()} style={{ width: '90vw', height: '85vh', background: C.bg, border: `1px solid ${C.border}`, borderRadius: 10, display: 'flex', flexDirection: 'column' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', borderBottom: `1px solid ${C.border}` }}>
           <strong style={{ flex: 1 }}>Workflow — {teamName}</strong>
-          <label style={{ fontSize: 12, color: C.fg3 }}>max hops <input type="number" min={1} value={maxHops} onChange={e => setMaxHops(Math.max(1, Number(e.target.value) || 1))} style={{ width: 56, marginLeft: 6 }} /></label>
-          <button onClick={reverseAllEdges} title="Flip the direction of every edge" style={{ fontSize: 12 }}>⇄ Reverse all</button>
-          <button onClick={() => setShowRaw(s => !s)} style={{ fontSize: 12 }}>{showRaw ? 'Canvas' : 'Raw config'}</button>
+          <label style={{ fontSize: 12, color: C.fg }}>max hops <input type="number" min={1} value={maxHops} onChange={e => setMaxHops(Math.max(1, Number(e.target.value) || 1))} style={{ width: 56, marginLeft: 6, background: C.surface3, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 4, padding: '2px 6px', colorScheme: effectiveTheme, WebkitAppearance: 'textfield' }} /></label>
+          <button onClick={reverseAllEdges} title="Flip the direction of every edge" style={secondaryBtn}>⇄ Reverse all</button>
+          <button onClick={() => setShowRaw(s => !s)} style={secondaryBtn}>{showRaw ? 'Canvas' : 'Raw config'}</button>
           {justSaved && <span style={{ fontSize: 12, color: C.green }}>Saved ✓</span>}
           <button onClick={save} style={{ fontSize: 12, color: C.onAccent, background: C.accent, border: 'none', borderRadius: 6, padding: '4px 12px' }}>Save</button>
-          <button onClick={onClose} style={{ fontSize: 12 }}>Close</button>
+          <button onClick={onClose} style={secondaryBtn}>Close</button>
         </div>
         {problems.length > 0 && (
           <div style={{ background: C.dangerBg, color: C.dangerFg, fontSize: 11, padding: '4px 12px' }}>{problems.join(' · ')}</div>
@@ -304,24 +313,24 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
                 <button key={w} draggable
                   onDragStart={e => e.dataTransfer.setData('application/codey-node', JSON.stringify({ kind: 'worker', worker: w }))}
                   onClick={() => addWorker(w)}
-                  style={{ display: 'block', width: '100%', textAlign: 'left', marginBottom: 4, fontSize: 12, padding: '8px 8px', minHeight: 40, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 6, cursor: 'pointer' }}>
+                  style={{ display: 'block', width: '100%', textAlign: 'left', marginBottom: 4, fontSize: 12, padding: '8px 8px', minHeight: 40, background: C.surface3, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, cursor: 'pointer' }}>
                   <div style={{ fontWeight: 600 }}>+ {w}</div>
-                  {workerRoles[w] && <div style={{ fontSize: 10, color: C.fg3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{workerRoles[w]}</div>}
+                  {workerRoles[w] && <div style={{ fontSize: 10, color: C.fg2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{workerRoles[w]}</div>}
                 </button>
               ))}
               <button draggable
                 onDragStart={e => e.dataTransfer.setData('application/codey-node', JSON.stringify({ kind: 'condition' }))}
                 onClick={() => addCondition()}
-                style={{ display: 'block', width: '100%', marginTop: 8, fontSize: 12, padding: '6px', background: C.surface2, border: `1px dashed ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>◇ + Condition</button>
+                style={{ display: 'block', width: '100%', marginTop: 8, fontSize: 12, padding: '6px', background: C.surface3, color: C.fg, border: `1px dashed ${C.accent}`, borderRadius: 6, cursor: 'pointer' }}>◇ + Condition</button>
             </div>
           )}
           {showRaw ? (
             <pre style={{ flex: 1, margin: 0, padding: 14, overflow: 'auto', fontSize: 12, color: C.fg }}>{JSON.stringify(current(), null, 2)}</pre>
           ) : (
             <div style={{ flex: 1, position: 'relative' }} onDrop={onDrop} onDragOver={onDragOver}>
-              <ReactFlow nodes={styledNodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }} onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }} onNodesDelete={(ns) => { if (ns.some(n => n.id === selNode)) setSelNode(null) }} onEdgesDelete={(es) => { if (es.some(e => e.id === selEdge)) setSelEdge(null) }} nodeTypes={nodeTypes} edgeTypes={edgeTypes} connectionMode={ConnectionMode.Loose} fitView fitViewOptions={{ maxZoom: 1, padding: 0.2 }} minZoom={0.2} maxZoom={1.5}>
-                <Background />
-                <Controls />
+              <ReactFlow nodes={styledNodes} edges={styledEdges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} onConnect={onConnect} onEdgeClick={(_, e) => { setSelEdge(e.id); setSelNode(null) }} onNodeClick={(_, n) => { setSelNode(n.id); setSelEdge(null) }} onNodesDelete={(ns) => { if (ns.some(n => n.id === selNode)) setSelNode(null) }} onEdgesDelete={(es) => { if (es.some(e => e.id === selEdge)) setSelEdge(null) }} nodeTypes={nodeTypes} edgeTypes={edgeTypes} connectionMode={ConnectionMode.Loose} fitView fitViewOptions={{ maxZoom: 1, padding: 0.2 }} minZoom={0.2} maxZoom={1.5} colorMode={effectiveTheme}>
+                <Background style={{ '--xy-background-color': C.bg, '--xy-background-pattern-color': C.border2 } as React.CSSProperties} />
+                <Controls style={{ '--xy-controls-button-background-color': C.surface2, '--xy-controls-button-background-color-hover': C.surface3, '--xy-controls-button-color': C.fg, '--xy-controls-button-border-color': C.border2 } as React.CSSProperties} />
               </ReactFlow>
             </div>
           )}
@@ -330,7 +339,7 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
               {selN.data?.type === 'worker' ? (
                 <>
                   <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{selN.data.worker}</div>
-                  <div style={{ fontSize: 11, color: C.fg3, marginBottom: 10, whiteSpace: 'pre-wrap' }}>
+                  <div style={{ fontSize: 11, color: C.fg2, marginBottom: 10, whiteSpace: 'pre-wrap' }}>
                     {workerRoles[selN.data.worker] || 'No description.'}
                   </div>
                   {selfLoops && (
@@ -338,7 +347,7 @@ function FlowEditorInner({ teamName, workerNames, workerRoles = {}, graph, onSav
                       Max self-loops
                       <input type="number" min={1} value={selN.data.maxCalls ?? ''} placeholder="∞"
                         onChange={e => updateNodeData(selN.id, { maxCalls: e.target.value === '' ? undefined : Math.max(1, Number(e.target.value) || 1) })}
-                        style={{ width: 64, marginLeft: 6 }} />
+                        style={{ width: 64, marginLeft: 6, background: C.surface3, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 4, padding: '2px 6px', colorScheme: effectiveTheme, WebkitAppearance: 'textfield' }} />
                     </label>
                   )}
                 </>

--- a/codey-mac/src/components/TeamRunFlow.tsx
+++ b/codey-mac/src/components/TeamRunFlow.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect } from 'react'
-import { ReactFlow, ReactFlowProvider, type Node, type Edge } from '@xyflow/react'
+import { ReactFlow, ReactFlowProvider, ConnectionMode, type Node, type Edge } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import type { ChatMessage } from '../types'
 import type { TeamGraph } from '../../../packages/core/src/team-graph'
@@ -67,6 +67,7 @@ function TeamRunFlowInner({ turn, isStreaming, teamGraph, askingWorker, onClose 
               nodeTypes={nodeTypes} edgeTypes={edgeTypes}
               onNodeClick={(_, n) => { const w = (n.data as any)?.worker; if (w) setSelWorker(w) }}
               nodesDraggable={false} nodesConnectable={false} elementsSelectable
+              connectionMode={ConnectionMode.Loose}
               fitView fitViewOptions={{ maxZoom: 1, padding: 0.2 }} minZoom={0.2} maxZoom={1.5}
               colorMode={effectiveTheme}
             />

--- a/codey-mac/src/components/TeamRunFlow.tsx
+++ b/codey-mac/src/components/TeamRunFlow.tsx
@@ -5,7 +5,8 @@ import type { ChatMessage } from '../types'
 import type { TeamGraph } from '../../../packages/core/src/team-graph'
 import { toFlow } from './flowEditorModel'
 import { nodeTypes, edgeTypes, rfNodeType } from './flowGraph'
-import { deriveWorkerRuns, synthesizeChainGraph, nodeStatuses } from './teamRunModel'
+import { deriveWorkerRuns, synthesizeChainGraph, nodeStatuses, toolCallsForStep } from './teamRunModel'
+import { ToolCallList } from './ToolCallList'
 import { C, useEffectiveTheme } from '../theme'
 import { Markdown } from './Markdown'
 
@@ -79,6 +80,8 @@ function TeamRunFlowInner({ turn, isStreaming, teamGraph, askingWorker, onClose 
                 <div style={{ fontSize: 11, color: C.fg2, marginBottom: 12 }}>Step {sel.step} · {sel.status}</div>
                 <div style={{ fontSize: 11, textTransform: 'uppercase', color: C.fg3, marginBottom: 6 }}>Output</div>
                 <Markdown variant="assistant">{sel.output || '(no output yet)'}</Markdown>
+                <div style={{ fontSize: 11, textTransform: 'uppercase', color: C.fg3, margin: '14px 0 6px' }}>Tool calls</div>
+                <ToolCallList toolCalls={toolCallsForStep(turn.toolCalls, sel.step)} emptyHint="(no tool calls)" />
                 {sel.thinking && (
                   <div style={{ marginTop: 14 }}>
                     <button onClick={() => setShowThinking(s => !s)} style={{ ...secondaryBtn, fontSize: 11 }}>

--- a/codey-mac/src/components/TeamRunFlow.tsx
+++ b/codey-mac/src/components/TeamRunFlow.tsx
@@ -81,7 +81,7 @@ function TeamRunFlowInner({ turn, isStreaming, teamGraph, askingWorker, onClose 
                 <div style={{ fontSize: 11, textTransform: 'uppercase', color: C.fg3, marginBottom: 6 }}>Output</div>
                 <Markdown variant="assistant">{sel.output || '(no output yet)'}</Markdown>
                 <div style={{ fontSize: 11, textTransform: 'uppercase', color: C.fg3, margin: '14px 0 6px' }}>Tool calls</div>
-                <ToolCallList toolCalls={toolCallsForStep(turn.toolCalls, sel.step)} emptyHint="(no tool calls)" />
+                <ToolCallList toolCalls={toolCallsForStep(turn.toolCalls, sel.step)} emptyHint="(no tool calls)" minimal />
                 {sel.thinking && (
                   <div style={{ marginTop: 14 }}>
                     <button onClick={() => setShowThinking(s => !s)} style={{ ...secondaryBtn, fontSize: 11 }}>

--- a/codey-mac/src/components/TeamRunFlow.tsx
+++ b/codey-mac/src/components/TeamRunFlow.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState, useEffect } from 'react'
+import { ReactFlow, ReactFlowProvider, type Node, type Edge } from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import type { ChatMessage } from '../types'
+import type { TeamGraph } from '../../../packages/core/src/team-graph'
+import { toFlow } from './flowEditorModel'
+import { nodeTypes, edgeTypes, rfNodeType } from './flowGraph'
+import { deriveWorkerRuns, synthesizeChainGraph, nodeStatuses } from './teamRunModel'
+import { C, useEffectiveTheme } from '../theme'
+import { Markdown } from './Markdown'
+
+interface Props {
+  turn: ChatMessage
+  isStreaming: boolean
+  teamGraph?: TeamGraph
+  askingWorker?: string
+  onClose: () => void
+}
+
+const secondaryBtn = { fontSize: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 12px', cursor: 'pointer' } as const
+
+function TeamRunFlowInner({ turn, isStreaming, teamGraph, askingWorker, onClose }: Props) {
+  const effectiveTheme = useEffectiveTheme()
+  const runs = useMemo(() => deriveWorkerRuns(turn, isStreaming), [turn.content, turn.thinkingByStep, isStreaming])
+  const graph: TeamGraph = useMemo(() => teamGraph ?? synthesizeChainGraph(runs), [teamGraph, runs])
+  const statuses = useMemo(() => nodeStatuses(graph, runs, askingWorker), [graph, runs, askingWorker])
+
+  const runByWorker = useMemo(() => {
+    const m = new Map<string, ReturnType<typeof deriveWorkerRuns>[number]>()
+    for (const r of runs) m.set(r.worker, r) // latest wins
+    return m
+  }, [runs])
+
+  const { nodes, edges } = useMemo(() => {
+    const f = toFlow(graph)
+    const rfNodes: Node[] = f.nodes.map(n => ({
+      ...n,
+      type: rfNodeType((n.data as any).type),
+      data: { ...n.data, status: statuses[n.id] },
+    })) as any
+    const rfEdges: Edge[] = f.edges.map(e => ({ ...e, type: 'flowEdge' })) as any
+    return { nodes: rfNodes, edges: rfEdges }
+  }, [graph, statuses])
+
+  // Default selection: the running worker, else the last run.
+  const [selWorker, setSelWorker] = useState<string | null>(null)
+  useEffect(() => {
+    if (selWorker && runByWorker.has(selWorker)) return
+    const running = runs.find(r => r.status === 'running')
+    setSelWorker((running ?? runs[runs.length - 1])?.worker ?? null)
+  }, [runs, selWorker, runByWorker])
+
+  const sel = selWorker ? runByWorker.get(selWorker) : undefined
+  const [showThinking, setShowThinking] = useState(false)
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: '90vw', height: '85vh', background: C.bg, border: `1px solid ${C.border}`, borderRadius: 10, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', borderBottom: `1px solid ${C.border}` }}>
+          <strong style={{ flex: 1 }}>Workflow run</strong>
+          <button onClick={onClose} style={secondaryBtn}>Close</button>
+        </div>
+        <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
+          <div style={{ flex: 1.4, minWidth: 0, borderRight: `1px solid ${C.border}` }}>
+            <ReactFlow
+              nodes={nodes} edges={edges}
+              nodeTypes={nodeTypes} edgeTypes={edgeTypes}
+              onNodeClick={(_, n) => { const w = (n.data as any)?.worker; if (w) setSelWorker(w) }}
+              nodesDraggable={false} nodesConnectable={false} elementsSelectable
+              fitView fitViewOptions={{ maxZoom: 1, padding: 0.2 }} minZoom={0.2} maxZoom={1.5}
+              colorMode={effectiveTheme}
+            />
+          </div>
+          <div style={{ flex: 1, minWidth: 260, padding: 16, overflowY: 'auto' }}>
+            {sel ? (
+              <>
+                <div style={{ fontWeight: 600, color: C.fg, marginBottom: 2 }}>{sel.worker}</div>
+                <div style={{ fontSize: 11, color: C.fg2, marginBottom: 12 }}>Step {sel.step} · {sel.status}</div>
+                <div style={{ fontSize: 11, textTransform: 'uppercase', color: C.fg3, marginBottom: 6 }}>Output</div>
+                <Markdown variant="assistant">{sel.output || '(no output yet)'}</Markdown>
+                {sel.thinking && (
+                  <div style={{ marginTop: 14 }}>
+                    <button onClick={() => setShowThinking(s => !s)} style={{ ...secondaryBtn, fontSize: 11 }}>
+                      {showThinking ? 'Hide thinking' : 'Thinking ▸'}
+                    </button>
+                    {showThinking && <div style={{ marginTop: 8, fontSize: 12, color: C.fg2, whiteSpace: 'pre-wrap' }}>{sel.thinking}</div>}
+                  </div>
+                )}
+              </>
+            ) : (
+              <div style={{ fontSize: 12, color: C.fg3 }}>Select a worker to see its output.</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function TeamRunFlow(props: Props) {
+  return <ReactFlowProvider><TeamRunFlowInner {...props} /></ReactFlowProvider>
+}

--- a/codey-mac/src/components/TeamRunFlow.tsx
+++ b/codey-mac/src/components/TeamRunFlow.tsx
@@ -21,7 +21,7 @@ const secondaryBtn = { fontSize: 12, background: C.surface2, color: C.fg, border
 
 function TeamRunFlowInner({ turn, isStreaming, teamGraph, askingWorker, onClose }: Props) {
   const effectiveTheme = useEffectiveTheme()
-  const runs = useMemo(() => deriveWorkerRuns(turn, isStreaming), [turn.content, turn.thinkingByStep, isStreaming])
+  const runs = useMemo(() => deriveWorkerRuns(turn, isStreaming), [turn.content, turn.thinkingByStep, turn.toolCalls?.length, isStreaming])
   const graph: TeamGraph = useMemo(() => teamGraph ?? synthesizeChainGraph(runs), [teamGraph, runs])
   const statuses = useMemo(() => nodeStatuses(graph, runs, askingWorker), [graph, runs, askingWorker])
 

--- a/codey-mac/src/components/ToolCallList.tsx
+++ b/codey-mac/src/components/ToolCallList.tsx
@@ -11,7 +11,7 @@ import type { ToolCallEntry } from '../types'
  * Returns null when there are no rows and no `emptyHint` is given (matches the
  * single-agent panel, which hides the section entirely when empty).
  */
-export const ToolCallList: React.FC<{ toolCalls: ToolCallEntry[]; emptyHint?: string }> = ({ toolCalls, emptyHint }) => {
+export const ToolCallList: React.FC<{ toolCalls: ToolCallEntry[]; emptyHint?: string; minimal?: boolean }> = ({ toolCalls, emptyHint, minimal }) => {
   const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
 
   type Row =
@@ -54,7 +54,7 @@ export const ToolCallList: React.FC<{ toolCalls: ToolCallEntry[]; emptyHint?: st
         if (r.kind === 'info') {
           return (
             <div key={r.id} style={timelineStyles.infoRow}>
-              <span style={timelineStyles.iconInfo}>ⓘ</span>
+              {!minimal && <span style={timelineStyles.iconInfo}>ⓘ</span>}
               <span>{r.message}</span>
             </div>
           )
@@ -73,9 +73,21 @@ export const ToolCallList: React.FC<{ toolCalls: ToolCallEntry[]; emptyHint?: st
               style={{ ...timelineStyles.callRow, cursor: hasDetail ? 'pointer' : 'default' }}
               onClick={hasDetail ? toggle : undefined}
             >
-              <span style={r.done ? timelineStyles.iconDone : timelineStyles.iconRunning}>{icon}</span>
-              <span style={timelineStyles.tool}>{r.tool ?? '(tool)'}</span>
-              <span style={timelineStyles.callMsg}>{r.message}</span>
+              {minimal ? (
+                // Clean variant: drop the colored status icon and the redundant
+                // tool label (the message already reads "Read(foo.ts)"); keep a
+                // subtle chevron only when there's detail to expand.
+                <>
+                  <span style={timelineStyles.chevron}>{hasDetail ? (isOpen ? '⌄' : '›') : ''}</span>
+                  <span style={timelineStyles.callMsg}>{r.message || r.tool}</span>
+                </>
+              ) : (
+                <>
+                  <span style={r.done ? timelineStyles.iconDone : timelineStyles.iconRunning}>{icon}</span>
+                  <span style={timelineStyles.tool}>{r.tool ?? '(tool)'}</span>
+                  <span style={timelineStyles.callMsg}>{r.message}</span>
+                </>
+              )}
             </div>
             {hasDetail && isOpen && (
               <div style={timelineStyles.detail}>
@@ -108,6 +120,7 @@ const timelineStyles: Record<string, React.CSSProperties> = {
     padding: '2px 0',
   },
   tool: { color: C.fg2, flexShrink: 0 },
+  chevron: { color: C.fg3, width: 10, flexShrink: 0 },
   callMsg: { color: C.fg2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   iconRunning: { color: C.accent, width: 12, flexShrink: 0 },
   iconDone: { color: C.green, width: 12, flexShrink: 0 },

--- a/codey-mac/src/components/ToolCallList.tsx
+++ b/codey-mac/src/components/ToolCallList.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { C } from '../theme'
+import { ToolDetail } from './toolFormat'
+import type { ToolCallEntry } from '../types'
+
+/**
+ * Renders a stream of ToolCallEntry items as an expandable timeline.
+ * Shared by the single-agent TOOLS tab (`ToolTimeline`) and the team run-flow
+ * worker drawer, so both surfaces present tool calls identically.
+ *
+ * Returns null when there are no rows and no `emptyHint` is given (matches the
+ * single-agent panel, which hides the section entirely when empty).
+ */
+export const ToolCallList: React.FC<{ toolCalls: ToolCallEntry[]; emptyHint?: string }> = ({ toolCalls, emptyHint }) => {
+  const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
+
+  type Row =
+    | { kind: 'call'; id: string; tool?: string; input?: Record<string, unknown>; output?: string; done: boolean; message: string }
+    | { kind: 'info'; id: string; message: string }
+  const rows: Row[] = []
+  const startIdxById = new Map<string, number>()
+  for (const tc of toolCalls) {
+    if (tc.type === 'info') {
+      rows.push({ kind: 'info', id: tc.id, message: tc.message })
+      continue
+    }
+    if (tc.type === 'tool_start') {
+      const idx = rows.push({
+        kind: 'call', id: tc.id, tool: tc.tool, input: tc.input,
+        done: false, message: tc.message,
+      }) - 1
+      startIdxById.set(tc.id, idx)
+    } else { // tool_end
+      const idx = startIdxById.get(tc.id)
+      if (idx != null) {
+        const row = rows[idx] as Extract<Row, { kind: 'call' }>
+        row.done = true
+        if (tc.output) row.output = tc.output
+        if (tc.message) row.message = tc.message
+        startIdxById.delete(tc.id)
+      } else {
+        rows.push({
+          kind: 'call', id: tc.id, tool: tc.tool, output: tc.output,
+          done: true, message: tc.message,
+        })
+      }
+    }
+  }
+
+  if (rows.length === 0) return emptyHint ? <div style={timelineStyles.emptyHint}>{emptyHint}</div> : null
+  return (
+    <div style={timelineStyles.list}>
+      {rows.map(r => {
+        if (r.kind === 'info') {
+          return (
+            <div key={r.id} style={timelineStyles.infoRow}>
+              <span style={timelineStyles.iconInfo}>ⓘ</span>
+              <span>{r.message}</span>
+            </div>
+          )
+        }
+        const isOpen = expanded.has(r.id)
+        const hasDetail = !!r.input || !!r.output
+        const toggle = () => setExpanded(prev => {
+          const next = new Set(prev)
+          next.has(r.id) ? next.delete(r.id) : next.add(r.id)
+          return next
+        })
+        const icon = isOpen ? '▾' : '▶'
+        return (
+          <div key={r.id}>
+            <div
+              style={{ ...timelineStyles.callRow, cursor: hasDetail ? 'pointer' : 'default' }}
+              onClick={hasDetail ? toggle : undefined}
+            >
+              <span style={r.done ? timelineStyles.iconDone : timelineStyles.iconRunning}>{icon}</span>
+              <span style={timelineStyles.tool}>{r.tool ?? '(tool)'}</span>
+              <span style={timelineStyles.callMsg}>{r.message}</span>
+            </div>
+            {hasDetail && isOpen && (
+              <div style={timelineStyles.detail}>
+                <ToolDetail rawTool={r.tool} input={r.input ?? {}} output={r.output} />
+                {!r.done && !r.output && (
+                  <div style={timelineStyles.detailLabel}>(no result yet)</div>
+                )}
+                {r.done && !r.output && !r.input && (
+                  <div style={timelineStyles.detailLabel}>(no result)</div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+const timelineStyles: Record<string, React.CSSProperties> = {
+  list: { display: 'flex', flexDirection: 'column', gap: 4 },
+  emptyHint: { color: C.fg3, fontSize: 11 },
+  infoRow: {
+    display: 'flex', alignItems: 'flex-start', gap: 6,
+    color: C.fg3, fontSize: 11, fontStyle: 'italic',
+  },
+  callRow: {
+    display: 'flex', alignItems: 'flex-start', gap: 6,
+    fontSize: 12, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    padding: '2px 0',
+  },
+  tool: { color: C.fg2, flexShrink: 0 },
+  callMsg: { color: C.fg2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  iconRunning: { color: C.accent, width: 12, flexShrink: 0 },
+  iconDone: { color: C.green, width: 12, flexShrink: 0 },
+  iconInfo: { color: C.fg3, width: 12, flexShrink: 0 },
+  detail: {
+    marginLeft: 18, marginTop: 4, marginBottom: 6,
+    padding: 8, background: 'rgba(0,0,0,0.3)',
+    border: `1px solid ${C.border}`, borderRadius: 6,
+    maxHeight: 280, overflowY: 'auto',
+  },
+  detailLabel: { color: C.fg3, fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 4 },
+}

--- a/codey-mac/src/components/flowGraph.tsx
+++ b/codey-mac/src/components/flowGraph.tsx
@@ -1,0 +1,122 @@
+import {
+  Handle, Position, NodeResizer,
+  BaseEdge, EdgeLabelRenderer, getBezierPath,
+  type NodeProps, type EdgeProps,
+} from '@xyflow/react'
+import { C } from '../theme'
+import type { NodeRunStatus } from './teamRunModel'
+
+export const EDGE_COLOR = C.accent
+
+export const resolveColor = (cssVar: string) =>
+  getComputedStyle(document.documentElement).getPropertyValue(cssVar.slice(4, -1)).trim()
+
+const HANDLE_IDS = ['t', 'r', 'b', 'l'] as const
+const HANDLE_POS = { t: Position.Top, r: Position.Right, b: Position.Bottom, l: Position.Left }
+
+function NodeHandles() {
+  return (
+    <>
+      {HANDLE_IDS.map(id => (
+        <Handle key={id} type="source" id={id} position={HANDLE_POS[id]} style={{ width: 9, height: 9, background: C.accent }} />
+      ))}
+    </>
+  )
+}
+
+function ring(selected?: boolean, bad?: boolean): string | undefined {
+  if (selected) return `0 0 0 3px ${C.accent}, 0 0 14px 2px ${C.accent}`
+  if (bad) return `0 0 0 1px ${C.red}`
+  return undefined
+}
+
+// Status-driven accents for the read-only run view. Returns undefined for
+// authoring (no status) so FlowEditor renders exactly as before.
+function statusBorder(status?: NodeRunStatus): string | undefined {
+  switch (status) {
+    case 'done': return C.green
+    case 'running': return C.accent
+    case 'failed': return C.red
+    case 'askedUser': return C.accent
+    default: return undefined
+  }
+}
+function statusGlow(status?: NodeRunStatus): string | undefined {
+  if (status === 'running') return `0 0 12px 1px ${C.accent}`
+  return undefined
+}
+const STATUS_ICON: Record<NodeRunStatus, string> = {
+  done: '✓', running: '◐', failed: '✕', askedUser: '？', pending: '○',
+}
+
+export function WorkerNodeView({ data, selected }: NodeProps) {
+  const d = data as { label: string; role?: string; bad?: boolean; status?: NodeRunStatus }
+  const sBorder = statusBorder(d.status)
+  return (
+    <div style={{ minWidth: 100, padding: '8px 12px', borderRadius: 8, background: C.surface2, border: `1px solid ${d.bad ? C.red : sBorder ?? C.border}`, color: C.fg, boxSizing: 'border-box', boxShadow: ring(selected, d.bad) ?? statusGlow(d.status), opacity: d.status === 'pending' ? 0.5 : 1 }}>
+      <NodeResizer isVisible={selected} minWidth={100} minHeight={44} />
+      <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap' }}>
+        {d.status && <span style={{ marginRight: 6, color: sBorder ?? C.fg2 }}>{STATUS_ICON[d.status]}</span>}
+        {d.label}
+      </div>
+      {d.role && <div style={{ fontSize: 11, color: C.fg2, marginTop: 2, maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
+      <NodeHandles />
+    </div>
+  )
+}
+
+export function ConditionNodeView({ data, selected }: NodeProps) {
+  const d = data as { condition?: string; bad?: boolean }
+  const text = d.condition?.trim() || 'condition?'
+  return (
+    <div style={{ width: 130, height: 130, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+      <div style={{ position: 'absolute', inset: 19, transform: 'rotate(45deg)', background: C.surface2, border: `1px solid ${d.bad ? C.red : C.accent}`, borderRadius: 8, boxShadow: ring(selected, d.bad) }} />
+      <span style={{ position: 'relative', fontSize: 10, lineHeight: 1.25, color: C.fg, width: 78, textAlign: 'center', display: '-webkit-box', WebkitLineClamp: 5, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{text}</span>
+      <NodeHandles />
+    </div>
+  )
+}
+
+export function TerminalNodeView({ data, selected }: NodeProps) {
+  const d = data as { label: string; bad?: boolean }
+  return (
+    <div style={{ padding: '10px 22px', borderRadius: 999, background: C.bg, border: `1px solid ${d.bad ? C.red : C.border}`, color: C.fg, fontSize: 14, fontWeight: 600, boxShadow: ring(selected, d.bad) }}>
+      {d.label}
+      <NodeHandles />
+    </div>
+  )
+}
+
+export const nodeTypes = { workerNode: WorkerNodeView, conditionNode: ConditionNodeView, terminalNode: TerminalNodeView }
+
+export function FlowEdgeView({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, label, data, selected }: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition })
+  const running = (data as any)?.running
+  const stroke = selected ? C.accent : running ? EDGE_COLOR : C.fg2
+  return (
+    <>
+      {selected && <path d={edgePath} fill="none" stroke={C.accent} strokeWidth={9} strokeLinecap="round" style={{ opacity: 0.25 }} />}
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ stroke, strokeWidth: selected ? 3.5 : 1.5 }} />
+      {running && (
+        <circle r={4} fill={stroke}>
+          <animateMotion dur="1.6s" repeatCount="indefinite" path={edgePath} rotate="auto" />
+        </circle>
+      )}
+      {label != null && label !== '' && (
+        <EdgeLabelRenderer>
+          <div style={{
+            position: 'absolute', transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            background: C.bg, color: C.fg2, fontSize: 10, padding: '1px 5px', borderRadius: 4,
+            border: `1px solid ${C.border}`, pointerEvents: 'none',
+          }}>{String(label)}</div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}
+
+export const edgeTypes = { flowEdge: FlowEdgeView }
+
+// data.type -> React Flow node type (mirrors the inline mapping FlowEditor used).
+export const rfNodeType = (t: string): string =>
+  t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'

--- a/codey-mac/src/components/teamMessageFormat.test.ts
+++ b/codey-mac/src/components/teamMessageFormat.test.ts
@@ -58,6 +58,59 @@ describe('parseTeamMessage', () => {
     ].join('\n')
     expect(parseTeamMessage(input)).toBeNull()
   })
+
+  // The Sequential / `all` dispatch paths (authored-graph teams) emit a
+  // different transcript than the `### Step` auto/advisor format: a
+  // "📊 Team **X** flow results" header followed by "**worker**:" blocks,
+  // optionally trailed by a "🧠 Team blackboard" section.
+  it('parses the Sequential "flow results" / **worker**: format', () => {
+    const input = [
+      '📊 Team **Feature** flow results',
+      '',
+      '**product-manager**:',
+      'PM wrote the spec.',
+      '',
+      'It has **bold** mid-output and a blank line.',
+      '',
+      '**architect**:',
+      'Design done.',
+    ].join('\n')
+    const r = parseTeamMessage(input)
+    expect(r).not.toBeNull()
+    expect(r!.steps).toHaveLength(2)
+    expect(r!.steps[0]).toEqual({
+      step: 1, worker: 'product-manager',
+      output: 'PM wrote the spec.\n\nIt has **bold** mid-output and a blank line.',
+    })
+    expect(r!.steps[1]).toMatchObject({ step: 2, worker: 'architect', output: 'Design done.' })
+  })
+
+  it('captures same-line worker output (failed step) and excludes the blackboard', () => {
+    const input = [
+      '📊 Team **Feature** flow results',
+      '',
+      '**product-manager**:',
+      'spec ok',
+      '',
+      '**developer**: ❌ Failed - build error',
+      '',
+      '---',
+      '',
+      '### 🧠 Team blackboard',
+      '',
+      '**Decisions:**',
+      '- *product-manager* — ship it',
+    ].join('\n')
+    const r = parseTeamMessage(input)
+    expect(r!.steps).toHaveLength(2)
+    expect(r!.steps[1]).toMatchObject({ step: 2, worker: 'developer', output: '❌ Failed - build error' })
+  })
+
+  it('also parses the "results" header without the "flow" word (all path)', () => {
+    const input = '📊 Team **Crew** results\n\n**alice**:\ndid a thing'
+    const r = parseTeamMessage(input)
+    expect(r!.steps).toEqual([{ step: 1, worker: 'alice', output: 'did a thing' }])
+  })
 })
 
 describe('extractPreview', () => {

--- a/codey-mac/src/components/teamMessageFormat.ts
+++ b/codey-mac/src/components/teamMessageFormat.ts
@@ -24,7 +24,7 @@ export function parseTeamMessage(content: string): ParsedTeamMessage | null {
     body = nl === -1 ? '' : body.slice(nl + 1).replace(/^\n+/, '')
   }
 
-  if (!body.startsWith('### Step ')) return null
+  if (!body.startsWith('### Step ')) return parseSequentialTeamMessage(content)
 
   const chunks = body.split('\n\n---\n\n')
   const steps: TeamStep[] = []
@@ -39,6 +39,54 @@ export function parseTeamMessage(content: string): ParsedTeamMessage | null {
   }
   if (steps.length === 0) return null
   return { summary, steps }
+}
+
+// The Sequential / `all` dispatch paths render a different transcript than the
+// `### Step` auto/advisor format. Shape (gateway `continueGraphRun` /
+// `runAllMembersInOrder`):
+//
+//   📊 Team **X** flow results
+//
+//   **worker-a**:
+//   <output, may span blank lines and contain **bold**>
+//
+//   **worker-b**: ❌ Failed - ...
+//
+//   ---
+//   ### 🧠 Team blackboard
+//   ...
+//
+// A "**name**:" worker header has its colon OUTSIDE the bold, which
+// distinguishes it from blackboard labels like "**Decisions:**" (colon inside).
+const SEQ_HEADER = /^📊 Team \*\*.+?\*\* (?:flow )?results\s*\n+/
+const BLACKBOARD_MARKER = '### 🧠 Team blackboard'
+const WORKER_HEADER = /^\*\*([^\n*]+?)\*\*:[ \t]?(.*)$/
+
+function parseSequentialTeamMessage(content: string): ParsedTeamMessage | null {
+  const header = content.match(SEQ_HEADER)
+  if (!header) return null
+  let body = content.slice(header[0].length)
+
+  // Drop the trailing blackboard section (and a preceding `---` separator).
+  const bbIdx = body.indexOf(BLACKBOARD_MARKER)
+  if (bbIdx !== -1) body = body.slice(0, bbIdx).replace(/\n*-{3,}\s*$/, '').trimEnd()
+
+  const steps: TeamStep[] = []
+  let current: { worker: string; lines: string[] } | null = null
+  const flush = () => {
+    if (current) steps.push({ step: steps.length + 1, worker: current.worker.trim(), output: current.lines.join('\n').trim() })
+  }
+  for (const line of body.split('\n')) {
+    const m = line.match(WORKER_HEADER)
+    if (m) {
+      flush()
+      current = { worker: m[1], lines: m[2] ? [m[2]] : [] }
+    } else if (current) {
+      current.lines.push(line)
+    }
+  }
+  flush()
+  return steps.length > 0 ? { summary: null, steps } : null
 }
 
 const MAX_PREVIEW = 120

--- a/codey-mac/src/components/teamRunModel.test.ts
+++ b/codey-mac/src/components/teamRunModel.test.ts
@@ -32,6 +32,48 @@ describe('deriveWorkerRuns', () => {
     expect(runs).toEqual([])
   })
 
+  // Mid-run, the Sequential transcript has no `**worker**:` structure yet —
+  // only live `info` step markers exist. deriveWorkerRuns must surface those so
+  // the overlay can highlight the active worker live.
+  it('derives live worker runs from info step markers when content is unstructured', () => {
+    const turn = teamTurn({
+      content: 'raw streamed tokens with no worker headers yet',
+      thinkingByStep: undefined,
+      toolCalls: [
+        { id: 'a', type: 'info', message: '🔄 Step 1: **product-manager** is working...' },
+        { id: 'b', type: 'info', message: '🔄 Step 2: **architect** is working...' },
+      ] as any,
+    })
+    const runs = deriveWorkerRuns(turn, true)
+    expect(runs).toHaveLength(2)
+    expect(runs[0]).toMatchObject({ step: 1, worker: 'product-manager', status: 'done' })
+    expect(runs[1]).toMatchObject({ step: 2, worker: 'architect', status: 'running' })
+  })
+
+  it('merges live info steps with structured output (output wins, live fills the running step)', () => {
+    const turn = teamTurn({
+      content: '📊 Team **Feature** flow results\n\n**product-manager**:\nPM done.',
+      thinkingByStep: undefined,
+      toolCalls: [
+        { id: 'a', type: 'info', message: '🔄 Step 1: **product-manager** is working...' },
+        { id: 'b', type: 'info', message: '🔄 Step 2: **architect** is working...' },
+      ] as any,
+    })
+    const runs = deriveWorkerRuns(turn, true)
+    expect(runs).toHaveLength(2)
+    expect(runs[0]).toMatchObject({ step: 1, worker: 'product-manager', output: 'PM done.', status: 'done' })
+    expect(runs[1]).toMatchObject({ step: 2, worker: 'architect', output: '', status: 'running' })
+  })
+
+  it('parses the auto-path info marker (Step N: worker — reason)', () => {
+    const turn = teamTurn({
+      content: 'unstructured', thinkingByStep: undefined,
+      toolCalls: [{ id: 'a', type: 'info', message: 'Step 1: alice — picked alice to start' }] as any,
+    })
+    const runs = deriveWorkerRuns(turn, true)
+    expect(runs[0]).toMatchObject({ step: 1, worker: 'alice', status: 'running' })
+  })
+
   // Authored-graph (Sequential) teams emit the "flow results" / **worker**:
   // transcript, not the `### Step` format. deriveWorkerRuns must handle it too.
   it('derives runs from the Sequential "flow results" transcript', () => {

--- a/codey-mac/src/components/teamRunModel.test.ts
+++ b/codey-mac/src/components/teamRunModel.test.ts
@@ -31,6 +31,23 @@ describe('deriveWorkerRuns', () => {
     const runs = deriveWorkerRuns(teamTurn({ content: 'just a normal reply' }), false)
     expect(runs).toEqual([])
   })
+
+  // Authored-graph (Sequential) teams emit the "flow results" / **worker**:
+  // transcript, not the `### Step` format. deriveWorkerRuns must handle it too.
+  it('derives runs from the Sequential "flow results" transcript', () => {
+    const content = [
+      '📊 Team **Feature** flow results',
+      '',
+      '**product-manager**:',
+      'PM output here.',
+      '',
+      '**developer**: ❌ Failed - build error',
+    ].join('\n')
+    const runs = deriveWorkerRuns(teamTurn({ content, thinkingByStep: undefined }), false)
+    expect(runs).toHaveLength(2)
+    expect(runs[0]).toMatchObject({ step: 1, worker: 'product-manager', output: 'PM output here.', status: 'done' })
+    expect(runs[1]).toMatchObject({ step: 2, worker: 'developer', status: 'failed' })
+  })
 })
 
 import { synthesizeChainGraph, nodeStatuses } from './teamRunModel'

--- a/codey-mac/src/components/teamRunModel.test.ts
+++ b/codey-mac/src/components/teamRunModel.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { deriveWorkerRuns } from './teamRunModel'
+import type { ChatMessage } from '../types'
+
+const teamTurn = (over: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: 't1', role: 'assistant', timestamp: 0, isComplete: true,
+  content: '### Step 1: product-manager\n\nPM output here.\n\n---\n\n### Step 2: developer\n\n❌ Failed - build error',
+  thinkingByStep: { 1: 'pm reasoning', 2: 'dev reasoning' },
+  ...over,
+})
+
+describe('deriveWorkerRuns', () => {
+  it('maps each step to a worker run with output and thinking', () => {
+    const runs = deriveWorkerRuns(teamTurn(), false)
+    expect(runs).toHaveLength(2)
+    expect(runs[0]).toMatchObject({ step: 1, worker: 'product-manager', output: 'PM output here.', thinking: 'pm reasoning', status: 'done' })
+    expect(runs[1]).toMatchObject({ step: 2, worker: 'developer', thinking: 'dev reasoning' })
+  })
+
+  it('marks the last step running while streaming', () => {
+    const runs = deriveWorkerRuns(teamTurn(), true)
+    expect(runs[1].status).toBe('running')
+  })
+
+  it('marks a failed-output step failed when not streaming', () => {
+    const runs = deriveWorkerRuns(teamTurn(), false)
+    expect(runs[1].status).toBe('failed')
+  })
+
+  it('returns [] for a non-team turn', () => {
+    const runs = deriveWorkerRuns(teamTurn({ content: 'just a normal reply' }), false)
+    expect(runs).toEqual([])
+  })
+})

--- a/codey-mac/src/components/teamRunModel.test.ts
+++ b/codey-mac/src/components/teamRunModel.test.ts
@@ -92,9 +92,33 @@ describe('deriveWorkerRuns', () => {
   })
 })
 
-import { synthesizeChainGraph, nodeStatuses } from './teamRunModel'
+import { synthesizeChainGraph, nodeStatuses, toolCallsForStep } from './teamRunModel'
 import type { WorkerRun } from './teamRunModel'
 import { validateGraph } from '../../../packages/core/src/team-graph'
+
+describe('toolCallsForStep', () => {
+  const calls = [
+    { id: 'm1', type: 'info', message: '🔄 Step 1: **product-manager** is working...' },
+    { id: 't1', type: 'tool_start', tool: 'Read', message: 'reading spec', input: { file: 'a' } },
+    { id: 't1', type: 'tool_end', tool: 'Read', output: 'contents' },
+    { id: 'm2', type: 'info', message: '🔄 Step 2: **developer** is working...' },
+    { id: 't2', type: 'tool_start', tool: 'Edit', message: 'editing' },
+  ] as any
+
+  it('returns only the tool calls that belong to a step', () => {
+    expect(toolCallsForStep(calls, 1).map(c => c.id)).toEqual(['t1', 't1'])
+    expect(toolCallsForStep(calls, 2).map(c => c.id)).toEqual(['t2'])
+  })
+
+  it('excludes the info step markers themselves', () => {
+    expect(toolCallsForStep(calls, 1).some(c => c.type === 'info')).toBe(false)
+  })
+
+  it('returns [] for a step with no tool calls or missing toolCalls', () => {
+    expect(toolCallsForStep(calls, 3)).toEqual([])
+    expect(toolCallsForStep(undefined, 1)).toEqual([])
+  })
+})
 
 const run = (step: number, worker: string, status: WorkerRun['status']): WorkerRun =>
   ({ step, worker, status, output: 'o' })

--- a/codey-mac/src/components/teamRunModel.test.ts
+++ b/codey-mac/src/components/teamRunModel.test.ts
@@ -32,3 +32,53 @@ describe('deriveWorkerRuns', () => {
     expect(runs).toEqual([])
   })
 })
+
+import { synthesizeChainGraph, nodeStatuses } from './teamRunModel'
+import type { WorkerRun } from './teamRunModel'
+import { validateGraph } from '../../../packages/core/src/team-graph'
+
+const run = (step: number, worker: string, status: WorkerRun['status']): WorkerRun =>
+  ({ step, worker, status, output: 'o' })
+
+describe('synthesizeChainGraph', () => {
+  it('builds start -> w1 -> w2 -> end and validates', () => {
+    const runs = [run(1, 'pm', 'done'), run(2, 'dev', 'running')]
+    const g = synthesizeChainGraph(runs)
+    expect(g.entry).toBe('start')
+    expect(g.nodes.find(n => n.type === 'start')).toBeTruthy()
+    expect(g.nodes.find(n => n.type === 'end')).toBeTruthy()
+    expect(g.nodes.filter(n => n.type === 'worker').map(n => n.worker)).toEqual(['pm', 'dev'])
+    expect(validateGraph(g, ['pm', 'dev'])).toEqual([])
+  })
+
+  it('dedupes a revisited worker into one node', () => {
+    const g = synthesizeChainGraph([run(1, 'pm', 'done'), run(2, 'dev', 'done'), run(3, 'pm', 'done')])
+    expect(g.nodes.filter(n => n.type === 'worker')).toHaveLength(2)
+  })
+})
+
+describe('nodeStatuses', () => {
+  it('maps run status onto matching worker nodes, pending for unreached', () => {
+    const runs = [run(1, 'pm', 'done')]
+    const g = synthesizeChainGraph([run(1, 'pm', 'done'), run(2, 'dev', 'done')])
+    const st = nodeStatuses(g, runs)
+    const pmNode = g.nodes.find(n => n.worker === 'pm')!
+    const devNode = g.nodes.find(n => n.worker === 'dev')!
+    expect(st[pmNode.id]).toBe('done')
+    expect(st[devNode.id]).toBe('pending')
+  })
+
+  it('marks the asking worker askedUser', () => {
+    const g = synthesizeChainGraph([run(1, 'pm', 'done'), run(2, 'dev', 'running')])
+    const st = nodeStatuses(g, [run(1, 'pm', 'done'), run(2, 'dev', 'running')], 'dev')
+    const devNode = g.nodes.find(n => n.worker === 'dev')!
+    expect(st[devNode.id]).toBe('askedUser')
+  })
+
+  it('end is pending while a run is running, done otherwise', () => {
+    const g = synthesizeChainGraph([run(1, 'pm', 'done')])
+    const endId = g.nodes.find(n => n.type === 'end')!.id
+    expect(nodeStatuses(g, [run(1, 'pm', 'running')])[endId]).toBe('pending')
+    expect(nodeStatuses(g, [run(1, 'pm', 'done')])[endId]).toBe('done')
+  })
+})

--- a/codey-mac/src/components/teamRunModel.ts
+++ b/codey-mac/src/components/teamRunModel.ts
@@ -11,7 +11,8 @@ export interface WorkerRun {
   thinking?: string
 }
 
-const FAILED_RE = /❌|\bFailed\b/
+// Gateway marks a failed team step with a leading ❌ in its output.
+const FAILED_RE = /❌/
 
 export function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): WorkerRun[] {
   const parsed = parseTeamMessage(turn.content)

--- a/codey-mac/src/components/teamRunModel.ts
+++ b/codey-mac/src/components/teamRunModel.ts
@@ -56,6 +56,22 @@ export function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): Worke
   })
 }
 
+// Attribute tool calls to a step. Team runs are serial, so each tool event
+// belongs to the most-recent preceding `🔄 Step N:` / `Step N:` marker in the
+// stream. Returns only tool_start/tool_end entries (not the info markers).
+export function toolCallsForStep(toolCalls: ToolCallEntry[] | undefined, step: number): ToolCallEntry[] {
+  const out: ToolCallEntry[] = []
+  let current = 0
+  for (const tc of toolCalls ?? []) {
+    if (tc.type === 'info' && tc.message) {
+      const m = tc.message.match(LIVE_SEQ) ?? tc.message.match(LIVE_AUTO)
+      if (m) { current = parseInt(m[1], 10); continue }
+    }
+    if ((tc.type === 'tool_start' || tc.type === 'tool_end') && current === step) out.push(tc)
+  }
+  return out
+}
+
 export function synthesizeChainGraph(runs: WorkerRun[]): TeamGraph {
   const workers: string[] = []
   for (const r of runs) if (!workers.includes(r.worker)) workers.push(r.worker)

--- a/codey-mac/src/components/teamRunModel.ts
+++ b/codey-mac/src/components/teamRunModel.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from '../types'
+import type { ChatMessage, ToolCallEntry } from '../types'
 import { parseTeamMessage } from './teamMessageFormat'
 import type { TeamGraph, TeamGraphNode, TeamGraphEdge } from '../../../packages/core/src/team-graph'
 
@@ -15,16 +15,44 @@ export interface WorkerRun {
 // Gateway marks a failed team step with a leading ❌ in its output.
 const FAILED_RE = /❌/
 
+// Live per-step "is working" markers streamed as `info` events. The structured
+// `**worker**:` transcript only lands when the run completes, so mid-run these
+// are the only signal of which worker is active.
+//   Sequential: "🔄 Step 1: **product-manager** is working..."
+//   Auto:       "Step 1: alice — <reason>"  (optionally " (revision)")
+const LIVE_SEQ = /^🔄 Step (\d+): \*\*(.+?)\*\* is working/
+const LIVE_AUTO = /^Step (\d+): (.+?)(?: —|$)/
+
+function parseLiveSteps(toolCalls?: ToolCallEntry[]): Array<{ step: number; worker: string }> {
+  const byStep = new Map<number, string>()
+  for (const tc of toolCalls ?? []) {
+    if (tc.type !== 'info' || !tc.message) continue
+    const m = tc.message.match(LIVE_SEQ) ?? tc.message.match(LIVE_AUTO)
+    if (m) byStep.set(parseInt(m[1], 10), m[2].trim())
+  }
+  return [...byStep.entries()].map(([step, worker]) => ({ step, worker })).sort((a, b) => a.step - b.step)
+}
+
 export function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): WorkerRun[] {
-  const parsed = parseTeamMessage(turn.content)
-  if (!parsed || parsed.steps.length === 0) return []
-  const lastStep = parsed.steps[parsed.steps.length - 1].step
-  return parsed.steps.map(s => {
+  // Structured transcript (has per-worker output) — authoritative once present.
+  const contentSteps = parseTeamMessage(turn.content)?.steps ?? []
+  // Live `info` markers — present from the moment each worker starts.
+  const liveSteps = parseLiveSteps(turn.toolCalls)
+  if (contentSteps.length === 0 && liveSteps.length === 0) return []
+
+  // Merge by step number; content wins (it carries the worker's output).
+  const byStep = new Map<number, { worker: string; output: string }>()
+  for (const s of liveSteps) byStep.set(s.step, { worker: s.worker, output: '' })
+  for (const s of contentSteps) byStep.set(s.step, { worker: s.worker, output: s.output })
+
+  const ordered = [...byStep.entries()].sort((a, b) => a[0] - b[0])
+  const lastStep = ordered[ordered.length - 1][0]
+  return ordered.map(([step, v]) => {
     const status: NodeRunStatus =
-      isStreaming && s.step === lastStep ? 'running'
-      : FAILED_RE.test(s.output) ? 'failed'
+      isStreaming && step === lastStep ? 'running'
+      : FAILED_RE.test(v.output) ? 'failed'
       : 'done'
-    return { step: s.step, worker: s.worker, status, output: s.output, thinking: turn.thinkingByStep?.[s.step] }
+    return { step, worker: v.worker, status, output: v.output, thinking: turn.thinkingByStep?.[step] }
   })
 }
 

--- a/codey-mac/src/components/teamRunModel.ts
+++ b/codey-mac/src/components/teamRunModel.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage } from '../types'
 import { parseTeamMessage } from './teamMessageFormat'
+import type { TeamGraph, TeamGraphNode, TeamGraphEdge } from '../../../packages/core/src/team-graph'
 
 export type NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'
 
@@ -25,4 +26,34 @@ export function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): Worke
       : 'done'
     return { step: s.step, worker: s.worker, status, output: s.output, thinking: turn.thinkingByStep?.[s.step] }
   })
+}
+
+export function synthesizeChainGraph(runs: WorkerRun[]): TeamGraph {
+  const workers: string[] = []
+  for (const r of runs) if (!workers.includes(r.worker)) workers.push(r.worker)
+  const nodes: TeamGraphNode[] = [{ id: 'start', type: 'start', x: 120, y: 40 }]
+  workers.forEach((w, i) => nodes.push({ id: `w_${i}`, type: 'worker', worker: w, x: 120, y: 120 + i * 90 }))
+  nodes.push({ id: 'end', type: 'end', x: 120, y: 120 + workers.length * 90 })
+
+  const order = ['start', ...workers.map((_, i) => `w_${i}`), 'end']
+  const edges: TeamGraphEdge[] = []
+  for (let i = 0; i < order.length - 1; i++) edges.push({ id: `e_${i}`, from: order[i], to: order[i + 1] })
+  return { entry: 'start', maxHops: workers.length + 2, nodes, edges }
+}
+
+export function nodeStatuses(graph: TeamGraph, runs: WorkerRun[], askingWorker?: string): Record<string, NodeRunStatus> {
+  const latest = new Map<string, NodeRunStatus>()
+  for (const r of runs) latest.set(r.worker, r.status) // later runs overwrite -> latest wins
+  const anyRunning = runs.some(r => r.status === 'running')
+  const out: Record<string, NodeRunStatus> = {}
+  for (const n of graph.nodes) {
+    if (n.type === 'start') out[n.id] = 'done'
+    else if (n.type === 'end') out[n.id] = runs.length && !anyRunning ? 'done' : 'pending'
+    else if (n.type === 'worker' && n.worker) {
+      if (askingWorker && n.worker === askingWorker) out[n.id] = 'askedUser'
+      else out[n.id] = latest.get(n.worker) ?? 'pending'
+    }
+    // condition nodes: omitted -> neutral default styling
+  }
+  return out
 }

--- a/codey-mac/src/components/teamRunModel.ts
+++ b/codey-mac/src/components/teamRunModel.ts
@@ -1,0 +1,27 @@
+import type { ChatMessage } from '../types'
+import { parseTeamMessage } from './teamMessageFormat'
+
+export type NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'
+
+export interface WorkerRun {
+  step: number
+  worker: string
+  status: NodeRunStatus
+  output: string
+  thinking?: string
+}
+
+const FAILED_RE = /❌|\bFailed\b/
+
+export function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): WorkerRun[] {
+  const parsed = parseTeamMessage(turn.content)
+  if (!parsed || parsed.steps.length === 0) return []
+  const lastStep = parsed.steps[parsed.steps.length - 1].step
+  return parsed.steps.map(s => {
+    const status: NodeRunStatus =
+      isStreaming && s.step === lastStep ? 'running'
+      : FAILED_RE.test(s.output) ? 'failed'
+      : 'done'
+    return { step: s.step, worker: s.worker, status, output: s.output, thinking: turn.thinkingByStep?.[s.step] }
+  })
+}

--- a/docs/superpowers/plans/2026-06-18-team-run-flow-view.md
+++ b/docs/superpowers/plans/2026-06-18-team-run-flow-view.md
@@ -1,0 +1,654 @@
+# Team Run Flow View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In team mode, add a full-screen flow-graph overlay where each worker is a node and clicking a worker shows that worker's output and thinking.
+
+**Architecture:** Three new Mac-only pieces — a pure run-model deriver (`teamRunModel.ts`), a shared graph renderer extracted from `FlowEditor.tsx` (`flowGraph.tsx`), and the overlay (`TeamRunFlow.tsx`) — wired into `ChatContextPanel`/`ChatTab`. No `packages/core` or `packages/gateway` changes. Per-worker tool calls are a deferred follow-up (the gateway doesn't stream them today).
+
+**Tech Stack:** React + TypeScript, `@xyflow/react` (React Flow), Vitest. Spec: `docs/superpowers/specs/2026-06-18-team-run-flow-view-design.md`.
+
+**Setup note:** Tests need Node ≥ 22 (`nvm use 22.17.1`). Run codey-mac tests with `npm test -w codey-mac` (which runs `vitest run`); target one file by appending the path.
+
+---
+
+### Task 1: Run-model deriver — `deriveWorkerRuns`
+
+**Files:**
+- Create: `codey-mac/src/components/teamRunModel.ts`
+- Test: `codey-mac/src/components/teamRunModel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// codey-mac/src/components/teamRunModel.test.ts
+import { describe, it, expect } from 'vitest'
+import { deriveWorkerRuns } from './teamRunModel'
+import type { ChatMessage } from '../types'
+
+const teamTurn = (over: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: 't1', role: 'assistant', timestamp: 0, isComplete: true,
+  content: '### Step 1: product-manager\n\nPM output here.\n\n---\n\n### Step 2: developer\n\n❌ Failed - build error',
+  thinkingByStep: { 1: 'pm reasoning', 2: 'dev reasoning' },
+  ...over,
+})
+
+describe('deriveWorkerRuns', () => {
+  it('maps each step to a worker run with output and thinking', () => {
+    const runs = deriveWorkerRuns(teamTurn(), false)
+    expect(runs).toHaveLength(2)
+    expect(runs[0]).toMatchObject({ step: 1, worker: 'product-manager', output: 'PM output here.', thinking: 'pm reasoning', status: 'done' })
+    expect(runs[1]).toMatchObject({ step: 2, worker: 'developer', thinking: 'dev reasoning' })
+  })
+
+  it('marks the last step running while streaming', () => {
+    const runs = deriveWorkerRuns(teamTurn(), true)
+    expect(runs[1].status).toBe('running')
+  })
+
+  it('marks a failed-output step failed when not streaming', () => {
+    const runs = deriveWorkerRuns(teamTurn(), false)
+    expect(runs[1].status).toBe('failed')
+  })
+
+  it('returns [] for a non-team turn', () => {
+    const runs = deriveWorkerRuns(teamTurn({ content: 'just a normal reply' }), false)
+    expect(runs).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -w codey-mac -- teamRunModel`
+Expected: FAIL — `deriveWorkerRuns` is not exported / module missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// codey-mac/src/components/teamRunModel.ts
+import type { ChatMessage } from '../types'
+import { parseTeamMessage } from './teamMessageFormat'
+
+export type NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'
+
+export interface WorkerRun {
+  step: number
+  worker: string
+  status: NodeRunStatus
+  output: string
+  thinking?: string
+}
+
+const FAILED_RE = /❌|\bFailed\b/
+
+export function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): WorkerRun[] {
+  const parsed = parseTeamMessage(turn.content)
+  if (!parsed || parsed.steps.length === 0) return []
+  const lastStep = parsed.steps[parsed.steps.length - 1].step
+  return parsed.steps.map(s => {
+    const status: NodeRunStatus =
+      isStreaming && s.step === lastStep ? 'running'
+      : FAILED_RE.test(s.output) ? 'failed'
+      : 'done'
+    return { step: s.step, worker: s.worker, status, output: s.output, thinking: turn.thinkingByStep?.[s.step] }
+  })
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -w codey-mac -- teamRunModel`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/teamRunModel.ts codey-mac/src/components/teamRunModel.test.ts
+git commit -m "feat(codey-mac): deriveWorkerRuns for team run flow view"
+```
+
+---
+
+### Task 2: Run-model deriver — `synthesizeChainGraph` + `nodeStatuses`
+
+**Files:**
+- Modify: `codey-mac/src/components/teamRunModel.ts`
+- Test: `codey-mac/src/components/teamRunModel.test.ts`
+
+- [ ] **Step 1: Write the failing test** (append to the existing test file)
+
+```ts
+import { synthesizeChainGraph, nodeStatuses } from './teamRunModel'
+import type { WorkerRun } from './teamRunModel'
+import { validateGraph } from '../../../packages/core/src/team-graph'
+
+const run = (step: number, worker: string, status: WorkerRun['status']): WorkerRun =>
+  ({ step, worker, status, output: 'o' })
+
+describe('synthesizeChainGraph', () => {
+  it('builds start -> w1 -> w2 -> end and validates', () => {
+    const runs = [run(1, 'pm', 'done'), run(2, 'dev', 'running')]
+    const g = synthesizeChainGraph(runs)
+    expect(g.entry).toBe('start')
+    expect(g.nodes.find(n => n.type === 'start')).toBeTruthy()
+    expect(g.nodes.find(n => n.type === 'end')).toBeTruthy()
+    expect(g.nodes.filter(n => n.type === 'worker').map(n => n.worker)).toEqual(['pm', 'dev'])
+    expect(validateGraph(g, ['pm', 'dev'])).toEqual([])
+  })
+
+  it('dedupes a revisited worker into one node', () => {
+    const g = synthesizeChainGraph([run(1, 'pm', 'done'), run(2, 'dev', 'done'), run(3, 'pm', 'done')])
+    expect(g.nodes.filter(n => n.type === 'worker')).toHaveLength(2)
+  })
+})
+
+describe('nodeStatuses', () => {
+  it('maps run status onto matching worker nodes, pending for unreached', () => {
+    const runs = [run(1, 'pm', 'done')]
+    const g = synthesizeChainGraph([run(1, 'pm', 'done'), run(2, 'dev', 'done')])
+    const st = nodeStatuses(g, runs)
+    const pmNode = g.nodes.find(n => n.worker === 'pm')!
+    const devNode = g.nodes.find(n => n.worker === 'dev')!
+    expect(st[pmNode.id]).toBe('done')
+    expect(st[devNode.id]).toBe('pending')
+  })
+
+  it('marks the asking worker askedUser', () => {
+    const g = synthesizeChainGraph([run(1, 'pm', 'done'), run(2, 'dev', 'running')])
+    const st = nodeStatuses(g, [run(1, 'pm', 'done'), run(2, 'dev', 'running')], 'dev')
+    const devNode = g.nodes.find(n => n.worker === 'dev')!
+    expect(st[devNode.id]).toBe('askedUser')
+  })
+
+  it('end is pending while a run is running, done otherwise', () => {
+    const g = synthesizeChainGraph([run(1, 'pm', 'done')])
+    const endId = g.nodes.find(n => n.type === 'end')!.id
+    expect(nodeStatuses(g, [run(1, 'pm', 'running')])[endId]).toBe('pending')
+    expect(nodeStatuses(g, [run(1, 'pm', 'done')])[endId]).toBe('done')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -w codey-mac -- teamRunModel`
+Expected: FAIL — `synthesizeChainGraph` / `nodeStatuses` not exported.
+
+- [ ] **Step 3: Write minimal implementation** (append to `teamRunModel.ts`)
+
+```ts
+import type { TeamGraph, TeamGraphNode, TeamGraphEdge } from '../../../packages/core/src/team-graph'
+
+export function synthesizeChainGraph(runs: WorkerRun[]): TeamGraph {
+  const workers: string[] = []
+  for (const r of runs) if (!workers.includes(r.worker)) workers.push(r.worker)
+  const nodes: TeamGraphNode[] = [{ id: 'start', type: 'start', x: 120, y: 40 }]
+  workers.forEach((w, i) => nodes.push({ id: `w_${i}`, type: 'worker', worker: w, x: 120, y: 120 + i * 90 }))
+  nodes.push({ id: 'end', type: 'end', x: 120, y: 120 + workers.length * 90 })
+
+  const order = ['start', ...workers.map((_, i) => `w_${i}`), 'end']
+  const edges: TeamGraphEdge[] = []
+  for (let i = 0; i < order.length - 1; i++) edges.push({ id: `e_${i}`, from: order[i], to: order[i + 1] })
+  return { entry: 'start', maxHops: workers.length + 2, nodes, edges }
+}
+
+export function nodeStatuses(graph: TeamGraph, runs: WorkerRun[], askingWorker?: string): Record<string, NodeRunStatus> {
+  const latest = new Map<string, NodeRunStatus>()
+  for (const r of runs) latest.set(r.worker, r.status) // later runs overwrite -> latest wins
+  const anyRunning = runs.some(r => r.status === 'running')
+  const out: Record<string, NodeRunStatus> = {}
+  for (const n of graph.nodes) {
+    if (n.type === 'start') out[n.id] = 'done'
+    else if (n.type === 'end') out[n.id] = runs.length && !anyRunning ? 'done' : 'pending'
+    else if (n.type === 'worker' && n.worker) {
+      if (askingWorker && n.worker === askingWorker) out[n.id] = 'askedUser'
+      else out[n.id] = latest.get(n.worker) ?? 'pending'
+    }
+    // condition nodes: omitted -> neutral default styling
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -w codey-mac -- teamRunModel`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/teamRunModel.ts codey-mac/src/components/teamRunModel.test.ts
+git commit -m "feat(codey-mac): synthesizeChainGraph + nodeStatuses"
+```
+
+---
+
+### Task 3: Extract shared graph renderer into `flowGraph.tsx`
+
+This is a refactor: move the node/edge renderers and helpers out of `FlowEditor.tsx` into a shared module, add optional `status` styling to worker/terminal nodes, and have `FlowEditor` import them. **No behavior change to FlowEditor.**
+
+**Files:**
+- Create: `codey-mac/src/components/flowGraph.tsx`
+- Modify: `codey-mac/src/components/FlowEditor.tsx`
+
+- [ ] **Step 1: Create `flowGraph.tsx`** — move these verbatim from `FlowEditor.tsx` (lines 14–124): `EDGE_COLOR`, `resolveColor`, `HANDLE_IDS`, `HANDLE_POS`, `NodeHandles`, `ring`, `WorkerNodeView`, `ConditionNodeView`, `TerminalNodeView`, `nodeTypes`, `FlowEdgeView`, `edgeTypes`. Add the imports they need and the new `status` styling + `rfNodeType`. Full file:
+
+```tsx
+// codey-mac/src/components/flowGraph.tsx
+import {
+  Handle, Position, NodeResizer,
+  BaseEdge, EdgeLabelRenderer, getBezierPath,
+  type NodeProps, type EdgeProps,
+} from '@xyflow/react'
+import { C } from '../theme'
+import type { NodeRunStatus } from './teamRunModel'
+
+export const EDGE_COLOR = C.accent
+
+export const resolveColor = (cssVar: string) =>
+  getComputedStyle(document.documentElement).getPropertyValue(cssVar.slice(4, -1)).trim()
+
+const HANDLE_IDS = ['t', 'r', 'b', 'l'] as const
+const HANDLE_POS = { t: Position.Top, r: Position.Right, b: Position.Bottom, l: Position.Left }
+
+function NodeHandles() {
+  return (
+    <>
+      {HANDLE_IDS.map(id => (
+        <Handle key={id} type="source" id={id} position={HANDLE_POS[id]} style={{ width: 9, height: 9, background: C.accent }} />
+      ))}
+    </>
+  )
+}
+
+function ring(selected?: boolean, bad?: boolean): string | undefined {
+  if (selected) return `0 0 0 3px ${C.accent}, 0 0 14px 2px ${C.accent}`
+  if (bad) return `0 0 0 1px ${C.red}`
+  return undefined
+}
+
+// Status-driven accents for the read-only run view. Returns undefined for
+// authoring (no status) so FlowEditor renders exactly as before.
+function statusBorder(status?: NodeRunStatus): string | undefined {
+  switch (status) {
+    case 'done': return C.green
+    case 'running': return C.accent
+    case 'failed': return C.red
+    case 'askedUser': return C.accent
+    default: return undefined
+  }
+}
+function statusGlow(status?: NodeRunStatus): string | undefined {
+  if (status === 'running') return `0 0 12px 1px ${C.accent}`
+  return undefined
+}
+const STATUS_ICON: Record<NodeRunStatus, string> = {
+  done: '✓', running: '◐', failed: '✕', askedUser: '？', pending: '○',
+}
+
+export function WorkerNodeView({ data, selected }: NodeProps) {
+  const d = data as { label: string; role?: string; bad?: boolean; status?: NodeRunStatus }
+  const sBorder = statusBorder(d.status)
+  return (
+    <div style={{ minWidth: 100, padding: '8px 12px', borderRadius: 8, background: C.surface2, border: `1px solid ${d.bad ? C.red : sBorder ?? C.border}`, color: C.fg, boxSizing: 'border-box', boxShadow: ring(selected, d.bad) ?? statusGlow(d.status), opacity: d.status === 'pending' ? 0.5 : 1 }}>
+      <NodeResizer isVisible={selected} minWidth={100} minHeight={44} />
+      <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap' }}>
+        {d.status && <span style={{ marginRight: 6, color: sBorder ?? C.fg2 }}>{STATUS_ICON[d.status]}</span>}
+        {d.label}
+      </div>
+      {d.role && <div style={{ fontSize: 11, color: C.fg2, marginTop: 2, maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.role}</div>}
+      <NodeHandles />
+    </div>
+  )
+}
+
+export function ConditionNodeView({ data, selected }: NodeProps) {
+  const d = data as { condition?: string; bad?: boolean }
+  const text = d.condition?.trim() || 'condition?'
+  return (
+    <div style={{ width: 130, height: 130, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+      <div style={{ position: 'absolute', inset: 19, transform: 'rotate(45deg)', background: C.surface2, border: `1px solid ${d.bad ? C.red : C.accent}`, borderRadius: 8, boxShadow: ring(selected, d.bad) }} />
+      <span style={{ position: 'relative', fontSize: 10, lineHeight: 1.25, color: C.fg, width: 78, textAlign: 'center', display: '-webkit-box', WebkitLineClamp: 5, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{text}</span>
+      <NodeHandles />
+    </div>
+  )
+}
+
+export function TerminalNodeView({ data, selected }: NodeProps) {
+  const d = data as { label: string; bad?: boolean }
+  return (
+    <div style={{ padding: '10px 22px', borderRadius: 999, background: C.bg, border: `1px solid ${d.bad ? C.red : C.border}`, color: C.fg, fontSize: 14, fontWeight: 600, boxShadow: ring(selected, d.bad) }}>
+      {d.label}
+      <NodeHandles />
+    </div>
+  )
+}
+
+export const nodeTypes = { workerNode: WorkerNodeView, conditionNode: ConditionNodeView, terminalNode: TerminalNodeView }
+
+export function FlowEdgeView({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, label, data, selected }: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition })
+  const running = (data as any)?.running
+  const stroke = selected ? C.accent : running ? EDGE_COLOR : C.fg2
+  return (
+    <>
+      {selected && <path d={edgePath} fill="none" stroke={C.accent} strokeWidth={9} strokeLinecap="round" style={{ opacity: 0.25 }} />}
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ stroke, strokeWidth: selected ? 3.5 : 1.5 }} />
+      {running && (
+        <circle r={4} fill={stroke}>
+          <animateMotion dur="1.6s" repeatCount="indefinite" path={edgePath} rotate="auto" />
+        </circle>
+      )}
+      {label != null && label !== '' && (
+        <EdgeLabelRenderer>
+          <div style={{
+            position: 'absolute', transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            background: C.bg, color: C.fg2, fontSize: 10, padding: '1px 5px', borderRadius: 4,
+            border: `1px solid ${C.border}`, pointerEvents: 'none',
+          }}>{String(label)}</div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}
+
+export const edgeTypes = { flowEdge: FlowEdgeView }
+
+// data.type -> React Flow node type (mirrors the inline mapping FlowEditor used).
+export const rfNodeType = (t: string): string =>
+  t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'
+```
+
+- [ ] **Step 2: Update `FlowEditor.tsx` to import from `flowGraph`**
+
+Delete the moved blocks (lines 14–124: `EDGE_COLOR` through `const edgeTypes`) and the now-unused imports they pulled in (`Handle`, `Position`, `NodeResizer`, `BaseEdge`, `EdgeLabelRenderer`, `getBezierPath`, `NodeProps`, `EdgeProps` — keep any still used elsewhere in the file). Add:
+
+```tsx
+import { nodeTypes, edgeTypes, EDGE_COLOR, resolveColor, rfNodeType } from './flowGraph'
+```
+
+Then replace the inline node-type mapping at the old `FlowEditor.tsx:142-143`:
+
+```tsx
+    const t = (n.data as any).type
+    const rfType = t === 'worker' ? 'workerNode' : t === 'condition' ? 'conditionNode' : 'terminalNode'
+```
+
+with:
+
+```tsx
+    const t = (n.data as any).type
+    const rfType = rfNodeType(t)
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd codey-mac && npx tsc --noEmit`
+Expected: no errors. (Fix any leftover unused-import errors by trimming the `@xyflow/react` import list in `FlowEditor.tsx`.)
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+Run: `npm test -w codey-mac`
+Expected: PASS — existing `flowEditorModel`/other suites unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/flowGraph.tsx codey-mac/src/components/FlowEditor.tsx
+git commit -m "refactor(codey-mac): extract shared flow graph renderer with status styling"
+```
+
+---
+
+### Task 4: The overlay — `TeamRunFlow.tsx`
+
+**Files:**
+- Create: `codey-mac/src/components/TeamRunFlow.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// codey-mac/src/components/TeamRunFlow.tsx
+import { useMemo, useState, useEffect } from 'react'
+import { ReactFlow, ReactFlowProvider, type Node, type Edge } from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import type { ChatMessage } from '../types'
+import type { TeamGraph } from '../../../packages/core/src/team-graph'
+import { toFlow } from './flowEditorModel'
+import { nodeTypes, edgeTypes, rfNodeType } from './flowGraph'
+import { deriveWorkerRuns, synthesizeChainGraph, nodeStatuses } from './teamRunModel'
+import { C, useEffectiveTheme } from '../theme'
+import Markdown from './Markdown'
+
+interface Props {
+  turn: ChatMessage
+  isStreaming: boolean
+  teamGraph?: TeamGraph
+  askingWorker?: string
+  onClose: () => void
+}
+
+const secondaryBtn = { fontSize: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 12px', cursor: 'pointer' } as const
+
+function TeamRunFlowInner({ turn, isStreaming, teamGraph, askingWorker, onClose }: Props) {
+  const effectiveTheme = useEffectiveTheme()
+  const runs = useMemo(() => deriveWorkerRuns(turn, isStreaming), [turn.content, turn.thinkingByStep, isStreaming])
+  const graph: TeamGraph = useMemo(() => teamGraph ?? synthesizeChainGraph(runs), [teamGraph, runs])
+  const statuses = useMemo(() => nodeStatuses(graph, runs, askingWorker), [graph, runs, askingWorker])
+
+  const runByWorker = useMemo(() => {
+    const m = new Map<string, ReturnType<typeof deriveWorkerRuns>[number]>()
+    for (const r of runs) m.set(r.worker, r) // latest wins
+    return m
+  }, [runs])
+
+  const { nodes, edges } = useMemo(() => {
+    const f = toFlow(graph)
+    const rfNodes: Node[] = f.nodes.map(n => ({
+      ...n,
+      type: rfNodeType((n.data as any).type),
+      data: { ...n.data, status: statuses[n.id] },
+    })) as any
+    const rfEdges: Edge[] = f.edges.map(e => ({ ...e, type: 'flowEdge' })) as any
+    return { nodes: rfNodes, edges: rfEdges }
+  }, [graph, statuses])
+
+  // Default selection: the running worker, else the last run.
+  const [selWorker, setSelWorker] = useState<string | null>(null)
+  useEffect(() => {
+    if (selWorker && runByWorker.has(selWorker)) return
+    const running = runs.find(r => r.status === 'running')
+    setSelWorker((running ?? runs[runs.length - 1])?.worker ?? null)
+  }, [runs, selWorker, runByWorker])
+
+  const sel = selWorker ? runByWorker.get(selWorker) : undefined
+  const [showThinking, setShowThinking] = useState(false)
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: '90vw', height: '85vh', background: C.bg, border: `1px solid ${C.border}`, borderRadius: 10, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', borderBottom: `1px solid ${C.border}` }}>
+          <strong style={{ flex: 1 }}>Workflow run</strong>
+          <button onClick={onClose} style={secondaryBtn}>Close</button>
+        </div>
+        <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
+          <div style={{ flex: 1.4, minWidth: 0, borderRight: `1px solid ${C.border}` }}>
+            <ReactFlow
+              nodes={nodes} edges={edges}
+              nodeTypes={nodeTypes} edgeTypes={edgeTypes}
+              onNodeClick={(_, n) => { const w = (n.data as any)?.worker; if (w) setSelWorker(w) }}
+              nodesDraggable={false} nodesConnectable={false} elementsSelectable
+              fitView fitViewOptions={{ maxZoom: 1, padding: 0.2 }} minZoom={0.2} maxZoom={1.5}
+              colorMode={effectiveTheme}
+            />
+          </div>
+          <div style={{ flex: 1, minWidth: 260, padding: 16, overflowY: 'auto' }}>
+            {sel ? (
+              <>
+                <div style={{ fontWeight: 600, color: C.fg, marginBottom: 2 }}>{sel.worker}</div>
+                <div style={{ fontSize: 11, color: C.fg2, marginBottom: 12 }}>Step {sel.step} · {sel.status}</div>
+                <div style={{ fontSize: 11, textTransform: 'uppercase', color: C.fg3, marginBottom: 6 }}>Output</div>
+                <Markdown>{sel.output || '(no output yet)'}</Markdown>
+                {sel.thinking && (
+                  <div style={{ marginTop: 14 }}>
+                    <button onClick={() => setShowThinking(s => !s)} style={{ ...secondaryBtn, fontSize: 11 }}>
+                      {showThinking ? 'Hide thinking' : 'Thinking ▸'}
+                    </button>
+                    {showThinking && <div style={{ marginTop: 8, fontSize: 12, color: C.fg2, whiteSpace: 'pre-wrap' }}>{sel.thinking}</div>}
+                  </div>
+                )}
+              </>
+            ) : (
+              <div style={{ fontSize: 12, color: C.fg3 }}>Select a worker to see its output.</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function TeamRunFlow(props: Props) {
+  return <ReactFlowProvider><TeamRunFlowInner {...props} /></ReactFlowProvider>
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd codey-mac && npx tsc --noEmit`
+Expected: no errors. If `Markdown`'s export is named rather than default, adjust the import to match `FlowEditor`/`ChatTab` usage (`grep "import .*Markdown" codey-mac/src/components/ChatTab.tsx`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/components/TeamRunFlow.tsx
+git commit -m "feat(codey-mac): TeamRunFlow overlay (graph + worker output/thinking drawer)"
+```
+
+---
+
+### Task 5: Wire the trigger into `ChatContextPanel` + fetch graph in `ChatTab`
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatContextPanel.tsx`
+- Modify: `codey-mac/src/components/ChatTab.tsx`
+
+- [ ] **Step 1: Fetch the team graph in `ChatTab.tsx`**
+
+Near the existing teams refresh (`ChatTab.tsx:393`, `apiService.getTeams(ws).then(setTeamNames)`), add state and a fetch for the selected team's graph:
+
+```tsx
+const [panelTeamGraph, setPanelTeamGraph] = useState<import('../../../packages/core/src/team-graph').TeamGraph | undefined>(undefined)
+
+useEffect(() => {
+  if (!panelTeamName) { setPanelTeamGraph(undefined); return }
+  apiService.getGlobalTeams()
+    .then(teams => setPanelTeamGraph((teams[panelTeamName] as any)?.graph))
+    .catch(() => setPanelTeamGraph(undefined))
+}, [panelTeamName])
+```
+
+Pass it to the panel (at the existing `<ChatContextPanel ... teamName={panelTeamName}` around line 1391):
+
+```tsx
+              teamGraph={panelTeamGraph}
+```
+
+- [ ] **Step 2: Accept the prop + render the trigger/overlay in `ChatContextPanel.tsx`**
+
+Add to the `Props` interface (near `teamName`):
+
+```tsx
+  /** Authored flow graph for the chat's team, if any. */
+  teamGraph?: import('../../../packages/core/src/team-graph').TeamGraph
+```
+
+Add `teamGraph` to the destructured props (the list starting `effectiveAgent, effectiveModel, workerName, teamName, workingDir,`).
+
+Add overlay state at the top of the component body:
+
+```tsx
+  const [flowOpen, setFlowOpen] = React.useState(false)
+```
+
+In the `tab === 'current'` branch, replace the existing `TeamFlow` block:
+
+```tsx
+            {turn && (
+              <TeamFlow
+                turn={turn}
+                isStreaming={isTurnStreaming}
+                onScrollToStep={onScrollToStep}
+              />
+            )}
+```
+
+with a version that adds the button (only meaningful for team turns — `TeamFlow` already returns null for non-team turns, and `deriveWorkerRuns` echoes that):
+
+```tsx
+            {turn && teamName && (
+              <Section title="Team flow">
+                <button onClick={() => setFlowOpen(true)} style={{ fontSize: 12, background: C.surface2, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 12px', cursor: 'pointer', marginBottom: 8 }}>
+                  View flow ⤢
+                </button>
+              </Section>
+            )}
+            {turn && (
+              <TeamFlow
+                turn={turn}
+                isStreaming={isTurnStreaming}
+                onScrollToStep={onScrollToStep}
+              />
+            )}
+```
+
+Add the overlay mount just before the closing `</>` of the `tab === 'current'` branch (after the `{!turn && ...}` line):
+
+```tsx
+            {flowOpen && turn && (
+              <TeamRunFlow
+                turn={turn}
+                isStreaming={isTurnStreaming}
+                teamGraph={teamGraph}
+                askingWorker={chat.pendingTeam?.askingWorker}
+                onClose={() => setFlowOpen(false)}
+              />
+            )}
+```
+
+Add the import at the top of `ChatContextPanel.tsx`:
+
+```tsx
+import TeamRunFlow from './TeamRunFlow'
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd codey-mac && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Build the renderer to confirm no runtime import cycles**
+
+Run: `npm run build -w codey-mac` (or the app's existing build script — check `codey-mac/package.json` `scripts`)
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/ChatContextPanel.tsx codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(codey-mac): View flow button + TeamRunFlow overlay wiring"
+```
+
+---
+
+### Task 6: Manual verification
+
+- [ ] **Step 1:** Launch the Mac app, open a chat whose selection is a team, and run a multi-worker `/team` task.
+- [ ] **Step 2:** In the TOOLS tab, click **View flow ⤢**. Confirm: the graph matches the FlowEditor canvas style; the running worker glows and is auto-selected; the drawer shows that worker's output (Markdown) and a collapsible Thinking section.
+- [ ] **Step 3:** Click other worker nodes — the drawer swaps to each worker's output/thinking. Done workers show ✓, unreached show dim ○.
+- [ ] **Step 4:** Confirm an authored-graph team (one with a workflow in FlowEditor) renders its real branches; an `auto`/`parallel` team renders the synthesized chain.
+- [ ] **Step 5:** Toggle dark/light (and classic/terminal) — node colors and drawer stay legible.
+```
+

--- a/docs/superpowers/specs/2026-06-18-team-run-flow-view-design.md
+++ b/docs/superpowers/specs/2026-06-18-team-run-flow-view-design.md
@@ -1,0 +1,136 @@
+# Team Run Flow View — Design
+
+**Date:** 2026-06-18
+**Status:** Approved (brainstorm), pending implementation plan
+**Surface:** `codey-mac` (Mac app)
+
+## Problem
+
+When a `/team` run executes, the right-side context panel ("TOOLS" tab) shows a single **flat** list of tool calls and step-narration `info` lines for the whole team. There's no way to see the team as a *flow* or to focus on one worker's activity — every worker's Reads, Edits, and Bash calls are interleaved into one scroll. For multi-worker runs (the screenshot shows product-manager → architect → developer → code-reviewer) this is hard to follow.
+
+The user wants, **for team mode**, a dedicated **flow view** (a graph of workers) where clicking a worker reveals *that worker's* tool calls — not the flat list.
+
+## Goals
+
+- In team mode, offer a graph view of the run: each worker is a node, wired in the team's flow.
+- Clicking a worker node shows that worker's tool calls, status, duration, and thinking — isolated from other workers.
+- The graph is **live**: nodes reflect run state (done / running / pending / failed / asked-user) and update as the run progresses, including when opened mid-run.
+- The graph's visual style **matches the FlowEditor canvas** (same node renderers, theme tokens, dark/light behavior). This is an explicit requirement.
+
+## Non-goals
+
+- Editing the flow from this view (it is read-only; authoring stays in FlowEditor).
+- Changing how teams execute or how tool calls are streamed/persisted.
+- Replacing the existing flat `ToolTimeline` / `TeamFlow` step list in the panel — the overlay is additive, opened on demand.
+- Perfect tool-call attribution for **parallel** teams in this iteration (see Known Limitations).
+
+## Chosen approach (option B from brainstorm)
+
+A **full-screen overlay** (modeled on FlowEditor's modal chrome) launched from the TOOLS tab via a "View flow ⤢" button, visible only when the selected chat is a team and the current turn is a team run.
+
+- **Left:** a read-only, live React-Flow graph reusing FlowEditor's node/edge renderers.
+- **Right:** a worker drawer. Selecting a node fills it with that worker's tool calls (rendered with the existing `toolFormat` helpers), status, duration, and collapsed thinking.
+- The currently-running worker is auto-selected when the overlay opens.
+
+Rejected: A (vertical accordion in the narrow panel — too cramped for branching graphs) and C (mini-graph + expand — extra surface for little gain once B exists).
+
+## Architecture
+
+Three pieces: a **shared graph renderer** (extracted from FlowEditor), a **pure run-model deriver** (new, tested), and the **overlay component** that composes them.
+
+### 1. Shared graph renderer — `codey-mac/src/components/flowGraph.tsx` (new)
+
+Extract from `FlowEditor.tsx`, with **no behavior change to FlowEditor**:
+
+- `WorkerNodeView`, `ConditionNodeView`, `TerminalNodeView`, `nodeTypes`, `edgeTypes`
+- the `resolveColor()` CSS-var→hex helper and edge-marker styling
+- `toFlow(graph)` graph→React-Flow conversion
+
+FlowEditor imports these instead of defining them inline. The node views gain an optional `data.status?: NodeRunStatus` that, when present, drives status styling (border/glow/icon). When absent (authoring mode), nodes render exactly as today. This is what guarantees the run view "matches the canvas style" — it *is* the same renderer.
+
+`NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'`, mapped to tokens: done→`C.green`, running→`C.accent` (with glow), pending→dim + dashed `C.border2`, failed→`C.dangerFg`, askedUser→`C.blue`/info tone.
+
+### 2. Run-model deriver — `codey-mac/src/components/teamRunModel.ts` (new, pure, unit-tested)
+
+Pure functions, no React, mirroring `flowEditorModel.ts` / `teamMessageFormat.ts`:
+
+```ts
+interface WorkerRun {
+  step: number;
+  worker: string;
+  status: NodeRunStatus;
+  toolCalls: ToolCallEntry[];   // this worker's slice of the flat stream
+  thinking?: string;            // from turn.thinkingByStep[step]
+  output?: string;              // from parseTeamMessage step output
+}
+
+function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): WorkerRun[]
+function synthesizeChainGraph(runs: WorkerRun[]): TeamGraph
+function applyRunStatus(graph: TeamGraph, runs: WorkerRun[], pending?: PendingTeamState): TeamGraph  // returns graph whose node.data.status is set
+```
+
+**Attribution (the core trick):** the flat `turn.toolCalls` stream is already delimited by `info` entries whose message starts with `"Step N:"` (the same markers `TeamFlow` parses today). Walk the stream in order; each `info` "Step N:" marker opens a new slice; subsequent `tool_start`/`tool_end` entries belong to the worker at that step (worker name from `parseTeamMessage(turn.content).steps`). Pair each step with `turn.thinkingByStep[step]`. No core/gateway/data-model change is required — attribution is derived client-side from data the app already receives.
+
+**Status derivation:**
+- `done` — step completed (a later step's marker exists, or the turn is complete).
+- `running` — the last step while `isStreaming`.
+- `failed` — the step's output/tool slice contains an error (e.g. a `tool_end` error or the existing "❌ Failed" output marker).
+- `askedUser` — matches `chat.pendingTeam.askingWorker`.
+- `pending` — a graph worker node never reached by any step.
+- A worker visited multiple times (loop/revision) maps to one node showing the **latest** run's status and a run-count badge; the drawer lists each visit.
+
+### 3. Overlay — `codey-mac/src/components/TeamRunFlow.tsx` (new)
+
+Props: `{ turn, isStreaming, teamGraph?, pendingTeam?, onClose }`.
+
+- Resolves the graph: if the chat's team has an **authored** `TeamGraph` (the `graph` field already parsed in `GlobalTeamsSection`/`TeamsSection` and passed down), use it directly so real branches/loops render. Otherwise (auto/parallel/no graph) call `synthesizeChainGraph(runs)` to build a linear `start → w1 → … → wN → end` chain. Either way the same renderer draws it.
+- Runs `applyRunStatus` to light up nodes; re-derives on each render so it updates live.
+- Left pane: `<ReactFlow ... nodeTypes edgeTypes colorMode={effectiveTheme} fitView>` — identical config to FlowEditor (read-only: no `onConnect`/drag-to-edit handlers; `onNodeClick` selects).
+- Right drawer: selected worker's `WorkerRun` rendered with `ToolDetail`/`normalizeTool` from `toolFormat.tsx` (consistent with the flat timeline), status + duration header, collapsed thinking section. Auto-selects the `running` worker (else the last) on open.
+- Chrome mirrors FlowEditor's modal (fixed overlay, `C.bg` panel, `Close` using the existing `secondaryBtn` style).
+
+### 4. Panel integration — `ChatContextPanel.tsx`
+
+In the `tab === 'current'` branch, when `teamName` is set and a team `turn` exists, render a **"View flow ⤢"** button (in the existing `TeamFlow` Section header). Clicking opens `TeamRunFlow`. The flat `ToolTimeline`/`TeamFlow`/`FilesTouched` stay as-is for users who prefer the list.
+
+## Data flow
+
+```
+gateway team run ──stream──> useChats reducer ──> ChatMessage{ content, toolCalls[], thinkingByStep }
+                                                          │
+                              parseTeamMessage(content) ──┤── steps[] (step→worker, output)
+                              deriveWorkerRuns(turn) ─────┴── WorkerRun[] (slice toolCalls by "Step N:" info markers)
+                                                          │
+        team config.graph (authored) ─or─ synthesizeChainGraph(runs) ──> applyRunStatus ──> live graph
+                                                          │
+                                          TeamRunFlow: React-Flow (left) + worker drawer (right)
+```
+
+No new wire events, no changes to `packages/core` or `packages/gateway`.
+
+## Testing
+
+`codey-mac/src/components/teamRunModel.test.ts` (Vitest), covering:
+- Partition a flat `toolCalls` stream with `Step 1:`/`Step 2:` markers into correct per-worker slices.
+- Status derivation: running (streaming last step), done, failed (error slice), askedUser (matches `pendingTeam`), pending (unreached graph node).
+- Loop/revisit: same worker at steps 2 and 4 → one node, latest status, both visits in the drawer data.
+- `synthesizeChainGraph`: N runs → `start → w1 → … → wN → end` with valid edges (passes `validateGraph`).
+- Edge cases: no `info` markers (single implicit step), empty `toolCalls`, non-team turn → `deriveWorkerRuns` returns `[]`.
+
+Renderer extraction is covered by the existing app build + a manual visual pass in all four palettes (no snapshot infra today).
+
+## Known limitations
+
+- **Parallel teams:** sequential `Step N:` markers can't perfectly attribute interleaved concurrent tool calls. MVP attributes best-effort by marker order; nodes and per-worker thinking still render correctly. A robust fix is to tag tool events with an optional `step` at emit time (`ToolCallEntry.step?`, set in the gateway's `TeamEmitter`, which already threads `step` through `onThinking`) — deferred as a follow-up, not required for the sequential/auto case in the screenshot.
+- Duration per worker is shown only when derivable from existing data; no new timing instrumentation is added.
+
+## Files
+
+| File | Change |
+|---|---|
+| `codey-mac/src/components/flowGraph.tsx` | **new** — node/edge renderers + helpers extracted from FlowEditor; `status`-aware node styling |
+| `codey-mac/src/components/FlowEditor.tsx` | import renderers from `flowGraph`; no behavior change |
+| `codey-mac/src/components/teamRunModel.ts` | **new** — pure run-model deriver |
+| `codey-mac/src/components/teamRunModel.test.ts` | **new** — unit tests |
+| `codey-mac/src/components/TeamRunFlow.tsx` | **new** — overlay (graph + worker drawer) |
+| `codey-mac/src/components/ChatContextPanel.tsx` | "View flow ⤢" trigger in team mode; mount overlay |

--- a/docs/superpowers/specs/2026-06-18-team-run-flow-view-design.md
+++ b/docs/superpowers/specs/2026-06-18-team-run-flow-view-design.md
@@ -1,136 +1,137 @@
 # Team Run Flow View — Design
 
 **Date:** 2026-06-18
-**Status:** Approved (brainstorm), pending implementation plan
-**Surface:** `codey-mac` (Mac app)
+**Status:** Approved (brainstorm), revised after code audit — Mac-only scope
+**Surface:** `codey-mac` (Mac app) only
 
 ## Problem
 
-When a `/team` run executes, the right-side context panel ("TOOLS" tab) shows a single **flat** list of tool calls and step-narration `info` lines for the whole team. There's no way to see the team as a *flow* or to focus on one worker's activity — every worker's Reads, Edits, and Bash calls are interleaved into one scroll. For multi-worker runs (the screenshot shows product-manager → architect → developer → code-reviewer) this is hard to follow.
+When a `/team` run executes, the right-side context panel ("TOOLS" tab) shows a single **flat** list of step-narration `info` lines for the whole team. There's no way to see the team as a *flow* or to focus on one worker's contribution — every worker's output is interleaved into one scroll. For multi-worker runs (the screenshot shows product-manager → architect → developer → code-reviewer) this is hard to follow.
 
-The user wants, **for team mode**, a dedicated **flow view** (a graph of workers) where clicking a worker reveals *that worker's* tool calls — not the flat list.
+The user wants, **for team mode**, a dedicated **flow view** (a graph of workers) where clicking a worker reveals *that worker's* contribution — its output and reasoning.
+
+### Code audit finding (scope decision)
+
+Per-worker **tool calls** (Read/Edit/Bash) are not available to show: during a team run the chat surface uses `ChatEmitter` (`packages/gateway/src/team-emitter.ts`), which emits only `stream`, `thinking`, and `info` events — never `tool_start`/`tool_end`. The worker path `runWorkerStep` forwards an `onStatus` callback to the agent (`gateway.ts:164`), but the team dispatch loop passes none, so worker tool events are discarded. Surfacing them would require a gateway change.
+
+**Decision (user, 2026-06-18):** keep this iteration **Mac-only**. The worker drawer shows each worker's **output and thinking**, which are already available client-side (`parseTeamMessage` step output + `ChatMessage.thinkingByStep`). Per-worker tool calls are a **deferred follow-up** that needs the gateway to forward step-tagged tool events.
 
 ## Goals
 
 - In team mode, offer a graph view of the run: each worker is a node, wired in the team's flow.
-- Clicking a worker node shows that worker's tool calls, status, duration, and thinking — isolated from other workers.
-- The graph is **live**: nodes reflect run state (done / running / pending / failed / asked-user) and update as the run progresses, including when opened mid-run.
-- The graph's visual style **matches the FlowEditor canvas** (same node renderers, theme tokens, dark/light behavior). This is an explicit requirement.
+- Clicking a worker node shows that worker's output and thinking — isolated from other workers.
+- The graph is **live**: nodes reflect run state (done / running / failed / asked-user / pending) and update as the run progresses, including when opened mid-run.
+- The graph's visual style **matches the FlowEditor canvas** (same node renderers, theme tokens, dark/light behavior). Explicit requirement.
 
 ## Non-goals
 
-- Editing the flow from this view (it is read-only; authoring stays in FlowEditor).
-- Changing how teams execute or how tool calls are streamed/persisted.
-- Replacing the existing flat `ToolTimeline` / `TeamFlow` step list in the panel — the overlay is additive, opened on demand.
-- Perfect tool-call attribution for **parallel** teams in this iteration (see Known Limitations).
+- Editing the flow from this view (read-only; authoring stays in FlowEditor).
+- Per-worker tool calls (deferred — needs gateway forwarding, see Follow-up).
+- Changing how teams execute or stream (no `packages/core` / `packages/gateway` changes).
+- Replacing the existing flat `TeamFlow` step list — the overlay is additive, opened on demand.
 
 ## Chosen approach (option B from brainstorm)
 
 A **full-screen overlay** (modeled on FlowEditor's modal chrome) launched from the TOOLS tab via a "View flow ⤢" button, visible only when the selected chat is a team and the current turn is a team run.
 
 - **Left:** a read-only, live React-Flow graph reusing FlowEditor's node/edge renderers.
-- **Right:** a worker drawer. Selecting a node fills it with that worker's tool calls (rendered with the existing `toolFormat` helpers), status, duration, and collapsed thinking.
+- **Right:** a worker drawer. Selecting a node fills it with that worker's output (rendered via the existing `Markdown` component) and collapsed thinking, plus a status + step header.
 - The currently-running worker is auto-selected when the overlay opens.
 
 Rejected: A (vertical accordion in the narrow panel — too cramped for branching graphs) and C (mini-graph + expand — extra surface for little gain once B exists).
 
 ## Architecture
 
-Three pieces: a **shared graph renderer** (extracted from FlowEditor), a **pure run-model deriver** (new, tested), and the **overlay component** that composes them.
+Three pieces, all in `codey-mac`: a **shared graph renderer** (extracted from FlowEditor), a **pure run-model deriver** (new, tested), and the **overlay component** that composes them.
 
 ### 1. Shared graph renderer — `codey-mac/src/components/flowGraph.tsx` (new)
 
 Extract from `FlowEditor.tsx`, with **no behavior change to FlowEditor**:
 
 - `WorkerNodeView`, `ConditionNodeView`, `TerminalNodeView`, `nodeTypes`, `edgeTypes`
-- the `resolveColor()` CSS-var→hex helper and edge-marker styling
-- `toFlow(graph)` graph→React-Flow conversion
+- `FlowEdgeView`, `EDGE_COLOR`, the `resolveColor()` CSS-var→hex helper, `NodeHandles`, `ring()`
+- a `rfNodeType(t)` helper for the `data.type → 'workerNode'|'conditionNode'|'terminalNode'` mapping that currently lives inline at `FlowEditor.tsx:142-143`
 
 FlowEditor imports these instead of defining them inline. The node views gain an optional `data.status?: NodeRunStatus` that, when present, drives status styling (border/glow/icon). When absent (authoring mode), nodes render exactly as today. This is what guarantees the run view "matches the canvas style" — it *is* the same renderer.
 
-`NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'`, mapped to tokens: done→`C.green`, running→`C.accent` (with glow), pending→dim + dashed `C.border2`, failed→`C.dangerFg`, askedUser→`C.blue`/info tone.
+`NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'`, mapped to tokens: done→`C.green`, running→`C.accent` (with glow), pending→dim + dashed `C.border2`, failed→`C.red`, askedUser→`C.accent` (info tone). The status type is defined in `teamRunModel.ts` (no React) and imported here to avoid a circular dependency.
 
 ### 2. Run-model deriver — `codey-mac/src/components/teamRunModel.ts` (new, pure, unit-tested)
 
 Pure functions, no React, mirroring `flowEditorModel.ts` / `teamMessageFormat.ts`:
 
 ```ts
-interface WorkerRun {
-  step: number;
-  worker: string;
-  status: NodeRunStatus;
-  toolCalls: ToolCallEntry[];   // this worker's slice of the flat stream
-  thinking?: string;            // from turn.thinkingByStep[step]
-  output?: string;              // from parseTeamMessage step output
+export type NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'
+
+export interface WorkerRun {
+  step: number
+  worker: string
+  status: NodeRunStatus
+  output: string            // from parseTeamMessage step output
+  thinking?: string         // from turn.thinkingByStep[step]
 }
 
 function deriveWorkerRuns(turn: ChatMessage, isStreaming: boolean): WorkerRun[]
 function synthesizeChainGraph(runs: WorkerRun[]): TeamGraph
-function applyRunStatus(graph: TeamGraph, runs: WorkerRun[], pending?: PendingTeamState): TeamGraph  // returns graph whose node.data.status is set
+function nodeStatuses(graph: TeamGraph, runs: WorkerRun[], askingWorker?: string): Record<string, NodeRunStatus>
 ```
 
-**Attribution (the core trick):** the flat `turn.toolCalls` stream is already delimited by `info` entries whose message starts with `"Step N:"` (the same markers `TeamFlow` parses today). Walk the stream in order; each `info` "Step N:" marker opens a new slice; subsequent `tool_start`/`tool_end` entries belong to the worker at that step (worker name from `parseTeamMessage(turn.content).steps`). Pair each step with `turn.thinkingByStep[step]`. No core/gateway/data-model change is required — attribution is derived client-side from data the app already receives.
+**`deriveWorkerRuns`:** `parseTeamMessage(turn.content)` already yields `steps[] = {step, worker, output}`. Map each step to a `WorkerRun`, attaching `turn.thinkingByStep?.[step]`. Status: the last step is `running` while `isStreaming`; a step whose output matches a failure marker (`❌` / `Failed`) is `failed`; otherwise `done`. (`askedUser` is applied later by `nodeStatuses` from `pendingTeam.askingWorker`.) Returns `[]` when the turn isn't a parseable team message. Output and thinking are available incrementally — `turn.content` is built up in `### Step N:` form as the run streams — so the drawer populates live.
 
-**Status derivation:**
-- `done` — step completed (a later step's marker exists, or the turn is complete).
-- `running` — the last step while `isStreaming`.
-- `failed` — the step's output/tool slice contains an error (e.g. a `tool_end` error or the existing "❌ Failed" output marker).
-- `askedUser` — matches `chat.pendingTeam.askingWorker`.
-- `pending` — a graph worker node never reached by any step.
-- A worker visited multiple times (loop/revision) maps to one node showing the **latest** run's status and a run-count badge; the drawer lists each visit.
+**`synthesizeChainGraph`:** unique workers in first-appearance order → `start → w1 → … → wN → end`, vertical layout (`x≈120`, `y` stepped). Must pass `validateGraph(graph, workerNames)`. Used when the team has no authored graph.
+
+**`nodeStatuses`:** maps each graph node id → status. Worker nodes: `askedUser` if `askingWorker` matches, else the latest matching `WorkerRun.status`, else `pending` (never reached). `start` → `done`. `end` → `done` when runs exist and none is `running`, else `pending`. Condition nodes are omitted (neutral default styling). A worker visited multiple times (loop) shows its latest status; the drawer lists each visit.
 
 ### 3. Overlay — `codey-mac/src/components/TeamRunFlow.tsx` (new)
 
-Props: `{ turn, isStreaming, teamGraph?, pendingTeam?, onClose }`.
+Props: `{ turn, isStreaming, teamGraph?, askingWorker?, onClose }`.
 
-- Resolves the graph: if the chat's team has an **authored** `TeamGraph` (the `graph` field already parsed in `GlobalTeamsSection`/`TeamsSection` and passed down), use it directly so real branches/loops render. Otherwise (auto/parallel/no graph) call `synthesizeChainGraph(runs)` to build a linear `start → w1 → … → wN → end` chain. Either way the same renderer draws it.
-- Runs `applyRunStatus` to light up nodes; re-derives on each render so it updates live.
-- Left pane: `<ReactFlow ... nodeTypes edgeTypes colorMode={effectiveTheme} fitView>` — identical config to FlowEditor (read-only: no `onConnect`/drag-to-edit handlers; `onNodeClick` selects).
-- Right drawer: selected worker's `WorkerRun` rendered with `ToolDetail`/`normalizeTool` from `toolFormat.tsx` (consistent with the flat timeline), status + duration header, collapsed thinking section. Auto-selects the `running` worker (else the last) on open.
-- Chrome mirrors FlowEditor's modal (fixed overlay, `C.bg` panel, `Close` using the existing `secondaryBtn` style).
+- Resolves the graph: if the chat's team has an **authored** `TeamGraph` (the `graph` field on the team config), use it so real branches/loops render. Otherwise call `synthesizeChainGraph(runs)`.
+- Builds React-Flow nodes via `toFlow` (from `flowEditorModel`), sets each node's React-Flow `type` via `rfNodeType`, and injects `data.status` from `nodeStatuses`. Re-derives on each render so it updates live.
+- Left pane: `<ReactFlow ... nodeTypes edgeTypes colorMode={effectiveTheme} fitView>` — same config as FlowEditor, read-only (no `onConnect`/drag-edit; `onNodeClick` selects).
+- Right drawer: selected worker's `WorkerRun` — status + step header, output via the existing `Markdown` component, a collapsed "Thinking ▸" section (`thinking`). Auto-selects the `running` worker (else the last) on open.
+- Chrome mirrors FlowEditor's modal (fixed overlay, `C.bg` panel, `Close` using FlowEditor's `secondaryBtn` style — promoted to a shared style or re-declared locally).
 
 ### 4. Panel integration — `ChatContextPanel.tsx`
 
-In the `tab === 'current'` branch, when `teamName` is set and a team `turn` exists, render a **"View flow ⤢"** button (in the existing `TeamFlow` Section header). Clicking opens `TeamRunFlow`. The flat `ToolTimeline`/`TeamFlow`/`FilesTouched` stay as-is for users who prefer the list.
+In the `tab === 'current'` branch, when `teamName` is set and a team `turn` exists, render a **"View flow ⤢"** button in the existing `TeamFlow` Section header. Clicking opens `TeamRunFlow`. The flat `TeamFlow` step list stays as-is. The chat's team graph is fetched in `ChatTab` via `apiService.getGlobalTeams()` (returns `Record<string, TeamConfigRaw>`, whose entry carries `graph`), keyed by `panelTeamName`, and passed down to the panel.
 
 ## Data flow
 
 ```
-gateway team run ──stream──> useChats reducer ──> ChatMessage{ content, toolCalls[], thinkingByStep }
-                                                          │
-                              parseTeamMessage(content) ──┤── steps[] (step→worker, output)
-                              deriveWorkerRuns(turn) ─────┴── WorkerRun[] (slice toolCalls by "Step N:" info markers)
-                                                          │
-        team config.graph (authored) ─or─ synthesizeChainGraph(runs) ──> applyRunStatus ──> live graph
-                                                          │
-                                          TeamRunFlow: React-Flow (left) + worker drawer (right)
+team run ──stream──> useChats reducer ──> ChatMessage{ content, thinkingByStep }
+                                                   │
+                       parseTeamMessage(content) ──┤── steps[] (step→worker, output)
+                       deriveWorkerRuns(turn) ─────┴── WorkerRun[] (output + thinking per step)
+                                                   │
+   team config.graph (authored) ─or─ synthesizeChainGraph(runs) ──> nodeStatuses ──> live graph
+                                                   │
+                                TeamRunFlow: React-Flow (left) + worker drawer (right)
 ```
 
-No new wire events, no changes to `packages/core` or `packages/gateway`.
+No changes to `packages/core` or `packages/gateway`. No new wire events.
 
 ## Testing
 
 `codey-mac/src/components/teamRunModel.test.ts` (Vitest), covering:
-- Partition a flat `toolCalls` stream with `Step 1:`/`Step 2:` markers into correct per-worker slices.
-- Status derivation: running (streaming last step), done, failed (error slice), askedUser (matches `pendingTeam`), pending (unreached graph node).
-- Loop/revisit: same worker at steps 2 and 4 → one node, latest status, both visits in the drawer data.
-- `synthesizeChainGraph`: N runs → `start → w1 → … → wN → end` with valid edges (passes `validateGraph`).
-- Edge cases: no `info` markers (single implicit step), empty `toolCalls`, non-team turn → `deriveWorkerRuns` returns `[]`.
+- `deriveWorkerRuns`: two-step team message → two runs with correct worker/output; `thinking` joined from `thinkingByStep`; last step `running` when streaming, `done` when not; failure-marker output → `failed`; non-team turn → `[]`.
+- `nodeStatuses`: worker run statuses mapped onto matching nodes; `askingWorker` → `askedUser`; unreached worker node → `pending`; `start` done, `end` pending while running then done; revisited worker shows latest status.
+- `synthesizeChainGraph`: N runs → `start → w1 → … → wN → end`, passes `validateGraph`; single run and empty-run edge cases.
 
-Renderer extraction is covered by the existing app build + a manual visual pass in all four palettes (no snapshot infra today).
+Renderer extraction is covered by the existing app build/`tsc` plus a manual visual pass in all four palettes (no snapshot infra today).
 
-## Known limitations
+## Follow-up (out of scope here)
 
-- **Parallel teams:** sequential `Step N:` markers can't perfectly attribute interleaved concurrent tool calls. MVP attributes best-effort by marker order; nodes and per-worker thinking still render correctly. A robust fix is to tag tool events with an optional `step` at emit time (`ToolCallEntry.step?`, set in the gateway's `TeamEmitter`, which already threads `step` through `onThinking`) — deferred as a follow-up, not required for the sequential/auto case in the screenshot.
-- Duration per worker is shown only when derivable from existing data; no new timing instrumentation is added.
+Per-worker **tool calls** in the drawer. Requires: add optional `step?: number` to `ToolCallEntry`; have the team dispatch loop pass an `onStatus` to `runWorkerStep` that forwards step-tagged `tool_start`/`tool_end` to the chat sink (plumbing to the agent already exists); add an `onTool(entry, step)` hook to `ChatEmitter` (no-op on `ChannelEmitter`); thread `step` through `useChats.tsx`. Then `deriveWorkerRuns` groups tool calls by `step` and the drawer renders them via `toolFormat`'s `ToolDetail`. Deferred at the user's request.
 
 ## Files
 
 | File | Change |
 |---|---|
-| `codey-mac/src/components/flowGraph.tsx` | **new** — node/edge renderers + helpers extracted from FlowEditor; `status`-aware node styling |
-| `codey-mac/src/components/FlowEditor.tsx` | import renderers from `flowGraph`; no behavior change |
+| `codey-mac/src/components/flowGraph.tsx` | **new** — node/edge renderers + helpers extracted from FlowEditor; `status`-aware node styling; `rfNodeType` |
+| `codey-mac/src/components/FlowEditor.tsx` | import renderers/helpers from `flowGraph`; no behavior change |
 | `codey-mac/src/components/teamRunModel.ts` | **new** — pure run-model deriver |
 | `codey-mac/src/components/teamRunModel.test.ts` | **new** — unit tests |
-| `codey-mac/src/components/TeamRunFlow.tsx` | **new** — overlay (graph + worker drawer) |
-| `codey-mac/src/components/ChatContextPanel.tsx` | "View flow ⤢" trigger in team mode; mount overlay |
+| `codey-mac/src/components/TeamRunFlow.tsx` | **new** — overlay (graph + worker drawer: output + thinking) |
+| `codey-mac/src/components/ChatContextPanel.tsx` | "View flow ⤢" trigger in team mode; mount overlay; accept `teamGraph` prop |
+| `codey-mac/src/components/ChatTab.tsx` | fetch team graph via `getGlobalTeams`, pass to panel |

--- a/docs/superpowers/specs/2026-06-18-workflow-programmatic-routing-design.md
+++ b/docs/superpowers/specs/2026-06-18-workflow-programmatic-routing-design.md
@@ -1,0 +1,113 @@
+# Workflow routing: programmatic walk, aide only at diamonds
+
+Date: 2026-06-18
+Status: Approved (design)
+
+## Problem
+
+A Sequential (`dispatch: 'all'`) team may define a workflow graph that routes
+execution between worker nodes, condition diamonds, `start`, and `end`. Today
+the gateway calls a **judge LLM on the large Advisor model after every worker
+and at every diamond** (`pickNextGraphEdge` → `runJudge` with
+`getAdvisorAgentAndModel()`), even when a node has a single outgoing edge and
+there is no decision to make.
+
+This is wasteful: following a straight sequence or a loop needs no LLM, and
+where a real choice exists at a worker the worker — itself an LLM that already
+has the full task context — can choose its own next edge. The only place that
+genuinely needs separate routing logic is a **condition diamond**, and that is
+a narrow yes/no classification that should run on the small **aide** model, not
+the Advisor.
+
+## Goals
+
+- No LLM call is made purely to advance the flow through single-edge workers,
+  `start`, or loops.
+- A worker with multiple outgoing edges routes itself (picks exactly one edge).
+- Condition diamonds are judged by the **aide** (small model), not the Advisor.
+- No graph-schema change, no new config, no FlowEditor change.
+
+## Non-goals (v1)
+
+- **Fan-out.** A worker activates exactly one outgoing edge. Activating several
+  branches (parallel sub-flows + merge) is explicitly out of scope and would be
+  modeled later, likely via an explicit fan-out node.
+- Changing `maxHops`, `maxCalls`/`eligibleEdges`, `[ASK_USER]` pause/resume, the
+  blackboard, or `resolveEdge` fallback semantics.
+- Changing graph validation. Multi-edge workers are already valid; flows are
+  still expected to reach an `end` node.
+
+## Design
+
+### Per-node behavior in `continueGraphRun` (packages/gateway/src/gateway.ts)
+
+The walk remains a single-cursor `GraphRunState` (one `currentNodeId`).
+
+1. **Worker, exactly 1 eligible outgoing edge** — follow it programmatically.
+   No LLM call. Emit the existing `↪️` status.
+2. **Worker, ≥2 eligible outgoing edges** — the worker self-routes:
+   - Before the worker runs, its prompt gains a short **"Next step"** section
+     listing each outgoing edge as a stable choice: the target (`worker name`
+     or `end`) plus the edge's condition/label text.
+   - The worker emits its choice as a marker in its output, e.g.
+     `[NEXT: <target>]`, parsed alongside the existing `[ASK_USER]` /
+     `[ASK_ADVISOR]` handling.
+   - Resolve the marker to one outgoing edge. Fallback order if the marker is
+     missing or does not match: the `isDefault` edge, else the first outgoing
+     edge. No judge LLM is involved.
+3. **Worker, 0 outgoing edges** — stop (end of flow). Safety stop only;
+   validation still expects an `end` node.
+4. **Condition diamond** — judge with the **aide**: `runJudge` is called with
+   `getAideAgentAndModel()` and the aide runner (instead of
+   `getAdvisorAgentAndModel()` + `advisorRunner`). This is the only LLM call
+   made purely for routing. `resolveEdge` keeps its current fallback (the `no`
+   branch when the judge's pick is invalid).
+
+`[ASK_USER]` pause/resume is unchanged. A self-routing worker that also asks the
+user pauses first (as today); on resume it completes and its `[NEXT: …]` choice
+is parsed from the resumed output.
+
+### Marker parsing and prompt snippet (packages/core)
+
+- Add `parseNextEdge(output, options)` — extracts the `[NEXT: <target>]` choice
+  and matches it to one of the offered targets (case-insensitive, tolerant of
+  the worker echoing the label). Returns the chosen edge id or `null`.
+- Add a small builder that renders the "Next step" options list, reused by the
+  worker-prompt assembly (`buildSequentialWorkerPrompt` gains the options, or a
+  sibling helper appends them).
+- The worker chooses by **target/label**, never by internal edge id.
+
+### Configuration
+
+Reuse the existing `aide.{agent, model}` in `gateway.json` (already falls back
+to the gateway default agent/model). No `judge` config is added.
+
+## Data flow
+
+```
+settle(start) → worker
+  worker: build prompt (+ Next-step options iff >1 edge) → run → ingest output
+    1 edge  → advance(edge)                         [no LLM]
+    >1 edge → parseNextEdge(output) → resolve → advance   [no routing LLM]
+    0 edges → stop
+  diamond: runJudge(aide) → resolveEdge → advance   [aide LLM only here]
+loop until end (done) or maxHops (capped)
+```
+
+## Testing
+
+- Single-edge worker advances with **no** routing LLM call (assert the
+  judge/aide runner is not invoked).
+- Multi-edge worker follows its emitted `[NEXT: …]` choice; falls back to the
+  default edge, then the first edge, when the marker is absent/invalid.
+- Condition diamond invokes the **aide** runner/model (not the Advisor).
+- Existing graph-walk tests (loops, `maxHops` cap, `[ASK_USER]` pause/resume)
+  continue to pass.
+
+## Risks
+
+- A worker may omit or malform the `[NEXT: …]` marker. Mitigated by the
+  default→first-edge fallback and by clear prompt instructions.
+- Worker self-routing relies on the worker prompt clearly describing the edge
+  targets; ambiguous condition labels degrade choice quality (falls back
+  gracefully).

--- a/packages/core/src/team-graph.test.ts
+++ b/packages/core/src/team-graph.test.ts
@@ -336,12 +336,16 @@ describe('eligibleEdges', () => {
     expect(ids).toContain('e2');
   });
 
-  it('ignores nodes without maxCalls (keeps every edge, including a self-edge)', () => {
-    // w2 has no maxCalls; even a huge runStreak must not drop any edge.
+  it('applies DEFAULT_MAX_SELF_LOOP (3) when a worker node omits maxCalls', () => {
+    // w2 has no maxCalls; default cap of 3 kicks in.
     const g2 = { ...g, edges: [...g.edges, { id: 'e3', from: 'w2', to: 'w2' }, { id: 'e4', from: 'w2', to: 'w1' }] };
-    const ids = eligibleEdges(g2, { ...startRun(g2), currentNodeId: 'w2', runStreak: 99 }, 'w2').map(e => e.id);
-    expect(ids).toContain('e3'); // self-edge kept
-    expect(ids).toContain('e4');
+    const below = eligibleEdges(g2, { ...startRun(g2), currentNodeId: 'w2', runStreak: 2 }, 'w2').map(e => e.id);
+    expect(below).toContain('e3'); // below cap, self-edge kept
+    expect(below).toContain('e4');
+
+    const atCap = eligibleEdges(g2, { ...startRun(g2), currentNodeId: 'w2', runStreak: 3 }, 'w2').map(e => e.id);
+    expect(atCap).not.toContain('e3'); // at default cap, self-edge dropped
+    expect(atCap).toContain('e4');
   });
 });
 

--- a/packages/core/src/team-graph.ts
+++ b/packages/core/src/team-graph.ts
@@ -40,6 +40,8 @@ export interface TeamGraph {
 }
 
 export const DEFAULT_MAX_HOPS = 20;
+/** Default cap on consecutive self-loops for a worker node that doesn't set maxCalls. */
+export const DEFAULT_MAX_SELF_LOOP = 3;
 
 /**
  * Returns a list of human-readable problems with the graph. Empty array means
@@ -150,14 +152,17 @@ export function outgoingEdges(graph: TeamGraph, nodeId: string): TeamGraphEdge[]
 
 /**
  * Outgoing edges the judge may choose from. Drops a worker's self-edge once its
- * consecutive-run streak has reached the node's maxCalls, forcing an exit. For
- * nodes without maxCalls (or non-worker nodes) this equals outgoingEdges.
+ * consecutive-run streak has reached the node's maxCalls, forcing an exit.
+ * Worker nodes that don't set maxCalls fall back to DEFAULT_MAX_SELF_LOOP.
  */
 export function eligibleEdges(graph: TeamGraph, state: GraphRunState, nodeId: string): TeamGraphEdge[] {
   const edges = outgoingEdges(graph, nodeId);
   const node = nodeMap(graph).get(nodeId);
-  if (node?.type === 'worker' && node.maxCalls !== undefined && state.runStreak >= node.maxCalls) {
-    return edges.filter(e => e.to !== nodeId);
+  if (node?.type === 'worker') {
+    const cap = node.maxCalls ?? DEFAULT_MAX_SELF_LOOP;
+    if (state.runStreak >= cap) {
+      return edges.filter(e => e.to !== nodeId);
+    }
   }
   return edges;
 }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3146,7 +3146,22 @@ Example: /model gpt-4.1 write a Python script`;
         buildBootstrapPrompt: () => this.wrapPromptWithMemory(workerPrompt, prompt, workerName),
         onStream: (text: string) => sink({ type: 'stream', chatId, token: text }),
         onThinking,
-        onStatus: (_update: any) => { /* status forwarded via sink elsewhere */ },
+        onStatus: (update: any) => {
+          // Forward each worker's tool events to the chat so the run-flow view
+          // can attribute them per worker (team runs here are serial; the Mac
+          // side buckets each call under the most-recent "Step N" marker).
+          // Mirrors the single-agent onStatus; step narration stays on
+          // emitter.status. (Parallel path below is left untouched — its tool
+          // events interleave and can't be attributed by order.)
+          try {
+            const parsed = typeof update === 'string' ? JSON.parse(update) : update;
+            if (parsed?.type === 'tool_start') {
+              sink({ type: 'tool_start', chatId, tool: parsed.tool, message: parsed.message ?? '', input: parsed.input });
+            } else if (parsed?.type === 'tool_end') {
+              sink({ type: 'tool_end', chatId, tool: parsed.tool, message: parsed.message ?? '', output: parsed.output });
+            }
+          } catch { /* non-JSON status */ }
+        },
         signal,
         workingDir,
       });


### PR DESCRIPTION
## Summary

- **Team run flow view** — visualize a running team's graph with per-worker output, thinking, and tool calls in a drawer overlay (`TeamRunFlow.tsx`, `flowGraph.tsx`, `ToolCallList.tsx`, `teamRunModel.ts`)
- **Programmatic routing spec** — design doc for aide-only routing at condition (diamond) nodes
- **Default self-loop cap** — `DEFAULT_MAX_SELF_LOOP = 3` applied in `eligibleEdges` when a worker node omits `maxCalls`, preventing uncapped self-loops from exhausting the global `maxHops` budget
- **Flow editor UX** — extracted shared graph renderer, dark-mode theming for controls/inputs, live active-worker highlight

## Test plan

- [ ] `npm test -w @codey/core` — verify `eligibleEdges` default cap test passes
- [ ] Open a workspace with a graph team, trigger a run, confirm the "View flow" button renders `TeamRunFlow` with correct node statuses
- [ ] Verify self-loop edge is dropped after 3 consecutive runs when `maxCalls` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)