### PR TITLE
chore: ignore local graphify-out/ and twitter-posts.md artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ voice/*.bin
 /gateway.js
 
 .superpowers/
+
+# Local tooling artifacts
+graphify-out/
+twitter-posts.md

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ voice/*.bin
 
 # Local tooling artifacts
 graphify-out/
-twitter-posts.md


### PR DESCRIPTION
Adds two local-only artifacts to `.gitignore` so they stop showing up as untracked:

- `graphify-out/` — 384 MB of generated knowledge-graph output from the local graphify tooling (reports, caches, label dumps). Machine-generated, never belongs in the repo.
- `twitter-posts.md` — personal build-in-public marketing draft, not source code.

Neither is committed; this just keeps `git status` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)