### PR TITLE
Add per-run activity logs to automation details

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1960,6 +1960,10 @@ app.whenReady().then(async () => {
     wrap(async () => inProcessGateway?.listAutomationRuns(id, limit) ?? [])
   )
 
+  ipcMain.handle('automations:runLog', async (_e, id: string, runId: string) =>
+    wrap(async () => inProcessGateway?.getAutomationRunLog(id, runId) ?? null)
+  )
+
   ipcMain.handle('automations:markSeen', async (_e, id: string, runId: string) =>
     wrap(async () => {
       inProcessGateway?.markAutomationRunSeen(id, runId)

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -44,6 +44,7 @@ contextBridge.exposeInMainWorld('codey', {
     runChat: (id: string) => ipcRenderer.invoke('automations:runChat', id),
     resume: (id: string, runId: string, answer: string) => ipcRenderer.invoke('automations:resume', id, runId, answer),
     history: (id: string, limit?: number) => ipcRenderer.invoke('automations:history', id, limit),
+    runLog: (id: string, runId: string) => ipcRenderer.invoke('automations:runLog', id, runId),
     markSeen: (id: string, runId: string) => ipcRenderer.invoke('automations:markSeen', id, runId),
     chatStart: (mode: 'create' | 'edit', automationId?: string) => ipcRenderer.invoke('automations:chat:start', mode, automationId),
     chatSend: (sessionId: string, text: string) => ipcRenderer.invoke('automations:chat:send', sessionId, text),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -75,6 +75,7 @@ declare global {
         runChat: (id: string) => Promise<IpcResult<{ chatId: string }>>
         resume: (id: string, runId: string, answer: string) => Promise<IpcResult<AutomationRun>>
         history: (id: string, limit?: number) => Promise<IpcResult<AutomationRun[]>>
+        runLog: (id: string, runId: string) => Promise<IpcResult<string | null>>
         markSeen: (id: string, runId: string) => Promise<IpcResult<void>>
         chatStart: (mode: 'create' | 'edit', automationId?: string) => Promise<IpcResult<ChatStep>>
         chatSend: (sessionId: string, text: string) => Promise<IpcResult<ChatStep>>

--- a/codey-mac/src/components/AutomationOnePager.tsx
+++ b/codey-mac/src/components/AutomationOnePager.tsx
@@ -10,6 +10,7 @@ import {
 } from './automationsModel'
 import type { Automation, AutomationRun } from '../../../packages/core/src/types/automation'
 import { UIIcon } from './UIIcons'
+import { Markdown } from './Markdown'
 
 const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
 const DAY = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -66,6 +67,10 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
   const [deleting, setDeleting] = useState(false)
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [resuming, setResuming] = useState<Record<string, boolean>>({})
+  // Per-run activity log expander: open flags + lazily fetched text
+  // (undefined = not fetched, null = fetched but no log exists).
+  const [logOpen, setLogOpen] = useState<Record<string, boolean>>({})
+  const [logText, setLogText] = useState<Record<string, string | null>>({})
   // Last automation the knobs were seeded from — lets refresh() tell "user is
   // mid-edit" apart from "an external edit changed the automation".
   const aRef = useRef<Automation | null>(null)
@@ -135,6 +140,18 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
     } catch (e: any) {
       setError(e?.message ?? String(e))
       setDeleting(false)
+    }
+  }
+
+  const toggleLog = async (runId: string) => {
+    const opening = !logOpen[runId]
+    setLogOpen(prev => ({ ...prev, [runId]: opening }))
+    if (!opening || logText[runId] !== undefined) return
+    try {
+      const text = unwrap(await window.codey.automations.runLog(id, runId))
+      setLogText(prev => ({ ...prev, [runId]: text }))
+    } catch {
+      setLogText(prev => ({ ...prev, [runId]: null }))
     }
   }
 
@@ -319,8 +336,18 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
                     />
                   </div>
                 )}
-                {r.output && <pre style={preStyle}>{r.output}</pre>}
+                {r.output && <div style={outputStyle}><Markdown variant="assistant">{r.output}</Markdown></div>}
                 {r.error && <pre style={{ ...preStyle, color: C.red }}>{r.error}</pre>}
+                <button style={logToggleStyle} onClick={() => void toggleLog(r.runId)}>
+                  {logOpen[r.runId] ? 'Hide full log' : 'Full log'}
+                </button>
+                {logOpen[r.runId] && (
+                  logText[r.runId] === undefined
+                    ? <div style={{ color: C.fg3, fontSize: 11, marginTop: 6 }}>Loading…</div>
+                    : logText[r.runId]
+                      ? <pre style={{ ...preStyle, maxHeight: 260, overflowY: 'auto' }}>{logText[r.runId]}</pre>
+                      : <div style={{ color: C.fg3, fontSize: 11, marginTop: 6 }}>No activity log for this run.</div>
+                )}
               </div>
             ))}
           </div>
