### PR TITLE
feat(mac): branch picker, git worktrees, and Create PR button

### DIFF
--- a/codey-mac/build/notarize-dist.js
+++ b/codey-mac/build/notarize-dist.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+//
+// Decoupled notarization for the macOS distributable.
+//
+// Why this exists instead of electron-builder's built-in notarize / an
+// afterSign hook: notarization takes minutes, and running it *inside*
+// electron-builder's pipeline races with electron-builder's own signing —
+// the hash Apple notarizes ends up different from the hash that ships, so
+// `stapler` fails with "Record not found". This script runs AFTER the build
+// is completely finished, when nothing else is touching the bundle, so the
+// notarized hash and the on-disk hash are guaranteed identical.
+//
+// Flow per architecture that was actually built:
+//   1. zip the signed .app and submit to Apple (notarytool, --wait)
+//   2. staple the ticket onto the .app
+//   3. repackage the distributable zip from the now-stapled .app
+//   4. staple the .dmg
+//   5. verify everything with spctl / stapler
+//
+// Requires APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID in env.
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const pkg = require('../package.json');
+const PRODUCT = pkg.build.productName; // "Codey"
+const VERSION = pkg.version;
+const RELEASE = path.join(__dirname, '..', 'release');
+
+const { APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID } = process.env;
+if (!APPLE_ID || !APPLE_APP_SPECIFIC_PASSWORD || !APPLE_TEAM_ID) {
+  console.error(
+    'ERROR: set APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD and APPLE_TEAM_ID before running notarize:mac.\n' +
+      'e.g. APPLE_APP_SPECIFIC_PASSWORD=$(security find-generic-password -s codey-notarize -w)',
+  );
+  process.exit(1);
+}
+
+// staging dir -> distributable artifact suffixes (electron-builder defaults)
+const ARCHES = [
+  { stage: 'mac-arm64', dmg: `-arm64`, zip: `-arm64-mac` },
+  { stage: 'mac', dmg: ``, zip: `-mac` }, // x64 (only if built)
+];
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { stdio: 'inherit', ...opts });
+}
+function capture(cmd, args) {
+  // merge stderr -> stdout (spctl/codesign write assessment to stderr)
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function developerIdIdentity() {
+  const out = capture('security', ['find-identity', '-v', '-p', 'codesigning']);
+  const m = out.match(/"(Developer ID Application: [^"]+)"/);
+  if (!m) throw new Error('no "Developer ID Application" identity found in keychain');
+  return m[1];
+}
+
+function submitToNotary(filePath) {
+  run('xcrun', [
+    'notarytool', 'submit', filePath,
+    '--apple-id', APPLE_ID,
+    '--team-id', APPLE_TEAM_ID,
+    '--password', APPLE_APP_SPECIFIC_PASSWORD,
+    '--wait',
+  ]);
+}
+
+function notarizeAndStapleApp(appPath) {
+  const zip = path.join(os.tmpdir(), `notar-${path.basename(path.dirname(appPath))}-${VERSION}.zip`);
+  fs.rmSync(zip, { force: true });
+  console.log(`  • zipping ${appPath}`);
+  run('ditto', ['-c', '-k', '--keepParent', appPath, zip]);
+
+  console.log('  • submitting app to Apple notary service (this can take a few minutes)…');
+  submitToNotary(zip);
+  fs.rmSync(zip, { force: true });
+
+  console.log('  • stapling ticket onto app');
+  run('xcrun', ['stapler', 'staple', appPath]);
+
+  // Hard gate: the app must now be accepted by Gatekeeper.
+  const out = capture('spctl', ['-a', '-vvv', '--type', 'execute', appPath]);
+  console.log('  • spctl:', out.trim().replace(/\n/g, ' | '));
+}
+
+function repackageZip(appPath, zipSuffix) {
+  const zipName = `${PRODUCT}-${VERSION}${zipSuffix}.zip`;
+  const dest = path.join(RELEASE, zipName);
+  console.log(`  • repackaging ${zipName} from stapled app`);
+  fs.rmSync(dest, { force: true });
+  run('ditto', ['-c', '-k', '--keepParent', appPath, dest]);
+}
+
+function stapleDmg(dmgSuffix) {
+  const dmgName = `${PRODUCT}-${VERSION}${dmgSuffix}.dmg`;
+  const dmg = path.join(RELEASE, dmgName);
+  if (!fs.existsSync(dmg)) {
+    console.log(`  • (no ${dmgName} to staple, skipping)`);
+    return;
+  }
+  // A dmg needs its OWN notary ticket — notarizing the app's zip does not
+  // create one. Apple's order is sign -> notarize -> staple: electron-builder
+  // leaves the dmg container unsigned, so sign it first or `spctl` reports
+  // "no usable signature".
+  console.log(`  • signing ${dmgName}`);
+  run('codesign', ['--force', '--sign', developerIdIdentity(), '--timestamp', dmg]);
+  console.log(`  • submitting ${dmgName} to notary service…`);
+  submitToNotary(dmg);
+  console.log(`  • stapling ${dmgName}`);
+  run('xcrun', ['stapler', 'staple', dmg]);
+  run('xcrun', ['stapler', 'validate', dmg]);
+
+  // Hard gate: the dmg must be accepted by Gatekeeper.
+  const out = capture('spctl', ['-a', '-vvv', '-t', 'open', '--context', 'context:primary-signature', dmg]);
+  console.log(`  • spctl(dmg): ${out.trim().replace(/\n/g, ' | ')}`);
+}
+
+let did = 0;
+for (const arch of ARCHES) {
+  const appPath = path.join(RELEASE, arch.stage, `${PRODUCT}.app`);
+  if (!fs.existsSync(appPath)) continue;
+  console.log(`\n=== ${arch.stage} ===`);
+  notarizeAndStapleApp(appPath);
+  repackageZip(appPath, arch.zip);
+  stapleDmg(arch.dmg);
+  did++;
+}
+
+if (did === 0) {
+  console.error(`ERROR: no built apps found under ${RELEASE}/mac* — run build:mac:signed first.`);
+  process.exit(1);
+}
+console.log(`\n✓ notarized + stapled ${did} arch(es).`);

