### PR TITLE
feat: automations — scheduled + run-now briefs over prompts and teams

### DIFF
--- a/codey-mac/electron/automation-notifications.test.ts
+++ b/codey-mac/electron/automation-notifications.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { decideAutomationNotification, findUnseenRuns } from './automation-notifications'
+
+const auto = (over: any = {}) => ({
+  id: 'a1', name: 'Morning news', report: { notify: true }, ...over,
+})
+const run = (over: any = {}) => ({
+  runId: 'r1', startedAt: 1000, endedAt: 2000, status: 'success',
+  trigger: 'schedule', output: 'Posted 5 items.', ...over,
+})
+
+describe('decideAutomationNotification', () => {
+  it('notifies on finished runs when report.notify is on', () => {
+    const d = decideAutomationNotification(auto(), run())
+    expect(d).toMatchObject({ title: expect.stringContaining('Morning news') })
+    expect(d!.body).toContain('Posted 5 items.')
+  })
+  it('returns null when notify is off', () => {
+    expect(decideAutomationNotification(auto({ report: { notify: false } }), run())).toBeNull()
+  })
+  it('surfaces the parked question', () => {
+    const d = decideAutomationNotification(auto(), run({ status: 'parked', question: 'Which account?' }))
+    expect(d!.body).toContain('Which account?')
+  })
+})
+
+describe('findUnseenRuns', () => {
+  it('returns unseen, ended, recent runs only', () => {
+    const now = 100 * 3600_000
+    const runs = [
+      run({ runId: 'seen', seenAt: 5 }),
+      run({ runId: 'old', endedAt: now - 25 * 3600_000 }),
+      run({ runId: 'active', endedAt: undefined }),
+      run({ runId: 'fresh', endedAt: now - 3600_000 }),
+    ]
+    expect(findUnseenRuns(runs, now).map(r => r.runId)).toEqual(['fresh'])
+  })
+})

--- a/codey-mac/electron/automation-notifications.ts
+++ b/codey-mac/electron/automation-notifications.ts
@@ -1,0 +1,41 @@
+// Pure decision logic for automation notifications and the launch-time
+// unseen-run scan. No Electron imports so it is unit-testable; main.ts
+// renders decisions with the Notification API.
+import { mdToPlainText, truncate } from './chat-notifications'
+
+export interface AutomationLike {
+  id: string
+  name: string
+  report: { notify: boolean }
+}
+export interface RunLike {
+  runId: string
+  startedAt: number
+  endedAt?: number
+  status: string
+  output?: string
+  error?: string
+  question?: string
+  seenAt?: number
+}
+export interface AutomationNotification { automationId: string; runId: string; title: string; body: string }
+
+const MAX_BODY = 180
+export const UNSEEN_WINDOW_MS = 24 * 3600_000
+
+export function decideAutomationNotification(a: AutomationLike, run: RunLike): AutomationNotification | null {
+  if (!a.report.notify) return null
+  const title =
+    run.status === 'parked' ? `⏸ ${a.name} needs an answer` :
+    run.status === 'failed' ? `❌ ${a.name} failed` :
+    `✅ ${a.name} finished`
+  const raw = run.status === 'parked' ? (run.question ?? '')
+    : run.status === 'failed' ? (run.error ?? '')
+    : (run.output ?? '')
+  return { automationId: a.id, runId: run.runId, title, body: truncate(mdToPlainText(raw), MAX_BODY) }
+}
+
+/** Runs that ended recently, unseen — surfaced (badge + notify) on app launch. */
+export function findUnseenRuns(runs: RunLike[], now: number): RunLike[] {
+  return runs.filter(r => !r.seenAt && r.endedAt !== undefined && now - r.endedAt <= UNSEEN_WINDOW_MS)
+}

