### PR TITLE
Preserve skill namespaces and release 0.9.4

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -9,7 +9,7 @@ import { decideNotification, createTurnTracker } from './chat-notifications'
 import { decideAutomationNotification, findUnseenRuns } from './automation-notifications'
 import { validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
-import { resolveUserPath, samePath, scanSkillsDir, uniqueSkills } from './skills'
+import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, uniqueSkills } from './skills'
 import type { ScannedSkill } from './skills'
 
 protocol.registerSchemesAsPrivileged([
@@ -2423,6 +2423,17 @@ app.whenReady().then(async () => {
     for (const dir of configuredUserSkillDirs(agentKey, home, pathMod)) {
       skills.push(...scanSkillsDir(fsMod, pathMod, dir, 'user'))
     }
+    if (agentKey === 'claude-code') {
+      const env = coreConfigManager?.get().agents?.['claude-code']?.env ?? {}
+      const configRoot = env.CLAUDE_CONFIG_DIR
+        ? resolveUserPath(pathMod, env.CLAUDE_CONFIG_DIR, home)
+        : pathMod.join(home, '.claude')
+      skills.push(...scanClaudePluginSkills(
+        fsMod,
+        pathMod,
+        pathMod.join(configRoot, 'plugins', 'installed_plugins.json'),
+      ))
+    }
 
     let projectDir: string | null = null
     const workingDir = getWorkingDir(fsMod, pathMod)
@@ -2449,7 +2460,7 @@ app.whenReady().then(async () => {
         source: 'gateway',
       }
       const skills: SlashCommand[] = skillResult.skills.map(skill => ({
-        name: skill.name,
+        name: skill.qualifiedName,
         description: skill.description || 'Agent skill',
         source: 'skill',
       }))
@@ -2457,8 +2468,13 @@ app.whenReady().then(async () => {
       // agent's own commands. A Set keeps the menu stable when a skill and an
       // agent command happen to share a name.
       const seen = new Set<string>()
+      const skillAliases = new Set(skills.flatMap(command => {
+        const separator = command.name.lastIndexOf(':')
+        return separator >= 0 ? [command.name.slice(separator + 1).toLowerCase()] : []
+      }))
       return [qq, ...skills, ...discovered].filter(command => {
         const key = command.name.toLowerCase()
+        if (command.source === 'agent' && skillAliases.has(key)) return false
         if (seen.has(key)) return false
         seen.add(key)
         return true
@@ -2505,12 +2521,20 @@ app.whenReady().then(async () => {
         }
         const rootSkillFile = pathMod.join(src, 'SKILL.md')
 
-        // A selected agent skills root is a collection, not one giant skill.
-        // Import its discovered children individually and never create the
-        // invalid <root>/skills self-copy that fs.cp rejects with EINVAL.
-        const sources = fsMod.existsSync(rootSkillFile)
-          ? [{ name: pathMod.basename(src), dir: src }]
-          : scanSkillsDir(fsMod, pathMod, src, 'user').map(skill => ({ name: pathMod.basename(skill.dir), dir: skill.dir }))
+        const discovered = fsMod.existsSync(rootSkillFile)
+          ? []
+          : scanSkillsDir(fsMod, pathMod, src, 'user')
+
+        // Preserve a named collection directory (for example `superpowers`)
+        // so its namespace survives installation. A generic `skills/` root is
+        // still imported child-by-child and never copied into itself.
+        const sourceName = pathMod.basename(src)
+        const preserveCollection = discovered.length > 0
+          && sourceName !== 'skills'
+          && !sourceName.startsWith('.')
+        const sources = fsMod.existsSync(rootSkillFile) || preserveCollection
+          ? [{ name: sourceName, dir: src }]
+          : discovered.map(skill => ({ name: pathMod.basename(skill.dir), dir: skill.dir }))
         if (sources.length === 0) throw new Error(`No SKILL.md found in: ${src}`)
 
         for (const source of sources) {

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { resolveUserPath, samePath, scanSkillsDir, uniqueSkills } from './skills'
+import { qualifySkillName, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, uniqueSkills } from './skills'
 
 const roots: string[] = []
 const temp = () => {
@@ -27,7 +27,54 @@ describe('agent skill discovery', () => {
     fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\r\nname: "Image Gen"\r\ndescription: Makes images\r\n---\r\n')
     fs.writeFileSync(path.join(skill, 'references', 'SKILL.md'), '---\nname: wrong\n---\n')
     expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
-      { name: 'Image Gen', description: 'Makes images', scope: 'user', dir: skill },
+      { name: 'Image Gen', qualifiedName: 'Image Gen', description: 'Makes images', scope: 'user', dir: skill },
+    ])
+  })
+
+  it('keeps a nested skill collection prefix in its command name', () => {
+    const root = temp()
+    const skill = path.join(root, 'superpowers', 'skills', 'brainstorming')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: brainstorming\ndescription: Explore ideas\n---\n')
+
+    expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
+      {
+        name: 'brainstorming',
+        qualifiedName: 'superpowers:brainstorming',
+        description: 'Explore ideas',
+        scope: 'user',
+        dir: skill,
+      },
+    ])
+  })
+
+  it('does not duplicate an explicit namespace from frontmatter', () => {
+    expect(qualifySkillName(path, '/skills', '/skills/superpowers/brainstorming', 'superpowers:brainstorming'))
+      .toBe('superpowers:brainstorming')
+  })
+
+  it('uses the Claude plugin id as the skill collection namespace', () => {
+    const root = temp()
+    const installPath = path.join(root, 'cache', 'superpowers', '4.1.1')
+    const skill = path.join(installPath, 'skills', 'brainstorming')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: brainstorming\n---\n')
+    const manifest = path.join(root, 'installed_plugins.json')
+    fs.writeFileSync(manifest, JSON.stringify({
+      plugins: {
+        'superpowers@superpowers-marketplace': [{ scope: 'user', installPath }],
+      },
+    }))
+
+    expect(scanClaudePluginSkills(fs, path, manifest)).toEqual([
+      {
+        name: 'brainstorming',
+        qualifiedName: 'superpowers:brainstorming',
+        managedBy: 'superpowers@superpowers-marketplace',
+        description: '',
+        scope: 'user',
+        dir: skill,
+      },
     ])
   })
 

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -5,6 +5,8 @@ export type SkillScope = 'user' | 'project'
 
 export interface ScannedSkill {
   name: string
+  qualifiedName: string
+  managedBy?: string
   description: string
   scope: SkillScope
   dir: string
@@ -36,6 +38,23 @@ function isDirectory(fsMod: typeof Fs, dir: string): boolean {
   try { return fsMod.statSync(dir).isDirectory() } catch { return false }
 }
 
+/** Preserve the collection namespace for skills nested below a shared root. */
+export function qualifySkillName(
+  pathMod: typeof Path,
+  root: string,
+  skillDir: string,
+  name: string,
+): string {
+  if (name.includes(':')) return name
+  const parts = pathMod.relative(pathMod.resolve(root), pathMod.resolve(skillDir))
+    .split(pathMod.sep)
+    .filter(Boolean)
+  if (parts.length < 2) return name
+  const collection = parts[0]
+  if (!collection || collection.startsWith('.') || collection === 'skills') return name
+  return `${collection}:${name}`
+}
+
 /**
  * Discover skills below an agent's configured root. Nested roots are supported
  * (for example Codex's .system skills); once SKILL.md is found, that directory
@@ -48,8 +67,9 @@ export function scanSkillsDir(
   scope: SkillScope,
 ): ScannedSkill[] {
   if (!isDirectory(fsMod, dir)) return []
+  const root = pathMod.resolve(dir)
   const result: ScannedSkill[] = []
-  const pending = [pathMod.resolve(dir)]
+  const pending = [root]
   const visited = new Set<string>()
 
   while (pending.length > 0) {
@@ -64,7 +84,14 @@ export function scanSkillsDir(
       try {
         const md = fsMod.readFileSync(skillMdPath, 'utf-8')
         const { name, description } = parseSkillFrontmatter(md)
-        result.push({ name: name || pathMod.basename(current), description, scope, dir: current })
+        const resolvedName = name || pathMod.basename(current)
+        result.push({
+          name: resolvedName,
+          qualifiedName: qualifySkillName(pathMod, root, current, resolvedName),
+          description,
+          scope,
+          dir: current,
+        })
       } catch { /* skip unreadable skill */ }
       continue
     }
@@ -79,6 +106,36 @@ export function scanSkillsDir(
   }
 
   return result.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/** Discover Claude plugin skills using the installed plugin id as namespace. */
+export function scanClaudePluginSkills(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  manifestPath: string,
+): ScannedSkill[] {
+  let manifest: any
+  try { manifest = JSON.parse(fsMod.readFileSync(manifestPath, 'utf-8')) } catch { return [] }
+  if (!manifest?.plugins || typeof manifest.plugins !== 'object') return []
+
+  const result: ScannedSkill[] = []
+  for (const [pluginId, rawInstalls] of Object.entries(manifest.plugins)) {
+    const collection = pluginId.split('@')[0]?.trim()
+    if (!collection || !Array.isArray(rawInstalls)) continue
+    for (const raw of rawInstalls) {
+      const install = raw as { installPath?: unknown; scope?: unknown }
+      if (typeof install.installPath !== 'string') continue
+      const scope: SkillScope = install.scope === 'project' ? 'project' : 'user'
+      for (const skill of scanSkillsDir(fsMod, pathMod, install.installPath, scope)) {
+        result.push({
+          ...skill,
+          qualifiedName: skill.name.includes(':') ? skill.name : `${collection}:${skill.name}`,
+          managedBy: pluginId,
+        })
+      }
+    }
+  }
+  return result.sort((a, b) => a.qualifiedName.localeCompare(b.qualifiedName))
 }
 
 export function samePath(fsMod: typeof Fs, pathMod: typeof Path, a: string, b: string): boolean {

--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -12,6 +12,8 @@ type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
 export interface SkillEntry {
   name: string
+  qualifiedName: string
+  managedBy?: string
   description: string
   scope: 'user' | 'project'
   dir: string

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -57,6 +57,9 @@ export const AppearanceTab: React.FC = () => {
   }, [])
 
   const toggleSkipPerms = (v: boolean) => {
+    if (v && !skipPerms && !window.confirm(
+      'Enable Skip permissions?\n\nAgents will be able to run shell commands, edit files, and make network requests without asking for confirmation.',
+    )) return
     setSkipPerms(v)
     window.codey?.config?.set?.({ gateway: { skipPermissions: v } }).catch(() => { /* ignore */ })
   }

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -80,7 +80,9 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
         <UIIcon name="code" size={14} /><span>{s?.branch ?? '—'}</span>
         {s && s.dirty > 0 && <span style={styles.dirty}>+{s.dirty}</span>}
         {boundLabel && <span style={styles.wt}><UIIcon name="workspace" size={13} />{boundLabel}</span>}
-        <span style={styles.caret}>⌄</span>
+        <span style={{ ...styles.caret, transform: open ? 'rotate(-90deg)' : 'rotate(90deg)' }}>
+          <UIIcon name="chevron" size={12} />
+        </span>
       </button>
 
       {open && (
@@ -161,7 +163,17 @@ const styles: Record<string, React.CSSProperties> = {
     overflow: 'hidden', whiteSpace: 'nowrap' },
   dirty: { color: C.yellow, opacity: 0.85 },
   wt: { color: C.green, display: 'inline-flex', alignItems: 'center', gap: 3 },
-  caret: { color: C.fg3 },
+  caret: {
+    color: C.fg3,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 14,
+    height: 14,
+    flexShrink: 0,
+    transformOrigin: 'center',
+    transition: 'transform 0.15s ease',
+  },
   menu: { position: 'absolute', top: 'calc(100% + 7px)', left: 0, zIndex: 20, width: 300,
     background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
     boxShadow: '0 14px 30px rgba(0,0,0,0.26)', padding: 8, display: 'flex', flexDirection: 'column', gap: 6 },

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -272,6 +272,14 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
             (count, chat) => count + (state.unreadChats[chat.id] ? 1 : 0),
             0,
           )
+          const runningCount = groups[ws].reduce(
+            (count, chat) => count + (state.inFlight[chat.id] ? 1 : 0),
+            0,
+          )
+          const attentionCount = groups[ws].reduce(
+            (count, chat) => count + (state.pendingPermissions[chat.id] ? 1 : 0),
+            0,
+          )
           return (
             <div key={ws}>
               <div
@@ -323,17 +331,35 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                     style={styles.renameInput}
                   />
                 ) : (
-                  <span style={styles.groupName}>{ws}</span>
+                  <span style={styles.groupIdentity}>
+                    <span style={styles.groupName}>{ws}</span>
+                    {ws === gatewayWorkspace && (
+                      <span style={styles.gatewayTag} title="Gateway default workspace — receives messages from chat platforms">
+                        Gateway
+                      </span>
+                    )}
+                  </span>
                 )}
-                {ws === gatewayWorkspace && (
-                  <span style={styles.gatewayBadge} title="Gateway default workspace — receives messages from chat platforms"/>
+                {attentionCount > 0 && (
+                  <span
+                    style={styles.attentionBadge}
+                    title={`${attentionCount} chat${attentionCount === 1 ? '' : 's'} need attention`}
+                    aria-label={`${attentionCount} chat${attentionCount === 1 ? '' : 's'} need attention`}
+                  >!</span>
+                )}
+                {runningCount > 0 && (
+                  <span
+                    style={styles.runningBadge}
+                    title={`${runningCount} chat${runningCount === 1 ? '' : 's'} running`}
+                    aria-label={`${runningCount} chat${runningCount === 1 ? '' : 's'} running`}
+                  ><UIIcon name="activity" size={12} /></span>
                 )}
                 {unreadCount > 0 && (
                   <span
-                    style={styles.unreadDot}
+                    style={styles.workspaceUnreadBadge}
                     title={`${unreadCount} unread chat${unreadCount === 1 ? '' : 's'}`}
                     aria-label={`${unreadCount} unread chat${unreadCount === 1 ? '' : 's'}`}
-                  />
+                  >{unreadCount}</span>
                 )}
                 <button
                   style={styles.groupAddBtn}
@@ -581,15 +607,30 @@ const styles: Record<string, React.CSSProperties> = {
   workspaceIcon: { color: C.fg3, display: 'inline-flex', flexShrink: 0 },
   groupHeaderDropTarget: { boxShadow: `inset 0 2px 0 ${C.accent}` },
   groupHeaderDragging: { opacity: 0.45 },
-  groupName: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  groupIdentity: { flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 6 },
+  groupName: { minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   groupAddBtn: {
     background: C.surface3, border: `1px solid ${C.border2}`, color: C.fg2,
     cursor: 'pointer', lineHeight: 1, padding: 3, borderRadius: 5, display: 'inline-flex',
   },
-  gatewayBadge: {
-    width: 8, height: 8, borderRadius: '50%',
-    background: C.green, boxShadow: `0 0 6px ${C.green}`,
-    flexShrink: 0,  
+  gatewayTag: {
+    color: C.fg3, background: C.surface3, border: `1px solid ${C.border2}`,
+    borderRadius: 4, padding: '1px 5px', fontSize: 9, fontWeight: 650,
+    lineHeight: 1.35, flexShrink: 0,
+  },
+  attentionBadge: {
+    width: 16, height: 16, borderRadius: 5, display: 'inline-flex', alignItems: 'center',
+    justifyContent: 'center', background: `${C.red}22`, color: C.red, fontSize: 11,
+    fontWeight: 800, flexShrink: 0,
+  },
+  runningBadge: {
+    width: 16, height: 16, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    color: C.green, flexShrink: 0, animation: 'codey-pulse-dot 1.2s infinite',
+  },
+  workspaceUnreadBadge: {
+    minWidth: 16, height: 16, borderRadius: 8, padding: '0 4px', boxSizing: 'border-box',
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    background: C.accent, color: C.onAccent, fontSize: 9, fontWeight: 750, flexShrink: 0,
   },
   chevron: { display: 'inline-flex', color: C.fg3, transition: 'transform 0.15s ease' },
   item: {

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -268,6 +268,10 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
         )}
         {groupNames.map(ws => {
           const collapsed = !!state.collapsedWorkspaces[ws]
+          const unreadCount = groups[ws].reduce(
+            (count, chat) => count + (state.unreadChats[chat.id] ? 1 : 0),
+            0,
+          )
           return (
             <div key={ws}>
               <div
@@ -323,6 +327,13 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                 )}
                 {ws === gatewayWorkspace && (
                   <span style={styles.gatewayBadge} title="Gateway default workspace — receives messages from chat platforms"/>
+                )}
+                {unreadCount > 0 && (
+                  <span
+                    style={styles.unreadDot}
+                    title={`${unreadCount} unread chat${unreadCount === 1 ? '' : 's'}`}
+                    aria-label={`${unreadCount} unread chat${unreadCount === 1 ? '' : 's'}`}
+                  />
                 )}
                 <button
                   style={styles.groupAddBtn}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1465,7 +1465,7 @@ export const ChatTab: React.FC<Props> = ({ chatId, isGatewayRunning, coreFailed 
                     <div style={styles.permissionActions}>
                       <button style={styles.permissionAllow} onClick={() => {
                         void resolvePermission(chatId, true).catch(err => alert(`Couldn’t grant permission: ${(err as Error).message}`))
-                      }}>Allow &amp; continue</button>
+                      }}>Accept</button>
                       <button style={styles.permissionDeny} onClick={() => { void resolvePermission(chatId, false) }}>Deny</button>
                     </div>
                   </div>

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -148,7 +148,7 @@ export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 })
           color: C.fg, fontSize: 13, fontWeight: 600,
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: 1,
         }}>
-          {skill.name}
+          {skill.qualifiedName}
         </span>
         <span style={{
           fontSize: 9, fontWeight: 600, letterSpacing: 0.3,
@@ -156,7 +156,7 @@ export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 })
           background: skill.scope === 'user' ? C.accentDim : C.surface3,
           color: skill.scope === 'user' ? C.accent : C.fg3,
         }}>
-          {skill.scope === 'user' ? 'User' : 'Project'}
+          {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
         </span>
       </div>
       {skill.description && (
@@ -189,14 +189,14 @@ export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 })
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-          <span style={{ color: C.fg, fontSize: 15, fontWeight: 700, flex: 1, minWidth: 0 }}>{skill.name}</span>
+          <span style={{ color: C.fg, fontSize: 15, fontWeight: 700, flex: 1, minWidth: 0 }}>{skill.qualifiedName}</span>
           <span style={{
             fontSize: 10, fontWeight: 600, letterSpacing: 0.3,
             padding: '2px 6px', borderRadius: 4,
             background: skill.scope === 'user' ? C.accentDim : C.surface3,
             color: skill.scope === 'user' ? C.accent : C.fg3,
           }}>
-            {skill.scope === 'user' ? 'User' : 'Project'}
+            {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
           </span>
           <button onClick={() => setSelected(null)} style={{ ...iconBtn, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }} title="Close" aria-label="Close"><UIIcon name="close" size={14} /></button>
         </div>
@@ -264,10 +264,12 @@ export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 })
           </div>
           <span style={{ flex: 1 }} />
           <button onClick={() => handleReveal(skill.dir)} style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="folder" size={14} />Reveal in Finder</button>
-          <button
-            onClick={() => { const s = skill; setSelected(null); void handleRemove(s) }}
-            style={{ ...pillButton('ghost'), color: C.red }}
-          ><UIIcon name="trash" size={14} />Remove</button>
+          {!skill.managedBy && (
+            <button
+              onClick={() => { const s = skill; setSelected(null); void handleRemove(s) }}
+              style={{ ...pillButton('ghost'), color: C.red }}
+            ><UIIcon name="trash" size={14} />Remove</button>
+          )}
         </div>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
@@ -12438,7 +12438,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12450,7 +12450,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codey/core",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codey/core",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What changed

- Preserve collection-qualified skill names such as `superpowers:brainstorming` in the Skills view and slash-command picker.
- Discover Claude plugin skills from `installed_plugins.json`, use the plugin id as the namespace, and suppress duplicate unqualified CLI entries.
- Preserve named collection directories when loading local skill bundles and protect plugin-managed skills from direct removal.
- Ask for confirmation before enabling Skip permissions.
- Center the Branch selector chevron and simplify the permission action to `Accept` while retaining automatic continuation.
- Clarify Workspace state with a `Gateway` role tag, running and attention icons, and an aggregate unread-count badge that remains visible while collapsed.
- Bump the monorepo, macOS app, core, and gateway versions to `0.9.4`.

## Why

Collection information was being lost during discovery and local installation, so plugin skills appeared without their original namespace. The permission and header controls also needed clearer, safer interaction behavior.

## Impact

Users can distinguish skills with the same name across collections, invoke Claude plugin skills using their canonical qualified name, and get a safety confirmation before bypassing permissions.

## Validation

- `vitest run electron/skills.test.ts` — 6 tests passed
- Renderer TypeScript check
- Electron TypeScript check
- Vite/Electron production build
- `git diff --check`
