### PR TITLE
Polish chat controls and improve agent resilience

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -534,7 +534,7 @@ async function detectInstalledAgents(): Promise<Record<string, { installed: bool
 interface SlashCommand {
   name: string
   description: string
-  source: 'agent' | 'gateway'
+  source: 'agent' | 'gateway' | 'skill'
 }
 
 const BUILTIN_SLASH: Record<string, SlashCommand[]> = {
@@ -2356,19 +2356,6 @@ app.whenReady().then(async () => {
     wrap(async () => detectInstalledAgents())
   )
 
-  ipcMain.handle('agents:slashCommands', async (_e, agent: string) =>
-    wrap(async () => {
-      const discovered = await discoverSlashCommands(agent)
-      const qq: SlashCommand = {
-        name: 'qq',
-        description: 'Quick Question — ask about this chat without affecting it',
-        source: 'gateway',
-      }
-      // Avoid a duplicate if a future discovery ever yields one.
-      return [qq, ...discovered.filter(c => c.name !== 'qq')]
-    })
-  )
-
   // ── Skills IPC ────────────────────────────────────────────────────
   const skillPaths: Record<string, { userDirs: string[]; projectSubdirs: string[] }> = {
     'claude-code': { userDirs: ['.claude/skills'], projectSubdirs: ['.claude/skills'] },
@@ -2405,31 +2392,64 @@ app.whenReady().then(async () => {
     } catch { return null }
   }
 
+  async function listAgentSkills(agentKey: string): Promise<{ skills: ScannedSkill[]; projectDir: string | null }> {
+    const fsMod = await import('fs')
+    const pathMod = await import('path')
+    const osMod = await import('os')
+    const home = osMod.homedir()
+    const paths = skillPaths[agentKey] ?? skillPaths['claude-code']
+
+    const skills: ScannedSkill[] = []
+    for (const dir of configuredUserSkillDirs(agentKey, home, pathMod)) {
+      skills.push(...scanSkillsDir(fsMod, pathMod, dir, 'user'))
+    }
+
+    let projectDir: string | null = null
+    const workingDir = getWorkingDir(fsMod, pathMod)
+    if (workingDir) {
+      for (const rel of paths.projectSubdirs) {
+        const dir = pathMod.join(workingDir, rel)
+        if (!projectDir) projectDir = dir
+        skills.push(...scanSkillsDir(fsMod, pathMod, dir, 'project'))
+      }
+    }
+
+    return { skills: uniqueSkills(fsMod, pathMod, skills), projectDir }
+  }
+
+  ipcMain.handle('agents:slashCommands', async (_e, agent: string) =>
+    wrap(async () => {
+      const [discovered, skillResult] = await Promise.all([
+        discoverSlashCommands(agent),
+        listAgentSkills(agent),
+      ])
+      const qq: SlashCommand = {
+        name: 'qq',
+        description: 'Quick Question — ask about this chat without affecting it',
+        source: 'gateway',
+      }
+      const skills: SlashCommand[] = skillResult.skills.map(skill => ({
+        name: skill.name,
+        description: skill.description || 'Agent skill',
+        source: 'skill',
+      }))
+      // Gateway commands take precedence, then installed skills, then the
+      // agent's own commands. A Set keeps the menu stable when a skill and an
+      // agent command happen to share a name.
+      const seen = new Set<string>()
+      return [qq, ...skills, ...discovered].filter(command => {
+        const key = command.name.toLowerCase()
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+    })
+  )
+
   ipcMain.handle('skills:list', async (_e, agent?: string) =>
     wrap(async () => {
-      const fsMod = await import('fs')
-      const pathMod = await import('path')
-      const osMod = await import('os')
-      const home = osMod.homedir()
       const agentKey = agent ?? 'claude-code'
-      const paths = skillPaths[agentKey] ?? skillPaths['claude-code']
-
-      const skills: ScannedSkill[] = []
-      for (const dir of configuredUserSkillDirs(agentKey, home, pathMod)) {
-        skills.push(...scanSkillsDir(fsMod, pathMod, dir, 'user'))
-      }
-
-      let projectDir: string | null = null
-      const workingDir = getWorkingDir(fsMod, pathMod)
-      if (workingDir) {
-        for (const rel of paths.projectSubdirs) {
-          const dir = pathMod.join(workingDir, rel)
-          if (!projectDir) projectDir = dir
-          skills.push(...scanSkillsDir(fsMod, pathMod, dir, 'project'))
-        }
-      }
-
-      return { skills: uniqueSkills(fsMod, pathMod, skills), projectDir }
+      return listAgentSkills(agentKey)
     })
   )
 

--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -145,7 +145,7 @@ declare global {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; env?: Record<string, string> }>>>
         set: (updates: Record<string, { enabled?: boolean; defaultModel?: string; env?: Record<string, string> }>) => Promise<IpcResult<void>>
         checkInstalled: () => Promise<IpcResult<Record<string, { installed: boolean; path?: string }>>>
-        slashCommands: (agent: string) => Promise<IpcResult<Array<{ name: string; description: string; source: 'agent' | 'gateway' }>>>
+        slashCommands: (agent: string) => Promise<IpcResult<Array<{ name: string; description: string; source: 'agent' | 'gateway' | 'skill' }>>>
       }
       chats: {
         upload: (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer) =>

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -584,7 +584,7 @@ const styles: Record<string, React.CSSProperties> = {
   item: {
     display: 'flex', alignItems: 'center', gap: 6,
     padding: '7px 9px', borderRadius: 8, cursor: 'pointer',
-    fontSize: 12, color: C.fg2, margin: '2px 2px', border: '1px solid transparent',
+    fontSize: 12, color: C.fg2, margin: '2px 2px 2px 20px', border: '1px solid transparent',
   },
   chatIcon: { display: 'inline-flex', flexShrink: 0 },
   title: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import type { ChatSelection, FileAttachment } from '../types'
 import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
@@ -312,6 +312,7 @@ const TeamRunGroup: React.FC<{
             onClick={() => onSelectTurn(m.id)}>
             <div style={styles.teamWorkerHead}>
               <span style={styles.teamStepLabel}>Step {m.step}: {m.worker}</span>
+              {m.model && <span style={styles.modelBadge} title={`${m.agent ?? 'Agent'} model`}>{m.model}</span>}
               {m.workerStatus === 'failed' && <span style={styles.teamWorkerFailed}>failed</span>}
               {running && <span style={styles.teamStepRunning}>● running</span>}
             </div>
@@ -341,7 +342,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   const [agentDefaultModels, setAgentDefaultModels] = useState<Record<string, string | undefined>>({})
   const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>(() => getDraft(chatId).attachments)
   const [isDragging, setIsDragging] = useState(false)
-  const [slashCommands, setSlashCommands] = useState<Array<{ name: string; description: string; source: 'agent' | 'gateway' }>>([])
+  const [slashCommands, setSlashCommands] = useState<Array<{ name: string; description: string; source: 'agent' | 'gateway' | 'skill' }>>([])
   const [slashIdx, setSlashIdx] = useState(0)
   const slashMenuRef = useRef<HTMLDivElement>(null)
   const [panelTab, setPanelTab] = useState<ContextPanelTab>('current')
@@ -358,6 +359,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   const [editors, setEditors] = useState<Array<{ id: string; name: string; installed: boolean }>>([])
   const [editorsLoaded, setEditorsLoaded] = useState(false)
   const [openingEditor, setOpeningEditor] = useState<string | null>(null)
+  const [preferredEditorId, setPreferredEditorId] = useState(() => localStorage.getItem('codey.preferredEditor') ?? '')
   const [runSettingsOpen, setRunSettingsOpen] = useState(false)
   const [followLatest, setFollowLatest] = useState(true)
   // Selected option labels for the active multi-select AskUserQuestion. Reset
@@ -469,13 +471,28 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
   // header BranchPicker both operate on this effective dir.
   const workingDir = chat?.workingDirOverride || workspaceDir
 
-  const openEditorMenu = async () => {
-    const nextOpen = !editorMenuOpen
-    setEditorMenuOpen(nextOpen)
-    if (!nextOpen || editorsLoaded) return
+  const loadEditors = useCallback(async () => {
+    if (editorsLoaded) return editors
     const result = await window.codey.editors.list()
-    if (result.ok) setEditors(result.data)
+    const next = result.ok ? result.data : []
+    if (result.ok) setEditors(next)
     setEditorsLoaded(true)
+    return next
+  }, [editors, editorsLoaded])
+
+  useEffect(() => { void loadEditors() }, [])
+
+  useEffect(() => {
+    if (!editorsLoaded) return
+    const installed = editors.filter(editor => editor.installed)
+    if (installed.length === 0 || installed.some(editor => editor.id === preferredEditorId)) return
+    setPreferredEditorId(installed[0].id)
+    localStorage.setItem('codey.preferredEditor', installed[0].id)
+  }, [editors, editorsLoaded, preferredEditorId])
+
+  const toggleEditorMenu = async () => {
+    if (!editorsLoaded) await loadEditors()
+    setEditorMenuOpen(open => !open)
   }
 
   const openInEditor = async (editor: { id: string; name: string }) => {
@@ -487,7 +504,15 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
       alert(`Couldn’t open ${editor.name}: ${result.error}`)
       return
     }
+    setPreferredEditorId(editor.id)
+    localStorage.setItem('codey.preferredEditor', editor.id)
     setEditorMenuOpen(false)
+  }
+
+  const openPreferredEditor = async () => {
+    const available = (editorsLoaded ? editors : await loadEditors()).filter(editor => editor.installed)
+    const preferred = available.find(editor => editor.id === preferredEditorId) ?? available[0]
+    if (preferred) await openInEditor(preferred)
   }
 
   const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)
@@ -710,6 +735,18 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
     })
     return () => { stale = true }
   }, [effectiveAgent])
+
+  // Skills can be installed while this chat remains mounted behind Settings.
+  // Re-scan when the slash menu is opened so newly loaded skills appear
+  // immediately without requiring an agent switch or app restart.
+  useEffect(() => {
+    if (input !== '/') return
+    let stale = false
+    window.codey.agents.slashCommands(effectiveAgent).then(r => {
+      if (!stale && r.ok) setSlashCommands(r.data)
+    })
+    return () => { stale = true }
+  }, [input, effectiveAgent])
 
   useEffect(() => { setSlashIdx(0) }, [input])
   useEffect(() => {
@@ -958,6 +995,14 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
 
   const panelWorkerName = chat.selection.type === 'worker' ? chat.selection.name : undefined
   const panelTeamName = chat.selection.type === 'team' ? chat.selection.name : undefined
+  const runSettingsSummary = chat.selection.type === 'team'
+    ? `${chat.selection.name ?? 'Team'} · per-runner routing`
+    : [
+        chat.selection.type === 'worker' ? chat.selection.name : null,
+        effectiveAgent,
+        effectiveModel ?? 'default model',
+        chat.soloAdvisor ? 'Advisor on' : null,
+      ].filter(Boolean).join(' · ')
   const [panelTeamGraph, setPanelTeamGraph] = useState<import('../../../packages/core/src/team-graph').TeamGraph | undefined>(undefined)
   useEffect(() => {
     if (!panelTeamName) { setPanelTeamGraph(undefined); return }
@@ -998,16 +1043,28 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
           }}
         />
         <div style={{ ...styles.openInWrap, marginLeft: 'auto' }}>
-          <button
-            onClick={() => void openEditorMenu()}
-            style={styles.openInButton}
-            disabled={!workingDir}
-            title={workingDir ? 'Open this project in an editor' : 'Project directory is unavailable'}
-          >
-            <UIIcon name="code" size={14} />
-            <span>Open in</span>
-            <span style={{ display: 'inline-flex', transform: editorMenuOpen ? 'rotate(-90deg)' : 'rotate(90deg)' }}><UIIcon name="chevron" size={12} /></span>
-          </button>
+          <div style={styles.openInSplit}>
+            <button
+              onClick={() => void openPreferredEditor()}
+              style={styles.openInPrimary}
+              disabled={!workingDir || openingEditor !== null || (editorsLoaded && !editors.some(editor => editor.installed))}
+              title={workingDir ? 'Open this project in the preferred editor' : 'Project directory is unavailable'}
+            >
+              <UIIcon name="code" size={14} />
+              <span>{openingEditor
+                ? 'Opening…'
+                : editors.find(editor => editor.id === preferredEditorId && editor.installed)?.name ?? 'Open in'}</span>
+            </button>
+            <button
+              onClick={() => void toggleEditorMenu()}
+              style={styles.openInDropdown}
+              disabled={!workingDir}
+              title="Choose another editor"
+              aria-label="Choose another editor"
+            >
+              <span style={{ display: 'inline-flex', transform: editorMenuOpen ? 'rotate(-90deg)' : 'rotate(90deg)' }}><UIIcon name="chevron" size={12} /></span>
+            </button>
+          </div>
           {editorMenuOpen && (
             <>
               <div onClick={() => setEditorMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 999 }} />
@@ -1022,7 +1079,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
                       disabled={openingEditor !== null}
                       onClick={() => void openInEditor(editor)}
                     >
-                      <UIIcon name="code" size={14} />
+                      <UIIcon name={editor.id === preferredEditorId ? 'check' : 'code'} size={14} />
                       <span>{openingEditor === editor.id ? `Opening ${editor.name}…` : editor.name}</span>
                     </button>
                   ))
@@ -1039,8 +1096,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
             style={styles.runSettingsButton}
             title="Configure worker, agent, model, and advisor"
           >
-            <UIIcon name="tools" size={14} />
-            <span>Run settings</span>
+            <span style={styles.runSettingsButtonSummary}>{runSettingsSummary}</span>
             <span style={{ display: 'inline-flex', transform: runSettingsOpen ? 'rotate(-90deg)' : 'rotate(90deg)' }}><UIIcon name="chevron" size={12} /></span>
           </button>
           {runSettingsOpen && (
@@ -1075,7 +1131,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
                         style={styles.runSettingSelect}
                         title={`Agent: ${effectiveAgent}${chat.agent ? ' (override)' : workerAgent ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
                       >
-                        <option value="">{effectiveAgent}</option>
+                        <option value="">Inherit ({effectiveAgent})</option>
                         {AGENT_NAMES.filter(n => enabledAgents.includes(n) || n === chat.agent).map(n => (
                           <option key={n} value={n}>{n}</option>
                         ))}
@@ -1090,7 +1146,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
                         title={`Model: ${effectiveModel ?? 'unset'}${chat.model ? ' (override)' : workerModel ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
                         disabled={modelsForAgent.length === 0}
                       >
-                        <option value="">{effectiveModel ?? '(default)'}</option>
+                        <option value="">Inherit ({effectiveModel ?? 'agent default'})</option>
                         {modelsForAgent.map(m => (
                           <option key={m.model} value={m.model}>{m.model}</option>
                         ))}
@@ -1418,6 +1474,14 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
               <div style={styles.tsLabel}>
                 <span>{fmtTime(msg.timestamp)}</span>
                 <span style={styles.tsRight}>
+                  {msg.role === 'assistant' && msg.model && (
+                    <span
+                      style={styles.modelBadge}
+                      title={`${msg.agent ?? 'Agent'} model`}
+                    >
+                      {msg.model}
+                    </span>
+                  )}
                   {msg.fallback && (
                     <span
                       style={styles.fallbackBadge}
@@ -1690,15 +1754,22 @@ const styles: Record<string, React.CSSProperties> = {
     flexShrink: 0, maxWidth: 180,
   },
   openInWrap: { position: 'relative', flexShrink: 0 },
-  openInButton: {
-    border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 8px', background: C.surface3,
+  openInSplit: { display: 'inline-flex', alignItems: 'stretch' },
+  openInPrimary: {
+    border: `1px solid ${C.border2}`, borderRadius: '6px 0 0 6px', padding: '4px 8px', background: C.surface3,
     color: C.fg2, cursor: 'pointer', fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 5,
+  },
+  openInDropdown: {
+    border: `1px solid ${C.border2}`, borderLeft: 'none', borderRadius: '0 6px 6px 0', padding: '4px 6px', background: C.surface3,
+    color: C.fg3, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
   },
   runSettingsWrap: { position: 'relative', flexShrink: 0 },
   runSettingsButton: {
     border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 8px', background: C.surface3,
-    color: C.fg2, cursor: 'pointer', fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 5,
+    color: C.fg2, cursor: 'pointer', fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 7,
+    maxWidth: 310, textAlign: 'left',
   },
+  runSettingsButtonSummary: { color: C.fg2, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   runSettingsMenu: {
     position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 1000, minWidth: 244,
     padding: 10, borderRadius: 9, background: C.surface2, border: `1px solid ${C.border2}`,
@@ -1731,6 +1802,12 @@ const styles: Record<string, React.CSSProperties> = {
   tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, paddingLeft: 4, paddingRight: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
   tsMeta: { color: C.fg3, opacity: 0.55, fontVariantNumeric: 'tabular-nums' },
   tsRight: { display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 },
+  modelBadge: {
+    color: C.fg3, background: C.surface3, border: `1px solid ${C.border2}`,
+    borderRadius: 5, padding: '1px 6px', fontSize: 10,
+    fontFamily: 'SF Mono, Menlo, monospace',
+    maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
   fallbackBadge: {
     color: C.warningFg, background: C.warningBg,
     borderRadius: 6, padding: '1px 6px', fontSize: 10,

--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -29,9 +29,9 @@ function baseState(): State {
 describe('team reducer routing', () => {
   it('workerStart appends a running worker message with the backend id', () => {
     let s = baseState();
-    s = reducer(s, { type: 'workerStart', chatId: 'c1', teamTurnId: 'tt1', messageId: 'w1', step: 1, worker: 'pm', reason: 'kickoff' });
+    s = reducer(s, { type: 'workerStart', chatId: 'c1', teamTurnId: 'tt1', messageId: 'w1', step: 1, worker: 'pm', reason: 'kickoff', agent: 'codex', model: 'gpt-5' });
     const m = s.chats.c1.messages.find(x => x.id === 'w1')!;
-    expect(m).toMatchObject({ id: 'w1', role: 'assistant', teamTurnId: 'tt1', worker: 'pm', workerStatus: 'running', advisorReason: 'kickoff' });
+    expect(m).toMatchObject({ id: 'w1', role: 'assistant', teamTurnId: 'tt1', worker: 'pm', workerStatus: 'running', advisorReason: 'kickoff', agent: 'codex', model: 'gpt-5' });
   });
 
   it('streamToken/toolCall route to the event messageId, not the single inFlight id', () => {

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -42,7 +42,7 @@ type Action =
   | { type: 'thinkingToken'; chatId: string; token: string; step?: number; messageId?: string }
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: 'working' | 'writing'; messageId?: string }
   | { type: 'queued'; chatId: string; position: number }
-  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion']; fallback?: ChatMessage['fallback'] }
+  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; agent?: ChatMessage['agent']; model?: string; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion']; fallback?: ChatMessage['fallback'] }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
   | { type: 'stoppedSend'; chatId: string; text: string }
   | { type: 'clearRestore'; chatId: string }
@@ -51,16 +51,16 @@ type Action =
   | { type: 'patchTaskBrief'; chatId: string; brief: TaskBrief }
   | { type: 'permissionRequest'; chatId: string; toolNames: string[] }
   | { type: 'dismissPermission'; chatId: string }
-  | { type: 'teamStart'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string }> }
-  | { type: 'workerStart'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; reason?: string }
+  | { type: 'teamStart'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string }> }
+  | { type: 'workerStart'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string; reason?: string }
   | { type: 'workerEnd'; chatId: string; messageId: string; step: number; status: 'running' | 'done' | 'failed' | 'askedUser' }
 
 function reorder(order: string[], chatId: string): string[] {
   return [chatId, ...order.filter(id => id !== chatId)]
 }
 
-function mkWorkerStub(teamTurnId: string, teamName: string, mode: ChatMessage['teamMode'], id: string, step: number, worker: string, reason?: string): ChatMessage {
-  return { id, role: 'assistant', content: '', timestamp: Date.now(), toolCalls: [], isComplete: false, teamTurnId, teamName, teamMode: mode, step, worker, workerStatus: 'running', advisorReason: reason }
+function mkWorkerStub(teamTurnId: string, teamName: string, mode: ChatMessage['teamMode'], id: string, step: number, worker: string, reason?: string, agent?: ChatMessage['agent'], model?: string): ChatMessage {
+  return { id, role: 'assistant', content: '', timestamp: Date.now(), toolCalls: [], isComplete: false, teamTurnId, teamName, teamMode: mode, step, worker, workerStatus: 'running', advisorReason: reason, agent, model }
 }
 
 export function reducer(state: State, action: Action): State {
@@ -261,7 +261,7 @@ export function reducer(state: State, action: Action): State {
     case 'teamStart': {
       const chat = state.chats[action.chatId]
       if (!chat) return state
-      const stubs = (action.workers ?? []).map(w => mkWorkerStub(action.teamTurnId, action.teamName, action.mode, w.messageId, w.step, w.worker))
+      const stubs = (action.workers ?? []).map(w => mkWorkerStub(action.teamTurnId, action.teamName, action.mode, w.messageId, w.step, w.worker, undefined, w.agent, w.model))
       if (stubs.length === 0) return state
       const existing = new Set(chat.messages.map(m => m.id))
       const messages = [...chat.messages, ...stubs.filter(s => !existing.has(s.id))]
@@ -273,7 +273,7 @@ export function reducer(state: State, action: Action): State {
       if (chat.messages.some(m => m.id === action.messageId)) return state
       const teamName = chat.messages.find(m => m.teamTurnId === action.teamTurnId)?.teamName ?? (chat.selection.type === 'team' ? chat.selection.name ?? '' : '')
       const mode = chat.messages.find(m => m.teamTurnId === action.teamTurnId)?.teamMode ?? 'auto'
-      const stub = mkWorkerStub(action.teamTurnId, teamName, mode, action.messageId, action.step, action.worker, action.reason)
+      const stub = mkWorkerStub(action.teamTurnId, teamName, mode, action.messageId, action.step, action.worker, action.reason, action.agent, action.model)
       return { ...state, chats: { ...state.chats, [chat.id]: { ...chat, messages: [...chat.messages, stub], updatedAt: Date.now() } } }
     }
     case 'workerEnd': {
@@ -295,7 +295,7 @@ export function reducer(state: State, action: Action): State {
       if (!chat) return state
       const messages = chat.messages.map(m =>
         m.id === action.assistantMessageId
-          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, isComplete: true, choices: action.choices, userQuestion: action.userQuestion, fallback: action.fallback }
+          ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, agent: action.agent, model: action.model, isComplete: true, choices: action.choices, userQuestion: action.userQuestion, fallback: action.fallback }
           : m
       )
       const updatedChat: Chat = { ...chat, messages, updatedAt: Date.now() }
@@ -504,7 +504,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           dispatch({ type: 'teamStart', chatId: ev.chatId, teamTurnId: ev.teamTurnId, teamName: ev.teamName, mode: ev.mode, workers: ev.workers })
           break
         case 'worker_start':
-          dispatch({ type: 'workerStart', chatId: ev.chatId, teamTurnId: ev.teamTurnId, messageId: ev.messageId, step: ev.step, worker: ev.worker, reason: ev.reason })
+          dispatch({ type: 'workerStart', chatId: ev.chatId, teamTurnId: ev.teamTurnId, messageId: ev.messageId, step: ev.step, worker: ev.worker, agent: ev.agent, model: ev.model, reason: ev.reason })
           break
         case 'worker_end':
           dispatch({ type: 'workerEnd', chatId: ev.chatId, messageId: ev.messageId, step: ev.step, status: ev.status })
@@ -520,6 +520,8 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               content: ev.response,
               tokens: ev.tokens,
               durationSec: ev.durationSec,
+              agent: ev.agent,
+              model: ev.model,
               title: ev.title,
               choices: ev.choices,
               userQuestion: ev.userQuestion,

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -11,10 +11,10 @@ export type ChatStreamEvent =
   | { type: 'info'; chatId: string; message: string }
   | { type: 'stream'; chatId: string; token: string; messageId?: string; step?: number }
   | { type: 'thinking'; chatId: string; token: string; step?: number; messageId?: string }
-  | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: string; model?: string }> }
-  | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: string; model?: string; reason?: string }
+  | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string }> }
+  | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; reason?: string }
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
@@ -12438,7 +12438,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12450,7 +12450,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codey/core",
-  "version": "0.6.0",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codey/core",
-      "version": "0.6.0",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -30,6 +30,10 @@ export interface ChatMessage {
   tokens?: number;
   /** Wall-clock seconds the agent took to produce the response. */
   durationSec?: number;
+  /** Agent/model that produced this assistant message. Stored per turn so
+   * historical labels remain accurate after the chat configuration changes. */
+  agent?: 'claude-code' | 'opencode' | 'codex';
+  model?: string;
   /**
    * Present when this turn was produced by a fallback agent after the primary
    * failed. Rendered as a small badge in the message footer. `from`/`to` are

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -1,4 +1,4 @@
-import { Chat, ChatMessage, FileAttachment, ToolCallEntry } from '@codey/core';
+import { Chat, ChatMessage, CodingAgent, FileAttachment, ToolCallEntry } from '@codey/core';
 
 export const MAX_CONCURRENT_AGENTS = 4;
 export const CHAT_CONTEXT_WINDOW = 40;
@@ -21,10 +21,10 @@ export type ChatStreamEvent =
   | { type: 'info'; chatId: string; message: string; skillNotice?: boolean }
   | { type: 'stream'; chatId: string; token: string; messageId?: string; step?: number }
   | { type: 'thinking'; chatId: string; token: string; step?: number; messageId?: string }
-  | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: string; model?: string }> }
-  | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: string; model?: string; reason?: string }
+  | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: CodingAgent; model?: string }> }
+  | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: CodingAgent; model?: string; reason?: string }
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/gateway/src/gateway.network-retry.test.ts
+++ b/packages/gateway/src/gateway.network-retry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentResponse } from '@codey/core';
+import { isRetryableNetworkFailure, MAX_NETWORK_RETRIES } from './gateway';
+
+const failed = (error: string): AgentResponse => ({ success: false, output: '', error });
+
+describe('network retry classification', () => {
+  it('caps retries at five', () => {
+    expect(MAX_NETWORK_RETRIES).toBe(5);
+  });
+
+  it.each([
+    'timeout',
+    'Request timed out',
+    'read ECONNRESET',
+    'getaddrinfo ENOTFOUND api.example.com',
+    'fetch failed',
+    '503 Service Unavailable',
+    '429 Too Many Requests',
+  ])('retries transient failure: %s', error => {
+    expect(isRetryableNetworkFailure(failed(error))).toBe(true);
+  });
+
+  it.each([
+    'Permission denied for tool Bash',
+    'Unknown model name',
+    'API key is missing',
+    'Invalid request payload',
+  ])('does not retry permanent failure: %s', error => {
+    expect(isRetryableNetworkFailure(failed(error))).toBe(false);
+  });
+
+  it('never retries a successful response', () => {
+    expect(isRetryableNetworkFailure({ success: true, output: 'ok' })).toBe(false);
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -47,6 +47,16 @@ interface DirectoryResolveResult {
 /** Max advisor escalation rounds per single-agent turn (solo advisor). */
 const SOLO_ADVISOR_MAX_ROUNDS = 2;
 
+/** A failed run may be retried this many times before fallback routing starts. */
+export const MAX_NETWORK_RETRIES = 5;
+
+/** Keep retries narrow: agent/config/permission failures must not be repeated. */
+export function isRetryableNetworkFailure(response: AgentResponse): boolean {
+  if (response.success) return false;
+  const text = `${response.error ?? ''}\n${response.output ?? ''}`.toLowerCase();
+  return /(?:\btimeout\b|timed out|deadline exceeded|etimedout|econnreset|econnrefused|enotfound|eai_again|socket hang up|fetch failed|network (?:error|unavailable)|connection (?:closed|lost|reset|refused|error)|temporarily unavailable|service unavailable|gateway timeout|\b(?:408|429|500|502|503|504)\b)/i.test(text);
+}
+
 /** Explicit `/skill <name> <task>` invocation. Threaded per-turn: handleMessage
  *  attaches it to the queued turn's payload, runOneTurn reads it from the
  *  payload, and (for channel-linked chats) it rides into sendToChat on the
@@ -3505,7 +3515,7 @@ Example: /model gpt-4.1 write a Python script`;
       const wmModel = workerManager.getWorkerModel(memberName);
       const modelConfig = wmModel ? this.getModelConfig(codingAgent, wmModel) : (opts.fallbackModel ?? this.getDefaultModelConfig(codingAgent));
       await emitter.status(`🔄 Worker **${worker.name}** is working...`);
-      emitter.beginWorker?.({ step: i + 1, worker: worker.name });
+      emitter.beginWorker?.({ step: i + 1, worker: worker.name, agent: codingAgent, model: modelConfig?.model });
       const roster = members.map(n => ({ name: n, hint: workerManager.getDispatchHint(n) }));
       const nextName = members[i + 1];
       const nextWorker = nextName
@@ -3720,7 +3730,7 @@ Example: /model gpt-4.1 write a Python script`;
         ? this.getModelConfig(codingAgent, wmModel)
         : (opts?.fallbackModel ?? this.getDefaultModelConfig(codingAgent));
       await emitter.status(`🔄 Step ${++stepIndex}: **${worker.name}** is working...`);
-      emitter.beginWorker?.({ step: stepIndex, worker: worker.name });
+      emitter.beginWorker?.({ step: stepIndex, worker: worker.name, agent: codingAgent, model: modelConfig?.model });
 
       const roster = graph.nodes
         .filter(n => n.type === 'worker' && n.worker)
@@ -3933,7 +3943,12 @@ Example: /model gpt-4.1 write a Python script`;
       }
       // Pre-create one stub message per worker so streaming events are routed
       // per-worker. Serial modes use beginWorker; parallel pre-creates them all.
-      workerMsgs.teamStart(team.members.map((w, i) => ({ step: i + 1, worker: w })));
+      workerMsgs.teamStart(team.members.map((w, i) => ({
+        step: i + 1,
+        worker: w,
+        agent: chatAgent ?? this.getDefaultAgent() as CodingAgent,
+        model: (chatModel ?? this.getDefaultModelConfig(chatAgent ?? this.getDefaultAgent() as CodingAgent))?.model,
+      })));
       const workerStep = new Map<string, number>(team.members.map((w, i) => [w, i + 1]));
 
       const runner = new ParallelTeamRunner({
@@ -4045,7 +4060,19 @@ Example: /model gpt-4.1 write a Python script`;
             // (beginWorker below). Don't also echo a "### Step N" header into the
             // turn's main message — that produced a second, redundant copy of the
             // whole run in a different format.
-            workerMsgs.beginWorker({ step: msg.step, worker: msg.worker, reason: msg.reason });
+            const wm = this.workspaceManager.getWorkerManager();
+            const workerAgent = (wm.getWorkerCodingAgent(msg.worker) ?? chatAgent ?? this.getDefaultAgent()) as CodingAgent;
+            const workerModelName = wm.getWorkerModel(msg.worker);
+            const workerModel = workerModelName
+              ? this.getModelConfig(workerAgent, workerModelName)
+              : (chatModel ?? this.getDefaultModelConfig(workerAgent));
+            workerMsgs.beginWorker({
+              step: msg.step,
+              worker: msg.worker,
+              reason: msg.reason,
+              agent: workerAgent,
+              model: workerModel?.model,
+            });
           } else {
             sink({ type: 'info', chatId, message: msg.summary });
           }
@@ -4247,8 +4274,39 @@ Example: /model gpt-4.1 write a Python script`;
     return out;
   }
 
+  private async waitForNetworkRetry(ms: number, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) return;
+    await new Promise<void>(resolve => {
+      const timer = setTimeout(done, ms);
+      const onAbort = () => done();
+      function done() {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  private async runAgentWithNetworkRetry(agent: CodingAgent, request: AgentRequest): Promise<AgentResponse> {
+    let response = await this.agentFactory.run(agent, request);
+    for (let retry = 1; retry <= MAX_NETWORK_RETRIES; retry++) {
+      if (request.signal?.aborted || !isRetryableNetworkFailure(response)) break;
+      // 1s, 2s, 4s, 8s, 8s: enough breathing room for transient outages
+      // without leaving the chat apparently frozen for a long time.
+      const delayMs = Math.min(1000 * 2 ** (retry - 1), 8000);
+      const message = `Network error — retrying ${retry}/${MAX_NETWORK_RETRIES} in ${delayMs / 1000}s`;
+      this.logger.warn(`${agent}: ${message}`);
+      request.onStatus?.({ type: 'info', message });
+      await this.waitForNetworkRetry(delayMs, request.signal);
+      if (request.signal?.aborted) break;
+      response = await this.agentFactory.run(agent, request);
+    }
+    return response;
+  }
+
   private async runWithFallback(agent: CodingAgent, request: AgentRequest): Promise<AgentResponse> {
-    const response = await this.agentFactory.run(agent, request);
+    const response = await this.runAgentWithNetworkRetry(agent, request);
     if (response.success) return response;
 
     // User-initiated abort — do NOT churn through every fallback agent,
@@ -4301,7 +4359,7 @@ Example: /model gpt-4.1 write a Python script`;
 
       const label = `${entry.agent}(${resolvedModel.model})`;
       this.logger.warn(`Agent ${agent} failed, trying ${label}...`);
-      const fallbackResponse = await this.agentFactory.run(entry.agent, {
+      const fallbackResponse = await this.runAgentWithNetworkRetry(entry.agent, {
         ...request,
         agent: entry.agent,
         model: resolvedModel,
@@ -5188,6 +5246,12 @@ Example: /model gpt-4.1 write a Python script`;
         }
       }
 
+      // Fallback metadata already carries the exact successful identity as
+      // "agent(model)". Persist that identity instead of the failed primary;
+      // otherwise use the configured agent/model for this turn.
+      const fallbackIdentity = singleAgentResponse?.fallback?.to.match(/^([^()]+)\((.+)\)$/);
+      const responseAgent = (fallbackIdentity?.[1] ?? agent) as CodingAgent;
+      const responseModel = fallbackIdentity?.[2] ?? model?.model;
       const assistantMessage: ChatMessage = {
         id: randomUUID(),
         role: 'assistant',
@@ -5199,6 +5263,8 @@ Example: /model gpt-4.1 write a Python script`;
         isComplete: true,
         tokens,
         durationSec,
+        agent: responseAgent,
+        ...(responseModel ? { model: responseModel } : {}),
         ...(surfacedChoices ? { choices: surfacedChoices } : {}),
         ...(agentUserQuestion ? { userQuestion: agentUserQuestion } : {}),
         ...(singleAgentResponse?.fallback ? { fallback: singleAgentResponse.fallback } : {}),
@@ -5227,7 +5293,7 @@ Example: /model gpt-4.1 write a Python script`;
         }
       }
 
-      sink({ type: 'done', chatId, response: output, thinking: singleAgentResponse?.thinking, tokens, durationSec, title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion, fallback: singleAgentResponse?.fallback, ...(teamTurnId ? { teamTurnId } : {}) });
+      sink({ type: 'done', chatId, response: output, thinking: singleAgentResponse?.thinking, tokens, durationSec, agent: responseAgent, ...(responseModel ? { model: responseModel } : {}), title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion, fallback: singleAgentResponse?.fallback, ...(teamTurnId ? { teamTurnId } : {}) });
 
       // ── Skills: post-run pass (fire-and-forget, response already delivered) ──
       // Skip the whole pass when this turn ended PAUSED — i.e. the team run
@@ -5313,6 +5379,8 @@ Example: /model gpt-4.1 write a Python script`;
         timestamp: Date.now(),
         toolCalls,
         isComplete: true,
+        agent,
+        ...(model?.model ? { model: model.model } : {}),
       };
       this.chatManager.appendMessage(chatId, assistantMessage);
       sink({ type: 'error', chatId, message });

--- a/packages/gateway/src/team-emitter.ts
+++ b/packages/gateway/src/team-emitter.ts
@@ -1,4 +1,4 @@
-import { ChannelType } from '@codey/core';
+import { ChannelType, CodingAgent } from '@codey/core';
 import type { WorkerMessageEmitter } from './worker-message-emitter';
 
 /** Surface-agnostic sink for team continuation output. */
@@ -12,7 +12,7 @@ export interface TeamEmitter {
   /** Per-worker streamed thinking token. */
   onThinking(token: string, step: number): void;
   /** Begin a per-worker chat message (chat surface only). */
-  beginWorker?(args: { step: number; worker: string; reason?: string }): void;
+  beginWorker?(args: { step: number; worker: string; reason?: string; agent?: CodingAgent; model?: string }): void;
   /** Finalize the active per-worker chat message (chat surface only). */
   endWorker?(status: 'done' | 'failed' | 'askedUser'): void;
   /** Accumulated assistant transcript (chat surface); '' for channels. */
@@ -45,7 +45,7 @@ export class ChatEmitter implements TeamEmitter {
     if (this.workerMsgs) { this.workerMsgs.onThinking(token, step); return; }
     try { this.sink({ type: 'thinking', chatId: this.chatId, token, step }); } catch { /* swallow */ }
   }
-  beginWorker(args: { step: number; worker: string; reason?: string }): void { this.workerMsgs?.beginWorker(args); }
+  beginWorker(args: { step: number; worker: string; reason?: string; agent?: CodingAgent; model?: string }): void { this.workerMsgs?.beginWorker(args); }
   endWorker(status: 'done' | 'failed' | 'askedUser'): void { this.workerMsgs?.endWorker(status); }
   get transcript(): string { return this.parts.join('\n\n'); }
   get choices(): string[] | undefined { return this._choices; }

--- a/packages/gateway/src/worker-message-emitter.test.ts
+++ b/packages/gateway/src/worker-message-emitter.test.ts
@@ -22,9 +22,9 @@ function harness() {
 describe('WorkerMessageEmitter — serial', () => {
   it('begin appends a running stub and emits worker_start with the same id', () => {
     const h = harness();
-    const id = h.em.beginWorker({ step: 1, worker: 'pm', reason: 'kickoff' });
+    const id = h.em.beginWorker({ step: 1, worker: 'pm', reason: 'kickoff', agent: 'codex', model: 'gpt-5' });
     expect(id).toBe('id-1');
-    expect(h.appended[0]).toMatchObject({ id: 'id-1', role: 'assistant', workerStatus: 'running', teamTurnId: 'tt1', step: 1, worker: 'pm', advisorReason: 'kickoff' });
+    expect(h.appended[0]).toMatchObject({ id: 'id-1', role: 'assistant', workerStatus: 'running', teamTurnId: 'tt1', step: 1, worker: 'pm', advisorReason: 'kickoff', agent: 'codex', model: 'gpt-5' });
     expect(h.events[0]).toMatchObject({ type: 'worker_start', messageId: 'id-1', step: 1, worker: 'pm', reason: 'kickoff' });
   });
 

--- a/packages/gateway/src/worker-message-emitter.ts
+++ b/packages/gateway/src/worker-message-emitter.ts
@@ -12,7 +12,7 @@ export interface WorkerMessageStore {
 
 interface Buf { messageId: string; step: number; worker: string; content: string; toolCalls: ToolCallEntry[]; thinking: string; }
 
-export interface BeginWorkerArgs { step: number; worker: string; reason?: string; agent?: string; model?: string; }
+export interface BeginWorkerArgs { step: number; worker: string; reason?: string; agent?: ChatMessage['agent']; model?: string; }
 
 /**
  * Owns the per-worker chat-message lifecycle for a single team run. All
@@ -34,9 +34,9 @@ export class WorkerMessageEmitter {
   ) {}
 
   /** Pre-create one stub per worker (parallel). Emits team_start. */
-  teamStart(workers: Array<{ step: number; worker: string; agent?: string; model?: string }>): void {
+  teamStart(workers: Array<{ step: number; worker: string; agent?: ChatMessage['agent']; model?: string }>): void {
     const list = workers.map(w => {
-      const buf = this.createStub(w.step, w.worker);
+      const buf = this.createStub(w.step, w.worker, undefined, w.agent, w.model);
       this.byWorker.set(w.worker, buf);
       return { messageId: buf.messageId, step: w.step, worker: w.worker, agent: w.agent, model: w.model };
     });
@@ -46,7 +46,7 @@ export class WorkerMessageEmitter {
   /** Start a worker (serial). Flushes any still-active worker as done first. */
   beginWorker(args: BeginWorkerArgs): string {
     if (this.active) this.endWorker('done');
-    const buf = this.createStub(args.step, args.worker, args.reason);
+    const buf = this.createStub(args.step, args.worker, args.reason, args.agent, args.model);
     this.active = buf;
     this.sink({ type: 'worker_start', chatId: this.chatId, teamTurnId: this.meta.teamTurnId, messageId: buf.messageId, step: args.step, worker: args.worker, reason: args.reason, agent: args.agent, model: args.model });
     return buf.messageId;
@@ -99,7 +99,7 @@ export class WorkerMessageEmitter {
     return worker ? (this.byWorker.get(worker) ?? null) : this.active;
   }
 
-  private createStub(step: number, worker: string, reason?: string): Buf {
+  private createStub(step: number, worker: string, reason?: string, agent?: ChatMessage['agent'], model?: string): Buf {
     const messageId = this.newId();
     const buf: Buf = { messageId, step, worker, content: '', toolCalls: [], thinking: '' };
     const stub: ChatMessage = {
@@ -107,6 +107,8 @@ export class WorkerMessageEmitter {
       toolCalls: [], isComplete: false,
       teamTurnId: this.meta.teamTurnId, teamName: this.meta.teamName, teamMode: this.meta.mode,
       step, worker, workerStatus: 'running',
+      ...(agent ? { agent } : {}),
+      ...(model ? { model } : {}),
       ...(reason ? { advisorReason: reason } : {}),
     };
     this.store.appendMessage(this.chatId, stub);

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     // added to this list.
     include: [
       'src/config.test.ts',
+      'src/gateway.network-retry.test.ts',
       'src/digit-mapping.test.ts',
       'src/team-pause.test.ts',
       'src/chats.discussion.test.ts',


### PR DESCRIPTION
## What changed

- merge installed agent skills into the chat slash-command menu and refresh them when `/` opens
- visually indent chat rows beneath workspace folders
- persist and display the actual model used for assistant and team-worker messages, including fallback answers
- retry transient network, timeout, rate-limit, and gateway failures up to five times with abortable backoff
- simplify Run Settings to show the effective configuration directly
- turn Open in into a split button that remembers the last successfully used editor
- bump the monorepo, Mac app, Core, and Gateway versions to `0.9.3`

## Why

The slash menu previously only used cached agent commands, message history did not retain per-turn model identity, transient network failures immediately entered fallback routing, and the header controls obscured current settings or required repeated editor selection.

## Impact

Users can invoke newly installed skills immediately, see which model produced each response, recover automatically from temporary network failures, distinguish workspace folders from chats, and use more compact run/editor controls.

## Validation

- Core TypeScript build passed
- Gateway TypeScript check passed
- Mac renderer and Electron TypeScript checks passed
- Mac production Vite/Electron build passed
- focused retry, emitter, skill, and reducer tests passed
- full Gateway suite completed 21 files / 148 assertions successfully, but Vitest exited non-zero because `parallel-team.test.ts` hit the local macOS `EMFILE: too many open files, watch` limit (8 watcher errors); the same result reproduced with one worker
