### PR TITLE
Fix native browser editor input

### DIFF
--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -52,6 +52,7 @@ describe('BrowserController agent controls', () => {
       getTitle: vi.fn(() => 'Example Dashboard'),
       executeJavaScript: vi.fn(async (_script: string) => executeResult),
       sendInputEvent: vi.fn(),
+      insertText: vi.fn(),
       debugger: {
         isAttached: vi.fn(() => debuggerAttached),
         attach: vi.fn(() => { debuggerAttached = true }),
@@ -136,12 +137,34 @@ describe('BrowserController agent controls', () => {
     expect(script).not.toContain('sessionStorage')
   })
 
-  it('safely embeds field values and dispatches the page-side fill script', async () => {
+  it('fills through Chromium native editing so stateful editors receive the text', async () => {
     const { controller, contents } = setup(true)
     await controller.fill('e4', `Jack's "post"`)
     const script = contents.executeJavaScript.mock.calls[0][0]
-    expect(script).toContain(`Jack's \\"post\\"`)
-    expect(script).toContain("dispatchEvent(new InputEvent('input'")
+    expect(script).toContain('range.selectNodeContents(el)')
+    expect(script).toContain('el.select()')
+    expect(script).not.toContain(`Jack's`)
+    expect(contents.insertText).toHaveBeenCalledWith(`Jack's "post"`)
+  })
+
+  it('sends a character event for the space key', async () => {
+    const { controller, contents } = setup(true)
+    await controller.press('Space', 'e4')
+    expect(contents.sendInputEvent.mock.calls.map(call => call[0])).toEqual([
+      { type: 'keyDown', keyCode: 'Space', modifiers: [] },
+      { type: 'char', keyCode: ' ', modifiers: [] },
+      { type: 'keyUp', keyCode: 'Space', modifiers: [] },
+    ])
+  })
+
+  it('clears a field through native editing when fill receives empty text', async () => {
+    const { controller, contents } = setup(true)
+    await controller.fill('e4', '')
+    expect(contents.insertText).not.toHaveBeenCalled()
+    expect(contents.sendInputEvent.mock.calls.map(call => call[0])).toEqual([
+      { type: 'keyDown', keyCode: 'Backspace' },
+      { type: 'keyUp', keyCode: 'Backspace' },
+    ])
   })
 
   it('supports coordinate clicks and drag gestures for maps and canvases', async () => {

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -615,26 +615,36 @@ export class BrowserController {
   async fill(ref: string, value: string): Promise<BrowserActionResult> {
     this.assertRef(ref)
     const contents = this.requirePage()
+    // Select through the DOM, then insert through Chromium's native editing
+    // pipeline. Assigning textContent/value only changes the rendered DOM and
+    // leaves stateful editors (Draft.js, ProseMirror, X's composer, etc.)
+    // unaware of the new text.
     await contents.executeJavaScript(`(() => {
       const el = document.querySelector('[data-codey-ref="${ref}"]')
       if (!el) throw new Error('Element ${ref} is no longer available; take a new snapshot')
       if (el.disabled || el.getAttribute('aria-disabled') === 'true') throw new Error('Element ${ref} is disabled')
-      const value = ${JSON.stringify(value)}
       el.focus()
       if (el.isContentEditable) {
-        el.textContent = value
+        const selection = window.getSelection()
+        const range = document.createRange()
+        range.selectNodeContents(el)
+        selection?.removeAllRanges()
+        selection?.addRange(range)
       } else if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
-        const prototype = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype
-        const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set
-        if (!setter) throw new Error('Element ${ref} cannot be filled')
-        setter.call(el, value)
+        el.select()
       } else {
         throw new Error('Element ${ref} is not a text field')
       }
-      el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }))
-      el.dispatchEvent(new Event('change', { bubbles: true }))
       return true
     })()`, true)
+    if (value) {
+      contents.insertText(value)
+    } else {
+      // insertText('') does not replace the active selection, so preserve the
+      // expected "fill with empty text" behavior through the same native path.
+      contents.sendInputEvent({ type: 'keyDown', keyCode: 'Backspace' })
+      contents.sendInputEvent({ type: 'keyUp', keyCode: 'Backspace' })
+    }
     return this.actionResult(`Filled ${ref}`)
   }
 
@@ -680,8 +690,8 @@ export class BrowserController {
       })()`, true)
     }
     const parts = key.split('+').filter(Boolean)
-    const keyCode = parts.pop()
-    if (!keyCode) throw new Error('A key is required')
+    const requestedKey = parts.pop()
+    if (!requestedKey) throw new Error('A key is required')
     const modifiers = parts.map(part => part.toLowerCase()).map(part => {
       if (part === 'cmd' || part === 'command' || part === 'meta') return 'meta'
       if (part === 'ctrl' || part === 'control') return 'control'
@@ -689,9 +699,11 @@ export class BrowserController {
       if (part === 'shift') return 'shift'
       throw new Error(`Unsupported key modifier: ${part}`)
     }) as Array<'meta' | 'control' | 'alt' | 'shift'>
+    const keyCode = [' ', 'space', 'spacebar'].includes(requestedKey.toLowerCase()) ? 'Space' : requestedKey
     contents.sendInputEvent({ type: 'keyDown', keyCode, modifiers })
-    if (keyCode.length === 1 && modifiers.length === 0) {
-      contents.sendInputEvent({ type: 'char', keyCode })
+    const printable = keyCode === 'Space' ? ' ' : keyCode.length === 1 && modifiers.length === 0 ? keyCode : undefined
+    if (printable !== undefined) {
+      contents.sendInputEvent({ type: 'char', keyCode: printable, modifiers })
     }
     contents.sendInputEvent({ type: 'keyUp', keyCode, modifiers })
     return this.actionResult(`Pressed ${key}${ref ? ` on ${ref}` : ''}`)


### PR DESCRIPTION
## Summary

- route browser `fill` operations through Chromium's native editing pipeline
- emit a real character event for the Space key
- preserve clearing behavior for empty fills
- add regression coverage for stateful editors, spaces, and empty values

## Root cause

The browser controller assigned `textContent` or `value` directly and then dispatched synthetic DOM events. Rich controlled editors such as X's composer rendered that text cosmetically without updating their internal editor state. The `press` implementation also skipped character events for named Space keys, making multi-word key-by-key input impossible.

## Impact

Browser automation can now enter multi-word content into controlled rich-text editors using trusted Chromium input, including X's composer.

## Validation

- `npm test` in `codey-mac`: 33 test files passed, 261 tests passed
- `git diff --check`