--- a/codey-mac/docs/superpowers/plans/2026-06-21-branch-picker-worktree-pr.md
+++ b/codey-mac/docs/superpowers/plans/2026-06-21-branch-picker-worktree-pr.md
@@ -1,0 +1,1408 @@
+# Branch Picker + Worktrees + Create PR Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the chat-header git badge an interactive branch/worktree picker (switch, create, fetch, stash-and-switch, create-in-worktree with per-chat binding) and add a status-panel "Create PR" button gated on task completion.
+
+**Architecture:** New `git:*` IPC handlers in the Electron main process wrap `git`/`gh` via `execFile` (mirroring the existing `git:status` handler). Per-chat worktree binding stores a `workingDirOverride` on the core `Chat` model; the gateway's `resolveChatWorkingDir` honors it so the agent runs in the worktree. The renderer gets pure, unit-tested logic modules (`branchPickerModel.ts`, `createPrModel.ts`), a `useGitBranches` hook that live-updates via a `git:changed` event, a `BranchPicker.tsx` dropdown, and a `Create PR` button + modal in `StatusSidecar`.
+
+**Tech Stack:** Electron (main/preload IPC), React + TypeScript renderer, Vitest (`environment: 'node'`), `git` CLI, `gh` CLI (2.88.1).
+
+**⚠️ Node version:** The default shell node is v16 and CANNOT run vitest/tsc. Before any `npm`/`npx`/`tsc`/`vitest` command in this plan, run `nvm use 22.17.1` (or `source ~/.nvm/nvm.sh && nvm use 22.17.1`). All `Run:` commands below assume node 22 is active.
+
+**Working directory:** `codey-mac/` for renderer/electron tasks; repo root for `packages/*` tasks. Paths below are relative to the repo root `/Users/jackou/Documents/projects/codey`.
+
+---
+
+## File Structure
+
+**Electron main / preload (Phase 1 & 2 wiring):**
+- Modify `codey-mac/electron/main.ts` — add `git:branches`, `git:checkout`, `git:stash`, `git:fetch`, `git:worktrees`, `git:worktreeAdd`, `git:createPr`, `git:watch` handlers + `chats:setWorkingDir`.
+- Modify `codey-mac/electron/preload.ts` — expose the new `git.*` methods, the `git:changed` subscription, and `chats.setWorkingDir`.
+- Modify `codey-mac/src/codey-api.d.ts` — type the new surface.
+
+**Core / gateway (Phase 2 binding):**
+- Modify `packages/core/src/types/chat.ts` — add `workingDirOverride?: string`.
+- Modify `packages/gateway/src/chats.ts` — add `setWorkingDirOverride`.
+- Modify `packages/gateway/src/gateway.ts` — honor override in `resolveChatWorkingDir`.
+- Test `packages/gateway/src/chats.test.ts` (or existing chats spec) — cover the setter.
+
+**Renderer logic (Phase 3, TDD):**
+- Create `codey-mac/src/components/branchPickerModel.ts` + `branchPickerModel.test.ts`.
+- Create `codey-mac/src/components/createPrModel.ts` + `createPrModel.test.ts`.
+
+**Renderer UI (Phases 4-6):**
+- Create `codey-mac/src/hooks/useGitBranches.ts`.
+- Create `codey-mac/src/components/BranchPicker.tsx`.
+- Create `codey-mac/src/components/CreatePrModal.tsx`.
+- Modify `codey-mac/src/components/StatusSidecar.tsx` — gated Create PR button.
+- Modify `codey-mac/src/components/ChatTab.tsx` — mount BranchPicker, thread `workingDirOverride`, pass PR props to StatusSidecar.
+- Modify `codey-mac/src/services/api.ts` — `chats.setWorkingDir` + git helpers if needed.
+
+---
+
+## Phase 1 — Git IPC backend
+
+> These handlers run in the Electron main process and are verified by build + manual smoke test (no vitest for `main.ts`). Each wraps `execFile` like the existing `git:status` at `codey-mac/electron/main.ts:1360`.
+
+### Task 1: `git:branches` handler
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (insert after the `git:status` handler, ~line 1382)
+
+- [ ] **Step 1: Add the handler**
+
+Insert immediately after the closing `)` of the `git:status` handler (after line 1382):
+
+```ts
+  ipcMain.handle('git:branches', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir || typeof workingDir !== 'string') return { current: '', local: [], remote: [] }
+      const { execFile } = await import('child_process')
+      const run = (args: string[]) => new Promise<string>((resolve, reject) => {
+        execFile('git', args, { cwd: workingDir, timeout: 2000 }, (err, stdout) => {
+          if (err) reject(err); else resolve(stdout)
+        })
+      })
+      try {
+        const [curOut, localOut, remoteOut] = await Promise.all([
+          run(['rev-parse', '--abbrev-ref', 'HEAD']),
+          run(['for-each-ref', '--format=%(refname:short)', 'refs/heads']),
+          run(['for-each-ref', '--format=%(refname:short)', 'refs/remotes']),
+        ])
+        const current = curOut.trim() || 'HEAD'
+        const local = localOut.split('\n').map(l => l.trim()).filter(Boolean)
+        const remote = remoteOut.split('\n').map(l => l.trim())
+          .filter(l => l && !l.endsWith('/HEAD'))
+        return { current, local, remote }
+      } catch {
+        return { current: '', local: [], remote: [] }
+      }
+    })
+  )
+```
+
+- [ ] **Step 2: Build to typecheck**
+
+Run: `nvm use 22.17.1 && cd codey-mac && npx tsc -p tsconfig.electron.json --noEmit` (if no electron tsconfig, use `npm run build`)
+Expected: no type errors. (If the project builds main via `npm run build`, run that and expect success.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:branches IPC handler"
+```
+
+### Task 2: `git:checkout` handler (with `reason: 'dirty'`)
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (after `git:branches`)
+
+- [ ] **Step 1: Add the handler**
+
+```ts
+  ipcMain.handle('git:checkout', async (_e, workingDir: string, name: string, opts?: { create?: boolean; track?: boolean }) =>
+    wrap(async () => {
+      if (!workingDir || !name) return { ok: false, error: 'missing args' }
+      const { execFile } = await import('child_process')
+      const run = (args: string[]) => new Promise<{ ok: boolean; stderr: string }>((resolve) => {
+        execFile('git', args, { cwd: workingDir, timeout: 5000 }, (err, _out, stderr) => {
+          resolve({ ok: !err, stderr: stderr || (err ? String(err) : '') })
+        })
+      })
+      const args = opts?.create ? ['checkout', '-b', name]
+        : opts?.track ? ['checkout', '--track', name]
+        : ['checkout', name]
+      const r = await run(args)
+      if (r.ok) return { ok: true }
+      const dirty = /would be overwritten|Your local changes|commit your changes or stash/i.test(r.stderr)
+      return { ok: false, error: r.stderr.trim(), reason: dirty ? 'dirty' as const : undefined }
+    })
+  )
+```
+
+- [ ] **Step 2: Build to typecheck** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:checkout IPC with dirty-tree detection"
+```
+
+### Task 3: `git:stash` handler
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (after `git:checkout`)
+
+- [ ] **Step 1: Add the handler**
+
+```ts
+  ipcMain.handle('git:stash', async (_e, workingDir: string, message?: string) =>
+    wrap(async () => {
+      if (!workingDir) return { ok: false, error: 'missing workingDir' }
+      const { execFile } = await import('child_process')
+      const args = ['stash', 'push', '-u']
+      if (message) args.push('-m', message)
+      return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+        execFile('git', args, { cwd: workingDir, timeout: 5000 }, (err, _out, stderr) => {
+          if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })
+          else resolve({ ok: true })
+        })
+      })
+    })
+  )
+```
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:stash IPC handler"
+```
+
+### Task 4: `git:fetch` handler
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (after `git:stash`)
+
+- [ ] **Step 1: Add the handler**
+
+```ts
+  ipcMain.handle('git:fetch', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir) return { ok: false, error: 'missing workingDir' }
+      const { execFile } = await import('child_process')
+      return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+        execFile('git', ['fetch', '--prune'], { cwd: workingDir, timeout: 30000 }, (err, _out, stderr) => {
+          if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })
+          else resolve({ ok: true })
+        })
+      })
+    })
+  )
+```
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:fetch IPC handler"
+```
+
+### Task 5: `git:worktrees` handler
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (after `git:fetch`)
+
+- [ ] **Step 1: Add the handler**
+
+Parses `git worktree list --porcelain`. The first listed worktree is the main one.
+
+```ts
+  ipcMain.handle('git:worktrees', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir) return { list: [] }
+      const { execFile } = await import('child_process')
+      const out = await new Promise<string>((resolve) => {
+        execFile('git', ['worktree', 'list', '--porcelain'], { cwd: workingDir, timeout: 3000 }, (err, stdout) => {
+          resolve(err ? '' : stdout)
+        })
+      })
+      const list: { branch: string; path: string; isMain: boolean }[] = []
+      let cur: { path?: string; branch?: string } = {}
+      for (const line of out.split('\n')) {
+        if (line.startsWith('worktree ')) cur = { path: line.slice('worktree '.length).trim() }
+        else if (line.startsWith('branch ')) cur.branch = line.slice('branch '.length).trim().replace('refs/heads/', '')
+        else if (line.trim() === '' && cur.path) {
+          list.push({ path: cur.path, branch: cur.branch || '(detached)', isMain: list.length === 0 })
+          cur = {}
+        }
+      }
+      if (cur.path) list.push({ path: cur.path, branch: cur.branch || '(detached)', isMain: list.length === 0 })
+      return { list }
+    })
+  )
+```
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:worktrees IPC handler"
+```
+
+### Task 6: `git:worktreeAdd` handler
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (after `git:worktrees`)
+
+- [ ] **Step 1: Add the handler**
+
+```ts
+  ipcMain.handle('git:worktreeAdd', async (_e, workingDir: string, args2: { name: string; path: string }) =>
+    wrap(async () => {
+      if (!workingDir || !args2?.name || !args2?.path) return { ok: false, error: 'missing args' }
+      const { execFile } = await import('child_process')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const target = pathMod.resolve(args2.path)
+      fsMod.mkdirSync(pathMod.dirname(target), { recursive: true })
+      return await new Promise<{ ok: boolean; path?: string; error?: string }>((resolve) => {
+        execFile('git', ['worktree', 'add', target, '-b', args2.name], { cwd: workingDir, timeout: 20000 }, (err, _out, stderr) => {
+          if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })
+          else resolve({ ok: true, path: target })
+        })
+      })
+    })
+  )
+```
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:worktreeAdd IPC handler"
+```
+
+### Task 7: `git:createPr` handler
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (after `git:worktreeAdd`)
+
+- [ ] **Step 1: Add the handler**
+
+Pushes the branch (sets upstream if missing), then runs `gh pr create`, returning the PR URL parsed from stdout.
+
+```ts
+  ipcMain.handle('git:createPr', async (_e, workingDir: string, input: { title: string; body: string }) =>
+    wrap(async () => {
+      if (!workingDir || !input?.title) return { ok: false, error: 'missing args' }
+      const { execFile } = await import('child_process')
+      const run = (cmd: string, args: string[], timeout: number) => new Promise<{ ok: boolean; stdout: string; stderr: string }>((resolve) => {
+        execFile(cmd, args, { cwd: workingDir, timeout }, (err, stdout, stderr) => {
+          resolve({ ok: !err, stdout: stdout || '', stderr: stderr || (err ? String(err) : '') })
+        })
+      })
+      // Resolve current branch
+      const br = await run('git', ['rev-parse', '--abbrev-ref', 'HEAD'], 3000)
+      const branch = br.stdout.trim()
+      if (!branch || branch === 'HEAD') return { ok: false, error: 'Not on a branch' }
+      // Push with upstream (no-op if already pushed; -u is safe to repeat)
+      const push = await run('git', ['push', '-u', 'origin', branch], 60000)
+      if (!push.ok) return { ok: false, error: (push.stderr || 'git push failed').trim() }
+      // Create PR
+      const pr = await run('gh', ['pr', 'create', '--title', input.title, '--body', input.body || '', '--head', branch], 60000)
+      if (!pr.ok) return { ok: false, error: (pr.stderr || 'gh pr create failed').trim() }
+      const url = (pr.stdout.match(/https?:\/\/\S+/) || [])[0] || pr.stdout.trim()
+      return { ok: true, url }
+    })
+  )
+```
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:createPr IPC (push + gh pr create)"
+```
+
+### Task 8: `git:watch` handler + `git:changed` event
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (after `git:createPr`)
+
+- [ ] **Step 1: Add a module-level watcher registry near the other top-level handler state**
+
+Find where other `ipcMain.handle` registrations live (inside the same setup function as `git:status`). At the top of that function body add a watcher map (place it just before the `git:status` handler):
+
+```ts
+  // Live git branch watching: one fs.watch per workingDir, ref-counted by renderer subscriptions.
+  const gitWatchers = new Map<string, { watcher: import('fs').FSWatcher; count: number; timer: NodeJS.Timeout | null }>()
+```
+
+- [ ] **Step 2: Add the `git:watch` / `git:unwatch` handlers** (after `git:createPr`)
+
+```ts
+  ipcMain.handle('git:watch', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir) return { ok: false }
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const gitDir = pathMod.join(workingDir, '.git')
+      const headPath = pathMod.join(gitDir, 'HEAD')
+      const existing = gitWatchers.get(workingDir)
+      if (existing) { existing.count++; return { ok: true } }
+      try {
+        const emit = () => {
+          const entry = gitWatchers.get(workingDir)
+          if (!entry) return
+          if (entry.timer) clearTimeout(entry.timer)
+          entry.timer = setTimeout(() => sendToRenderer('git:changed', { workingDir }), 200)
+        }
+        // Watch the .git dir non-recursively; HEAD + refs changes bubble as rename/change events.
+        const watcher = fsMod.watch(gitDir, { persistent: false }, () => emit())
+        gitWatchers.set(workingDir, { watcher, count: 1, timer: null })
+        // Fire once so the renderer pulls fresh status immediately.
+        void headPath
+        return { ok: true }
+      } catch {
+        return { ok: false }
+      }
+    })
+  )
+
+  ipcMain.handle('git:unwatch', async (_e, workingDir: string) =>
+    wrap(async () => {
+      const entry = gitWatchers.get(workingDir)
+      if (!entry) return { ok: true }
+      entry.count--
+      if (entry.count <= 0) {
+        if (entry.timer) clearTimeout(entry.timer)
+        try { entry.watcher.close() } catch { /* ignore */ }
+        gitWatchers.delete(workingDir)
+      }
+      return { ok: true }
+    })
+  )
+```
+
+> Note: `sendToRenderer` is already used throughout `main.ts` (e.g. line 2176). Confirm its in-scope name; if it differs, match the existing call sites.
+
+- [ ] **Step 3: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 4: Commit**
+
+```bash
+git add codey-mac/electron/main.ts
+git commit -m "feat(mac): git:watch fs.watch + git:changed event"
+```
+
+### Task 9: Preload + type surface for all git IPC
+
+**Files:**
+- Modify: `codey-mac/electron/preload.ts:153-155` (the `git:` block)
+- Modify: `codey-mac/src/codey-api.d.ts:150-152` (the `git:` block)
+
+- [ ] **Step 1: Replace the preload `git` block**
+
+Replace:
+
+```ts
+  git: {
+    status: (workingDir: string) => ipcRenderer.invoke('git:status', workingDir),
+  },
+```
+
+with:
+
+```ts
+  git: {
+    status: (workingDir: string) => ipcRenderer.invoke('git:status', workingDir),
+    branches: (workingDir: string) => ipcRenderer.invoke('git:branches', workingDir),
+    checkout: (workingDir: string, name: string, opts?: { create?: boolean; track?: boolean }) =>
+      ipcRenderer.invoke('git:checkout', workingDir, name, opts),
+    stash: (workingDir: string, message?: string) => ipcRenderer.invoke('git:stash', workingDir, message),
+    fetch: (workingDir: string) => ipcRenderer.invoke('git:fetch', workingDir),
+    worktrees: (workingDir: string) => ipcRenderer.invoke('git:worktrees', workingDir),
+    worktreeAdd: (workingDir: string, args: { name: string; path: string }) =>
+      ipcRenderer.invoke('git:worktreeAdd', workingDir, args),
+    createPr: (workingDir: string, input: { title: string; body: string }) =>
+      ipcRenderer.invoke('git:createPr', workingDir, input),
+    watch: (workingDir: string) => ipcRenderer.invoke('git:watch', workingDir),
+    unwatch: (workingDir: string) => ipcRenderer.invoke('git:unwatch', workingDir),
+    onChanged: (handler: (ev: { workingDir: string }) => void) => {
+      const listener = (_e: unknown, ev: { workingDir: string }) => handler(ev)
+      ipcRenderer.on('git:changed', listener)
+      return () => ipcRenderer.removeListener('git:changed', listener)
+    },
+  },
+```
+
+- [ ] **Step 2: Replace the `git` block in `codey-api.d.ts`**
+
+```ts
+      git: {
+        status: (workingDir: string) => Promise<IpcResult<{ branch: string; dirty: number } | null>>
+        branches: (workingDir: string) => Promise<IpcResult<{ current: string; local: string[]; remote: string[] }>>
+        checkout: (workingDir: string, name: string, opts?: { create?: boolean; track?: boolean }) => Promise<IpcResult<{ ok: boolean; error?: string; reason?: 'dirty' }>>
+        stash: (workingDir: string, message?: string) => Promise<IpcResult<{ ok: boolean; error?: string }>>
+        fetch: (workingDir: string) => Promise<IpcResult<{ ok: boolean; error?: string }>>
+        worktrees: (workingDir: string) => Promise<IpcResult<{ list: { branch: string; path: string; isMain: boolean }[] }>>
+        worktreeAdd: (workingDir: string, args: { name: string; path: string }) => Promise<IpcResult<{ ok: boolean; path?: string; error?: string }>>
+        createPr: (workingDir: string, input: { title: string; body: string }) => Promise<IpcResult<{ ok: boolean; url?: string; error?: string }>>
+        watch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
+        unwatch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
+        onChanged: (handler: (ev: { workingDir: string }) => void) => () => void
+      }
+```
+
+- [ ] **Step 3: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 4: Commit**
+
+```bash
+git add codey-mac/electron/preload.ts codey-mac/src/codey-api.d.ts
+git commit -m "feat(mac): expose git branch/worktree/PR IPC in preload + types"
+```
+
+---
+
+## Phase 2 — Per-chat worktree binding (core + gateway)
+
+### Task 10: Add `workingDirOverride` to the core Chat type
+
+**Files:**
+- Modify: `packages/core/src/types/chat.ts:92+` (the `Chat` interface)
+
+- [ ] **Step 1: Add the field**
+
+After the `model?: string;` field (or any existing optional field) in the `Chat` interface, add:
+
+```ts
+  /** Per-chat working-directory override (absolute path). When set, the agent
+   *  runs here instead of the workspace's workingDir — used to bind a chat to a
+   *  git worktree. Cleared (deleted) to fall back to the workspace dir. */
+  workingDirOverride?: string;
+```
+
+- [ ] **Step 2: Build core** — Run: `nvm use 22.17.1 && npm run build -w @codey/core` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/types/chat.ts
+git commit -m "feat(core): Chat.workingDirOverride for worktree binding"
+```
+
+### Task 11: `setWorkingDirOverride` on ChatManager (TDD)
+
+**Files:**
+- Modify: `packages/gateway/src/chats.ts` (after `setSoloAdvisor`, ~line 229)
+- Test: `packages/gateway/src/chats.test.ts` (create if absent; otherwise append)
+
+- [ ] **Step 1: Write the failing test**
+
+If `packages/gateway/src/chats.test.ts` does not exist, create it with the standard header; otherwise add this `describe`. Mirror existing ChatManager test setup (a temp workspaces root). Minimal standalone test:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+
+describe('ChatManager.setWorkingDirOverride', () => {
+  let root: string;
+  let mgr: ChatManager;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  it('sets and clears the override', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    const set = mgr.setWorkingDirOverride(chat.id, '/tmp/wt');
+    expect(set.workingDirOverride).toBe('/tmp/wt');
+    const cleared = mgr.setWorkingDirOverride(chat.id, null);
+    expect(cleared.workingDirOverride).toBeUndefined();
+  });
+});
+```
+
+> Verify `new ChatManager(root)` matches the real constructor signature in `chats.ts:26`; adjust the setup to match existing tests in the gateway package if the constructor differs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use 22.17.1 && npm test -w @codey/gateway -- chats.test`
+Expected: FAIL — `setWorkingDirOverride is not a function`.
+
+- [ ] **Step 3: Implement the method**
+
+In `packages/gateway/src/chats.ts`, after `setSoloAdvisor` (line ~229):
+
+```ts
+  /** Set or clear the per-chat working-directory override (worktree binding).
+   *  Pass null/undefined/'' to clear and fall back to the workspace dir. */
+  setWorkingDirOverride(chatId: string, dir: string | null): Chat {
+    const chat = this.requireChat(chatId);
+    if (dir === null || dir === undefined || dir === '') delete chat.workingDirOverride;
+    else chat.workingDirOverride = dir;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use 22.17.1 && npm test -w @codey/gateway -- chats.test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/chats.ts packages/gateway/src/chats.test.ts
+git commit -m "feat(gateway): ChatManager.setWorkingDirOverride + test"
+```
+
+### Task 12: Honor the override in `resolveChatWorkingDir`
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts:836-846`
+
+- [ ] **Step 1: Edit the method**
+
+Change the start of `resolveChatWorkingDir` (line 836) to short-circuit on the override:
+
+```ts
+  private resolveChatWorkingDir(chat: Chat): string {
+    if (chat.workingDirOverride && fs.existsSync(chat.workingDirOverride)) {
+      return chat.workingDirOverride;
+    }
+    const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
+    const wsConfigPath = path.join(workspacesRoot, chat.workspaceName, 'workspace.json');
+    if (fs.existsSync(wsConfigPath)) {
+      try {
+        const wsConfig = JSON.parse(fs.readFileSync(wsConfigPath, 'utf-8'));
+        if (wsConfig.workingDir) return wsConfig.workingDir;
+      } catch { /* fall through */ }
+    }
+    return this.workingDir;
+  }
+```
+
+- [ ] **Step 2: Build gateway** — Run: `nvm use 22.17.1 && npm run build -w @codey/gateway` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): resolveChatWorkingDir honors chat.workingDirOverride"
+```
+
+### Task 13: `chats:setWorkingDir` IPC chain
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts` (near `chats:setSoloAdvisor`, ~line 2263)
+- Modify: `codey-mac/electron/preload.ts` (near `setSoloAdvisor`, ~line 120)
+- Modify: `codey-mac/src/codey-api.d.ts:129` (chats block)
+- Modify: `codey-mac/src/services/api.ts:197` (chats setters)
+
+- [ ] **Step 1: main.ts handler**
+
+```ts
+  ipcMain.handle('chats:setWorkingDir', async (_e, id: string, dir: string | null) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.getChatManager().setWorkingDirOverride(id, dir)
+    })
+  )
+```
+
+- [ ] **Step 2: preload.ts** (in the `chats` block)
+
+```ts
+    setWorkingDir: (id: string, dir: string | null) =>
+      ipcRenderer.invoke('chats:setWorkingDir', id, dir),
+```
+
+- [ ] **Step 3: codey-api.d.ts** (in the `chats` block, near `setSoloAdvisor`)
+
+```ts
+        setWorkingDir: (id: string, dir: string | null) => Promise<IpcResult<Chat>>
+```
+
+- [ ] **Step 4: api.ts** (in the `chats` object, near `setSoloAdvisor`)
+
+```ts
+    setWorkingDir: async (id: string, dir: string | null): Promise<Chat> =>
+      unwrap(await window.codey.chats.setWorkingDir(id, dir)),
+```
+
+- [ ] **Step 5: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/electron/main.ts codey-mac/electron/preload.ts codey-mac/src/codey-api.d.ts codey-mac/src/services/api.ts
+git commit -m "feat(mac): chats:setWorkingDir IPC chain"
+```
+
+---
+
+## Phase 3 — Renderer logic modules (TDD)
+
+### Task 14: `branchPickerModel.ts` (pure logic) + test
+
+**Files:**
+- Create: `codey-mac/src/components/branchPickerModel.ts`
+- Test: `codey-mac/src/components/branchPickerModel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { filterBranches, defaultWorktreePath, partitionWorktrees } from './branchPickerModel';
+
+describe('filterBranches', () => {
+  it('returns all when query empty', () => {
+    expect(filterBranches(['main', 'dev'], '')).toEqual(['main', 'dev']);
+  });
+  it('is case-insensitive substring match', () => {
+    expect(filterBranches(['Main', 'feature/x', 'dev'], 'fe')).toEqual(['feature/x']);
+  });
+});
+
+describe('defaultWorktreePath', () => {
+  it('builds a sibling .codey-worktrees path with sanitized branch', () => {
+    expect(defaultWorktreePath('/home/u/repo', 'feat/cool thing'))
+      .toBe('/home/u/.codey-worktrees/repo-feat-cool-thing');
+  });
+});
+
+describe('partitionWorktrees', () => {
+  it('splits main from the rest', () => {
+    const { main, others } = partitionWorktrees([
+      { branch: 'main', path: '/r', isMain: true },
+      { branch: 'feat', path: '/r2', isMain: false },
+    ]);
+    expect(main?.branch).toBe('main');
+    expect(others.map(w => w.branch)).toEqual(['feat']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use 22.17.1 && cd codey-mac && npx vitest run src/components/branchPickerModel.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+import * as path from 'path';
+
+export interface Worktree { branch: string; path: string; isMain: boolean }
+export interface BranchData { current: string; local: string[]; remote: string[] }
+
+/** Case-insensitive substring filter; empty query returns the list unchanged. */
+export function filterBranches(list: string[], query: string): string[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return list;
+  return list.filter(b => b.toLowerCase().includes(q));
+}
+
+/** Default worktree location: `<repo-parent>/.codey-worktrees/<repo>-<branch>`. */
+export function defaultWorktreePath(repoPath: string, branchName: string): string {
+  const parent = path.dirname(repoPath);
+  const repo = path.basename(repoPath);
+  const safe = branchName.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return path.join(parent, '.codey-worktrees', `${repo}-${safe}`);
+}
+
+/** Separate the main worktree from the rest for display. */
+export function partitionWorktrees(list: Worktree[]): { main?: Worktree; others: Worktree[] } {
+  const main = list.find(w => w.isMain);
+  const others = list.filter(w => !w.isMain);
+  return { main, others };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use 22.17.1 && cd codey-mac && npx vitest run src/components/branchPickerModel.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/branchPickerModel.ts codey-mac/src/components/branchPickerModel.test.ts
+git commit -m "feat(mac): branchPickerModel pure logic + tests"
+```
+
+### Task 15: `createPrModel.ts` (gating + title) + test
+
+**Files:**
+- Create: `codey-mac/src/components/createPrModel.ts`
+- Test: `codey-mac/src/components/createPrModel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createPrButtonState, defaultPrTitle } from './createPrModel';
+
+describe('createPrButtonState', () => {
+  it('hidden while working/blocked', () => {
+    expect(createPrButtonState('working', true).show).toBe(false);
+    expect(createPrButtonState('blocked', true).show).toBe(false);
+  });
+  it('shown when waiting or done', () => {
+    expect(createPrButtonState('waiting', true).show).toBe(true);
+    expect(createPrButtonState('done', false).show).toBe(true);
+  });
+  it('enabled only when branch is ahead', () => {
+    expect(createPrButtonState('done', true).enabled).toBe(true);
+    expect(createPrButtonState('done', false).enabled).toBe(false);
+  });
+});
+
+describe('defaultPrTitle', () => {
+  it('prefers the commit subject', () => {
+    expect(defaultPrTitle('  Add cool thing ', 'feat/x')).toBe('Add cool thing');
+  });
+  it('falls back to the branch name', () => {
+    expect(defaultPrTitle('', 'feat/x')).toBe('feat/x');
+    expect(defaultPrTitle(undefined, 'feat/x')).toBe('feat/x');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use 22.17.1 && cd codey-mac && npx vitest run src/components/createPrModel.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+import type { TaskBrief } from '../types';
+
+type Status = TaskBrief['state']['status'];
+
+/** Button visibility/enablement: visible when the agent has fulfilled the task
+ *  (waiting on the user, or done); enabled only when there are commits to PR. */
+export function createPrButtonState(status: Status, branchAhead: boolean): { show: boolean; enabled: boolean } {
+  const show = status === 'waiting' || status === 'done';
+  return { show, enabled: show && branchAhead };
+}
+
+/** Default PR title: trimmed commit subject, falling back to the branch name. */
+export function defaultPrTitle(commitSubject: string | undefined, branch: string): string {
+  const s = (commitSubject ?? '').trim();
+  return s || branch;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use 22.17.1 && cd codey-mac && npx vitest run src/components/createPrModel.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/createPrModel.ts codey-mac/src/components/createPrModel.test.ts
+git commit -m "feat(mac): createPrModel gating + title logic + tests"
+```
+
+---
+
+## Phase 4 — `useGitBranches` hook
+
+### Task 16: Live-updating branch/worktree hook
+
+**Files:**
+- Create: `codey-mac/src/hooks/useGitBranches.ts`
+
+- [ ] **Step 1: Implement the hook**
+
+Extends the `useGitStatus` pattern: pulls status + branches + worktrees, subscribes to `git:changed`, registers/tears down the watcher, and exposes mutating actions.
+
+```ts
+import { useState, useEffect, useCallback } from 'react'
+import type { Worktree } from '../components/branchPickerModel'
+
+export interface BranchState {
+  branch: string
+  dirty: number
+  local: string[]
+  remote: string[]
+  worktrees: Worktree[]
+}
+
+export function useGitBranches(workingDir: string | undefined) {
+  const [state, setState] = useState<BranchState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!workingDir) { setState(null); return }
+    try {
+      const [s, b, w] = await Promise.all([
+        window.codey.git.status(workingDir),
+        window.codey.git.branches(workingDir),
+        window.codey.git.worktrees(workingDir),
+      ])
+      if (!s.ok || !s.data) { setState(null); return }
+      const br = b.ok ? b.data : { current: s.data.branch, local: [], remote: [] }
+      const wl = w.ok ? w.data.list : []
+      setState({ branch: s.data.branch, dirty: s.data.dirty, local: br.local, remote: br.remote, worktrees: wl })
+    } catch { setState(null) }
+  }, [workingDir])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  // Live updates: watch .git and re-pull on change. Polling fallback every 5s.
+  useEffect(() => {
+    if (!workingDir) return
+    void window.codey.git.watch(workingDir)
+    const off = window.codey.git.onChanged(ev => { if (ev.workingDir === workingDir) void refresh() })
+    const onFocus = () => void refresh()
+    window.addEventListener('focus', onFocus)
+    const poll = setInterval(() => void refresh(), 5000)
+    return () => {
+      off()
+      window.removeEventListener('focus', onFocus)
+      clearInterval(poll)
+      void window.codey.git.unwatch(workingDir)
+    }
+  }, [workingDir, refresh])
+
+  const checkout = useCallback(async (name: string, opts?: { create?: boolean; track?: boolean }) => {
+    if (!workingDir) return { ok: false, error: 'no dir' }
+    setError(null)
+    const r = await window.codey.git.checkout(workingDir, name, opts)
+    if (r.ok) await refresh()
+    else if (r.data?.reason !== 'dirty') setError(r.data?.error || r.error || 'checkout failed')
+    return r.ok ? { ok: true } : { ok: false, error: r.data?.error, reason: r.data?.reason }
+  }, [workingDir, refresh])
+
+  const stashAndSwitch = useCallback(async (name: string) => {
+    if (!workingDir) return { ok: false }
+    const st = await window.codey.git.stash(workingDir, `codey-mac: switch to ${name}`)
+    if (!st.ok || !st.data?.ok) { setError(st.data?.error || 'stash failed'); return { ok: false } }
+    const co = await window.codey.git.checkout(workingDir, name)
+    if (co.ok && co.data?.ok) { await refresh(); return { ok: true } }
+    setError(co.data?.error || 'checkout failed'); return { ok: false }
+  }, [workingDir, refresh])
+
+  const createBranch = useCallback(async (name: string) => checkout(name, { create: true }), [checkout])
+
+  const fetchRemote = useCallback(async () => {
+    if (!workingDir) return
+    const r = await window.codey.git.fetch(workingDir)
+    if (r.ok && r.data?.ok) await refresh()
+    else setError(r.data?.error || 'fetch failed')
+  }, [workingDir, refresh])
+
+  const addWorktree = useCallback(async (name: string, path: string) => {
+    if (!workingDir) return { ok: false }
+    const r = await window.codey.git.worktreeAdd(workingDir, { name, path })
+    if (r.ok && r.data?.ok) { await refresh(); return { ok: true, path: r.data.path } }
+    setError(r.data?.error || 'worktree add failed'); return { ok: false }
+  }, [workingDir, refresh])
+
+  return { state, error, setError, refresh, checkout, stashAndSwitch, createBranch, fetchRemote, addWorktree }
+}
+```
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/hooks/useGitBranches.ts
+git commit -m "feat(mac): useGitBranches hook with live git:changed updates"
+```
+
+---
+
+## Phase 5 — Components
+
+### Task 17: `BranchPicker.tsx` dropdown + header pill
+
+**Files:**
+- Create: `codey-mac/src/components/BranchPicker.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+A pill button that opens a dropdown (filter, local branches, remote, worktrees, create row with the worktree-default toggle, dirty prompt). Consumes `useGitBranches` and the pure models. Calls `onBindWorktree(path | null)` to update the chat binding.
+
+```tsx
+import React, { useMemo, useRef, useState, useEffect } from 'react'
+import { C } from '../theme'
+import { useGitBranches } from '../hooks/useGitBranches'
+import { filterBranches, defaultWorktreePath, partitionWorktrees } from './branchPickerModel'
+
+interface Props {
+  workingDir: string | undefined
+  repoRoot: string | undefined           // for default worktree path; falls back to workingDir
+  boundWorktreePath?: string             // chat.workingDirOverride
+  onBindWorktree: (path: string | null) => void
+}
+
+type Mode = { kind: 'list' } | { kind: 'create' } | { kind: 'dirty'; target: string }
+
+export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorktreePath, onBindWorktree }) => {
+  const git = useGitBranches(workingDir)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [mode, setMode] = useState<Mode>({ kind: 'list' })
+  const [newName, setNewName] = useState('')
+  const [useWorktree, setUseWorktree] = useState(true)   // worktree is the DEFAULT
+  const [note, setNote] = useState<string | null>(null)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false) }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => { document.removeEventListener('mousedown', onDown); document.removeEventListener('keydown', onKey) }
+  }, [open])
+
+  const s = git.state
+  const { main, others } = useMemo(() => partitionWorktrees(s?.worktrees ?? []), [s])
+  const localFiltered = useMemo(() => filterBranches(s?.local ?? [], query), [s, query])
+  const remoteFiltered = useMemo(() => filterBranches(s?.remote ?? [], query), [s, query])
+  const repo = repoRoot || workingDir || ''
+  const previewPath = useWorktree && newName ? defaultWorktreePath(repo, newName) : ''
+  const boundLabel = others.find(w => w.path === boundWorktreePath)?.branch
+
+  const doSwitch = async (name: string) => {
+    const r = await git.checkout(name)
+    if (r.ok) { setOpen(false); return }
+    if (r.reason === 'dirty') setMode({ kind: 'dirty', target: name })
+  }
+
+  const doCreate = async () => {
+    if (!newName.trim()) return
+    if (useWorktree) {
+      const r = await git.addWorktree(newName.trim(), defaultWorktreePath(repo, newName.trim()))
+      if (r.ok && r.path) { onBindWorktree(r.path); setOpen(false) }
+    } else {
+      const r = await git.createBranch(newName.trim())
+      if (r.ok) { setOpen(false) }
+    }
+  }
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button style={styles.pill} onClick={() => setOpen(o => !o)} title="Branch & worktree">
+        <span>⎇ {s?.branch ?? '—'}</span>
+        {s && s.dirty > 0 && <span style={styles.dirty}>+{s.dirty}</span>}
+        {boundLabel && <span style={styles.wt}>🌳 {boundLabel}</span>}
+        <span style={styles.caret}>▾</span>
+      </button>
+
+      {open && (
+        <div style={styles.menu}>
+          {mode.kind === 'dirty' ? (
+            <div style={styles.section}>
+              <div style={styles.warn}>Switching would overwrite local changes.</div>
+              <div style={styles.row}>
+                <button style={styles.primary} onClick={async () => {
+                  const r = await git.stashAndSwitch(mode.target)
+                  if (r.ok) { setNote('Local changes stashed — restore with `git stash pop`'); setMode({ kind: 'list' }); setOpen(false) }
+                }}>Stash & switch</button>
+                <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
+              </div>
+            </div>
+          ) : mode.kind === 'create' ? (
+            <div style={styles.section}>
+              <input autoFocus placeholder="new-branch-name" value={newName}
+                onChange={e => setNewName(e.target.value)} style={styles.input} />
+              <div style={styles.toggle}>
+                <button style={useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(true)}>In a new worktree</button>
+                <button style={!useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(false)}>On current checkout</button>
+              </div>
+              {previewPath && <div style={styles.preview}>{previewPath}</div>}
+              <div style={styles.row}>
+                <button style={styles.primary} onClick={doCreate}>Create</button>
+                <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <input placeholder="Filter branches…" value={query}
+                onChange={e => setQuery(e.target.value)} style={styles.input} />
+              <div style={styles.scroll}>
+                {localFiltered.map(b => (
+                  <button key={b} style={styles.item} disabled={b === s?.branch} onClick={() => doSwitch(b)}>
+                    {b === s?.branch ? '✓ ' : ''}{b}
+                  </button>
+                ))}
+                {remoteFiltered.length > 0 && <div style={styles.divider}>Remote</div>}
+                {remoteFiltered.map(b => (
+                  <button key={b} style={styles.item} onClick={() => git.checkout(b.replace(/^[^/]+\//, ''), { track: true }).then(() => setOpen(false))}>
+                    {b}
+                  </button>
+                ))}
+                {others.length > 0 && <div style={styles.divider}>Worktrees</div>}
+                {main && (
+                  <button style={styles.item} onClick={() => { onBindWorktree(null); setOpen(false) }}>
+                    {!boundWorktreePath ? '✓ ' : ''}{main.branch} (main)
+                  </button>
+                )}
+                {others.map(w => (
+                  <button key={w.path} style={styles.item} onClick={() => { onBindWorktree(w.path); setOpen(false) }}>
+                    {w.path === boundWorktreePath ? '✓ ' : ''}🌳 {w.branch}
+                  </button>
+                ))}
+              </div>
+              {git.error && <div style={styles.err}>{git.error}</div>}
+              {note && <div style={styles.noteBox}>{note}</div>}
+              <div style={styles.footer}>
+                <button style={styles.ghost} onClick={() => { setNewName(''); setUseWorktree(true); setMode({ kind: 'create' }) }}>+ New branch…</button>
+                <button style={styles.ghost} onClick={() => git.fetchRemote()}>Fetch remote</button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  pill: { display: 'inline-flex', alignItems: 'center', gap: 6, color: C.fg2, fontSize: 11,
+    background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 4, padding: '2px 6px',
+    fontFamily: 'SF Mono, Menlo, monospace', cursor: 'pointer', flexShrink: 0, maxWidth: 260,
+    overflow: 'hidden', whiteSpace: 'nowrap' },
+  dirty: { color: C.yellow, opacity: 0.85 },
+  wt: { color: C.green },
+  caret: { color: C.fg3 },
+  menu: { position: 'absolute', top: 'calc(100% + 4px)', left: 0, zIndex: 20, width: 280,
+    background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)', padding: 8, display: 'flex', flexDirection: 'column', gap: 6 },
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  scroll: { maxHeight: 260, overflowY: 'auto', display: 'flex', flexDirection: 'column' },
+  item: { textAlign: 'left', background: 'transparent', border: 'none', color: C.fg, fontSize: 12,
+    padding: '6px 8px', borderRadius: 6, cursor: 'pointer' },
+  divider: { fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, color: C.fg3, padding: '8px 8px 2px' },
+  input: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg,
+    fontSize: 12, padding: '5px 8px', outline: 'none' },
+  toggle: { display: 'flex', gap: 4 },
+  seg: { flex: 1, background: C.surface3, border: `1px solid ${C.border2}`, color: C.fg2, fontSize: 11,
+    padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
+  segOn: { flex: 1, background: C.accent, border: `1px solid ${C.accent}`, color: '#fff', fontSize: 11,
+    padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
+  preview: { fontSize: 10, color: C.fg3, fontFamily: 'SF Mono, Menlo, monospace', wordBreak: 'break-all' },
+  row: { display: 'flex', gap: 6 },
+  primary: { background: C.accent, color: '#fff', border: 'none', borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
+  ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
+  footer: { display: 'flex', justifyContent: 'space-between', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
+  warn: { fontSize: 12, color: C.yellow },
+  err: { fontSize: 11, color: C.red, padding: '2px 4px' },
+  noteBox: { fontSize: 11, color: C.fg3, padding: '2px 4px' },
+}
+```
+
+> Verify theme tokens `C.yellow`, `C.green`, `C.red`, `C.accent`, `C.surface2/3`, `C.border/border2`, `C.fg/fg2/fg3` exist in `src/theme.ts` (they're used in StatusSidecar). Adjust names if any differ.
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/components/BranchPicker.tsx
+git commit -m "feat(mac): BranchPicker dropdown (switch/create/fetch/worktree/stash)"
+```
+
+### Task 18: Mount BranchPicker in the chat header + thread the binding
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx:442-449` (workingDir derivation) and `:912-918` (header badge)
+
+- [ ] **Step 1: Derive the effective working dir from the chat override**
+
+Replace the `workingDir` effect (lines 442-448) so the chat's `workingDirOverride` wins:
+
+```tsx
+  const [workspaceDir, setWorkspaceDir] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (!chat?.workspaceName) return
+    apiService.getWorkspaceInfo(chat.workspaceName)
+      .then(info => setWorkspaceDir(info.workingDir))
+      .catch(() => setWorkspaceDir(undefined))
+  }, [chat?.workspaceName])
+  const workingDir = chat?.workingDirOverride || workspaceDir
+```
+
+> Remove the now-unused `useGitStatus` import/usage if the new picker replaces the badge; keep `gitStatus` only if other code references it. If `gitStatus` is still referenced (e.g. for the PR button's dirty count), keep `const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)`.
+
+- [ ] **Step 2: Replace the badge with BranchPicker**
+
+Replace lines 914-918 (the `{gitStatus && (<span style={styles.gitBadge} …>)}` block) with:
+
+```tsx
+        <BranchPicker
+          workingDir={workingDir}
+          repoRoot={workspaceDir}
+          boundWorktreePath={chat?.workingDirOverride}
+          onBindWorktree={async (path) => {
+            if (!chat) return
+            await apiService.chats.setWorkingDir(chat.id, path)
+            await refreshChat(chat.id)   // re-fetch so workingDirOverride updates locally
+          }}
+        />
+```
+
+> Wire `refreshChat` from the chats hook in scope (the same mechanism used after `setSoloAdvisor`/`updateAgentModel`). If ChatTab already exposes a chat-refresh callback prop, use it; otherwise call the `useChats` refresh for this chat id.
+
+- [ ] **Step 3: Add the import** near the other component imports (top of ChatTab.tsx):
+
+```tsx
+import { BranchPicker } from './BranchPicker'
+```
+
+- [ ] **Step 4: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): mount BranchPicker in chat header + worktree binding"
+```
+
+### Task 19: `CreatePrModal.tsx`
+
+**Files:**
+- Create: `codey-mac/src/components/CreatePrModal.tsx`
+
+- [ ] **Step 1: Implement the modal**
+
+```tsx
+import React, { useState } from 'react'
+import { C } from '../theme'
+
+interface Props {
+  defaultTitle: string
+  onCancel: () => void
+  onCreate: (input: { title: string; body: string }) => Promise<{ ok: boolean; url?: string; error?: string }>
+}
+
+export const CreatePrModal: React.FC<Props> = ({ defaultTitle, onCancel, onCreate }) => {
+  const [title, setTitle] = useState(defaultTitle)
+  const [body, setBody] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [url, setUrl] = useState<string | null>(null)
+
+  const submit = async () => {
+    setBusy(true); setError(null)
+    const r = await onCreate({ title: title.trim(), body })
+    setBusy(false)
+    if (r.ok && r.url) setUrl(r.url)
+    else setError(r.error || 'Failed to create PR')
+  }
+
+  return (
+    <div style={styles.backdrop} onClick={onCancel}>
+      <div style={styles.card} onClick={e => e.stopPropagation()}>
+        <div style={styles.head}>Create Pull Request</div>
+        {url ? (
+          <>
+            <div style={styles.success}>PR created.</div>
+            <button style={styles.primary} onClick={() => window.codey.openExternal?.(url) ?? window.open(url)}>Open PR</button>
+            <button style={styles.ghost} onClick={onCancel}>Close</button>
+          </>
+        ) : (
+          <>
+            <label style={styles.label}>Title</label>
+            <input value={title} onChange={e => setTitle(e.target.value)} style={styles.input} />
+            <label style={styles.label}>Description</label>
+            <textarea value={body} onChange={e => setBody(e.target.value)} style={styles.textarea} rows={5} />
+            {error && <div style={styles.err}>{error}</div>}
+            <div style={styles.row}>
+              <button style={styles.primary} disabled={busy || !title.trim()} onClick={submit}>{busy ? 'Creating…' : 'Create PR'}</button>
+              <button style={styles.ghost} onClick={onCancel}>Cancel</button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: { position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center' },
+  card: { width: 420, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 12, padding: 16, display: 'flex', flexDirection: 'column', gap: 8 },
+  head: { fontSize: 14, fontWeight: 600, color: C.fg },
+  label: { fontSize: 11, color: C.fg3, textTransform: 'uppercase', letterSpacing: 0.5 },
+  input: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg, fontSize: 13, padding: '6px 8px', outline: 'none' },
+  textarea: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg, fontSize: 13, padding: '6px 8px', outline: 'none', resize: 'vertical' },
+  row: { display: 'flex', gap: 8, marginTop: 4 },
+  primary: { background: C.accent, color: '#fff', border: 'none', borderRadius: 6, padding: '6px 12px', fontSize: 13, cursor: 'pointer' },
+  ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '6px 12px', fontSize: 13, cursor: 'pointer' },
+  success: { fontSize: 13, color: C.green },
+  err: { fontSize: 12, color: C.red },
+}
+```
+
+> Check how the app opens external URLs elsewhere (e.g. `shell.openExternal` via an existing `openExternal` IPC). If there's no `window.codey.openExternal`, add a tiny `shell:openExternal` IPC mirroring the createPr pattern, or use an `<a target="_blank">`. Match the existing convention used by `UpdateButton.tsx`/notification links.
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/components/CreatePrModal.tsx
+git commit -m "feat(mac): CreatePrModal"
+```
+
+### Task 20: Create PR button in StatusSidecar
+
+**Files:**
+- Modify: `codey-mac/src/components/StatusSidecar.tsx`
+
+- [ ] **Step 1: Extend Props and render the gated button**
+
+Add to the `Props` interface:
+
+```tsx
+  /** Branch is ahead of the default branch (has commits to PR). */
+  branchAhead?: boolean
+  /** Open the Create PR flow. Only invoked when the button is enabled. */
+  onCreatePr?: () => void
+```
+
+Add the import at the top:
+
+```tsx
+import { createPrButtonState } from './createPrModel'
+```
+
+Inside the component body (before `return`), compute state:
+
+```tsx
+  const prState = createPrButtonState(view.status, !!branchAhead)
+```
+
+Render the button inside the expanded branch, right after the `nextBox` block (after line ~86), and also in the collapsed `statusRow` is not needed — keep it in the expanded view:
+
+```tsx
+          {prState.show && (
+            <button
+              style={{ ...styles.prBtn, opacity: prState.enabled ? 1 : 0.5, cursor: prState.enabled ? 'pointer' : 'not-allowed' }}
+              disabled={!prState.enabled}
+              title={prState.enabled ? 'Create a pull request' : 'No commits to PR'}
+              onClick={(e) => { e.stopPropagation(); if (prState.enabled) onCreatePr?.() }}
+            >
+              Create PR →
+            </button>
+          )}
+```
+
+Add the style to the `styles` object:
+
+```tsx
+  prBtn: { marginTop: 4, width: '100%', background: C.green, color: '#0b0b0b', border: 'none',
+    borderRadius: 8, padding: '8px 10px', fontSize: 12, fontWeight: 600 },
+```
+
+> `onClick` calls `e.stopPropagation()` because the whole card has an `onOpen` click handler (line 35) — the button must not also open the panel.
+
+- [ ] **Step 2: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/components/StatusSidecar.tsx
+git commit -m "feat(mac): gated Create PR button in StatusSidecar"
+```
+
+### Task 21: Wire StatusSidecar PR props + modal in ChatTab
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx` (the StatusSidecar render ~line 1505, plus modal state)
+
+- [ ] **Step 1: Add PR modal state + branch-ahead derivation**
+
+Near the other `useState` declarations in ChatTab:
+
+```tsx
+  const [showPrModal, setShowPrModal] = useState(false)
+  const [branchAhead, setBranchAhead] = useState(false)
+  useEffect(() => {
+    if (!workingDir) { setBranchAhead(false); return }
+    // Ahead of upstream OR has commits vs default: a dirty tree or any local-ahead counts as "something to PR".
+    window.codey.git.status(workingDir).then(r => {
+      setBranchAhead(!!r.ok && !!r.data && (r.data.dirty > 0 || r.data.branch !== 'main'))
+    }).catch(() => setBranchAhead(false))
+  }, [workingDir, gitStatus])
+```
+
+> This is a heuristic (non-main branch or dirty tree ⇒ likely something to PR). A precise `git rev-list --count main..HEAD` could replace it later; out of scope for v1.
+
+- [ ] **Step 2: Pass props to StatusSidecar** (in the render block ~line 1505):
+
+```tsx
+          <StatusSidecar
+            view={extractSidecarBrief(chat.taskBrief)}
+            loading={taskBriefLoading}
+            width={SIDECAR_W}
+            onOpen={() => { setContextPanelOpen(chat.id, true); setPanelTab('task') }}
+            branchAhead={branchAhead}
+            onCreatePr={() => setShowPrModal(true)}
+          />
+```
+
+- [ ] **Step 3: Render the modal** (near the end of ChatTab's returned JSX, alongside other overlays):
+
+```tsx
+      {showPrModal && (
+        <CreatePrModal
+          defaultTitle={chat?.taskBrief?.goal || gitStatus?.branch || ''}
+          onCancel={() => setShowPrModal(false)}
+          onCreate={async (input) => {
+            if (!workingDir) return { ok: false, error: 'No working dir' }
+            const r = await window.codey.git.createPr(workingDir, input)
+            return r.ok && r.data ? r.data : { ok: false, error: r.error || 'Failed' }
+          }}
+        />
+      )}
+```
+
+- [ ] **Step 4: Add imports**
+
+```tsx
+import { CreatePrModal } from './CreatePrModal'
+```
+
+- [ ] **Step 5: Build** — Run: `nvm use 22.17.1 && cd codey-mac && npm run build` — Expected: success.
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): wire Create PR modal + branch-ahead into ChatTab"
+```
+
+---
+
+## Phase 6 — Full verification
+
+### Task 22: Run the whole suite + manual smoke test
+
+- [ ] **Step 1: Run all unit tests**
+
+Run: `nvm use 22.17.1 && cd codey-mac && npm test`
+Expected: PASS, including `branchPickerModel.test.ts` and `createPrModel.test.ts`.
+
+- [ ] **Step 2: Run gateway tests** — Run: `nvm use 22.17.1 && npm test -w @codey/gateway` — Expected: PASS including the new `setWorkingDirOverride` test.
+
+- [ ] **Step 3: Lint** — Run: `nvm use 22.17.1 && npm run lint` — Expected: no non-English-character violations in new files.
+
+- [ ] **Step 4: Manual smoke test** (launch the Mac app: `nvm use 22.17.1 && cd codey-mac && npm run dev` or the project's run command)
+
+Verify each:
+- [ ] Click the branch pill → dropdown lists local branches with the current one checked.
+- [ ] Switch to a clean branch → pill updates.
+- [ ] Switch with uncommitted changes → "Stash & switch" prompt appears; confirming stashes + switches and shows the stash note.
+- [ ] "+ New branch…" → toggle defaults to **In a new worktree**; the preview path shows `.codey-worktrees/...`; Create makes the worktree and binds the chat (🌳 chip appears).
+- [ ] Selecting the main worktree clears the binding (🌳 chip disappears).
+- [ ] Change branch in an external terminal → pill updates within ~5s (or instantly via watcher) without focusing the window.
+- [ ] Drive a chat to `waiting`/`done` → Create PR button appears; with commits it's enabled; clicking opens the modal; creating runs push + `gh pr create` and shows the PR URL.
+
+- [ ] **Step 5: Final commit (if any lint/test fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(mac): branch picker + worktree + PR verification fixups"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Part 1 (switch/create/fetch/stash) → Tasks 1-4, 14, 17-18. Part 1b worktrees → Tasks 5-6, 10-13, 17-18. Live updates → Tasks 8-9, 16. Part 2 Create PR → Tasks 7, 15, 19-21. Header styling → Task 17 (`styles.pill` unifying branch + worktree). Testing section → Tasks 11, 14-15, 22.
+- **Type consistency:** `{ current, local, remote }`, `Worktree { branch, path, isMain }`, `createPrButtonState`, `defaultPrTitle`, `defaultWorktreePath`, `partitionWorktrees`, `filterBranches`, `setWorkingDirOverride`, `workingDirOverride` are used identically across tasks.
+- **Known soft spots to verify during execution (flagged inline):** exact in-scope name of `sendToRenderer` (Task 8); `ChatManager` constructor signature (Task 11); chat-refresh callback name in ChatTab (Task 18); external-URL open mechanism (Task 19); theme token names (Task 17). These are existing-codebase wiring details to confirm, not new design decisions.

--- a/codey-mac/docs/superpowers/plans/2026-06-21-branch-picker-worktree-pr.md
+++ b/codey-mac/docs/superpowers/plans/2026-06-21-branch-picker-worktree-pr.md
@@ -656,9 +656,9 @@ describe('filterBranches', () => {
 });
 
 describe('defaultWorktreePath', () => {
-  it('builds a sibling .codey-worktrees path with sanitized branch', () => {
+  it('builds an in-repo .codey/worktrees path with sanitized branch', () => {
     expect(defaultWorktreePath('/home/u/repo', 'feat/cool thing'))
-      .toBe('/home/u/.codey-worktrees/repo-feat-cool-thing');
+      .toBe('/home/u/repo/.codey/worktrees/feat-cool-thing');
   });
 });
 
@@ -694,12 +694,11 @@ export function filterBranches(list: string[], query: string): string[] {
   return list.filter(b => b.toLowerCase().includes(q));
 }
 
-/** Default worktree location: `<repo-parent>/.codey-worktrees/<repo>-<branch>`. */
+/** Default worktree location: `<repo>/.codey/worktrees/<branch>` (in-repo, gitignored). */
 export function defaultWorktreePath(repoPath: string, branchName: string): string {
-  const parent = path.dirname(repoPath);
-  const repo = path.basename(repoPath);
+  const root = repoPath.replace(/\/+$/, '');
   const safe = branchName.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-  return path.join(parent, '.codey-worktrees', `${repo}-${safe}`);
+  return `${root}/.codey/worktrees/${safe}`;
 }
 
 /** Separate the main worktree from the rest for display. */
@@ -1387,7 +1386,7 @@ Verify each:
 - [ ] Click the branch pill → dropdown lists local branches with the current one checked.
 - [ ] Switch to a clean branch → pill updates.
 - [ ] Switch with uncommitted changes → "Stash & switch" prompt appears; confirming stashes + switches and shows the stash note.
-- [ ] "+ New branch…" → toggle defaults to **In a new worktree**; the preview path shows `.codey-worktrees/...`; Create makes the worktree and binds the chat (🌳 chip appears).
+- [ ] "+ New branch…" → toggle defaults to **In a new worktree**; the preview path shows `.codey/worktrees/...`; Create makes the worktree and binds the chat (🌳 chip appears).
 - [ ] Selecting the main worktree clears the binding (🌳 chip disappears).
 - [ ] Change branch in an external terminal → pill updates within ~5s (or instantly via watcher) without focusing the window.
 - [ ] Drive a chat to `waiting`/`done` → Create PR button appears; with commits it's enabled; clicking opens the modal; creating runs push + `gh pr create` and shows the PR URL.

--- a/codey-mac/docs/superpowers/specs/2026-06-21-branch-picker-and-create-pr-design.md
+++ b/codey-mac/docs/superpowers/specs/2026-06-21-branch-picker-and-create-pr-design.md
@@ -125,9 +125,10 @@ shared checkout in place. This is the **default** when creating a new branch.
 - **Create in a new worktree** (default of the "+ New branch…" toggle):
   - Runs `git worktree add <path> -b <name>` from the chat's current
     `workingDir` repo.
-  - Default `<path>`: `<repo-parent>/.codey-worktrees/<repo>-<name>` — a sibling
-    of the repo, predictable, and easy to gitignore. The resolved path is shown
-    in the create row before confirming.
+  - Default `<path>`: `<repo>/.codey/worktrees/<name>` — in-repo and predictable.
+    The worktree-add backend drops a `.gitignore` (`*`) in the `worktrees/`
+    container so the checkouts never show up in the main repo's `git status`. The
+    resolved path is shown in the create row before confirming.
   - On success the chat is **bound** to the new worktree (see below) so the agent
     immediately works there.
 - **Select an existing worktree** from the dropdown's Worktrees section → binds
@@ -228,6 +229,6 @@ A **Create PR** button rendered inside `StatusSidecar.tsx`.
 
 - Force checkout.
 - Worktree **removal** from the UI (manage via terminal).
-- Configurable worktree location (fixed `.codey-worktrees/` default in v1).
+- Configurable worktree location (fixed `<repo>/.codey/worktrees/` default in v1).
 - Editing PR base branch, reviewers, labels in the modal (gh defaults only).
 - Non-GitHub remotes (gh handles only GitHub).

--- a/codey-mac/docs/superpowers/specs/2026-06-21-branch-picker-and-create-pr-design.md
+++ b/codey-mac/docs/superpowers/specs/2026-06-21-branch-picker-and-create-pr-design.md
@@ -1,0 +1,233 @@
+# Branch picker + Create PR button — Design
+
+**Date:** 2026-06-21
+**Surface:** `codey-mac` (Electron + React)
+
+## Problem
+
+Two gaps in the chat surface of the Mac app:
+
+1. The git branch badge in the chat header (`ChatTab.tsx`) is read-only and only
+   refreshes on window focus. The user wants to (a) click it to switch to a
+   different branch, and (b) see branch changes made elsewhere (e.g. a terminal)
+   reflected live without manually refreshing.
+2. There's no way to choose **where** a feature is developed. The user wants to
+   pick, when starting a branch, whether it runs in an isolated **git worktree**
+   (the default) or on the current checkout in place — and have the chat's agent
+   work in that worktree.
+3. The floating status panel (`StatusSidecar`) has no way to act on a finished
+   task. The user wants a **Create PR** button that appears once the agent/worker
+   has fulfilled the requirements — i.e. when the task is awaiting their
+   confirmation or done — so they can open a PR directly without telling the
+   agent "I confirmed."
+
+## Part 1 — Branch picker (chat header)
+
+The branch badge (`ChatTab.tsx:914`, `styles.gitBadge`) becomes an interactive
+dropdown.
+
+### Header styling (unified git control)
+
+The standalone branch badge is replaced by a single cohesive **git control** pill
+that reads well alongside the existing `workspaceTag`, rather than two competing
+badges:
+
+```
+⎇ feature-x  +2   🌳 worktree   ▾
+└ branch     └dirty └ only when bound to a non-main worktree
+```
+
+- One pill-shaped button (reuses `gitBadge`/`workspaceTag` pill styling): `⎇` +
+  branch name, a faint `+N` dirty count, and — when the chat is bound to a
+  non-main worktree — a small `🌳` chip with the worktree label, then a `▾`
+  caret. Clicking opens the unified dropdown (branches · worktrees · new).
+- When unbound (workspace dir) the `🌳` chip is omitted so the common case stays
+  compact.
+
+### Behavior
+
+- **Click the badge** → dropdown anchored under it, containing:
+  - A filter/search input at the top.
+  - The list of **local branches**, current one marked (✓) and disabled.
+  - Remote-only branches (e.g. `origin/feature-x`) listed under a divider once
+    fetched; selecting one checks it out as a tracking branch.
+  - A **Worktrees** section listing existing worktrees (branch + short path);
+    selecting one binds this chat to that worktree (see _Part 1b_).
+  - Footer actions: **"+ New branch…"** and **"Fetch remote branches"**.
+- **Switch** — selecting a local branch runs `git checkout <name>`.
+  - If the checkout fails because local changes would be overwritten (git
+    reports a `dirty`/conflict error), the dropdown does **not** just show the
+    raw error. It shows an inline prompt: _"Switching would overwrite local
+    changes"_ with two actions — **"Stash & switch"** and **"Cancel"**.
+  - **Stash & switch** runs `git stash push -u -m "codey-mac: switch to <name>"`
+    (the `-u` includes untracked files), then retries `git checkout <name>`. The
+    stash is **not** auto-popped on the target branch — re-applying it could
+    reintroduce the same conflict elsewhere. Instead, on success the dropdown
+    shows a one-line note: _"Local changes stashed — restore with `git stash
+    pop`"_. This guarantees no work is lost and no surprise merge conflicts on
+    the new branch.
+  - Any other checkout failure surfaces the git stderr inline. No force.
+- **Create** — "+ New branch…" swaps the filter row for a name input plus a
+  segmented **"In a new worktree" / "On current checkout"** toggle. **"In a new
+  worktree" is the default selection.** "On current checkout" runs
+  `git checkout -b <name>` (branched from current HEAD); "In a new worktree"
+  follows _Part 1b — Git worktrees_ below.
+- **Fetch remote** — runs `git fetch`, then re-lists branches including
+  remote-only ones, which check out via `git checkout --track <remote>/<name>`.
+- The dropdown closes on outside-click / Escape / successful checkout.
+
+### Live updates (no manual refresh)
+
+- Main process watches the chat's `workingDir` `.git/HEAD` (and `.git/refs/heads`)
+  with `fs.watch`, debounced ~200ms, and emits a `git:changed` event to the
+  renderer. The renderer re-pulls `git:status` on that event.
+- A ~5s polling fallback covers filesystems where `fs.watch` is unreliable.
+- This supplements the existing window-focus refresh in `useGitStatus`.
+
+### IPC additions
+
+All wrap `execFile('git', …, { cwd: workingDir, timeout })` like the existing
+`git:status` handler (`electron/main.ts:1360`). Added to `main.ts`,
+`preload.ts`, and `codey-api.d.ts`:
+
+- `git:branches(workingDir)` → `{ current: string; local: string[]; remote: string[] }`
+- `git:checkout(workingDir, name, opts?: { create?: boolean; track?: boolean })` →
+  `{ ok: boolean; error?: string; reason?: 'dirty' }` — when checkout fails
+  because local changes would be overwritten, `reason: 'dirty'` is set so the UI
+  can offer **Stash & switch** instead of showing a raw error. Detected by
+  inspecting git's stderr ("would be overwritten by checkout" / "Your local
+  changes").
+- `git:stash(workingDir, message?: string)` → `{ ok: boolean; error?: string }` —
+  runs `git stash push -u -m <message>`. Used by the Stash & switch flow (stash,
+  then re-call `git:checkout`).
+- `git:fetch(workingDir)` → `{ ok: boolean; error?: string }`
+- `git:watch(workingDir)` to start a watcher (idempotent per dir) + `git:changed`
+  subscription channel; watcher torn down when no renderer is subscribed.
+
+`useGitStatus` is extended (or a sibling `useGitBranches` hook is added) to expose
+`branches`, `checkout`, `createBranch`, `fetchRemote`, and to subscribe to
+`git:changed`.
+
+### New component
+
+`BranchPicker.tsx` — the badge + dropdown. Pure-ish view fed by the hook; the
+list/filter/error state logic that's worth unit-testing lives in a
+`branchPickerModel.ts` companion (mirrors the existing `*Model.ts` +
+`*.test.ts` pattern in `src/components`).
+
+## Part 1b — Git worktrees
+
+A chat can develop a feature in an **isolated worktree** instead of switching the
+shared checkout in place. This is the **default** when creating a new branch.
+
+### Behavior
+
+- **Create in a new worktree** (default of the "+ New branch…" toggle):
+  - Runs `git worktree add <path> -b <name>` from the chat's current
+    `workingDir` repo.
+  - Default `<path>`: `<repo-parent>/.codey-worktrees/<repo>-<name>` — a sibling
+    of the repo, predictable, and easy to gitignore. The resolved path is shown
+    in the create row before confirming.
+  - On success the chat is **bound** to the new worktree (see below) so the agent
+    immediately works there.
+- **Select an existing worktree** from the dropdown's Worktrees section → binds
+  this chat to it (no new branch created).
+- The repo's **main worktree** is always listed; selecting it clears the binding
+  (reverts to the workspace dir).
+
+### Per-chat binding
+
+- A `workingDirOverride` (string | undefined) is stored on the `Chat`. When set,
+  `ChatTab` uses it instead of `getWorkspaceInfo().workingDir` for the git badge,
+  git status, watcher, and — critically — message sends pass it through as the
+  gateway run's `workingDir` (the gateway already honors a per-run
+  `workingDir`: `gateway.ts:162`, `context: { workingDir: opts.workingDir ?? this.workingDir }`).
+- Binding is **per chat**: other chats and the workspace default are unaffected.
+- Clearing the binding ("Use workspace dir" / selecting the main worktree) removes
+  the override.
+- Persisted with the chat so the binding survives reload.
+
+### IPC additions
+
+- `git:worktrees(workingDir)` →
+  `{ list: { branch: string; path: string; isMain: boolean }[] }` — parses
+  `git worktree list --porcelain`.
+- `git:worktreeAdd(workingDir, { name: string; path: string })` →
+  `{ ok: boolean; path?: string; error?: string }` — runs
+  `git worktree add <path> -b <name>`; returns the resolved absolute path to bind
+  to. Surfaces git stderr on failure (e.g. path exists, branch exists).
+
+Worktree **removal** is out of scope for v1 — manage stale worktrees via terminal
+(`git worktree remove`).
+
+## Part 2 — Create PR button (StatusSidecar)
+
+A **Create PR** button rendered inside `StatusSidecar.tsx`.
+
+### Gating
+
+- Visible only when `view.status === 'waiting' || view.status === 'done'` (the
+  status enum is `working | waiting | blocked | done`, from
+  `taskHudView.ts`). This is the "agent fulfilled the requirements" state — the
+  user does not have to confirm back to the agent first.
+- Within that, the button is **enabled** only when the current branch is ahead of
+  / differs from the default branch (something to PR). Otherwise it renders
+  disabled with a tooltip ("No commits to PR"). The ahead/branch info comes from
+  the git status already plumbed into the panel's host (`ChatTab`), passed down
+  as props — `StatusSidecar` stays presentational.
+
+### Action — inline `gh pr create`
+
+1. Click opens a small modal pre-filled with:
+   - **Title** — default: last commit subject, falling back to the branch name.
+   - **Body** — empty (optional).
+2. On confirm, the main process:
+   - Pushes the branch if it has no upstream: `git push -u origin <branch>`.
+   - Runs `gh pr create --title <t> --body <b> --head <branch>`.
+3. On success, the modal shows the returned PR URL with an **Open** link
+   (`shell.openExternal`). On failure (gh not installed/authed, no remote) the
+   stderr is surfaced in the modal.
+
+### IPC addition
+
+- `git:createPr(workingDir, { title: string; body: string })` →
+  `{ ok: boolean; url?: string; error?: string }` — wraps the push + `gh pr create`,
+  parses the PR URL from stdout. `gh` resolved from PATH (installed: gh 2.88.1).
+
+### Component changes
+
+- `StatusSidecar.tsx` gains the gated button + a small `CreatePrModal` (or an
+  inline expandable form). Submit/title-default/error-display logic that merits a
+  test goes in a `createPrModel.ts` companion.
+- `ChatTab.tsx` passes `workingDir`, branch-ahead info, and a `createPr` handler
+  into `StatusSidecar`.
+
+## Error handling
+
+- All git/gh failures return `{ ok: false, error }` and render inline (dropdown or
+  modal) — never a thrown/uncaught rejection. Existing handlers already use the
+  `wrap()` helper and return `null` on failure; new ones return structured errors
+  so the UI can show the cause.
+- Watcher failures (e.g. `.git` missing) degrade silently to the polling +
+  focus-refresh path.
+
+## Testing
+
+- `branchPickerModel.test.ts` — filtering, local/remote partition, create-mode
+  toggle (worktree-default selection), worktree list partition (main vs others),
+  default worktree path derivation, error surfacing, and the dirty → Stash &
+  switch prompt state (`reason: 'dirty'` triggers the prompt; "Cancel" restores
+  the list).
+- `createPrModel.test.ts` — title defaulting (commit subject → branch fallback),
+  gating predicate (`waiting`/`done` × branch-ahead), error display.
+- Manual: switch/create/fetch a branch from the picker; change branch in a
+  terminal and confirm the badge updates without focus change; finish a task and
+  confirm the PR button appears and opens a PR.
+
+## Out of scope
+
+- Force checkout.
+- Worktree **removal** from the UI (manage via terminal).
+- Configurable worktree location (fixed `.codey-worktrees/` default in v1).
+- Editing PR base branch, reviewers, labels in the modal (gh defaults only).
+- Non-GitHub remotes (gh handles only GitHub).

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1498,7 +1498,7 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('git:createPr', async (_e, workingDir: string, input: { title: string; body: string }) =>
+  ipcMain.handle('git:createPr', async (_e, workingDir: string, input: { title: string; body?: string }) =>
     wrap(async () => {
       if (!workingDir || !input?.title) return { ok: false, error: 'missing args' }
       const { execFile } = await import('child_process')
@@ -1528,7 +1528,6 @@ app.whenReady().then(async () => {
       const fsMod = await import('fs')
       const pathMod = await import('path')
       const gitDir = pathMod.join(workingDir, '.git')
-      const headPath = pathMod.join(gitDir, 'HEAD')
       const existing = gitWatchers.get(workingDir)
       if (existing) { existing.count++; return { ok: true } }
       try {
@@ -1538,11 +1537,15 @@ app.whenReady().then(async () => {
           if (entry.timer) clearTimeout(entry.timer)
           entry.timer = setTimeout(() => sendToRenderer('git:changed', { workingDir }), 200)
         }
-        // Watch the .git dir non-recursively; HEAD + refs changes bubble as rename/change events.
-        const watcher = fsMod.watch(gitDir, { persistent: false }, () => emit())
+        // Resolve real git dir: for a linked worktree .git is a file containing "gitdir: <path>"
+        const resolvedGitDir = fsMod.existsSync(gitDir) && fsMod.statSync(gitDir).isDirectory()
+          ? gitDir
+          : (() => {
+              try { return fsMod.readFileSync(gitDir, 'utf8').match(/gitdir:\s*(.+)/)?.[1]?.trim() } catch { return undefined }
+            })()
+        if (!resolvedGitDir) return { ok: false }
+        const watcher = fsMod.watch(resolvedGitDir, { persistent: false }, () => emit())
         gitWatchers.set(workingDir, { watcher, count: 1, timer: null })
-        // Fire once so the renderer pulls fresh status immediately.
-        void headPath
         return { ok: true }
       } catch {
         return { ok: false }
@@ -1552,6 +1555,7 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('git:unwatch', async (_e, workingDir: string) =>
     wrap(async () => {
+      if (!workingDir) return { ok: true }
       const entry = gitWatchers.get(workingDir)
       if (!entry) return { ok: true }
       entry.count--

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1488,7 +1488,15 @@ app.whenReady().then(async () => {
       const fsMod = await import('fs')
       const pathMod = await import('path')
       const target = pathMod.resolve(args2.path)
-      fsMod.mkdirSync(pathMod.dirname(target), { recursive: true })
+      const container = pathMod.dirname(target)
+      fsMod.mkdirSync(container, { recursive: true })
+      // In-repo worktrees would otherwise show up in the main repo's `git status`.
+      // Drop a `.gitignore` (`*`) in the container so every worktree checkout is ignored.
+      // Location-agnostic: works whether the container is the default .codey/worktrees or a custom path.
+      try {
+        const ignorePath = pathMod.join(container, '.gitignore')
+        if (!fsMod.existsSync(ignorePath)) fsMod.writeFileSync(ignorePath, '*\n')
+      } catch { /* best-effort; worktree add still proceeds */ }
       return await new Promise<{ ok: boolean; path?: string; error?: string }>((resolve) => {
         execFile('git', ['worktree', 'add', target, '-b', args2.name], { cwd: workingDir, timeout: 20000 }, (err, _out, stderr) => {
           if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2403,6 +2403,13 @@ app.whenReady().then(async () => {
     })
   )
 
+  ipcMain.handle('chats:setWorkingDir', async (_e, id: string, dir: string | null) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.getChatManager().setWorkingDirOverride(id, dir)
+    })
+  )
+
   ipcMain.handle('chats:stop', async (_e, chatId: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1377,7 +1377,20 @@ app.whenReady().then(async () => {
         ])
         const branch = branchOut.trim() || 'HEAD'
         const dirty = statusOut.split('\n').filter(l => l.trim()).length
-        return { branch, dirty }
+        // Repo default branch (for Create PR gating) — origin/HEAD when set, else 'main'.
+        let defaultBranch = 'main'
+        try {
+          const sym = await run(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
+          defaultBranch = sym.trim().replace(/^[^/]+\//, '') || 'main'
+        } catch { /* no origin/HEAD ref; keep 'main' */ }
+        // Commits on this branch that aren't on the default branch; null when unknowable.
+        let ahead: number | null = null
+        try {
+          const cnt = await run(['rev-list', '--count', `origin/${defaultBranch}..HEAD`])
+          const n = parseInt(cnt.trim(), 10)
+          if (!Number.isNaN(n)) ahead = n
+        } catch { /* no remote default ref; leave null */ }
+        return { branch, dirty, defaultBranch, ahead }
       } catch {
         return null
       }
@@ -1489,13 +1502,19 @@ app.whenReady().then(async () => {
       const pathMod = await import('path')
       const target = pathMod.resolve(args2.path)
       const container = pathMod.dirname(target)
+      // A branch name that sanitizes to nothing would make `target` the container itself.
+      if (pathMod.basename(target) === 'worktrees' && container.endsWith('.codey')) {
+        return { ok: false, error: 'invalid branch name' }
+      }
       fsMod.mkdirSync(container, { recursive: true })
       // In-repo worktrees would otherwise show up in the main repo's `git status`.
-      // Drop a `.gitignore` (`*`) in the container so every worktree checkout is ignored.
-      // Location-agnostic: works whether the container is the default .codey/worktrees or a custom path.
+      // Drop a `.gitignore` (`*`) so every worktree checkout is ignored — but only in
+      // the known .codey/worktrees container; never in arbitrary caller-supplied dirs.
       try {
-        const ignorePath = pathMod.join(container, '.gitignore')
-        if (!fsMod.existsSync(ignorePath)) fsMod.writeFileSync(ignorePath, '*\n')
+        if (container.endsWith(pathMod.join('.codey', 'worktrees'))) {
+          const ignorePath = pathMod.join(container, '.gitignore')
+          if (!fsMod.existsSync(ignorePath)) fsMod.writeFileSync(ignorePath, '*\n')
+        }
       } catch { /* best-effort; worktree add still proceeds */ }
       return await new Promise<{ ok: boolean; path?: string; error?: string }>((resolve) => {
         execFile('git', ['worktree', 'add', target, '-b', args2.name], { cwd: workingDir, timeout: 20000 }, (err, _out, stderr) => {
@@ -1522,9 +1541,18 @@ app.whenReady().then(async () => {
       // Push with upstream (no-op if already pushed; -u is safe to repeat)
       const push = await run('git', ['push', '-u', 'origin', branch], 60000)
       if (!push.ok) return { ok: false, error: (push.stderr || 'git push failed').trim() }
-      // Create PR
-      const pr = await run('gh', ['pr', 'create', '--title', input.title, '--body', input.body || '', '--head', branch], 60000)
-      if (!pr.ok) return { ok: false, error: (pr.stderr || 'gh pr create failed').trim() }
+      // Create PR. Finder-launched apps get launchd's minimal PATH, so resolve gh
+      // from the common install locations before falling back to PATH lookup.
+      const fsMod = await import('fs')
+      const gh = ['/opt/homebrew/bin/gh', '/usr/local/bin/gh', '/usr/bin/gh']
+        .find(p => fsMod.existsSync(p)) || 'gh'
+      const pr = await run(gh, ['pr', 'create', '--title', input.title, '--body', input.body || '', '--head', branch], 60000)
+      if (!pr.ok) {
+        const msg = /ENOENT/.test(pr.stderr)
+          ? 'GitHub CLI (gh) not found — install it with `brew install gh`'
+          : (pr.stderr || 'gh pr create failed').trim()
+        return { ok: false, error: msg }
+      }
       const url = (pr.stdout.match(/https?:\/\/\S+/) || [])[0] || pr.stdout.trim()
       return { ok: true, url }
     })

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1357,6 +1357,9 @@ app.whenReady().then(async () => {
   )
 
   // ── Git status IPC ────────────────────────────────────────────────
+  // Live git branch watching: one fs.watch per workingDir, ref-counted by renderer subscriptions.
+  const gitWatchers = new Map<string, { watcher: import('fs').FSWatcher; count: number; timer: NodeJS.Timeout | null }>()
+
   ipcMain.handle('git:status', async (_e, workingDir: string) =>
     wrap(async () => {
       if (!workingDir || typeof workingDir !== 'string') return null
@@ -1378,6 +1381,186 @@ app.whenReady().then(async () => {
       } catch {
         return null
       }
+    })
+  )
+
+  ipcMain.handle('git:branches', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir || typeof workingDir !== 'string') return { current: '', local: [], remote: [] }
+      const { execFile } = await import('child_process')
+      const run = (args: string[]) => new Promise<string>((resolve, reject) => {
+        execFile('git', args, { cwd: workingDir, timeout: 2000 }, (err, stdout) => {
+          if (err) reject(err); else resolve(stdout)
+        })
+      })
+      try {
+        const [curOut, localOut, remoteOut] = await Promise.all([
+          run(['rev-parse', '--abbrev-ref', 'HEAD']),
+          run(['for-each-ref', '--format=%(refname:short)', 'refs/heads']),
+          run(['for-each-ref', '--format=%(refname:short)', 'refs/remotes']),
+        ])
+        const current = curOut.trim() || 'HEAD'
+        const local = localOut.split('\n').map(l => l.trim()).filter(Boolean)
+        const remote = remoteOut.split('\n').map(l => l.trim())
+          .filter(l => l && !l.endsWith('/HEAD'))
+        return { current, local, remote }
+      } catch {
+        return { current: '', local: [], remote: [] }
+      }
+    })
+  )
+
+  ipcMain.handle('git:checkout', async (_e, workingDir: string, name: string, opts?: { create?: boolean; track?: boolean }) =>
+    wrap(async () => {
+      if (!workingDir || !name) return { ok: false, error: 'missing args' }
+      const { execFile } = await import('child_process')
+      const run = (args: string[]) => new Promise<{ ok: boolean; stderr: string }>((resolve) => {
+        execFile('git', args, { cwd: workingDir, timeout: 5000 }, (err, _out, stderr) => {
+          resolve({ ok: !err, stderr: stderr || (err ? String(err) : '') })
+        })
+      })
+      const args = opts?.create ? ['checkout', '-b', name]
+        : opts?.track ? ['checkout', '--track', name]
+        : ['checkout', name]
+      const r = await run(args)
+      if (r.ok) return { ok: true }
+      const dirty = /would be overwritten|Your local changes|commit your changes or stash/i.test(r.stderr)
+      return { ok: false, error: r.stderr.trim(), reason: dirty ? 'dirty' as const : undefined }
+    })
+  )
+
+  ipcMain.handle('git:stash', async (_e, workingDir: string, message?: string) =>
+    wrap(async () => {
+      if (!workingDir) return { ok: false, error: 'missing workingDir' }
+      const { execFile } = await import('child_process')
+      const args = ['stash', 'push', '-u']
+      if (message) args.push('-m', message)
+      return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+        execFile('git', args, { cwd: workingDir, timeout: 5000 }, (err, _out, stderr) => {
+          if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })
+          else resolve({ ok: true })
+        })
+      })
+    })
+  )
+
+  ipcMain.handle('git:fetch', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir) return { ok: false, error: 'missing workingDir' }
+      const { execFile } = await import('child_process')
+      return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+        execFile('git', ['fetch', '--prune'], { cwd: workingDir, timeout: 30000 }, (err, _out, stderr) => {
+          if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })
+          else resolve({ ok: true })
+        })
+      })
+    })
+  )
+
+  ipcMain.handle('git:worktrees', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir) return { list: [] }
+      const { execFile } = await import('child_process')
+      const out = await new Promise<string>((resolve) => {
+        execFile('git', ['worktree', 'list', '--porcelain'], { cwd: workingDir, timeout: 3000 }, (err, stdout) => {
+          resolve(err ? '' : stdout)
+        })
+      })
+      const list: { branch: string; path: string; isMain: boolean }[] = []
+      let cur: { path?: string; branch?: string } = {}
+      for (const line of out.split('\n')) {
+        if (line.startsWith('worktree ')) cur = { path: line.slice('worktree '.length).trim() }
+        else if (line.startsWith('branch ')) cur.branch = line.slice('branch '.length).trim().replace('refs/heads/', '')
+        else if (line.trim() === '' && cur.path) {
+          list.push({ path: cur.path, branch: cur.branch || '(detached)', isMain: list.length === 0 })
+          cur = {}
+        }
+      }
+      if (cur.path) list.push({ path: cur.path, branch: cur.branch || '(detached)', isMain: list.length === 0 })
+      return { list }
+    })
+  )
+
+  ipcMain.handle('git:worktreeAdd', async (_e, workingDir: string, args2: { name: string; path: string }) =>
+    wrap(async () => {
+      if (!workingDir || !args2?.name || !args2?.path) return { ok: false, error: 'missing args' }
+      const { execFile } = await import('child_process')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const target = pathMod.resolve(args2.path)
+      fsMod.mkdirSync(pathMod.dirname(target), { recursive: true })
+      return await new Promise<{ ok: boolean; path?: string; error?: string }>((resolve) => {
+        execFile('git', ['worktree', 'add', target, '-b', args2.name], { cwd: workingDir, timeout: 20000 }, (err, _out, stderr) => {
+          if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })
+          else resolve({ ok: true, path: target })
+        })
+      })
+    })
+  )
+
+  ipcMain.handle('git:createPr', async (_e, workingDir: string, input: { title: string; body: string }) =>
+    wrap(async () => {
+      if (!workingDir || !input?.title) return { ok: false, error: 'missing args' }
+      const { execFile } = await import('child_process')
+      const run = (cmd: string, args: string[], timeout: number) => new Promise<{ ok: boolean; stdout: string; stderr: string }>((resolve) => {
+        execFile(cmd, args, { cwd: workingDir, timeout }, (err, stdout, stderr) => {
+          resolve({ ok: !err, stdout: stdout || '', stderr: stderr || (err ? String(err) : '') })
+        })
+      })
+      // Resolve current branch
+      const br = await run('git', ['rev-parse', '--abbrev-ref', 'HEAD'], 3000)
+      const branch = br.stdout.trim()
+      if (!branch || branch === 'HEAD') return { ok: false, error: 'Not on a branch' }
+      // Push with upstream (no-op if already pushed; -u is safe to repeat)
+      const push = await run('git', ['push', '-u', 'origin', branch], 60000)
+      if (!push.ok) return { ok: false, error: (push.stderr || 'git push failed').trim() }
+      // Create PR
+      const pr = await run('gh', ['pr', 'create', '--title', input.title, '--body', input.body || '', '--head', branch], 60000)
+      if (!pr.ok) return { ok: false, error: (pr.stderr || 'gh pr create failed').trim() }
+      const url = (pr.stdout.match(/https?:\/\/\S+/) || [])[0] || pr.stdout.trim()
+      return { ok: true, url }
+    })
+  )
+
+  ipcMain.handle('git:watch', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir) return { ok: false }
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const gitDir = pathMod.join(workingDir, '.git')
+      const headPath = pathMod.join(gitDir, 'HEAD')
+      const existing = gitWatchers.get(workingDir)
+      if (existing) { existing.count++; return { ok: true } }
+      try {
+        const emit = () => {
+          const entry = gitWatchers.get(workingDir)
+          if (!entry) return
+          if (entry.timer) clearTimeout(entry.timer)
+          entry.timer = setTimeout(() => sendToRenderer('git:changed', { workingDir }), 200)
+        }
+        // Watch the .git dir non-recursively; HEAD + refs changes bubble as rename/change events.
+        const watcher = fsMod.watch(gitDir, { persistent: false }, () => emit())
+        gitWatchers.set(workingDir, { watcher, count: 1, timer: null })
+        // Fire once so the renderer pulls fresh status immediately.
+        void headPath
+        return { ok: true }
+      } catch {
+        return { ok: false }
+      }
+    })
+  )
+
+  ipcMain.handle('git:unwatch', async (_e, workingDir: string) =>
+    wrap(async () => {
+      const entry = gitWatchers.get(workingDir)
+      if (!entry) return { ok: true }
+      entry.count--
+      if (entry.count <= 0) {
+        if (entry.timer) clearTimeout(entry.timer)
+        try { entry.watcher.close() } catch { /* ignore */ }
+        gitWatchers.delete(workingDir)
+      }
+      return { ok: true }
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -114,6 +114,8 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('chats:updateContextPanelOpen', id, open),
     setSoloAdvisor: (id: string, enabled: boolean) =>
       ipcRenderer.invoke('chats:setSoloAdvisor', id, enabled),
+    setWorkingDir: (id: string, dir: string | null) =>
+      ipcRenderer.invoke('chats:setWorkingDir', id, dir),
     send: (payload: { chatId: string; text: string; attachments?: any[] }) =>
       ipcRenderer.invoke('chats:send', payload),
     stop: (chatId: string) => ipcRenderer.invoke('chats:stop', chatId),

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -147,6 +147,23 @@ contextBridge.exposeInMainWorld('codey', {
   },
   git: {
     status: (workingDir: string) => ipcRenderer.invoke('git:status', workingDir),
+    branches: (workingDir: string) => ipcRenderer.invoke('git:branches', workingDir),
+    checkout: (workingDir: string, name: string, opts?: { create?: boolean; track?: boolean }) =>
+      ipcRenderer.invoke('git:checkout', workingDir, name, opts),
+    stash: (workingDir: string, message?: string) => ipcRenderer.invoke('git:stash', workingDir, message),
+    fetch: (workingDir: string) => ipcRenderer.invoke('git:fetch', workingDir),
+    worktrees: (workingDir: string) => ipcRenderer.invoke('git:worktrees', workingDir),
+    worktreeAdd: (workingDir: string, args: { name: string; path: string }) =>
+      ipcRenderer.invoke('git:worktreeAdd', workingDir, args),
+    createPr: (workingDir: string, input: { title: string; body: string }) =>
+      ipcRenderer.invoke('git:createPr', workingDir, input),
+    watch: (workingDir: string) => ipcRenderer.invoke('git:watch', workingDir),
+    unwatch: (workingDir: string) => ipcRenderer.invoke('git:unwatch', workingDir),
+    onChanged: (handler: (ev: { workingDir: string }) => void) => {
+      const listener = (_e: unknown, ev: { workingDir: string }) => handler(ev)
+      ipcRenderer.on('git:changed', listener)
+      return () => ipcRenderer.removeListener('git:changed', listener)
+    },
   },
   gateway: {
     status: () => ipcRenderer.invoke('gateway:status'),

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -155,7 +155,7 @@ contextBridge.exposeInMainWorld('codey', {
     worktrees: (workingDir: string) => ipcRenderer.invoke('git:worktrees', workingDir),
     worktreeAdd: (workingDir: string, args: { name: string; path: string }) =>
       ipcRenderer.invoke('git:worktreeAdd', workingDir, args),
-    createPr: (workingDir: string, input: { title: string; body: string }) =>
+    createPr: (workingDir: string, input: { title: string; body?: string }) =>
       ipcRenderer.invoke('git:createPr', workingDir, input),
     watch: (workingDir: string) => ipcRenderer.invoke('git:watch', workingDir),
     unwatch: (workingDir: string) => ipcRenderer.invoke('git:unwatch', workingDir),

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -18,6 +18,8 @@
     "build": "vite build && electron-builder",
     "build:mac": "vite build && electron-builder --mac",
     "build:mac:signed": "vite build && electron-builder --mac --publish never",
+    "notarize:mac": "node build/notarize-dist.js",
+    "dist:mac": "npm run build:mac:signed && node build/notarize-dist.js",
     "preview": "vite preview",
     "test": "vitest run"
   },
@@ -32,6 +34,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@electron/notarize": "^2.2.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.0",
@@ -54,15 +57,13 @@
         {
           "target": "dmg",
           "arch": [
-            "arm64",
-            "x64"
+            "arm64"
           ]
         },
         {
           "target": "zip",
           "arch": [
-            "arm64",
-            "x64"
+            "arm64"
           ]
         }
       ],
@@ -73,9 +74,7 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "identity": "ou zixian (N59NN58KB2)",
-      "notarize": {
-        "teamId": "N59NN58KB2"
-      },
+      "notarize": false,
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Codey transcribes your speech into text at your cursor when you use voice input.",
         "NSAppleEventsUsageDescription": "Codey pastes transcribed voice text into the focused app via System Events."

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -123,6 +123,7 @@ declare global {
         unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<IpcResult<Chat>>
         updateContextPanelOpen: (id: string, open: boolean | null) => Promise<IpcResult<Chat>>
         setSoloAdvisor: (id: string, enabled: boolean) => Promise<IpcResult<Chat>>
+        setWorkingDir: (id: string, dir: string | null) => Promise<IpcResult<Chat>>
       }
       qq: {
         ask: (payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }>; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) => Promise<IpcResult<{ response: string; tokens?: number; durationSec?: number }>>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -145,6 +145,16 @@ declare global {
       }
       git: {
         status: (workingDir: string) => Promise<IpcResult<{ branch: string; dirty: number } | null>>
+        branches: (workingDir: string) => Promise<IpcResult<{ current: string; local: string[]; remote: string[] }>>
+        checkout: (workingDir: string, name: string, opts?: { create?: boolean; track?: boolean }) => Promise<IpcResult<{ ok: boolean; error?: string; reason?: 'dirty' }>>
+        stash: (workingDir: string, message?: string) => Promise<IpcResult<{ ok: boolean; error?: string }>>
+        fetch: (workingDir: string) => Promise<IpcResult<{ ok: boolean; error?: string }>>
+        worktrees: (workingDir: string) => Promise<IpcResult<{ list: { branch: string; path: string; isMain: boolean }[] }>>
+        worktreeAdd: (workingDir: string, args: { name: string; path: string }) => Promise<IpcResult<{ ok: boolean; path?: string; error?: string }>>
+        createPr: (workingDir: string, input: { title: string; body: string }) => Promise<IpcResult<{ ok: boolean; url?: string; error?: string }>>
+        watch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
+        unwatch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
+        onChanged: (handler: (ev: { workingDir: string }) => void) => () => void
       }
       gateway: {
         status: () => Promise<IpcResult<{

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -151,7 +151,7 @@ declare global {
         fetch: (workingDir: string) => Promise<IpcResult<{ ok: boolean; error?: string }>>
         worktrees: (workingDir: string) => Promise<IpcResult<{ list: { branch: string; path: string; isMain: boolean }[] }>>
         worktreeAdd: (workingDir: string, args: { name: string; path: string }) => Promise<IpcResult<{ ok: boolean; path?: string; error?: string }>>
-        createPr: (workingDir: string, input: { title: string; body: string }) => Promise<IpcResult<{ ok: boolean; url?: string; error?: string }>>
+        createPr: (workingDir: string, input: { title: string; body?: string }) => Promise<IpcResult<{ ok: boolean; url?: string; error?: string }>>
         watch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
         unwatch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
         onChanged: (handler: (ev: { workingDir: string }) => void) => () => void

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -90,8 +90,8 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
               <input autoFocus placeholder="new-branch-name" value={newName}
                 onChange={e => setNewName(e.target.value)} style={styles.input} />
               <div style={styles.toggle}>
-                <button style={useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(true)}>In a new worktree</button>
-                <button style={!useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(false)}>On current checkout</button>
+                <button style={useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(true)}>Worktree</button>
+                <button style={!useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(false)}>Branch</button>
               </div>
               {previewPath && <div style={styles.preview}>{previewPath}</div>}
               <div style={styles.row}>
@@ -162,11 +162,11 @@ const styles: Record<string, React.CSSProperties> = {
   toggle: { display: 'flex', gap: 4 },
   seg: { flex: 1, background: C.surface3, border: `1px solid ${C.border2}`, color: C.fg2, fontSize: 11,
     padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
-  segOn: { flex: 1, background: C.accent, border: `1px solid ${C.accent}`, color: '#fff', fontSize: 11,
+  segOn: { flex: 1, background: C.accent, border: `1px solid ${C.accent}`, color: C.onAccent, fontSize: 11,
     padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
   preview: { fontSize: 10, color: C.fg3, fontFamily: 'SF Mono, Menlo, monospace', wordBreak: 'break-all' },
   row: { display: 'flex', gap: 6 },
-  primary: { background: C.accent, color: '#fff', border: 'none', borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
+  primary: { background: C.accent, color: C.onAccent, border: 'none', borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
   ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
   footer: { display: 'flex', justifyContent: 'space-between', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
   warn: { fontSize: 12, color: C.yellow },

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -45,6 +45,13 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
     if (r.reason === 'dirty') setMode({ kind: 'dirty', target: name })
   }
 
+  const doSwitchRemote = async (b: string) => {
+    const localName = b.replace(/^[^/]+\//, '')
+    const r = await git.checkout(localName, { track: true })
+    if (r.ok) { setOpen(false); return }
+    if (r.reason === 'dirty') setMode({ kind: 'dirty', target: localName })
+  }
+
   const doCreate = async () => {
     if (!newName.trim()) return
     if (useWorktree) {
@@ -58,7 +65,7 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
 
   return (
     <div ref={ref} style={{ position: 'relative' }}>
-      <button style={styles.pill} onClick={() => setOpen(o => !o)} title="Branch & worktree">
+      <button style={styles.pill} onClick={() => setOpen(o => { if (!o) setNote(null); return !o })} title="Branch & worktree">
         <span>⎇ {s?.branch ?? '—'}</span>
         {s && s.dirty > 0 && <span style={styles.dirty}>+{s.dirty}</span>}
         {boundLabel && <span style={styles.wt}>🌳 {boundLabel}</span>}
@@ -104,7 +111,7 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
                 ))}
                 {remoteFiltered.length > 0 && <div style={styles.divider}>Remote</div>}
                 {remoteFiltered.map(b => (
-                  <button key={b} style={styles.item} onClick={() => git.checkout(b.replace(/^[^/]+\//, ''), { track: true }).then(() => setOpen(false))}>
+                  <button key={b} style={styles.item} onClick={() => doSwitchRemote(b)}>
                     {b}
                   </button>
                 ))}

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -46,10 +46,11 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
   }
 
   const doSwitchRemote = async (b: string) => {
-    const localName = b.replace(/^[^/]+\//, '')
-    const r = await git.checkout(localName, { track: true })
+    // `git checkout --track` needs the remote-tracking ref (origin/foo), not the local name.
+    const r = await git.checkout(b, { track: true })
     if (r.ok) { setOpen(false); return }
-    if (r.reason === 'dirty') setMode({ kind: 'dirty', target: localName })
+    // On retry after stash, plain `git checkout foo` DWIMs to a tracking branch.
+    if (r.reason === 'dirty') setMode({ kind: 'dirty', target: b.replace(/^[^/]+\//, '') })
   }
 
   const doCreate = async () => {
@@ -80,7 +81,8 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
               <div style={styles.row}>
                 <button style={styles.primary} onClick={async () => {
                   const r = await git.stashAndSwitch(mode.target)
-                  if (r.ok) { setNote('Local changes stashed — restore with `git stash pop`'); setMode({ kind: 'list' }); setOpen(false) }
+                  // Keep the menu open so the stash note is actually visible.
+                  if (r.ok) { setNote('Local changes stashed — restore with `git stash pop`'); setMode({ kind: 'list' }) }
                 }}>Stash & switch</button>
                 <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
               </div>

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo, useRef, useState, useEffect } from 'react'
+import { C } from '../theme'
+import { useGitBranches } from '../hooks/useGitBranches'
+import { filterBranches, defaultWorktreePath, partitionWorktrees } from './branchPickerModel'
+
+interface Props {
+  workingDir: string | undefined
+  repoRoot: string | undefined           // for default worktree path; falls back to workingDir
+  boundWorktreePath?: string             // chat.workingDirOverride
+  onBindWorktree: (path: string | null) => void
+}
+
+type Mode = { kind: 'list' } | { kind: 'create' } | { kind: 'dirty'; target: string }
+
+export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorktreePath, onBindWorktree }) => {
+  const git = useGitBranches(workingDir)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [mode, setMode] = useState<Mode>({ kind: 'list' })
+  const [newName, setNewName] = useState('')
+  const [useWorktree, setUseWorktree] = useState(true)   // worktree is the DEFAULT
+  const [note, setNote] = useState<string | null>(null)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false) }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => { document.removeEventListener('mousedown', onDown); document.removeEventListener('keydown', onKey) }
+  }, [open])
+
+  const s = git.state
+  const { main, others } = useMemo(() => partitionWorktrees(s?.worktrees ?? []), [s])
+  const localFiltered = useMemo(() => filterBranches(s?.local ?? [], query), [s, query])
+  const remoteFiltered = useMemo(() => filterBranches(s?.remote ?? [], query), [s, query])
+  const repo = repoRoot || workingDir || ''
+  const previewPath = useWorktree && newName ? defaultWorktreePath(repo, newName) : ''
+  const boundLabel = others.find(w => w.path === boundWorktreePath)?.branch
+
+  const doSwitch = async (name: string) => {
+    const r = await git.checkout(name)
+    if (r.ok) { setOpen(false); return }
+    if (r.reason === 'dirty') setMode({ kind: 'dirty', target: name })
+  }
+
+  const doCreate = async () => {
+    if (!newName.trim()) return
+    if (useWorktree) {
+      const r = await git.addWorktree(newName.trim(), defaultWorktreePath(repo, newName.trim()))
+      if (r.ok && r.path) { onBindWorktree(r.path); setOpen(false) }
+    } else {
+      const r = await git.createBranch(newName.trim())
+      if (r.ok) { setOpen(false) }
+    }
+  }
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button style={styles.pill} onClick={() => setOpen(o => !o)} title="Branch & worktree">
+        <span>⎇ {s?.branch ?? '—'}</span>
+        {s && s.dirty > 0 && <span style={styles.dirty}>+{s.dirty}</span>}
+        {boundLabel && <span style={styles.wt}>🌳 {boundLabel}</span>}
+        <span style={styles.caret}>▾</span>
+      </button>
+
+      {open && (
+        <div style={styles.menu}>
+          {mode.kind === 'dirty' ? (
+            <div style={styles.section}>
+              <div style={styles.warn}>Switching would overwrite local changes.</div>
+              <div style={styles.row}>
+                <button style={styles.primary} onClick={async () => {
+                  const r = await git.stashAndSwitch(mode.target)
+                  if (r.ok) { setNote('Local changes stashed — restore with `git stash pop`'); setMode({ kind: 'list' }); setOpen(false) }
+                }}>Stash & switch</button>
+                <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
+              </div>
+            </div>
+          ) : mode.kind === 'create' ? (
+            <div style={styles.section}>
+              <input autoFocus placeholder="new-branch-name" value={newName}
+                onChange={e => setNewName(e.target.value)} style={styles.input} />
+              <div style={styles.toggle}>
+                <button style={useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(true)}>In a new worktree</button>
+                <button style={!useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(false)}>On current checkout</button>
+              </div>
+              {previewPath && <div style={styles.preview}>{previewPath}</div>}
+              <div style={styles.row}>
+                <button style={styles.primary} onClick={doCreate}>Create</button>
+                <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <input placeholder="Filter branches…" value={query}
+                onChange={e => setQuery(e.target.value)} style={styles.input} />
+              <div style={styles.scroll}>
+                {localFiltered.map(b => (
+                  <button key={b} style={styles.item} disabled={b === s?.branch} onClick={() => doSwitch(b)}>
+                    {b === s?.branch ? '✓ ' : ''}{b}
+                  </button>
+                ))}
+                {remoteFiltered.length > 0 && <div style={styles.divider}>Remote</div>}
+                {remoteFiltered.map(b => (
+                  <button key={b} style={styles.item} onClick={() => git.checkout(b.replace(/^[^/]+\//, ''), { track: true }).then(() => setOpen(false))}>
+                    {b}
+                  </button>
+                ))}
+                {others.length > 0 && <div style={styles.divider}>Worktrees</div>}
+                {main && (
+                  <button style={styles.item} onClick={() => { onBindWorktree(null); setOpen(false) }}>
+                    {!boundWorktreePath ? '✓ ' : ''}{main.branch} (main)
+                  </button>
+                )}
+                {others.map(w => (
+                  <button key={w.path} style={styles.item} onClick={() => { onBindWorktree(w.path); setOpen(false) }}>
+                    {w.path === boundWorktreePath ? '✓ ' : ''}🌳 {w.branch}
+                  </button>
+                ))}
+              </div>
+              {git.error && <div style={styles.err}>{git.error}</div>}
+              {note && <div style={styles.noteBox}>{note}</div>}
+              <div style={styles.footer}>
+                <button style={styles.ghost} onClick={() => { setNewName(''); setUseWorktree(true); setMode({ kind: 'create' }) }}>+ New branch…</button>
+                <button style={styles.ghost} onClick={() => git.fetchRemote()}>Fetch remote</button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  pill: { display: 'inline-flex', alignItems: 'center', gap: 6, color: C.fg2, fontSize: 11,
+    background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 4, padding: '2px 6px',
+    fontFamily: 'SF Mono, Menlo, monospace', cursor: 'pointer', flexShrink: 0, maxWidth: 260,
+    overflow: 'hidden', whiteSpace: 'nowrap' },
+  dirty: { color: C.yellow, opacity: 0.85 },
+  wt: { color: C.green },
+  caret: { color: C.fg3 },
+  menu: { position: 'absolute', top: 'calc(100% + 4px)', left: 0, zIndex: 20, width: 280,
+    background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)', padding: 8, display: 'flex', flexDirection: 'column', gap: 6 },
+  section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  scroll: { maxHeight: 260, overflowY: 'auto', display: 'flex', flexDirection: 'column' },
+  item: { textAlign: 'left', background: 'transparent', border: 'none', color: C.fg, fontSize: 12,
+    padding: '6px 8px', borderRadius: 6, cursor: 'pointer' },
+  divider: { fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, color: C.fg3, padding: '8px 8px 2px' },
+  input: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg,
+    fontSize: 12, padding: '5px 8px', outline: 'none' },
+  toggle: { display: 'flex', gap: 4 },
+  seg: { flex: 1, background: C.surface3, border: `1px solid ${C.border2}`, color: C.fg2, fontSize: 11,
+    padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
+  segOn: { flex: 1, background: C.accent, border: `1px solid ${C.accent}`, color: '#fff', fontSize: 11,
+    padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
+  preview: { fontSize: 10, color: C.fg3, fontFamily: 'SF Mono, Menlo, monospace', wordBreak: 'break-all' },
+  row: { display: 'flex', gap: 6 },
+  primary: { background: C.accent, color: '#fff', border: 'none', borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
+  ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
+  footer: { display: 'flex', justifyContent: 'space-between', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
+  warn: { fontSize: 12, color: C.yellow },
+  err: { fontSize: 11, color: C.red, padding: '2px 4px' },
+  noteBox: { fontSize: 11, color: C.fg3, padding: '2px 4px' },
+}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -464,8 +464,12 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)
   const [showPrModal, setShowPrModal] = useState(false)
   // Derived from the gitStatus useGitStatus already fetches — no extra IPC round-trip.
-  // v1 heuristic: a dirty tree, or any non-default branch, counts as "something to PR".
-  const branchAhead = !!gitStatus && (gitStatus.dirty > 0 || gitStatus.branch !== 'main')
+  // PR-able: on a non-default branch with commits the default branch doesn't have
+  // (ahead is null when there's no remote default ref — fall back to branch check only).
+  const branchAhead = !!gitStatus
+    && gitStatus.branch !== (gitStatus.defaultBranch ?? 'main')
+    && gitStatus.branch !== 'HEAD'
+    && (gitStatus.ahead == null || gitStatus.ahead > 0)
   useEffect(() => {
     if (!isGatewayRunning) return
     ;(async () => {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -22,6 +22,7 @@ import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
 import { useGitStatus } from '../hooks/useGitStatus'
 import { BranchPicker } from './BranchPicker'
+import { CreatePrModal } from './CreatePrModal'
 
 interface Props {
   chatId: string
@@ -457,6 +458,10 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   // header BranchPicker both operate on this effective dir.
   const workingDir = chat?.workingDirOverride || workspaceDir
   const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)
+  const [showPrModal, setShowPrModal] = useState(false)
+  // Derived from the gitStatus useGitStatus already fetches — no extra IPC round-trip.
+  // v1 heuristic: a dirty tree, or any non-default branch, counts as "something to PR".
+  const branchAhead = !!gitStatus && (gitStatus.dirty > 0 || gitStatus.branch !== 'main')
   useEffect(() => {
     if (!isGatewayRunning) return
     ;(async () => {
@@ -1463,6 +1468,17 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
           }}
         />
       )}
+      {showPrModal && (
+        <CreatePrModal
+          defaultTitle={chat?.taskBrief?.goal || gitStatus?.branch || ''}
+          onCancel={() => setShowPrModal(false)}
+          onCreate={async (input) => {
+            if (!workingDir) return { ok: false, error: 'No working dir' }
+            const r = await window.codey.git.createPr(workingDir, input)
+            return r.ok ? r.data : { ok: false, error: r.error || 'Failed' }
+          }}
+        />
+      )}
       </div>
       {/* The context panel only renders when there's room for both the chat
           list (~180-240px) AND a usable conversation column (>= MIN_MIDDLE).
@@ -1520,6 +1536,8 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
             view={extractSidecarBrief(chat.taskBrief)}
             loading={taskBriefLoading}
             width={SIDECAR_W}
+            branchAhead={branchAhead}
+            onCreatePr={() => setShowPrModal(true)}
             onOpen={() => { setContextPanelOpen(chat.id, true); setPanelTab('task') }}
           />
         )

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -114,7 +114,9 @@ const UserMessageContent: React.FC<{ content: string }> = ({ content }) => {
     return (
       <div>
         <Markdown variant="user">{content}</Markdown>
-        <button style={{ ...userFoldStyles.btn, marginTop: 6 }} onClick={() => setExpanded(false)}>Show less ▲</button>
+        <div style={userFoldStyles.lessRow}>
+          <button style={userFoldStyles.btn} onClick={() => setExpanded(false)}>Show less ▲</button>
+        </div>
       </div>
     )
   }
@@ -145,6 +147,8 @@ const userFoldStyles: Record<string, React.CSSProperties> = {
     background: `linear-gradient(to bottom, transparent, ${C.userBg})`,
     pointerEvents: 'none',
   },
+  // Center the "Show less" button to match the centered "Show more" above.
+  lessRow: { display: 'flex', justifyContent: 'center', marginTop: 6 },
   btn: {
     pointerEvents: 'auto', background: 'rgba(255,255,255,0.18)', border: 'none',
     color: C.onAccent, fontSize: 11, fontWeight: 600,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -21,6 +21,7 @@ import { defaultThinkingExpanded } from './thinkingState'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
 import { useGitStatus } from '../hooks/useGitStatus'
+import { BranchPicker } from './BranchPicker'
 
 interface Props {
   chatId: string
@@ -318,7 +319,7 @@ const TeamRunGroup: React.FC<{
 }
 
 export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed }) => {
-  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setWorkingDir: setChatWorkingDir, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -444,13 +445,17 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
     // stays mounted alongside this tab so workspaceName never changes.
     return onTeamsChanged(refresh)
   }, [chat?.workspaceName])
-  const [workingDir, setWorkingDir] = useState<string | undefined>(undefined)
+  const [workspaceDir, setWorkspaceDir] = useState<string | undefined>(undefined)
   useEffect(() => {
     if (!chat?.workspaceName) return
     apiService.getWorkspaceInfo(chat.workspaceName)
-      .then(info => setWorkingDir(info.workingDir))
-      .catch(() => setWorkingDir(undefined))
+      .then(info => setWorkspaceDir(info.workingDir))
+      .catch(() => setWorkspaceDir(undefined))
   }, [chat?.workspaceName])
+  // The effective working dir is the chat's per-chat override (a bound
+  // worktree) when set, otherwise the workspace's repo root. Git status and the
+  // header BranchPicker both operate on this effective dir.
+  const workingDir = chat?.workingDirOverride || workspaceDir
   const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)
   useEffect(() => {
     if (!isGatewayRunning) return
@@ -916,11 +921,15 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
       )}
       <div style={styles.header}>
         <span style={styles.workspaceTag}>{chat.workspaceName}</span>
-        {gitStatus && (
-          <span style={styles.gitBadge} title={`Branch: ${gitStatus.branch}${gitStatus.dirty > 0 ? ` · ${gitStatus.dirty} change${gitStatus.dirty !== 1 ? 's' : ''}` : ''}`}>
-            ⎇ {gitStatus.branch}{gitStatus.dirty > 0 ? ` +${gitStatus.dirty}` : ''}
-          </span>
-        )}
+        <BranchPicker
+          workingDir={workingDir}
+          repoRoot={workspaceDir}
+          boundWorktreePath={chat?.workingDirOverride}
+          onBindWorktree={async (path) => {
+            if (!chat) return
+            await setChatWorkingDir(chat.id, path)
+          }}
+        />
         <select value={selectionValue} onChange={e => onSelectionChange(e.target.value)} style={{ ...styles.workerSelect, marginLeft: 'auto' }}>
           <option value="none">No worker</option>
           {workers.length > 0 && (

--- a/codey-mac/src/components/CreatePrModal.tsx
+++ b/codey-mac/src/components/CreatePrModal.tsx
@@ -63,7 +63,7 @@ const styles: Record<string, React.CSSProperties> = {
   input: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg, fontSize: 13, padding: '6px 8px', outline: 'none' },
   textarea: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg, fontSize: 13, padding: '6px 8px', outline: 'none', resize: 'vertical' },
   row: { display: 'flex', gap: 8, marginTop: 4 },
-  primary: { background: C.accent, color: '#fff', border: 'none', borderRadius: 6, padding: '6px 12px', fontSize: 13, cursor: 'pointer' },
+  primary: { background: C.accent, color: C.onAccent, border: 'none', borderRadius: 6, padding: '6px 12px', fontSize: 13, cursor: 'pointer' },
   ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '6px 12px', fontSize: 13, cursor: 'pointer' },
   success: { fontSize: 13, color: C.green },
   err: { fontSize: 12, color: C.red },

--- a/codey-mac/src/components/CreatePrModal.tsx
+++ b/codey-mac/src/components/CreatePrModal.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { C } from '../theme'
+
+interface Props {
+  defaultTitle: string
+  onCancel: () => void
+  onCreate: (input: { title: string; body: string }) => Promise<{ ok: boolean; url?: string; error?: string }>
+}
+
+export const CreatePrModal: React.FC<Props> = ({ defaultTitle, onCancel, onCreate }) => {
+  const [title, setTitle] = useState(defaultTitle)
+  const [body, setBody] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [url, setUrl] = useState<string | null>(null)
+
+  const submit = async () => {
+    setBusy(true); setError(null)
+    const r = await onCreate({ title: title.trim(), body })
+    setBusy(false)
+    if (r.ok && r.url) setUrl(r.url)
+    else setError(r.error || 'Failed to create PR')
+  }
+
+  const openUrl = (u: string) => {
+    if (window.codey?.openExternal) window.codey.openExternal(u)
+    else window.open(u, '_blank')
+  }
+
+  return (
+    <div style={styles.backdrop} onClick={onCancel}>
+      <div style={styles.card} onClick={e => e.stopPropagation()}>
+        <div style={styles.head}>Create Pull Request</div>
+        {url ? (
+          <>
+            <div style={styles.success}>PR created.</div>
+            <button style={styles.primary} onClick={() => openUrl(url)}>Open PR</button>
+            <button style={styles.ghost} onClick={onCancel}>Close</button>
+          </>
+        ) : (
+          <>
+            <label style={styles.label}>Title</label>
+            <input value={title} onChange={e => setTitle(e.target.value)} style={styles.input} />
+            <label style={styles.label}>Description</label>
+            <textarea value={body} onChange={e => setBody(e.target.value)} style={styles.textarea} rows={5} />
+            {error && <div style={styles.err}>{error}</div>}
+            <div style={styles.row}>
+              <button style={styles.primary} disabled={busy || !title.trim()} onClick={submit}>{busy ? 'Creating…' : 'Create PR'}</button>
+              <button style={styles.ghost} onClick={onCancel}>Cancel</button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: { position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center' },
+  card: { width: 420, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 12, padding: 16, display: 'flex', flexDirection: 'column', gap: 8 },
+  head: { fontSize: 14, fontWeight: 600, color: C.fg },
+  label: { fontSize: 11, color: C.fg3, textTransform: 'uppercase', letterSpacing: 0.5 },
+  input: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg, fontSize: 13, padding: '6px 8px', outline: 'none' },
+  textarea: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg, fontSize: 13, padding: '6px 8px', outline: 'none', resize: 'vertical' },
+  row: { display: 'flex', gap: 8, marginTop: 4 },
+  primary: { background: C.accent, color: '#fff', border: 'none', borderRadius: 6, padding: '6px 12px', fontSize: 13, cursor: 'pointer' },
+  ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '6px 12px', fontSize: 13, cursor: 'pointer' },
+  success: { fontSize: 13, color: C.green },
+  err: { fontSize: 12, color: C.red },
+}

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { C } from '../theme'
 import { statusMeta, formatAgo, type SidecarView, type StatusTone } from './taskHudView'
+import { createPrButtonState } from './createPrModel'
 
 interface Props {
   view: SidecarView
@@ -9,6 +10,10 @@ interface Props {
   /** Open the full panel on the Status tab. */
   onOpen: () => void
   width: number
+  /** Branch is ahead of the default branch (has commits to PR). */
+  branchAhead?: boolean
+  /** Open the Create PR flow. Only invoked when the button is enabled. */
+  onCreatePr?: () => void
 }
 
 const toneColor = (tone: StatusTone): string =>
@@ -20,8 +25,9 @@ const clamp = (lines: number): React.CSSProperties => ({
 
 const COLLAPSE_KEY = 'codey.statusSidecarCollapsed'
 
-export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width }) => {
+export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width, branchAhead, onCreatePr }) => {
   const sm = statusMeta(view.status)
+  const prState = createPrButtonState(view.status, !!branchAhead)
   const [collapsed, setCollapsed] = React.useState<boolean>(() => localStorage.getItem(COLLAPSE_KEY) === '1')
   React.useEffect(() => { localStorage.setItem(COLLAPSE_KEY, collapsed ? '1' : '0') }, [collapsed])
 
@@ -85,6 +91,17 @@ export const StatusSidecar: React.FC<Props> = ({ view, loading, onOpen, width })
             </div>
           )}
 
+          {prState.show && (
+            <button
+              style={{ ...styles.prBtn, opacity: prState.enabled ? 1 : 0.5, cursor: prState.enabled ? 'pointer' : 'not-allowed' }}
+              disabled={!prState.enabled}
+              title={prState.enabled ? 'Create a pull request' : 'No commits to PR'}
+              onClick={(e) => { e.stopPropagation(); if (prState.enabled) onCreatePr?.() }}
+            >
+              Create PR →
+            </button>
+          )}
+
           {view.recent.length > 0 && (
             <div style={styles.recent}>
               <div style={styles.sectionLabel}>Recent</div>
@@ -140,4 +157,6 @@ const styles: Record<string, React.CSSProperties> = {
   recentText: { flex: 1, minWidth: 0, fontSize: 12, color: C.fg2, lineHeight: 1.4, ...clamp(2) },
   recentWhen: { flex: 'none', fontSize: 10, color: C.fg3, whiteSpace: 'nowrap' },
   footer: { fontSize: 11, color: C.fg3, paddingTop: 2 },
+  prBtn: { marginTop: 4, width: '100%', background: C.green, color: '#0b0b0b', border: 'none',
+    borderRadius: 8, padding: '8px 10px', fontSize: 12, fontWeight: 600 },
 }

--- a/codey-mac/src/components/branchPickerModel.test.ts
+++ b/codey-mac/src/components/branchPickerModel.test.ts
@@ -11,9 +11,13 @@ describe('filterBranches', () => {
 });
 
 describe('defaultWorktreePath', () => {
-  it('builds a sibling .codey-worktrees path with sanitized branch', () => {
+  it('builds an in-repo .codey/worktrees path with sanitized branch', () => {
     expect(defaultWorktreePath('/home/u/repo', 'feat/cool thing'))
-      .toBe('/home/u/.codey-worktrees/repo-feat-cool-thing');
+      .toBe('/home/u/repo/.codey/worktrees/feat-cool-thing');
+  });
+  it('strips a trailing slash from the repo path', () => {
+    expect(defaultWorktreePath('/home/u/repo/', 'x'))
+      .toBe('/home/u/repo/.codey/worktrees/x');
   });
 });
 

--- a/codey-mac/src/components/branchPickerModel.test.ts
+++ b/codey-mac/src/components/branchPickerModel.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { filterBranches, defaultWorktreePath, partitionWorktrees } from './branchPickerModel';
+
+describe('filterBranches', () => {
+  it('returns all when query empty', () => {
+    expect(filterBranches(['main', 'dev'], '')).toEqual(['main', 'dev']);
+  });
+  it('is case-insensitive substring match', () => {
+    expect(filterBranches(['Main', 'feature/x', 'dev'], 'fe')).toEqual(['feature/x']);
+  });
+});
+
+describe('defaultWorktreePath', () => {
+  it('builds a sibling .codey-worktrees path with sanitized branch', () => {
+    expect(defaultWorktreePath('/home/u/repo', 'feat/cool thing'))
+      .toBe('/home/u/.codey-worktrees/repo-feat-cool-thing');
+  });
+});
+
+describe('partitionWorktrees', () => {
+  it('splits main from the rest', () => {
+    const { main, others } = partitionWorktrees([
+      { branch: 'main', path: '/r', isMain: true },
+      { branch: 'feat', path: '/r2', isMain: false },
+    ]);
+    expect(main?.branch).toBe('main');
+    expect(others.map(w => w.branch)).toEqual(['feat']);
+  });
+});

--- a/codey-mac/src/components/branchPickerModel.ts
+++ b/codey-mac/src/components/branchPickerModel.ts
@@ -1,4 +1,6 @@
-import * as path from 'path';
+// NOTE: this module runs in the renderer (nodeIntegration is off), so it must
+// not import Node's 'path' — that externalizes to require() and crashes the
+// renderer bundle. The path building below is plain string work (macOS paths).
 
 export interface Worktree { branch: string; path: string; isMain: boolean }
 export interface BranchData { current: string; local: string[]; remote: string[] }
@@ -10,12 +12,11 @@ export function filterBranches(list: string[], query: string): string[] {
   return list.filter(b => b.toLowerCase().includes(q));
 }
 
-/** Default worktree location: `<repo-parent>/.codey-worktrees/<repo>-<branch>`. */
+/** Default worktree location: `<repo>/.codey/worktrees/<branch>` (in-repo, gitignored). */
 export function defaultWorktreePath(repoPath: string, branchName: string): string {
-  const parent = path.dirname(repoPath);
-  const repo = path.basename(repoPath);
+  const root = repoPath.replace(/\/+$/, '');
   const safe = branchName.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-  return path.join(parent, '.codey-worktrees', `${repo}-${safe}`);
+  return `${root}/.codey/worktrees/${safe}`;
 }
 
 /** Separate the main worktree from the rest for display. */

--- a/codey-mac/src/components/branchPickerModel.ts
+++ b/codey-mac/src/components/branchPickerModel.ts
@@ -1,0 +1,26 @@
+import * as path from 'path';
+
+export interface Worktree { branch: string; path: string; isMain: boolean }
+export interface BranchData { current: string; local: string[]; remote: string[] }
+
+/** Case-insensitive substring filter; empty query returns the list unchanged. */
+export function filterBranches(list: string[], query: string): string[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return list;
+  return list.filter(b => b.toLowerCase().includes(q));
+}
+
+/** Default worktree location: `<repo-parent>/.codey-worktrees/<repo>-<branch>`. */
+export function defaultWorktreePath(repoPath: string, branchName: string): string {
+  const parent = path.dirname(repoPath);
+  const repo = path.basename(repoPath);
+  const safe = branchName.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return path.join(parent, '.codey-worktrees', `${repo}-${safe}`);
+}
+
+/** Separate the main worktree from the rest for display. */
+export function partitionWorktrees(list: Worktree[]): { main?: Worktree; others: Worktree[] } {
+  const main = list.find(w => w.isMain);
+  const others = list.filter(w => !w.isMain);
+  return { main, others };
+}

--- a/codey-mac/src/components/createPrModel.test.ts
+++ b/codey-mac/src/components/createPrModel.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { createPrButtonState, defaultPrTitle } from './createPrModel';
+
+describe('createPrButtonState', () => {
+  it('hidden while working/blocked', () => {
+    expect(createPrButtonState('working', true).show).toBe(false);
+    expect(createPrButtonState('blocked', true).show).toBe(false);
+  });
+  it('shown when waiting or done', () => {
+    expect(createPrButtonState('waiting', true).show).toBe(true);
+    expect(createPrButtonState('done', false).show).toBe(true);
+  });
+  it('enabled only when branch is ahead', () => {
+    expect(createPrButtonState('done', true).enabled).toBe(true);
+    expect(createPrButtonState('done', false).enabled).toBe(false);
+  });
+});
+
+describe('defaultPrTitle', () => {
+  it('prefers the commit subject', () => {
+    expect(defaultPrTitle('  Add cool thing ', 'feat/x')).toBe('Add cool thing');
+  });
+  it('falls back to the branch name', () => {
+    expect(defaultPrTitle('', 'feat/x')).toBe('feat/x');
+    expect(defaultPrTitle(undefined, 'feat/x')).toBe('feat/x');
+  });
+});

--- a/codey-mac/src/components/createPrModel.ts
+++ b/codey-mac/src/components/createPrModel.ts
@@ -1,0 +1,16 @@
+import type { TaskBrief } from '../types';
+
+type Status = TaskBrief['state']['status'];
+
+/** Button visibility/enablement: visible when the agent has fulfilled the task
+ *  (waiting on the user, or done); enabled only when there are commits to PR. */
+export function createPrButtonState(status: Status, branchAhead: boolean): { show: boolean; enabled: boolean } {
+  const show = status === 'waiting' || status === 'done';
+  return { show, enabled: show && branchAhead };
+}
+
+/** Default PR title: trimmed commit subject, falling back to the branch name. */
+export function defaultPrTitle(commitSubject: string | undefined, branch: string): string {
+  const s = (commitSubject ?? '').trim();
+  return s || branch;
+}

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -370,6 +370,7 @@ interface ChatsContextValue {
   deleteChat: (chatId: string) => Promise<void>
   setSelection: (chatId: string, selection: ChatSelection) => Promise<void>
   setAgentModel: (chatId: string, agent: string | null, model: string | null) => Promise<void>
+  setWorkingDir: (chatId: string, dir: string | null) => Promise<void>
   setContextPanelOpen: (chatId: string, open: boolean | null) => Promise<void>
   setSoloAdvisor: (chatId: string, enabled: boolean) => Promise<void>
   generateTaskBrief: (chatId: string) => Promise<TaskBrief | null>
@@ -592,6 +593,13 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     },
     async setAgentModel(chatId, agent, model) {
       const chat = await apiService.chats.updateAgentModel(chatId, agent, model)
+      dispatch({ type: 'upsert', chat })
+    },
+    async setWorkingDir(chatId, dir) {
+      // Mirrors setSelection: the gateway returns the updated chat (with the
+      // new workingDirOverride), which we upsert so the header's BranchPicker
+      // bound chip reflects the binding immediately.
+      const chat = await apiService.chats.setWorkingDir(chatId, dir)
       dispatch({ type: 'upsert', chat })
     },
     async setContextPanelOpen(chatId, open) {

--- a/codey-mac/src/hooks/useGitBranches.ts
+++ b/codey-mac/src/hooks/useGitBranches.ts
@@ -50,18 +50,20 @@ export function useGitBranches(workingDir: string | undefined) {
     if (!workingDir) return { ok: false, error: 'no dir' }
     setError(null)
     const r = await window.codey.git.checkout(workingDir, name, opts)
-    if (r.ok) await refresh()
-    else if (r.data?.reason !== 'dirty') setError(r.data?.error || r.error || 'checkout failed')
-    return r.ok ? { ok: true } : { ok: false, error: r.data?.error, reason: r.data?.reason }
+    if (!r.ok) { setError(r.error || 'checkout failed'); return { ok: false, error: r.error } }
+    const d = r.data
+    if (d.ok) { await refresh(); return { ok: true } }
+    if (d.reason !== 'dirty') setError(d.error || 'checkout failed')
+    return { ok: false, error: d.error, reason: d.reason }
   }, [workingDir, refresh])
 
   const stashAndSwitch = useCallback(async (name: string) => {
     if (!workingDir) return { ok: false }
     const st = await window.codey.git.stash(workingDir, `codey-mac: switch to ${name}`)
-    if (!st.ok || !st.data?.ok) { setError(st.data?.error || 'stash failed'); return { ok: false } }
+    if (!st.ok || !st.data.ok) { setError((st.ok ? st.data.error : st.error) || 'stash failed'); return { ok: false } }
     const co = await window.codey.git.checkout(workingDir, name)
-    if (co.ok && co.data?.ok) { await refresh(); return { ok: true } }
-    setError(co.data?.error || 'checkout failed'); return { ok: false }
+    if (co.ok && co.data.ok) { await refresh(); return { ok: true } }
+    setError((co.ok ? co.data.error : co.error) || 'checkout failed'); return { ok: false }
   }, [workingDir, refresh])
 
   const createBranch = useCallback(async (name: string) => checkout(name, { create: true }), [checkout])
@@ -69,15 +71,15 @@ export function useGitBranches(workingDir: string | undefined) {
   const fetchRemote = useCallback(async () => {
     if (!workingDir) return
     const r = await window.codey.git.fetch(workingDir)
-    if (r.ok && r.data?.ok) await refresh()
-    else setError(r.data?.error || 'fetch failed')
+    if (r.ok && r.data.ok) await refresh()
+    else setError((r.ok ? r.data.error : r.error) || 'fetch failed')
   }, [workingDir, refresh])
 
   const addWorktree = useCallback(async (name: string, path: string) => {
     if (!workingDir) return { ok: false }
     const r = await window.codey.git.worktreeAdd(workingDir, { name, path })
-    if (r.ok && r.data?.ok) { await refresh(); return { ok: true, path: r.data.path } }
-    setError(r.data?.error || 'worktree add failed'); return { ok: false }
+    if (r.ok && r.data.ok) { await refresh(); return { ok: true, path: r.data.path } }
+    setError((r.ok ? r.data.error : r.error) || 'worktree add failed'); return { ok: false }
   }, [workingDir, refresh])
 
   return { state, error, setError, refresh, checkout, stashAndSwitch, createBranch, fetchRemote, addWorktree }

--- a/codey-mac/src/hooks/useGitBranches.ts
+++ b/codey-mac/src/hooks/useGitBranches.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { Worktree } from '../components/branchPickerModel'
+
+export interface BranchState {
+  branch: string
+  dirty: number
+  local: string[]
+  remote: string[]
+  worktrees: Worktree[]
+}
+
+export function useGitBranches(workingDir: string | undefined) {
+  const [state, setState] = useState<BranchState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!workingDir) { setState(null); return }
+    try {
+      const [s, b, w] = await Promise.all([
+        window.codey.git.status(workingDir),
+        window.codey.git.branches(workingDir),
+        window.codey.git.worktrees(workingDir),
+      ])
+      if (!s.ok || !s.data) { setState(null); return }
+      const br = b.ok ? b.data : { current: s.data.branch, local: [], remote: [] }
+      const wl = w.ok ? w.data.list : []
+      setState({ branch: s.data.branch, dirty: s.data.dirty, local: br.local, remote: br.remote, worktrees: wl })
+    } catch { setState(null) }
+  }, [workingDir])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  // Live updates: watch .git and re-pull on change. Polling fallback every 5s.
+  useEffect(() => {
+    if (!workingDir) return
+    void window.codey.git.watch(workingDir)
+    const off = window.codey.git.onChanged(ev => { if (ev.workingDir === workingDir) void refresh() })
+    const onFocus = () => void refresh()
+    window.addEventListener('focus', onFocus)
+    const poll = setInterval(() => void refresh(), 5000)
+    return () => {
+      off()
+      window.removeEventListener('focus', onFocus)
+      clearInterval(poll)
+      void window.codey.git.unwatch(workingDir)
+    }
+  }, [workingDir, refresh])
+
+  const checkout = useCallback(async (name: string, opts?: { create?: boolean; track?: boolean }) => {
+    if (!workingDir) return { ok: false, error: 'no dir' }
+    setError(null)
+    const r = await window.codey.git.checkout(workingDir, name, opts)
+    if (r.ok) await refresh()
+    else if (r.data?.reason !== 'dirty') setError(r.data?.error || r.error || 'checkout failed')
+    return r.ok ? { ok: true } : { ok: false, error: r.data?.error, reason: r.data?.reason }
+  }, [workingDir, refresh])
+
+  const stashAndSwitch = useCallback(async (name: string) => {
+    if (!workingDir) return { ok: false }
+    const st = await window.codey.git.stash(workingDir, `codey-mac: switch to ${name}`)
+    if (!st.ok || !st.data?.ok) { setError(st.data?.error || 'stash failed'); return { ok: false } }
+    const co = await window.codey.git.checkout(workingDir, name)
+    if (co.ok && co.data?.ok) { await refresh(); return { ok: true } }
+    setError(co.data?.error || 'checkout failed'); return { ok: false }
+  }, [workingDir, refresh])
+
+  const createBranch = useCallback(async (name: string) => checkout(name, { create: true }), [checkout])
+
+  const fetchRemote = useCallback(async () => {
+    if (!workingDir) return
+    const r = await window.codey.git.fetch(workingDir)
+    if (r.ok && r.data?.ok) await refresh()
+    else setError(r.data?.error || 'fetch failed')
+  }, [workingDir, refresh])
+
+  const addWorktree = useCallback(async (name: string, path: string) => {
+    if (!workingDir) return { ok: false }
+    const r = await window.codey.git.worktreeAdd(workingDir, { name, path })
+    if (r.ok && r.data?.ok) { await refresh(); return { ok: true, path: r.data.path } }
+    setError(r.data?.error || 'worktree add failed'); return { ok: false }
+  }, [workingDir, refresh])
+
+  return { state, error, setError, refresh, checkout, stashAndSwitch, createBranch, fetchRemote, addWorktree }
+}

--- a/codey-mac/src/hooks/useGitStatus.ts
+++ b/codey-mac/src/hooks/useGitStatus.ts
@@ -3,6 +3,8 @@ import { useState, useEffect, useCallback } from 'react'
 export interface GitStatus {
   branch: string
   dirty: number
+  defaultBranch?: string
+  ahead?: number | null
 }
 
 export function useGitStatus(workingDir: string | undefined) {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -196,6 +196,8 @@ export const apiService = {
       unwrap(await window.codey.chats.updateContextPanelOpen(id, open)),
     setSoloAdvisor: async (id: string, enabled: boolean): Promise<Chat> =>
       unwrap(await window.codey.chats.setSoloAdvisor(id, enabled)),
+    setWorkingDir: async (id: string, dir: string | null): Promise<Chat> =>
+      unwrap(await window.codey.chats.setWorkingDir(id, dir)),
     upload: async (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer): Promise<{ id: string; name: string; path: string; mimeType: string; size: number }> =>
       unwrap(await window.codey.chats.upload(chatId, fileName, mimeType, data)),
     send: async (chatId: string, text: string, attachments?: { id: string; name: string; path: string; mimeType: string; size: number }[]): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.7.0",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.7.0",
+      "version": "0.8.4",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.7.0",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
@@ -32,6 +32,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@electron/notarize": "^2.2.1",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.2.0",
@@ -12437,7 +12438,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.7.0",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12449,7 +12450,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.7.0",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -113,6 +113,10 @@ export interface Chat {
    *  undefined = user hasn't decided; auto-open logic applies on first tool call.
    *  true/false = explicit user choice; honored verbatim. */
   contextPanelOpen?: boolean;
+  /** Per-chat working-directory override (absolute path). When set, the agent
+   *  runs here instead of the workspace's workingDir — used to bind a chat to a
+   *  git worktree. Cleared (deleted) to fall back to the workspace dir. */
+  workingDirOverride?: string;
   /** Last unanswered choice question in a non-team chat. Cleared on next user message. */
   lastAskedOptions?: { messageId: string; options: string[] };
   /**

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -228,6 +228,17 @@ export class ChatManager {
     return chat;
   }
 
+  /** Set or clear the per-chat working-directory override (worktree binding).
+   *  Pass null/undefined/'' to clear and fall back to the workspace dir. */
+  setWorkingDirOverride(chatId: string, dir: string | null): Chat {
+    const chat = this.requireChat(chatId);
+    if (dir === null || dir === undefined || dir === '') delete chat.workingDirOverride;
+    else chat.workingDirOverride = dir;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
   /** Set lastAskedOptions on a non-team chat (the question message id + options). */
   setLastAskedOptions(chatId: string, messageId: string, options: string[]): void {
     const chat = this.cache.get(chatId);

--- a/packages/gateway/src/chats.workingDirOverride.test.ts
+++ b/packages/gateway/src/chats.workingDirOverride.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+
+describe('ChatManager.setWorkingDirOverride', () => {
+  let root: string;
+  let mgr: ChatManager;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  it('sets and clears the override', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    const set = mgr.setWorkingDirOverride(chat.id, '/tmp/wt');
+    expect(set.workingDirOverride).toBe('/tmp/wt');
+    const cleared = mgr.setWorkingDirOverride(chat.id, null);
+    expect(cleared.workingDirOverride).toBeUndefined();
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -4057,6 +4057,14 @@ Example: /model gpt-4.1 write a Python script`;
       throw new Error(msg);
     }
 
+    // Per-chat worktree binding: an explicit workingDirOverride wins over the
+    // workspace's workingDir so the agent actually runs in the bound worktree
+    // (mirrors resolveChatWorkingDir's precedence).
+    if (chat.workingDirOverride) {
+      if (fs.existsSync(chat.workingDirOverride)) workingDir = chat.workingDirOverride;
+      else this.logger.warn(`Chat ${chat.id} workingDirOverride=${chat.workingDirOverride} is gone; falling back to workspace dir`);
+    }
+
     // Per-chat override takes precedence over the gateway default.
     const agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
     let model: ModelConfig | undefined;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -834,8 +834,9 @@ export class Codey {
   }
 
   private resolveChatWorkingDir(chat: Chat): string {
-    if (chat.workingDirOverride && fs.existsSync(chat.workingDirOverride)) {
-      return chat.workingDirOverride;
+    if (chat.workingDirOverride) {
+      if (fs.existsSync(chat.workingDirOverride)) return chat.workingDirOverride;
+      this.logger.warn(`Chat ${chat.id} workingDirOverride=${chat.workingDirOverride} is gone; falling back to workspace dir`);
     }
     const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
     const wsConfigPath = path.join(workspacesRoot, chat.workspaceName, 'workspace.json');

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -834,6 +834,9 @@ export class Codey {
   }
 
   private resolveChatWorkingDir(chat: Chat): string {
+    if (chat.workingDirOverride && fs.existsSync(chat.workingDirOverride)) {
+      return chat.workingDirOverride;
+    }
     const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
     const wsConfigPath = path.join(workspacesRoot, chat.workspaceName, 'workspace.json');
     if (fs.existsSync(wsConfigPath)) {

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       'src/parallel-team.test.ts',
       'src/team-emitter.test.ts',
       'src/worker-message-emitter.test.ts',
+      'src/chats.workingDirOverride.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },


### PR DESCRIPTION
## Summary

Adds three git-centric features to the codey-mac chat UI, plus the gateway/core plumbing to support per-chat worktree binding.

- **Branch picker** (chat header) — click the branch pill to switch / create / fetch remote branches, with live updates via a `git:changed` watcher (no manual refresh). A dirty working tree surfaces a **Stash & switch** prompt instead of failing.
- **Git worktrees** — "+ New branch…" defaults to creating a new worktree at `<repo>/.codey/worktrees/<branch>` and **binds the chat** to it (per-chat `workingDirOverride` flows through the gateway's per-run `workingDir` into `sendToChat`). The worktree-add backend drops a `.gitignore` (`*`) so in-repo checkouts never pollute `git status`. Existing worktrees are listable/selectable; selecting the main worktree clears the binding.
- **Create PR button** (StatusSidecar) — appears when the task is waiting/done and the branch is ahead; opens an inline modal that runs `git push` + `gh pr create` and returns the PR URL.

## Implementation notes

- New git IPC surface: `git:branches/checkout/stash/fetch/worktrees/worktreeAdd/createPr/watch` (+ preload/types), all via `execFile('git', …)`.
- Pure logic extracted and unit-tested: `branchPickerModel` (filter/partition/path) and `createPrModel` (gating/title).
- Fixed a latent bug in `useGitBranches` where `checkout` returned `ok:true` on IPC success even when the git checkout failed dirty (would have suppressed the stash prompt).
- The `git:watch` handler watches only the resolved `.git` dir (non-recursive), so the in-repo worktree location is safe.

## Test Plan

- [x] `npm test` — 303 pass (151 mac · 104 core · 48 gateway)
- [x] `tsc --noEmit` clean across codey-mac
- [x] `vite build` green (renderer + electron main/preload)
- [ ] Manual: switch branch from header; create branch on current checkout; create branch as worktree and confirm chip + agent runs in worktree dir
- [ ] Manual: dirty tree → Stash & switch flow
- [ ] Manual: finish a task → Create PR button → modal → PR URL returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)