### PR TITLE
Clean up leaked temp dirs in gateway chat tests

### DIFF
--- a/packages/gateway/src/chats.discussion.test.ts
+++ b/packages/gateway/src/chats.discussion.test.ts
@@ -1,13 +1,24 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { Chat, DiscussionMeta } from '@codey/core';
 import { ChatManager } from './chats';
 
+const roots: string[] = [];
+function tmpRoot(prefix: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
 describe('Chat.discussion metadata', () => {
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
   it('roundtrips through persistence', () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-discussion-'));
+    const root = tmpRoot('codey-chats-discussion-');
     fs.mkdirSync(path.join(root, 'main'), { recursive: true });
 
     const mgr = new ChatManager(root);
@@ -42,12 +53,10 @@ describe('Chat.discussion metadata', () => {
     fs.writeFileSync(chatFile, JSON.stringify(raw, null, 2), 'utf8');
     const reloaded2 = new ChatManager(root);
     expect(reloaded2.get(chat.id)?.discussion).toEqual(terminated);
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it('deletes the discussion directory when the chat is deleted', () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-del-'));
+    const root = tmpRoot('codey-chats-del-');
     fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
     const mgr = new ChatManager(root);
     const chat = mgr.create({ workspaceName: 'demo', title: 't' });
@@ -56,6 +65,5 @@ describe('Chat.discussion metadata', () => {
     fs.writeFileSync(path.join(discDir, 'topic.md'), 'x');
     mgr.delete(chat.id);
     expect(fs.existsSync(discDir)).toBe(false);
-    fs.rmSync(root, { recursive: true, force: true });
   });
 });

--- a/packages/gateway/src/chats.fallbackHeal.test.ts
+++ b/packages/gateway/src/chats.fallbackHeal.test.ts
@@ -1,11 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { ChatManager } from './chats';
 
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
 function tmpRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+  roots.push(root);
   fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
   return root;
 }

--- a/packages/gateway/src/chats.taskBrief.test.ts
+++ b/packages/gateway/src/chats.taskBrief.test.ts
@@ -1,12 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { ChatManager } from './chats';
 import type { TaskBrief } from '@codey/core';
 
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
 function tmpManager(): { mgr: ChatManager; root: string } {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+  roots.push(root);
   fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
   return { mgr: new ChatManager(root), root };
 }

--- a/packages/gateway/src/chats.test.ts
+++ b/packages/gateway/src/chats.test.ts
@@ -7,75 +7,78 @@ import { ChatManager } from './chats';
 
 async function run() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
-  fs.mkdirSync(path.join(root, 'main'), { recursive: true });
+  try {
+    fs.mkdirSync(path.join(root, 'main'), { recursive: true });
 
-  const mgr = new ChatManager(root);
-  const chat = mgr.create({ workspaceName: 'main', title: 't' });
+    const mgr = new ChatManager(root);
+    const chat = mgr.create({ workspaceName: 'main', title: 't' });
 
-  const r = mgr.addRoute(chat.id, {
-    channel: 'telegram',
-    channelUserId: 'u1',
-    channelChatId: 'c1',
-    attachedAt: 1,
-  });
-  assert.strictEqual(r.routes?.length, 1);
-  assert.strictEqual(r.routes?.[0].channel, 'telegram');
-  assert.strictEqual(r.routes?.[0].channelChatId, 'c1');
+    const r = mgr.addRoute(chat.id, {
+      channel: 'telegram',
+      channelUserId: 'u1',
+      channelChatId: 'c1',
+      attachedAt: 1,
+    });
+    assert.strictEqual(r.routes?.length, 1);
+    assert.strictEqual(r.routes?.[0].channel, 'telegram');
+    assert.strictEqual(r.routes?.[0].channelChatId, 'c1');
 
-  mgr.addRoute(chat.id, {
-    channel: 'telegram',
-    channelUserId: 'u1',
-    channelChatId: 'c1',
-    attachedAt: 2,
-  });
-  assert.strictEqual(mgr.get(chat.id)?.routes?.length, 1);
+    mgr.addRoute(chat.id, {
+      channel: 'telegram',
+      channelUserId: 'u1',
+      channelChatId: 'c1',
+      attachedAt: 2,
+    });
+    assert.strictEqual(mgr.get(chat.id)?.routes?.length, 1);
 
-  const found = mgr.findByRoute('telegram', 'u1');
-  assert.strictEqual(found?.id, chat.id);
-  assert.strictEqual(mgr.findByRoute('telegram', 'other'), undefined);
+    const found = mgr.findByRoute('telegram', 'u1');
+    assert.strictEqual(found?.id, chat.id);
+    assert.strictEqual(mgr.findByRoute('telegram', 'other'), undefined);
 
-  const after = mgr.removeRoute(chat.id, 'telegram', 'u1');
-  assert.strictEqual(after.routes?.length ?? 0, 0);
-  assert.strictEqual(mgr.findByRoute('telegram', 'u1'), undefined);
+    const after = mgr.removeRoute(chat.id, 'telegram', 'u1');
+    assert.strictEqual(after.routes?.length ?? 0, 0);
+    assert.strictEqual(mgr.findByRoute('telegram', 'u1'), undefined);
 
-  const r2 = mgr.addRoute(chat.id, {
-    channel: 'discord',
-    channelUserId: 'd1',
-    channelChatId: 'dc1',
-    attachedAt: 3,
-  });
-  assert.strictEqual(r2.routes?.length, 1);
-  const reloaded = new ChatManager(root);
-  assert.strictEqual(reloaded.findByRoute('discord', 'd1')?.id, chat.id);
+    const r2 = mgr.addRoute(chat.id, {
+      channel: 'discord',
+      channelUserId: 'd1',
+      channelChatId: 'dc1',
+      attachedAt: 3,
+    });
+    assert.strictEqual(r2.routes?.length, 1);
+    const reloaded = new ChatManager(root);
+    assert.strictEqual(reloaded.findByRoute('discord', 'd1')?.id, chat.id);
 
-  // pendingTeam round-trip
-  const pending = {
-    mode: 'sequential' as const,
-    teamName: 'review',
-    task: 'audit pr',
-    teamTurnId: 'test-turn-id',
-    memberIndex: 1,
-    carry: 'previous output',
-    askingWorker: 'reviewer',
-    question: 'should I include style nits?',
-    askedAt: 1_700_000_000_000,
-  };
-  mgr.setPendingTeam(chat.id, pending);
-  assert.deepStrictEqual(mgr.get(chat.id)?.pendingTeam, pending);
+    // pendingTeam round-trip
+    const pending = {
+      mode: 'sequential' as const,
+      teamName: 'review',
+      task: 'audit pr',
+      teamTurnId: 'test-turn-id',
+      memberIndex: 1,
+      carry: 'previous output',
+      askingWorker: 'reviewer',
+      question: 'should I include style nits?',
+      askedAt: 1_700_000_000_000,
+    };
+    mgr.setPendingTeam(chat.id, pending);
+    assert.deepStrictEqual(mgr.get(chat.id)?.pendingTeam, pending);
 
-  const reloadedForPending = new ChatManager(root);
-  assert.deepStrictEqual(reloadedForPending.get(chat.id)?.pendingTeam, pending);
+    const reloadedForPending = new ChatManager(root);
+    assert.deepStrictEqual(reloadedForPending.get(chat.id)?.pendingTeam, pending);
 
-  mgr.setPendingTeam(chat.id, null);
-  assert.strictEqual(mgr.get(chat.id)?.pendingTeam, undefined);
+    mgr.setPendingTeam(chat.id, null);
+    assert.strictEqual(mgr.get(chat.id)?.pendingTeam, undefined);
 
-  // Note: pendingSkillSuggestion coverage lives in
-  // chats.pendingSkillSuggestion.test.ts (vitest, runs in CI).
-  // Note: fallback-title heal coverage lives in chats.fallbackHeal.test.ts
-  // (a vitest file that actually runs in CI; this script is ts-node only).
+    // Note: pendingSkillSuggestion coverage lives in
+    // chats.pendingSkillSuggestion.test.ts (vitest, runs in CI).
+    // Note: fallback-title heal coverage lives in chats.fallbackHeal.test.ts
+    // (a vitest file that actually runs in CI; this script is ts-node only).
 
-  fs.rmSync(root, { recursive: true, force: true });
-  console.log('chats.test ok');
+    console.log('chats.test ok');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }
 
 run().catch(e => { console.error(e); process.exit(1); });

--- a/packages/gateway/src/chats.workingDirOverride.test.ts
+++ b/packages/gateway/src/chats.workingDirOverride.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -12,6 +12,7 @@ describe('ChatManager.setWorkingDirOverride', () => {
     fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
     mgr = new ChatManager(root);
   });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
 
   it('sets and clears the override', () => {
     const chat = mgr.create({ workspaceName: 'ws' });


### PR DESCRIPTION
## Summary
- The `chats.*.test.ts` suites in `packages/gateway` created `codey-chats-*` directories under `os.tmpdir()` but several never removed them, accumulating dozens of stale folders in `/var/folders/.../T` after each test/watch run.
- `chats.workingDirOverride.test.ts`, `chats.taskBrief.test.ts`, and `chats.fallbackHeal.test.ts` had no cleanup at all; they now remove every dir they create in `afterEach` hooks.
- `chats.discussion.test.ts` cleaned up inline at the end of each test (skipped on assertion failure); cleanup moved to `afterEach` via a shared `tmpRoot` helper.
- The ts-node-only `chats.test.ts` script now wraps its body in `try/finally` so the dir is removed even when an assertion throws.

## Test plan
- [x] All 6 vitest files pass (13 tests)
- [x] `npx ts-node packages/gateway/src/chats.test.ts` passes
- [x] Temp-dir count in `$TMPDIR` is identical before and after a full run (zero leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THQKLXVq8rQETVVpQ7fjVv