### PR TITLE
fix(gateway): stop auto-mode team run from rendering twice

### DIFF
--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -3338,7 +3338,6 @@ Example: /model gpt-4.1 write a Python script`;
     // === end parallel dispatch branch ===
 
     if (useAdvisor) {
-      let isFirstStep = true;
       const result = await this.runAdvisorLoop(
         team,
         prompt,
@@ -3352,10 +3351,10 @@ Example: /model gpt-4.1 write a Python script`;
               chatId,
               message: `Step ${msg.step}: ${msg.worker}${msg.isRevision ? ' (revision)' : ''} — ${msg.reason}`,
             });
-            const label = msg.isRevision ? `${msg.worker} (revision)` : msg.worker;
-            const sep = isFirstStep ? '' : '\n\n---\n\n';
-            sink({ type: 'stream', chatId, token: `${sep}### Step ${msg.step}: ${label}\n\n` });
-            isFirstStep = false;
+            // Each worker streams its full output into its own per-worker bubble
+            // (beginWorker below). Don't also echo a "### Step N" header into the
+            // turn's main message — that produced a second, redundant copy of the
+            // whole run in a different format.
             workerMsgs.beginWorker({ step: msg.step, worker: msg.worker, reason: msg.reason });
           } else {
             sink({ type: 'info', chatId, message: msg.summary });
@@ -3397,16 +3396,23 @@ Example: /model gpt-4.1 write a Python script`;
         sink({ type: 'stream', chatId, token: rendered5.text });
         return { response: rendered5.text, choices: rendered5.choices, teamTurnId };
       } else {
+        // Per-worker bubbles already render each step's full output, so the
+        // turn's main message is just the Advisor's wrap-up summary (a short
+        // recap when the run produced a lot of detail) plus the blackboard —
+        // not a second copy of every step.
+        const summary = result.finalSummary?.trim()
+          ? `🧭 Advisor summary: ${result.finalSummary.trim()}`
+          : '';
         if (signal?.aborted) {
-          return { response: this.formatAdvisorParts(result.parts, result.finalSummary), teamTurnId };
+          return { response: summary, teamTurnId };
         }
         if (result.fallbackMidRun) {
           sink({ type: 'info', chatId, message: `Advisor halted mid-run: ${result.fallbackMidRun.reason}` });
         }
         const bbBlock = result.blackboard.renderForUser();
-        const formatted = this.formatAdvisorParts(result.parts, result.finalSummary);
         this.persistBlackboardDecisions(result.blackboard, teamName);
-        return { response: bbBlock ? `${formatted}\n\n${bbBlock}` : formatted, thinkingByStep: result.thinkingByStep, teamTurnId };
+        const response = [summary, bbBlock].filter(Boolean).join('\n\n');
+        return { response, thinkingByStep: result.thinkingByStep, teamTurnId };
       }
     }
 


### PR DESCRIPTION
## Problem

In Team **Auto Mode**, the chat/Mac surface rendered the same run twice in two different formats:

1. **Rich per-worker bubbles** (`TeamRunGroup` — one bubble per worker, with tool calls / thinking) ✅
2. **A separate main message** that re-rendered every step's full output via `formatAdvisorParts`, plus the `### Step N` headers streamed into it live ❌

The second one is redundant — it duplicates everything already shown in the per-worker bubbles.

## Fix

In `runTeamForChat`'s auto-advisor branch (`packages/gateway/src/gateway.ts`):

- **Stop streaming `### Step N` headers into the turn's main message.** Each worker's output already streams into its own per-worker bubble via `beginWorker`.
- **The main message now carries only the Advisor's wrap-up summary + blackboard**, not a second copy of every step. This doubles as the "summarizing statement when there's a lot of info" — `🧭 Advisor summary: …`.

Net result: one per-step display (the bubbles) + a concise recap.

## Scope

- The pure-channel path (`runTeamTask`, e.g. Telegram/Discord) is unchanged — it has no rich bubbles, so its `📊 Team results` summary remains the sole complete record. `formatAdvisorParts` is still used there.

## Verification

- `npx tsc -p packages/gateway --noEmit` passes.
- Suggested manual check: run `/team <auto-team> <task>` in the Mac app and confirm only the worker bubbles + one trailing summary appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)