### PR TITLE
chore: bump version to 0.8.3 across all packages

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.3",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.7.0",
+  "version": "0.8.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.7.0",
+  "version": "0.8.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps all package versions to **0.8.3**:

| Package | Was | Now |
|---------|-----|-----|
| `codey-monorepo` (root) | 0.7.0 | 0.8.3 |
| `@codey/core` | 0.7.0 | 0.8.3 |
| `@codey/gateway` | 0.7.0 | 0.8.3 |
| `codey-mac` | 0.8.1 | 0.8.3 |

Touches only the four `package.json` files, matching the established bump convention. Generated artifacts (`latest-mac.yml`, lockfile versions) regenerate on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)