@@ -370,6 +397,17 @@ const setupRow: React.CSSProperties = {
 
 const cardStyle: React.CSSProperties = {
   background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10, padding: '12px 14px',
+}
+
+const logToggleStyle: React.CSSProperties = {
+  marginTop: 8, padding: '3px 10px', fontSize: 11, borderRadius: 6, cursor: 'pointer',
+  border: `1px solid ${C.border2}`, background: 'transparent', color: C.fg2,
+}
+
+const outputStyle: React.CSSProperties = {
+  marginTop: 8, padding: '8px 10px', borderRadius: 6,
+  background: C.codeBg ?? C.surface3, color: C.codeFg ?? C.fg2,
+  fontSize: 12, lineHeight: 1.5, wordBreak: 'break-word',
 }
 
 const preStyle: React.CSSProperties = {

--- a/docs/superpowers/specs/2026-07-18-automation-run-activity-log-design.md
+++ b/docs/superpowers/specs/2026-07-18-automation-run-activity-log-design.md
@@ -1,0 +1,41 @@
+# Automation run activity log
+
+Date: 2026-07-18. Status: approved (chat).
+
+## Problem
+
+Automation run records persist only the agent's final response (capped at
+`OUTPUT_CAP` = 32k). The rich `ChatStreamEvent` stream produced during a run —
+tool calls with inputs/outputs, team worker steps, errors — is discarded by the
+no-op sink in `Gateway.runAutomationTurn`. Users cannot see what an automation
+actually *did*, only what it said.
+
+## Design
+
+**Capture.** `runAutomationTurn` gains a real sink when a `runId` is supplied:
+each `ChatStreamEvent` is formatted into a timestamped text line
+(`formatRunLogEvent` in `packages/gateway/src/automations/run-log.ts`) and
+appended to a per-run log file. `stream`/`thinking` token events are skipped
+(one token per event, redundant with the final output). Per-event payloads
+(tool input JSON, tool output) are truncated to 2,000 chars.
+
+**Plumbing.** `AutomationEngine` deps change to `runTarget(a, runId)` and
+`resumeTarget(a, answer, runId)`; `execute()` passes `run.runId` to the exec
+callback. A resumed run logs to its own new runId (linked via `resumedFrom`).
+
+**Storage.** `~/.codey/automation-runs/<automationId>/<runId>.log`, plain text,
+append-only. `AutomationStore.appendRunLog / readRunLog`; the directory is
+removed together with the run history on `delete()`. Log write failures never
+fail the run.
+
+**Surface.** `Gateway.getAutomationRunLog(id, runId)` → Mac app IPC
+`automations:runLog` → preload → renderer. In `AutomationOnePager`'s Runs tab
+each run row gets a lazy "Full log" expander rendering the log in a scrollable
+monospace block; runs without a file show "No activity log for this run."
+
+## Out of scope
+
+Capturing the agent CLI's internal session transcript (not visible to Codey's
+adapters), log rotation/caps beyond per-event truncation, daemon HTTP API
+exposure (Mac app reads via in-process gateway; files are shared under
+`~/.codey` either way).

