### PR TITLE
Polish workspace sidebar and order by date added

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -759,7 +759,7 @@ async function bootInProcessCore() {
       fsMod.mkdirSync(defaultDir, { recursive: true })
       fsMod.writeFileSync(
         join(defaultDir, 'workspace.json'),
-        JSON.stringify({ workingDir: app.getPath('home'), teams: [] }, null, 2)
+        JSON.stringify({ workingDir: app.getPath('home'), createdAt: new Date().toISOString(), teams: [] }, null, 2)
       )
       fsMod.writeFileSync(join(defaultDir, 'memory.md'), '# default — Project Memory\n')
       existing = workspaceManager.listWorkspaces()

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -36,19 +36,6 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   const [wsRenameValue, setWsRenameValue] = useState('')
   const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
-  // User-defined workspace ordering (drag to reorder). Persisted locally; names
-  // not in the list fall back to alphabetical after the ordered ones.
-  const [wsOrder, setWsOrder] = useState<string[]>(() => {
-    try { const v = JSON.parse(localStorage.getItem('codey.workspaceOrder') || '[]'); return Array.isArray(v) ? v : [] }
-    catch { return [] }
-  })
-  const [draggingWs, setDraggingWs] = useState<string | null>(null)
-  const [dragOverWs, setDragOverWs] = useState<string | null>(null)
-
-  const persistWsOrder = (next: string[]) => {
-    setWsOrder(next)
-    localStorage.setItem('codey.workspaceOrder', JSON.stringify(next))
-  }
   const refreshWs = useCallback(() => {
     apiService.getCurrentWorkspace()
       .then(setGatewayWorkspace)
@@ -211,25 +198,14 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   for (const ws of workspaces) {
     if (!groups[ws]) groups[ws] = []
   }
-  // Order by the user's saved arrangement; unknown names sort alphabetically
-  // after the explicitly-ordered ones.
-  const orderIndex = (name: string) => {
-    const i = wsOrder.indexOf(name)
-    return i === -1 ? Number.MAX_SAFE_INTEGER : i
-  }
+  // The workspace manager returns newest-added first. Chats whose workspace
+  // has since been deleted remain grouped after the live workspaces.
+  const orderIndex = new Map(workspaces.map((name, index) => [name, index]))
   const groupNames = Object.keys(groups).sort((a, b) => {
-    const ia = orderIndex(a), ib = orderIndex(b)
+    const ia = orderIndex.get(a) ?? Number.MAX_SAFE_INTEGER
+    const ib = orderIndex.get(b) ?? Number.MAX_SAFE_INTEGER
     return ia !== ib ? ia - ib : a.localeCompare(b)
   })
-
-  const reorderWs = (dragged: string, target: string) => {
-    if (dragged === target) return
-    const without = groupNames.filter(n => n !== dragged)
-    const idx = without.indexOf(target)
-    if (idx === -1) return
-    without.splice(idx, 0, dragged)
-    persistWsOrder(without)
-  }
 
   return (
     <div style={styles.root}>
@@ -285,38 +261,15 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
               <div
                 style={{
                   ...styles.groupHeader,
-                  ...(dragOverWs === ws && draggingWs && draggingWs !== ws ? styles.groupHeaderDropTarget : null),
-                  ...(draggingWs === ws ? styles.groupHeaderDragging : null),
                 }}
-                draggable={renamingWs !== ws}
                 onClick={() => renamingWs === ws ? null : toggleWorkspace(ws)}
                 onContextMenu={(e) => {
                   e.preventDefault()
                   setWsMenu({ workspace: ws, x: e.clientX, y: e.clientY })
                 }}
-                onDragStart={(e) => {
-                  setDraggingWs(ws)
-                  e.dataTransfer.effectAllowed = 'move'
-                  // Some platforms require data to be set for drag to initiate.
-                  try { e.dataTransfer.setData('text/plain', ws) } catch { /* ignore */ }
-                }}
-                onDragOver={(e) => {
-                  if (!draggingWs) return
-                  e.preventDefault()
-                  e.dataTransfer.dropEffect = 'move'
-                  if (dragOverWs !== ws) setDragOverWs(ws)
-                }}
-                onDragLeave={() => { if (dragOverWs === ws) setDragOverWs(null) }}
-                onDrop={(e) => {
-                  e.preventDefault()
-                  if (draggingWs) reorderWs(draggingWs, ws)
-                  setDraggingWs(null)
-                  setDragOverWs(null)
-                }}
-                onDragEnd={() => { setDraggingWs(null); setDragOverWs(null) }}
               >
                 <span style={{ ...styles.chevron, transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)' }}><UIIcon name="chevron" size={13} /></span>
-                <span style={styles.workspaceIcon}><UIIcon name="folder" size={14} /></span>
+                <span style={styles.workspaceIcon}><UIIcon name={collapsed ? 'folder' : 'folder-open'} size={16} /></span>
                 {renamingWs === ws ? (
                   <input
                     autoFocus
@@ -334,8 +287,12 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                   <span style={styles.groupIdentity}>
                     <span style={styles.groupName}>{ws}</span>
                     {ws === gatewayWorkspace && (
-                      <span style={styles.gatewayTag} title="Gateway default workspace — receives messages from chat platforms">
-                        Gateway
+                      <span
+                        style={styles.gatewayIcon}
+                        title="Gateway default workspace — receives messages from chat platforms"
+                        aria-label="Gateway default workspace"
+                      >
+                        <UIIcon name="server" size={12} strokeWidth={2} />
                       </span>
                     )}
                   </span>
@@ -352,7 +309,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                     style={styles.runningBadge}
                     title={`${runningCount} chat${runningCount === 1 ? '' : 's'} running`}
                     aria-label={`${runningCount} chat${runningCount === 1 ? '' : 's'} running`}
-                  ><UIIcon name="activity" size={12} /></span>
+                  />
                 )}
                 {unreadCount > 0 && (
                   <span
@@ -604,18 +561,16 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer', userSelect: 'none',
   },
   workspaceIcon: { color: C.fg3, display: 'inline-flex', flexShrink: 0 },
-  groupHeaderDropTarget: { boxShadow: `inset 0 2px 0 ${C.accent}` },
-  groupHeaderDragging: { opacity: 0.45 },
   groupIdentity: { flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 6 },
   groupName: { minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   groupAddBtn: {
     background: C.surface3, border: `1px solid ${C.border2}`, color: C.fg2,
     cursor: 'pointer', lineHeight: 1, padding: 3, borderRadius: 5, display: 'inline-flex',
   },
-  gatewayTag: {
-    color: C.fg3, background: C.surface3, border: `1px solid ${C.border2}`,
-    borderRadius: 4, padding: '1px 5px', fontSize: 9, fontWeight: 650,
-    lineHeight: 1.35, flexShrink: 0,
+  gatewayIcon: {
+    color: C.accent, background: C.accentDim, border: `1px solid ${C.accent}55`,
+    borderRadius: 5, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    width: 18, height: 18, boxSizing: 'border-box', flexShrink: 0,
   },
   attentionBadge: {
     width: 16, height: 16, borderRadius: 5, display: 'inline-flex', alignItems: 'center',
@@ -623,8 +578,8 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 800, flexShrink: 0,
   },
   runningBadge: {
-    width: 16, height: 16, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-    color: C.green, flexShrink: 0, animation: 'codey-pulse-dot 1.2s infinite',
+    width: 7, height: 7, borderRadius: '50%', background: C.green,
+    flexShrink: 0, animation: 'codey-pulse-dot 1.2s infinite',
   },
   workspaceUnreadBadge: {
     minWidth: 16, height: 16, borderRadius: 8, padding: '0 4px', boxSizing: 'border-box',

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -8,6 +8,7 @@ import { UpdateButton } from './UpdateButton'
 import { setPendingPairing } from './pendingPairing'
 import { onWorkspacesChanged } from './workspacesChanged'
 import { UIIcon } from './UIIcons'
+import { moveWorkspace, reconcileWorkspaceOrder } from './workspaceOrder'
 
 interface Props {
   onOpenSettings: (tab?: string) => void
@@ -36,6 +37,14 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   const [wsRenameValue, setWsRenameValue] = useState('')
   const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
+  const [wsOrder, setWsOrder] = useState<string[]>(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('codey.workspaceOrder') || '[]')
+      return Array.isArray(saved) ? saved : []
+    } catch { return [] }
+  })
+  const [draggingWs, setDraggingWs] = useState<string | null>(null)
+  const [dragOverWs, setDragOverWs] = useState<string | null>(null)
   const refreshWs = useCallback(() => {
     apiService.getCurrentWorkspace()
       .then(setGatewayWorkspace)
@@ -43,6 +52,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
     apiService.getWorkspaces()
       .then(w => {
         setWorkspaces(w)
+        setWsOrder(prev => reconcileWorkspaceOrder(prev, w))
         setLastWorkspace(prev => {
           if (prev && w.includes(prev)) return prev
           const stored = localStorage.getItem('codey.lastWorkspace')
@@ -67,6 +77,10 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   useEffect(() => {
     if (lastWorkspace) localStorage.setItem('codey.lastWorkspace', lastWorkspace)
   }, [lastWorkspace])
+
+  useEffect(() => {
+    localStorage.setItem('codey.workspaceOrder', JSON.stringify(wsOrder))
+  }, [wsOrder])
 
   const selectedWorkspace = activeChatId ? state.chats[activeChatId]?.workspaceName : undefined
   const newChatWorkspace = selectedWorkspace || lastWorkspace
@@ -99,6 +113,10 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
       await apiService.renameWorkspace(oldName, newName)
       const fresh = await apiService.getWorkspaces()
       setWorkspaces(fresh)
+      setWsOrder(prev => reconcileWorkspaceOrder(
+        prev.map(name => name === oldName ? newName : name),
+        fresh,
+      ))
       await refreshWorkspaces()
       // Rename cascades to the chats' workspaceName on the backend; reload them
       // so they regroup under the new name instead of stranding the old group.
@@ -120,6 +138,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
       await apiService.deleteWorkspace(ws)
       const fresh = await apiService.getWorkspaces()
       setWorkspaces(fresh)
+      setWsOrder(prev => reconcileWorkspaceOrder(prev, fresh))
       await refreshWorkspaces()
       // Deleting a workspace also deletes its chats; drop them from the store so
       // the group disappears instead of lingering until a reload.
@@ -179,6 +198,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
       const name = await apiService.createWorkspaceFromDir(dir)
       const fresh = await apiService.getWorkspaces()
       setWorkspaces(fresh)
+      setWsOrder(prev => reconcileWorkspaceOrder(prev, fresh))
       await refreshWorkspaces()
       const chat = await createChat(name)
       setLastWorkspace(chat.workspaceName)
@@ -198,14 +218,18 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   for (const ws of workspaces) {
     if (!groups[ws]) groups[ws] = []
   }
-  // The workspace manager returns newest-added first. Chats whose workspace
-  // has since been deleted remain grouped after the live workspaces.
-  const orderIndex = new Map(workspaces.map((name, index) => [name, index]))
+  // The backend supplies the newest-added-first default. wsOrder preserves any
+  // drag override, while reconciliation inserts newly added workspaces on top.
+  const orderIndex = new Map(wsOrder.map((name, index) => [name, index]))
   const groupNames = Object.keys(groups).sort((a, b) => {
     const ia = orderIndex.get(a) ?? Number.MAX_SAFE_INTEGER
     const ib = orderIndex.get(b) ?? Number.MAX_SAFE_INTEGER
     return ia !== ib ? ia - ib : a.localeCompare(b)
   })
+
+  const reorderWs = (dragged: string, target: string) => {
+    setWsOrder(prev => moveWorkspace(prev, dragged, target))
+  }
 
   return (
     <div style={styles.root}>
@@ -261,12 +285,34 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
               <div
                 style={{
                   ...styles.groupHeader,
+                  ...(dragOverWs === ws && draggingWs && draggingWs !== ws ? styles.groupHeaderDropTarget : null),
+                  ...(draggingWs === ws ? styles.groupHeaderDragging : null),
                 }}
+                draggable={renamingWs !== ws}
                 onClick={() => renamingWs === ws ? null : toggleWorkspace(ws)}
                 onContextMenu={(e) => {
                   e.preventDefault()
                   setWsMenu({ workspace: ws, x: e.clientX, y: e.clientY })
                 }}
+                onDragStart={(e) => {
+                  setDraggingWs(ws)
+                  e.dataTransfer.effectAllowed = 'move'
+                  try { e.dataTransfer.setData('text/plain', ws) } catch { /* ignore */ }
+                }}
+                onDragOver={(e) => {
+                  if (!draggingWs) return
+                  e.preventDefault()
+                  e.dataTransfer.dropEffect = 'move'
+                  if (dragOverWs !== ws) setDragOverWs(ws)
+                }}
+                onDragLeave={() => { if (dragOverWs === ws) setDragOverWs(null) }}
+                onDrop={(e) => {
+                  e.preventDefault()
+                  if (draggingWs) reorderWs(draggingWs, ws)
+                  setDraggingWs(null)
+                  setDragOverWs(null)
+                }}
+                onDragEnd={() => { setDraggingWs(null); setDragOverWs(null) }}
               >
                 <span style={{ ...styles.chevron, transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)' }}><UIIcon name="chevron" size={13} /></span>
                 <span style={styles.workspaceIcon}><UIIcon name={collapsed ? 'folder' : 'folder-open'} size={16} /></span>
@@ -561,6 +607,8 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer', userSelect: 'none',
   },
   workspaceIcon: { color: C.fg3, display: 'inline-flex', flexShrink: 0 },
+  groupHeaderDropTarget: { boxShadow: `inset 0 2px 0 ${C.accent}` },
+  groupHeaderDragging: { opacity: 0.45 },
   groupIdentity: { flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 6 },
   groupName: { minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   groupAddBtn: {

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export type IconName =
   | 'activity' | 'add' | 'archive' | 'bot' | 'chat' | 'check' | 'chevron' | 'close'
-  | 'code' | 'folder' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'play' | 'plus'
+  | 'code' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'play' | 'plus'
   | 'refresh' | 'server' | 'settings' | 'sparkle' | 'tools' | 'trash' | 'users' | 'workspace'
 
 interface Props {
@@ -28,6 +28,7 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     close: <path {...common} d="M6 6l12 12M18 6L6 18" />,
     code: <><path {...common} d="M8 9l-3 3 3 3M16 9l3 3-3 3M14 6l-4 12" /></>,
     folder: <path {...common} d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />,
+    'folder-open': <><path {...common} d="M3 18V7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v1" /><path {...common} d="M3.2 19h15.2a2 2 0 001.94-1.51l1.25-5A2 2 0 0019.65 10H8l-2 3H3" /></>,
     key: <><circle {...common} cx="7.5" cy="15.5" r="3.5" /><path {...common} d="M10 13l8-8M15 6l3 3M13 8l3 3" /></>,
     link: <><path {...common} d="M10 13a5 5 0 007.07.07l2-2a5 5 0 00-7.07-7.07l-1.15 1.15" /><path {...common} d="M14 11a5 5 0 00-7.07-.07l-2 2A5 5 0 0012 20l1.15-1.15" /></>,
     mic: <><rect {...common} x="8" y="3" width="8" height="12" rx="4" /><path {...common} d="M5 11a7 7 0 0014 0M12 18v3M8 21h8" /></>,
@@ -37,9 +38,9 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     plus: <path {...common} d="M12 5v14M5 12h14" />,
     refresh: <><path {...common} d="M20 11a8 8 0 00-14.7-4.4L3 9" /><path {...common} d="M3 4v5h5M4 13a8 8 0 0014.7 4.4L21 15" /><path {...common} d="M21 20v-5h-5" /></>,
     server: <><rect {...common} x="3" y="4" width="18" height="6" rx="2" /><rect {...common} x="3" y="14" width="18" height="6" rx="2" /><path {...common} d="M7 7h.01M7 17h.01" /></>,
-    settings: <><circle {...common} cx="12" cy="12" r="3" /><path {...common} d="M19.4 15a1.7 1.7 0 00.34 1.88l.06.06-2.12 2.12-.06-.06a1.7 1.7 0 00-1.88-.34 1.7 1.7 0 00-1.03 1.56v.08h-3v-.08A1.7 1.7 0 0010.68 18.7a1.7 1.7 0 00-1.88.34l-.06.06-2.12-2.12.06-.06A1.7 1.7 0 007.02 15a1.7 1.7 0 00-1.56-1.03h-.08v-3h.08A1.7 1.7 0 007.02 9.94 1.7 1.7 0 006.68 8.06l-.06-.06 2.12-2.12.06.06a1.7 1.7 0 001.88.34 1.7 1.7 0 001.03-1.56v-.08h3v.08a1.7 1.7 0 001.03 1.56 1.7 1.7 0 001.88-.34l.06-.06 2.12 2.12-.06.06a1.7 1.7 0 00-.34 1.88 1.7 1.7 0 001.56 1.03h.08v3h-.08A1.7 1.7 0 0019.4 15z" /></>,
+    settings: <><path {...common} d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.09a2 2 0 011 1.74v.5a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.38a2 2 0 00-.73-2.73l-.15-.09a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z" /><circle {...common} cx="12" cy="12" r="3" /></>,
     sparkle: <path {...common} d="M12 3l1.5 5.5L19 10l-5.5 1.5L12 17l-1.5-5.5L5 10l5.5-1.5L12 3zM19 16l.7 2.3L22 19l-2.3.7L19 22l-.7-2.3L16 19l2.3-.7L19 16z" />,
-    tools: <><path {...common} d="M14.7 6.3a4.3 4.3 0 01-5.5 5.5L4 17v3h3l5.2-5.2a4.3 4.3 0 005.5-5.5l-2.5 2.5-2-2 2.5-2.5z" /></>,
+    tools: <path {...common} d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94z" />,
     trash: <><path {...common} d="M4 7h16M10 11v5M14 11v5M9 7l1-3h4l1 3M6 7l1 13h10l1-13" /></>,
     users: <><path {...common} d="M16 20v-1.5a4.5 4.5 0 00-4.5-4.5h-4A4.5 4.5 0 003 18.5V20M9.5 10a3.5 3.5 0 100-7 3.5 3.5 0 000 7zM17 11a3 3 0 000-6M21 20v-1.5A4.5 4.5 0 0017.5 14" /></>,
     workspace: <><rect {...common} x="3" y="4" width="18" height="16" rx="2" /><path {...common} d="M3 9h18M8 14h3" /></>,

--- a/codey-mac/src/components/workspaceOrder.test.ts
+++ b/codey-mac/src/components/workspaceOrder.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { moveWorkspace, reconcileWorkspaceOrder } from './workspaceOrder'
+
+describe('workspace ordering', () => {
+  it('uses newest-added-first order when no override exists', () => {
+    expect(reconcileWorkspaceOrder([], ['newest', 'middle', 'oldest']))
+      .toEqual(['newest', 'middle', 'oldest'])
+  })
+
+  it('preserves a custom order and puts newly added workspaces on top', () => {
+    expect(reconcileWorkspaceOrder(
+      ['oldest', 'middle', 'removed'],
+      ['newest', 'middle', 'oldest'],
+    )).toEqual(['newest', 'oldest', 'middle'])
+  })
+
+  it('moves a workspace before its drop target', () => {
+    expect(moveWorkspace(['newest', 'middle', 'oldest'], 'oldest', 'newest'))
+      .toEqual(['oldest', 'newest', 'middle'])
+  })
+})

--- a/codey-mac/src/components/workspaceOrder.ts
+++ b/codey-mac/src/components/workspaceOrder.ts
@@ -1,0 +1,17 @@
+/** Merge the backend's newest-first workspace list into a saved user order.
+ * Existing names keep their custom positions; newly added names go on top. */
+export function reconcileWorkspaceOrder(saved: string[], liveNewestFirst: string[]): string[] {
+  const live = new Set(liveNewestFirst)
+  const kept = saved.filter((name, index) => live.has(name) && saved.indexOf(name) === index)
+  const keptSet = new Set(kept)
+  return [...liveNewestFirst.filter(name => !keptSet.has(name)), ...kept]
+}
+
+export function moveWorkspace(order: string[], dragged: string, target: string): string[] {
+  if (dragged === target || !order.includes(dragged)) return order
+  const next = order.filter(name => name !== dragged)
+  const targetIndex = next.indexOf(target)
+  if (targetIndex === -1) return order
+  next.splice(targetIndex, 0, dragged)
+  return next
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -19,7 +19,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",
@@ -12438,7 +12438,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12450,7 +12450,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Codey — a gateway that routes prompts from chat platforms to coding agents",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -112,6 +112,27 @@ function makeWM(): TestWM {
   return new TestWM(workers, '/tmp/ws');
 }
 
+describe('WorkspaceManager workspace ordering', () => {
+  it('lists workspaces by date added, newest first', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-order-'));
+    const wsDir = path.join(root, 'workspaces');
+    fs.mkdirSync(path.join(wsDir, 'older'), { recursive: true });
+    fs.mkdirSync(path.join(wsDir, 'newer'), { recursive: true });
+    fs.writeFileSync(
+      path.join(wsDir, 'older', 'workspace.json'),
+      JSON.stringify({ workingDir: root, createdAt: '2026-01-01T00:00:00.000Z' }),
+    );
+    fs.writeFileSync(
+      path.join(wsDir, 'newer', 'workspace.json'),
+      JSON.stringify({ workingDir: root, createdAt: '2026-02-01T00:00:00.000Z' }),
+    );
+
+    const manager = new WorkspaceManager(new WorkerManager(path.join(root, 'workers')), wsDir);
+    expect(manager.listWorkspaces()).toEqual(['newer', 'older']);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
 const validGraph = {
   entry: 'start',
   maxHops: 5,

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -49,6 +49,8 @@ export interface TeamConfig {
 
 export interface WorkspaceJson {
   workingDir: string;
+  /** ISO timestamp recorded when the workspace was first added to Codey. */
+  createdAt?: string;
   /**
    * Names of global teams enabled for this workspace. Definitions live in the
    * gateway-level team library; this is just the opt-in list.
@@ -136,7 +138,7 @@ export class WorkspaceManager {
         fs.mkdirSync(fallbackPath, { recursive: true });
         fs.writeFileSync(
           path.join(fallbackPath, 'workspace.json'),
-          JSON.stringify({ workingDir: process.cwd() }, null, 2),
+          JSON.stringify({ workingDir: process.cwd(), createdAt: new Date().toISOString() }, null, 2),
         );
         this.currentWorkspace = fallback;
       }
@@ -290,7 +292,7 @@ export class WorkspaceManager {
     const workspacePath = path.join(this.workspacesDir, name);
     fs.mkdirSync(workspacePath, { recursive: true });
 
-    const config: WorkspaceJson = { workingDir: dir };
+    const config: WorkspaceJson = { workingDir: dir, createdAt: new Date().toISOString() };
     fs.writeFileSync(path.join(workspacePath, 'workspace.json'), JSON.stringify(config, null, 2));
     fs.writeFileSync(path.join(workspacePath, 'memory.md'), `# ${name} — Project Memory\n`);
 
@@ -436,7 +438,24 @@ export class WorkspaceManager {
       // filters out stray dirs (logs/, memory/) that may have leaked into
       // the workspaces root.
       return fs.existsSync(path.join(dir, 'workspace.json'));
-    });
+    }).map(name => {
+      const dir = path.join(this.workspacesDir, name);
+      const configPath = path.join(dir, 'workspace.json');
+      let addedAt = 0;
+      try {
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as WorkspaceJson;
+        const parsed = config.createdAt ? Date.parse(config.createdAt) : NaN;
+        if (Number.isFinite(parsed)) addedAt = parsed;
+      } catch { /* keep the filesystem fallback below */ }
+      // Existing workspaces predate createdAt. Directory birth time is the
+      // closest durable equivalent to the date they were added.
+      if (!addedAt) {
+        const stat = fs.statSync(dir);
+        addedAt = stat.birthtimeMs || stat.ctimeMs;
+      }
+      return { name, addedAt };
+    }).sort((a, b) => b.addedAt - a.addedAt || a.name.localeCompare(b.name))
+      .map(({ name }) => name);
   }
 
   getTeam(name: string): TeamConfig | undefined {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- replace the Gateway text pill with a highlighted server icon while preserving the green running indicator
- refine the Settings and Tools SVGs and show a larger open-folder icon for expanded workspaces
- order workspaces newest-added first using a durable `createdAt` value with a filesystem fallback for existing workspaces
- preserve user-defined drag-and-drop ordering while inserting newly added workspaces at the top
- bump the monorepo version from 0.9.4 to 0.9.5

## Why

The workspace header had too much visual weight, several shell icons rendered unevenly, and workspace ordering was driven by local manual state instead of when projects were added.

## Impact

Workspace headers are more compact and stateful, expanded folders are easier to distinguish, and the initial workspace order remains chronological across app sessions. Users can customize that order by dragging; later additions appear at the top without resetting the custom arrangement. Existing workspaces migrate without a config rewrite by falling back to directory creation time.

## Validation

- Mac app TypeScript check
- Core TypeScript check
- Vite production build (renderer, Electron main, and preload)
- Mac app test suite: 204 passed
- Workspace manager tests: 13 passed
