### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
@@ -12438,7 +12438,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12450,7 +12450,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps all workspace versions (root, @codey/core, @codey/gateway, codey-mac) and the lockfile from 0.8.4 to 0.9.0, covering the playbooks/Tools window (#163), automations (#160–#162), and self-crystallizing skills (#158–#159) feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)