### PR TITLE
Complete branch picker and align header controls

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1446,12 +1446,20 @@ app.whenReady().then(async () => {
         const [curOut, localOut, remoteOut] = await Promise.all([
           run(['rev-parse', '--abbrev-ref', 'HEAD']),
           run(['for-each-ref', '--format=%(refname:short)', 'refs/heads']),
-          run(['for-each-ref', '--format=%(refname:short)', 'refs/remotes']),
+          run(['for-each-ref', '--format=%(refname:short)%09%(symref)', 'refs/remotes']),
         ])
         const current = curOut.trim() || 'HEAD'
         const local = localOut.split('\n').map(l => l.trim()).filter(Boolean)
-        const remote = remoteOut.split('\n').map(l => l.trim())
-          .filter(l => l && !l.endsWith('/HEAD'))
+        // %(refname:short) renders refs/remotes/origin/HEAD as the misleading
+        // bare label "origin" on some Git versions. Include %(symref) so those
+        // symbolic aliases can be removed without hiding real branches.
+        const remote = remoteOut.split('\n')
+          .map(line => {
+            const [name, symref] = line.split('\t')
+            return { name: name?.trim(), symref: symref?.trim() }
+          })
+          .filter(ref => ref.name && !ref.symref && !ref.name.endsWith('/HEAD'))
+          .map(ref => ref.name!)
         return { current, local, remote }
       } catch {
         return { current: '', local: [], remote: [] }
@@ -1497,12 +1505,24 @@ app.whenReady().then(async () => {
     wrap(async () => {
       if (!workingDir) return { ok: false, error: 'missing workingDir' }
       const { execFile } = await import('child_process')
-      return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
-        execFile('git', ['fetch', '--prune'], { cwd: workingDir, timeout: 30000 }, (err, _out, stderr) => {
-          if (err) resolve({ ok: false, error: (stderr || String(err)).trim() })
-          else resolve({ ok: true })
+      const run = (args: string[], timeout = 30000) => new Promise<{ ok: boolean; stdout: string; error?: string }>((resolve) => {
+        execFile('git', args, { cwd: workingDir, timeout }, (err, stdout, stderr) => {
+          if (err) resolve({ ok: false, stdout: stdout || '', error: (stderr || String(err)).trim() })
+          else resolve({ ok: true, stdout: stdout || '' })
         })
       })
+      const remotesResult = await run(['remote'], 3000)
+      if (!remotesResult.ok) return { ok: false, error: remotesResult.error }
+      const remotes = remotesResult.stdout.split('\n').map(remote => remote.trim()).filter(Boolean)
+      if (remotes.length === 0) return { ok: true }
+
+      // Explicitly fetch every head. Plain `git fetch --all` still honors a
+      // single-branch clone's narrow refspec and leaves the picker incomplete.
+      const results = await Promise.all(remotes.map(remote =>
+        run(['fetch', '--prune', remote, `+refs/heads/*:refs/remotes/${remote}/*`])
+      ))
+      const failed = results.find(result => !result.ok)
+      return failed ? { ok: false, error: failed.error } : { ok: true }
     })
   )
 

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -67,7 +67,16 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
 
   return (
     <div ref={ref} style={{ position: 'relative' }}>
-      <button style={styles.pill} onClick={() => setOpen(o => { if (!o) setNote(null); return !o })} title="Branch & worktree">
+      <button style={styles.pill} onClick={() => setOpen(o => {
+        if (!o) {
+          setNote(null)
+          // A branch may have been created by Codex/Terminal while the app was
+          // in the background. Refresh at the moment the user opens the menu
+          // instead of relying only on the .git watcher or 5s polling fallback.
+          void git.refresh()
+        }
+        return !o
+      })} title="Branch & worktree">
         <UIIcon name="code" size={14} /><span>{s?.branch ?? '—'}</span>
         {s && s.dirty > 0 && <span style={styles.dirty}>+{s.dirty}</span>}
         {boundLabel && <span style={styles.wt}><UIIcon name="workspace" size={13} />{boundLabel}</span>}
@@ -107,12 +116,13 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
               <input placeholder="Filter branches…" value={query}
                 onChange={e => setQuery(e.target.value)} style={styles.input} />
               <div style={styles.scroll}>
+                {localFiltered.length > 0 && <div style={styles.divider}>Local · {s?.local.length ?? 0}</div>}
                 {localFiltered.map(b => (
                   <button key={b} style={styles.item} disabled={b === s?.branch} onClick={() => doSwitch(b)}>
                     {b === s?.branch && <UIIcon name="check" size={13} />}{b}
                   </button>
                 ))}
-                {remoteFiltered.length > 0 && <div style={styles.divider}>Remote</div>}
+                {remoteFiltered.length > 0 && <div style={styles.divider}>Remote · {s?.remote.length ?? 0}</div>}
                 {remoteFiltered.map(b => (
                   <button key={b} style={styles.item} onClick={() => doSwitchRemote(b)}>
                     {b}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1754,20 +1754,22 @@ const styles: Record<string, React.CSSProperties> = {
     flexShrink: 0, maxWidth: 180,
   },
   openInWrap: { position: 'relative', flexShrink: 0 },
-  openInSplit: { display: 'inline-flex', alignItems: 'stretch' },
+  openInSplit: { display: 'inline-flex', alignItems: 'stretch', height: 32 },
   openInPrimary: {
     border: `1px solid ${C.border2}`, borderRadius: '6px 0 0 6px', padding: '4px 8px', background: C.surface3,
     color: C.fg2, cursor: 'pointer', fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 5,
+    height: 32, boxSizing: 'border-box',
   },
   openInDropdown: {
     border: `1px solid ${C.border2}`, borderLeft: 'none', borderRadius: '0 6px 6px 0', padding: '4px 6px', background: C.surface3,
     color: C.fg3, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    height: 32, boxSizing: 'border-box',
   },
   runSettingsWrap: { position: 'relative', flexShrink: 0 },
   runSettingsButton: {
     border: `1px solid ${C.border2}`, borderRadius: 6, padding: '4px 8px', background: C.surface3,
     color: C.fg2, cursor: 'pointer', fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 7,
-    maxWidth: 310, textAlign: 'left',
+    maxWidth: 310, textAlign: 'left', height: 32, boxSizing: 'border-box',
   },
   runSettingsButtonSummary: { color: C.fg2, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   runSettingsMenu: {
@@ -2026,6 +2028,11 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer',
     fontSize: 12,
     color: C.fg,
+    height: 32,
+    boxSizing: 'border-box',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   linkMenu: {
     position: 'absolute', top: 'calc(100% + 4px)', right: 0, zIndex: 1000,


### PR DESCRIPTION
## What changed

- refresh the Branch Picker immediately when it opens
- show local and remote branch counts
- fetch all remote heads even for single-branch clones
- hide symbolic remote aliases such as the misleading bare `origin` entry
- give the Open in split control, run configuration control, and header icon controls a consistent 32px height

## Why

The Branch Picker could show only `main` and `origin/main` even when many local and remote refs existed, and adjacent header controls could differ in height because their content used different font and icon sizes.

## Validation

- Mac renderer and Electron TypeScript checks passed
- Branch Picker tests passed (5/5)
- Mac production Vite/Electron build passed