--- a/packages/gateway/src/automations/engine.test.ts
+++ b/packages/gateway/src/automations/engine.test.ts
@@ -153,7 +153,7 @@ describe('resume', () => {
     const a = seed();
     store.appendRun(a.id, { runId: 'r0', startedAt: now, status: 'parked', trigger: 'schedule', question: 'q' });
     await makeEngine().resume(a.id, 'r0', 'use option a');
-    expect(deps.resumeTarget).toHaveBeenCalledWith(expect.objectContaining({ id: a.id }), 'use option a');
+    expect(deps.resumeTarget).toHaveBeenCalledWith(expect.objectContaining({ id: a.id }), 'use option a', expect.any(String));
     const [latest] = store.listRuns(a.id);
     expect(latest).toMatchObject({ status: 'resumed', resumedFrom: 'r0', output: 'resumed ok' });
   });

--- a/packages/gateway/src/automations/engine.ts
+++ b/packages/gateway/src/automations/engine.ts
@@ -15,10 +15,12 @@ export interface TargetResult { output: string; parked?: ParkedInfo; error?: str
 export interface EngineDeps {
   store: AutomationStore;
   lease: SchedulerLease;
-  /** Execute the automation's rendered brief headlessly (gateway adapter). */
-  runTarget: (a: Automation) => Promise<TargetResult>;
-  /** Feed an answer into the parked continuation (gateway adapter). */
-  resumeTarget: (a: Automation, answer: string) => Promise<TargetResult>;
+  /** Execute the automation's rendered brief headlessly (gateway adapter).
+   *  `runId` identifies the run for per-run activity logging. */
+  runTarget: (a: Automation, runId: string) => Promise<TargetResult>;
+  /** Feed an answer into the parked continuation (gateway adapter).
+   *  `runId` is the NEW (resuming) run's id, not the parked one's. */
+  resumeTarget: (a: Automation, answer: string, runId: string) => Promise<TargetResult>;
   /** Deliver report.channel / prep notify. Returns a failure description or undefined. */
   report: (a: Automation, run: AutomationRun) => Promise<string | undefined>;
   onEvent?: (ev: AutomationEvent) => void;
@@ -88,7 +90,7 @@ export class AutomationEngine {
     if (this.active.has(id)) { this.log(`skip ${a.name}: previous run still active`); return null; }
     const latest = this.deps.store.listRuns(id, 1)[0];
     if (latest?.status === 'parked') { this.log(`skip ${a.name}: parked run awaiting an answer`); return null; }
-    return this.execute(a, trigger, res => this.deps.runTarget(res));
+    return this.execute(a, trigger, (auto, runId) => this.deps.runTarget(auto, runId));
   }
 
   /** Answer a parked run's question; appends a linked 'resumed' record. */
@@ -98,7 +100,7 @@ export class AutomationEngine {
     const parked = this.deps.store.listRuns(id).find(r => r.runId === runId);
     if (!parked || parked.status !== 'parked') throw new Error(`Run ${runId} is not parked`);
     if (this.active.has(id)) throw new Error(`Automation ${a.name} already has an active run`);
-    const run = await this.execute(a, parked.trigger, auto => this.deps.resumeTarget(auto, answer), runId);
+    const run = await this.execute(a, parked.trigger, (auto, newRunId) => this.deps.resumeTarget(auto, answer, newRunId), runId);
     // The attempt consumed the parked continuation whether it succeeded or
     // failed, so the original run must stop being answerable — the "not
     // parked" rejection above then also catches second answers.
@@ -109,7 +111,7 @@ export class AutomationEngine {
   private async execute(
     a: Automation,
     trigger: 'manual' | 'schedule',
-    exec: (a: Automation) => Promise<TargetResult>,
+    exec: (a: Automation, runId: string) => Promise<TargetResult>,
     resumedFrom?: string,
   ): Promise<AutomationRun> {
     this.active.add(a.id);
@@ -118,7 +120,7 @@ export class AutomationEngine {
     };
     this.emit({ type: 'run-started', automationId: a.id, runId: run.runId });
     try {
-      const res = await exec(a);
+      const res = await exec(a, run.runId);
       run.output = capOutput(res.output ?? '');
       if (res.parked) {
         run.status = 'parked';

--- a/packages/gateway/src/automations/run-log.test.ts
+++ b/packages/gateway/src/automations/run-log.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AutomationStore } from './store';
+import { formatRunLogEvent, EVENT_PAYLOAD_CAP } from './run-log';
+import type { ChatStreamEvent } from '../chat-runner';
+
+const T = Date.UTC(2026, 6, 18, 12, 0, 0);
+const STAMP = '[2026-07-18T12:00:00.000Z]';
+
+describe('formatRunLogEvent', () => {
+  it('formats tool_start with one-lined, capped input', () => {
+    const e: ChatStreamEvent = {
+      type: 'tool_start', chatId: 'c', tool: 'Bash',
+      message: 'running', input: { command: 'ls\n-la' },
+    };
+    expect(formatRunLogEvent(e, T)).toBe(`${STAMP} tool_start Bash {"command":"ls\\n-la"}`);
+  });
+
+  it('formats tool_end and truncates long output', () => {
+    const e: ChatStreamEvent = {
+      type: 'tool_end', chatId: 'c', tool: 'Bash', message: 'done',
+      output: 'x'.repeat(EVENT_PAYLOAD_CAP + 10),
+    };
+    const line = formatRunLogEvent(e, T)!;
+    expect(line.startsWith(`${STAMP} tool_end Bash → ${'x'.repeat(20)}`)).toBe(true);
+    expect(line.endsWith('… [truncated]')).toBe(true);
+    expect(line.length).toBeLessThan(EVENT_PAYLOAD_CAP + 100);
+  });
+
+  it('formats team and worker lifecycle events', () => {
+    expect(formatRunLogEvent(
+      { type: 'team_start', chatId: 'c', teamTurnId: 't', teamName: 'devs', mode: 'sequential' }, T,
+    )).toBe(`${STAMP} team_start devs (sequential)`);
+    expect(formatRunLogEvent(
+      { type: 'worker_start', chatId: 'c', teamTurnId: 't', messageId: 'm', step: 2, worker: 'coder', agent: 'claude-code', model: 'sonnet' }, T,
+    )).toBe(`${STAMP} worker_start #2 coder [claude-code/sonnet]`);
+    expect(formatRunLogEvent(
+      { type: 'worker_end', chatId: 'c', messageId: 'm', step: 2, status: 'done', durationSec: 12, tokens: 340 }, T,
+    )).toBe(`${STAMP} worker_end #2 done (12s) 340 tokens`);
+  });
+
+  it('collapses multi-line messages to one log line', () => {
+    const line = formatRunLogEvent({ type: 'error', chatId: 'c', message: 'boom\n  at foo' }, T)!;
+    expect(line).toBe(`${STAMP} error boom ⏎ at foo`);
+    expect(line).not.toContain('\n');
+  });
+
+  it('summarizes done and permission_denials', () => {
+    expect(formatRunLogEvent(
+      { type: 'done', chatId: 'c', response: 'r', tokens: 100, durationSec: 5, agent: 'claude-code' }, T,
+    )).toBe(`${STAMP} done agent=claude-code tokens=100 duration=5s`);
+    expect(formatRunLogEvent(
+      { type: 'permission_denials', chatId: 'c', denials: [{ toolName: 'Bash' }, { toolName: 'Write' }] }, T,
+    )).toBe(`${STAMP} permission_denied Bash, Write`);
+  });
+
+  it('skips token-level events', () => {
+    expect(formatRunLogEvent({ type: 'stream', chatId: 'c', token: 'a' }, T)).toBeNull();
+    expect(formatRunLogEvent({ type: 'thinking', chatId: 'c', token: 'a' }, T)).toBeNull();
+  });
+});
+
+describe('AutomationStore run logs', () => {
+  let dir: string;
+  let store: AutomationStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-runlog-'));
+    store = new AutomationStore(dir);
+  });
+
+  it('appends and reads back lines per run', () => {
+    store.appendRunLog('auto-1', 'run-a', 'line 1');
+    store.appendRunLog('auto-1', 'run-a', 'line 2');
+    store.appendRunLog('auto-1', 'run-b', 'other run');
+    expect(store.readRunLog('auto-1', 'run-a')).toBe('line 1\nline 2\n');
+    expect(store.readRunLog('auto-1', 'run-b')).toBe('other run\n');
+  });
+
+  it('returns undefined for runs with no log', () => {
+    expect(store.readRunLog('auto-1', 'missing')).toBeUndefined();
+  });
+
+  it('rejects path-escaping ids', () => {
+    store.appendRunLog('auto-1', '../evil', 'nope');
+    expect(fs.existsSync(path.join(dir, 'automation-runs', 'evil.log'))).toBe(false);
+    expect(store.readRunLog('../..', 'x')).toBeUndefined();
+  });
+
+  it('removes the log directory when the automation is deleted', () => {
+    const a = store.create({
+      name: 'n', enabled: true,
+      target: { kind: 'prompt', workspaceName: 'default' },
+      brief: 'b', params: {}, report: { notify: 'none' },
+    }, 1000);
+    store.appendRunLog(a.id, 'run-a', 'line');
+    const logDir = path.join(dir, 'automation-runs', a.id);
+    expect(fs.existsSync(logDir)).toBe(true);
+    store.delete(a.id);
+    expect(fs.existsSync(logDir)).toBe(false);
+  });
+});

--- a/packages/gateway/src/automations/run-log.ts
+++ b/packages/gateway/src/automations/run-log.ts
@@ -1,0 +1,67 @@
+// packages/gateway/src/automations/run-log.ts
+//
+// Formats ChatStreamEvents into the per-run activity-log lines persisted at
+// automation-runs/<automationId>/<runId>.log. Token-level events (stream,
+// thinking) return null — one token per event, redundant with the run's
+// persisted final output.
+import type { ChatStreamEvent } from '../chat-runner';
+
+/** Per-event payload cap (tool input JSON, tool output, messages). */
+export const EVENT_PAYLOAD_CAP = 2_000;
+
+function cap(s: string): string {
+  if (s.length <= EVENT_PAYLOAD_CAP) return s;
+  return `${s.slice(0, EVENT_PAYLOAD_CAP)}… [truncated]`;
+}
+
+/** Multi-line payloads collapse to one log line each. */
+function oneLine(s: string): string {
+  return s.replace(/\s*\n\s*/g, ' ⏎ ');
+}
+
+export function formatRunLogEvent(e: ChatStreamEvent, now: number): string | null {
+  const t = new Date(now).toISOString();
+  switch (e.type) {
+    case 'tool_start': {
+      const input = e.input ? ` ${cap(oneLine(JSON.stringify(e.input)))}` : '';
+      return `[${t}] tool_start ${e.tool ?? '?'}${input}`;
+    }
+    case 'tool_end': {
+      const output = e.output ? ` → ${cap(oneLine(e.output))}` : '';
+      return `[${t}] tool_end ${e.tool ?? '?'}${output}`;
+    }
+    case 'team_start':
+      return `[${t}] team_start ${e.teamName} (${e.mode})`;
+    case 'worker_start': {
+      const agent = e.agent ? ` [${e.agent}${e.model ? `/${e.model}` : ''}]` : '';
+      const reason = e.reason ? ` — ${cap(oneLine(e.reason))}` : '';
+      return `[${t}] worker_start #${e.step} ${e.worker}${agent}${reason}`;
+    }
+    case 'worker_end': {
+      const duration = e.durationSec != null ? ` (${e.durationSec}s)` : '';
+      const tokens = e.tokens != null ? ` ${e.tokens} tokens` : '';
+      return `[${t}] worker_end #${e.step} ${e.status}${duration}${tokens}`;
+    }
+    case 'info':
+      return `[${t}] info ${cap(oneLine(e.message))}`;
+    case 'error':
+      return `[${t}] error ${cap(oneLine(e.message))}`;
+    case 'permission_denials':
+      return `[${t}] permission_denied ${e.denials.map(d => d.toolName).join(', ')}`;
+    case 'queued':
+      return `[${t}] queued position=${e.position}`;
+    case 'stopped':
+      return `[${t}] stopped`;
+    case 'done': {
+      const parts = [
+        e.agent ? `agent=${e.agent}` : '',
+        e.model ? `model=${e.model}` : '',
+        e.tokens != null ? `tokens=${e.tokens}` : '',
+        e.durationSec != null ? `duration=${e.durationSec}s` : '',
+      ].filter(Boolean).join(' ');
+      return `[${t}] done${parts ? ` ${parts}` : ''}`;
+    }
+    default:
+      return null; // stream, thinking
+  }
+}

--- a/packages/gateway/src/automations/store.ts
+++ b/packages/gateway/src/automations/store.ts
@@ -98,6 +98,7 @@ export class AutomationStore {
       raw.automations = raw.automations.filter(a => a.id !== id);
     });
     try { fs.unlinkSync(this.runFile(id)); } catch { /* no history yet */ }
+    try { fs.rmSync(this.runLogDir(id), { recursive: true, force: true }); } catch { /* no logs yet */ }
   }
 
   setEnabled(id: string, enabled: boolean, now: number): Automation {
@@ -135,6 +136,35 @@ export class AutomationStore {
     }
     runs.reverse();
     return limit !== undefined ? runs.slice(0, limit) : runs;
+  }
+
+  // ---- run activity logs ----
+
+  private runLogDir(id: string): string {
+    return path.join(this.runsDir, id);
+  }
+
+  private runLogFile(id: string, runId: string): string {
+    return path.join(this.runLogDir(id), `${runId}.log`);
+  }
+
+  /** IDs come over IPC — refuse anything that could escape runsDir. */
+  private static isSafeId(s: string): boolean {
+    return /^[\w-]+$/.test(s);
+  }
+
+  /** Append one activity-log line. Failures are the caller's to swallow —
+   *  logging must never fail a run. */
+  appendRunLog(id: string, runId: string, line: string): void {
+    if (!AutomationStore.isSafeId(id) || !AutomationStore.isSafeId(runId)) return;
+    fs.mkdirSync(this.runLogDir(id), { recursive: true });
+    fs.appendFileSync(this.runLogFile(id, runId), line + '\n', 'utf8');
+  }
+
+  /** Full activity log for a run, or undefined if none was written. */
+  readRunLog(id: string, runId: string): string | undefined {
+    if (!AutomationStore.isSafeId(id) || !AutomationStore.isSafeId(runId)) return undefined;
+    try { return fs.readFileSync(this.runLogFile(id, runId), 'utf8'); } catch { return undefined; }
   }
 
   /** Read-patch-rewrite (atomic). Caps retained history at MAX_HISTORY_REWRITE. */

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -10,6 +10,7 @@ import { AutomationChatManager, ChatStep } from './automations/chat';
 import { DryRunManager } from './automations/dry-run';
 import { detectParked } from './automations/parked';
 import { formatRunSummary } from './automations/report';
+import { formatRunLogEvent } from './automations/run-log';
 import { ConfigManager } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, ChannelHandler } from './channels';
 import { AgentFactory } from '@codey/core';
@@ -894,8 +895,8 @@ export class Codey {
     this.automationEngine = new AutomationEngine({
       store: this.automationStore,
       lease: new SchedulerLease(path.join(base, 'automation-scheduler.lock'), role),
-      runTarget: (a) => this.runAutomationTurn(a, renderBrief(a.brief, a.params)),
-      resumeTarget: (a, answer) => this.runAutomationTurn(a, answer, { resume: true }),
+      runTarget: (a, runId) => this.runAutomationTurn(a, renderBrief(a.brief, a.params), { runId }),
+      resumeTarget: (a, answer, runId) => this.runAutomationTurn(a, answer, { resume: true, runId }),
       report: (a, run) => this.deliverAutomationReport(a, run),
       onEvent: (ev) => { try { this.automationEventListener?.(ev); } catch { /* swallow */ } },
       log: (msg) => this.logger.info(`[automations] ${msg}`),
@@ -960,7 +961,7 @@ export class Codey {
    * collecting sink, then decide parked/success from the persisted chat state.
    * Resume is the same call — sendToChat's pendingTeam continuation handles it.
    */
-  private async runAutomationTurn(a: Automation, text: string, opts?: { resume?: boolean }): Promise<TargetResult> {
+  private async runAutomationTurn(a: Automation, text: string, opts?: { resume?: boolean; runId?: string }): Promise<TargetResult> {
     // Automation chats are shared across the daemon and embedded gateways;
     // the in-memory cache may be stale. Refresh before the pendingTeam
     // handling below — an embedded process resuming a daemon-parked run must
@@ -978,7 +979,16 @@ export class Codey {
     if (!opts?.resume && this.chatManager.get(chatId)?.pendingTeam) {
       this.chatManager.setPendingTeam(chatId, null);
     }
-    const sink: ChatStreamSink = () => { /* headless — response comes from the return value */ };
+    // Headless — the response comes from the return value, but the event
+    // stream is the run's activity log (tool calls, worker steps, errors).
+    const runId = opts?.runId;
+    const sink: ChatStreamSink = runId
+      ? (e) => {
+          const line = formatRunLogEvent(e, Date.now());
+          if (!line) return;
+          try { this.automationStore?.appendRunLog(a.id, runId, line); } catch { /* logging must never fail the run */ }
+        }
+      : () => { /* dry-run and other unlogged turns */ };
     try {
       const { response } = await this.sendToChat(chatId, text, sink);
       const parked = detectParked(this.chatManager.get(chatId), a.target, response);
@@ -1086,6 +1096,10 @@ export class Codey {
   }
   markAutomationRunSeen(id: string, runId: string): void {
     this.automationStore?.markSeen(id, runId, Date.now());
+  }
+  /** Per-run activity log (tool calls, worker steps), or undefined if none. */
+  getAutomationRunLog(id: string, runId: string): string | undefined {
+    return this.automationStore?.readRunLog(id, runId);
   }
   runAutomationNow(id: string): Promise<AutomationRun | null> {
     return this.requireAutomationEngine().runNow(id, 'manual');


### PR DESCRIPTION
## Summary
- Automation runs previously threw away their live event stream (`runAutomationTurn` used a no-op sink), so run history showed only the 32k-capped final response. Each run now writes a per-run activity log — tool calls with inputs/outputs, team worker steps, errors, and a final done summary — to `~/.codey/automation-runs/<automationId>/<runId>.log`.
- The Mac app's automation Runs tab gains a lazy **Full log** expander per run, and run output is now rendered as markdown instead of raw `<pre>` text.
- Design spec: `docs/superpowers/specs/2026-07-18-automation-run-activity-log-design.md`.

## Implementation notes
- `run-log.ts` formats `ChatStreamEvent`s into timestamped one-line entries (2k chars/event cap); token-level `stream`/`thinking` events are skipped as redundant with the persisted output.
- `AutomationEngine` deps changed to `runTarget(a, runId)` / `resumeTarget(a, answer, runId)`; resumed runs log under their own new runId (linked by `resumedFrom`).
- `AutomationStore.appendRunLog`/`readRunLog` validate both ids (they arrive over IPC) against path escapes; the log dir is removed on automation delete; log-write failures never fail the run.
- Surface: `Gateway.getAutomationRunLog` → `automations:runLog` IPC → preload → `AutomationOnePager`.

## Testing
- New `run-log.test.ts`: formatter cases (truncation, multi-line collapse, team/worker events, skipped token events) + store append/read/path-safety/delete-cleanup.
- Full workspace suite passes: core 180, gateway 151, codey-mac 212.
- Manual: run an automation from the app and expand "Full log" on the new run (old runs show "No activity log for this run").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016otnosaZV7uDDX3YAzXcyN