--- a/codey-mac/electron/automation-validate.test.ts
+++ b/codey-mac/electron/automation-validate.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { validateSchedule, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
+
+describe('validateSchedule', () => {
+  it('accepts a valid schedule and no schedule at all', () => {
+    expect(() => validateSchedule({ hour: 9, minute: 30, tz: 'Asia/Shanghai' })).not.toThrow()
+    expect(() => validateSchedule(undefined)).not.toThrow()
+  })
+
+  it('rejects out-of-range or non-integer hour/minute', () => {
+    expect(() => validateSchedule({ hour: 24, minute: 0, tz: 'UTC' })).toThrow(/hour/)
+    expect(() => validateSchedule({ hour: 9.5, minute: 0, tz: 'UTC' })).toThrow(/hour/)
+    expect(() => validateSchedule({ hour: 9, minute: 60, tz: 'UTC' })).toThrow(/minute/)
+    expect(() => validateSchedule({ hour: 9, minute: -1, tz: 'UTC' })).toThrow(/minute/)
+  })
+
+  it('rejects a tz that Intl does not know', () => {
+    expect(() => validateSchedule({ hour: 9, minute: 0, tz: 'Beijing' })).toThrow(/time zone/)
+    expect(() => validateSchedule({ hour: 9, minute: 0 })).toThrow(/time zone/)
+  })
+})
+
+describe('validateAutomationDraft / validateAutomationPatch', () => {
+  it('requires report.notify boolean on create, only present fields on update', () => {
+    expect(() => validateAutomationDraft({ report: { notify: true } })).not.toThrow()
+    expect(() => validateAutomationDraft({})).toThrow(/report\.notify/)
+    expect(() => validateAutomationDraft({ report: { notify: 'yes' } })).toThrow(/report\.notify/)
+    expect(() => validateAutomationPatch({ name: 'x' })).not.toThrow() // no schedule on the patch
+    expect(() => validateAutomationPatch({ schedule: { hour: 9, minute: 0, tz: 'Beijing' } })).toThrow(/time zone/)
+  })
+})

--- a/codey-mac/electron/automation-validate.ts
+++ b/codey-mac/electron/automation-validate.ts
@@ -1,0 +1,42 @@
+// Pure IPC-boundary validation for automation drafts/patches. Bad data (a
+// garbage tz especially — Intl throws RangeError on it) must be rejected here
+// so it never reaches the store and starves the scheduler tick. No Electron
+// imports so it is unit-testable.
+
+function validTz(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Throws Error('invalid schedule: ...') when the schedule shape is bad. */
+export function validateSchedule(schedule: unknown): void {
+  if (schedule === undefined || schedule === null) return // manual-only is fine
+  const s = schedule as { hour?: unknown; minute?: unknown; tz?: unknown }
+  if (typeof s !== 'object') throw new Error('invalid schedule: must be an object')
+  if (!Number.isInteger(s.hour) || (s.hour as number) < 0 || (s.hour as number) > 23) {
+    throw new Error('invalid schedule: hour must be an integer 0-23')
+  }
+  if (!Number.isInteger(s.minute) || (s.minute as number) < 0 || (s.minute as number) > 59) {
+    throw new Error('invalid schedule: minute must be an integer 0-59')
+  }
+  if (typeof s.tz !== 'string' || !validTz(s.tz)) {
+    throw new Error(`invalid schedule: unknown time zone "${String(s.tz)}"`)
+  }
+}
+
+/** Create-time validation: schedule (if any) plus a report object with boolean notify. */
+export function validateAutomationDraft(draft: any): void {
+  validateSchedule(draft?.schedule)
+  if (!draft?.report || typeof draft.report !== 'object' || typeof draft.report.notify !== 'boolean') {
+    throw new Error('invalid automation: report.notify (boolean) is required')
+  }
+}
+
+/** Update-time validation: only checks fields present on the patch. */
+export function validateAutomationPatch(patch: any): void {
+  if (patch && 'schedule' in patch) validateSchedule(patch.schedule)
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -6,6 +6,8 @@ import { findAvailablePort } from './portUtils'
 import { initAutoUpdater, registerUpdaterIpc } from './updater'
 import { createCoreStateStore } from './core-state'
 import { decideNotification, createTurnTracker } from './chat-notifications'
+import { decideAutomationNotification, findUnseenRuns } from './automation-notifications'
+import { validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
 
 protocol.registerSchemesAsPrivileged([
@@ -311,6 +313,15 @@ function sendToRenderer(channel: string, ...args: any[]) {
     pendingRendererMessages.push({ channel, args })
     if (pendingRendererMessages.length > 500) pendingRendererMessages.shift()
   }
+}
+// Same gate the chat path applies inside decideNotification (via maybeNotify's
+// ctx): global notifications toggle off → no OS notification; window focused →
+// the user is already looking at the app, so skip the OS notification (the
+// renderer still receives the underlying event either way).
+function osNotificationsAllowed(): boolean {
+  const enabled = ((coreConfigManager?.get() as any)?.notifications?.enabled ?? true) as boolean
+  const focused = mainWindow?.isFocused() ?? false
+  return enabled && !focused
 }
 // Native macOS notifications for background chats. Decisions are pure
 // (chat-notifications.ts); this is the impure shell: focus check, config
@@ -713,6 +724,10 @@ function buildRuntimeConfig(json: any): any {
     // Back-compat: old `dispatcher` block becomes `advisor`.
     advisor: json?.advisor ?? json?.dispatcher,
     aide: json?.aide,
+    // The Mac app is a secondary surface: a standalone `codey-gateway` daemon
+    // (if running) owns the scheduler lease. Embedded yields to it instead of
+    // racing for "who fires this automation".
+    automationRole: 'embedded',
   }
 }
 
@@ -776,7 +791,30 @@ async function bootInProcessCore() {
     // discord, imessage) connect. Done after returning so IPC handler
     // registration in app.whenReady() isn't blocked by network I/O
     // (e.g. Telegram setMyCommands hanging).
-    void inProcessGateway.start().catch((err: any) => {
+    void inProcessGateway.start().then(() => {
+      // Launch scan: surface results fired by the daemon while the app was closed.
+      // Runs only after start() resolves — automations aren't initialized until
+      // the end of Codey.start(), so listAutomations()/listAutomationRuns()
+      // would see nothing beforehand. Its own try/catch keeps a scan failure
+      // from being mislabeled as a gateway.start failure below.
+      try {
+        for (const a of inProcessGateway!.listAutomations()) {
+          const unseen = findUnseenRuns(inProcessGateway!.listAutomationRuns(a.id, 20) as any, Date.now())
+          if (unseen.length === 0) continue
+          sendToRenderer('automation-unseen', { automationId: a.id, runIds: unseen.map((r: any) => r.runId) })
+          if (!osNotificationsAllowed()) continue
+          const d = decideAutomationNotification(a as any, unseen[0] as any)
+          if (d) {
+            new Notification({
+              title: d.title,
+              body: unseen.length > 1 ? `${d.body} (+${unseen.length - 1} more)` : d.body,
+            }).show()
+          }
+        }
+      } catch (err: any) {
+        sendToRenderer('gateway-log', `[core] automation launch scan failed: ${err?.message ?? err}`)
+      }
+    }).catch((err: any) => {
       sendToRenderer('gateway-log', `[core] gateway.start failed: ${err?.message ?? err}`)
     })
     // The voice helper (and any other localhost client) polls /voice/config via
@@ -814,6 +852,19 @@ async function bootInProcessCore() {
     })
     inProcessGateway.setPairingEventListener((ev: any) => {
       sendToRenderer('pairing:event', ev)
+    })
+    // Forward automation lifecycle events to the renderer, and fire an OS
+    // notification for finished/parked runs whose automation opted in via
+    // report.notify (decision logic lives in automation-notifications.ts).
+    inProcessGateway.setAutomationEventListener((ev: any) => {
+      sendToRenderer('automation-event', ev)
+      if ((ev.type === 'run-finished' || ev.type === 'run-parked') && ev.run && osNotificationsAllowed()) {
+        const a = inProcessGateway?.getAutomation(ev.automationId)
+        if (a) {
+          const d = decideAutomationNotification(a as any, ev.run)
+          if (d) new Notification({ title: d.title, body: d.body }).show()
+        }
+      }
     })
     coreStateStore.setReady()
   } catch (err: any) {
@@ -1806,6 +1857,95 @@ app.whenReady().then(async () => {
       )
       if (!result.ok) throw new Error(result.error)
       return result.worker
+    })
+  )
+
+  // ── Automations IPC ───────────────────────────────────────────────
+  ipcMain.handle('automations:list', async () =>
+    wrap(async () => inProcessGateway?.listAutomations() ?? [])
+  )
+
+  ipcMain.handle('automations:get', async (_e, id: string) =>
+    wrap(async () => {
+      const a = inProcessGateway?.getAutomation(id)
+      if (!a) throw new Error(`Automation not found: ${id}`)
+      return a
+    })
+  )
+
+  ipcMain.handle('automations:create', async (_e, draft: any) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      // Reject bad data (garbage tz especially) at the boundary — once stored,
+      // it would make the scheduler's Intl calls throw on every tick.
+      validateAutomationDraft(draft)
+      return inProcessGateway.createAutomation(draft)
+    })
+  )
+
+  ipcMain.handle('automations:update', async (_e, id: string, patch: any) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      validateAutomationPatch(patch)
+      return inProcessGateway.updateAutomation(id, patch)
+    })
+  )
+
+  ipcMain.handle('automations:delete', async (_e, id: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      inProcessGateway.deleteAutomation(id)
+    })
+  )
+
+  ipcMain.handle('automations:setEnabled', async (_e, id: string, enabled: boolean) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.setAutomationEnabled(id, enabled)
+    })
+  )
+
+  ipcMain.handle('automations:runNow', async (_e, id: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.runAutomationNow(id)
+    })
+  )
+
+  ipcMain.handle('automations:resume', async (_e, id: string, runId: string, answer: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.resumeAutomationRun(id, runId, answer)
+    })
+  )
+
+  ipcMain.handle('automations:history', async (_e, id: string, limit?: number) =>
+    wrap(async () => inProcessGateway?.listAutomationRuns(id, limit) ?? [])
+  )
+
+  ipcMain.handle('automations:markSeen', async (_e, id: string, runId: string) =>
+    wrap(async () => {
+      inProcessGateway?.markAutomationRunSeen(id, runId)
+    })
+  )
+
+  ipcMain.handle('automations:interview:start', async (_e, goal: string, targetContext: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.startAutomationInterview(goal, targetContext)
+    })
+  )
+
+  ipcMain.handle('automations:interview:answer', async (_e, sessionId: string, text: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.answerAutomationInterview(sessionId, text)
+    })
+  )
+
+  ipcMain.handle('automations:interview:cancel', async (_e, sessionId: string) =>
+    wrap(async () => {
+      inProcessGateway?.cancelAutomationInterview(sessionId)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -29,6 +29,31 @@ contextBridge.exposeInMainWorld('codey', {
     get: () => ipcRenderer.invoke('globalTeams:get'),
     set: (teams: Record<string, unknown>) => ipcRenderer.invoke('globalTeams:set', teams),
   },
+  automations: {
+    list: () => ipcRenderer.invoke('automations:list'),
+    get: (id: string) => ipcRenderer.invoke('automations:get', id),
+    create: (draft: any) => ipcRenderer.invoke('automations:create', draft),
+    update: (id: string, patch: any) => ipcRenderer.invoke('automations:update', id, patch),
+    delete: (id: string) => ipcRenderer.invoke('automations:delete', id),
+    setEnabled: (id: string, enabled: boolean) => ipcRenderer.invoke('automations:setEnabled', id, enabled),
+    runNow: (id: string) => ipcRenderer.invoke('automations:runNow', id),
+    resume: (id: string, runId: string, answer: string) => ipcRenderer.invoke('automations:resume', id, runId, answer),
+    history: (id: string, limit?: number) => ipcRenderer.invoke('automations:history', id, limit),
+    markSeen: (id: string, runId: string) => ipcRenderer.invoke('automations:markSeen', id, runId),
+    interviewStart: (goal: string, targetContext: string) => ipcRenderer.invoke('automations:interview:start', goal, targetContext),
+    interviewAnswer: (sessionId: string, text: string) => ipcRenderer.invoke('automations:interview:answer', sessionId, text),
+    interviewCancel: (sessionId: string) => ipcRenderer.invoke('automations:interview:cancel', sessionId),
+    onEvent: (handler: (ev: any) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, ev: any) => handler(ev)
+      ipcRenderer.on('automation-event', listener)
+      return () => ipcRenderer.removeListener('automation-event', listener)
+    },
+    onUnseen: (handler: (msg: { automationId: string; runIds: string[] }) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, msg: any) => handler(msg)
+      ipcRenderer.on('automation-unseen', listener)
+      return () => ipcRenderer.removeListener('automation-unseen', listener)
+    },
+  },
   conversations: {
     list: () => ipcRenderer.invoke('conversations:list'),
   },

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -8,6 +8,8 @@ import { ChatsProvider, useChats } from './hooks/useChats'
 import { QuickQuestionProvider } from './hooks/useQuickQuestion'
 import { useGateway } from './hooks/useGateway'
 import { CoreOfflineBanner } from './components/CoreOfflineBanner'
+import { AutomationsView } from './components/AutomationsView'
+import { unwrap } from './components/settingsAtoms'
 import {
   C,
   applyTheme,
@@ -27,6 +29,11 @@ const Shell: React.FC = () => {
   const { state, createChat, selectChat, refreshWorkspaces } = useChats()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<string | undefined>(undefined)
+  const [automationsOpen, setAutomationsOpen] = useState(false)
+  // Unseen automation-run keys (`${automationId}:${runId}`), for the sidebar
+  // badge. A Set so the one-shot 'automation-unseen' push and the on-mount
+  // recompute from history can both add to it without racing each other.
+  const [unseenRunKeys, setUnseenRunKeys] = useState<Set<string>>(new Set())
   const [leftCollapsed, setLeftCollapsed] = useState<boolean>(
     () => localStorage.getItem('codey.leftPanelCollapsed') === '1'
   )
@@ -73,6 +80,48 @@ const Shell: React.FC = () => {
     return off
   }, [])
 
+  // Addition 3: the nav badge must not rely solely on the one-shot
+  // 'automation-unseen' push (missed if it fires before this mounts, or if
+  // the app was relaunched) — also recompute from history on mount. Both
+  // paths merge into the same Set, whichever arrives.
+  useEffect(() => {
+    let cancelled = false
+    const off = window.codey.automations.onUnseen((msg) => {
+      setUnseenRunKeys(prev => {
+        const next = new Set(prev)
+        for (const runId of msg.runIds) next.add(`${msg.automationId}:${runId}`)
+        return next
+      })
+    })
+    void (async () => {
+      try {
+        const autos = unwrap(await window.codey.automations.list())
+        const perAuto = await Promise.all(autos.map(async a => {
+          try {
+            const runs = unwrap(await window.codey.automations.history(a.id, 50))
+            return runs.filter(r => r.endedAt && !r.seenAt).map(r => `${a.id}:${r.runId}`)
+          } catch {
+            return [] as string[]
+          }
+        }))
+        if (cancelled) return
+        setUnseenRunKeys(prev => {
+          const next = new Set(prev)
+          for (const keys of perAuto) for (const k of keys) next.add(k)
+          return next
+        })
+      } catch {
+        // gateway not ready yet — the push will still arrive when it fires
+      }
+    })()
+    return () => { cancelled = true; off() }
+  }, [])
+
+  const openAutomations = () => {
+    setUnseenRunKeys(new Set())
+    setAutomationsOpen(true)
+  }
+
   useEffect(() => {
     applyTheme(getStoredThemeMode())
     applyPalette(getStoredPalette())
@@ -114,6 +163,8 @@ const Shell: React.FC = () => {
         {!leftCollapsed && (
           <ChatListPanel
             onOpenSettings={(tab) => { setSettingsTab(tab); setSettingsOpen(true) }}
+            onOpenAutomations={openAutomations}
+            automationsUnseenCount={unseenRunKeys.size}
             activeChatId={state.selectedChatId}
           />
         )}
@@ -136,6 +187,7 @@ const Shell: React.FC = () => {
           )}
         </div>
         {settingsOpen && <SettingsOverlay initialTab={settingsTab} onClose={() => { setSettingsOpen(false); setSettingsTab(undefined); refreshWorkspaces() }} />}
+        {automationsOpen && <AutomationsView onClose={() => setAutomationsOpen(false)} />}
         <VoiceRecorder />
       </div>
       <style>{`

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -5,6 +5,8 @@ import type { TeamConfigRaw } from '../../packages/core/src/workspace'
 import type { ApiKeyEntry } from '../../packages/core/src/types/index'
 import type { UpdaterEvent } from './hooks/updaterState'
 import type { CoreState } from '../electron/core-state'
+import type { Automation, AutomationRun, AutomationEvent } from '../../packages/core/src/types/automation'
+import type { InterviewStep } from '../../packages/gateway/src/automations/interview'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
@@ -55,6 +57,23 @@ declare global {
       globalTeams: {
         get: () => Promise<IpcResult<Record<string, TeamConfigRaw>>>
         set: (teams: Record<string, TeamConfigRaw>) => Promise<IpcResult<void>>
+      }
+      automations: {
+        list: () => Promise<IpcResult<Automation[]>>
+        get: (id: string) => Promise<IpcResult<Automation>>
+        create: (draft: any) => Promise<IpcResult<Automation>>
+        update: (id: string, patch: Partial<Automation>) => Promise<IpcResult<Automation>>
+        delete: (id: string) => Promise<IpcResult<void>>
+        setEnabled: (id: string, enabled: boolean) => Promise<IpcResult<Automation>>
+        runNow: (id: string) => Promise<IpcResult<AutomationRun | null>>
+        resume: (id: string, runId: string, answer: string) => Promise<IpcResult<AutomationRun>>
+        history: (id: string, limit?: number) => Promise<IpcResult<AutomationRun[]>>
+        markSeen: (id: string, runId: string) => Promise<IpcResult<void>>
+        interviewStart: (goal: string, targetContext: string) => Promise<IpcResult<InterviewStep>>
+        interviewAnswer: (sessionId: string, text: string) => Promise<IpcResult<InterviewStep>>
+        interviewCancel: (sessionId: string) => Promise<IpcResult<void>>
+        onEvent: (handler: (ev: AutomationEvent) => void) => () => void
+        onUnseen: (handler: (msg: { automationId: string; runIds: string[] }) => void) => () => void
       }
       conversations: {
         list: () => Promise<IpcResult<string[]>>

--- a/codey-mac/src/components/AutomationsView.tsx
+++ b/codey-mac/src/components/AutomationsView.tsx
@@ -1,0 +1,692 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { C } from '../theme'
+import { pillButton, unwrap, inputStyle, selectStyle } from './settingsAtoms'
+import { scheduleSummary, canSchedule, timeOfDayToSchedule } from './automationsModel'
+import type { Automation, AutomationRun, AutomationTarget } from '../../../packages/core/src/types/automation'
+import type { InterviewStep } from '../../../packages/gateway/src/automations/interview'
+
+interface Props { onClose: () => void }
+
+type Panel =
+  | { kind: 'list' }
+  | { kind: 'edit'; id: string | null }
+  | { kind: 'history'; id: string }
+
+const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+export const AutomationsView: React.FC<Props> = ({ onClose }) => {
+  const [panel, setPanel] = useState<Panel>({ kind: 'list' })
+  const [automations, setAutomations] = useState<Automation[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      setAutomations(unwrap(await window.codey.automations.list()))
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  // Addition 1: the view is open and the user is looking at it — mark
+  // finished/parked runs seen as their events arrive, so they don't
+  // re-notify on next launch.
+  useEffect(() => {
+    const off = window.codey.automations.onEvent((ev) => {
+      if (ev.type === 'run-finished' || ev.type === 'run-parked') {
+        void window.codey.automations.markSeen(ev.automationId, ev.runId).catch(() => {})
+      }
+      void refresh()
+    })
+    return off
+  }, [refresh])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' && panel.kind === 'list') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, panel.kind])
+
+  return (
+    <div style={styles.backdrop} onClick={panel.kind === 'list' ? onClose : undefined}>
+      <div style={styles.window} onClick={e => e.stopPropagation()}>
+        <div style={styles.titleBar}>
+          <button
+            onClick={panel.kind === 'list' ? onClose : () => setPanel({ kind: 'list' })}
+            style={styles.closeBtn}
+            title={panel.kind === 'list' ? 'Close (Esc)' : 'Back'}
+            aria-label={panel.kind === 'list' ? 'Close' : 'Back'}
+          >
+            <span style={styles.closeDot} />
+          </button>
+          <div style={styles.titleText}>Automations</div>
+          <div style={{ width: 60 }} />
+        </div>
+        <div style={styles.body}>
+          {error && <div style={styles.errorBanner}>{error}</div>}
+          {panel.kind === 'list' && (
+            <AutomationList
+              automations={automations}
+              loading={loading}
+              onRefresh={refresh}
+              onNew={() => setPanel({ kind: 'edit', id: null })}
+              onEdit={(id) => setPanel({ kind: 'edit', id })}
+              onHistory={(id) => setPanel({ kind: 'history', id })}
+              setError={setError}
+            />
+          )}
+          {panel.kind === 'edit' && (
+            <AutomationEditor
+              key={panel.id ?? 'new'}
+              id={panel.id}
+              automation={panel.id ? automations.find(a => a.id === panel.id) ?? null : null}
+              onDone={() => { setPanel({ kind: 'list' }); void refresh() }}
+              onCancel={() => setPanel({ kind: 'list' })}
+              setError={setError}
+            />
+          )}
+          {panel.kind === 'history' && (
+            <RunHistory key={panel.id} id={panel.id} setError={setError} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+interface ListProps {
+  automations: Automation[]
+  loading: boolean
+  onRefresh: () => void
+  onNew: () => void
+  onEdit: (id: string) => void
+  onHistory: (id: string) => void
+  setError: (e: string | null) => void
+}
+
+const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, onNew, onEdit, onHistory, setError }) => {
+  const [lastStatus, setLastStatus] = useState<Record<string, AutomationRun | undefined>>({})
+  const [runningIds, setRunningIds] = useState<Record<string, boolean>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const entries = await Promise.all(automations.map(async a => {
+        try {
+          const runs = unwrap(await window.codey.automations.history(a.id, 1))
+          const last = runs[0]
+          // Displaying the last-run status in the list counts as seeing it:
+          // mark it seen (from the fresh data just fetched) so the launch
+          // scan doesn't re-notify / re-badge list-viewed runs on every
+          // subsequent app start.
+          if (last && last.endedAt && !last.seenAt) {
+            void window.codey.automations.markSeen(a.id, last.runId).catch(() => {})
+          }
+          return [a.id, last] as const
+        } catch {
+          return [a.id, undefined] as const
+        }
+      }))
+      if (!cancelled) setLastStatus(Object.fromEntries(entries))
+    })()
+    return () => { cancelled = true }
+  }, [automations])
+
+  const toggle = async (a: Automation) => {
+    try {
+      await window.codey.automations.setEnabled(a.id, !a.enabled)
+      onRefresh()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
+  }
+
+  const runNow = async (id: string) => {
+    setRunningIds(prev => ({ ...prev, [id]: true }))
+    try {
+      unwrap(await window.codey.automations.runNow(id))
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setRunningIds(prev => ({ ...prev, [id]: false }))
+    }
+  }
+
+  const targetLabel = (t: AutomationTarget) =>
+    t.kind === 'team' ? `team: ${t.teamName} (${t.workspaceName})` : `prompt: ${t.workspaceName}`
+
+  return (
+    <div style={{ padding: '16px 20px', flex: 1, overflowY: 'auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+        <button style={pillButton('primary')} onClick={onNew}>+ New automation</button>
+      </div>
+      {loading ? (
+        <div style={{ color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 20 }}>Loading…</div>
+      ) : automations.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: '36px 20px', color: C.fg3, fontSize: 13 }}>
+          <div style={{ fontSize: 28, marginBottom: 12, opacity: 0.4 }}>⏱</div>
+          <div style={{ fontWeight: 500, color: C.fg2, marginBottom: 4 }}>No automations yet</div>
+          <div style={{ fontSize: 12 }}>
+            Create one — Codey will interview you to remove every runtime ambiguity, then it can run unattended.
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {automations.map(a => {
+            const last = lastStatus[a.id]
+            return (
+              <div key={a.id} style={rowStyle}>
+                <input
+                  type="checkbox"
+                  checked={a.enabled}
+                  onChange={() => void toggle(a)}
+                  title={a.enabled ? 'Enabled' : 'Disabled'}
+                  style={{ marginTop: 3 }}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ color: C.fg, fontSize: 13, fontWeight: 600 }}>{a.name}</span>
+                    <span style={{ color: C.fg3, fontSize: 11 }}>{scheduleSummary(a.schedule)}</span>
+                  </div>
+                  <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>{targetLabel(a.target)}</div>
+                  {last && (
+                    <div style={{ color: last.status === 'failed' ? C.red : C.fg3, fontSize: 11, marginTop: 2 }}>
+                      last run: {last.status}{last.reportFailure ? ' ⚠ report delivery failed' : ''}
+                    </div>
+                  )}
+                </div>
+                <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+                  <button style={pillButton('ghost')} onClick={() => onEdit(a.id)}>Edit</button>
+                  <button style={pillButton('ghost')} onClick={() => onHistory(a.id)}>History</button>
+                  <button style={pillButton('ghost')} disabled={!!runningIds[a.id]} onClick={() => void runNow(a.id)}>
+                    {runningIds[a.id] ? 'Running…' : 'Run now'}
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+interface EditorProps {
+  id: string | null
+  automation: Automation | null
+  onDone: () => void
+  onCancel: () => void
+  setError: (e: string | null) => void
+}
+
+const AutomationEditor: React.FC<EditorProps> = ({ id, automation, onDone, onCancel, setError }) => {
+  const [name, setName] = useState(automation?.name ?? '')
+  const [targetKind, setTargetKind] = useState<'prompt' | 'team'>(automation?.target.kind ?? 'prompt')
+  const [teamName, setTeamName] = useState(automation?.target.kind === 'team' ? automation.target.teamName : '')
+  const [workspaceName, setWorkspaceName] = useState(automation?.target.workspaceName ?? '')
+  const [teams, setTeams] = useState<string[]>([])
+  const [workspaces, setWorkspaces] = useState<string[]>([])
+
+  const [goal, setGoal] = useState('')
+  const [brief, setBrief] = useState(automation?.brief ?? '')
+  const [params, setParams] = useState<Record<string, string>>(automation?.params ?? {})
+
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const sessionIdRef = useRef<string | null>(null)
+  const [question, setQuestion] = useState<{ question: string; why?: string } | null>(null)
+  const [qaLog, setQaLog] = useState<Array<{ q: string; a: string }>>([])
+  const [answer, setAnswer] = useState('')
+  const [interviewBusy, setInterviewBusy] = useState(false)
+
+  const [notify, setNotify] = useState(automation?.report.notify ?? true)
+  const [scheduleOn, setScheduleOn] = useState(!!automation?.schedule)
+  const [time, setTime] = useState(automation?.schedule ? `${String(automation.schedule.hour).padStart(2, '0')}:${String(automation.schedule.minute).padStart(2, '0')}` : '09:00')
+  const [daysOfWeek, setDaysOfWeek] = useState<number[]>(automation?.schedule?.daysOfWeek ?? [])
+
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [testRunning, setTestRunning] = useState(false)
+
+  useEffect(() => {
+    window.codey.workspaces?.list?.().then(r => setWorkspaces(unwrap(r))).catch(() => {})
+    window.codey.globalTeams?.get?.().then(r => setTeams(Object.keys(unwrap(r)))).catch(() => {})
+  }, [])
+
+  // Addition 4: cancel an in-progress interview when the editor unmounts or
+  // the user navigates away, instead of leaking the session server-side.
+  useEffect(() => {
+    sessionIdRef.current = sessionId
+  }, [sessionId])
+  useEffect(() => {
+    return () => {
+      const sid = sessionIdRef.current
+      if (sid) void window.codey.automations.interviewCancel(sid).catch(() => {})
+    }
+  }, [])
+
+  const cancelInterview = useCallback(() => {
+    if (sessionId) void window.codey.automations.interviewCancel(sessionId).catch(() => {})
+    setSessionId(null)
+    setQuestion(null)
+    setQaLog([])
+  }, [sessionId])
+
+  const startInterview = async () => {
+    if (!goal.trim()) return
+    setInterviewBusy(true)
+    try {
+      const targetContext = targetKind === 'team'
+        ? `team: ${teamName || '(unnamed)'}`
+        : 'plain prompt to a coding agent'
+      const step: InterviewStep = unwrap(await window.codey.automations.interviewStart(goal.trim(), targetContext))
+      applyStep(step)
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setInterviewBusy(false)
+    }
+  }
+
+  const applyStep = (step: InterviewStep) => {
+    setSessionId(step.done ? null : step.sessionId)
+    if (step.done) {
+      setBrief(step.brief ?? '')
+      setParams(step.params ?? {})
+      setQuestion(null)
+    } else if (step.question) {
+      setQuestion({ question: step.question.question, why: step.question.why })
+    }
+  }
+
+  const submitAnswer = async () => {
+    if (!sessionId || !question || !answer.trim()) return
+    setInterviewBusy(true)
+    const asked = question.question
+    const given = answer.trim()
+    try {
+      const step: InterviewStep = unwrap(await window.codey.automations.interviewAnswer(sessionId, given))
+      // Log the Q/A pair only after the answer was accepted, so an IPC
+      // failure + retry doesn't duplicate the entry.
+      setQaLog(prev => [...prev, { q: asked, a: given }])
+      setAnswer('')
+      applyStep(step)
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setInterviewBusy(false)
+    }
+  }
+
+  const canSave = name.trim().length > 0 && brief.trim().length > 0
+
+  const buildTarget = (): AutomationTarget =>
+    targetKind === 'team'
+      ? { kind: 'team', teamName, workspaceName }
+      : { kind: 'prompt', workspaceName }
+
+  const save = async () => {
+    if (!canSave) return
+    setSaving(true)
+    try {
+      const schedule = scheduleOn && canSchedule({ brief }) ? timeOfDayToSchedule(time, TZ, daysOfWeek.length ? daysOfWeek : undefined) : undefined
+      if (scheduleOn && !schedule) throw new Error('Invalid time')
+      const payload = {
+        name: name.trim(),
+        target: buildTarget(),
+        brief,
+        params,
+        schedule: schedule ?? undefined,
+        report: { notify },
+      }
+      if (id) {
+        unwrap(await window.codey.automations.update(id, payload as any))
+      } else {
+        unwrap(await window.codey.automations.create({ ...payload, enabled: true } as any))
+      }
+      onDone()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const testRun = async () => {
+    if (!id) return
+    setTestRunning(true)
+    try {
+      unwrap(await window.codey.automations.runNow(id))
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setTestRunning(false)
+    }
+  }
+
+  const del = async () => {
+    if (!id) return
+    if (!confirm(`Delete automation "${name}"?`)) return
+    setDeleting(true)
+    try {
+      unwrap(await window.codey.automations.delete(id))
+      onDone()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+      setDeleting(false)
+    }
+  }
+
+  const back = () => {
+    cancelInterview()
+    onCancel()
+  }
+
+  return (
+    <div style={{ padding: '16px 20px', flex: 1, overflowY: 'auto' }}>
+      <label style={fieldLabel}>Name</label>
+      <input style={{ ...inputStyle, width: '100%' }} value={name} onChange={e => setName(e.target.value)} placeholder="e.g. Morning news digest" />
+
+      <label style={fieldLabel}>Target</label>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <select style={selectStyle} value={targetKind} onChange={e => setTargetKind(e.target.value as 'prompt' | 'team')}>
+          <option value="prompt">Plain prompt</option>
+          <option value="team">Team</option>
+        </select>
+        {targetKind === 'team' && (
+          teams.length > 0 ? (
+            <select style={selectStyle} value={teamName} onChange={e => setTeamName(e.target.value)}>
+              <option value="">— Select team —</option>
+              {teams.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          ) : (
+            <span style={{ color: C.fg3, fontSize: 12, alignSelf: 'center' }}>No teams available</span>
+          )
+        )}
+        {workspaces.length > 0 ? (
+          <select style={selectStyle} value={workspaceName} onChange={e => setWorkspaceName(e.target.value)}>
+            <option value="">— Select workspace —</option>
+            {workspaces.map(w => <option key={w} value={w}>{w}</option>)}
+          </select>
+        ) : (
+          <span style={{ color: C.fg3, fontSize: 12, alignSelf: 'center' }}>No workspaces available</span>
+        )}
+      </div>
+
+      {!brief && (
+        <>
+          <label style={fieldLabel}>Goal</label>
+          <textarea
+            style={{ ...inputStyle, width: '100%', minHeight: 60, resize: 'vertical' }}
+            value={goal}
+            onChange={e => setGoal(e.target.value)}
+            placeholder="What should this automation do?"
+            disabled={!!sessionId}
+          />
+          {!sessionId && (
+            <div style={{ marginTop: 8 }}>
+              <button style={pillButton('primary')} disabled={!goal.trim() || interviewBusy} onClick={() => void startInterview()}>
+                {interviewBusy ? 'Starting…' : 'Start clarification interview'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {sessionId && (
+        <div style={{ marginTop: 12, ...cardStyle }}>
+          {qaLog.length > 0 && (
+            <div style={{ marginBottom: 10, display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {qaLog.map((row, i) => (
+                <div key={i} style={{ fontSize: 12 }}>
+                  <div style={{ color: C.fg2 }}>Q: {row.q}</div>
+                  <div style={{ color: C.fg3 }}>A: {row.a}</div>
+                </div>
+              ))}
+            </div>
+          )}
+          {question && (
+            <div>
+              <div style={{ color: C.fg, fontSize: 13, fontWeight: 500, marginBottom: 2 }}>{question.question}</div>
+              {question.why && <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>{question.why}</div>}
+              <input
+                autoFocus
+                style={{ ...inputStyle, width: '100%' }}
+                value={answer}
+                onChange={e => setAnswer(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') void submitAnswer() }}
+                placeholder="Your answer…"
+                disabled={interviewBusy}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {brief && (
+        <>
+          <label style={fieldLabel}>Brief (frozen by the interview)</label>
+          <pre style={briefStyle}>{brief}</pre>
+          {Object.keys(params).length > 0 && (
+            <>
+              <label style={fieldLabel}>Params</label>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {Object.entries(params).map(([k, v]) => (
+                  <div key={k} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <span style={{ color: C.fg3, fontSize: 12, width: 100, flexShrink: 0 }}>{k}</span>
+                    <input
+                      style={{ ...inputStyle, flex: 1, width: 'auto' }}
+                      value={v}
+                      onChange={e => setParams(prev => ({ ...prev, [k]: e.target.value }))}
+                    />
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+          <button style={{ ...pillButton('ghost'), marginTop: 8 }} onClick={() => { setBrief(''); setParams({}); setGoal('') }}>
+            Re-run interview
+          </button>
+        </>
+      )}
+
+      <label style={fieldLabel}>
+        <input type="checkbox" checked={scheduleOn} disabled={!canSchedule({ brief })} onChange={e => setScheduleOn(e.target.checked)} />
+        {' '}Schedule{!canSchedule({ brief }) ? ' (complete the interview first)' : ''}
+      </label>
+      {scheduleOn && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <input type="time" style={inputStyle} value={time} onChange={e => setTime(e.target.value)} />
+          <span style={{ color: C.fg3, fontSize: 11 }}>{TZ}</span>
+        </div>
+      )}
+
+      <label style={fieldLabel}>
+        <input type="checkbox" checked={notify} onChange={e => setNotify(e.target.checked)} />
+        {' '}Notify on completion
+      </label>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 20 }}>
+        <button style={pillButton('primary')} disabled={!canSave || saving} onClick={() => void save()}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        {id && (
+          <button style={pillButton('ghost')} disabled={testRunning} onClick={() => void testRun()}>
+            {testRunning ? 'Running…' : 'Test run now'}
+          </button>
+        )}
+        {id && (
+          <button style={{ ...pillButton('danger') }} disabled={deleting} onClick={() => void del()}>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </button>
+        )}
+        <span style={{ flex: 1 }} />
+        <button style={pillButton('ghost')} onClick={back}>Cancel</button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+interface HistoryProps { id: string; setError: (e: string | null) => void }
+
+const RunHistory: React.FC<HistoryProps> = ({ id, setError }) => {
+  const [runs, setRuns] = useState<AutomationRun[]>([])
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  // Per-run in-flight guard so a double-click on an option (or a second
+  // Enter on the text answer) can't fire resume twice for the same run.
+  const [resuming, setResuming] = useState<Record<string, boolean>>({})
+
+  const refresh = useCallback(async () => {
+    try {
+      const fresh = unwrap(await window.codey.automations.history(id, 50))
+      setRuns(fresh)
+      // Addition 2: mark unseen ended runs from the FRESH data just fetched,
+      // not from a stale closure over the previous `runs` state.
+      const toMark = fresh.filter(r => r.endedAt && !r.seenAt)
+      await Promise.all(toMark.map(r => window.codey.automations.markSeen(id, r.runId).catch(() => {})))
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
+  }, [id, setError])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  const resume = async (runId: string, option: string) => {
+    if (resuming[runId]) return
+    setResuming(prev => ({ ...prev, [runId]: true }))
+    try {
+      unwrap(await window.codey.automations.resume(id, runId, option))
+      void refresh()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setResuming(prev => ({ ...prev, [runId]: false }))
+    }
+  }
+
+  return (
+    <div style={{ padding: '16px 20px', flex: 1, overflowY: 'auto' }}>
+      {runs.length === 0 ? (
+        <div style={{ color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 20 }}>No runs yet.</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {runs.map(r => (
+            <div key={r.runId} style={cardStyle}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                <span style={{ color: C.fg, fontSize: 12, fontWeight: 600 }}>{new Date(r.startedAt).toLocaleString()}</span>
+                <span style={{ color: C.fg3, fontSize: 11 }}>{r.trigger}</span>
+                <span style={{ color: r.status === 'failed' ? C.red : C.fg3, fontSize: 11 }}>{r.status}</span>
+                {r.reportFailure && <span style={{ color: C.red, fontSize: 11 }}>⚠ report delivery failed</span>}
+              </div>
+              {r.status === 'parked' && r.question && (
+                <div style={{ marginTop: 8 }}>
+                  <div style={{ color: C.fg2, fontSize: 12, marginBottom: 6 }}>{r.question}</div>
+                  {r.options && r.options.length > 0 && (
+                    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 6 }}>
+                      {r.options.map(opt => (
+                        <button
+                          key={opt}
+                          style={pillButton('ghost')}
+                          disabled={!!resuming[r.runId]}
+                          onClick={() => void resume(r.runId, opt)}
+                        >{opt}</button>
+                      ))}
+                    </div>
+                  )}
+                  <input
+                    style={{ ...inputStyle, width: '100%' }}
+                    placeholder={resuming[r.runId] ? 'Resuming…' : 'Free-text answer…'}
+                    disabled={!!resuming[r.runId]}
+                    value={answers[r.runId] ?? ''}
+                    onChange={e => setAnswers(prev => ({ ...prev, [r.runId]: e.target.value }))}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') {
+                        const v = (answers[r.runId] ?? '').trim()
+                        if (v) void resume(r.runId, v)
+                      }
+                    }}
+                  />
+                </div>
+              )}
+              {r.output && <pre style={preStyle}>{r.output}</pre>}
+              {r.error && <pre style={{ ...preStyle, color: C.red }}>{r.error}</pre>}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex', gap: 10, alignItems: 'flex-start',
+  background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10,
+  padding: '12px 14px',
+}
+
+const cardStyle: React.CSSProperties = {
+  background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10, padding: '12px 14px',
+}
+
+const fieldLabel: React.CSSProperties = {
+  display: 'block', color: C.fg3, fontSize: 11, fontWeight: 600,
+  textTransform: 'uppercase', letterSpacing: 0.4, marginTop: 16, marginBottom: 6,
+}
+
+const briefStyle: React.CSSProperties = {
+  margin: 0, padding: '10px 12px', borderRadius: 8, background: C.surface3, color: C.fg2,
+  fontSize: 12, lineHeight: '1.5', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+}
+
+const preStyle: React.CSSProperties = {
+  marginTop: 8, padding: '8px 10px', borderRadius: 6, background: C.codeBg ?? C.surface3, color: C.codeFg ?? C.fg2,
+  fontSize: 11, lineHeight: '1.5', fontFamily: 'monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: {
+    position: 'absolute', inset: 0,
+    background: 'rgba(0,0,0,0.55)',
+    backdropFilter: 'blur(3px)',
+    WebkitBackdropFilter: 'blur(3px)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    zIndex: 50,
+  },
+  window: {
+    width: 'min(900px, 92%)',
+    height: 'min(620px, 88%)',
+    background: C.bg,
+    border: `1px solid ${C.border2}`,
+    borderRadius: 10,
+    boxShadow: '0 24px 60px rgba(0,0,0,0.55), 0 2px 8px rgba(0,0,0,0.3)',
+    display: 'flex', flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  titleBar: {
+    height: 40, flexShrink: 0, display: 'flex', alignItems: 'center',
+    borderBottom: `1px solid ${C.border}`, padding: '0 12px',
+  },
+  closeBtn: {
+    width: 24, height: 24, borderRadius: '50%', border: 'none',
+    background: 'transparent', cursor: 'pointer',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+  closeDot: { width: 12, height: 12, borderRadius: '50%', background: C.red },
+  titleText: { flex: 1, textAlign: 'center', color: C.fg, fontSize: 13, fontWeight: 600 },
+  body: { flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+  errorBanner: {
+    margin: '10px 20px 0', background: C.dangerBg ?? (C.red + '22'), color: C.dangerFg ?? C.red,
+    padding: 10, borderRadius: 8, fontSize: 12,
+  },
+}

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -10,6 +10,8 @@ import { onWorkspacesChanged } from './workspacesChanged'
 
 interface Props {
   onOpenSettings: (tab?: string) => void
+  onOpenAutomations: () => void
+  automationsUnseenCount: number
   activeChatId: string | null
 }
 
@@ -19,7 +21,7 @@ interface WsMenuState {
   y: number
 }
 
-export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId }) => {
+export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomations, automationsUnseenCount, activeChatId }) => {
   const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace, refreshWorkspaces, refreshChats, linkChannel, unlinkChannel } = useChats()
   const [addingWorkspace, setAddingWorkspace] = useState(false)
   const [workspaces, setWorkspaces] = useState<string[]>([])
@@ -379,6 +381,12 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, activeChatId })
           disabled={addingWorkspace}
           title="Pick a folder and create a new workspace + chat"
         >{addingWorkspace ? 'Picking…' : '+ Add Workspace'}</button>
+        <button style={styles.settingsBtn} onClick={onOpenAutomations}>
+          ⏱ Automations
+          {automationsUnseenCount > 0 && (
+            <span style={styles.navBadge}>{automationsUnseenCount > 9 ? '9+' : automationsUnseenCount}</span>
+          )}
+        </button>
         <button style={styles.settingsBtn} onClick={() => onOpenSettings()}>⚙ Settings</button>
       </div>
       {wsMenu && (
@@ -552,6 +560,12 @@ const styles: Record<string, React.CSSProperties> = {
     width: '100%', padding: '8px 10px', border: 'none',
     background: 'transparent', color: C.fg2, cursor: 'pointer',
     textAlign: 'left', borderRadius: 6, fontSize: 13,
+    display: 'flex', alignItems: 'center', gap: 6,
+  },
+  navBadge: {
+    marginLeft: 'auto', minWidth: 16, height: 16, padding: '0 4px',
+    borderRadius: 8, background: '#E5484D', color: '#fff',
+    fontSize: 10, fontWeight: 700, lineHeight: '16px', textAlign: 'center',
   },
   menu: {
     position: 'fixed', zIndex: 1000,

--- a/codey-mac/src/components/automationsModel.test.ts
+++ b/codey-mac/src/components/automationsModel.test.ts
@@ -1,0 +1,30 @@
+// codey-mac/src/components/automationsModel.test.ts
+import { describe, it, expect } from 'vitest'
+import { scheduleSummary, canSchedule, timeOfDayToSchedule } from './automationsModel'
+
+describe('scheduleSummary', () => {
+  it('renders daily and weekly summaries', () => {
+    expect(scheduleSummary({ hour: 9, minute: 0, tz: 'Asia/Shanghai' })).toBe('daily 09:00')
+    expect(scheduleSummary({ hour: 18, minute: 30, daysOfWeek: [1, 2, 3, 4, 5], tz: 'UTC' }))
+      .toBe('Mon–Fri 18:30')
+    expect(scheduleSummary({ hour: 8, minute: 5, daysOfWeek: [0, 6], tz: 'UTC' })).toBe('Sun, Sat 08:05')
+    expect(scheduleSummary(undefined)).toBe('manual')
+  })
+})
+
+describe('canSchedule', () => {
+  it('requires a synthesized brief (spec: interview is the gate)', () => {
+    expect(canSchedule({ brief: '' })).toBe(false)
+    expect(canSchedule({ brief: '  ' })).toBe(false)
+    expect(canSchedule({ brief: 'Post news.' })).toBe(true)
+  })
+})
+
+describe('timeOfDayToSchedule', () => {
+  it('maps an HH:MM picker value + tz into a structured schedule', () => {
+    expect(timeOfDayToSchedule('09:30', 'Asia/Shanghai', [1, 3]))
+      .toEqual({ hour: 9, minute: 30, tz: 'Asia/Shanghai', daysOfWeek: [1, 3] })
+    expect(timeOfDayToSchedule('9:5', 'UTC')).toEqual({ hour: 9, minute: 5, tz: 'UTC' })
+    expect(timeOfDayToSchedule('25:00', 'UTC')).toBeNull()
+  })
+})

--- a/codey-mac/src/components/automationsModel.ts
+++ b/codey-mac/src/components/automationsModel.ts
@@ -1,0 +1,32 @@
+// codey-mac/src/components/automationsModel.ts
+// Pure helpers for the Automations view — kept separate for unit tests.
+
+export interface ScheduleLike { hour: number; minute: number; daysOfWeek?: number[]; tz: string }
+
+const DAY = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const pad = (n: number) => String(n).padStart(2, '0')
+
+export function scheduleSummary(s: ScheduleLike | undefined): string {
+  if (!s) return 'manual'
+  const time = `${pad(s.hour)}:${pad(s.minute)}`
+  if (!s.daysOfWeek || s.daysOfWeek.length === 0 || s.daysOfWeek.length === 7) return `daily ${time}`
+  const days = [...s.daysOfWeek].sort((a, b) => a - b)
+  const contiguous = days.length > 2 && days.every((d, i) => i === 0 || d === days[i - 1] + 1)
+  const label = contiguous
+    ? `${DAY[days[0]]}–${DAY[days[days.length - 1]]}`
+    : days.map(d => DAY[d]).join(', ')
+  return `${label} ${time}`
+}
+
+/** The interview is the gate: no schedule without a synthesized brief. */
+export function canSchedule(a: { brief: string }): boolean {
+  return a.brief.trim().length > 0
+}
+
+export function timeOfDayToSchedule(hhmm: string, tz: string, daysOfWeek?: number[]): ScheduleLike | null {
+  const m = hhmm.match(/^(\d{1,2}):(\d{1,2})$/)
+  if (!m) return null
+  const hour = Number(m[1]); const minute = Number(m[2])
+  if (hour > 23 || minute > 59) return null
+  return { hour, minute, tz, ...(daysOfWeek && daysOfWeek.length ? { daysOfWeek } : {}) }
+}

--- a/docs/superpowers/specs/2026-07-02-automations-design.md
+++ b/docs/superpowers/specs/2026-07-02-automations-design.md
@@ -55,7 +55,10 @@ Electron main (holds the Codey instance)
     ├── AutomationStore     (~/.codey/automations.json + per-id run history .jsonl)
     ├── AutomationEngine    (schedule loop, runNow, executeAutomation, result routing)
     └── AutomationInterviewer (authoring-time clarification, reuses Aide role)
-         └── runs via a new headless entry point over the existing run paths
+         └── runs each automation's rendered brief as a turn in a hidden
+             system chat (Chat.kind: 'automation'), via the existing
+             sendToChat pipeline — see "Execution: the hidden system chat"
+             below. There is no separate headless entry point.
 ```
 
 ### Scheduler leadership (single scheduler across processes)
@@ -94,10 +97,14 @@ interface Automation {
   name: string;
   enabled: boolean;
 
-  // What it runs
+  // What it runs. `workspaceName` replaces the originally-sketched `workingDir`:
+  // the hidden chat this automation owns (see `chatId` below) is created in
+  // that workspace, and `sendToChat` resolves the actual `workingDir` from the
+  // chat's workspace the same way any normal chat does — there is no parallel
+  // working-directory mechanism for automations.
   target:
-    | { kind: 'prompt'; workingDir?: string; agent?: CodingAgent; model?: ModelConfig }
-    | { kind: 'team';   teamName: string };
+    | { kind: 'prompt'; workspaceName: string; agent?: CodingAgent; model?: string }
+    | { kind: 'team';   teamName: string; workspaceName: string };
 
   // Baked at authoring time (Q6)
   brief: string;                    // frozen, enriched, self-contained instruction block
@@ -124,6 +131,15 @@ interface Automation {
     channel?: { platform: string; target: string };  // optional chat/channel post
   };
 
+  // The hidden system chat (Chat.kind: 'automation') this automation executes
+  // in, created lazily on first run. This chat IS the headless entry point —
+  // every run and every resume is just another turn sent into it via
+  // `sendToChat` with a collecting sink, so team pause/resume
+  // (`chat.pendingTeam` + the existing continuation machinery) and
+  // conversation context work completely unchanged. There is no separate
+  // headless code path (see "Execution: the hidden system chat" below).
+  chatId?: string;
+
   lastFiredAt?: number;             // for missed-slot / double-fire protection
   createdAt: number;
   updatedAt: number;
@@ -142,6 +158,9 @@ interface AutomationRun {
   output?: string;          // capped (e.g. 32KB, truncation marked) — team runs can
                             // produce huge transcripts and the UI reads this file
   error?: string;
+  question?: string;        // pending question when status === 'parked'
+  options?: string[];       // choice options, when the parked question was [ASK_USER:choice]
+  resumedFrom?: string;     // runId of the parked run this record resumed
   reportFailure?: string;   // notify/channel delivery failure, recorded not just logged
   seenAt?: number;          // set when the Mac app has surfaced the result (badge clear)
 }
@@ -163,31 +182,42 @@ fields** on rewrite of both definitions and run records (forward-compatible migr
   - **skip missed slots on restart** — if a scheduled slot elapsed while the process was
     down, **log and skip; never back-fire** (a 3am job must not blast at noon).
 - **Triggers** — `runNow(id, trigger)` (manual, allowed even without the lease) and the
-  schedule path both funnel into one `executeAutomation(automation, trigger)`.
-- **Execution — a new headless entry point.** The existing run paths are not directly
-  callable here: `runTeamTask` is `private` on the gateway and takes a channel-shaped
-  `UserMessage` plus response plumbing, and the chat paths assume a chat to stream into.
-  The gateway therefore exposes `runHeadless(automation, trigger)` which builds a
-  synthetic message from the rendered brief (placeholders substituted from `params`)
-  and a **collecting emitter sink** (a `TeamEmitter` sink that accumulates the
-  transcript instead of streaming to a surface — mirroring what `sendToChat` does for
-  the chat surface):
-  - `kind: 'prompt'` → run through the agent adapter path with the automation's
-    `workingDir`/`agent`/`model`, fully autonomous.
-  - `kind: 'team'` → dispatch through `runTeamTask` (via the headless wrapper) with the
-    brief as the task; flow graphs and the judge work unchanged.
-- **Unattended safety & parked runs** — runs have **no interactive surface bound**. An
-  unexpected `[ASK_USER]` is caught: the run is recorded `parked` with the pending
-  question in `output`, pause state persisted via the existing `TeamEmitter`
-  continuation machinery (keyed by `runId` instead of a chat id), and the user is
-  notified. The engine **never guesses**. A parked run is **resumable**: the run-history
-  detail in the Mac app shows the question with an answer box; the answer feeds the
-  persisted continuation exactly like a chat reply would, and the resumed execution
-  appends a new `resumed` run record linked by `runId`. Parked state survives restarts
-  (it is persisted), but a parked run older than 7 days is expired to `failed` so
-  stale questions don't resume against a changed world.
-- **Concurrency** — reuses the existing `RunSemaphore`. An automation that fires while its
-  previous run is still active (or parked) is **skipped and logged**, not double-queued.
+  schedule path both funnel into `AutomationEngine.execute`, which calls out to a
+  gateway-supplied `runTarget`/`resumeTarget` adapter.
+- **Execution: the hidden system chat.** There is no separate headless entry point.
+  Each automation lazily gets its own hidden system chat (`Chat.kind: 'automation'`,
+  `Automation.chatId`), created on first run in the target's `workspaceName` (with a
+  `team` selection for `kind: 'team'` targets). Every run — scheduled, manual, or
+  resumed — is simply a turn sent into that chat through the existing `sendToChat`
+  pipeline with a collecting sink (`runAutomationTurn` on `Codey`):
+  - `kind: 'prompt'` → `sendToChat` runs the automation's `agent`/`model` override
+    against the rendered brief (placeholders substituted from `params`), fully
+    autonomous, with `workingDir` resolved from the chat's workspace exactly as any
+    normal chat turn resolves it.
+  - `kind: 'team'` → `sendToChat`'s existing team dispatch runs the brief as the task;
+    flow graphs, the judge, and `chat.pendingTeam` pause/resume work unchanged because
+    this is the same code path a real chat uses.
+  - Because the run lives in a real (hidden) chat, conversation context and history
+    carry between runs and across resumes for free — no parallel continuation store
+    was needed.
+- **Unattended safety & parked runs** — runs have **no interactive surface bound**. Two
+  parking paths are detected after each turn (`detectParked`): a `team` target parks via
+  the persisted `chat.pendingTeam` (the existing pause machinery — authoritative for
+  teams); a `prompt` target parks when the single agent's response itself contains an
+  `[ASK_USER]` marker (a solo prompt has no team pause state to consult, so the marker
+  is the signal). Either way the run is recorded `parked` with the pending
+  `question`/`options`, and the user is notified. The engine **never guesses**. A parked
+  run is **resumable**: the run-history detail in the Mac app shows the question with an
+  answer box; the answer is simply the **next turn sent into the same hidden chat**
+  (conversation context carries the original question forward, so no separate
+  continuation keying by `runId` was needed), and the resumed execution appends a new
+  `resumed` run record linked by `runId` via `resumedFrom`. Parked state survives
+  restarts (it is persisted on the chat and in the run record), but a parked run older
+  than 7 days is expired to `failed` so stale questions don't resume against a changed
+  world — see "Hardening" below for the exact expiry and resume-consumption semantics.
+- **Concurrency** — a per-process `active` set skips an automation whose previous run is
+  still in flight; a fresh fire is also skipped while the latest run record is `parked`.
+  See "Hardening" for the v1 limits this accepts.
 - **Result routing** — on finish: append to run-history `.jsonl`; then best-effort
   delivery, with any failure recorded in the run's `reportFailure` (not just logged):
   - `report.notify` → emit `automation-run-finished`; if an Electron main is attached it
@@ -197,6 +227,68 @@ fields** on rewrite of both definitions and run records (forward-compatible migr
     (notification-on-launch for anything unseen and recent).
   - `report.channel` → post summary via channel machinery **if that platform is
     connected in this process**; otherwise record the delivery failure.
+
+### Hardening (from implementation review)
+
+Points below were tightened after an implementation-review pass; each is a one-line
+guarantee the code (and its tests) rely on:
+
+- **Resume consumes the parked record.** After a resume attempt — success or failure —
+  the original run is patched to `resumed`, so it stops being answerable; a second
+  answer against the same `runId` is rejected (`resume()` requires `status === 'parked'`).
+- **Parked expiry is leader-only, idempotent, and observable.** Only the scheduler
+  lease-holder runs `expireParked` (a non-leader running it could clobber the leader's
+  concurrent `appendRun`, since `patchRun` is a whole-file rewrite); expiring an already-
+  expired run is a no-op; and expiry emits `run-finished` with the patched (`failed`)
+  run so the Mac app notifies exactly as it would for any other finish.
+- **Stale `pendingTeam` is cleared before fresh turns, not resumes.** A fresh automation
+  turn (not a resume) clears any stale `chat.pendingTeam` on the hidden chat before
+  calling `sendToChat` — this guards against an expiry/failed-resume desync where the
+  chat still thinks a team is paused but the run record has already moved past `parked`.
+  A resume turn relies on `pendingTeam` being present and does not clear it.
+- **One bad automation can't stall the tick.** The engine tick evaluates each automation
+  in its own `try/catch`; garbage schedule data (e.g. an invalid IANA tz, which makes
+  `Intl` throw a `RangeError` inside `shouldFire`) logs and skips just that automation
+  instead of aborting the whole tick and starving every other schedule.
+- **Skill machinery is gated off for automation chats.** Auto-apply, skill-suggestion
+  resolution, and the post-run crystallizer pass are all skipped when `chat.kind ===
+  'automation'` — an unattended run executes a frozen brief and must not silently pick
+  up or apply skills mid-run. Automation chat titles are also never LLM-rewritten.
+- **`InterviewManager` is defensive about failure and reentrancy.** A session is removed
+  from the in-memory map whether `synthesize` succeeds or throws (a failed interview
+  restarts from scratch rather than retrying into duplicated state); `cancel(sessionId)`
+  lets the Mac app drop an in-progress interview when its editor closes; and `answer()`
+  clears the session's `current` question before awaiting the follow-up check, so a
+  reentrant call for the same session hits the "unknown/no pending question" guard
+  instead of racing.
+- **The Mac IPC boundary validates before the store sees anything.** `automations:create`
+  and `automations:update` run drafts/patches through `validateAutomationDraft` /
+  `validateAutomationPatch` (hour/minute integer-range checks, an `Intl.DateTimeFormat`
+  probe to reject a bad tz, and a `report.notify` boolean check) — bad data is rejected
+  at the IPC handler, before it can reach `AutomationStore` and later starve the
+  scheduler tick.
+- **OS notifications respect global settings and window focus.** Both the launch-time
+  unseen scan and the live `run-finished`/`run-parked` listener gate the actual
+  `Notification` call behind `osNotificationsAllowed()`, which checks the app's global
+  `notifications.enabled` setting and suppresses the OS notification while the main
+  window is focused (the user is already looking at the app). Renderer-side events
+  (`automation-event`, `automation-unseen`) and badges are unaffected by this gate —
+  they always flow, since the renderer needs them to keep its own state in sync.
+- **"Seen" is driven by display, not a separate acknowledgment step.** Simply displaying
+  a run's status — the latest-status badge in the automations list, or opening the run
+  history panel — marks that run `seenAt` via `automations:markSeen`. The launch-time
+  scan only re-notifies runs that are still unseen *and* ended within the last 24h
+  (`findUnseenRuns`), so a daemon-fired run from days ago doesn't resurface.
+- **Accepted v1 limits.** These are known, intentional gaps, not bugs: the `active`-run
+  guard is per-process only, so a second process (e.g. the standalone daemon and the
+  embedded Mac-app gateway both pointed at the same store) can race two `runNow` calls
+  for the same automation concurrently; `AutomationEngine.stop()` clears the tick timer
+  and releases the lease but does not await any in-flight run; the Automations editor
+  only authors daily/every-day schedules (`daysOfWeek` is preserved on an existing
+  automation and round-tripped on save, but there is no UI control to edit which days
+  fire); and a `report.notify`-only automation running on a headless daemon (no attached
+  Electron main) produces no notification surface at all — the run simply waits in
+  history for the Mac app's next launch scan.
 
 ## Authoring flow (the clarification interview)
 
@@ -261,13 +353,17 @@ Vitest, `*.test.ts` colocated per package; runs under `npm test`.
   double-fire within one slot (`lastFiredAt`).
 - Leadership: only the lease holder ticks; embedded holder stands down when a daemon
   claims; stale lock (dead heartbeat) is stolen; non-leader still serves `runNow`.
-- `executeAutomation`: prompt- and team-targets dispatch through the headless entry
-  point to the correct run path (mocked); params substituted into brief placeholders.
-- Unattended safety: `[ASK_USER]` → `parked` + continuation persisted; never guesses;
-  `resume(runId, answer)` continues the run and appends a `resumed` record; parked runs
-  expire to `failed` after 7 days.
+- `execute`: prompt- and team-targets dispatch through the injected `runTarget`/
+  `resumeTarget` adapter (mocked in engine tests; backed by the hidden-chat
+  `runAutomationTurn` in the real gateway) to the correct run path; params substituted
+  into brief placeholders.
+- Unattended safety: `[ASK_USER]` (prompt targets) or `chat.pendingTeam` (team targets)
+  → `parked`, never guesses; `resume(id, runId, answer)` continues the run, patches the
+  original run to `resumed` (so a second answer is rejected), and appends a linked
+  `resumed` record; parked runs expire to `failed` after 7 days, leader-only and
+  idempotent.
 - Concurrency: overlapping fire (active or parked previous run) skipped, not
-  double-queued.
+  double-queued; a single bad automation's schedule data doesn't abort the tick.
 - Result routing: run appended to `.jsonl` with output capped; notify + channel called
   when configured; delivery failure lands in `reportFailure`.
 
@@ -287,3 +383,7 @@ UI stays manual/visual.
 - Event/webhook/message triggers (design storage so they can be added without rework).
 - `/automation` chat command (fast-follow once store + engine exist).
 - Multi-user sharing of automations.
+- Flipping the Mac app's launch-at-login default: `setLoginItemSettings` already exists
+  (`codey-mac/electron/main.ts`) and needed no new work here beyond documenting that a
+  scheduled, app-only (no standalone daemon) automation setup requires it enabled —
+  otherwise nothing fires the schedule while the app isn't running.

--- a/docs/superpowers/specs/2026-07-02-automations-design.md
+++ b/docs/superpowers/specs/2026-07-02-automations-design.md
@@ -1,0 +1,208 @@
+# Codey Automations — Design (v1)
+
+**Date:** 2026-07-02
+**Status:** Approved (brainstorming) — pending implementation plan
+
+## Summary
+
+Automations let a user define a **fully actionable, self-contained process** that Codey
+runs either **on demand ("run now")** or **on a time-of-day schedule** — for example,
+"post the day's top AI news to my X account every morning." Each automation runs an
+existing Codey execution primitive:
+
+- a **plain prompt** to an agent, or
+- an existing **team / flow graph**.
+
+The defining principle: **all ambiguity is resolved at authoring time**, not at run
+time. When you create an automation, Codey runs an **interactive clarification
+interview** — the agent asks everything it would otherwise need mid-run, you answer,
+and the answers are baked into a frozen brief. Scheduled runs are therefore **fully
+autonomous**; a run that still hits an unforeseen `[ASK_USER]` **parks and notifies**
+rather than guessing.
+
+## Decisions (from brainstorming)
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Execution unit | Plain **prompt** or existing **team/flow** |
+| 2 | Triggers | **Manual (run-now) + scheduled (time-of-day)**; event triggers out of scope for v1 |
+| 3 | Scheduler host | **Gateway/core layer** (shared), not the Electron main process |
+| 4 | Runtime reality | Both standalone daemon **and** embedded-in-Mac-app gateway must run schedules |
+| 5 | Unattended approvals | Clarify at **authoring**; runtime is autonomous; unexpected pause → **park + notify** |
+| 6 | Clarification output | **Frozen brief + surfaced editable params** |
+| 7 | Output/notifications | **Run history + Mac notification + optional post to a chat/channel** |
+| 8 | Authoring surface | **Mac app only** for v1; `/automation` chat command is a fast-follow |
+
+## Architecture
+
+The scheduler cannot live in the Electron main process, because the user runs Codey
+**both** as a standalone `packages/gateway` daemon and embedded inside the Mac app
+(`codey-mac/electron/main.ts` imports `Codey` from `@codey/gateway`). Placing the engine
+in the shared gateway layer means whichever process instantiates `Codey` gets the cron
+loop for free — no duplication. The Mac app additionally gains a launch-at-login /
+background mode so the app-only case can still fire schedules.
+
+```
+Mac app (Automations view)
+    │  IPC (list/create/interview/runNow/history)
+    ▼
+Electron main (holds the Codey instance)
+    ▼
+@codey/gateway
+    ├── AutomationStore     (~/.codey/automations.json + per-id run history .jsonl)
+    ├── AutomationEngine    (cron loop, runNow, executeAutomation, result routing)
+    └── AutomationInterviewer (authoring-time clarification, reuses Aide role)
+         └── reuses existing run paths: agent chat run / runTeamTask + graph/judge
+```
+
+## Data model & storage
+
+Definitions live in `~/.codey/automations.json` (owned by `@codey/gateway`, read/written
+by both the daemon and the embedded gateway). Run history is **separate, append-only,
+per-automation** so history never bloats the definition store.
+
+```ts
+interface Automation {
+  id: string;
+  name: string;
+  enabled: boolean;
+
+  // What it runs
+  target:
+    | { kind: 'prompt'; workingDir?: string; agent?: CodingAgent; model?: ModelConfig }
+    | { kind: 'team';   teamName: string };
+
+  // Baked at authoring time (Q6)
+  brief: string;                    // frozen, enriched, self-contained instruction block
+  params: Record<string, string>;   // surfaced editable knobs (account, count, tone, …)
+
+  // When it runs (Q2/Q4)
+  schedule?: { cron: string; tz: string };   // absent = manual-only
+
+  // Where results go (Q7)
+  report: {
+    notify: boolean;                                  // Mac notification
+    channel?: { platform: string; target: string };  // optional chat/channel post
+  };
+
+  lastFiredAt?: number;             // for missed-slot / double-fire protection
+  createdAt: number;
+  updatedAt: number;
+}
+```
+
+Run history: `~/.codey/automation-runs/<id>.jsonl`, one JSON object per line:
+
+```ts
+interface AutomationRun {
+  runId: string;
+  startedAt: number;
+  endedAt?: number;
+  status: 'success' | 'failed' | 'parked';
+  trigger: 'manual' | 'schedule';
+  output?: string;
+  error?: string;
+}
+```
+
+Store requirements: load/save `automations.json`; append run records; filter by
+`enabled`; **preserve unknown fields** on rewrite (forward-compatible migration).
+
+## Scheduler & execution engine
+
+`AutomationEngine` in `@codey/gateway`, instantiated by `Codey`:
+
+- **Cron loop** — a single timer (~30s tick) evaluates each enabled automation's
+  `schedule.cron` against its `tz`, using persisted `lastFiredAt` to:
+  - avoid double-firing within one slot, and
+  - **skip missed slots on restart** — if a scheduled slot elapsed while the process was
+    down, **log and skip; never back-fire** (a 3am job must not blast at noon).
+- **Triggers** — `runNow(id, trigger)` (manual) and the cron path both funnel into one
+  `executeAutomation(automation, trigger)`.
+- **Execution**:
+  - `kind: 'prompt'` → build run prompt from `brief` + `params`, run through the existing
+    agent run path, **fully autonomous** (no interactive channel bound).
+  - `kind: 'team'` → call existing `runTeamTask` with the brief as the task.
+- **Unattended safety** — runs with **no interactive channel bound**. An unexpected
+  `[ASK_USER]` is caught: run ends `parked`, pause state persisted (reusing existing
+  pause machinery), user notified. The engine **never guesses**.
+- **Concurrency** — reuses the existing `RunSemaphore`. An automation that fires while its
+  previous run is still active is **skipped and logged**, not double-queued.
+- **Result routing** — on finish: append to run-history `.jsonl`; fire Mac notification if
+  `report.notify`; post summary to `report.channel` if set (reusing channel machinery).
+
+## Authoring flow (the clarification interview)
+
+The interview is the gate: an automation cannot be scheduled until it has a synthesized
+brief.
+
+1. **Goal** — free text + choose target kind (prompt, or pick an existing team).
+2. **Clarification pass** — an interviewer LLM (reuses the **Aide** role in
+   `packages/core/src/aide.ts`) reads the goal (and, for a team target, the team/worker
+   definitions) and produces the **open questions** it would otherwise hit at runtime:
+   missing specifics, choices, accounts/credentials, ambiguities, edge cases ("what if
+   there's no notable news today?"). Questions are presented **one at a time**.
+3. **Answers** — user answers each; the interviewer may ask **one bounded follow-up** per
+   question if an answer opens a new gap (guard against loops).
+4. **Brief synthesis** — fold goal + answers into (a) the frozen self-contained `brief`
+   (building on the existing `TaskBrief` shape) and (b) a small set of surfaced `params`.
+5. **Dry-run (recommended)** — "Test run now" executes once immediately and shows output;
+   user accepts or returns to answer more. This is the verification step before trusting
+   a schedule.
+6. **Schedule + report target** — time-of-day → `cron` + `tz`; notify toggle + optional
+   channel. Save.
+
+Editing `params` later is cheap (no re-interview). Changing the **goal** re-opens the
+interview and regenerates the brief.
+
+## Mac app UI & IPC
+
+**New "Automations" view** in the renderer, alongside chats/flows:
+
+- **List** — name, target kind, schedule summary ("daily 9:00"), enabled toggle,
+  last-run status badge, **Run now**.
+- **Create/Edit** — goal + target picker → clarification interview panel (chat-like, one
+  question at a time) → read-only brief preview (regenerated on goal change) → editable
+  `params` → schedule picker + report target → **Test run now**.
+- **Run history** — per-automation timeline read from the `.jsonl`; each run expandable to
+  output/error.
+
+**IPC / wiring** (Electron main ↔ embedded `Codey`, following the existing pattern):
+
+- `automations:list | get | create | update | delete | setEnabled`
+- `automations:runNow(id)`
+- `automations:interview:start | answer | next`
+- Engine emits `automation-run-started | finished | parked` → forwarded to the renderer
+  for live status and to `chat-notifications.ts` for the OS notification.
+
+The renderer holds **no new persistence** — it is a pure client over the gateway store,
+consistent with how chats already work.
+
+## Testing strategy
+
+Vitest, `*.test.ts` colocated per package; runs under `npm test`.
+
+**`@codey/gateway` — engine (highest value):**
+- Cron: fires at the right slot; **skips a missed slot on restart (no back-fire)**; no
+  double-fire within one slot (`lastFiredAt`).
+- `executeAutomation`: prompt- and team-targets dispatch to the correct existing run path
+  (mocked).
+- Unattended safety: `[ASK_USER]` → `parked` + pause state persisted; never guesses.
+- Concurrency: overlapping fire skipped, not double-queued.
+- Result routing: run appended to `.jsonl`; notify + channel called when configured.
+
+**Store:** load/save `automations.json`; per-id run-history append; enabled filtering;
+unknown-field preservation.
+
+**`@codey/core` — interviewer/brief:** given goal + canned answers (mocked Aide),
+synthesizes a non-empty self-contained brief + params; goal change re-opens interview;
+follow-up bounded.
+
+**Mac app (light):** cron ⇄ time-of-day mapping; "can't schedule without a brief" guard.
+UI stays manual/visual.
+
+## Out of scope (v1)
+
+- Event/webhook/message triggers (design storage so they can be added without rework).
+- `/automation` chat command (fast-follow once store + engine exist).
+- Multi-user sharing of automations.

--- a/docs/superpowers/specs/2026-07-02-automations-design.md
+++ b/docs/superpowers/specs/2026-07-02-automations-design.md
@@ -32,6 +32,9 @@ rather than guessing.
 | 6 | Clarification output | **Frozen brief + surfaced editable params** |
 | 7 | Output/notifications | **Run history + Mac notification + optional post to a chat/channel** |
 | 8 | Authoring surface | **Mac app only** for v1; `/automation` chat command is a fast-follow |
+| 9 | Scheduler leadership | **One scheduler at a time** — lease lockfile; daemon wins over embedded gateway |
+| 10 | Schedule format | **Structured time-of-day** (`{hour, minute, daysOfWeek?, tz}`), not cron strings, for v1 |
+| 11 | Parked runs | **Resumable** from the run-history detail (answer box → existing continuation path) |
 
 ## Architecture
 
@@ -50,10 +53,34 @@ Electron main (holds the Codey instance)
     ▼
 @codey/gateway
     ├── AutomationStore     (~/.codey/automations.json + per-id run history .jsonl)
-    ├── AutomationEngine    (cron loop, runNow, executeAutomation, result routing)
+    ├── AutomationEngine    (schedule loop, runNow, executeAutomation, result routing)
     └── AutomationInterviewer (authoring-time clarification, reuses Aide role)
-         └── reuses existing run paths: agent chat run / runTeamTask + graph/judge
+         └── runs via a new headless entry point over the existing run paths
 ```
+
+### Scheduler leadership (single scheduler across processes)
+
+The user can run the standalone daemon and the embedded Mac-app gateway **at the same
+time**, and both read the same `~/.codey/automations.json`. If both ran the schedule
+loop, every automation would fire twice, and `lastFiredAt` cannot save us — each process
+races to persist it, and concurrent `automations.json` writes are last-writer-wins.
+Therefore exactly **one process holds the scheduler lease** at a time:
+
+- **Lease lockfile** — `~/.codey/automation-scheduler.lock` containing
+  `{ pid, role: 'daemon' | 'embedded', heartbeatAt }`. The holder refreshes
+  `heartbeatAt` every tick; a lock whose heartbeat is older than 3 ticks is stale and
+  may be taken over. Lock acquisition uses an atomic create (`wx` open) with a
+  read-verify-steal path for stale locks.
+- **Daemon wins** — the daemon always attempts to acquire (stealing a stale or
+  embedded-held lease at startup is allowed after a takeover handshake: embedded holders
+  re-check the lockfile each tick and stand down when they see a daemon claim). The
+  embedded gateway acquires only if no live daemon holds the lease.
+- **Non-leaders stay useful** — a process without the lease still serves the store
+  (list/edit/history) and can `runNow`; it just never fires schedules.
+- **Write discipline** — `automations.json` rewrites are read-modify-write on the latest
+  file contents with an atomic rename, so an edit from the Mac app and a `lastFiredAt`
+  update from the daemon don't clobber each other. Run-history `.jsonl` files are
+  append-only per automation and safe to append from either process.
 
 ## Data model & storage
 
@@ -75,9 +102,21 @@ interface Automation {
   // Baked at authoring time (Q6)
   brief: string;                    // frozen, enriched, self-contained instruction block
   params: Record<string, string>;   // surfaced editable knobs (account, count, tone, …)
+  // Params are injected as {{placeholders}} in the brief; any param without a
+  // placeholder is appended as a trailing "Parameters:" block. The synthesizer
+  // emits placeholders for every surfaced param so edits take effect without
+  // re-synthesis.
 
-  // When it runs (Q2/Q4)
-  schedule?: { cron: string; tz: string };   // absent = manual-only
+  // When it runs (Q2/Q10). Structured time-of-day, NOT a cron string: the v1 UI
+  // only expresses time-of-day, structured form is trivially tz-safe to evaluate
+  // with Intl (no cron parser dep, no hand-rolled cron bugs). A `cron?: string`
+  // field can be added later for power users without migration.
+  schedule?: {
+    hour: number;          // 0-23, in tz
+    minute: number;        // 0-59
+    daysOfWeek?: number[]; // 0=Sun … 6=Sat; absent = every day
+    tz: string;            // IANA zone, e.g. "Asia/Shanghai"
+  };                       // absent = manual-only
 
   // Where results go (Q7)
   report: {
@@ -98,38 +137,66 @@ interface AutomationRun {
   runId: string;
   startedAt: number;
   endedAt?: number;
-  status: 'success' | 'failed' | 'parked';
+  status: 'success' | 'failed' | 'parked' | 'resumed';
   trigger: 'manual' | 'schedule';
-  output?: string;
+  output?: string;          // capped (e.g. 32KB, truncation marked) — team runs can
+                            // produce huge transcripts and the UI reads this file
   error?: string;
+  reportFailure?: string;   // notify/channel delivery failure, recorded not just logged
+  seenAt?: number;          // set when the Mac app has surfaced the result (badge clear)
 }
 ```
 
-Store requirements: load/save `automations.json`; append run records; filter by
-`enabled`; **preserve unknown fields** on rewrite (forward-compatible migration).
+Store requirements: load/save `automations.json` with read-modify-write + atomic rename
+(see scheduler leadership); append run records; filter by `enabled`; **preserve unknown
+fields** on rewrite of both definitions and run records (forward-compatible migration).
 
 ## Scheduler & execution engine
 
 `AutomationEngine` in `@codey/gateway`, instantiated by `Codey`:
 
-- **Cron loop** — a single timer (~30s tick) evaluates each enabled automation's
-  `schedule.cron` against its `tz`, using persisted `lastFiredAt` to:
+- **Schedule loop** — a single timer (~30s tick), active only while this process holds
+  the scheduler lease. Each tick evaluates every enabled automation's structured
+  `schedule` in its `tz` (via `Intl.DateTimeFormat` parts — no cron dep), using
+  persisted `lastFiredAt` to:
   - avoid double-firing within one slot, and
   - **skip missed slots on restart** — if a scheduled slot elapsed while the process was
     down, **log and skip; never back-fire** (a 3am job must not blast at noon).
-- **Triggers** — `runNow(id, trigger)` (manual) and the cron path both funnel into one
-  `executeAutomation(automation, trigger)`.
-- **Execution**:
-  - `kind: 'prompt'` → build run prompt from `brief` + `params`, run through the existing
-    agent run path, **fully autonomous** (no interactive channel bound).
-  - `kind: 'team'` → call existing `runTeamTask` with the brief as the task.
-- **Unattended safety** — runs with **no interactive channel bound**. An unexpected
-  `[ASK_USER]` is caught: run ends `parked`, pause state persisted (reusing existing
-  pause machinery), user notified. The engine **never guesses**.
+- **Triggers** — `runNow(id, trigger)` (manual, allowed even without the lease) and the
+  schedule path both funnel into one `executeAutomation(automation, trigger)`.
+- **Execution — a new headless entry point.** The existing run paths are not directly
+  callable here: `runTeamTask` is `private` on the gateway and takes a channel-shaped
+  `UserMessage` plus response plumbing, and the chat paths assume a chat to stream into.
+  The gateway therefore exposes `runHeadless(automation, trigger)` which builds a
+  synthetic message from the rendered brief (placeholders substituted from `params`)
+  and a **collecting emitter sink** (a `TeamEmitter` sink that accumulates the
+  transcript instead of streaming to a surface — mirroring what `sendToChat` does for
+  the chat surface):
+  - `kind: 'prompt'` → run through the agent adapter path with the automation's
+    `workingDir`/`agent`/`model`, fully autonomous.
+  - `kind: 'team'` → dispatch through `runTeamTask` (via the headless wrapper) with the
+    brief as the task; flow graphs and the judge work unchanged.
+- **Unattended safety & parked runs** — runs have **no interactive surface bound**. An
+  unexpected `[ASK_USER]` is caught: the run is recorded `parked` with the pending
+  question in `output`, pause state persisted via the existing `TeamEmitter`
+  continuation machinery (keyed by `runId` instead of a chat id), and the user is
+  notified. The engine **never guesses**. A parked run is **resumable**: the run-history
+  detail in the Mac app shows the question with an answer box; the answer feeds the
+  persisted continuation exactly like a chat reply would, and the resumed execution
+  appends a new `resumed` run record linked by `runId`. Parked state survives restarts
+  (it is persisted), but a parked run older than 7 days is expired to `failed` so
+  stale questions don't resume against a changed world.
 - **Concurrency** — reuses the existing `RunSemaphore`. An automation that fires while its
-  previous run is still active is **skipped and logged**, not double-queued.
-- **Result routing** — on finish: append to run-history `.jsonl`; fire Mac notification if
-  `report.notify`; post summary to `report.channel` if set (reusing channel machinery).
+  previous run is still active (or parked) is **skipped and logged**, not double-queued.
+- **Result routing** — on finish: append to run-history `.jsonl`; then best-effort
+  delivery, with any failure recorded in the run's `reportFailure` (not just logged):
+  - `report.notify` → emit `automation-run-finished`; if an Electron main is attached it
+    fires the OS notification. **If the daemon holds the lease and the Mac app is
+    closed, there is no notification surface** — the run record's `seenAt` stays unset,
+    and the Mac app badges the Automations view with unseen results on next launch
+    (notification-on-launch for anything unseen and recent).
+  - `report.channel` → post summary via channel machinery **if that platform is
+    connected in this process**; otherwise record the delivery failure.
 
 ## Authoring flow (the clarification interview)
 
@@ -149,8 +216,8 @@ brief.
 5. **Dry-run (recommended)** — "Test run now" executes once immediately and shows output;
    user accepts or returns to answer more. This is the verification step before trusting
    a schedule.
-6. **Schedule + report target** — time-of-day → `cron` + `tz`; notify toggle + optional
-   channel. Save.
+6. **Schedule + report target** — time-of-day picker → structured `schedule`
+   (`hour`/`minute`/`daysOfWeek`/`tz`); notify toggle + optional channel. Save.
 
 Editing `params` later is cheap (no re-interview). Changing the **goal** re-opens the
 interview and regenerates the brief.
@@ -164,16 +231,22 @@ interview and regenerates the brief.
 - **Create/Edit** — goal + target picker → clarification interview panel (chat-like, one
   question at a time) → read-only brief preview (regenerated on goal change) → editable
   `params` → schedule picker + report target → **Test run now**.
-- **Run history** — per-automation timeline read from the `.jsonl`; each run expandable to
-  output/error.
+- **Run history** — per-automation timeline read from the `.jsonl`; each run expandable
+  to output/error. A **parked** run shows the pending question with an **answer box**;
+  submitting resumes the run (Q11). Unseen results badge the Automations view; opening
+  a run marks it `seenAt`.
 
 **IPC / wiring** (Electron main ↔ embedded `Codey`, following the existing pattern):
 
 - `automations:list | get | create | update | delete | setEnabled`
 - `automations:runNow(id)`
+- `automations:resume(id, runId, answer)` — answer a parked run's question
+- `automations:markSeen(id, runId)`
 - `automations:interview:start | answer | next`
 - Engine emits `automation-run-started | finished | parked` → forwarded to the renderer
-  for live status and to `chat-notifications.ts` for the OS notification.
+  for live status and to `chat-notifications.ts` for the OS notification. On app launch,
+  the main process scans run history for unseen recent results and notifies/badges
+  (covers runs fired by the daemon while the app was closed).
 
 The renderer holds **no new persistence** — it is a pure client over the gateway store,
 consistent with how chats already work.
@@ -183,16 +256,24 @@ consistent with how chats already work.
 Vitest, `*.test.ts` colocated per package; runs under `npm test`.
 
 **`@codey/gateway` — engine (highest value):**
-- Cron: fires at the right slot; **skips a missed slot on restart (no back-fire)**; no
+- Schedule eval: fires at the right slot across tz boundaries (structured schedule +
+  `Intl`, incl. DST transitions); **skips a missed slot on restart (no back-fire)**; no
   double-fire within one slot (`lastFiredAt`).
-- `executeAutomation`: prompt- and team-targets dispatch to the correct existing run path
-  (mocked).
-- Unattended safety: `[ASK_USER]` → `parked` + pause state persisted; never guesses.
-- Concurrency: overlapping fire skipped, not double-queued.
-- Result routing: run appended to `.jsonl`; notify + channel called when configured.
+- Leadership: only the lease holder ticks; embedded holder stands down when a daemon
+  claims; stale lock (dead heartbeat) is stolen; non-leader still serves `runNow`.
+- `executeAutomation`: prompt- and team-targets dispatch through the headless entry
+  point to the correct run path (mocked); params substituted into brief placeholders.
+- Unattended safety: `[ASK_USER]` → `parked` + continuation persisted; never guesses;
+  `resume(runId, answer)` continues the run and appends a `resumed` record; parked runs
+  expire to `failed` after 7 days.
+- Concurrency: overlapping fire (active or parked previous run) skipped, not
+  double-queued.
+- Result routing: run appended to `.jsonl` with output capped; notify + channel called
+  when configured; delivery failure lands in `reportFailure`.
 
-**Store:** load/save `automations.json`; per-id run-history append; enabled filtering;
-unknown-field preservation.
+**Store:** load/save `automations.json` (read-modify-write + atomic rename; concurrent
+writers don't clobber); per-id run-history append; enabled filtering; unknown-field
+preservation in definitions and run records.
 
 **`@codey/core` — interviewer/brief:** given goal + canned answers (mocked Aide),
 synthesizes a non-empty self-contained brief + params; goal change re-opens interview;

--- a/docs/superpowers/specs/2026-07-02-automations-design.md
+++ b/docs/superpowers/specs/2026-07-02-automations-design.md
@@ -288,7 +288,12 @@ guarantee the code (and its tests) rely on:
   automation and round-tripped on save, but there is no UI control to edit which days
   fire); and a `report.notify`-only automation running on a headless daemon (no attached
   Electron main) produces no notification surface at all — the run simply waits in
-  history for the Mac app's next launch scan.
+  history for the Mac app's next launch scan. Two further gaps in the same class:
+  daemon-fired runs are surfaced in the open Mac app only via the launch scan and
+  App-mount recompute (there is no periodic re-scan, so a run the daemon fires while
+  the app sits open shows up on next launch/navigation); and `report.channel` plus
+  prompt-target `agent`/`model` overrides are fully plumbed end to end but have no
+  editor UI yet — they are reachable only by editing `automations.json` directly.
 
 ## Authoring flow (the clarification interview)
 

--- a/packages/core/src/aide-automation.test.ts
+++ b/packages/core/src/aide-automation.test.ts
@@ -1,0 +1,63 @@
+// packages/core/src/aide-automation.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  generateAutomationQuestions, generateAutomationFollowup,
+  synthesizeAutomationBrief, renderBrief,
+} from './aide-automation';
+import type { AideOptions } from './aide';
+import type { AgentRequest, AgentResponse } from './types';
+
+const aide = (output: string): AideOptions => ({
+  agent: 'claude-code',
+  runner: async (_req: AgentRequest): Promise<AgentResponse> =>
+    ({ success: true, output } as AgentResponse),
+});
+
+describe('generateAutomationQuestions', () => {
+  it('parses questions from Aide JSON', async () => {
+    const qs = await generateAutomationQuestions('post AI news daily', 'target: prompt',
+      aide('{"questions":[{"id":"q1","question":"Which X account?","why":"needed to post"}]}'));
+    expect(qs).toEqual([{ id: 'q1', question: 'Which X account?', why: 'needed to post' }]);
+  });
+  it('returns [] on malformed output', async () => {
+    expect(await generateAutomationQuestions('g', 't', aide('not json'))).toEqual([]);
+  });
+});
+
+describe('generateAutomationFollowup', () => {
+  it('returns the follow-up question or null', async () => {
+    expect(await generateAutomationFollowup('g', 'Which account?', 'the usual',
+      aide('{"followup":"Which one is \\"the usual\\"?"}'))).toBe('Which one is "the usual"?');
+    expect(await generateAutomationFollowup('g', 'q', 'a', aide('{"followup":null}'))).toBeNull();
+  });
+});
+
+describe('synthesizeAutomationBrief', () => {
+  it('returns brief + params from Aide JSON', async () => {
+    const out = await synthesizeAutomationBrief('g', [{ question: 'q', answer: 'a' }],
+      aide('{"brief":"Post to {{account}}.","params":{"account":"@jack"}}'));
+    expect(out.brief).toBe('Post to {{account}}.');
+    expect(out.params).toEqual({ account: '@jack' });
+  });
+  it('throws when the Aide returns no brief', async () => {
+    await expect(synthesizeAutomationBrief('g', [], aide('{}'))).rejects.toThrow();
+  });
+});
+
+describe('renderBrief', () => {
+  it('substitutes placeholders and appends leftovers as a Parameters block', () => {
+    const out = renderBrief('Post {{count}} items to {{account}}.', {
+      count: '5', account: '@jack', tone: 'dry',
+    });
+    expect(out).toContain('Post 5 items to @jack.');
+    expect(out).toContain('Parameters:\n- tone: dry');
+  });
+  it('does not resolve placeholders from Object.prototype', () => {
+    expect(renderBrief('Hi {{constructor}}', { who: 'you' }))
+      .toBe('Hi {{constructor}}\n\nParameters:\n- who: you');
+  });
+  it('leaves unknown placeholders intact and skips the block when all used', () => {
+    expect(renderBrief('Hi {{who}}', {})).toBe('Hi {{who}}');
+    expect(renderBrief('Hi {{who}}', { who: 'you' })).toBe('Hi you');
+  });
+});

--- a/packages/core/src/aide-automation.ts
+++ b/packages/core/src/aide-automation.ts
@@ -1,0 +1,93 @@
+// packages/core/src/aide-automation.ts
+import { AideOptions, runAideJson } from './aide';
+
+/** One clarification question surfaced by the authoring interview. */
+export interface InterviewQuestion { id: string; question: string; why?: string }
+export interface InterviewAnswer { question: string; answer: string }
+
+const QUESTIONS_PROMPT = (goal: string, targetContext: string) => `You are preparing an UNATTENDED automation. It will run on a schedule with nobody available to answer questions, so every ambiguity must be resolved NOW, at authoring time.
+
+Automation goal:
+${goal}
+
+Execution target:
+${targetContext}
+
+List the questions you would otherwise need answered mid-run: missing specifics, choices, accounts/handles, formats, limits, and edge cases (e.g. "what if there is nothing to report today?"). Ask only what materially changes the run. 3-7 questions.
+
+Respond with ONLY this JSON:
+{"questions":[{"id":"q1","question":"...","why":"one-line reason"}]}`;
+
+const FOLLOWUP_PROMPT = (goal: string, question: string, answer: string) => `An automation is being configured. Goal: ${goal}
+
+You asked: ${question}
+The user answered: ${answer}
+
+If — and only if — this answer opens exactly one NEW concrete gap that would block an unattended run, ask one short follow-up. Otherwise return null.
+
+Respond with ONLY this JSON:
+{"followup":"..." }  or  {"followup":null}`;
+
+const SYNTHESIS_PROMPT = (goal: string, qa: InterviewAnswer[]) => `Fold this automation goal and the clarification answers into a frozen, fully self-contained instruction brief for an UNATTENDED agent run. The brief must stand alone: no references to "the user said" or to this conversation; include concrete values, edge-case handling, and output expectations.
+
+Additionally surface a SMALL set of knobs a user may want to tweak later (account, count, tone, …) as params. In the brief, write each knob as a {{placeholder}} and put its current value in params.
+
+Goal:
+${goal}
+
+Clarifications:
+${qa.map(x => `Q: ${x.question}\nA: ${x.answer}`).join('\n')}
+
+Respond with ONLY this JSON:
+{"brief":"...","params":{"name":"current value"}}`;
+
+export async function generateAutomationQuestions(
+  goal: string, targetContext: string, opts: AideOptions,
+): Promise<InterviewQuestion[]> {
+  const res = await runAideJson<{ questions?: unknown }>(QUESTIONS_PROMPT(goal, targetContext), opts);
+  if (!res || !Array.isArray(res.questions)) return [];
+  return (res.questions as Array<Record<string, unknown>>)
+    .filter(q => typeof q?.question === 'string' && (q.question as string).trim())
+    .map((q, i) => ({
+      id: typeof q.id === 'string' ? q.id : `q${i + 1}`,
+      question: (q.question as string).trim(),
+      why: typeof q.why === 'string' ? q.why : undefined,
+    }));
+}
+
+export async function generateAutomationFollowup(
+  goal: string, question: string, answer: string, opts: AideOptions,
+): Promise<string | null> {
+  const res = await runAideJson<{ followup?: unknown }>(FOLLOWUP_PROMPT(goal, question, answer), opts);
+  return res && typeof res.followup === 'string' && res.followup.trim() ? res.followup.trim() : null;
+}
+
+export async function synthesizeAutomationBrief(
+  goal: string, qa: InterviewAnswer[], opts: AideOptions,
+): Promise<{ brief: string; params: Record<string, string> }> {
+  const res = await runAideJson<{ brief?: unknown; params?: unknown }>(SYNTHESIS_PROMPT(goal, qa), opts);
+  const brief = res && typeof res.brief === 'string' ? res.brief.trim() : '';
+  if (!brief) throw new Error('Aide returned no brief');
+  const params: Record<string, string> = {};
+  if (res!.params && typeof res!.params === 'object') {
+    for (const [k, v] of Object.entries(res!.params as Record<string, unknown>)) {
+      if (typeof v === 'string') params[k] = v;
+    }
+  }
+  return { brief, params };
+}
+
+/**
+ * Resolve {{placeholders}} from params; params without a placeholder are
+ * appended as a trailing "Parameters:" block so edits always take effect.
+ */
+export function renderBrief(brief: string, params: Record<string, string>): string {
+  const used = new Set<string>();
+  const out = brief.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (match, key: string) => {
+    if (Object.prototype.hasOwnProperty.call(params, key)) { used.add(key); return params[key]; }
+    return match;
+  });
+  const leftovers = Object.entries(params).filter(([k]) => !used.has(k));
+  if (leftovers.length === 0) return out;
+  return `${out}\n\nParameters:\n${leftovers.map(([k, v]) => `- ${k}: ${v}`).join('\n')}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './advisor-personality';
 export * from './solo-advisor';
 export * from './aide';
 export * from './aide-tasks';
+export * from './aide-automation';
 export * from './task-brief';
 export * from './discussion/files';
 export * from './discussion/control';

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -1,0 +1,75 @@
+import type { CodingAgent } from './index';
+
+/** Structured time-of-day schedule (spec decision #10 — not a cron string). */
+export interface AutomationSchedule {
+  /** 0-23, in `tz`. */
+  hour: number;
+  /** 0-59. */
+  minute: number;
+  /** 0=Sun … 6=Sat. Absent = every day. */
+  daysOfWeek?: number[];
+  /** IANA zone, e.g. "Asia/Shanghai". */
+  tz: string;
+}
+
+export type AutomationTarget =
+  | { kind: 'prompt'; workspaceName: string; agent?: CodingAgent; model?: string }
+  | { kind: 'team'; teamName: string; workspaceName: string };
+
+export interface AutomationReport {
+  /** Fire an OS notification (delivered by the Mac app when attached). */
+  notify: boolean;
+  /** Optional chat/channel post, e.g. { platform: 'telegram', target: '<chatId>' }. */
+  channel?: { platform: string; target: string };
+}
+
+export interface Automation {
+  id: string;
+  name: string;
+  enabled: boolean;
+  target: AutomationTarget;
+  /** Frozen, self-contained instruction block synthesized by the interview.
+   *  May contain {{param}} placeholders resolved from `params` at run time. */
+  brief: string;
+  /** Surfaced editable knobs. Editing these does not re-open the interview. */
+  params: Record<string, string>;
+  /** Absent = manual-only. */
+  schedule?: AutomationSchedule;
+  report: AutomationReport;
+  /** Hidden system chat this automation executes in (created lazily). */
+  chatId?: string;
+  /** Last slot fired, for double-fire protection. Never used to back-fire. */
+  lastFiredAt?: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type AutomationRunStatus = 'success' | 'failed' | 'parked' | 'resumed';
+
+export interface AutomationRun {
+  runId: string;
+  startedAt: number;
+  endedAt?: number;
+  status: AutomationRunStatus;
+  trigger: 'manual' | 'schedule';
+  /** Capped at OUTPUT_CAP chars by the engine; truncation is marked. */
+  output?: string;
+  error?: string;
+  /** Pending question when status === 'parked'. */
+  question?: string;
+  /** Choice options when the parked question was [ASK_USER:choice]. */
+  options?: string[];
+  /** runId of the parked run this record resumed. */
+  resumedFrom?: string;
+  /** notify/channel delivery failure, recorded not just logged. */
+  reportFailure?: string;
+  /** Set when the Mac app has surfaced this result. */
+  seenAt?: number;
+}
+
+export interface AutomationEvent {
+  type: 'run-started' | 'run-finished' | 'run-parked';
+  automationId: string;
+  runId: string;
+  run?: AutomationRun;
+}

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -17,7 +17,9 @@ export type AutomationTarget =
   | { kind: 'team'; teamName: string; workspaceName: string };
 
 export interface AutomationReport {
-  /** Fire an OS notification (delivered by the Mac app when attached). */
+  /** Fire an OS notification (delivered by the Mac app when attached).
+   *  Delivery rides on automation events: a headless daemon with no event
+   *  listener produces no notification. */
   notify: boolean;
   /** Optional chat/channel post, e.g. { platform: 'telegram', target: '<chatId>' }. */
   channel?: { platform: string; target: string };

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -93,6 +93,8 @@ export interface Chat {
   id: string;
   title: string;
   workspaceName: string;
+  /** 'automation' marks a hidden system chat owned by an automation; absent = normal user chat. */
+  kind?: 'automation';
   selection: ChatSelection;
   messages: ChatMessage[];
   createdAt: number;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -285,8 +285,12 @@ export interface GatewayConfig {
   advisor?: AdvisorSettings;
   /** Aide (lightweight housekeeping LLM) settings. */
   aide?: AideSettings;
+  /** Which scheduler-lease role this process claims. Daemon wins over embedded.
+   *  Default 'daemon' (the standalone gateway). The Mac app passes 'embedded'. */
+  automationRole?: 'daemon' | 'embedded';
 }
 
 export * from './chat';
 export * from './route';
 export * from './pending-team';
+export * from './automation';

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       'src/team-graph.test.ts',
       'src/judge.test.ts',
       'src/skill-crystallizer.test.ts',
+      'src/aide-automation.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/src/automations/chats-hidden.test.ts
+++ b/packages/gateway/src/automations/chats-hidden.test.ts
@@ -4,11 +4,13 @@ import * as os from 'os';
 import * as path from 'path';
 import { ChatManager } from '../chats';
 
-const makeManager = () => {
+const makeRoot = () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chats-hidden-'));
   fs.mkdirSync(path.join(root, 'default'), { recursive: true });
-  return new ChatManager(root);
+  return root;
 };
+
+const makeManager = () => new ChatManager(makeRoot());
 
 describe('automation chats are hidden', () => {
   it('list() excludes kind=automation by default, includes with the flag', () => {
@@ -27,6 +29,32 @@ describe('automation chats are hidden', () => {
       id: 'm1', role: 'user', content: 'Summarize yesterday commits and open PRs', timestamp: Date.now(), isComplete: true,
     });
     expect(m.get(c.id)?.title).toBe('Automation: daily digest');
+  });
+
+  it('reload sees cross-process changes, new chats, and deletions', () => {
+    // Two managers on the same root simulate the daemon + embedded gateways.
+    const root = makeRoot();
+    const a = new ChatManager(root);
+    const b = new ChatManager(root);
+
+    // Both caches warm, then B mutates: A is stale until reload.
+    const shared = a.create({ workspaceName: 'default', title: 'Automation: x', kind: 'automation' });
+    b.setPendingTeam(shared.id, {
+      teamName: 't', task: 'deploy', mode: 'sequential', teamTurnId: 'turn-1',
+      memberIndex: 0, carry: '', askingWorker: 'w', question: 'Deploy now?', askedAt: Date.now(),
+    });
+    expect(a.get(shared.id)?.pendingTeam).toBeUndefined(); // stale cache
+    expect(a.reload(shared.id)?.pendingTeam?.question).toBe('Deploy now?');
+
+    // Chat created by B after A loaded: invisible to A's get, found by reload.
+    const fresh = b.create({ workspaceName: 'default', title: 'Automation: y', kind: 'automation' });
+    expect(a.get(fresh.id)).toBeUndefined();
+    expect(a.reload(fresh.id)?.title).toBe('Automation: y');
+
+    // Deleted on disk by B: reload evicts A's cache entry and returns undefined.
+    b.delete(shared.id);
+    expect(a.reload(shared.id)).toBeUndefined();
+    expect(a.get(shared.id)).toBeUndefined();
   });
 
   it('create honors agent/model overrides', () => {

--- a/packages/gateway/src/automations/chats-hidden.test.ts
+++ b/packages/gateway/src/automations/chats-hidden.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from '../chats';
+
+const makeManager = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chats-hidden-'));
+  fs.mkdirSync(path.join(root, 'default'), { recursive: true });
+  return new ChatManager(root);
+};
+
+describe('automation chats are hidden', () => {
+  it('list() excludes kind=automation by default, includes with the flag', () => {
+    const m = makeManager();
+    m.create({ workspaceName: 'default', title: 'normal' });
+    const hidden = m.create({ workspaceName: 'default', title: 'Automation: x', kind: 'automation' });
+    expect(m.list('default').map(c => c.title)).toEqual(['normal']);
+    expect(m.list('default', { includeAutomation: true })).toHaveLength(2);
+    expect(m.get(hidden.id)?.kind).toBe('automation');
+  });
+
+  it('appendMessage does not clobber an automation chat title', () => {
+    const m = makeManager();
+    const c = m.create({ workspaceName: 'default', title: 'Automation: daily digest', kind: 'automation' });
+    m.appendMessage(c.id, {
+      id: 'm1', role: 'user', content: 'Summarize yesterday commits and open PRs', timestamp: Date.now(), isComplete: true,
+    });
+    expect(m.get(c.id)?.title).toBe('Automation: daily digest');
+  });
+
+  it('create honors agent/model overrides', () => {
+    const m = makeManager();
+    const c = m.create({ workspaceName: 'default', kind: 'automation', agent: 'claude-code', model: 'opus' });
+    expect(c.agent).toBe('claude-code');
+    expect(c.model).toBe('opus');
+  });
+});

--- a/packages/gateway/src/automations/engine.test.ts
+++ b/packages/gateway/src/automations/engine.test.ts
@@ -1,0 +1,196 @@
+// packages/gateway/src/automations/engine.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AutomationEngine, OUTPUT_CAP, PARKED_TTL_MS, type EngineDeps } from './engine';
+import { AutomationStore } from './store';
+import { SchedulerLease } from './lease';
+import type { Automation, AutomationEvent } from '@codey/core';
+
+// 2026-07-02T09:00:00 Asia/Shanghai
+const SH_9AM = Date.UTC(2026, 6, 2, 1, 0, 0);
+
+let dir: string;
+let store: AutomationStore;
+let events: AutomationEvent[];
+let deps: EngineDeps;
+let now: number;
+
+const makeEngine = (over: Partial<EngineDeps> = {}) =>
+  new AutomationEngine({ ...deps, ...over });
+
+const seed = (over: Partial<Automation> = {}) =>
+  store.create({
+    name: 'a', enabled: true,
+    target: { kind: 'prompt', workspaceName: 'w' },
+    brief: 'do it', params: {}, report: { notify: false },
+    schedule: { hour: 9, minute: 0, tz: 'Asia/Shanghai' },
+    ...over,
+  }, 1);
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-'));
+  store = new AutomationStore(dir);
+  events = [];
+  now = SH_9AM;
+  deps = {
+    store,
+    lease: new SchedulerLease(path.join(dir, 'scheduler.lock'), 'daemon'),
+    runTarget: vi.fn(async () => ({ output: 'ok' })),
+    resumeTarget: vi.fn(async () => ({ output: 'resumed ok' })),
+    report: vi.fn(async () => undefined),
+    onEvent: ev => events.push(ev),
+    now: () => now,
+  };
+});
+
+describe('tick', () => {
+  it('fires a due schedule once, records lastFiredAt and a success run', async () => {
+    const a = seed();
+    const engine = makeEngine();
+    await engine.tick();
+    now += 30_000;
+    await engine.tick(); // same slot — must not double-fire
+    expect(deps.runTarget).toHaveBeenCalledTimes(1);
+    expect(store.get(a.id)!.lastFiredAt).toBe(SH_9AM);
+    const runs = store.listRuns(a.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ status: 'success', trigger: 'schedule', output: 'ok' });
+  });
+
+  it('skips disabled and unscheduled automations', async () => {
+    seed({ enabled: false });
+    seed({ schedule: undefined });
+    await makeEngine().tick();
+    expect(deps.runTarget).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without the lease', async () => {
+    fs.writeFileSync(path.join(dir, 'scheduler.lock'),
+      JSON.stringify({ pid: 999999, role: 'daemon', heartbeatAt: now }));
+    seed();
+    const engine = makeEngine({ lease: new SchedulerLease(path.join(dir, 'scheduler.lock'), 'embedded') });
+    await engine.tick();
+    expect(deps.runTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe('runNow / execution', () => {
+  it('records failed runs with the error', async () => {
+    const a = seed();
+    const engine = makeEngine({ runTarget: vi.fn(async () => ({ output: '', error: 'boom' })) });
+    await engine.runNow(a.id, 'manual');
+    expect(store.listRuns(a.id)[0]).toMatchObject({ status: 'failed', error: 'boom' });
+  });
+
+  it('caps output and marks truncation', async () => {
+    const a = seed();
+    const engine = makeEngine({ runTarget: vi.fn(async () => ({ output: 'x'.repeat(OUTPUT_CAP + 100) })) });
+    await engine.runNow(a.id, 'manual');
+    const out = store.listRuns(a.id)[0].output!;
+    expect(out.length).toBeLessThanOrEqual(OUTPUT_CAP + 50);
+    expect(out).toContain('[output truncated]');
+  });
+
+  it('records parked runs with the question and emits run-parked', async () => {
+    const a = seed();
+    const engine = makeEngine({
+      runTarget: vi.fn(async () => ({ output: 'partial', parked: { question: 'which?', options: ['a', 'b'] } })),
+    });
+    await engine.runNow(a.id, 'manual');
+    expect(store.listRuns(a.id)[0]).toMatchObject({ status: 'parked', question: 'which?', options: ['a', 'b'] });
+    expect(events.map(e => e.type)).toEqual(['run-started', 'run-parked']);
+  });
+
+  it('skips overlapping fires (active run) without a run record', async () => {
+    const a = seed();
+    let release!: () => void;
+    const gate = new Promise<void>(r => { release = r; });
+    const engine = makeEngine({ runTarget: vi.fn(async () => { await gate; return { output: 'ok' }; }) });
+    const first = engine.runNow(a.id, 'manual');
+    await engine.runNow(a.id, 'manual'); // overlaps — skipped
+    release!();
+    await first;
+    expect(store.listRuns(a.id)).toHaveLength(1);
+  });
+
+  it('skips firing while the latest run is parked', async () => {
+    const a = seed();
+    store.appendRun(a.id, { runId: 'r0', startedAt: now, status: 'parked', trigger: 'manual', question: 'q' });
+    await makeEngine().runNow(a.id, 'manual');
+    expect(deps.runTarget).not.toHaveBeenCalled();
+  });
+
+  it('records report delivery failures on the run', async () => {
+    const a = seed();
+    const engine = makeEngine({ report: vi.fn(async () => 'channel telegram not connected') });
+    await engine.runNow(a.id, 'manual');
+    expect(store.listRuns(a.id)[0].reportFailure).toBe('channel telegram not connected');
+  });
+
+  it('records reportFailure when report() throws', async () => {
+    const a = seed();
+    const engine = makeEngine({ report: vi.fn(async () => { throw new Error('notify daemon down'); }) });
+    await engine.runNow(a.id, 'manual');
+    expect(store.listRuns(a.id)[0]).toMatchObject({ status: 'success', reportFailure: 'notify daemon down' });
+  });
+});
+
+describe('resume', () => {
+  it('resumes the latest parked run and appends a linked resumed record', async () => {
+    const a = seed();
+    store.appendRun(a.id, { runId: 'r0', startedAt: now, status: 'parked', trigger: 'schedule', question: 'q' });
+    await makeEngine().resume(a.id, 'r0', 'use option a');
+    expect(deps.resumeTarget).toHaveBeenCalledWith(expect.objectContaining({ id: a.id }), 'use option a');
+    const [latest] = store.listRuns(a.id);
+    expect(latest).toMatchObject({ status: 'resumed', resumedFrom: 'r0', output: 'resumed ok' });
+  });
+
+  it('consumes the parked continuation: a second resume of the same run rejects', async () => {
+    const a = seed();
+    store.appendRun(a.id, { runId: 'r0', startedAt: now, status: 'parked', trigger: 'schedule', question: 'q' });
+    const engine = makeEngine();
+    await engine.resume(a.id, 'r0', 'first answer');
+    await expect(engine.resume(a.id, 'r0', 'second answer')).rejects.toThrow(/not parked/i);
+    expect(deps.resumeTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects resuming a non-parked run', async () => {
+    const a = seed();
+    store.appendRun(a.id, { runId: 'r0', startedAt: now, status: 'success', trigger: 'manual' });
+    await expect(makeEngine().resume(a.id, 'r0', 'x')).rejects.toThrow(/not parked/i);
+  });
+});
+
+describe('parked expiry', () => {
+  it('expires parked runs older than the TTL to failed', async () => {
+    const a = seed({ schedule: undefined });
+    store.appendRun(a.id, { runId: 'r0', startedAt: now - PARKED_TTL_MS - 1, status: 'parked', trigger: 'schedule', question: 'q' });
+    await makeEngine().tick();
+    expect(store.listRuns(a.id)[0]).toMatchObject({ status: 'failed', error: expect.stringContaining('expired') });
+  });
+
+  it('emits run-finished for the expired run', async () => {
+    const a = seed({ schedule: undefined });
+    store.appendRun(a.id, { runId: 'r0', startedAt: now - PARKED_TTL_MS - 1, status: 'parked', trigger: 'schedule', question: 'q' });
+    await makeEngine().tick();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'run-finished', automationId: a.id, runId: 'r0',
+      run: { status: 'failed', error: expect.stringContaining('expired') },
+    });
+  });
+
+  it('is idempotent: a second tick after expiry does not patch or emit again', async () => {
+    const a = seed({ schedule: undefined });
+    store.appendRun(a.id, { runId: 'r0', startedAt: now - PARKED_TTL_MS - 1, status: 'parked', trigger: 'schedule', question: 'q' });
+    const engine = makeEngine();
+    await engine.tick();
+    const afterFirst = events.length;
+    now += 30_000;
+    await engine.tick();
+    expect(events).toHaveLength(afterFirst);
+    expect(store.listRuns(a.id)).toHaveLength(1);
+  });
+});

--- a/packages/gateway/src/automations/engine.test.ts
+++ b/packages/gateway/src/automations/engine.test.ts
@@ -66,6 +66,17 @@ describe('tick', () => {
     expect(deps.runTarget).not.toHaveBeenCalled();
   });
 
+  it('one automation with an invalid tz does not starve the others', async () => {
+    seed({ name: 'broken', schedule: { hour: 9, minute: 0, tz: 'Beijing' } }); // Intl throws RangeError
+    const good = seed({ name: 'good' });
+    const logs: string[] = [];
+    await makeEngine({ log: msg => logs.push(msg) }).tick();
+    await new Promise(r => setTimeout(r, 0)); // tick fires runNow without awaiting it
+    expect(deps.runTarget).toHaveBeenCalledTimes(1);
+    expect(store.listRuns(good.id)).toHaveLength(1);
+    expect(logs.some(l => l.includes('schedule eval failed for broken'))).toBe(true);
+  });
+
   it('does nothing without the lease', async () => {
     fs.writeFileSync(path.join(dir, 'scheduler.lock'),
       JSON.stringify({ pid: 999999, role: 'daemon', heartbeatAt: now }));

--- a/packages/gateway/src/automations/engine.ts
+++ b/packages/gateway/src/automations/engine.ts
@@ -1,0 +1,161 @@
+// packages/gateway/src/automations/engine.ts
+import { randomUUID } from 'crypto';
+import type { Automation, AutomationEvent, AutomationRun } from '@codey/core';
+import { AutomationStore } from './store';
+import { SchedulerLease } from './lease';
+import { shouldFire } from './schedule';
+import type { ParkedInfo } from './parked';
+
+export const OUTPUT_CAP = 32_000;
+export const PARKED_TTL_MS = 7 * 24 * 3600_000;
+export const TICK_MS = 30_000;
+
+export interface TargetResult { output: string; parked?: ParkedInfo; error?: string }
+
+export interface EngineDeps {
+  store: AutomationStore;
+  lease: SchedulerLease;
+  /** Execute the automation's rendered brief headlessly (gateway adapter). */
+  runTarget: (a: Automation) => Promise<TargetResult>;
+  /** Feed an answer into the parked continuation (gateway adapter). */
+  resumeTarget: (a: Automation, answer: string) => Promise<TargetResult>;
+  /** Deliver report.channel / prep notify. Returns a failure description or undefined. */
+  report: (a: Automation, run: AutomationRun) => Promise<string | undefined>;
+  onEvent?: (ev: AutomationEvent) => void;
+  now?: () => number;
+  log?: (msg: string) => void;
+}
+
+function capOutput(s: string): string {
+  if (s.length <= OUTPUT_CAP) return s;
+  return `${s.slice(0, OUTPUT_CAP)}\n\n[output truncated]`;
+}
+
+export class AutomationEngine {
+  private timer?: NodeJS.Timeout;
+  /** Per-process overlap guard only; a concurrent embedded-gateway runNow is accepted single-user risk (v1). */
+  private active = new Set<string>();
+  private _isLeader = false;
+
+  constructor(private deps: EngineDeps) {}
+
+  private now(): number { return this.deps.now ? this.deps.now() : Date.now(); }
+  private log(msg: string): void { this.deps.log?.(msg); }
+  private emit(ev: AutomationEvent): void { try { this.deps.onEvent?.(ev); } catch { /* listener bug must not kill runs */ } }
+
+  get isLeader(): boolean { return this._isLeader; }
+
+  start(tickMs: number = TICK_MS): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => { void this.tick().catch(err => this.log(`tick failed: ${err?.message}`)); }, tickMs);
+    this.timer.unref?.();
+    void this.tick().catch(err => this.log(`tick failed: ${err?.message}`));
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+    this.deps.lease.release();
+    this._isLeader = false;
+  }
+
+  async tick(): Promise<void> {
+    const now = this.now();
+    this._isLeader = this.deps.lease.heartbeat(now) || this.deps.lease.tryAcquire(now);
+    if (!this._isLeader) return;
+    // Leader-only: patchRun is a whole-file rewrite, so a non-leader running
+    // expiry could clobber the leader's concurrent appendRun.
+    this.expireParked(now);
+    for (const a of this.deps.store.list()) {
+      if (!a.enabled || !a.schedule) continue;
+      if (!shouldFire(a.schedule, a.lastFiredAt, now)) continue;
+      // Record the slot BEFORE running so a crash mid-run can't re-fire it.
+      this.deps.store.recordLastFired(a.id, now);
+      void this.runNow(a.id, 'schedule').catch(err => this.log(`scheduled run failed: ${err?.message}`));
+    }
+  }
+
+  /** Manual + scheduled entry. Works without the lease (spec: non-leaders serve runNow). */
+  async runNow(id: string, trigger: 'manual' | 'schedule'): Promise<AutomationRun | null> {
+    const a = this.deps.store.get(id);
+    if (!a) throw new Error(`Automation not found: ${id}`);
+    if (this.active.has(id)) { this.log(`skip ${a.name}: previous run still active`); return null; }
+    const latest = this.deps.store.listRuns(id, 1)[0];
+    if (latest?.status === 'parked') { this.log(`skip ${a.name}: parked run awaiting an answer`); return null; }
+    return this.execute(a, trigger, res => this.deps.runTarget(res));
+  }
+
+  /** Answer a parked run's question; appends a linked 'resumed' record. */
+  async resume(id: string, runId: string, answer: string): Promise<AutomationRun> {
+    const a = this.deps.store.get(id);
+    if (!a) throw new Error(`Automation not found: ${id}`);
+    const parked = this.deps.store.listRuns(id).find(r => r.runId === runId);
+    if (!parked || parked.status !== 'parked') throw new Error(`Run ${runId} is not parked`);
+    if (this.active.has(id)) throw new Error(`Automation ${a.name} already has an active run`);
+    const run = await this.execute(a, parked.trigger, auto => this.deps.resumeTarget(auto, answer), runId);
+    // The attempt consumed the parked continuation whether it succeeded or
+    // failed, so the original run must stop being answerable — the "not
+    // parked" rejection above then also catches second answers.
+    this.deps.store.patchRun(a.id, runId, { status: 'resumed' });
+    return run;
+  }
+
+  private async execute(
+    a: Automation,
+    trigger: 'manual' | 'schedule',
+    exec: (a: Automation) => Promise<TargetResult>,
+    resumedFrom?: string,
+  ): Promise<AutomationRun> {
+    this.active.add(a.id);
+    const run: AutomationRun = {
+      runId: randomUUID(), startedAt: this.now(), status: 'failed', trigger, resumedFrom,
+    };
+    this.emit({ type: 'run-started', automationId: a.id, runId: run.runId });
+    try {
+      const res = await exec(a);
+      run.output = capOutput(res.output ?? '');
+      if (res.parked) {
+        run.status = 'parked';
+        run.question = res.parked.question;
+        run.options = res.parked.options;
+      } else if (res.error) {
+        run.status = 'failed';
+        run.error = res.error;
+      } else {
+        run.status = resumedFrom ? 'resumed' : 'success';
+      }
+    } catch (err) {
+      run.status = 'failed';
+      run.error = (err as Error).message;
+    } finally {
+      this.active.delete(a.id);
+    }
+    run.endedAt = this.now();
+    try {
+      run.reportFailure = await this.deps.report(a, run);
+    } catch (err) {
+      run.reportFailure = (err as Error).message;
+    }
+    this.deps.store.appendRun(a.id, run);
+    this.emit({
+      type: run.status === 'parked' ? 'run-parked' : 'run-finished',
+      automationId: a.id, runId: run.runId, run,
+    });
+    return run;
+  }
+
+  /** Parked questions older than the TTL fail out — a changed world shouldn't resume. */
+  private expireParked(now: number): void {
+    for (const a of this.deps.store.list()) {
+      const latest = this.deps.store.listRuns(a.id, 1)[0];
+      if (latest?.status === 'parked' && now - latest.startedAt > PARKED_TTL_MS) {
+        const error = 'parked question expired after 7 days without an answer';
+        this.deps.store.patchRun(a.id, latest.runId, { status: 'failed', error });
+        // Expiry must not be silent; notifying is the UI layer's job via the event.
+        this.emit({
+          type: 'run-finished', automationId: a.id, runId: latest.runId,
+          run: { ...latest, status: 'failed', error },
+        });
+      }
+    }
+  }
+}

--- a/packages/gateway/src/automations/engine.ts
+++ b/packages/gateway/src/automations/engine.ts
@@ -66,11 +66,18 @@ export class AutomationEngine {
     // expiry could clobber the leader's concurrent appendRun.
     this.expireParked(now);
     for (const a of this.deps.store.list()) {
-      if (!a.enabled || !a.schedule) continue;
-      if (!shouldFire(a.schedule, a.lastFiredAt, now)) continue;
-      // Record the slot BEFORE running so a crash mid-run can't re-fire it.
-      this.deps.store.recordLastFired(a.id, now);
-      void this.runNow(a.id, 'schedule').catch(err => this.log(`scheduled run failed: ${err?.message}`));
+      // One automation with garbage data (e.g. an invalid tz makes Intl throw
+      // a RangeError inside shouldFire) must not abort the whole tick and
+      // starve every other schedule.
+      try {
+        if (!a.enabled || !a.schedule) continue;
+        if (!shouldFire(a.schedule, a.lastFiredAt, now)) continue;
+        // Record the slot BEFORE running so a crash mid-run can't re-fire it.
+        this.deps.store.recordLastFired(a.id, now);
+        void this.runNow(a.id, 'schedule').catch(err => this.log(`scheduled run failed: ${err?.message}`));
+      } catch (err) {
+        this.log(`schedule eval failed for ${a.name}: ${(err as Error)?.message}`);
+      }
     }
   }
 

--- a/packages/gateway/src/automations/interview.test.ts
+++ b/packages/gateway/src/automations/interview.test.ts
@@ -1,0 +1,105 @@
+// packages/gateway/src/automations/interview.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { InterviewManager, type InterviewDeps, type InterviewStep } from './interview';
+
+const deps = (over: Partial<InterviewDeps> = {}): InterviewDeps => ({
+  generateQuestions: vi.fn(async () => [
+    { id: 'q1', question: 'Which account?' },
+    { id: 'q2', question: 'How many items?' },
+  ]),
+  generateFollowup: vi.fn(async () => null),
+  synthesize: vi.fn(async () => ({ brief: 'Post to {{account}}.', params: { account: '@jack' } })),
+  ...over,
+});
+
+describe('InterviewManager', () => {
+  it('walks questions one at a time and synthesizes at the end', async () => {
+    const m = new InterviewManager(deps());
+    const s = await m.start('post news', 'target: prompt');
+    expect(s.question?.question).toBe('Which account?');
+    const step2 = await m.answer(s.sessionId, '@jack');
+    expect(step2.done).toBe(false);
+    expect(step2.question?.question).toBe('How many items?');
+    const end = await m.answer(s.sessionId, '5');
+    expect(end.done).toBe(true);
+    expect(end.brief).toBe('Post to {{account}}.');
+    expect(end.params).toEqual({ account: '@jack' });
+  });
+
+  it('asks at most ONE follow-up per question', async () => {
+    const followup = vi.fn(async () => 'Follow up?');
+    const m = new InterviewManager(deps({
+      generateQuestions: vi.fn(async () => [{ id: 'q1', question: 'Q?' }]),
+      generateFollowup: followup,
+    }));
+    const s = await m.start('g', 't');
+    const f = await m.answer(s.sessionId, 'vague');
+    expect(f.question?.question).toBe('Follow up?');
+    const end = await m.answer(s.sessionId, 'still vague'); // no second follow-up
+    expect(end.done).toBe(true);
+    expect(followup).toHaveBeenCalledTimes(1);
+  });
+
+  it('synthesizes immediately when no questions come back', async () => {
+    const m = new InterviewManager(deps({ generateQuestions: vi.fn(async () => []) }));
+    const s = await m.start('g', 't');
+    expect(s.done).toBe(true);
+    expect(s.brief).toBe('Post to {{account}}.');
+  });
+
+  it('throws on unknown session', async () => {
+    await expect(new InterviewManager(deps()).answer('nope', 'x')).rejects.toThrow();
+  });
+
+  it('removes the session when synthesize throws — retry hits unknown session', async () => {
+    const m = new InterviewManager(deps({
+      synthesize: vi.fn(async () => { throw new Error('Aide returned no brief'); }),
+    }));
+    const s = await m.start('g', 't');
+    await m.answer(s.sessionId, '@jack');
+    await expect(m.answer(s.sessionId, '5')).rejects.toThrow('Aide returned no brief');
+    await expect(m.answer(s.sessionId, 'x')).rejects.toThrow(/Unknown interview session/);
+  });
+
+  it('cancel() discards the session', async () => {
+    const m = new InterviewManager(deps());
+    const s = await m.start('g', 't');
+    m.cancel(s.sessionId);
+    await expect(m.answer(s.sessionId, 'x')).rejects.toThrow(/Unknown interview session/);
+  });
+
+  it('moves to the next BASE question after a follow-up is answered', async () => {
+    const followup = vi.fn(async (): Promise<string | null> => null)
+      .mockResolvedValueOnce('Follow up?');
+    const m = new InterviewManager(deps({ generateFollowup: followup }));
+    const s = await m.start('g', 't');
+    expect(s.question?.question).toBe('Which account?');
+    const f = await m.answer(s.sessionId, 'vague');
+    expect(f.question?.question).toBe('Follow up?');
+    const next = await m.answer(s.sessionId, 'clarified');
+    expect(next.done).toBe(false);
+    expect(next.question?.question).toBe('How many items?');
+    const end = await m.answer(s.sessionId, '5');
+    expect(end.done).toBe(true);
+    // Once per BASE answer; the follow-up answer itself never triggers another.
+    expect(followup).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an overlapping answer for the same session', async () => {
+    const m = new InterviewManager(deps());
+    const s = await m.start('g', 't');
+    const results = await Promise.allSettled([
+      m.answer(s.sessionId, 'a'),
+      m.answer(s.sessionId, 'b'),
+    ]);
+    const fulfilled = results.filter(r => r.status === 'fulfilled') as PromiseFulfilledResult<InterviewStep>[];
+    const rejected = results.filter(r => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // State did not skip a question: the winning call advanced to q2 only.
+    expect(fulfilled[0].value.done).toBe(false);
+    expect(fulfilled[0].value.question?.question).toBe('How many items?');
+    const end = await m.answer(s.sessionId, '5');
+    expect(end.done).toBe(true);
+  });
+});

--- a/packages/gateway/src/automations/interview.ts
+++ b/packages/gateway/src/automations/interview.ts
@@ -1,0 +1,90 @@
+// packages/gateway/src/automations/interview.ts
+import { randomUUID } from 'crypto';
+import type { InterviewQuestion, InterviewAnswer } from '@codey/core';
+
+export interface InterviewDeps {
+  generateQuestions: (goal: string, targetContext: string) => Promise<InterviewQuestion[]>;
+  generateFollowup: (goal: string, question: string, answer: string) => Promise<string | null>;
+  synthesize: (goal: string, qa: InterviewAnswer[]) => Promise<{ brief: string; params: Record<string, string> }>;
+}
+
+export interface InterviewStep {
+  sessionId: string;
+  done: boolean;
+  question?: InterviewQuestion;
+  brief?: string;
+  params?: Record<string, string>;
+}
+
+interface Session {
+  goal: string;
+  questions: InterviewQuestion[];
+  index: number;
+  /** True while the current question is a follow-up (never chain a second). */
+  inFollowup: boolean;
+  current?: InterviewQuestion;
+  qa: InterviewAnswer[];
+}
+
+/** Drives one authoring interview: base questions in order, at most one
+ *  bounded follow-up each, then brief synthesis. State is in-memory only —
+ *  an interview is an interactive Mac-app session, not a persisted run. */
+export class InterviewManager {
+  private sessions = new Map<string, Session>();
+
+  constructor(private deps: InterviewDeps) {}
+
+  async start(goal: string, targetContext: string): Promise<InterviewStep> {
+    const questions = await this.deps.generateQuestions(goal, targetContext);
+    const sessionId = randomUUID();
+    const s: Session = { goal, questions, index: 0, inFollowup: false, qa: [] };
+    this.sessions.set(sessionId, s);
+    if (questions.length === 0) return this.finish(sessionId, s);
+    s.current = questions[0];
+    return { sessionId, done: false, question: s.current };
+  }
+
+  async answer(sessionId: string, text: string): Promise<InterviewStep> {
+    const s = this.sessions.get(sessionId);
+    if (!s || !s.current) throw new Error(`Unknown interview session: ${sessionId}`);
+    // Reentrancy defense: clear the pending question so an overlapping
+    // answer() for the same session hits the guard above.
+    const current = s.current;
+    s.current = undefined;
+    s.qa.push({ question: current.question, answer: text });
+
+    if (!s.inFollowup) {
+      const followup = await this.deps.generateFollowup(s.goal, current.question, text);
+      if (followup) {
+        s.inFollowup = true;
+        s.current = { id: `${s.questions[s.index].id}-f`, question: followup };
+        return { sessionId, done: false, question: s.current };
+      }
+    }
+
+    s.inFollowup = false;
+    s.index += 1;
+    if (s.index < s.questions.length) {
+      s.current = s.questions[s.index];
+      return { sessionId, done: false, question: s.current };
+    }
+    return this.finish(sessionId, s);
+  }
+
+  /** Discard an in-progress interview (e.g. the authoring UI was closed). */
+  cancel(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  private async finish(sessionId: string, s: Session): Promise<InterviewStep> {
+    // On synthesize failure the interview is over — the session is removed
+    // either way, so the caller restarts rather than retrying into
+    // duplicated state.
+    try {
+      const { brief, params } = await this.deps.synthesize(s.goal, s.qa);
+      return { sessionId, done: true, brief, params };
+    } finally {
+      this.sessions.delete(sessionId);
+    }
+  }
+}

--- a/packages/gateway/src/automations/lease.test.ts
+++ b/packages/gateway/src/automations/lease.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SchedulerLease } from './lease';
+
+let lock: string;
+beforeEach(() => {
+  lock = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'lease-')), 'scheduler.lock');
+});
+
+const STALE = 90_000;
+const write = (pid: number, role: 'daemon' | 'embedded', heartbeatAt: number) =>
+  fs.writeFileSync(lock, JSON.stringify({ pid, role, heartbeatAt }));
+
+describe('SchedulerLease', () => {
+  it('acquires when no lock exists', () => {
+    expect(new SchedulerLease(lock, 'embedded', STALE).tryAcquire(1000)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lock, 'utf8')).pid).toBe(process.pid);
+  });
+
+  it('embedded does not steal a live daemon lock', () => {
+    write(99999, 'daemon', 1000);
+    expect(new SchedulerLease(lock, 'embedded', STALE).tryAcquire(2000)).toBe(false);
+  });
+
+  it('daemon steals a live embedded lock', () => {
+    write(99999, 'embedded', 1000);
+    expect(new SchedulerLease(lock, 'daemon', STALE).tryAcquire(2000)).toBe(true);
+  });
+
+  it('anyone steals a stale lock', () => {
+    write(99999, 'daemon', 1000);
+    expect(new SchedulerLease(lock, 'embedded', STALE).tryAcquire(1000 + STALE + 1)).toBe(true);
+  });
+
+  it('re-acquire by the same pid refreshes the heartbeat', () => {
+    const l = new SchedulerLease(lock, 'daemon', STALE);
+    l.tryAcquire(1000);
+    expect(l.tryAcquire(5000)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lock, 'utf8')).heartbeatAt).toBe(5000);
+  });
+
+  it('heartbeat returns false after another process claims (stand-down)', () => {
+    const l = new SchedulerLease(lock, 'embedded', STALE);
+    l.tryAcquire(1000);
+    write(99999, 'daemon', 2000); // daemon stole it
+    expect(l.heartbeat(3000)).toBe(false);
+  });
+
+  it('treats a corrupt lock file as absent', () => {
+    fs.writeFileSync(lock, 'not json');
+    expect(new SchedulerLease(lock, 'embedded', STALE).tryAcquire(1000)).toBe(true);
+  });
+
+  it('release removes our lock but not a foreign one', () => {
+    const l = new SchedulerLease(lock, 'daemon', STALE);
+    l.tryAcquire(1000);
+    l.release();
+    expect(fs.existsSync(lock)).toBe(false);
+    write(99999, 'daemon', 1000);
+    l.release();
+    expect(fs.existsSync(lock)).toBe(true);
+  });
+});

--- a/packages/gateway/src/automations/lease.ts
+++ b/packages/gateway/src/automations/lease.ts
@@ -1,0 +1,66 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface LeaseFile { pid: number; role: 'daemon' | 'embedded'; heartbeatAt: number }
+
+export const DEFAULT_STALE_MS = 90_000; // 3 × 30s ticks
+
+/**
+ * Single-scheduler lease over a lockfile. Daemon wins over embedded; anyone
+ * takes a stale lock. Steal is unlink + exclusive create — a same-host race
+ * loses one write and converges next tick, which is acceptable at 30s cadence.
+ */
+export class SchedulerLease {
+  constructor(
+    private readonly lockPath: string,
+    private readonly role: 'daemon' | 'embedded',
+    private readonly staleMs: number = DEFAULT_STALE_MS,
+  ) {}
+
+  private read(): LeaseFile | null {
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.lockPath, 'utf8'));
+      if (typeof raw?.pid === 'number' && typeof raw?.heartbeatAt === 'number' && (raw.role === 'daemon' || raw.role === 'embedded')) return raw;
+    } catch { /* absent or corrupt */ }
+    return null;
+  }
+
+  private write(now: number): void {
+    fs.mkdirSync(path.dirname(this.lockPath), { recursive: true });
+    fs.writeFileSync(this.lockPath, JSON.stringify({ pid: process.pid, role: this.role, heartbeatAt: now }));
+  }
+
+  /** True when this process holds the lease after the call. */
+  tryAcquire(now: number): boolean {
+    const cur = this.read();
+    if (cur && cur.pid === process.pid) { this.write(now); return true; }
+    const stale = !cur || now - cur.heartbeatAt > this.staleMs;
+    const daemonSteal = this.role === 'daemon' && cur?.role === 'embedded';
+    if (cur && !stale && !daemonSteal) return false;
+    try {
+      // Unlink unconditionally: a corrupt lock reads as null but the file
+      // still exists and would make the exclusive create below fail forever.
+      try { fs.unlinkSync(this.lockPath); } catch { /* already gone */ }
+      fs.mkdirSync(path.dirname(this.lockPath), { recursive: true });
+      fs.writeFileSync(this.lockPath, JSON.stringify({ pid: process.pid, role: this.role, heartbeatAt: now }), { flag: 'wx' });
+      return true;
+    } catch {
+      return false; // lost the race
+    }
+  }
+
+  /** Refresh if we still hold it; false = someone else claimed → stand down. */
+  heartbeat(now: number): boolean {
+    const cur = this.read();
+    if (!cur || cur.pid !== process.pid) return false;
+    this.write(now);
+    return true;
+  }
+
+  release(): void {
+    const cur = this.read();
+    if (cur && cur.pid === process.pid) {
+      try { fs.unlinkSync(this.lockPath); } catch { /* already gone */ }
+    }
+  }
+}

--- a/packages/gateway/src/automations/parked.test.ts
+++ b/packages/gateway/src/automations/parked.test.ts
@@ -1,0 +1,70 @@
+// packages/gateway/src/automations/parked.test.ts
+import { describe, it, expect } from 'vitest';
+import { detectParked } from './parked';
+import { formatRunSummary } from './report';
+import type { Chat, Automation, AutomationRun } from '@codey/core';
+
+const teamTarget: Automation['target'] = { kind: 'team', teamName: 't', workspaceName: 'w' };
+const promptTarget: Automation['target'] = { kind: 'prompt', workspaceName: 'w' };
+
+describe('detectParked', () => {
+  it('reports a paused team via chat.pendingTeam', () => {
+    const chat = { pendingTeam: { question: 'Deploy now?', options: ['yes', 'no'] } } as unknown as Chat;
+    expect(detectParked(chat, teamTarget, 'irrelevant'))
+      .toEqual({ question: 'Deploy now?', options: ['yes', 'no'] });
+  });
+  it('reports an [ASK_USER] marker in a prompt-target response', () => {
+    const parked = detectParked(undefined, promptTarget, 'work...\n[ASK_USER]: Which repo?');
+    expect(parked?.question).toBe('Which repo?');
+  });
+  it('ignores [ASK_USER] markers for team targets (pendingTeam is authoritative)', () => {
+    expect(detectParked({ } as Chat, teamTarget, '[ASK_USER]: q?')).toBeNull();
+  });
+  it('returns null when nothing is pending', () => {
+    expect(detectParked({} as Chat, promptTarget, 'all done')).toBeNull();
+  });
+  it('propagates options from an [ASK_USER:choice] marker in a prompt-target response', () => {
+    const parked = detectParked(undefined, promptTarget, 'thinking...\n[ASK_USER:choice]: Which env? | staging | prod');
+    expect(parked).toEqual({ question: 'Which env?', options: ['staging', 'prod'] });
+  });
+});
+
+describe('formatRunSummary', () => {
+  const auto = { name: 'Morning news' } as Automation;
+  it('summarizes success with a body preview', () => {
+    const s = formatRunSummary(auto, { status: 'success', output: 'Posted 5 items.' } as AutomationRun);
+    expect(s).toContain('Morning news');
+    expect(s).toContain('✅');
+    expect(s).toContain('Posted 5 items.');
+  });
+  it('summarizes parked runs with the question', () => {
+    const s = formatRunSummary(auto, { status: 'parked', question: 'Which account?' } as AutomationRun);
+    expect(s).toContain('⏸');
+    expect(s).toContain('Which account?');
+  });
+  it('summarizes failure with the error', () => {
+    const s = formatRunSummary(auto, { status: 'failed', error: 'boom' } as AutomationRun);
+    expect(s).toContain('❌');
+    expect(s).toContain('boom');
+  });
+  it('summarizes resumed runs with a success head', () => {
+    const s = formatRunSummary(auto, { status: 'resumed', output: 'done after answer' } as AutomationRun);
+    expect(s).toContain('✅');
+    expect(s).toContain('resumed');
+    expect(s).toContain('done after answer');
+  });
+  it('returns head only (no trailing newlines) when the body is empty', () => {
+    const s = formatRunSummary(auto, { status: 'success', output: '   ' } as AutomationRun);
+    expect(s).toBe('✅ Automation "Morning news" succeeded');
+  });
+  it('truncates long output with an ellipsis without splitting a surrogate pair', () => {
+    // Place an astral emoji so its high surrogate sits exactly at the cut
+    // index (399): 398 'x' chars, then '😀' spans indices 398-399.
+    const output = 'x'.repeat(398) + '😀' + 'y'.repeat(50);
+    const s = formatRunSummary(auto, { status: 'success', output } as AutomationRun);
+    expect(s.endsWith('…')).toBe(true);
+    // The char right before the ellipsis must not be a lone high surrogate.
+    expect(/[\uD800-\uDBFF]$/.test(s.slice(0, -1))).toBe(false);
+    expect(s).not.toContain('�');
+  });
+});

--- a/packages/gateway/src/automations/parked.ts
+++ b/packages/gateway/src/automations/parked.ts
@@ -1,0 +1,23 @@
+import { parseAskUser } from '@codey/core';
+import type { Chat, Automation } from '@codey/core';
+
+export interface ParkedInfo { question: string; options?: string[] }
+
+/**
+ * Decide whether a finished headless turn actually parked. Team targets park
+ * via the persisted chat.pendingTeam (the existing pause machinery); prompt
+ * targets park when the single agent emitted an [ASK_USER] marker.
+ */
+export function detectParked(
+  chat: Chat | undefined,
+  target: Automation['target'],
+  response: string,
+): ParkedInfo | null {
+  const pending = chat?.pendingTeam;
+  if (pending) return { question: pending.question, options: pending.options };
+  if (target.kind === 'prompt') {
+    const ask = parseAskUser(response);
+    if (ask) return { question: ask.question, options: ask.options };
+  }
+  return null;
+}

--- a/packages/gateway/src/automations/report.ts
+++ b/packages/gateway/src/automations/report.ts
@@ -1,0 +1,24 @@
+import type { Automation, AutomationRun } from '@codey/core';
+
+const PREVIEW = 400;
+
+/** Human-readable one-message summary for channel posts / notifications. */
+export function formatRunSummary(a: Automation, run: AutomationRun): string {
+  const head =
+    run.status === 'success' ? `✅ Automation "${a.name}" succeeded` :
+    run.status === 'parked' ? `⏸ Automation "${a.name}" is parked on a question` :
+    run.status === 'resumed' ? `✅ Automation "${a.name}" resumed and finished` :
+    `❌ Automation "${a.name}" failed`;
+  // Parked options are intentionally not embedded here — the engine/notification
+  // layer carries run.options separately.
+  const body =
+    run.status === 'parked' ? (run.question ?? '') :
+    run.status === 'failed' ? (run.error ?? '') :
+    (run.output ?? '');
+  const trimmed = body.trim();
+  const cut = trimmed.slice(0, PREVIEW - 1);
+  // Don't split a surrogate pair at the truncation boundary (astral emoji → "�").
+  const safe = /[\uD800-\uDBFF]$/.test(cut) ? cut.slice(0, -1) : cut;
+  const preview = trimmed.length > PREVIEW ? `${safe}…` : trimmed;
+  return preview ? `${head}\n\n${preview}` : head;
+}

--- a/packages/gateway/src/automations/schedule.test.ts
+++ b/packages/gateway/src/automations/schedule.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { localParts, slotId, shouldFire } from './schedule';
+import type { AutomationSchedule } from '@codey/core';
+
+// 2026-07-02T09:00:00 in Asia/Shanghai is 2026-07-02T01:00:00Z
+const SH_9AM = Date.UTC(2026, 6, 2, 1, 0, 0);
+const sched = (over: Partial<AutomationSchedule> = {}): AutomationSchedule =>
+  ({ hour: 9, minute: 0, tz: 'Asia/Shanghai', ...over });
+
+describe('localParts', () => {
+  it('converts an instant into tz-local wall-clock parts', () => {
+    const p = localParts(SH_9AM, 'Asia/Shanghai');
+    expect(p).toMatchObject({ hour: 9, minute: 0, dayOfWeek: 4 }); // Thursday
+  });
+  it('handles midnight as hour 0, not 24', () => {
+    const p = localParts(Date.UTC(2026, 6, 1, 16, 0, 0), 'Asia/Shanghai'); // 2026-07-02 00:00 SH
+    expect(p.hour).toBe(0);
+  });
+});
+
+describe('shouldFire', () => {
+  it('fires when local hour:minute matches and no prior fire', () => {
+    expect(shouldFire(sched(), undefined, SH_9AM)).toBe(true);
+  });
+  it('does not fire off-slot', () => {
+    expect(shouldFire(sched(), undefined, SH_9AM + 60_000)).toBe(false);
+  });
+  it('does not double-fire within the same minute slot', () => {
+    expect(shouldFire(sched(), SH_9AM, SH_9AM + 30_000)).toBe(false);
+  });
+  it('fires again the next day', () => {
+    expect(shouldFire(sched(), SH_9AM, SH_9AM + 24 * 3600_000)).toBe(true);
+  });
+  it('never back-fires: a missed slot simply does not match', () => {
+    // Process restarts at 12:00 having missed the 09:00 slot.
+    expect(shouldFire(sched(), undefined, SH_9AM + 3 * 3600_000)).toBe(false);
+  });
+  it('respects daysOfWeek', () => {
+    // SH_9AM is a Thursday (4)
+    expect(shouldFire(sched({ daysOfWeek: [4] }), undefined, SH_9AM)).toBe(true);
+    expect(shouldFire(sched({ daysOfWeek: [0, 6] }), undefined, SH_9AM)).toBe(false);
+  });
+  it('evaluates in the schedule tz, not UTC (DST-safe)', () => {
+    // 09:00 NY on 2026-11-01 (fall back day) is 14:00Z.
+    const nyFallBack9am = Date.UTC(2026, 10, 1, 14, 0, 0);
+    expect(shouldFire(sched({ tz: 'America/New_York' }), undefined, nyFallBack9am)).toBe(true);
+  });
+});
+
+describe('slotId', () => {
+  it('is stable within a minute and distinct across minutes', () => {
+    expect(slotId(SH_9AM, 'Asia/Shanghai')).toBe(slotId(SH_9AM + 59_000, 'Asia/Shanghai'));
+    expect(slotId(SH_9AM, 'Asia/Shanghai')).not.toBe(slotId(SH_9AM + 60_000, 'Asia/Shanghai'));
+  });
+});

--- a/packages/gateway/src/automations/schedule.ts
+++ b/packages/gateway/src/automations/schedule.ts
@@ -1,0 +1,58 @@
+import type { AutomationSchedule } from '@codey/core';
+
+/** Wall-clock parts of an instant in an IANA time zone. */
+export interface LocalParts {
+  year: number; month: number; day: number;
+  hour: number; minute: number;
+  /** 0=Sun … 6=Sat */
+  dayOfWeek: number;
+}
+
+const DOW: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+const fmtCache = new Map<string, Intl.DateTimeFormat>();
+
+function formatter(tz: string): Intl.DateTimeFormat {
+  let f = fmtCache.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz, hourCycle: 'h23', weekday: 'short',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+    });
+    fmtCache.set(tz, f);
+  }
+  return f;
+}
+
+export function localParts(ms: number, tz: string): LocalParts {
+  const parts: Record<string, string> = {};
+  for (const p of formatter(tz).formatToParts(new Date(ms))) parts[p.type] = p.value;
+  return {
+    year: Number(parts.year), month: Number(parts.month), day: Number(parts.day),
+    hour: Number(parts.hour), minute: Number(parts.minute),
+    dayOfWeek: DOW[parts.weekday] ?? 0,
+  };
+}
+
+/** Minute-granularity identity of the slot `ms` falls in, in `tz`. */
+export function slotId(ms: number, tz: string): string {
+  const p = localParts(ms, tz);
+  return `${p.year}-${p.month}-${p.day} ${p.hour}:${p.minute}`;
+}
+
+/**
+ * True when `now` lands in the schedule's minute slot and that slot hasn't
+ * fired yet. Missed slots never match later instants — restart-safe, no
+ * back-fire by construction.
+ */
+export function shouldFire(
+  schedule: AutomationSchedule,
+  lastFiredAt: number | undefined,
+  now: number,
+): boolean {
+  const p = localParts(now, schedule.tz);
+  if (p.hour !== schedule.hour || p.minute !== schedule.minute) return false;
+  if (schedule.daysOfWeek && !schedule.daysOfWeek.includes(p.dayOfWeek)) return false;
+  if (lastFiredAt !== undefined && slotId(lastFiredAt, schedule.tz) === slotId(now, schedule.tz)) return false;
+  return true;
+}

--- a/packages/gateway/src/automations/store.test.ts
+++ b/packages/gateway/src/automations/store.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AutomationStore } from './store';
+import type { Automation, AutomationRun } from '@codey/core';
+
+let dir: string;
+let store: AutomationStore;
+
+const draft = (over: Partial<Automation> = {}) => ({
+  name: 'Morning news',
+  enabled: true,
+  target: { kind: 'prompt' as const, workspaceName: 'default' },
+  brief: 'Post top AI news to {{account}}.',
+  params: { account: '@jack' },
+  report: { notify: true },
+  ...over,
+});
+
+const run = (over: Partial<AutomationRun> = {}): AutomationRun => ({
+  runId: `r-${Math.random().toString(36).slice(2)}`,
+  startedAt: 1000, endedAt: 2000, status: 'success', trigger: 'manual', ...over,
+});
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'automation-store-'));
+  store = new AutomationStore(dir);
+});
+
+describe('definitions', () => {
+  it('creates with generated id/timestamps and lists', () => {
+    const a = store.create(draft(), 111);
+    expect(a.id).toBeTruthy();
+    expect(a.createdAt).toBe(111);
+    expect(store.list()).toHaveLength(1);
+    expect(store.get(a.id)?.name).toBe('Morning news');
+  });
+
+  it('persists across instances', () => {
+    const a = store.create(draft(), 111);
+    expect(new AutomationStore(dir).get(a.id)?.brief).toContain('{{account}}');
+  });
+
+  it('update patches and bumps updatedAt', () => {
+    const a = store.create(draft(), 111);
+    const b = store.update(a.id, { name: 'Renamed' }, 222);
+    expect(b.name).toBe('Renamed');
+    expect(b.updatedAt).toBe(222);
+  });
+
+  it('preserves unknown fields on rewrite (forward-compat)', () => {
+    const a = store.create(draft(), 111);
+    const file = path.join(dir, 'automations.json');
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+    raw.automations[0].futureField = { keep: 'me' };
+    raw.topLevelFuture = 42;
+    fs.writeFileSync(file, JSON.stringify(raw));
+    new AutomationStore(dir).update(a.id, { name: 'x' }, 222);
+    const after = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(after.automations[0].futureField).toEqual({ keep: 'me' });
+    expect(after.topLevelFuture).toBe(42);
+  });
+
+  it('delete removes definition and history file', () => {
+    const a = store.create(draft(), 111);
+    store.appendRun(a.id, run());
+    store.delete(a.id);
+    expect(store.get(a.id)).toBeUndefined();
+    expect(fs.existsSync(path.join(dir, 'automation-runs', `${a.id}.jsonl`))).toBe(false);
+  });
+
+  it('setEnabled + recordLastFired persist', () => {
+    const a = store.create(draft(), 111);
+    store.setEnabled(a.id, false, 222);
+    store.recordLastFired(a.id, 333);
+    const back = new AutomationStore(dir).get(a.id)!;
+    expect(back.enabled).toBe(false);
+    expect(back.lastFiredAt).toBe(333);
+  });
+});
+
+describe('run history', () => {
+  it('appends and lists newest-first with limit', () => {
+    const a = store.create(draft(), 111);
+    store.appendRun(a.id, run({ runId: 'r1', startedAt: 1 }));
+    store.appendRun(a.id, run({ runId: 'r2', startedAt: 2 }));
+    const runs = store.listRuns(a.id);
+    expect(runs.map(r => r.runId)).toEqual(['r2', 'r1']);
+    expect(store.listRuns(a.id, 1)).toHaveLength(1);
+  });
+
+  it('patchRun rewrites a single record, preserving unknown fields', () => {
+    const a = store.create(draft(), 111);
+    store.appendRun(a.id, { ...run({ runId: 'r1', status: 'parked' }), extra: 'kept' } as AutomationRun);
+    store.patchRun(a.id, 'r1', { status: 'failed', error: 'expired' });
+    const r = store.listRuns(a.id)[0] as AutomationRun & { extra?: string };
+    expect(r.status).toBe('failed');
+    expect(r.extra).toBe('kept');
+  });
+
+  it('markSeen stamps seenAt', () => {
+    const a = store.create(draft(), 111);
+    store.appendRun(a.id, run({ runId: 'r1' }));
+    store.markSeen(a.id, 'r1', 999);
+    expect(store.listRuns(a.id)[0].seenAt).toBe(999);
+  });
+
+  it('listRuns tolerates a corrupt trailing line', () => {
+    const a = store.create(draft(), 111);
+    store.appendRun(a.id, run({ runId: 'r1' }));
+    fs.appendFileSync(path.join(dir, 'automation-runs', `${a.id}.jsonl`), '{oops\n');
+    expect(store.listRuns(a.id)).toHaveLength(1);
+  });
+});

--- a/packages/gateway/src/automations/store.ts
+++ b/packages/gateway/src/automations/store.ts
@@ -1,0 +1,146 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import type { Automation, AutomationRun } from '@codey/core';
+
+/** Fields callers supply on create; id/timestamps are generated. */
+export type AutomationDraft =
+  Omit<Automation, 'id' | 'createdAt' | 'updatedAt' | 'lastFiredAt' | 'chatId'>;
+
+const MAX_HISTORY_REWRITE = 500;
+
+/**
+ * Definitions in `<baseDir>/automations.json`, run history in
+ * `<baseDir>/automation-runs/<id>.jsonl` (append-only; patch = bounded
+ * rewrite). All definition writes are read-modify-write over the raw JSON so
+ * unknown fields survive (forward-compat) and concurrent writers converge.
+ *
+ * Concurrency contract: concurrent read-modify-write cycles from two
+ * processes can still lose one side's field-level change (last-writer-wins
+ * on the whole doc); the design accepts this — re-reading the file
+ * immediately before every write keeps the race window to microseconds, and
+ * the scheduler lease ensures only one process fires schedules.
+ */
+export class AutomationStore {
+  private readonly file: string;
+  private readonly runsDir: string;
+
+  constructor(baseDir: string) {
+    this.file = path.join(baseDir, 'automations.json');
+    this.runsDir = path.join(baseDir, 'automation-runs');
+  }
+
+  // ---- definitions ----
+
+  private loadRaw(): Record<string, unknown> & { automations: Array<Record<string, unknown>> } {
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.file, 'utf8'));
+      if (raw && Array.isArray(raw.automations)) return raw;
+    } catch { /* first run or unreadable — start fresh */ }
+    return { automations: [] };
+  }
+
+  private writeRaw(raw: Record<string, unknown>): void {
+    fs.mkdirSync(path.dirname(this.file), { recursive: true });
+    // Unique tmp per write: two processes share this store, so a fixed tmp
+    // path could be truncated mid-write by the other side before rename.
+    const tmp = `${this.file}.${process.pid}.${randomUUID()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(raw, null, 2), 'utf8');
+    fs.renameSync(tmp, this.file);
+  }
+
+  /** Re-reads the file, applies `fn` to the raw doc, writes atomically. */
+  private mutate<T>(fn: (raw: { automations: Array<Record<string, unknown>> }) => T): T {
+    const raw = this.loadRaw();
+    const out = fn(raw);
+    this.writeRaw(raw);
+    return out;
+  }
+
+  list(): Automation[] {
+    return this.loadRaw().automations as unknown as Automation[];
+  }
+
+  get(id: string): Automation | undefined {
+    return this.list().find(a => a.id === id);
+  }
+
+  create(draft: AutomationDraft, now: number): Automation {
+    return this.mutate(raw => {
+      const a = { ...draft, id: randomUUID(), createdAt: now, updatedAt: now } as Automation;
+      raw.automations.push(a as unknown as Record<string, unknown>);
+      return a;
+    });
+  }
+
+  update(id: string, patch: Partial<Automation>, now: number): Automation {
+    return this.mutate(raw => {
+      const cur = raw.automations.find(a => a.id === id);
+      if (!cur) throw new Error(`Automation not found: ${id}`);
+      Object.assign(cur, patch, { updatedAt: now });
+      return cur as unknown as Automation;
+    });
+  }
+
+  delete(id: string): void {
+    this.mutate(raw => {
+      raw.automations = raw.automations.filter(a => a.id !== id);
+    });
+    try { fs.unlinkSync(this.runFile(id)); } catch { /* no history yet */ }
+  }
+
+  setEnabled(id: string, enabled: boolean, now: number): Automation {
+    return this.update(id, { enabled }, now);
+  }
+
+  /** lastFiredAt bump without touching updatedAt (not a user edit). */
+  recordLastFired(id: string, ts: number): void {
+    const raw = this.loadRaw();
+    const cur = raw.automations.find(a => a.id === id);
+    if (!cur) return; // unknown id — don't rewrite the file for a no-op
+    cur.lastFiredAt = ts;
+    this.writeRaw(raw);
+  }
+
+  // ---- run history ----
+
+  private runFile(id: string): string {
+    return path.join(this.runsDir, `${id}.jsonl`);
+  }
+
+  appendRun(id: string, run: AutomationRun): void {
+    fs.mkdirSync(this.runsDir, { recursive: true });
+    fs.appendFileSync(this.runFile(id), JSON.stringify(run) + '\n', 'utf8');
+  }
+
+  /** Newest-first. Skips unparseable lines. */
+  listRuns(id: string, limit?: number): AutomationRun[] {
+    let text: string;
+    try { text = fs.readFileSync(this.runFile(id), 'utf8'); } catch { return []; }
+    const runs: AutomationRun[] = [];
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try { runs.push(JSON.parse(line)); } catch { /* corrupt line — skip */ }
+    }
+    runs.reverse();
+    return limit !== undefined ? runs.slice(0, limit) : runs;
+  }
+
+  /** Read-patch-rewrite (atomic). Caps retained history at MAX_HISTORY_REWRITE. */
+  patchRun(id: string, runId: string, patch: Partial<AutomationRun>): void {
+    const oldestFirst = this.listRuns(id).reverse().slice(-MAX_HISTORY_REWRITE);
+    let found = false;
+    const lines = oldestFirst.map(r => {
+      if (r.runId === runId) { found = true; return JSON.stringify({ ...r, ...patch }); }
+      return JSON.stringify(r);
+    });
+    if (!found) return;
+    const tmp = `${this.runFile(id)}.${process.pid}.${randomUUID()}.tmp`;
+    fs.writeFileSync(tmp, lines.join('\n') + '\n', 'utf8');
+    fs.renameSync(tmp, this.runFile(id));
+  }
+
+  markSeen(id: string, runId: string, now: number): void {
+    this.patchRun(id, runId, { seenAt: now });
+  }
+}

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -142,6 +142,45 @@ export class ChatManager {
     return this.cache.get(chatId);
   }
 
+  /**
+   * Re-read one chat's file from disk into the cache. Automation chats are
+   * shared across the daemon and embedded (Mac app) gateways — each process
+   * loads chats once, so the in-memory copy can be stale (missing a chat the
+   * other process created, or missing its pendingTeam pause state). If the
+   * chat is not cached, its file is looked up across all workspace dirs
+   * (mirrors ensureLoaded's scan). If the file is gone, the cache entry is
+   * evicted and undefined is returned. Safe to call any time: persist() is
+   * synchronous (write + atomic rename), so this process never has a pending
+   * unflushed change that a reload could clobber.
+   */
+  reload(chatId: string): Chat | undefined {
+    this.ensureLoaded();
+    const cached = this.cache.get(chatId);
+    let candidates: string[];
+    if (cached) {
+      candidates = [this.chatFile(cached.workspaceName, chatId)];
+    } else {
+      let workspaces: string[] = [];
+      try {
+        workspaces = fs.readdirSync(this.workspacesRoot, { withFileTypes: true })
+          .filter(e => e.isDirectory())
+          .map(e => e.name);
+      } catch { /* root gone — treat as no candidates */ }
+      candidates = workspaces.map(ws => this.chatFile(ws, chatId));
+    }
+    for (const file of candidates) {
+      try {
+        const chat = JSON.parse(fs.readFileSync(file, 'utf8')) as Chat;
+        if (chat.id === chatId && chat.workspaceName) {
+          this.cache.set(chat.id, chat);
+          return chat;
+        }
+      } catch { /* missing or unreadable — try next candidate */ }
+    }
+    this.cache.delete(chatId);
+    return undefined;
+  }
+
   create(input: CreateChatInput): Chat {
     this.ensureLoaded();
     const now = Date.now();

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -10,6 +10,11 @@ export interface CreateChatInput {
   workspaceName: string;
   selection?: ChatSelection;
   title?: string;
+  /** 'automation' = hidden system chat (excluded from list() by default). */
+  kind?: 'automation';
+  /** Per-chat agent/model overrides, set at creation (used by automations). */
+  agent?: Chat['agent'];
+  model?: string;
 }
 
 /**
@@ -122,9 +127,10 @@ export class ChatManager {
     fs.renameSync(tmp, file);
   }
 
-  list(workspaceName?: string): Chat[] {
+  list(workspaceName?: string, opts?: { includeAutomation?: boolean }): Chat[] {
     this.ensureLoaded();
-    const all = [...this.cache.values()];
+    const all = [...this.cache.values()]
+      .filter(c => opts?.includeAutomation || c.kind !== 'automation');
     const filtered = workspaceName
       ? all.filter(c => c.workspaceName === workspaceName)
       : all;
@@ -147,6 +153,9 @@ export class ChatManager {
       messages: [],
       createdAt: now,
       updatedAt: now,
+      ...(input.kind ? { kind: input.kind } : {}),
+      ...(input.agent ? { agent: input.agent } : {}),
+      ...(input.model ? { model: input.model } : {}),
     };
     this.cache.set(chat.id, chat);
     this.persist(chat);
@@ -324,7 +333,8 @@ export class ChatManager {
     const chat = this.requireChat(chatId);
     chat.messages.push(message);
     chat.updatedAt = Date.now();
-    if (chat.messages.length === 1 && message.role === 'user') {
+    // Automation chats keep their authoritative "Automation: <name>" title.
+    if (chat.messages.length === 1 && message.role === 'user' && chat.kind !== 'automation') {
       chat.title = deriveTitle(message.content);
     }
     this.persist(chat);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -898,6 +898,11 @@ export class Codey {
 
   /** The hidden system chat an automation executes in (created lazily). */
   private async ensureAutomationChat(a: Automation): Promise<string> {
+    // Automation chats are shared across the daemon and embedded gateways;
+    // the in-memory cache may be stale (e.g. the Mac app created the chat
+    // after this daemon booted). Re-read from disk before deciding the chat
+    // is missing — otherwise we'd create a duplicate and clobber a.chatId.
+    if (a.chatId) this.chatManager.reload(a.chatId);
     if (a.chatId && this.chatManager.get(a.chatId)) return a.chatId;
     const selection = a.target.kind === 'team'
       ? { type: 'team' as const, name: a.target.teamName }
@@ -920,6 +925,12 @@ export class Codey {
    * Resume is the same call — sendToChat's pendingTeam continuation handles it.
    */
   private async runAutomationTurn(a: Automation, text: string, opts?: { resume?: boolean }): Promise<TargetResult> {
+    // Automation chats are shared across the daemon and embedded gateways;
+    // the in-memory cache may be stale. Refresh before the pendingTeam
+    // handling below — an embedded process resuming a daemon-parked run must
+    // see the daemon-persisted pendingTeam, or the answer would be dispatched
+    // as a fresh team task (and its persist would clobber the daemon's file).
+    if (a.chatId) this.chatManager.reload(a.chatId);
     const chatId = await this.ensureAutomationChat(a);
     // Fresh runs must not inherit a stale pendingTeam: the engine can mark a
     // parked run failed (7-day expiry) or consume it via a failed resume (e.g.
@@ -963,6 +974,21 @@ export class Codey {
     return this.requireAutomationStore().create(draft, Date.now());
   }
   updateAutomation(id: string, patch: Partial<Automation>): Automation {
+    // A target change invalidates the hidden chat: its selection, workspace,
+    // and agent/model overrides were frozen at creation from the OLD target.
+    // Delete that chat and clear chatId so the next run lazily creates a
+    // fresh one matching the new target. (store.update Object.assigns the
+    // patch, so chatId becomes undefined and JSON.stringify drops the key
+    // from the persisted document.)
+    if (patch.target) {
+      const prev = this.requireAutomationStore().get(id);
+      if (prev?.chatId) {
+        // reload first so a chat created by the other process is deletable.
+        this.chatManager.reload(prev.chatId);
+        try { this.chatManager.delete(prev.chatId); } catch { /* already gone */ }
+      }
+      patch = { ...patch, chatId: undefined };
+    }
     return this.requireAutomationStore().update(id, patch, Date.now());
   }
   deleteAutomation(id: string): void { this.requireAutomationStore().delete(id); }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,14 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill } from '@codey/core';
+import * as os from 'os';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, Automation, AutomationRun, AutomationEvent, renderBrief, generateAutomationQuestions, generateAutomationFollowup, synthesizeAutomationBrief } from '@codey/core';
 import { randomUUID } from 'crypto';
+import { AutomationStore } from './automations/store';
+import { AutomationEngine, TargetResult } from './automations/engine';
+import { SchedulerLease } from './automations/lease';
+import { InterviewManager } from './automations/interview';
+import { detectParked } from './automations/parked';
+import { formatRunSummary } from './automations/report';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
 import { AgentFactory } from '@codey/core';
@@ -70,6 +77,10 @@ export class Codey {
   private turnQueue: TurnQueue;
   private chatEventListener: ((ev: any) => void) | undefined;
   private pairingEventListener: ((ev: { type: 'completed'; channel: ChannelKind; channelUserId: string }) => void) | undefined;
+  private automationStore?: AutomationStore;
+  private automationEngine?: AutomationEngine;
+  private automationInterviews?: InterviewManager;
+  private automationEventListener?: (ev: AutomationEvent) => void;
 
   // Rate limiting: userId -> last request timestamp
   private userCooldowns: Map<string, number> = new Map();
@@ -853,6 +864,147 @@ export class Codey {
 
     // Send startup notification to all active channels
     await this.sendStartupNotification();
+
+    // Automations: hidden-chat scheduler + engine, wired last so channels/chat
+    // manager are already up.
+    this.initAutomations();
+  }
+
+  /** Base dir mirrors workspace.ts: CODEY_HOME override, else ~/.codey. */
+  private codeyHome(): string {
+    return process.env.CODEY_HOME ?? path.join(os.homedir(), '.codey');
+  }
+
+  private initAutomations(): void {
+    const base = this.codeyHome();
+    this.automationStore = new AutomationStore(base);
+    const role = this.config.automationRole ?? 'daemon';
+    this.automationEngine = new AutomationEngine({
+      store: this.automationStore,
+      lease: new SchedulerLease(path.join(base, 'automation-scheduler.lock'), role),
+      runTarget: (a) => this.runAutomationTurn(a, renderBrief(a.brief, a.params)),
+      resumeTarget: (a, answer) => this.runAutomationTurn(a, answer, { resume: true }),
+      report: (a, run) => this.deliverAutomationReport(a, run),
+      onEvent: (ev) => { try { this.automationEventListener?.(ev); } catch { /* swallow */ } },
+      log: (msg) => this.logger.info(`[automations] ${msg}`),
+    });
+    this.automationEngine.start();
+    this.automationInterviews = new InterviewManager({
+      generateQuestions: (goal, ctx) => generateAutomationQuestions(goal, ctx, this.getAideOptions()),
+      generateFollowup: (goal, q, ans) => generateAutomationFollowup(goal, q, ans, this.getAideOptions()),
+      synthesize: (goal, qa) => synthesizeAutomationBrief(goal, qa, this.getAideOptions()),
+    });
+  }
+
+  /** The hidden system chat an automation executes in (created lazily). */
+  private async ensureAutomationChat(a: Automation): Promise<string> {
+    if (a.chatId && this.chatManager.get(a.chatId)) return a.chatId;
+    const selection = a.target.kind === 'team'
+      ? { type: 'team' as const, name: a.target.teamName }
+      : { type: 'none' as const };
+    const chat = this.chatManager.create({
+      workspaceName: a.target.workspaceName,
+      title: `Automation: ${a.name}`,
+      selection,
+      kind: 'automation',
+      agent: a.target.kind === 'prompt' ? a.target.agent : undefined,
+      model: a.target.kind === 'prompt' ? a.target.model : undefined,
+    });
+    this.automationStore!.update(a.id, { chatId: chat.id }, Date.now());
+    return chat.id;
+  }
+
+  /**
+   * One headless turn: send `text` into the automation's hidden chat with a
+   * collecting sink, then decide parked/success from the persisted chat state.
+   * Resume is the same call — sendToChat's pendingTeam continuation handles it.
+   */
+  private async runAutomationTurn(a: Automation, text: string, opts?: { resume?: boolean }): Promise<TargetResult> {
+    const chatId = await this.ensureAutomationChat(a);
+    // Fresh runs must not inherit a stale pendingTeam: the engine can mark a
+    // parked run failed (7-day expiry) or consume it via a failed resume (e.g.
+    // sendToChat throws before its own pendingTeam clear) WITHOUT the chat's
+    // pause state being cleared. Left in place, the next fresh brief would be
+    // treated by sendToChat as the "answer" to that dead question and fed into
+    // the team-resume continuation. Resume turns keep it — that continuation
+    // IS the resume mechanism.
+    if (!opts?.resume && this.chatManager.get(chatId)?.pendingTeam) {
+      this.chatManager.setPendingTeam(chatId, null);
+    }
+    const sink: ChatStreamSink = () => { /* headless — response comes from the return value */ };
+    try {
+      const { response } = await this.sendToChat(chatId, text, sink);
+      const parked = detectParked(this.chatManager.get(chatId), a.target, response);
+      return parked ? { output: response, parked } : { output: response };
+    } catch (err) {
+      return { output: '', error: (err as Error).message };
+    }
+  }
+
+  /** Post the run summary to report.channel if configured. Returns failure text. */
+  private async deliverAutomationReport(a: Automation, run: AutomationRun): Promise<string | undefined> {
+    if (!a.report.channel) return undefined;
+    const channel = a.report.channel.platform as ChannelType;
+    const handler = this.handlers.get(channel);
+    if (!handler) return `channel ${a.report.channel.platform} not connected in this process`;
+    try {
+      await this.sendResponse({ chatId: a.report.channel.target, channel, text: formatRunSummary(a, run) });
+      return undefined;
+    } catch (err) {
+      return (err as Error).message;
+    }
+  }
+
+  // ---- Automations public API ----
+
+  listAutomations(): Automation[] { return this.automationStore?.list() ?? []; }
+  getAutomation(id: string): Automation | undefined { return this.automationStore?.get(id); }
+  createAutomation(draft: Parameters<AutomationStore['create']>[0]): Automation {
+    return this.requireAutomationStore().create(draft, Date.now());
+  }
+  updateAutomation(id: string, patch: Partial<Automation>): Automation {
+    return this.requireAutomationStore().update(id, patch, Date.now());
+  }
+  deleteAutomation(id: string): void { this.requireAutomationStore().delete(id); }
+  setAutomationEnabled(id: string, enabled: boolean): Automation {
+    return this.requireAutomationStore().setEnabled(id, enabled, Date.now());
+  }
+  listAutomationRuns(id: string, limit?: number): AutomationRun[] {
+    return this.automationStore?.listRuns(id, limit) ?? [];
+  }
+  markAutomationRunSeen(id: string, runId: string): void {
+    this.automationStore?.markSeen(id, runId, Date.now());
+  }
+  runAutomationNow(id: string): Promise<AutomationRun | null> {
+    return this.requireAutomationEngine().runNow(id, 'manual');
+  }
+  resumeAutomationRun(id: string, runId: string, answer: string): Promise<AutomationRun> {
+    return this.requireAutomationEngine().resume(id, runId, answer);
+  }
+  startAutomationInterview(goal: string, targetContext: string) {
+    return this.requireAutomationInterviews().start(goal, targetContext);
+  }
+  answerAutomationInterview(sessionId: string, text: string) {
+    return this.requireAutomationInterviews().answer(sessionId, text);
+  }
+  cancelAutomationInterview(sessionId: string): void {
+    this.automationInterviews?.cancel(sessionId);
+  }
+  setAutomationEventListener(fn: (ev: AutomationEvent) => void): void {
+    this.automationEventListener = fn;
+  }
+
+  private requireAutomationStore(): AutomationStore {
+    if (!this.automationStore) throw new Error('Automations not initialized (gateway not started)');
+    return this.automationStore;
+  }
+  private requireAutomationEngine(): AutomationEngine {
+    if (!this.automationEngine) throw new Error('Automations not initialized (gateway not started)');
+    return this.automationEngine;
+  }
+  private requireAutomationInterviews(): InterviewManager {
+    if (!this.automationInterviews) throw new Error('Automations not initialized (gateway not started)');
+    return this.automationInterviews;
   }
 
   private resolveChatWorkingDir(chat: Chat): string {
@@ -929,6 +1081,9 @@ export class Codey {
       clearInterval(this.conversationCleanupInterval);
       this.conversationCleanupInterval = undefined;
     }
+    // Note: engine.stop() does not await in-flight runs and releases the
+    // scheduler lease immediately (accepted v1 risk).
+    this.automationEngine?.stop();
     this.contextManager.shutdown();
     for (const handler of this.handlers.values()) {
       await handler.stop();
@@ -4473,7 +4628,9 @@ Example: /model gpt-4.1 write a Python script`;
     // A paused team's question takes precedence: when pendingTeam is set this
     // turn is the user's answer to the team, so leave the suggestion persisted
     // untouched — it can still be answered after the team resumes/finishes.
-    if (chat.pendingSkillSuggestion && !isSlashTurn && !pendingTeam) {
+    // Automation chats never resolve suggestions: an unattended brief starting
+    // with "yes"/"no" must not be consumed as a suggestion reply.
+    if (chat.pendingSkillSuggestion && !isSlashTurn && !pendingTeam && chat.kind !== 'automation') {
       const s = chat.pendingSkillSuggestion;
       const reply = userText.trim().toLowerCase();
       const renameMatch = reply.match(/^rename\s+([a-z][a-z0-9-]{2,29})$/);
@@ -4638,6 +4795,8 @@ Example: /model gpt-4.1 write a Python script`;
       prompt = applySkill(prompt, appliedChatSkill);
       this.logger.info(`[skills] explicit invoke (chat): ${appliedChatSkill.name} v${appliedChatSkill.version}`);
     } else if (skillsCfg?.enabled && skillsCfg.autoApply
+        // Unattended automation runs execute a frozen brief — never auto-apply skills.
+        && chat.kind !== 'automation'
         && chat.selection.type !== 'team' && !isSlashTurn) {
       // Skills are per-workspace: match against the CHAT's workspace store
       // (mirrors how workingDir/teams above come from chat.workspaceName).
@@ -4669,8 +4828,10 @@ Example: /model gpt-4.1 write a Python script`;
     // with the agent turn; we await it just before the 'done' event. The
     // truncated title set by appendMessage stays visible until then, and acts
     // as the fallback if the Aide fails or returns nothing.
+    // Automation chats keep their authoritative "Automation: <name>" title —
+    // no LLM title generation.
     const titlePromise: Promise<string> | undefined =
-      afterUser.messages.length === 1 && this.isAideConfigured()
+      afterUser.messages.length === 1 && this.isAideConfigured() && chat.kind !== 'automation'
         ? this.generateChatTitleSafe(userText)
         : undefined;
 
@@ -4959,7 +5120,9 @@ Example: /model gpt-4.1 write a Python script`;
       // with the team's question on the next user turn), and no use/success
       // bookkeeping for an applied skill either — the run isn't finished yet.
       const pausedAfterRun = !!this.chatManager.get(chatId)?.pendingTeam;
-      if (skillsCfg?.enabled && !pausedAfterRun) {
+      // Automation chats skip the pass entirely — unattended runs must not
+      // generate skill suggestions (nobody is there to answer them).
+      if (skillsCfg?.enabled && !pausedAfterRun && chat.kind !== 'automation') {
         // Real success signal: the solo path exposes it on singleAgentResponse
         // (a failed run reaches here with success:false and output = streamed
         // partial text or ''). Team paths have no structured flag — they throw

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       'src/automations/lease.test.ts',
       'src/automations/parked.test.ts',
       'src/automations/engine.test.ts',
+      'src/automations/interview.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'src/automations/schedule.test.ts',
       'src/automations/store.test.ts',
       'src/automations/lease.test.ts',
+      'src/automations/parked.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       'src/chats.workingDirOverride.test.ts',
       'src/chats.pendingSkillSuggestion.test.ts',
       'src/automations/schedule.test.ts',
+      'src/automations/store.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'src/automations/parked.test.ts',
       'src/automations/engine.test.ts',
       'src/automations/interview.test.ts',
+      'src/automations/chats-hidden.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       'src/automations/store.test.ts',
       'src/automations/lease.test.ts',
       'src/automations/parked.test.ts',
+      'src/automations/engine.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'src/chats.pendingSkillSuggestion.test.ts',
       'src/automations/schedule.test.ts',
       'src/automations/store.test.ts',
+      'src/automations/lease.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       'src/worker-message-emitter.test.ts',
       'src/chats.workingDirOverride.test.ts',
       'src/chats.pendingSkillSuggestion.test.ts',
+      'src/automations/schedule.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },


### PR DESCRIPTION
## Summary

Codey Automations: unattended, scheduled (or run-now) processes that execute a frozen, interview-synthesized brief against a prompt or a team, in a hidden system chat, with lease-guarded scheduling, parked-run resume, run history, and a Mac Automations view.

Spec: `docs/superpowers/specs/2026-07-02-automations-design.md` (synced with everything that shipped, including review-driven hardening and accepted v1 limits).

### How it works
- **Authoring**: the Mac app interviews you (Aide-driven, at most one follow-up per question) and folds the answers into a self-contained brief with `{{param}}` knobs editable without re-interviewing.
- **Execution**: each automation owns a hidden chat (`Chat.kind: 'automation'`, excluded from chat lists); a run is one headless `sendToChat` turn — team pause/resume and conversation context work unchanged. Skill machinery and LLM titling are gated off for these chats.
- **Scheduling**: structured tz-aware time-of-day schedules (`Intl`, no cron lib), 30s tick, slot recorded before run (no re-fire on crash), per-automation isolation so one bad schedule can't starve the rest.
- **Dual process**: `automation-scheduler.lock` lease — daemon wins, embedded Mac gateway stands down, 90s stale-steal; automation chats reload from disk so daemon and app converge.
- **Parked runs**: team `[ASK_USER]` pauses and solo `[ASK_USER]` markers park the run with the question/options; answer from the Mac run-history to resume (resume consumes the parked record; 7-day TTL expiry, leader-only, evented).
- **Reporting**: optional channel post (chunked through the existing pipeline) + Mac OS notifications (respecting the global notifications toggle and window focus), launch-time unseen scan with seen-state persistence.

### Surface
- `@codey/core`: automation types, interview prompts + `renderBrief`
- `@codey/gateway`: `automations/` module (store, schedule, lease, engine, interview, parked, report) + `Codey` wiring and public API
- `codey-mac`: `automations:*` IPC, preload bridge, notifications + launch scan, Automations view (list / interview editor / run history with resume), draft validation at the IPC boundary

### Testing
- 464 tests across the workspaces (core 169, gateway 121, mac 174), lint clean, packaged app built and smoke-tested manually.
- Every task went through spec-compliance + code-quality review with fix loops; a final integration review traced the create→schedule→run→report and park→resume flows end to end (two cross-process blockers found and fixed: chat reload from disk, hidden-chat reset on target change).

### Known v1 limits (documented in the spec)
- Editor authors daily schedules only (`daysOfWeek` round-trips but has no UI); `report.channel` and prompt-target agent/model overrides are plumbed but UI-less.
- Daemon-fired runs surface in an open Mac app on next launch/scan, not live.
- Per-process overlap guard; `stop()` doesn't await in-flight runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)