### PR TITLE
Refactor automation creation, schedules, and management UI

### DIFF
--- a/codey-mac/electron/automation-validate.test.ts
+++ b/codey-mac/electron/automation-validate.test.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect } from 'vitest'
-import { validateSchedule, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
+import { validateSchedule, validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 
 describe('validateSchedule', () => {
-  it('accepts a valid schedule (times shape and legacy single) and no schedule at all', () => {
+  it('accepts a valid schedule (slots shape and legacy forms) and no schedule at all', () => {
+    expect(() => validateSchedule({ slots: [{ hour: 9, minute: 30 }], tz: 'Asia/Shanghai' })).not.toThrow()
+    expect(() => validateSchedule({ slots: [{ hour: 9, minute: 0, daysOfWeek: [1, 2, 3] }, { hour: 18, minute: 0, daysOfWeek: [4, 5] }], tz: 'UTC' })).not.toThrow()
     expect(() => validateSchedule({ times: [{ hour: 9, minute: 30 }], tz: 'Asia/Shanghai' })).not.toThrow()
-    expect(() => validateSchedule({ times: [{ hour: 9, minute: 0 }, { hour: 18, minute: 0 }], tz: 'UTC' })).not.toThrow()
     expect(() => validateSchedule({ hour: 9, minute: 30, tz: 'Asia/Shanghai' })).not.toThrow() // legacy
     expect(() => validateSchedule(undefined)).not.toThrow()
   })
 
   it('rejects an empty or non-array times', () => {
+    expect(() => validateSchedule({ slots: [], tz: 'UTC' })).toThrow(/slots/)
+    expect(() => validateSchedule({ slots: 'daily', tz: 'UTC' })).toThrow(/slots/)
     expect(() => validateSchedule({ times: [], tz: 'UTC' })).toThrow(/times/)
     expect(() => validateSchedule({ times: 'daily', tz: 'UTC' })).toThrow(/times/)
   })
@@ -26,19 +29,59 @@ describe('validateSchedule', () => {
     expect(() => validateSchedule({ times: [{ hour: 9, minute: 0 }], tz: 'Beijing' })).toThrow(/time zone/)
     expect(() => validateSchedule({ times: [{ hour: 9, minute: 0 }] })).toThrow(/time zone/)
   })
+
+  it('validates weekday values', () => {
+    expect(() => validateSchedule({ slots: [{ hour: 9, minute: 0, daysOfWeek: [1, 5] }], tz: 'UTC' })).not.toThrow()
+    expect(() => validateSchedule({ slots: [{ hour: 9, minute: 0, daysOfWeek: [7] }], tz: 'UTC' })).toThrow(/daysOfWeek/)
+    expect(() => validateSchedule({ times: [{ hour: 9, minute: 0 }], daysOfWeek: [], tz: 'UTC' })).not.toThrow()
+    expect(() => validateSchedule({ times: [{ hour: 9, minute: 0 }], daysOfWeek: [1, 5], tz: 'UTC' })).not.toThrow()
+    expect(() => validateSchedule({ times: [{ hour: 9, minute: 0 }], daysOfWeek: [7], tz: 'UTC' })).toThrow(/daysOfWeek/)
+    expect(() => validateSchedule({ times: [{ hour: 9, minute: 0 }], daysOfWeek: 'weekdays', tz: 'UTC' })).toThrow(/daysOfWeek/)
+  })
 })
 
 describe('validateAutomationDraft / validateAutomationPatch', () => {
-  it('requires a valid report.notify on create, only present fields on update', () => {
-    expect(() => validateAutomationDraft({ report: { notify: true } })).toThrow(/report\.notify/) // booleans are not modes
+  const validDraft = (over: Record<string, unknown> = {}) => ({
+    name: 'News', enabled: true,
+    target: { kind: 'prompt', workspaceName: 'default' },
+    brief: 'Post the news.', params: {}, report: { notify: 'none' },
+    ...over,
+  })
+
+  it('requires a complete valid definition on create', () => {
+    expect(() => validateAutomationDraft(validDraft())).not.toThrow()
+    expect(() => validateAutomationDraft(validDraft({ report: { notify: true } }))).toThrow(/report\.notify/) // booleans are not modes
     for (const mode of ['all', 'failure', 'success', 'none']) {
-      expect(() => validateAutomationDraft({ report: { notify: mode } })).not.toThrow()
+      expect(() => validateAutomationDraft(validDraft({ report: { notify: mode } }))).not.toThrow()
     }
-    expect(() => validateAutomationDraft({})).toThrow(/report\.notify/)
-    expect(() => validateAutomationDraft({ report: { notify: 'yes' } })).toThrow(/report\.notify/)
+    expect(() => validateAutomationDraft({})).toThrow(/name/)
+    expect(() => validateAutomationDraft(validDraft({ name: ' ' }))).toThrow(/name/)
+    expect(() => validateAutomationDraft(validDraft({ target: { kind: 'team', workspaceName: 'default' } }))).toThrow(/target/)
+    expect(() => validateAutomationDraft(validDraft({ params: { count: 3 } }))).toThrow(/params/)
+    expect(() => validateAutomationDraft(validDraft({ id: 'caller-chosen' }))).toThrow(/cannot be changed/)
+  })
+
+  it('allows only mutable, valid fields on update', () => {
     expect(() => validateAutomationPatch({ name: 'x' })).not.toThrow() // no schedule on the patch
     expect(() => validateAutomationPatch({ schedule: { hour: 9, minute: 0, tz: 'Beijing' } })).toThrow(/time zone/)
     expect(() => validateAutomationPatch({ report: { notify: 'failure' } })).not.toThrow()
     expect(() => validateAutomationPatch({ report: { notify: 'sometimes' } })).toThrow(/report\.notify/)
+    expect(() => validateAutomationPatch({ createdAt: 123 })).toThrow(/cannot be changed/)
+    expect(() => validateAutomationPatch({ chatId: 'other' })).toThrow(/cannot be changed/)
+    expect(() => validateAutomationPatch(null)).toThrow(/patch must be an object/)
+  })
+})
+
+describe('validateAutomationChatPatch', () => {
+  it('accepts draft fields and explicit clears', () => {
+    expect(() => validateAutomationChatPatch({ name: 'News', notify: 'failure' })).not.toThrow()
+    expect(() => validateAutomationChatPatch({ schedule: null, brief: null })).not.toThrow()
+    expect(() => validateAutomationChatPatch({ target: { kind: 'team', workspaceName: 'default', teamName: 'news' } })).not.toThrow()
+  })
+
+  it('rejects persisted/internal fields and malformed values', () => {
+    expect(() => validateAutomationChatPatch({ id: 'x' })).toThrow(/cannot be changed/)
+    expect(() => validateAutomationChatPatch({ notify: 'sometimes' })).toThrow(/notify/)
+    expect(() => validateAutomationChatPatch({ params: { count: 3 } })).toThrow(/params/)
   })
 })

--- a/codey-mac/electron/automation-validate.ts
+++ b/codey-mac/electron/automation-validate.ts
@@ -23,20 +23,35 @@ function validateTime(t: unknown): void {
   }
 }
 
+function validateDays(days: unknown): void {
+  if (days !== undefined && (!Array.isArray(days) || !days.every(d => Number.isInteger(d) && d >= 0 && d <= 6))) {
+    throw new Error('invalid schedule: daysOfWeek must contain integers 0-6')
+  }
+}
+
 /** Throws Error('invalid schedule: ...') when the schedule shape is bad.
- *  Accepts the current {times: [...]} shape and the legacy single
- *  {hour, minute} shape (the store normalizes legacy data on read). */
+ *  Accepts current {slots: [...]} schedules plus both legacy shapes. */
 export function validateSchedule(schedule: unknown): void {
   if (schedule === undefined || schedule === null) return // manual-only is fine
-  const s = schedule as { times?: unknown; tz?: unknown }
+  const s = schedule as { slots?: unknown; times?: unknown; tz?: unknown; daysOfWeek?: unknown }
   if (typeof s !== 'object') throw new Error('invalid schedule: must be an object')
-  if (s.times !== undefined) {
+  if (s.slots !== undefined) {
+    if (!Array.isArray(s.slots) || s.slots.length === 0) {
+      throw new Error('invalid schedule: slots must be a non-empty array')
+    }
+    for (const slot of s.slots) {
+      validateTime(slot)
+      validateDays((slot as { daysOfWeek?: unknown }).daysOfWeek)
+    }
+  } else if (s.times !== undefined) {
     if (!Array.isArray(s.times) || s.times.length === 0) {
       throw new Error('invalid schedule: times must be a non-empty array')
     }
     for (const t of s.times) validateTime(t)
+    validateDays(s.daysOfWeek)
   } else {
     validateTime(s)
+    validateDays(s.daysOfWeek)
   }
   if (typeof s.tz !== 'string' || !validTz(s.tz)) {
     throw new Error(`invalid schedule: unknown time zone "${String(s.tz)}"`)
@@ -48,19 +63,109 @@ function validNotify(v: unknown): boolean {
 }
 
 function validateReport(report: unknown): void {
-  if (!report || typeof report !== 'object' || !validNotify((report as { notify?: unknown }).notify)) {
+  if (!report || typeof report !== 'object' || Array.isArray(report) || !validNotify((report as { notify?: unknown }).notify)) {
     throw new Error('invalid automation: report.notify ("all" | "failure" | "success" | "none") is required')
+  }
+  const channel = (report as { channel?: unknown }).channel
+  if (channel !== undefined) {
+    const c = channel as { platform?: unknown; target?: unknown }
+    if (!c || typeof c !== 'object' || Array.isArray(c)
+      || typeof c.platform !== 'string' || !c.platform.trim()
+      || typeof c.target !== 'string' || !c.target.trim()) {
+      throw new Error('invalid automation: report.channel requires platform and target')
+    }
   }
 }
 
-/** Create-time validation: schedule (if any) plus a report object with a valid notify mode. */
-export function validateAutomationDraft(draft: any): void {
-  validateSchedule(draft?.schedule)
-  validateReport(draft?.report)
+const CREATE_FIELDS = new Set(['name', 'enabled', 'target', 'brief', 'params', 'schedule', 'report'])
+const UPDATE_FIELDS = new Set(['name', 'target', 'brief', 'params', 'schedule', 'report'])
+const CHAT_FIELDS = new Set(['name', 'target', 'brief', 'params', 'schedule', 'notify'])
+const AGENTS = new Set(['claude-code', 'opencode', 'codex'])
+
+function validateObject(value: unknown, label: string): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`invalid automation: ${label} must be an object`)
+  }
 }
 
-/** Update-time validation: only checks fields present on the patch. */
+function validateFields(value: Record<string, unknown>, allowed: Set<string>): void {
+  const disallowed = Object.keys(value).filter(k => !allowed.has(k))
+  if (disallowed.length) throw new Error(`invalid automation: field cannot be changed: ${disallowed.join(', ')}`)
+}
+
+function validateName(value: unknown): void {
+  if (typeof value !== 'string' || !value.trim()) throw new Error('invalid automation: name is required')
+}
+
+function validateBrief(value: unknown): void {
+  if (typeof value !== 'string' || !value.trim()) throw new Error('invalid automation: brief is required')
+}
+
+function validateParams(value: unknown): void {
+  validateObject(value, 'params')
+  if (!Object.values(value).every(v => typeof v === 'string')) {
+    throw new Error('invalid automation: params values must be strings')
+  }
+}
+
+function validateTarget(value: unknown): void {
+  validateObject(value, 'target')
+  if (typeof value.workspaceName !== 'string' || !value.workspaceName.trim()) {
+    throw new Error('invalid automation: target.workspaceName is required')
+  }
+  if (value.kind === 'prompt') {
+    if (value.agent !== undefined && !AGENTS.has(value.agent as string)) {
+      throw new Error('invalid automation: unknown prompt target agent')
+    }
+    if (value.model !== undefined && (typeof value.model !== 'string' || !value.model.trim())) {
+      throw new Error('invalid automation: target.model must be a non-empty string')
+    }
+    return
+  }
+  if (value.kind === 'team' && typeof value.teamName === 'string' && value.teamName.trim()) return
+  throw new Error('invalid automation: target must be a prompt or named team')
+}
+
+function validateMutableFields(value: Record<string, unknown>): void {
+  if ('name' in value) validateName(value.name)
+  if ('target' in value) validateTarget(value.target)
+  if ('brief' in value) validateBrief(value.brief)
+  if ('params' in value) validateParams(value.params)
+  if ('schedule' in value) validateSchedule(value.schedule)
+  if ('report' in value) validateReport(value.report)
+}
+
+/** Create-time validation for the complete persisted definition. */
+export function validateAutomationDraft(draft: any): void {
+  validateObject(draft, 'draft')
+  validateFields(draft, CREATE_FIELDS)
+  validateName(draft.name)
+  validateTarget(draft.target)
+  validateBrief(draft.brief)
+  validateParams(draft.params)
+  if (typeof draft.enabled !== 'boolean') throw new Error('invalid automation: enabled must be a boolean')
+  validateSchedule(draft.schedule)
+  validateReport(draft.report)
+}
+
+/** Update-time validation: allowlisted mutable fields only. */
 export function validateAutomationPatch(patch: any): void {
-  if (patch && 'schedule' in patch) validateSchedule(patch.schedule)
-  if (patch && 'report' in patch) validateReport(patch.report)
+  validateObject(patch, 'patch')
+  validateFields(patch, UPDATE_FIELDS)
+  validateMutableFields(patch)
+}
+
+/** Partial draft edits from the structured authoring form. Null clears a field. */
+export function validateAutomationChatPatch(patch: any): void {
+  validateObject(patch, 'chat patch')
+  validateFields(patch, CHAT_FIELDS)
+  const present = (key: string) => key in patch && patch[key] !== null
+  if (present('name')) validateName(patch.name)
+  if (present('target')) validateTarget(patch.target)
+  if (present('brief')) validateBrief(patch.brief)
+  if (present('params')) validateParams(patch.params)
+  if (present('schedule')) validateSchedule(patch.schedule)
+  if (present('notify') && !validNotify(patch.notify)) {
+    throw new Error('invalid automation: notify mode is invalid')
+  }
 }

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -7,7 +7,7 @@ import { initAutoUpdater, registerUpdaterIpc } from './updater'
 import { createCoreStateStore } from './core-state'
 import { decideNotification, createTurnTracker } from './chat-notifications'
 import { decideAutomationNotification, findUnseenRuns } from './automation-notifications'
-import { validateAutomationDraft, validateAutomationPatch } from './automation-validate'
+import { validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
 import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, uniqueSkills } from './skills'
 import type { ScannedSkill } from './skills'
@@ -2201,6 +2201,28 @@ app.whenReady().then(async () => {
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not ready')
       return inProcessGateway.sendAutomationChat(sessionId, text)
+    })
+  )
+
+  ipcMain.handle('automations:chat:patch', async (_e, sessionId: string, patch: any) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      validateAutomationChatPatch(patch)
+      return inProcessGateway.patchAutomationChat(sessionId, patch)
+    })
+  )
+
+  ipcMain.handle('automations:chat:retryCheck', async (_e, sessionId: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.retryAutomationChatCheck(sessionId)
+    })
+  )
+
+  ipcMain.handle('automations:chat:save', async (_e, sessionId: string, allowUnchecked?: boolean) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.saveAutomationChat(sessionId, allowUnchecked === true)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -48,6 +48,9 @@ contextBridge.exposeInMainWorld('codey', {
     markSeen: (id: string, runId: string) => ipcRenderer.invoke('automations:markSeen', id, runId),
     chatStart: (mode: 'create' | 'edit', automationId?: string) => ipcRenderer.invoke('automations:chat:start', mode, automationId),
     chatSend: (sessionId: string, text: string) => ipcRenderer.invoke('automations:chat:send', sessionId, text),
+    chatPatch: (sessionId: string, patch: any) => ipcRenderer.invoke('automations:chat:patch', sessionId, patch),
+    chatRetryCheck: (sessionId: string) => ipcRenderer.invoke('automations:chat:retryCheck', sessionId),
+    chatSave: (sessionId: string, allowUnchecked?: boolean) => ipcRenderer.invoke('automations:chat:save', sessionId, allowUnchecked),
     chatCancel: (sessionId: string) => ipcRenderer.invoke('automations:chat:cancel', sessionId),
     onEvent: (handler: (ev: any) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, ev: any) => handler(ev)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -6,6 +6,7 @@ import type { ApiKeyEntry } from '../../packages/core/src/types/index'
 import type { UpdaterEvent } from './hooks/updaterState'
 import type { CoreState } from '../electron/core-state'
 import type { Automation, AutomationRun, AutomationEvent } from '../../packages/core/src/types/automation'
+import type { AutomationDraft } from '../../packages/core/src/aide-automation'
 import type { ChatStep } from '../../packages/gateway/src/automations/chat'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
@@ -178,6 +179,9 @@ declare global {
         markSeen: (id: string, runId: string) => Promise<IpcResult<void>>
         chatStart: (mode: 'create' | 'edit', automationId?: string) => Promise<IpcResult<ChatStep>>
         chatSend: (sessionId: string, text: string) => Promise<IpcResult<ChatStep>>
+        chatPatch: (sessionId: string, patch: Partial<AutomationDraft>) => Promise<IpcResult<ChatStep>>
+        chatRetryCheck: (sessionId: string) => Promise<IpcResult<ChatStep>>
+        chatSave: (sessionId: string, allowUnchecked?: boolean) => Promise<IpcResult<Automation>>
         chatCancel: (sessionId: string) => Promise<IpcResult<void>>
         onEvent: (handler: (ev: AutomationEvent) => void) => () => void
         onUnseen: (handler: (msg: { automationId: string; runIds: string[] }) => void) => () => void

--- a/codey-mac/src/components/AutomationChatCreate.tsx
+++ b/codey-mac/src/components/AutomationChatCreate.tsx
@@ -1,11 +1,15 @@
-// codey-mac/src/components/AutomationChatCreate.tsx
-// Chat-driven automation authoring: chat column + live summary panel.
+// Draft-first automation composer: assistant chat and deterministic form
+// controls edit the same server-owned authoring session.
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { C } from '../theme'
-import { pillButton, unwrap, inputStyle } from './settingsAtoms'
+import { pillButton, unwrap, inputStyle, selectStyle } from './settingsAtoms'
 import { Markdown } from './Markdown'
-import { scheduleSummary, draftComplete, checkLabel, notifyLabel } from './automationsModel'
+import {
+  checkLabel, draftComplete, formatHHMM, NOTIFY_OPTIONS, scheduleSummary,
+  slotsToSchedule, type NotifyMode, type ScheduleSlotInput,
+} from './automationsModel'
 import type { AutomationDraft } from '../../../packages/core/src/aide-automation'
+import type { AutomationSchedule } from '../../../packages/core/src/types/automation'
 import type { ChatStep } from '../../../packages/gateway/src/automations/chat'
 
 interface Props {
@@ -16,6 +20,8 @@ interface Props {
 }
 
 interface Bubble { role: 'user' | 'assistant'; text: string }
+type ComposerContext = ChatStep['context']
+const DAY = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
 const SendIcon: React.FC<{ color: string }> = ({ color }) => (
   <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
@@ -26,150 +32,132 @@ const SendIcon: React.FC<{ color: string }> = ({ color }) => (
 export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDone, setError }) => {
   const [sessionId, setSessionId] = useState<string | null>(null)
   const sessionIdRef = useRef<string | null>(null)
+  const mountedRef = useRef(true)
   const [messages, setMessages] = useState<Bubble[]>([])
   const [draft, setDraft] = useState<AutomationDraft>({})
+  const [context, setContext] = useState<ComposerContext>({ workspaces: [], teams: [], agents: [], models: [], tz: Intl.DateTimeFormat().resolvedOptions().timeZone })
   const [suggestions, setSuggestions] = useState<string[]>([])
   const [ready, setReady] = useState(false)
   const [check, setCheck] = useState<ChatStep['check']>(undefined)
-  const [checkDetail, setCheckDetail] = useState<string | undefined>(undefined)
-  const [busy, setBusy] = useState(false)
+  const [checkDetail, setCheckDetail] = useState<string | undefined>()
+  const [chatBusy, setChatBusy] = useState(false)
+  const [formBusy, setFormBusy] = useState(false)
+  const [saving, setSaving] = useState(false)
   const [failedText, setFailedText] = useState<string | null>(null)
   const [sessionLost, setSessionLost] = useState(false)
   const [input, setInput] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [briefOpen, setBriefOpen] = useState(false)
+  const [newParam, setNewParam] = useState('')
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
-  // A chat-check push event can beat the in-flight send() response, whose
-  // stale 'pending' would otherwise overwrite the verdict; a legitimate
-  // re-arm always passes through an undefined step first since ready must
-  // drop before it can rise again.
+  // A check event can beat the request response that triggered it. A resolved
+  // verdict wins over a stale pending response; callers clear first when they
+  // intentionally re-arm a check.
   const applyCheck = (incoming: ChatStep['check']) =>
-    setCheck(prev =>
-      incoming === 'pending' && prev !== undefined && prev !== 'pending' ? prev : incoming)
+    setCheck(prev => incoming === 'pending' && prev !== undefined && prev !== 'pending' ? prev : incoming)
 
-  const mountedRef = useRef(true)
+  const applyStep = (step: ChatStep, appendReply = false) => {
+    setDraft(step.draft)
+    setContext(step.context)
+    setSuggestions(step.suggestions)
+    setReady(step.ready)
+    applyCheck(step.check)
+    if (appendReply && step.reply) setMessages(prev => [...prev, { role: 'assistant', text: step.reply }])
+  }
+
   useEffect(() => { sessionIdRef.current = sessionId }, [sessionId])
-  // Cancel the server-side session when the view unmounts.
   useEffect(() => () => {
     mountedRef.current = false
     const sid = sessionIdRef.current
     if (sid) void window.codey.automations.chatCancel(sid).catch(() => {})
   }, [])
 
+  const begin = useCallback(async () => {
+    const step: ChatStep = unwrap(await window.codey.automations.chatStart(mode, automationId))
+    if (!mountedRef.current) {
+      void window.codey.automations.chatCancel(step.sessionId).catch(() => {})
+      return
+    }
+    setSessionId(step.sessionId)
+    setMessages([{ role: 'assistant', text: step.reply }])
+    setSessionLost(false)
+    setCheckDetail(undefined)
+    applyStep(step)
+  }, [mode, automationId])
+
   useEffect(() => {
     let cancelled = false
-    ;(async () => {
-      try {
-        const step: ChatStep = unwrap(await window.codey.automations.chatStart(mode, automationId))
-        if (cancelled) { void window.codey.automations.chatCancel(step.sessionId).catch(() => {}); return }
-        setSessionId(step.sessionId)
-        setMessages([{ role: 'assistant', text: step.reply }])
-        setDraft(step.draft)
-        setSuggestions(step.suggestions)
-        setReady(step.ready)
-        applyCheck(step.check)
-      } catch (e: any) {
-        setError(e?.message ?? String(e))
-      }
-    })()
+    void begin().catch((e: any) => { if (!cancelled) setError(e?.message ?? String(e)) })
     return () => { cancelled = true }
-  }, [mode, automationId, setError])
+  }, [begin, setError])
 
-  // Dry-run verdicts arrive as chat-check events on the automation-event
-  // channel (session-keyed; the draft is not saved yet, so no automationId).
   useEffect(() => {
     if (!sessionId) return
     return window.codey.automations.onEvent(ev => {
       if (ev.type !== 'chat-check' || ev.sessionId !== sessionId) return
       applyCheck(ev.check)
       setCheckDetail(ev.detail)
-      const msg = ev.message
-      if (msg) setMessages(ms => [...ms, { role: 'assistant', text: msg }])
+      if (ev.message) setMessages(ms => [...ms, { role: 'assistant', text: ev.message! }])
     })
   }, [sessionId])
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
-  }, [messages, busy])
+  }, [messages, chatBusy])
 
-  const send = useCallback(async (text: string, isRetry = false) => {
+  const send = useCallback(async (text: string, retry = false) => {
     const sid = sessionIdRef.current
     const trimmed = text.trim()
-    if (!sid || !trimmed || busy) return
-    setBusy(true)
+    if (!sid || !trimmed || chatBusy || formBusy) return
+    setChatBusy(true)
     setFailedText(null)
     setSuggestions([])
-    if (!isRetry) setMessages(prev => [...prev, { role: 'user', text: trimmed }])
+    setCheck(undefined)
+    if (!retry) setMessages(prev => [...prev, { role: 'user', text: trimmed }])
     try {
       const step: ChatStep = unwrap(await window.codey.automations.chatSend(sid, trimmed))
-      setMessages(prev => [...prev, { role: 'assistant', text: step.reply }])
-      setDraft(step.draft)
-      setSuggestions(step.suggestions)
-      setReady(step.ready)
-      applyCheck(step.check)
+      applyStep(step, true)
     } catch (e: any) {
-      // Unknown session = gateway restarted or the session hit its TTL —
-      // only starting over helps. Anything else is retryable in place.
       if (/Unknown automation chat session/.test(e?.message ?? '')) {
         setSessionLost(true)
-        setInput(trimmed) // keep the user's text for the restarted chat
+        setInput(trimmed)
       } else {
         setFailedText(trimmed)
       }
     } finally {
-      setBusy(false)
+      setChatBusy(false)
     }
-  }, [busy])
+  }, [chatBusy, formBusy])
 
-  const startOver = () => {
-    // Remount-free restart: clear local state and re-run the start effect
-    // by clearing the session; simplest is to reload via chatStart directly.
-    setSessionLost(false)
-    setMessages([])
-    setDraft({})
-    setSuggestions([])
-    setReady(false)
+  const patchDraft = async (patch: Partial<AutomationDraft>) => {
+    const sid = sessionIdRef.current
+    if (!sid || formBusy || chatBusy) return
+    setFormBusy(true)
     setCheck(undefined)
-    setCheckDetail(undefined)
-    void (async () => {
-      try {
-        const step: ChatStep = unwrap(await window.codey.automations.chatStart(mode, automationId))
-        if (!mountedRef.current) { void window.codey.automations.chatCancel(step.sessionId).catch(() => {}); return }
-        setSessionId(step.sessionId)
-        setMessages([{ role: 'assistant', text: step.reply }])
-        setDraft(step.draft)
-        setSuggestions(step.suggestions)
-        setReady(step.ready)
-        applyCheck(step.check)
-      } catch (e: any) {
-        setError(e?.message ?? String(e))
-      }
-    })()
+    try {
+      const step: ChatStep = unwrap(await window.codey.automations.chatPatch(sid, patch as any))
+      applyStep(step)
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setFormBusy(false)
+    }
   }
 
   const submit = () => {
-    const t = input.trim()
-    if (t) { setInput(''); void send(t) }
+    const text = input.trim()
+    if (!text) return
+    setInput('')
+    void send(text)
   }
 
-  const save = async () => {
-    if (!draftComplete(draft) || saving) return
+  const save = async (allowUnchecked = false) => {
+    const sid = sessionIdRef.current
+    if (!sid || saving) return
+    if (allowUnchecked && !confirm('The unattended check failed. Save this automation anyway?')) return
     setSaving(true)
     try {
-      const payload = {
-        name: draft.name!.trim(),
-        target: draft.target!,
-        brief: draft.brief!,
-        params: draft.params ?? {},
-        schedule: draft.schedule ?? undefined,
-        report: { notify: draft.notify ?? 'none' },
-      }
-      if (mode === 'edit' && automationId) {
-        unwrap(await window.codey.automations.update(automationId, payload as any))
-      } else {
-        unwrap(await window.codey.automations.create({ ...payload, enabled: true } as any))
-      }
+      unwrap(await window.codey.automations.chatSave(sid, allowUnchecked))
+      sessionIdRef.current = null
       onDone()
     } catch (e: any) {
       setError(e?.message ?? String(e))
@@ -177,163 +165,333 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
     }
   }
 
-  const targetText = draft.target
-    ? draft.target.kind === 'team'
-      ? `team ${draft.target.teamName} (${draft.target.workspaceName})`
-      : `${draft.target.workspaceName} (prompt)`
-    : undefined
+  const retryCheck = async () => {
+    const sid = sessionIdRef.current
+    if (!sid) return
+    setCheck(undefined)
+    try {
+      const step: ChatStep = unwrap(await window.codey.automations.chatRetryCheck(sid))
+      applyStep(step)
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
+  }
+
+  const setTargetKind = (kind: 'prompt' | 'team') => {
+    const workspaceName = draft.target?.workspaceName || context.workspaces[0] || ''
+    const target = kind === 'team'
+      ? { kind, workspaceName, teamName: context.teams[0] || '' } as const
+      : { kind, workspaceName } as const
+    void patchDraft({ target })
+  }
+
+  const setWorkspace = (workspaceName: string) => {
+    const target = draft.target?.kind === 'team'
+      ? { ...draft.target, workspaceName }
+      : { kind: 'prompt' as const, ...draft.target, workspaceName }
+    void patchDraft({ target })
+  }
+
+  const setSchedule = (schedule?: AutomationSchedule) =>
+    void patchDraft({ schedule: (schedule ?? null) as any })
+
+  const scheduleSlots: ScheduleSlotInput[] = draft.schedule?.slots.map(slot => ({
+    time: formatHHMM(slot.hour, slot.minute),
+    days: [...(slot.daysOfWeek ?? [])],
+  })) ?? [{ time: '09:00', days: [] }]
+  const rebuildSchedule = (slots: ScheduleSlotInput[]) => {
+    const next = slotsToSchedule(slots, draft.schedule?.tz ?? context.tz)
+    if (next) setSchedule(next)
+  }
+
+  const addParam = () => {
+    const key = newParam.trim()
+    if (!key || Object.prototype.hasOwnProperty.call(draft.params ?? {}, key)) return
+    setNewParam('')
+    void patchDraft({ params: { ...(draft.params ?? {}), [key]: '' } })
+  }
+
+  const missing = [
+    !draft.name?.trim() && 'name',
+    !draft.target?.workspaceName?.trim() && 'workspace',
+    draft.target?.kind === 'team' && !draft.target.teamName?.trim() && 'team',
+    !draft.brief?.trim() && 'instructions',
+  ].filter(Boolean) as string[]
+  const checkInfo = checkLabel(check)
+  const locked = chatBusy || formBusy || saving || sessionLost
 
   return (
-    <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+    <div style={shellStyle}>
+      <section style={chatColumn}>
+        <div style={columnHeader}>
+          <div>
+            <div style={eyebrow}>AI ASSISTANT</div>
+            <div style={columnTitle}>Describe the outcome</div>
+          </div>
+          <span style={helperText}>Chat fills the setup; every field remains editable.</span>
+        </div>
         <div ref={scrollRef} style={chatScroll}>
-          {messages.map((m, i) => (
-            m.role === 'user'
-              ? <div key={i} style={bubbleUser}>{m.text}</div>
-              : <div key={i} style={{ ...bubbleAssistant, whiteSpace: 'normal' }}><Markdown>{m.text}</Markdown></div>
-          ))}
-          {busy && <div style={{ ...bubbleAssistant, color: C.fg3, fontStyle: 'italic' }}>Thinking…</div>}
-          {failedText !== null && (
-            <div style={{ ...bubbleAssistant, border: `1px solid ${C.red}`, color: C.red }}>
-              Something went wrong.{' '}
-              <button style={pillButton('ghost')} onClick={() => void send(failedText, true)}>Retry</button>
+          {messages.map((message, index) => message.role === 'user'
+            ? <div key={index} style={bubbleUser}>{message.text}</div>
+            : <div key={index} style={{ ...bubbleAssistant, whiteSpace: 'normal' }}><Markdown>{message.text}</Markdown></div>)}
+          {chatBusy && <div style={{ ...bubbleAssistant, color: C.fg3, fontStyle: 'italic' }}>Refining the automation…</div>}
+          {failedText && (
+            <div style={{ ...bubbleAssistant, borderColor: C.red, color: C.red }}>
+              That message did not go through. <button style={inlineButton} onClick={() => void send(failedText, true)}>Retry</button>
             </div>
           )}
           {sessionLost && (
-            <div style={{ ...bubbleAssistant, border: `1px solid ${C.red}`, color: C.red }}>
-              This session expired.{' '}
-              <button style={pillButton('ghost')} onClick={startOver}>Start over</button>
+            <div style={{ ...bubbleAssistant, borderColor: C.red, color: C.red }}>
+              This draft session expired. <button style={inlineButton} onClick={() => void begin()}>Start a new draft</button>
             </div>
           )}
-          {!busy && failedText === null && suggestions.length > 0 && (
-            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-              {suggestions.map(sug => (
-                <button key={sug} style={pillButton('ghost')} onClick={() => void send(sug)}>{sug}</button>
-              ))}
-            </div>
+          {!chatBusy && !failedText && suggestions.length > 0 && (
+            <div style={suggestionRow}>{suggestions.map(s => <button key={s} style={pillButton('ghost')} onClick={() => void send(s)}>{s}</button>)}</div>
           )}
         </div>
-        <div style={{ display: 'flex', gap: 8, padding: '10px 20px', borderTop: `1px solid ${C.border}` }}>
-          <input
-            autoFocus
-            style={{ ...inputStyle, flex: 1, width: 'auto' }}
-            value={input}
+        <div style={composerBar}>
+          <textarea
+            autoFocus value={input} disabled={!sessionId || locked}
             onChange={e => setInput(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') submit() }}
-            placeholder={sessionId ? 'Message…' : 'Starting…'}
-            disabled={!sessionId || busy}
+            onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submit() } }}
+            placeholder="Describe a workflow, or ask the assistant to refine the current setup…"
+            style={composerInput}
           />
-          {(() => {
-            const canSend = !!sessionId && !busy && !!input.trim()
-            return (
-              <button
-                style={{ ...sendButtonStyle, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
-                onClick={submit}
-                disabled={!canSend}
-              >
-                <SendIcon color={canSend ? C.onAccent : C.fg3} />
-              </button>
-            )
-          })()}
+          <button style={{ ...sendButton, background: input.trim() && !locked ? C.accent : C.surface3 }} disabled={!input.trim() || locked} onClick={submit}>
+            <SendIcon color={input.trim() && !locked ? C.onAccent : C.fg3} />
+          </button>
         </div>
-      </div>
+      </section>
 
-      <div style={panelStyle}>
-        <div style={{ flex: 1, overflowY: 'auto' }}>
-          <div style={{ color: C.fg, fontSize: 13, fontWeight: 600, marginBottom: 10 }}>
-            {draft.name ?? <span style={dim}>New automation</span>}
+      <section style={setupColumn}>
+        <div style={setupScroll}>
+          <div style={setupHeading}>
+            <div>
+              <div style={eyebrow}>{mode === 'edit' ? 'EDIT AUTOMATION' : 'NEW AUTOMATION'}</div>
+              <div style={{ ...columnTitle, fontSize: 18 }}>{draft.name?.trim() || 'Untitled automation'}</div>
+            </div>
+            {draft.schedule && <span style={summaryPill}>{scheduleSummary(draft.schedule)}</span>}
           </div>
-          <SummaryRow label="Runs" value={draft.schedule ? scheduleSummary(draft.schedule) : ready ? 'manual' : undefined} placeholder="schedule…" />
-          <SummaryRow label="Where" value={targetText} placeholder="workspace…" />
-          <SummaryRow label="Notify" value={draft.notify === undefined ? undefined : notifyLabel(draft.notify)} placeholder="notify…" />
-          {(() => {
-            const cl = checkLabel(check)
-            if (!cl) return null
-            const toneColor = { good: C.green, warn: C.yellow, dim: C.fg3 }[cl.tone]
-            return <SummaryRow label="Check" value={cl.text} placeholder="" valueColor={toneColor} title={check === 'error' ? checkDetail : undefined} />
-          })()}
-          {draft.params && Object.keys(draft.params).length > 0 && (
-            <SummaryRow
-              label="Knobs"
-              value={Object.entries(draft.params).map(([k, v]) => `${k}=${v}`).join(', ')}
-              placeholder=""
+
+          <SetupSection title="Basics" description="A clear name and the workspace where this runs.">
+            <Field label="Name" required>
+              <input
+                value={draft.name ?? ''} disabled={locked} style={wideInput}
+                placeholder="Weekly release notes"
+                onChange={e => setDraft(d => ({ ...d, name: e.target.value }))}
+                onBlur={e => void patchDraft({ name: (e.target.value.trim() || null) as any })}
+              />
+            </Field>
+            <div style={twoColumns}>
+              <Field label="Run as" required>
+                <select value={draft.target?.kind ?? 'prompt'} disabled={locked} style={wideSelect} onChange={e => setTargetKind(e.target.value as 'prompt' | 'team')}>
+                  <option value="prompt">Single agent</option>
+                  <option value="team" disabled={context.teams.length === 0}>Worker team</option>
+                </select>
+              </Field>
+              <Field label="Workspace" required>
+                <select value={draft.target?.workspaceName ?? ''} disabled={locked} style={wideSelect} onChange={e => setWorkspace(e.target.value)}>
+                  <option value="" disabled>Select workspace</option>
+                  {context.workspaces.map(w => <option key={w} value={w}>{w}</option>)}
+                </select>
+              </Field>
+            </div>
+            {draft.target?.kind === 'team' && (
+              <Field label="Team" required>
+                <select value={draft.target.teamName} disabled={locked} style={wideSelect}
+                  onChange={e => void patchDraft({ target: { ...draft.target!, teamName: e.target.value } as any })}>
+                  <option value="" disabled>Select team</option>
+                  {context.teams.map(team => <option key={team} value={team}>{team}</option>)}
+                </select>
+              </Field>
+            )}
+            {draft.target?.kind === 'prompt' && (
+              <div style={twoColumns}>
+                <Field label="Agent override">
+                  <select value={draft.target.agent ?? ''} disabled={locked} style={wideSelect}
+                    onChange={e => void patchDraft({ target: { ...draft.target!, agent: (e.target.value || undefined) as any } as any })}>
+                    <option value="">Gateway default</option>
+                    {(context.agents ?? []).map(agent => <option key={agent} value={agent}>{agent}</option>)}
+                  </select>
+                </Field>
+                <Field label="Model override">
+                  <select value={draft.target.model ?? ''} disabled={locked} style={wideSelect}
+                    onChange={e => void patchDraft({ target: { ...draft.target!, model: e.target.value || undefined } as any })}>
+                    <option value="">Agent default</option>
+                    {(context.models ?? []).map(model => <option key={model} value={model}>{model}</option>)}
+                  </select>
+                </Field>
+              </div>
+            )}
+          </SetupSection>
+
+          <SetupSection title="Instructions" description="The exact brief used for every unattended run.">
+            <textarea
+              value={draft.brief ?? ''} disabled={locked} style={briefInput}
+              placeholder="The assistant will synthesize a self-contained run brief here. You can edit it directly."
+              onChange={e => setDraft(d => ({ ...d, brief: e.target.value }))}
+              onBlur={e => void patchDraft({ brief: (e.target.value.trim() || null) as any })}
             />
-          )}
-          <div style={{ marginTop: 12 }}>
-            <div style={panelLabel}>Brief</div>
-            {draft.brief ? (
+          </SetupSection>
+
+          <SetupSection title="Variables" description="Values you expect to tune without rewriting the instructions.">
+            {Object.entries(draft.params ?? {}).length === 0 && <div style={emptyHint}>No variables yet. The assistant adds them when useful.</div>}
+            {Object.entries(draft.params ?? {}).map(([key, value]) => (
+              <div key={key} style={paramRow}>
+                <code style={paramKey}>{key}</code>
+                <input value={value} disabled={locked} style={{ ...wideInput, flex: 1 }}
+                  onChange={e => setDraft(d => ({ ...d, params: { ...(d.params ?? {}), [key]: e.target.value } }))}
+                  onBlur={e => void patchDraft({ params: { ...(draft.params ?? {}), [key]: e.target.value } })} />
+                <button title="Remove variable" style={removeButton} disabled={locked} onClick={() => {
+                  const params = { ...(draft.params ?? {}) }; delete params[key]; void patchDraft({ params })
+                }}>×</button>
+              </div>
+            ))}
+            <div style={paramAddRow}>
+              <input value={newParam} disabled={locked} style={{ ...wideInput, flex: 1 }} placeholder="New variable name"
+                onChange={e => setNewParam(e.target.value.replace(/[^\w.-]/g, ''))}
+                onKeyDown={e => { if (e.key === 'Enter') addParam() }} />
+              <button style={pillButton('ghost')} disabled={!newParam.trim() || locked} onClick={addParam}>Add</button>
+            </div>
+          </SetupSection>
+
+          <SetupSection title="Schedule & alerts" description={`Times use ${draft.schedule?.tz ?? context.tz}. Leave scheduling off to run manually.`}>
+            <Field label="Scheduled">
+              <label style={toggleLabel}>
+                <input type="checkbox" checked={!!draft.schedule} disabled={locked}
+                  onChange={e => e.target.checked
+                    ? setSchedule({ slots: [{ hour: 9, minute: 0 }], tz: context.tz })
+                    : setSchedule(undefined)} />
+                <span>{draft.schedule ? 'On' : 'Manual only'}</span>
+              </label>
+            </Field>
+            {draft.schedule && (
               <>
-                <pre style={{ ...briefBox, maxHeight: briefOpen ? undefined : 96, overflow: 'hidden' }}>{draft.brief}</pre>
-                <button style={{ ...pillButton('ghost'), marginTop: 4 }} onClick={() => setBriefOpen(o => !o)}>
-                  {briefOpen ? 'Collapse' : 'Expand'}
-                </button>
+                <Field label="Time slots">
+                  <div style={slotList}>
+                    {scheduleSlots.map((slot, slotIndex) => (
+                      <div key={slotIndex} style={slotCard}>
+                        <div style={slotTopRow}>
+                          <input type="time" value={slot.time} disabled={locked} style={compactInput}
+                            aria-label={`Time slot ${slotIndex + 1}`}
+                            onChange={e => rebuildSchedule(scheduleSlots.map((item, index) => index === slotIndex ? { ...item, time: e.target.value } : item))} />
+                          <span style={slotDaySummary}>{slot.days.length ? `${slot.days.length} selected days` : 'Every day'}</span>
+                          {scheduleSlots.length > 1 && <button title="Remove time slot" style={removeButton}
+                            onClick={() => rebuildSchedule(scheduleSlots.filter((_, index) => index !== slotIndex))}>×</button>}
+                        </div>
+                        <div style={dayRow}>{DAY.map((day, dayIndex) => {
+                          const selected = slot.days.length === 0 || slot.days.includes(dayIndex)
+                          return <button key={dayIndex} title={['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][dayIndex]}
+                            style={dayButton(selected)} disabled={locked} onClick={() => {
+                              const current = slot.days.length === 0 ? [0, 1, 2, 3, 4, 5, 6] : slot.days
+                              const days = current.includes(dayIndex) ? current.filter(d => d !== dayIndex) : [...current, dayIndex].sort()
+                              rebuildSchedule(scheduleSlots.map((item, index) => index === slotIndex
+                                ? { ...item, days: days.length === 7 ? [] : days }
+                                : item))
+                            }}>{day}</button>
+                        })}</div>
+                      </div>
+                    ))}
+                    <button style={addSlotButton} disabled={locked}
+                      onClick={() => rebuildSchedule([...scheduleSlots, { time: '12:00', days: [] }])}>+ Add another time slot</button>
+                  </div>
+                </Field>
               </>
+            )}
+            <Field label="Notify">
+              <select value={draft.notify ?? 'none'} disabled={locked} style={wideSelect}
+                onChange={e => void patchDraft({ notify: e.target.value as NotifyMode })}>
+                {NOTIFY_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+              </select>
+            </Field>
+          </SetupSection>
+        </div>
+
+        <footer style={footerStyle}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {missing.length > 0 ? (
+              <div style={statusMuted}>Complete: {missing.join(', ')}</div>
+            ) : checkInfo ? (
+              <div style={{ color: checkInfo.tone === 'good' ? C.green : checkInfo.tone === 'warn' ? C.yellow : C.fg3, fontSize: 12 }}>
+                {checkInfo.text}
+                {check === 'gaps' && ' — answer the assistant’s questions'}
+                {check === 'error' && <button style={inlineButton} title={checkDetail} onClick={() => void retryCheck()}>Retry</button>}
+              </div>
             ) : (
-              <span style={dim}>synthesized as you chat…</span>
+              <div style={statusMuted}>Ready for unattended check</div>
             )}
           </div>
-        </div>
-        {ready && draftComplete(draft) && (
-          <button style={{ ...pillButton('primary'), marginTop: 10 }} disabled={saving} onClick={() => void save()}>
-            {saving ? 'Saving…' : mode === 'edit' ? 'Save changes' : 'Create automation'}
-          </button>
-        )}
-      </div>
+          {ready && draftComplete(draft) && check === 'clean' && (
+            <button style={pillButton('primary')} disabled={saving} onClick={() => void save()}>{saving ? 'Saving…' : mode === 'edit' ? 'Save changes' : 'Create automation'}</button>
+          )}
+          {ready && draftComplete(draft) && check === 'pending' && <button style={pillButton('primary')} disabled>Checking…</button>}
+          {ready && draftComplete(draft) && check === 'error' && (
+            <button style={pillButton('ghost')} disabled={saving} onClick={() => void save(true)}>Save anyway…</button>
+          )}
+        </footer>
+      </section>
     </div>
   )
 }
 
-const SummaryRow: React.FC<{ label: string; value?: string; placeholder: string; valueColor?: string; title?: string }> = ({ label, value, placeholder, valueColor, title }) => (
-  <div style={{ display: 'flex', gap: 8, fontSize: 12, margin: '3px 0' }}>
-    <span style={{ color: C.fg3, width: 56, flexShrink: 0 }}>{label}</span>
-    {value ? (
-      <span style={{ color: valueColor ?? C.fg2, wordBreak: 'break-word' }} title={title}>{value}</span>
-    ) : (
-      <span style={dim}>{placeholder}</span>
-    )}
+const SetupSection: React.FC<{ title: string; description: string; children: React.ReactNode }> = ({ title, description, children }) => (
+  <div style={sectionCard}>
+    <div style={{ marginBottom: 12 }}>
+      <div style={sectionTitle}>{title}</div>
+      <div style={sectionDescription}>{description}</div>
+    </div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>{children}</div>
   </div>
 )
 
-const dim: React.CSSProperties = { color: C.fg3, opacity: 0.55, fontStyle: 'italic' }
+const Field: React.FC<{ label: string; required?: boolean; children: React.ReactNode }> = ({ label, required, children }) => (
+  <label style={fieldBlock}>
+    <span style={fieldLabel}>{label}{required && <span style={{ color: C.accent }}> *</span>}</span>
+    {children}
+  </label>
+)
 
-const sendButtonStyle: React.CSSProperties = {
-  width: 38, height: 38, borderRadius: 11, border: 'none',
-  display: 'flex', alignItems: 'center', justifyContent: 'center',
-  flexShrink: 0, transition: 'background 0.15s',
-}
-
-const chatScroll: React.CSSProperties = {
-  flex: 1, overflowY: 'auto', padding: '16px 20px',
-  display: 'flex', flexDirection: 'column', gap: 8,
-}
-
-const bubbleBase: React.CSSProperties = {
-  maxWidth: '82%', padding: '8px 12px', borderRadius: 12,
-  fontSize: 13, lineHeight: 1.45, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-}
-
-const bubbleAssistant: React.CSSProperties = {
-  ...bubbleBase, alignSelf: 'flex-start', background: C.surface,
-  border: `1px solid ${C.border}`, borderBottomLeftRadius: 4, color: C.fg,
-}
-
-const bubbleUser: React.CSSProperties = {
-  ...bubbleBase, alignSelf: 'flex-end', background: C.surface3,
-  borderBottomRightRadius: 4, color: C.fg,
-}
-
-const panelStyle: React.CSSProperties = {
-  width: 250, flexShrink: 0, display: 'flex', flexDirection: 'column',
-  borderLeft: `1px solid ${C.border}`, padding: '16px 16px 12px',
-  overflow: 'hidden',
-}
-
-const panelLabel: React.CSSProperties = {
-  color: C.fg3, fontSize: 11, fontWeight: 600,
-  marginBottom: 4,
-}
-
-const briefBox: React.CSSProperties = {
-  margin: 0, padding: '8px 10px', borderRadius: 8, background: C.surface3, color: C.fg2,
-  fontSize: 11, lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-}
+const shellStyle: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'minmax(320px, 0.9fr) minmax(430px, 1.1fr)', flex: 1, minHeight: 0, background: C.bg }
+const chatColumn: React.CSSProperties = { minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column', borderRight: `1px solid ${C.border}`, background: C.surface }
+const setupColumn: React.CSSProperties = { minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }
+const columnHeader: React.CSSProperties = { padding: '18px 20px 14px', borderBottom: `1px solid ${C.border}`, display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'flex-end' }
+const eyebrow: React.CSSProperties = { color: C.accent, fontSize: 9, fontWeight: 800, letterSpacing: 1.1, marginBottom: 4 }
+const columnTitle: React.CSSProperties = { color: C.fg, fontSize: 14, fontWeight: 720, letterSpacing: '-0.01em' }
+const helperText: React.CSSProperties = { color: C.fg3, fontSize: 10, lineHeight: 1.4, maxWidth: 180, textAlign: 'right' }
+const chatScroll: React.CSSProperties = { flex: 1, overflowY: 'auto', padding: '18px 20px', display: 'flex', flexDirection: 'column', gap: 9 }
+const bubbleBase: React.CSSProperties = { maxWidth: '86%', padding: '9px 12px', borderRadius: 12, fontSize: 12.5, lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }
+const bubbleAssistant: React.CSSProperties = { ...bubbleBase, alignSelf: 'flex-start', background: C.bg, border: `1px solid ${C.border}`, borderBottomLeftRadius: 4, color: C.fg }
+const bubbleUser: React.CSSProperties = { ...bubbleBase, alignSelf: 'flex-end', background: C.surface3, borderBottomRightRadius: 4, color: C.fg }
+const suggestionRow: React.CSSProperties = { display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 2 }
+const composerBar: React.CSSProperties = { display: 'flex', gap: 8, padding: '12px 14px', borderTop: `1px solid ${C.border}`, alignItems: 'flex-end' }
+const composerInput: React.CSSProperties = { ...inputStyle, flex: 1, width: 'auto', resize: 'none', minHeight: 40, maxHeight: 100, lineHeight: 1.45, fontFamily: 'inherit' }
+const sendButton: React.CSSProperties = { width: 40, height: 40, borderRadius: 10, border: 'none', display: 'grid', placeItems: 'center', flexShrink: 0 }
+const setupScroll: React.CSSProperties = { flex: 1, overflowY: 'auto', padding: '20px 22px 28px' }
+const setupHeading: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', gap: 14, alignItems: 'center', marginBottom: 16 }
+const summaryPill: React.CSSProperties = { padding: '5px 9px', borderRadius: 999, background: C.accentDim, color: C.accent, fontSize: 10, fontWeight: 650 }
+const sectionCard: React.CSSProperties = { background: C.surface, border: `1px solid ${C.border}`, borderRadius: 12, padding: '14px 15px', marginBottom: 12 }
+const sectionTitle: React.CSSProperties = { color: C.fg, fontSize: 12, fontWeight: 700 }
+const sectionDescription: React.CSSProperties = { color: C.fg3, fontSize: 10.5, lineHeight: 1.4, marginTop: 2 }
+const fieldBlock: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 5 }
+const fieldLabel: React.CSSProperties = { color: C.fg2, fontSize: 10.5, fontWeight: 650 }
+const wideInput: React.CSSProperties = { ...inputStyle, boxSizing: 'border-box', width: '100%' }
+const wideSelect: React.CSSProperties = { ...selectStyle, boxSizing: 'border-box', width: '100%' }
+const compactInput: React.CSSProperties = { ...inputStyle, width: 104, padding: '6px 8px' }
+const briefInput: React.CSSProperties = { ...wideInput, minHeight: 128, resize: 'vertical', lineHeight: 1.5, fontFamily: 'inherit' }
+const twoColumns: React.CSSProperties = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }
+const emptyHint: React.CSSProperties = { color: C.fg3, fontSize: 11, fontStyle: 'italic' }
+const paramRow: React.CSSProperties = { display: 'flex', gap: 7, alignItems: 'center' }
+const paramKey: React.CSSProperties = { color: C.accent, fontSize: 10.5, width: 92, overflow: 'hidden', textOverflow: 'ellipsis' }
+const paramAddRow: React.CSSProperties = { display: 'flex', gap: 7 }
+const removeButton: React.CSSProperties = { width: 27, height: 27, borderRadius: 7, border: `1px solid ${C.border}`, background: 'transparent', color: C.fg3, cursor: 'pointer' }
+const toggleLabel: React.CSSProperties = { display: 'flex', gap: 7, alignItems: 'center', color: C.fg2, fontSize: 12 }
+const slotList: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 8 }
+const slotCard: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 8, padding: '10px 11px', borderRadius: 10, border: `1px solid ${C.border}`, background: C.surface2 }
+const slotTopRow: React.CSSProperties = { display: 'flex', gap: 8, alignItems: 'center' }
+const slotDaySummary: React.CSSProperties = { color: C.fg3, fontSize: 10, flex: 1 }
+const addSlotButton: React.CSSProperties = { ...pillButton('ghost'), alignSelf: 'flex-start', padding: '6px 10px' }
+const dayRow: React.CSSProperties = { display: 'flex', gap: 5 }
+const dayButton = (selected: boolean): React.CSSProperties => ({ width: 29, height: 29, borderRadius: 8, border: `1px solid ${selected ? C.accent : C.border2}`, background: selected ? C.accentDim : C.surface3, color: selected ? C.accent : C.fg3, cursor: 'pointer', fontSize: 10, fontWeight: 700 })
+const footerStyle: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 12, padding: '12px 18px', borderTop: `1px solid ${C.border}`, background: C.surface }
+const statusMuted: React.CSSProperties = { color: C.fg3, fontSize: 11 }
+const inlineButton: React.CSSProperties = { border: 'none', background: 'transparent', color: C.accent, cursor: 'pointer', fontSize: 'inherit', padding: '0 4px', textDecoration: 'underline' }

--- a/codey-mac/src/components/AutomationOnePager.tsx
+++ b/codey-mac/src/components/AutomationOnePager.tsx
@@ -5,11 +5,11 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { C } from '../theme'
 import { pillButton, unwrap, inputStyle, selectStyle } from './settingsAtoms'
 import {
-  scheduleSummary, timesToSchedule, nextRunAt, humanizeDelta,
+  scheduleSummary, slotsToSchedule, nextRunAt, humanizeDelta,
   knobsFrom, knobsEqual, NOTIFY_OPTIONS, type Knobs, type NotifyMode,
 } from './automationsModel'
 import type { Automation, AutomationRun } from '../../../packages/core/src/types/automation'
-import { UIIcon } from './UIIcons'
+import { UIIcon, type IconName } from './UIIcons'
 import { Markdown } from './Markdown'
 
 const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -42,7 +42,7 @@ const ParkedPrompt: React.FC<{
       </div>
     )}
     <input
-      style={{ ...inputStyle, width: '100%' }}
+      style={{ ...inputStyle, width: '100%', boxSizing: 'border-box' }}
       placeholder={resuming ? 'Resuming…' : 'Free-text answer…'}
       disabled={resuming}
       value={answer}
@@ -71,6 +71,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
   // (undefined = not fetched, null = fetched but no log exists).
   const [logOpen, setLogOpen] = useState<Record<string, boolean>>({})
   const [logText, setLogText] = useState<Record<string, string | null>>({})
+  const [outputOpen, setOutputOpen] = useState<Record<string, boolean>>({})
   // Last automation the knobs were seeded from — lets refresh() tell "user is
   // mid-edit" apart from "an external edit changed the automation".
   const aRef = useRef<Automation | null>(null)
@@ -176,7 +177,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
     setSavingKnobs(true)
     try {
       const schedule = knobs.scheduleOn
-        ? timesToSchedule(knobs.times, a.schedule?.tz ?? TZ, knobs.days.length ? knobs.days : undefined)
+        ? slotsToSchedule(knobs.slots, a.schedule?.tz ?? TZ)
         : undefined
       if (knobs.scheduleOn && !schedule) throw new Error('Invalid time')
       const fresh: Automation = unwrap(await window.codey.automations.update(id, {
@@ -197,45 +198,70 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
   if (!a) return <div style={{ color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 24 }}>Loading…</div>
 
   const next = a.schedule && a.enabled ? nextRunAt(a.schedule, Date.now()) : null
-  const subtitle = a.schedule
-    ? `${scheduleSummary(a.schedule)} (${a.schedule.tz})${next ? ` · next run ${humanizeDelta(next - Date.now())}` : ''}`
-    : 'manual only'
   const latest = runs[0]
+  const health = automationHealth(a, latest)
+  const targetTitle = a.target.kind === 'team' ? a.target.teamName : a.target.workspaceName
+  const targetDetail = a.target.kind === 'team'
+    ? `Team · ${a.target.workspaceName}`
+    : [a.target.agent ?? 'Default agent', a.target.model].filter(Boolean).join(' · ')
+  const notifyTitle = NOTIFY_OPTIONS.find(option => option.value === a.report.notify)?.label ?? 'Never'
 
   return (
-    <div style={{ padding: '14px 20px', flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+    <div style={pageStyle}>
+      <header style={heroStyle}>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ color: C.fg, fontSize: 15, fontWeight: 600 }}>{a.name}</div>
-          <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>{subtitle}</div>
+          <div style={eyebrow}>AUTOMATION</div>
+          <div style={titleRow}>
+            <h2 style={titleStyle}>{a.name}</h2>
+            <span style={healthBadge(health.color)}><span style={healthDot(health.color)} />{health.label}</span>
+          </div>
+          <div style={subtitleStyle}>
+            {a.schedule ? `${scheduleSummary(a.schedule)} · ${a.schedule.tz}` : 'Runs manually'}
+          </div>
         </div>
-        <button style={{ ...pillButton('primary'), display: 'inline-flex', alignItems: 'center', gap: 6 }} disabled={running} onClick={() => void runNow()}>
-          <UIIcon name="play" size={14} />{running ? 'Running…' : 'Run now'}
-        </button>
-        <button style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }} onClick={onEditInChat}><UIIcon name="chat" size={14} />Edit in chat</button>
-        <label style={{ color: C.fg3, fontSize: 11, display: 'flex', alignItems: 'center', gap: 4 }}>
-          <input type="checkbox" checked={a.enabled} onChange={() => void toggleEnabled()} />
-          Enabled
-        </label>
-        <button style={{ ...pillButton('danger'), display: 'inline-flex', alignItems: 'center', gap: 6 }} disabled={deleting} onClick={() => void del()}>
-          <UIIcon name="trash" size={14} />{deleting ? 'Deleting…' : 'Delete'}
-        </button>
-      </div>
+        <div style={heroActions}>
+          <label style={enabledControl} title={a.enabled ? 'Pause scheduled runs' : 'Enable scheduled runs'}>
+            <input type="checkbox" checked={a.enabled} onChange={() => void toggleEnabled()} />
+            {a.enabled ? 'Enabled' : 'Paused'}
+          </label>
+          <button style={iconButton} onClick={onEditInChat}><UIIcon name="settings" size={14} />Edit setup</button>
+          <button style={{ ...pillButton('primary'), ...actionButton }} disabled={running} onClick={() => void runNow()}>
+            <UIIcon name="play" size={14} />{running ? 'Starting…' : 'Run now'}
+          </button>
+        </div>
+      </header>
 
       {latest?.status === 'parked' && latest.question && (
         <div style={parkedBanner}>
-          <div style={{ color: C.fg, fontSize: 12, fontWeight: 500, marginBottom: 6 }}>
-            Waiting on you: {latest.question}
+          <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+            <span style={attentionIcon}>!</span>
+            <div style={{ flex: 1 }}>
+              <div style={{ color: C.fg, fontSize: 12, fontWeight: 700 }}>This automation needs your input</div>
+              <div style={{ color: C.fg2, fontSize: 12, margin: '3px 0 8px' }}>{latest.question}</div>
+              <ParkedPrompt
+                run={latest}
+                resuming={!!resuming[latest.runId]}
+                answer={answers[latest.runId] ?? ''}
+                onAnswerChange={v => setAnswers(prev => ({ ...prev, [latest.runId]: v }))}
+                onResume={opt => void resume(latest.runId, opt)}
+              />
+            </div>
           </div>
-          <ParkedPrompt
-            run={latest}
-            resuming={!!resuming[latest.runId]}
-            answer={answers[latest.runId] ?? ''}
-            onAnswerChange={v => setAnswers(prev => ({ ...prev, [latest.runId]: v }))}
-            onResume={opt => void resume(latest.runId, opt)}
-          />
         </div>
       )}
+
+      <div style={summaryGrid}>
+        <SummaryCard label="Next run" icon="activity"
+          value={!a.enabled ? 'Paused' : next ? humanizeDelta(next - Date.now()) : a.schedule ? 'Not scheduled' : 'Manual only'}
+          detail={next ? new Date(next).toLocaleString() : a.schedule ? scheduleSummary(a.schedule) : 'Use Run now whenever needed'} />
+        <SummaryCard label="Last run" icon="archive"
+          value={latest ? statusLabel(latest.status) : 'No runs yet'}
+          detail={latest ? new Date(latest.startedAt).toLocaleString() : 'History will appear after the first run'}
+          tone={latest?.status === 'failed' ? C.red : latest?.status === 'parked' ? C.yellow : undefined} />
+        <SummaryCard label="Runs in" icon={a.target.kind === 'team' ? 'users' : 'workspace'} value={targetTitle} detail={targetDetail} />
+        <SummaryCard label="Notifications" icon="bot" value={notifyTitle}
+          detail={a.report.channel ? `Also posts to ${a.report.channel.platform}` : 'Mac notifications'} />
+      </div>
 
       <div style={tabBar}>
         <button style={{ ...tabStyle(tab === 'overview'), display: 'inline-flex', alignItems: 'center', gap: 6 }} onClick={() => setTab('overview')}><UIIcon name="activity" size={13} />Overview</button>
@@ -243,71 +269,98 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
       </div>
 
       {tab === 'overview' && knobs && (
-        <div>
-          <div style={sectLabel}>What it does</div>
-          <pre style={briefBox}>{a.brief}</pre>
+        <div style={overviewGrid}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <DetailCard title="What it does" description="The frozen instructions sent at the beginning of each run." action={
+              <button style={textButton} onClick={onEditInChat}>Edit instructions</button>
+            }>
+              <div style={briefBox}><Markdown variant="assistant">{a.brief}</Markdown></div>
+            </DetailCard>
 
-          <div style={sectLabel}>Knobs — edit directly</div>
-          {Object.entries(knobs.params).map(([k, v]) => (
-            <div key={k} style={knobRow}>
-              <span style={knobKey}>{k}</span>
-              <input style={{ ...inputStyle, flex: 1, width: 'auto' }} value={v}
-                onChange={e => setKnobs({ ...knobs, params: { ...knobs.params, [k]: e.target.value } })} />
-            </div>
-          ))}
-          <div style={knobRow}>
-            <span style={knobKey}>schedule</span>
-            <input type="checkbox" checked={knobs.scheduleOn}
-              onChange={e => setKnobs({ ...knobs, scheduleOn: e.target.checked })} />
-            {knobs.scheduleOn && (
-              <>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                  {knobs.times.map((t, i) => (
-                    <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-                      <input type="time" style={inputStyle} value={t}
-                        onChange={e => setKnobs({ ...knobs, times: knobs.times.map((x, j) => j === i ? e.target.value : x) })} />
-                      {knobs.times.length > 1 && (
-                        <button style={{ ...pillButton('ghost'), padding: '2px 7px' }} title="Remove this time"
-                          onClick={() => setKnobs({ ...knobs, times: knobs.times.filter((_, j) => j !== i) })}>×</button>
-                      )}
-                    </div>
-                  ))}
-                  <button style={{ ...pillButton('ghost'), alignSelf: 'flex-start', padding: '2px 7px', fontSize: 10 }}
-                    onClick={() => setKnobs({ ...knobs, times: [...knobs.times, '12:00'] })}>+ time</button>
-                </div>
-                <div style={{ display: 'flex', gap: 4 }}>
-                  {DAY.map((d, i) => (
-                    <button key={d}
-                      style={{ ...pillButton(knobs.days.includes(i) ? 'primary' : 'ghost'), padding: '2px 7px', fontSize: 10 }}
-                      onClick={() => setKnobs({
-                        ...knobs,
-                        days: knobs.days.includes(i) ? knobs.days.filter(x => x !== i) : [...knobs.days, i].sort(),
-                      })}
-                    >{d}</button>
-                  ))}
-                </div>
-              </>
-            )}
+            <DetailCard title="Variables" description="Tune these values without changing the underlying instructions.">
+              {Object.keys(knobs.params).length === 0 ? (
+                <div style={emptyState}>No editable variables. Add them from Edit setup.</div>
+              ) : Object.entries(knobs.params).map(([key, value]) => (
+                <label key={key} style={settingRow}>
+                  <span style={settingLabel}><code>{key}</code></span>
+                  <input style={settingInput} value={value}
+                    onChange={e => setKnobs({ ...knobs, params: { ...knobs.params, [key]: e.target.value } })} />
+                </label>
+              ))}
+            </DetailCard>
           </div>
-          <div style={knobRow}>
-            <span style={knobKey}>notify</span>
-            <select style={selectStyle} value={knobs.notify}
-              onChange={e => setKnobs({ ...knobs, notify: e.target.value as NotifyMode })}>
-              {NOTIFY_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-            </select>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <DetailCard title="Schedule" description={`Times are interpreted in ${a.schedule?.tz ?? TZ}.`}>
+              <label style={settingRow}>
+                <span style={settingLabel}>Scheduled runs</span>
+                <span style={inlineToggle}><input type="checkbox" checked={knobs.scheduleOn}
+                  onChange={e => setKnobs({ ...knobs, scheduleOn: e.target.checked })} />{knobs.scheduleOn ? 'On' : 'Off'}</span>
+              </label>
+              {knobs.scheduleOn && (
+                <>
+                  <div style={scheduleSlotList}>
+                    {knobs.slots.map((slot, slotIndex) => (
+                      <div key={slotIndex} style={scheduleSlotCard}>
+                        <div style={slotHeader}>
+                          <input type="time" style={compactInput} value={slot.time} aria-label={`Time slot ${slotIndex + 1}`}
+                            onChange={e => setKnobs({ ...knobs, slots: knobs.slots.map((item, index) => index === slotIndex ? { ...item, time: e.target.value } : item) })} />
+                          <span style={slotSummary}>{slot.days.length ? `${slot.days.length} selected days` : 'Every day'}</span>
+                          {knobs.slots.length > 1 && <button style={removeButton} title="Remove time slot"
+                            onClick={() => setKnobs({ ...knobs, slots: knobs.slots.filter((_, index) => index !== slotIndex) })}>×</button>}
+                        </div>
+                        <div style={dayEditor}>{DAY.map((day, dayIndex) => {
+                          const active = slot.days.length === 0 || slot.days.includes(dayIndex)
+                          return <button key={dayIndex} style={dayButton(active)} title={day}
+                            onClick={() => {
+                              const current = slot.days.length === 0 ? [0, 1, 2, 3, 4, 5, 6] : slot.days
+                              const days = current.includes(dayIndex) ? current.filter(x => x !== dayIndex) : [...current, dayIndex].sort()
+                              setKnobs({ ...knobs, slots: knobs.slots.map((item, index) => index === slotIndex
+                                ? { ...item, days: days.length === 7 ? [] : days }
+                                : item) })
+                            }}>{day.slice(0, 1)}</button>
+                        })}</div>
+                      </div>
+                    ))}
+                    <button style={{ ...smallButton, alignSelf: 'flex-start' }}
+                      onClick={() => setKnobs({ ...knobs, slots: [...knobs.slots, { time: '12:00', days: [] }] })}>+ Add another time slot</button>
+                  </div>
+                </>
+              )}
+            </DetailCard>
+
+            <DetailCard title="Notifications" description="Choose which run outcomes should interrupt you.">
+              <label style={settingRow}>
+                <span style={settingLabel}>Mac notification</span>
+                <select style={settingSelect} value={knobs.notify}
+                  onChange={e => setKnobs({ ...knobs, notify: e.target.value as NotifyMode })}>
+                  {NOTIFY_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+              </label>
+              {a.report.channel && <div style={infoRow}><span>Channel delivery</span><strong>{a.report.channel.platform}</strong></div>}
+            </DetailCard>
+
+            <DetailCard title="Details" description="Execution target and record metadata.">
+              <div style={infoRow}><span>Target</span><strong>{targetTitle}</strong></div>
+              <div style={infoRow}><span>Created</span><strong>{new Date(a.createdAt).toLocaleDateString()}</strong></div>
+              <div style={infoRow}><span>Updated</span><strong>{new Date(a.updatedAt).toLocaleDateString()}</strong></div>
+            </DetailCard>
           </div>
+
           {knobsDirty && (
-            <button style={{ ...pillButton('primary'), marginTop: 8 }} disabled={savingKnobs} onClick={() => void saveKnobs()}>
-              {savingKnobs ? 'Saving…' : 'Save knobs'}
-            </button>
+            <div style={saveBar}>
+              <div style={noticeCopy}><strong>Unsaved settings</strong><span>Your schedule, variables, or notifications changed.</span></div>
+              <div style={{ display: 'flex', gap: 7 }}>
+                <button style={pillButton('ghost')} disabled={savingKnobs} onClick={() => setKnobs(knobsFrom(a))}>Discard</button>
+                <button style={pillButton('primary')} disabled={savingKnobs} onClick={() => void saveKnobs()}>{savingKnobs ? 'Saving…' : 'Save settings'}</button>
+              </div>
+            </div>
           )}
 
-          <div style={sectLabel}>Setup</div>
-          <div style={setupRow}><span style={knobKey}>Runs in</span>
-            <span>{a.target.kind === 'team' ? `team ${a.target.teamName} (${a.target.workspaceName})` : `workspace ${a.target.workspaceName} (prompt)`}</span>
+          <div style={dangerCard}>
+            <div style={noticeCopy}><strong>Delete automation</strong><span>Removes its definition, run history, logs, and hidden run chat.</span></div>
+            <button style={compactDeleteButton} disabled={deleting} onClick={() => void del()}><UIIcon name="trash" size={11} />{deleting ? 'Deleting…' : 'Delete'}</button>
           </div>
-          <div style={setupRow}><span style={knobKey}>Created</span><span>{new Date(a.createdAt).toLocaleString()}</span></div>
-          <div style={setupRow}><span style={knobKey}>Updated</span><span>{new Date(a.updatedAt).toLocaleString()}</span></div>
         </div>
       )}
 
@@ -315,17 +368,26 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
         runs.length === 0 ? (
           <div style={{ color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 20 }}>No runs yet.</div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div style={runsList}>
             {runs.map(r => (
-              <div key={r.runId} style={cardStyle}>
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-                  <span style={{ color: C.fg, fontSize: 12, fontWeight: 600 }}>{new Date(r.startedAt).toLocaleString()}</span>
-                  <span style={{ color: C.fg3, fontSize: 11 }}>{r.trigger}</span>
-                  <span style={{ color: r.status === 'failed' ? C.red : C.fg3, fontSize: 11 }}>{r.status}</span>
-                  {r.reportFailure && <span style={{ color: C.red, fontSize: 11 }}>report delivery failed</span>}
+              <div key={r.runId} style={runCard}>
+                <div style={runHeader}>
+                  <span style={runStatusIcon(statusColor(r.status))}><UIIcon name={r.status === 'success' || r.status === 'resumed' ? 'check' : r.status === 'parked' ? 'chat' : 'close'} size={14} /></span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', gap: 7, alignItems: 'center' }}>
+                      <strong style={{ color: C.fg, fontSize: 12 }}>{statusLabel(r.status)}</strong>
+                      <span style={triggerBadge}>{r.trigger === 'manual' ? 'Manual' : 'Scheduled'}</span>
+                    </div>
+                    <div style={runMeta}>{new Date(r.startedAt).toLocaleString()}{r.endedAt ? ` · ${formatDuration(r.endedAt - r.startedAt)}` : ''}</div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    {r.output && <button style={smallButton} onClick={() => setOutputOpen(prev => ({ ...prev, [r.runId]: !prev[r.runId] }))}>{outputOpen[r.runId] ? 'Hide result' : 'View result'}</button>}
+                    <button style={smallButton} onClick={() => void toggleLog(r.runId)}>{logOpen[r.runId] ? 'Hide activity' : 'Activity log'}</button>
+                  </div>
                 </div>
+                {r.reportFailure && <div style={errorNotice}>Report delivery failed: {r.reportFailure}</div>}
                 {r.status === 'parked' && r.question && (
-                  <div style={{ marginTop: 8 }}>
+                  <div style={runBody}>
                     <div style={{ color: C.fg2, fontSize: 12, marginBottom: 6 }}>{r.question}</div>
                     <ParkedPrompt
                       run={r}
@@ -336,16 +398,13 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
                     />
                   </div>
                 )}
-                {r.output && <div style={outputStyle}><Markdown variant="assistant">{r.output}</Markdown></div>}
+                {r.output && outputOpen[r.runId] && <div style={outputStyle}><Markdown variant="assistant">{r.output}</Markdown></div>}
                 {r.error && <pre style={{ ...preStyle, color: C.red }}>{r.error}</pre>}
-                <button style={logToggleStyle} onClick={() => void toggleLog(r.runId)}>
-                  {logOpen[r.runId] ? 'Hide full log' : 'Full log'}
-                </button>
                 {logOpen[r.runId] && (
                   logText[r.runId] === undefined
                     ? <div style={{ color: C.fg3, fontSize: 11, marginTop: 6 }}>Loading…</div>
                     : logText[r.runId]
-                      ? <pre style={{ ...preStyle, maxHeight: 260, overflowY: 'auto' }}>{logText[r.runId]}</pre>
+                      ? <pre style={{ ...preStyle, maxHeight: 320, overflowY: 'auto' }}>{logText[r.runId]}</pre>
                       : <div style={{ color: C.fg3, fontSize: 11, marginTop: 6 }}>No activity log for this run.</div>
                 )}
               </div>
@@ -357,61 +416,140 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
   )
 }
 
-const parkedBanner: React.CSSProperties = {
-  marginTop: 12, padding: '10px 12px', borderRadius: 8,
-  border: `1px solid ${C.border2}`, background: C.surface3,
+const SummaryCard: React.FC<{ label: string; value: string; detail: string; icon: IconName; tone?: string }> = ({ label, value, detail, icon, tone }) => (
+  <div style={summaryCard}>
+    <span style={summaryIcon}><UIIcon name={icon} size={15} /></span>
+    <div style={{ minWidth: 0 }}>
+      <div style={summaryLabel}>{label}</div>
+      <div style={{ ...summaryValue, color: tone ?? C.fg }}>{value}</div>
+      <div style={summaryDetail} title={detail}>{detail}</div>
+    </div>
+  </div>
+)
+
+const DetailCard: React.FC<{ title: string; description: string; action?: React.ReactNode; children: React.ReactNode }> = ({ title, description, action, children }) => (
+  <section style={detailCard}>
+    <div style={cardHeading}>
+      <div>
+        <div style={cardTitle}>{title}</div>
+        <div style={cardDescription}>{description}</div>
+      </div>
+      {action}
+    </div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>{children}</div>
+  </section>
+)
+
+function statusLabel(status: AutomationRun['status']): string {
+  return { success: 'Completed', failed: 'Failed', parked: 'Needs input', resumed: 'Resumed' }[status]
 }
 
+function statusColor(status: AutomationRun['status']): string {
+  if (status === 'failed') return C.red
+  if (status === 'parked') return C.yellow
+  return C.green
+}
+
+function automationHealth(a: Automation, latest?: AutomationRun): { label: string; color: string } {
+  if (!a.enabled) return { label: 'Paused', color: C.fg3 }
+  if (latest?.status === 'parked') return { label: 'Needs input', color: C.yellow }
+  if (latest?.status === 'failed') return { label: 'Last run failed', color: C.red }
+  return { label: 'Healthy', color: C.green }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return '<1s'
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.round((ms % 60_000) / 1000)
+  return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`
+}
+
+const pageStyle: React.CSSProperties = { padding: '18px 22px 28px', flex: 1, overflowY: 'auto', background: C.bg }
+const heroStyle: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 18 }
+const eyebrow: React.CSSProperties = { color: C.accent, fontSize: 9, fontWeight: 800, letterSpacing: 1.1, marginBottom: 4 }
+const titleRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 9, minWidth: 0 }
+const titleStyle: React.CSSProperties = { color: C.fg, fontSize: 19, lineHeight: 1.2, fontWeight: 750, margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+const subtitleStyle: React.CSSProperties = { color: C.fg3, fontSize: 11, marginTop: 4 }
+const heroActions: React.CSSProperties = { display: 'flex', gap: 7, alignItems: 'center', flexShrink: 0 }
+const actionButton: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: 6 }
+const iconButton: React.CSSProperties = { ...pillButton('ghost'), ...actionButton }
+const enabledControl: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 5, padding: '7px 9px', color: C.fg2, fontSize: 11, border: `1px solid ${C.border}`, borderRadius: 8, background: C.surface }
+const healthBadge = (color: string): React.CSSProperties => ({ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 8px', borderRadius: 999, color, background: C.surface3, fontSize: 10, fontWeight: 700, whiteSpace: 'nowrap' })
+const healthDot = (color: string): React.CSSProperties => ({ width: 6, height: 6, borderRadius: 999, background: color, boxShadow: `0 0 0 3px ${C.surface2}` })
+
+const parkedBanner: React.CSSProperties = {
+  marginTop: 14, padding: '12px 14px', borderRadius: 11,
+  border: `1px solid ${C.yellow}`, background: C.warningBg,
+}
+const attentionIcon: React.CSSProperties = { width: 24, height: 24, flexShrink: 0, display: 'grid', placeItems: 'center', borderRadius: 8, background: C.yellow, color: C.bg, fontWeight: 900, fontSize: 12 }
+
+const summaryGrid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 9, marginTop: 15 }
+const summaryCard: React.CSSProperties = { display: 'flex', gap: 10, minWidth: 0, padding: '11px 12px', border: `1px solid ${C.border}`, borderRadius: 11, background: C.surface }
+const summaryIcon: React.CSSProperties = { width: 30, height: 30, flexShrink: 0, display: 'grid', placeItems: 'center', borderRadius: 9, background: C.accentDim, color: C.accent }
+const summaryLabel: React.CSSProperties = { color: C.fg3, fontSize: 9.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.4 }
+const summaryValue: React.CSSProperties = { fontSize: 12, fontWeight: 700, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+const summaryDetail: React.CSSProperties = { color: C.fg3, fontSize: 9.5, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+
 const tabBar: React.CSSProperties = {
-  display: 'flex', gap: 2, borderBottom: `1px solid ${C.border}`, margin: '14px 0 12px',
+  display: 'flex', gap: 4, borderBottom: `1px solid ${C.border}`, margin: '18px 0 14px',
 }
 
 const tabStyle = (on: boolean): React.CSSProperties => ({
-  padding: '5px 14px', fontSize: 12, border: 'none', cursor: 'pointer',
-  borderRadius: '6px 6px 0 0', background: on ? C.surface : 'transparent',
-  color: on ? C.fg : C.fg3, fontWeight: on ? 600 : 400,
+  padding: '7px 13px', fontSize: 11.5, border: 'none', cursor: 'pointer',
+  borderBottom: `2px solid ${on ? C.accent : 'transparent'}`, background: 'transparent',
+  color: on ? C.fg : C.fg3, fontWeight: on ? 700 : 500,
 })
 
-const sectLabel: React.CSSProperties = {
-  color: C.fg3, fontSize: 11, fontWeight: 600,
-  textTransform: 'uppercase', letterSpacing: 0.4, marginTop: 16, marginBottom: 6,
-}
+const overviewGrid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', alignItems: 'start', gap: 12 }
+const detailCard: React.CSSProperties = { background: C.surface, border: `1px solid ${C.border}`, borderRadius: 12, padding: '14px 15px' }
+const cardHeading: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start', marginBottom: 12 }
+const cardTitle: React.CSSProperties = { color: C.fg, fontSize: 12.5, fontWeight: 750 }
+const cardDescription: React.CSSProperties = { color: C.fg3, fontSize: 10.5, lineHeight: 1.4, marginTop: 2 }
+const textButton: React.CSSProperties = { border: 'none', background: 'transparent', color: C.accent, cursor: 'pointer', fontSize: 10.5, whiteSpace: 'nowrap' }
 
 const briefBox: React.CSSProperties = {
-  margin: 0, padding: '10px 12px', borderRadius: 8, background: C.surface3, color: C.fg2,
-  fontSize: 12, lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+  padding: '10px 12px', borderRadius: 9, background: C.surface3, color: C.fg2,
+  fontSize: 12, lineHeight: 1.55, wordBreak: 'break-word',
 }
+const settingRow: React.CSSProperties = { display: 'flex', gap: 12, alignItems: 'center', justifyContent: 'space-between', minHeight: 32 }
+const settingLabel: React.CSSProperties = { color: C.fg2, fontSize: 11, minWidth: 90 }
+const settingInput: React.CSSProperties = { ...inputStyle, boxSizing: 'border-box', flex: 1, width: 'auto', minWidth: 0 }
+const settingSelect: React.CSSProperties = { ...selectStyle, width: 155 }
+const inlineToggle: React.CSSProperties = { display: 'flex', gap: 5, alignItems: 'center', color: C.fg2, fontSize: 11 }
+const compactInput: React.CSSProperties = { ...inputStyle, width: 88, padding: '5px 7px', fontSize: 11 }
+const removeButton: React.CSSProperties = { width: 25, height: 25, borderRadius: 7, border: `1px solid ${C.border}`, background: C.surface3, color: C.fg3, cursor: 'pointer' }
+const smallButton: React.CSSProperties = { padding: '5px 8px', borderRadius: 7, border: `1px solid ${C.border2}`, background: C.surface3, color: C.fg2, cursor: 'pointer', fontSize: 10 }
+const scheduleSlotList: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 8 }
+const scheduleSlotCard: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 8, padding: '9px 10px', border: `1px solid ${C.border}`, borderRadius: 9, background: C.surface2 }
+const slotHeader: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7 }
+const slotSummary: React.CSSProperties = { color: C.fg3, fontSize: 10, flex: 1 }
+const dayEditor: React.CSSProperties = { display: 'flex', gap: 4 }
+const dayButton = (active: boolean): React.CSSProperties => ({ width: 25, height: 25, borderRadius: 7, border: `1px solid ${active ? C.accent : C.border2}`, background: active ? C.accentDim : C.surface3, color: active ? C.accent : C.fg3, cursor: 'pointer', fontSize: 9, fontWeight: 750 })
+const infoRow: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', gap: 12, color: C.fg3, fontSize: 10.5, padding: '2px 0' }
+const emptyState: React.CSSProperties = { color: C.fg3, fontSize: 11, padding: '8px 0', fontStyle: 'italic' }
+const saveBar: React.CSSProperties = { gridColumn: '1 / -1', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, position: 'sticky', bottom: 8, zIndex: 2, padding: '11px 13px', border: `1px solid ${C.accent}`, borderRadius: 11, background: C.surface2, boxShadow: '0 8px 25px rgba(0,0,0,.22)', color: C.fg, fontSize: 11 }
+const dangerCard: React.CSSProperties = { gridColumn: '1 / -1', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginTop: 2, padding: '12px 14px', border: `1px solid ${C.dangerBorder}`, borderRadius: 11, background: C.dangerBg, color: C.dangerFg, fontSize: 11 }
+const noticeCopy: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 2 }
+const compactDeleteButton: React.CSSProperties = { ...pillButton('danger'), display: 'inline-flex', alignItems: 'center', gap: 4, padding: '5px 8px', borderRadius: 7, fontSize: 10, fontWeight: 600 }
 
-const knobRow: React.CSSProperties = {
-  display: 'flex', gap: 8, alignItems: 'center', margin: '4px 0',
-}
-
-const knobKey: React.CSSProperties = {
-  color: C.fg3, fontSize: 12, width: 90, flexShrink: 0,
-}
-
-const setupRow: React.CSSProperties = {
-  display: 'flex', gap: 8, alignItems: 'baseline', margin: '2px 0',
-  color: C.fg2, fontSize: 12,
-}
-
-const cardStyle: React.CSSProperties = {
-  background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10, padding: '12px 14px',
-}
-
-const logToggleStyle: React.CSSProperties = {
-  marginTop: 8, padding: '3px 10px', fontSize: 11, borderRadius: 6, cursor: 'pointer',
-  border: `1px solid ${C.border2}`, background: 'transparent', color: C.fg2,
-}
+const runsList: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 9 }
+const runCard: React.CSSProperties = { background: C.surface, border: `1px solid ${C.border}`, borderRadius: 11, overflow: 'hidden' }
+const runHeader: React.CSSProperties = { display: 'flex', gap: 10, alignItems: 'center', padding: '11px 13px' }
+const runStatusIcon = (color: string): React.CSSProperties => ({ width: 30, height: 30, display: 'grid', placeItems: 'center', borderRadius: 9, background: C.surface3, color, flexShrink: 0 })
+const triggerBadge: React.CSSProperties = { padding: '2px 6px', borderRadius: 999, background: C.surface3, color: C.fg3, fontSize: 9.5 }
+const runMeta: React.CSSProperties = { color: C.fg3, fontSize: 10, marginTop: 3 }
+const runBody: React.CSSProperties = { borderTop: `1px solid ${C.border}`, padding: '11px 13px', background: C.surface2 }
+const errorNotice: React.CSSProperties = { borderTop: `1px solid ${C.dangerBorder}`, padding: '8px 13px', background: C.dangerBg, color: C.dangerFg, fontSize: 10.5 }
 
 const outputStyle: React.CSSProperties = {
-  marginTop: 8, padding: '8px 10px', borderRadius: 6,
+  borderTop: `1px solid ${C.border}`, padding: '10px 13px',
   background: C.codeBg ?? C.surface3, color: C.codeFg ?? C.fg2,
   fontSize: 12, lineHeight: 1.5, wordBreak: 'break-word',
 }
 
 const preStyle: React.CSSProperties = {
-  marginTop: 8, padding: '8px 10px', borderRadius: 6,
+  margin: 0, padding: '10px 13px', borderTop: `1px solid ${C.border}`,
   background: C.codeBg ?? C.surface3, color: C.codeFg ?? C.fg2,
   fontSize: 11, lineHeight: 1.5, fontFamily: 'monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
 }

--- a/codey-mac/src/components/AutomationsView.tsx
+++ b/codey-mac/src/components/AutomationsView.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
 import { OverlayWindow } from './OverlayWindow'
 import { pillButton, unwrap } from './settingsAtoms'
-import { scheduleSummary } from './automationsModel'
+import { humanizeDelta, nextRunAt, scheduleSummary } from './automationsModel'
 import { AutomationChatCreate } from './AutomationChatCreate'
 import { AutomationOnePager } from './AutomationOnePager'
 import { UIIcon } from './UIIcons'
@@ -163,13 +163,25 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
     }
   }
 
-  const targetLabel = (t: AutomationTarget) =>
-    t.kind === 'team' ? `team: ${t.teamName} (${t.workspaceName})` : `prompt: ${t.workspaceName}`
+  const targetLabel = (t: AutomationTarget) => t.kind === 'team'
+    ? `Team · ${t.teamName} · ${t.workspaceName}`
+    : [t.workspaceName, t.agent && `${t.agent}${t.model ? ` · ${t.model}` : ''}`].filter(Boolean).join(' · ')
+
+  const attentionCount = automations.filter(a => {
+    const status = lastStatus[a.id]?.status
+    return status === 'failed' || status === 'parked'
+  }).length
+  const activeCount = automations.filter(a => a.enabled).length
+  const scheduledCount = automations.filter(a => a.enabled && a.schedule).length
+  const ordered = [...automations].sort((a, b) => {
+    const attention = (automation: Automation) => ['failed', 'parked'].includes(lastStatus[automation.id]?.status ?? '') ? 1 : 0
+    return attention(b) - attention(a) || Number(b.enabled) - Number(a.enabled) || b.updatedAt - a.updatedAt
+  })
 
   return (
     <div style={styles.list}>
       <div style={styles.listTop}>
-        <div><div style={styles.listTitle}>Automations</div><div style={styles.listSub}>Let Codey run routine work on a schedule.</div></div>
+        <div><div style={styles.listTitle}>Your automations</div><div style={styles.listSub}>Scheduled and manual workflows managed in one place.</div></div>
         {automations.length > 0 && (
           <button style={{ ...pillButton('primary'), display: 'inline-flex', alignItems: 'center', gap: 6 }} onClick={onNew}><UIIcon name="add" size={15} />New automation</button>
         )}
@@ -184,53 +196,104 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
           <button style={{ ...pillButton('primary'), marginTop: 16, display: 'inline-flex', alignItems: 'center', gap: 6 }} onClick={onNew}><UIIcon name="add" size={15} />Create automation</button>
         </div>
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {automations.map(a => {
+        <>
+          <div style={styles.listSummary}>
+            <ListStat value={activeCount} label="Active" tone={C.green} />
+            <ListStat value={scheduledCount} label="Scheduled" tone={C.accent} />
+            <ListStat value={attentionCount} label="Need attention" tone={attentionCount ? C.yellow : C.fg3} />
+          </div>
+          <div style={styles.cardList}>
+          {ordered.map(a => {
             const last = lastStatus[a.id]
+            const health = listHealth(a, last)
+            const next = a.enabled && a.schedule ? nextRunAt(a.schedule, Date.now()) : null
             return (
-              <div key={a.id} style={{ ...rowStyle, borderColor: a.enabled ? C.border2 : C.border }}>
-                <input
-                  type="checkbox"
-                  checked={a.enabled}
-                  onChange={() => void toggle(a)}
-                  title={a.enabled ? 'Enabled' : 'Disabled'}
-                  style={{ marginTop: 3 }}
-                />
-                <div style={{ flex: 1, minWidth: 0, cursor: 'pointer' }} onClick={() => onOpen(a.id)}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ width: 30, height: 30, borderRadius: 9, display: 'grid', placeItems: 'center', background: a.enabled ? C.accentDim : C.surface3, color: a.enabled ? C.accent : C.fg3 }}><UIIcon name="activity" size={15} /></span>
-                    <span style={{ color: C.fg, fontSize: 13, fontWeight: 600 }}>{a.name}</span>
-                    <span style={{ color: C.fg3, fontSize: 11 }}>{scheduleSummary(a.schedule)}</span>
+              <div key={a.id} style={{ ...rowStyle, opacity: a.enabled ? 1 : .76 }}>
+                <span style={{ ...statusRail, background: health.color }} />
+                <button style={cardMain} onClick={() => onOpen(a.id)}>
+                  <span style={automationIcon(a.enabled)}><UIIcon name={a.target.kind === 'team' ? 'users' : 'activity'} size={16} /></span>
+                  <span style={cardCopy}>
+                    <span style={nameRow}>
+                      <strong style={automationName}>{a.name}</strong>
+                      <span style={statusPill(health.color)}><span style={{ ...statusDot, background: health.color }} />{health.label}</span>
+                    </span>
+                    <span style={scheduleLine}>
+                      <UIIcon name="activity" size={12} />
+                      <span>{scheduleSummary(a.schedule)}</span>
+                      {a.schedule && <span style={timezoneText}>{a.schedule.tz}</span>}
+                    </span>
+                    <span style={targetLine}>{targetLabel(a.target)}</span>
+                  </span>
+                </button>
+                <div style={cardAside}>
+                  <div style={runRecency}>
+                    <span style={runRecencyLabel}>{last ? 'Last run' : next ? 'Next run' : 'Run history'}</span>
+                    <strong style={{ color: last?.status === 'failed' ? C.red : C.fg2, fontSize: 10.5 }}>
+                      {last ? runStatusText(last) : next ? humanizeDelta(next - Date.now()) : 'Not run yet'}
+                    </strong>
+                    {last && <span style={runDate}>{new Date(last.startedAt).toLocaleString()}</span>}
                   </div>
-                  <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>{targetLabel(a.target)}</div>
-                  {last && (
-                    <div style={{ color: last.status === 'failed' ? C.red : C.fg3, fontSize: 11, marginTop: 2 }}>
-                      last run: {last.status}{last.reportFailure ? ' - report delivery failed' : ''}
-                    </div>
-                  )}
-                </div>
-                <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
-                  <button style={pillButton('ghost')} onClick={() => onOpen(a.id)}>Details</button>
-                  <button style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 5 }} disabled={!!runningIds[a.id]} onClick={() => void runNow(a.id)}>
-                    <UIIcon name="play" size={13} />{runningIds[a.id] ? 'Running…' : 'Run'}
+                  <label style={enableToggle} title={a.enabled ? 'Pause automation' : 'Enable automation'}>
+                    <input type="checkbox" checked={a.enabled} onChange={() => void toggle(a)} />
+                    {a.enabled ? 'On' : 'Off'}
+                  </label>
+                  <button style={runButton} disabled={!!runningIds[a.id]} onClick={() => void runNow(a.id)}>
+                    <UIIcon name="play" size={12} />{runningIds[a.id] ? 'Starting…' : 'Run'}
                   </button>
+                  <button style={openButton} title="Open details" aria-label={`Open ${a.name}`} onClick={() => onOpen(a.id)}><UIIcon name="chevron" size={15} /></button>
                 </div>
               </div>
             )
           })}
-        </div>
+          </div>
+        </>
       )}
     </div>
   )
 }
 
+const ListStat: React.FC<{ value: number; label: string; tone: string }> = ({ value, label, tone }) => (
+  <div style={listStat}><strong style={{ color: tone, fontSize: 15 }}>{value}</strong><span>{label}</span></div>
+)
+
+function listHealth(a: Automation, last?: AutomationRun): { label: string; color: string } {
+  if (!a.enabled) return { label: 'Paused', color: C.fg3 }
+  if (last?.status === 'parked') return { label: 'Needs input', color: C.yellow }
+  if (last?.status === 'failed') return { label: 'Needs attention', color: C.red }
+  return { label: a.schedule ? 'Scheduled' : 'Ready', color: C.green }
+}
+
+function runStatusText(run: AutomationRun): string {
+  if (run.reportFailure) return 'Delivery failed'
+  return { success: 'Completed', failed: 'Failed', parked: 'Needs input', resumed: 'Resumed' }[run.status]
+}
+
 // ---------------------------------------------------------------------------
 
 const rowStyle: React.CSSProperties = {
-  display: 'flex', gap: 10, alignItems: 'flex-start',
+  display: 'flex', alignItems: 'stretch', position: 'relative', overflow: 'hidden',
   background: C.surface, border: `1px solid ${C.border}`, borderRadius: 13,
-  padding: '14px 15px', boxShadow: '0 5px 14px rgba(0,0,0,0.06)',
+  boxShadow: '0 5px 14px rgba(0,0,0,0.05)',
 }
+const statusRail: React.CSSProperties = { width: 3, flexShrink: 0 }
+const cardMain: React.CSSProperties = { flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 11, padding: '13px 14px', border: 'none', background: 'transparent', textAlign: 'left', cursor: 'pointer', color: 'inherit' }
+const automationIcon = (enabled: boolean): React.CSSProperties => ({ width: 34, height: 34, flexShrink: 0, display: 'grid', placeItems: 'center', borderRadius: 10, background: enabled ? C.accentDim : C.surface3, color: enabled ? C.accent : C.fg3 })
+const cardCopy: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0 }
+const nameRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }
+const automationName: React.CSSProperties = { color: C.fg, fontSize: 13, fontWeight: 720, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+const statusPill = (color: string): React.CSSProperties => ({ display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0, padding: '2px 6px', borderRadius: 999, color, background: C.surface3, fontSize: 9, fontWeight: 700 })
+const statusDot: React.CSSProperties = { width: 5, height: 5, borderRadius: 999 }
+const scheduleLine: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 5, color: C.fg2, fontSize: 10.5, minWidth: 0 }
+const timezoneText: React.CSSProperties = { color: C.fg3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+const targetLine: React.CSSProperties = { color: C.fg3, fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+const cardAside: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7, flexShrink: 0, padding: '10px 11px 10px 6px' }
+const runRecency: React.CSSProperties = { width: 130, display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 1, paddingRight: 5 }
+const runRecencyLabel: React.CSSProperties = { color: C.fg3, fontSize: 8.5, fontWeight: 750, textTransform: 'uppercase', letterSpacing: .45 }
+const runDate: React.CSSProperties = { color: C.fg3, fontSize: 8.5, whiteSpace: 'nowrap' }
+const enableToggle: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 4, color: C.fg3, fontSize: 9.5, cursor: 'pointer', padding: '5px 6px' }
+const runButton: React.CSSProperties = { ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 4, padding: '6px 9px', fontSize: 10.5 }
+const openButton: React.CSSProperties = { width: 28, height: 28, display: 'grid', placeItems: 'center', border: 'none', borderRadius: 8, background: 'transparent', color: C.fg3, cursor: 'pointer' }
+const listStat: React.CSSProperties = { display: 'flex', alignItems: 'baseline', gap: 6, color: C.fg3, fontSize: 10.5, padding: '7px 11px', borderRight: `1px solid ${C.border}` }
 
 const styles: Record<string, React.CSSProperties> = {
   body: { flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' },
@@ -242,6 +305,8 @@ const styles: Record<string, React.CSSProperties> = {
   listTop: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16, marginBottom: 20 },
   listTitle: { color: C.fg, fontSize: 17, fontWeight: 750, letterSpacing: '-0.02em' },
   listSub: { color: C.fg3, fontSize: 12, marginTop: 4 },
+  listSummary: { display: 'inline-flex', alignItems: 'center', border: `1px solid ${C.border}`, borderRadius: 10, background: C.surface, overflow: 'hidden', marginBottom: 12 },
+  cardList: { display: 'flex', flexDirection: 'column', gap: 8 },
   loading: { color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 46 },
   emptyState: { display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', maxWidth: 320, margin: '70px auto 0' },
   emptyIcon: { width: 60, height: 60, display: 'grid', placeItems: 'center', borderRadius: 18, background: C.accentDim, color: C.accent, border: `1px solid ${C.accent}` },

--- a/codey-mac/src/components/automationsModel.test.ts
+++ b/codey-mac/src/components/automationsModel.test.ts
@@ -1,41 +1,45 @@
 // codey-mac/src/components/automationsModel.test.ts
 import { describe, it, expect } from 'vitest'
-import { scheduleSummary, timesToSchedule, nextRunAt, humanizeDelta, draftComplete, formatHHMM, knobsFrom, knobsEqual, checkLabel } from './automationsModel'
+import { scheduleSummary, slotsToSchedule, nextRunAt, humanizeDelta, draftComplete, formatHHMM, knobsFrom, knobsEqual, checkLabel } from './automationsModel'
 
-const t = (hour: number, minute: number) => ({ hour, minute })
+const t = (hour: number, minute: number, daysOfWeek?: number[]) => ({ hour, minute, ...(daysOfWeek ? { daysOfWeek } : {}) })
 
 describe('scheduleSummary', () => {
   it('renders daily and weekly summaries', () => {
-    expect(scheduleSummary({ times: [t(9, 0)], tz: 'Asia/Shanghai' })).toBe('daily 09:00')
-    expect(scheduleSummary({ times: [t(18, 30)], daysOfWeek: [1, 2, 3, 4, 5], tz: 'UTC' }))
+    expect(scheduleSummary({ slots: [t(9, 0)], tz: 'Asia/Shanghai' })).toBe('daily 09:00')
+    expect(scheduleSummary({ slots: [t(18, 30, [1, 2, 3, 4, 5])], tz: 'UTC' }))
       .toBe('Mon–Fri 18:30')
-    expect(scheduleSummary({ times: [t(8, 5)], daysOfWeek: [0, 6], tz: 'UTC' })).toBe('Sun, Sat 08:05')
+    expect(scheduleSummary({ slots: [t(8, 5, [0, 6])], tz: 'UTC' })).toBe('Sun, Sat 08:05')
     expect(scheduleSummary(undefined)).toBe('manual')
   })
   it('lists every time of a multi-time schedule', () => {
-    expect(scheduleSummary({ times: [t(9, 0), t(18, 30)], tz: 'UTC' })).toBe('daily 09:00, 18:30')
+    expect(scheduleSummary({ slots: [t(9, 0), t(18, 30)], tz: 'UTC' })).toBe('daily 09:00, 18:30')
+  })
+  it('keeps each time connected to its own weekdays', () => {
+    expect(scheduleSummary({ slots: [t(21, 0, [1, 2, 3]), t(12, 0, [4, 5])], tz: 'UTC' }))
+      .toBe('Mon–Wed 21:00 · Thu–Fri 12:00')
   })
 })
 
-describe('timesToSchedule', () => {
-  it('maps HH:MM picker values + tz into a structured schedule', () => {
-    expect(timesToSchedule(['09:30'], 'Asia/Shanghai', [1, 3]))
-      .toEqual({ times: [t(9, 30)], tz: 'Asia/Shanghai', daysOfWeek: [1, 3] })
-    expect(timesToSchedule(['9:5'], 'UTC')).toEqual({ times: [t(9, 5)], tz: 'UTC' })
-    expect(timesToSchedule(['25:00'], 'UTC')).toBeNull()
+describe('slotsToSchedule', () => {
+  it('maps linked time/day picker values into a structured schedule', () => {
+    expect(slotsToSchedule([{ time: '09:30', days: [1, 3] }], 'Asia/Shanghai'))
+      .toEqual({ slots: [t(9, 30, [1, 3])], tz: 'Asia/Shanghai' })
+    expect(slotsToSchedule([{ time: '9:5', days: [] }], 'UTC')).toEqual({ slots: [t(9, 5)], tz: 'UTC' })
+    expect(slotsToSchedule([{ time: '25:00', days: [] }], 'UTC')).toBeNull()
   })
-  it('sorts and dedupes multiple times; rejects empty or partially invalid lists', () => {
-    expect(timesToSchedule(['18:00', '09:00', '18:00'], 'UTC'))
-      .toEqual({ times: [t(9, 0), t(18, 0)], tz: 'UTC' })
-    expect(timesToSchedule([], 'UTC')).toBeNull()
-    expect(timesToSchedule(['09:00', 'bogus'], 'UTC')).toBeNull()
+  it('sorts and dedupes slots; rejects empty or partially invalid lists', () => {
+    expect(slotsToSchedule([{ time: '18:00', days: [] }, { time: '09:00', days: [] }, { time: '18:00', days: [] }], 'UTC'))
+      .toEqual({ slots: [t(9, 0), t(18, 0)], tz: 'UTC' })
+    expect(slotsToSchedule([], 'UTC')).toBeNull()
+    expect(slotsToSchedule([{ time: '09:00', days: [] }, { time: 'bogus', days: [] }], 'UTC')).toBeNull()
   })
 })
 
 describe('nextRunAt', () => {
   // 2026-07-02T09:00 Asia/Shanghai (a Thursday) is 2026-07-02T01:00Z; SH has no DST.
   const SH_9AM = Date.UTC(2026, 6, 2, 1, 0, 0)
-  const daily = { times: [t(9, 0)], tz: 'Asia/Shanghai' }
+  const daily = { slots: [t(9, 0)], tz: 'Asia/Shanghai' }
 
   it('returns the next slot today when still ahead', () => {
     expect(nextRunAt(daily, SH_9AM - 3600_000)).toBe(SH_9AM)
@@ -45,27 +49,35 @@ describe('nextRunAt', () => {
   })
   it('respects daysOfWeek', () => {
     // Thursday 08:00 with Friday-only schedule -> Friday 09:00
-    expect(nextRunAt({ ...daily, daysOfWeek: [5] }, SH_9AM - 3600_000)).toBe(SH_9AM + 86_400_000)
+    expect(nextRunAt({ ...daily, slots: [t(9, 0, [5])] }, SH_9AM - 3600_000)).toBe(SH_9AM + 86_400_000)
   })
   it('returns null for manual-only', () => {
     expect(nextRunAt(undefined, SH_9AM)).toBeNull()
   })
   it('picks the nearest of multiple daily times', () => {
-    const multi = { times: [t(9, 0), t(18, 0)], tz: 'Asia/Shanghai' }
+    const multi = { slots: [t(9, 0), t(18, 0)], tz: 'Asia/Shanghai' }
     // Just after 09:00: next slot is 18:00 today, not 09:00 tomorrow.
     expect(nextRunAt(multi, SH_9AM)).toBe(SH_9AM + 9 * 3600_000)
     expect(nextRunAt(multi, SH_9AM + 9 * 3600_000)).toBe(SH_9AM + 86_400_000)
   })
+  it('keeps weekdays linked to their individual times', () => {
+    const linked = { slots: [t(21, 0, [1, 2, 3]), t(12, 0, [4, 5])], tz: 'Asia/Shanghai' }
+    // Thursday at 11:00: noon today is valid; Thursday 21:00 is not.
+    const thursday11 = Date.UTC(2026, 6, 2, 3, 0, 0)
+    expect(nextRunAt(linked, thursday11)).toBe(Date.UTC(2026, 6, 2, 4, 0, 0))
+    // After Thursday noon, next is Friday noon—not Thursday 21:00.
+    expect(nextRunAt(linked, Date.UTC(2026, 6, 2, 5, 0, 0))).toBe(Date.UTC(2026, 6, 3, 4, 0, 0))
+  })
   it('crosses a spring-forward transition correctly (DST)', () => {
     // 2026-03-08 02:00 America/New_York springs forward; 09:00 NY that day is 13:00Z
     const before = Date.UTC(2026, 2, 8, 1, 0, 0) // 2026-03-07 20:00 NY
-    expect(nextRunAt({ times: [t(9, 0)], tz: 'America/New_York' }, before))
+    expect(nextRunAt({ slots: [t(9, 0)], tz: 'America/New_York' }, before))
       .toBe(Date.UTC(2026, 2, 8, 13, 0, 0))
   })
   it('does not skip a calendar day near midnight before spring-forward', () => {
     // Sat 2026-03-07 23:30 NY; daily 23:00 schedule -> Sunday Mar 8 23:00 EDT = Mar 9 03:00Z
     const satLate = Date.UTC(2026, 2, 8, 4, 30, 0)
-    expect(nextRunAt({ times: [t(23, 0)], tz: 'America/New_York' }, satLate))
+    expect(nextRunAt({ slots: [t(23, 0)], tz: 'America/New_York' }, satLate))
       .toBe(Date.UTC(2026, 2, 9, 3, 0, 0))
   })
 })
@@ -90,7 +102,7 @@ describe('formatHHMM', () => {
 describe('knobsFrom', () => {
   const base = {
     params: { topic: 'ai' },
-    schedule: { times: [t(9, 5), t(18, 0)], daysOfWeek: [5, 1, 3], tz: 'UTC' },
+    schedule: { slots: [t(9, 5, [5, 1, 3]), t(18, 0, [5, 1, 3])], tz: 'UTC' },
     report: { notify: 'all' as const },
   }
 
@@ -98,8 +110,7 @@ describe('knobsFrom', () => {
     expect(knobsFrom(base)).toEqual({
       params: { topic: 'ai' },
       scheduleOn: true,
-      times: ['09:05', '18:00'],
-      days: [1, 3, 5],
+      slots: [{ time: '09:05', days: [1, 3, 5] }, { time: '18:00', days: [1, 3, 5] }],
       notify: 'all',
     })
   })
@@ -108,8 +119,7 @@ describe('knobsFrom', () => {
     expect(knobsFrom({ params: {}, report: { notify: 'none' } })).toEqual({
       params: {},
       scheduleOn: false,
-      times: ['09:00'],
-      days: [],
+      slots: [{ time: '09:00', days: [] }],
       notify: 'none',
     })
   })
@@ -122,7 +132,7 @@ describe('knobsFrom', () => {
 describe('knobsEqual', () => {
   const auto = {
     params: { topic: 'ai' },
-    schedule: { times: [t(9, 5), t(18, 0)], daysOfWeek: [5, 1, 3], tz: 'UTC' },
+    schedule: { slots: [t(9, 5, [5, 1, 3]), t(18, 0, [5, 1, 3])], tz: 'UTC' },
     report: { notify: 'all' as const },
   }
 
@@ -132,7 +142,7 @@ describe('knobsEqual', () => {
 
   it('tolerates unsorted persisted daysOfWeek (no phantom dirty)', () => {
     const seeded = knobsFrom(auto)
-    expect(seeded.days).toEqual([1, 3, 5])
+    expect(seeded.slots[0].days).toEqual([1, 3, 5])
     expect(knobsEqual(seeded, auto)).toBe(true)
   })
 
@@ -141,12 +151,12 @@ describe('knobsEqual', () => {
   })
 
   it('is false when times differ', () => {
-    expect(knobsEqual({ ...knobsFrom(auto), times: ['10:05', '18:00'] }, auto)).toBe(false)
-    expect(knobsEqual({ ...knobsFrom(auto), times: ['09:05'] }, auto)).toBe(false)
+    expect(knobsEqual({ ...knobsFrom(auto), slots: [{ time: '10:05', days: [1, 3, 5] }, { time: '18:00', days: [1, 3, 5] }] }, auto)).toBe(false)
+    expect(knobsEqual({ ...knobsFrom(auto), slots: [{ time: '09:05', days: [1, 3, 5] }] }, auto)).toBe(false)
   })
 
   it('tolerates unordered staged times (no phantom dirty)', () => {
-    expect(knobsEqual({ ...knobsFrom(auto), times: ['18:00', '09:05'] }, auto)).toBe(true)
+    expect(knobsEqual({ ...knobsFrom(auto), slots: [...knobsFrom(auto).slots].reverse() }, auto)).toBe(true)
   })
 
   it('is false when notify differs', () => {
@@ -159,7 +169,7 @@ describe('knobsEqual', () => {
 
   it('ignores times/days when the schedule is off on both sides', () => {
     const manual = { params: {}, report: { notify: 'all' as const } }
-    expect(knobsEqual({ ...knobsFrom(manual), times: ['17:00'], days: [2] }, manual)).toBe(true)
+    expect(knobsEqual({ ...knobsFrom(manual), slots: [{ time: '17:00', days: [2] }] }, manual)).toBe(true)
   })
 })
 
@@ -170,15 +180,17 @@ describe('draftComplete', () => {
     expect(draftComplete({ name: ' ', brief: 'b', target: { workspaceName: 'w' } })).toBe(false)
     expect(draftComplete({ name: 'n', brief: 'b', target: { workspaceName: ' ' } })).toBe(false)
     expect(draftComplete({ name: 'n', brief: 'b', target: { workspaceName: 'w' } })).toBe(true)
+    expect(draftComplete({ name: 'n', brief: 'b', target: { kind: 'team', workspaceName: 'w' } })).toBe(false)
+    expect(draftComplete({ name: 'n', brief: 'b', target: { kind: 'team', workspaceName: 'w', teamName: 'news' } })).toBe(true)
   })
 })
 
 describe('checkLabel', () => {
   it('maps each check state to its status-row label', () => {
-    expect(checkLabel('pending')).toEqual({ text: 'checking…', tone: 'dim' })
-    expect(checkLabel('clean')).toEqual({ text: 'unattended-ready', tone: 'good' })
-    expect(checkLabel('gaps')).toEqual({ text: 'may need input during runs', tone: 'warn' })
-    expect(checkLabel('error')).toEqual({ text: 'check failed', tone: 'dim' })
+    expect(checkLabel('pending')).toEqual({ text: 'Checking setup…', tone: 'dim' })
+    expect(checkLabel('clean')).toEqual({ text: 'Ready to run unattended', tone: 'good' })
+    expect(checkLabel('gaps')).toEqual({ text: 'Needs clarification', tone: 'warn' })
+    expect(checkLabel('error')).toEqual({ text: 'Check couldn’t run', tone: 'dim' })
     expect(checkLabel(undefined)).toBeNull()
   })
 })

--- a/codey-mac/src/components/automationsModel.ts
+++ b/codey-mac/src/components/automationsModel.ts
@@ -1,37 +1,52 @@
 // codey-mac/src/components/automationsModel.ts
 // Pure helpers for the Automations view — kept separate for unit tests.
 
-export interface ScheduleTimeLike { hour: number; minute: number }
-export interface ScheduleLike { times: ScheduleTimeLike[]; daysOfWeek?: number[]; tz: string }
+export interface ScheduleSlotLike { hour: number; minute: number; daysOfWeek?: number[] }
+export interface ScheduleLike { slots: ScheduleSlotLike[]; tz: string }
+export interface ScheduleSlotInput { time: string; days: number[] }
 
 const DAY = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const pad = (n: number) => String(n).padStart(2, '0')
 
 export function scheduleSummary(s: ScheduleLike | undefined): string {
   if (!s) return 'manual'
-  const time = s.times.map(t => `${pad(t.hour)}:${pad(t.minute)}`).join(', ')
-  if (!s.daysOfWeek || s.daysOfWeek.length === 0 || s.daysOfWeek.length === 7) return `daily ${time}`
-  const days = [...s.daysOfWeek].sort((a, b) => a - b)
-  const contiguous = days.length > 2 && days.every((d, i) => i === 0 || d === days[i - 1] + 1)
-  const label = contiguous
-    ? `${DAY[days[0]]}–${DAY[days[days.length - 1]]}`
-    : days.map(d => DAY[d]).join(', ')
-  return `${label} ${time}`
+  const groups = new Map<string, { days: number[]; times: string[] }>()
+  for (const slot of s.slots) {
+    const days = [...(slot.daysOfWeek ?? [])].sort((a, b) => a - b)
+    const key = days.join(',')
+    const group = groups.get(key) ?? { days, times: [] }
+    group.times.push(`${pad(slot.hour)}:${pad(slot.minute)}`)
+    groups.set(key, group)
+  }
+  return [...groups.values()].map(group => `${dayLabel(group.days)} ${group.times.join(', ')}`).join(' · ')
 }
 
-/** Build a schedule from "HH:MM" strings; null when empty or any is invalid. */
-export function timesToSchedule(hhmms: string[], tz: string, daysOfWeek?: number[]): ScheduleLike | null {
-  if (hhmms.length === 0) return null
-  const times: ScheduleTimeLike[] = []
-  for (const hhmm of hhmms) {
-    const m = hhmm.match(/^(\d{1,2}):(\d{1,2})$/)
+function dayLabel(days: number[]): string {
+  if (days.length === 0 || days.length === 7) return 'daily'
+  const contiguous = days.length > 1 && days.every((d, i) => i === 0 || d === days[i - 1] + 1)
+  return contiguous
+    ? `${DAY[days[0]]}–${DAY[days[days.length - 1]]}`
+    : days.map(d => DAY[d]).join(', ')
+}
+
+/** Build a schedule from linked time/day inputs; null when any slot is invalid. */
+export function slotsToSchedule(inputs: ScheduleSlotInput[], tz: string): ScheduleLike | null {
+  if (inputs.length === 0) return null
+  const slots: ScheduleSlotLike[] = []
+  for (const input of inputs) {
+    const m = input.time.match(/^(\d{1,2}):(\d{1,2})$/)
     if (!m) return null
     const hour = Number(m[1]); const minute = Number(m[2])
     if (hour > 23 || minute > 59) return null
-    if (!times.some(t => t.hour === hour && t.minute === minute)) times.push({ hour, minute })
+    const days = [...new Set(input.days)].sort((a, b) => a - b)
+    if (!days.every(day => Number.isInteger(day) && day >= 0 && day <= 6)) return null
+    const slot = { hour, minute, ...(days.length && days.length < 7 ? { daysOfWeek: days } : {}) }
+    const key = `${hour}:${minute}:${slot.daysOfWeek?.join(',') ?? '*'}`
+    if (!slots.some(existing => `${existing.hour}:${existing.minute}:${existing.daysOfWeek?.join(',') ?? '*'}` === key)) slots.push(slot)
   }
-  times.sort((a, b) => (a.hour * 60 + a.minute) - (b.hour * 60 + b.minute))
-  return { times, tz, ...(daysOfWeek && daysOfWeek.length ? { daysOfWeek } : {}) }
+  slots.sort((a, b) => (a.hour * 60 + a.minute) - (b.hour * 60 + b.minute)
+    || (a.daysOfWeek?.join(',') ?? '').localeCompare(b.daysOfWeek?.join(',') ?? ''))
+  return { slots, tz }
 }
 
 // ---- Notify mode ----
@@ -90,14 +105,14 @@ export function nextRunAt(s: ScheduleLike | undefined, nowMs: number): number | 
   for (let dayOffset = 0; dayOffset <= 7; dayOffset++) {
     // Iterate calendar days (Date.UTC normalizes day overflow) so a real-time
     // step across a spring-forward transition can never skip a date.
-    const candidates = s.times
-      .map(t => zonedInstant(base.year, base.month, base.day + dayOffset, t.hour, t.minute, s.tz))
-      .filter(c => c > nowMs)
-      .sort((a, b) => a - b)
+    const candidates = s.slots
+      .map(slot => ({ slot, instant: zonedInstant(base.year, base.month, base.day + dayOffset, slot.hour, slot.minute, s.tz) }))
+      .filter(candidate => candidate.instant > nowMs)
+      .sort((a, b) => a.instant - b.instant)
     for (const candidate of candidates) {
-      const dow = localParts(candidate, s.tz).dayOfWeek
-      if (s.daysOfWeek && s.daysOfWeek.length > 0 && !s.daysOfWeek.includes(dow)) continue
-      return candidate
+      const dow = localParts(candidate.instant, s.tz).dayOfWeek
+      if (candidate.slot.daysOfWeek?.length && !candidate.slot.daysOfWeek.includes(dow)) continue
+      return candidate.instant
     }
   }
   return null
@@ -118,9 +133,7 @@ export function formatHHMM(hour: number, minute: number): string {
 export interface Knobs {
   params: Record<string, string>
   scheduleOn: boolean
-  /** "HH:MM" strings, one per daily firing time. */
-  times: string[]
-  days: number[]
+  slots: ScheduleSlotInput[]
   notify: NotifyMode
 }
 
@@ -131,13 +144,14 @@ interface KnobSource {
 }
 
 /** Seed knobs from an automation. Days are sorted so an unsorted persisted
- *  daysOfWeek can't create a phantom-dirty state. */
+ *  weekday order can't create a phantom-dirty state. */
 export function knobsFrom(a: KnobSource): Knobs {
   return {
     params: { ...a.params },
     scheduleOn: !!a.schedule,
-    times: a.schedule ? a.schedule.times.map(t => formatHHMM(t.hour, t.minute)) : ['09:00'],
-    days: [...(a.schedule?.daysOfWeek ?? [])].sort((x, y) => x - y),
+    slots: a.schedule
+      ? a.schedule.slots.map(slot => ({ time: formatHHMM(slot.hour, slot.minute), days: [...(slot.daysOfWeek ?? [])].sort((x, y) => x - y) }))
+      : [{ time: '09:00', days: [] }],
     notify: a.report.notify,
   }
 }
@@ -147,12 +161,11 @@ export function knobsEqual(k: Knobs, a: KnobSource): boolean {
   if (JSON.stringify(k.params) !== JSON.stringify(a.params)) return false
   if (k.scheduleOn !== !!a.schedule) return false
   if (k.scheduleOn) {
-    const kt = [...k.times].sort()
-    const at = (a.schedule?.times ?? []).map(t => formatHHMM(t.hour, t.minute)).sort()
-    if (JSON.stringify(kt) !== JSON.stringify(at)) return false
-    const kd = [...k.days].sort((x, y) => x - y)
-    const ad = [...(a.schedule?.daysOfWeek ?? [])].sort((x, y) => x - y)
-    if (JSON.stringify(kd) !== JSON.stringify(ad)) return false
+    const canonical = (slots: ScheduleSlotInput[]) => slots
+      .map(slot => ({ time: slot.time, days: [...slot.days].sort((x, y) => x - y) }))
+      .sort((x, y) => x.time.localeCompare(y.time) || x.days.join(',').localeCompare(y.days.join(',')))
+    const actual = (a.schedule?.slots ?? []).map(slot => ({ time: formatHHMM(slot.hour, slot.minute), days: [...(slot.daysOfWeek ?? [])] }))
+    if (JSON.stringify(canonical(k.slots)) !== JSON.stringify(canonical(actual))) return false
   }
   return k.notify === a.report.notify
 }
@@ -160,12 +173,15 @@ export function knobsEqual(k: Knobs, a: KnobSource): boolean {
 export interface DraftLike {
   name?: string
   brief?: string
-  target?: { workspaceName?: string }
+  target?: { kind?: 'prompt' | 'team'; workspaceName?: string; teamName?: string }
 }
 
 /** Client-side gate for the Create/Save button in the authoring chat. */
 export function draftComplete(d: DraftLike): boolean {
-  return !!(d.name?.trim() && d.brief?.trim() && d.target?.workspaceName?.trim())
+  return !!(
+    d.name?.trim() && d.brief?.trim() && d.target?.workspaceName?.trim()
+    && (d.target.kind !== 'team' || d.target.teamName?.trim())
+  )
 }
 
 export type CheckTone = 'dim' | 'good' | 'warn'
@@ -175,10 +191,10 @@ export function checkLabel(
   check: 'pending' | 'clean' | 'gaps' | 'error' | undefined,
 ): { text: string; tone: CheckTone } | null {
   switch (check) {
-    case 'pending': return { text: 'checking…', tone: 'dim' }
-    case 'clean': return { text: 'unattended-ready', tone: 'good' }
-    case 'gaps': return { text: 'may need input during runs', tone: 'warn' }
-    case 'error': return { text: 'check failed', tone: 'dim' }
+    case 'pending': return { text: 'Checking setup…', tone: 'dim' }
+    case 'clean': return { text: 'Ready to run unattended', tone: 'good' }
+    case 'gaps': return { text: 'Needs clarification', tone: 'warn' }
+    case 'error': return { text: 'Check couldn’t run', tone: 'dim' }
     default: return null
   }
 }

--- a/packages/core/src/aide-automation.test.ts
+++ b/packages/core/src/aide-automation.test.ts
@@ -71,16 +71,16 @@ describe('automationChatTurn', () => {
     // Numeric-string hour in the legacy single shape: coerced, not lost.
     const legacy = await automationChatTurn(msgs, {}, ctx, aide(
       '{"reply":"ok","draftPatch":{"schedule":{"hour":"9","minute":0,"tz":"UTC"}}}'));
-    expect(legacy.draftPatch).toEqual({ schedule: { times: [{ hour: 9, minute: 0 }], tz: 'UTC' } });
+    expect(legacy.draftPatch).toEqual({ schedule: { slots: [{ hour: 9, minute: 0 }], tz: 'UTC' } });
     // Missing tz falls back to the user's zone; times are sorted.
     const noTz = await automationChatTurn(msgs, {}, ctx, aide(
       '{"reply":"ok","draftPatch":{"schedule":{"times":[{"hour":18,"minute":30},{"hour":9,"minute":0}]}}}'));
     expect(noTz.draftPatch).toEqual({
-      schedule: { times: [{ hour: 9, minute: 0 }, { hour: 18, minute: 30 }], tz: 'Asia/Shanghai' },
+      schedule: { slots: [{ hour: 9, minute: 0 }, { hour: 18, minute: 30 }], tz: 'Asia/Shanghai' },
     });
     const good = await automationChatTurn(msgs, {}, ctx, aide(
       '{"reply":"ok","draftPatch":{"schedule":{"times":[{"hour":9,"minute":0}],"tz":"UTC","daysOfWeek":[1,2]}}}'));
-    expect(good.draftPatch).toEqual({ schedule: { times: [{ hour: 9, minute: 0 }], daysOfWeek: [1, 2], tz: 'UTC' } });
+    expect(good.draftPatch).toEqual({ schedule: { slots: [{ hour: 9, minute: 0, daysOfWeek: [1, 2] }], tz: 'UTC' } });
   });
 
   it('drops an unusable schedule patch', async () => {

--- a/packages/core/src/aide-automation.ts
+++ b/packages/core/src/aide-automation.ts
@@ -1,6 +1,7 @@
 // packages/core/src/aide-automation.ts
 import { AideOptions, runAideJson } from './aide';
 import type { AutomationNotifyMode, AutomationSchedule, AutomationTarget } from './types/automation';
+import type { CodingAgent } from './types/index';
 import { NOTIFY_MODES, normalizeSchedule } from './types/automation';
 
 /**
@@ -33,6 +34,9 @@ export interface AutomationDraft {
 export interface AutomationChatContext {
   workspaces: string[];
   teams: string[];
+  /** Available execution overrides for prompt targets. */
+  agents?: CodingAgent[];
+  models?: string[];
   /** User's IANA zone, e.g. "Asia/Shanghai". */
   tz: string;
   /** Current local datetime string, for resolving "every morning" etc. */
@@ -57,7 +61,11 @@ const DRAFT_KEYS = new Set(['name', 'target', 'schedule', 'notify', 'brief', 'pa
 function isValidTargetPatch(v: unknown): v is AutomationTarget {
   if (!v || typeof v !== 'object' || Array.isArray(v)) return false;
   const t = v as Record<string, unknown>;
-  if (t.kind === 'prompt') return typeof t.workspaceName === 'string' && !!t.workspaceName;
+  if (t.kind === 'prompt') {
+    const agentOk = t.agent === undefined || t.agent === 'claude-code' || t.agent === 'opencode' || t.agent === 'codex';
+    const modelOk = t.model === undefined || (typeof t.model === 'string' && !!t.model.trim());
+    return typeof t.workspaceName === 'string' && !!t.workspaceName && agentOk && modelOk;
+  }
   if (t.kind === 'team') return typeof t.teamName === 'string' && !!t.teamName && typeof t.workspaceName === 'string' && !!t.workspaceName;
   return false;
 }
@@ -69,6 +77,8 @@ const CHAT_TURN_PROMPT = (
 Environment:
 - Workspaces (the only valid choices): ${ctx.workspaces.join(', ') || '(none)'}
 - Teams (optional execution target): ${ctx.teams.join(', ') || '(none)'}
+- Agent overrides: ${ctx.agents?.join(', ') || '(use gateway default)'}
+- Model overrides: ${ctx.models?.join(', ') || '(use agent default)'}
 - User timezone: ${ctx.tz}; current time: ${ctx.nowIso}
 - Mode: ${ctx.mode === 'edit' ? 'editing an existing automation - only change what the user asks to change' : 'creating a new automation'}
 
@@ -79,7 +89,7 @@ Conversation so far:
 ${messages.map(m => `${m.role === 'user' ? 'User' : 'You'}: ${m.text}`).join('\n')}
 
 Your job this turn:
-1. Update the draft with anything the user's latest message settles. draftPatch contains ONLY fields that changed; set a field to null to clear it. Draft fields: name (short title), target ({"kind":"prompt","workspaceName":"..."} or {"kind":"team","teamName":"...","workspaceName":"..."}), schedule ({"times":[{"hour":0-23,"minute":0-59},...],"daysOfWeek":[0-6] optional,"tz":"${ctx.tz}"} or null for manual-only; times holds one entry per firing time, so "9am and 6pm" is [{"hour":9,"minute":0},{"hour":18,"minute":0}]), notify ("all" | "failure" | "success" | "none" - which run outcomes fire an OS notification; default "none"), brief (string), params (object of string values).
+1. Update the draft with anything the user's latest message settles. draftPatch contains ONLY fields that changed; set a field to null to clear it. Draft fields: name (short title), target ({"kind":"prompt","workspaceName":"...","agent":"optional","model":"optional"} or {"kind":"team","teamName":"...","workspaceName":"..."}), schedule ({"slots":[{"hour":0-23,"minute":0-59,"daysOfWeek":[0-6] optional},...],"tz":"${ctx.tz}"} or null for manual-only). Each slot owns its weekdays; absent daysOfWeek means every day. Example: Mon-Wed at 9pm plus Thu-Fri at noon is {"slots":[{"hour":21,"minute":0,"daysOfWeek":[1,2,3]},{"hour":12,"minute":0,"daysOfWeek":[4,5]}],"tz":"${ctx.tz}"}. notify ("all" | "failure" | "success" | "none" - which run outcomes fire an OS notification; default "none"), brief (string), params (object of string values).
 2. Reply conversationally and ask about ONE thing at a time - the next most important gap: missing specifics, choices, accounts/handles, formats, limits, edge cases (e.g. "what if there is nothing to report?"). Never ask about something the user already answered, even in passing. If the user revises an earlier choice, just patch it and move on. Patch schedule whenever the user's message settles timing, but do not steer the conversation toward scheduling.
 3. When the answer space is enumerable (workspace names, team names, times, yes/no), offer 2-5 short suggestions the user can tap. Only ever suggest workspace/team names that appear in the environment above.
 4. Maintain the brief as you learn: a frozen, fully self-contained instruction block for an unattended agent - no "the user said", concrete values, edge-case handling, expected output. Surface tweakable knobs as {{placeholder}} in the brief with current values in params.

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -1,59 +1,65 @@
 import type { CodingAgent } from './index';
 
-/** One firing time within a day, in the schedule's `tz`. */
-export interface AutomationScheduleTime {
+/** One independently configured firing slot in the schedule's `tz`. */
+export interface AutomationScheduleSlot {
   /** 0-23. */
   hour: number;
   /** 0-59. */
   minute: number;
+  /** 0=Sun … 6=Sat. Absent = every day. */
+  daysOfWeek?: number[];
 }
 
 /** Structured time-of-day schedule (spec decision #10 — not a cron string). */
 export interface AutomationSchedule {
-  /** One or more firing times per active day (unique, sorted). */
-  times: AutomationScheduleTime[];
-  /** 0=Sun … 6=Sat. Absent = every day. */
-  daysOfWeek?: number[];
+  /** One or more independently scheduled time/day combinations. */
+  slots: AutomationScheduleSlot[];
   /** IANA zone, e.g. "Asia/Shanghai". */
   tz: string;
 }
 
-function coerceScheduleTime(v: unknown): AutomationScheduleTime | undefined {
-  const t = v as { hour?: unknown; minute?: unknown };
+function normalizeDays(v: unknown): number[] | undefined | null {
+  if (v === undefined) return undefined;
+  if (!Array.isArray(v) || !v.every(d => typeof d === 'number' && Number.isInteger(d) && d >= 0 && d <= 6)) return null;
+  const unique = [...new Set(v as number[])].sort((a, b) => a - b);
+  return unique.length === 0 || unique.length === 7 ? undefined : unique;
+}
+
+function coerceScheduleSlot(v: unknown, fallbackDays?: number[]): AutomationScheduleSlot | undefined {
+  const t = v as { hour?: unknown; minute?: unknown; daysOfWeek?: unknown };
   const hour = typeof t?.hour === 'string' ? Number(t.hour) : t?.hour;
   const minute = typeof t?.minute === 'string' ? Number(t.minute) : t?.minute;
   if (typeof hour !== 'number' || !Number.isInteger(hour) || hour < 0 || hour > 23) return undefined;
   if (typeof minute !== 'number' || !Number.isInteger(minute) || minute < 0 || minute > 59) return undefined;
-  return { hour, minute };
+  const days = normalizeDays(t.daysOfWeek === undefined ? fallbackDays : t.daysOfWeek);
+  if (days === null) return undefined;
+  return { hour, minute, ...(days ? { daysOfWeek: days } : {}) };
 }
 
 /**
- * Coerce a schedule-shaped value to the current schema, or undefined if it
- * can't be one. Accepts the legacy single {hour, minute} shape (pre-`times`
- * files) and numeric strings; dedupes and sorts times. `tz` is NOT defaulted
- * here — callers with a known zone pass `fallbackTz`.
+ * Coerce a schedule-shaped value to the current slot schema, or undefined if
+ * it can't be one. Accepts legacy {times, daysOfWeek} schedules and the oldest
+ * single {hour, minute} shape. `tz` is not defaulted unless supplied.
  */
 export function normalizeSchedule(v: unknown, fallbackTz?: string): AutomationSchedule | undefined {
   if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
-  const s = v as { times?: unknown; daysOfWeek?: unknown; tz?: unknown; hour?: unknown; minute?: unknown };
-  const rawTimes = Array.isArray(s.times) ? s.times : [s];
-  const times: AutomationScheduleTime[] = [];
-  for (const raw of rawTimes) {
-    const t = coerceScheduleTime(raw);
-    if (!t) return undefined;
-    if (!times.some(x => x.hour === t.hour && x.minute === t.minute)) times.push(t);
+  const s = v as { slots?: unknown; times?: unknown; daysOfWeek?: unknown; tz?: unknown; hour?: unknown; minute?: unknown };
+  const legacyDays = normalizeDays(s.daysOfWeek);
+  if (legacyDays === null) return undefined;
+  const rawSlots = Array.isArray(s.slots) ? s.slots : Array.isArray(s.times) ? s.times : [s];
+  const slots: AutomationScheduleSlot[] = [];
+  for (const raw of rawSlots) {
+    const slot = coerceScheduleSlot(raw, legacyDays);
+    if (!slot) return undefined;
+    const key = `${slot.hour}:${slot.minute}:${slot.daysOfWeek?.join(',') ?? '*'}`;
+    if (!slots.some(x => `${x.hour}:${x.minute}:${x.daysOfWeek?.join(',') ?? '*'}` === key)) slots.push(slot);
   }
-  if (times.length === 0) return undefined;
-  times.sort((a, b) => (a.hour * 60 + a.minute) - (b.hour * 60 + b.minute));
+  if (slots.length === 0) return undefined;
+  slots.sort((a, b) => (a.hour * 60 + a.minute) - (b.hour * 60 + b.minute)
+    || (a.daysOfWeek?.join(',') ?? '').localeCompare(b.daysOfWeek?.join(',') ?? ''));
   const tz = typeof s.tz === 'string' && s.tz ? s.tz : fallbackTz;
   if (!tz) return undefined;
-  let daysOfWeek: number[] | undefined;
-  if (s.daysOfWeek !== undefined) {
-    if (!Array.isArray(s.daysOfWeek)) return undefined;
-    if (!s.daysOfWeek.every(d => typeof d === 'number' && Number.isInteger(d) && d >= 0 && d <= 6)) return undefined;
-    daysOfWeek = s.daysOfWeek as number[];
-  }
-  return { times, ...(daysOfWeek !== undefined ? { daysOfWeek } : {}), tz };
+  return { slots, tz };
 }
 
 export type AutomationTarget =

--- a/packages/gateway/src/automations/chat.test.ts
+++ b/packages/gateway/src/automations/chat.test.ts
@@ -3,6 +3,10 @@ import { AutomationChatManager, SESSION_TTL_MS } from './chat';
 import type { AutomationChatTurn } from '@codey/core';
 
 const CTX = { workspaces: ['default'], teams: ['news'], tz: 'Asia/Shanghai', nowIso: 'now' };
+const COMPLETE = {
+  name: 'News', target: { kind: 'prompt' as const, workspaceName: 'default' },
+  brief: 'Post five items.', params: {},
+};
 
 const turnResult = (over: Partial<AutomationChatTurn> = {}): AutomationChatTurn =>
   ({ reply: 'ok', draftPatch: {}, suggestions: [], ready: false, ...over });
@@ -65,7 +69,7 @@ describe('send', () => {
   it('a null patch value clears the field', async () => {
     const turn = vi.fn(async () => turnResult({ draftPatch: { schedule: null } as any }));
     const { mgr } = manager(turn);
-    const { sessionId } = mgr.start('edit', { schedule: { times: [{ hour: 9, minute: 0 }], tz: 'UTC' } });
+    const { sessionId } = mgr.start('edit', { schedule: { slots: [{ hour: 9, minute: 0 }], tz: 'UTC' } });
     const step = await mgr.send(sessionId, 'make it manual');
     expect('schedule' in step.draft).toBe(false);
   });
@@ -114,15 +118,15 @@ describe('dry-run check state', () => {
   it('sets check=pending and fires onReadyTransition only on a false->true ready transition', async () => {
     const onReadyTransition = vi.fn();
     const turn = vi.fn()
-      .mockResolvedValueOnce(turnResult({ ready: true, draftPatch: { name: 'N' } }))
+      .mockResolvedValueOnce(turnResult({ ready: true }))
       .mockResolvedValueOnce(turnResult({ ready: true }));
     const mgr = new AutomationChatManager({ turn, context: () => CTX, onReadyTransition });
-    const { sessionId } = mgr.start('create');
+    const { sessionId } = mgr.start('create', COMPLETE);
 
     const first = await mgr.send(sessionId, 'go');
     expect(first.check).toBe('pending');
     expect(onReadyTransition).toHaveBeenCalledTimes(1);
-    expect(onReadyTransition).toHaveBeenCalledWith(sessionId, { name: 'N' });
+    expect(onReadyTransition).toHaveBeenCalledWith(sessionId, COMPLETE);
 
     const second = await mgr.send(sessionId, 'still ready');
     expect(onReadyTransition).toHaveBeenCalledTimes(1); // no re-trigger while ready stays true
@@ -136,7 +140,7 @@ describe('dry-run check state', () => {
       .mockResolvedValueOnce(turnResult({ ready: false }))
       .mockResolvedValueOnce(turnResult({ ready: true }));
     const mgr = new AutomationChatManager({ turn, context: () => CTX, onReadyTransition });
-    const { sessionId } = mgr.start('create');
+    const { sessionId } = mgr.start('create', COMPLETE);
     await mgr.send(sessionId, 'a');
     const dropped = await mgr.send(sessionId, 'b');
     expect(dropped.check).toBeUndefined();
@@ -147,7 +151,7 @@ describe('dry-run check state', () => {
   it('resolveCheck records the verdict and appends the message to the transcript', async () => {
     const turn = vi.fn().mockResolvedValue(turnResult({ ready: true }));
     const mgr = new AutomationChatManager({ turn, context: () => CTX });
-    const { sessionId } = mgr.start('create');
+    const { sessionId } = mgr.start('create', COMPLETE);
     await mgr.send(sessionId, 'go');
 
     expect(mgr.resolveCheck(sessionId, 'clean', 'Dry run passed.')).toBe(true);
@@ -160,7 +164,7 @@ describe('dry-run check state', () => {
   it('resolveCheck is rejected when the check is not pending or the session is gone', async () => {
     const turn = vi.fn().mockResolvedValue(turnResult({ ready: true }));
     const mgr = new AutomationChatManager({ turn, context: () => CTX });
-    const { sessionId } = mgr.start('create');
+    const { sessionId } = mgr.start('create', COMPLETE);
     expect(mgr.resolveCheck(sessionId, 'clean')).toBe(false); // never went pending
     await mgr.send(sessionId, 'go');
     expect(mgr.resolveCheck(sessionId, 'gaps', 'q')).toBe(true);
@@ -173,9 +177,52 @@ describe('dry-run check state', () => {
       .mockResolvedValueOnce(turnResult({ ready: true }))
       .mockResolvedValueOnce(turnResult({ ready: false }));
     const mgr = new AutomationChatManager({ turn, context: () => CTX });
-    const { sessionId } = mgr.start('create');
+    const { sessionId } = mgr.start('create', COMPLETE);
     await mgr.send(sessionId, 'go');       // check -> pending
     await mgr.send(sessionId, 'actually'); // ready drops, check cleared
     expect(mgr.resolveCheck(sessionId, 'clean')).toBe(false);
+  });
+
+  it('direct form patches become ready and recheck only execution-relevant changes', () => {
+    const onReadyTransition = vi.fn();
+    const mgr = new AutomationChatManager({ turn: vi.fn(), context: () => CTX, onReadyTransition });
+    const { sessionId } = mgr.start('create');
+    const complete = mgr.patch(sessionId, COMPLETE);
+    expect(complete.ready).toBe(true);
+    expect(complete.check).toBe('pending');
+    expect(onReadyTransition).toHaveBeenCalledTimes(1);
+    expect(mgr.resolveCheck(sessionId, 'clean')).toBe(true);
+
+    const renamed = mgr.patch(sessionId, { name: 'Renamed' });
+    expect(renamed.check).toBe('clean');
+    expect(onReadyTransition).toHaveBeenCalledTimes(1);
+
+    const changed = mgr.patch(sessionId, { brief: 'Post ten items.' });
+    expect(changed.check).toBe('pending');
+    expect(onReadyTransition).toHaveBeenCalledTimes(2);
+  });
+
+  it('finalizes only checked drafts and retains edit source identity', () => {
+    const mgr = new AutomationChatManager({ turn: vi.fn(), context: () => CTX });
+    const { sessionId } = mgr.start('edit', COMPLETE, 'automation-1');
+    mgr.patch(sessionId, { name: 'Renamed' });
+    expect(() => mgr.finalize(sessionId)).toThrow(/check/i);
+    expect(mgr.resolveCheck(sessionId, 'clean')).toBe(true);
+    expect(mgr.finalize(sessionId)).toEqual({
+      mode: 'edit', sourceAutomationId: 'automation-1', draft: { ...COMPLETE, name: 'Renamed' },
+    });
+  });
+
+  it('allows an explicit override only for a failed check, never gaps', () => {
+    const mgr = new AutomationChatManager({ turn: vi.fn(), context: () => CTX });
+    const gaps = mgr.start('create', COMPLETE).sessionId;
+    mgr.patch(gaps, { name: 'Ready' });
+    mgr.resolveCheck(gaps, 'gaps');
+    expect(() => mgr.finalize(gaps, true)).toThrow(/pass/i);
+
+    const failed = mgr.start('create', COMPLETE).sessionId;
+    mgr.patch(failed, { name: 'Ready' });
+    mgr.resolveCheck(failed, 'error');
+    expect(mgr.finalize(failed, true).draft.name).toBe('Ready');
   });
 });

--- a/packages/gateway/src/automations/chat.ts
+++ b/packages/gateway/src/automations/chat.ts
@@ -10,7 +10,7 @@ export interface ChatManagerDeps {
   ) => Promise<AutomationChatTurn>;
   /** Live grounding lists - re-read per turn so new workspaces/teams appear. */
   context: () => Omit<AutomationChatContext, 'mode'>;
-  /** Fired when a session's ready flag rises false->true (dry-run trigger). */
+  /** Fired when a complete draft needs a new unattended dry-run check. */
   onReadyTransition?: (sessionId: string, draft: AutomationDraft) => void;
   now?: () => number;
 }
@@ -24,6 +24,8 @@ export interface ChatStep {
   ready: boolean;
   /** Dry-run check state; undefined until the first ready transition. */
   check?: AutomationCheckStatus;
+  /** Live choices used by the structured editor. */
+  context: Omit<AutomationChatContext, 'mode' | 'nowIso'>;
 }
 
 interface Session {
@@ -32,8 +34,10 @@ interface Session {
   draft: AutomationDraft;
   inFlight: boolean;
   touchedAt: number;
-  wasReady: boolean;
+  sourceAutomationId?: string;
   check?: AutomationCheckStatus;
+  /** Execution configuration covered by the current check. */
+  checkFingerprint?: string;
 }
 
 export const SESSION_TTL_MS = 30 * 60_000;
@@ -63,7 +67,7 @@ export class AutomationChatManager {
   }
 
   /** Fixed opener - no Aide call, so opening the panel is instant. */
-  start(mode: 'create' | 'edit', initialDraft: AutomationDraft = {}): ChatStep {
+  start(mode: 'create' | 'edit', initialDraft: AutomationDraft = {}, sourceAutomationId?: string): ChatStep {
     this.sweep();
     const sessionId = randomUUID();
     const reply = OPENER[mode];
@@ -73,10 +77,10 @@ export class AutomationChatManager {
       draft: { ...initialDraft },
       inFlight: false,
       touchedAt: this.now(),
-      wasReady: false,
+      sourceAutomationId,
     };
     this.sessions.set(sessionId, s);
-    return { sessionId, reply, draft: { ...s.draft }, suggestions: [], ready: false };
+    return this.step(sessionId, s, reply, [], false);
   }
 
   async send(sessionId: string, text: string): Promise<ChatStep> {
@@ -97,15 +101,9 @@ export class AutomationChatManager {
       if (!this.sessions.has(sessionId)) throw new Error(`Unknown automation chat session: ${sessionId}`);
       s.messages.push({ role: 'user', text }, { role: 'assistant', text: turn.reply });
       applyDraftPatch(s.draft, turn.draftPatch);
-      const transition = turn.ready && !s.wasReady;
-      s.wasReady = turn.ready;
-      if (!turn.ready) s.check = undefined;
-      else if (transition) s.check = 'pending';
-      if (transition) {
-        try { this.deps.onReadyTransition?.(sessionId, { ...s.draft }); }
-        catch { /* dry-run trigger must not fail the turn */ }
-      }
-      return { sessionId, reply: turn.reply, draft: { ...s.draft }, suggestions: turn.suggestions, ready: turn.ready, check: s.check };
+      const ready = turn.ready && draftComplete(s.draft);
+      this.reconcileCheck(sessionId, s, ready);
+      return this.step(sessionId, s, turn.reply, turn.suggestions, ready);
     } finally {
       s.inFlight = false;
     }
@@ -113,6 +111,45 @@ export class AutomationChatManager {
 
   cancel(sessionId: string): void {
     this.sessions.delete(sessionId);
+  }
+
+  /** Apply deterministic form edits to the same draft the assistant sees. */
+  patch(sessionId: string, patch: Partial<AutomationDraft>): ChatStep {
+    this.sweep();
+    const s = this.sessions.get(sessionId);
+    if (!s) throw new Error(`Unknown automation chat session: ${sessionId}`);
+    if (s.inFlight) throw new Error('A turn is already in flight for this session');
+    s.touchedAt = this.now();
+    applyDraftPatch(s.draft, patch);
+    const ready = draftComplete(s.draft);
+    this.reconcileCheck(sessionId, s, ready);
+    return this.step(sessionId, s, '', [], ready);
+  }
+
+  retryCheck(sessionId: string): ChatStep {
+    this.sweep();
+    const s = this.sessions.get(sessionId);
+    if (!s) throw new Error(`Unknown automation chat session: ${sessionId}`);
+    const ready = draftComplete(s.draft);
+    if (!ready) throw new Error('Automation draft is incomplete');
+    s.check = undefined;
+    s.checkFingerprint = undefined;
+    this.reconcileCheck(sessionId, s, true);
+    return this.step(sessionId, s, '', [], true);
+  }
+
+  /** Return a server-owned draft only when it is safe to persist. */
+  finalize(sessionId: string, allowUnchecked = false): {
+    mode: 'create' | 'edit'; sourceAutomationId?: string; draft: AutomationDraft;
+  } {
+    this.sweep();
+    const s = this.sessions.get(sessionId);
+    if (!s) throw new Error(`Unknown automation chat session: ${sessionId}`);
+    if (!draftComplete(s.draft)) throw new Error('Automation draft is incomplete');
+    if (s.check !== 'clean' && !(allowUnchecked && s.check === 'error')) {
+      throw new Error(s.check === 'pending' ? 'Unattended check is still running' : 'Automation must pass its unattended check');
+    }
+    return { mode: s.mode, sourceAutomationId: s.sourceAutomationId, draft: { ...s.draft } };
   }
 
   /**
@@ -129,6 +166,37 @@ export class AutomationChatManager {
     if (message) s.messages.push({ role: 'assistant', text: message });
     return true;
   }
+
+  private reconcileCheck(sessionId: string, s: Session, ready: boolean): void {
+    if (!ready) {
+      s.check = undefined;
+      s.checkFingerprint = undefined;
+      return;
+    }
+    const fingerprint = executionFingerprint(s.draft);
+    if (s.checkFingerprint === fingerprint && s.check) return;
+    s.check = 'pending';
+    s.checkFingerprint = fingerprint;
+    try { this.deps.onReadyTransition?.(sessionId, { ...s.draft }); }
+    catch { /* dry-run trigger must not fail the edit */ }
+  }
+
+  private step(sessionId: string, s: Session, reply: string, suggestions: string[], ready: boolean): ChatStep {
+    const { workspaces, teams, agents, models, tz } = this.deps.context();
+    return {
+      sessionId, reply, draft: { ...s.draft }, suggestions, ready, check: s.check,
+      context: { workspaces, teams, agents, models, tz },
+    };
+  }
+}
+
+export function draftComplete(draft: AutomationDraft): boolean {
+  if (!draft.name?.trim() || !draft.brief?.trim() || !draft.target?.workspaceName?.trim()) return false;
+  return draft.target.kind !== 'team' || !!draft.target.teamName?.trim();
+}
+
+function executionFingerprint(draft: AutomationDraft): string {
+  return JSON.stringify({ target: draft.target, brief: draft.brief?.trim(), params: draft.params ?? {} });
 }
 
 /** Shallow merge; an explicit null clears the field. */

--- a/packages/gateway/src/automations/dry-run.test.ts
+++ b/packages/gateway/src/automations/dry-run.test.ts
@@ -23,8 +23,8 @@ describe('DryRunManager', () => {
     await flush();
 
     expect(execute).toHaveBeenCalledTimes(1);
-    const [ws, prompt] = execute.mock.calls[0];
-    expect(ws).toBe('default');
+    const [target, prompt] = execute.mock.calls[0];
+    expect(target).toEqual({ kind: 'prompt', workspaceName: 'default' });
     expect(prompt).toMatch(/DRY RUN/);
     expect(prompt).toContain('Post 5 items.');
     expect(classify).toHaveBeenCalledWith('agent output');
@@ -43,8 +43,20 @@ describe('DryRunManager', () => {
     await flush();
 
     expect(teamContext).toHaveBeenCalledWith('blog', 'news');
-    expect(execute.mock.calls[0][0]).toBe('blog');
+    expect(execute.mock.calls[0][0]).toEqual({ kind: 'team', teamName: 'news', workspaceName: 'blog' });
     expect(execute.mock.calls[0][1]).toContain('{"members":["a"]}');
+  });
+
+  it('passes prompt agent/model overrides through to execution', async () => {
+    const execute = vi.fn().mockResolvedValue('out');
+    const mgr = new DryRunManager({
+      execute, classify: vi.fn().mockResolvedValue({ status: 'clean' as const }),
+      teamContext: () => undefined, onResult: vi.fn(),
+    });
+    const target = { kind: 'prompt' as const, workspaceName: 'default', agent: 'codex' as const, model: 'gpt-x' };
+    mgr.start('s1', draft({ target }));
+    await flush();
+    expect(execute.mock.calls[0][0]).toEqual(target);
   });
 
   it('maps execute/classify failures to an error verdict, never gaps', async () => {

--- a/packages/gateway/src/automations/dry-run.ts
+++ b/packages/gateway/src/automations/dry-run.ts
@@ -1,10 +1,10 @@
 // packages/gateway/src/automations/dry-run.ts
 import { buildDryRunPrompt } from '@codey/core';
-import type { AutomationDraft, DryRunVerdict } from '@codey/core';
+import type { AutomationDraft, AutomationTarget, DryRunVerdict } from '@codey/core';
 
 export interface DryRunDeps {
   /** One-shot no-act prompt execution in a workspace (agent-adapter path). */
-  execute: (workspaceName: string, prompt: string) => Promise<string>;
+  execute: (target: AutomationTarget, prompt: string) => Promise<string>;
   /** Aide classification of the agent's dry-run report. */
   classify: (output: string) => Promise<DryRunVerdict>;
   /** Team definitions to inline for team targets (undefined = none found). */
@@ -47,7 +47,7 @@ export class DryRunManager {
         ? this.deps.teamContext(draft.target.workspaceName, draft.target.teamName)
         : undefined;
       const prompt = buildDryRunPrompt(draft.brief, draft.params ?? {}, team);
-      const output = await this.deps.execute(draft.target.workspaceName, prompt);
+      const output = await this.deps.execute(draft.target, prompt);
       verdict = await this.deps.classify(output);
     } catch (err) {
       verdict = { status: 'error', message: (err as Error).message };

--- a/packages/gateway/src/automations/engine.test.ts
+++ b/packages/gateway/src/automations/engine.test.ts
@@ -25,7 +25,7 @@ const seed = (over: Partial<Automation> = {}) =>
     name: 'a', enabled: true,
     target: { kind: 'prompt', workspaceName: 'w' },
     brief: 'do it', params: {}, report: { notify: 'none' as const },
-    schedule: { times: [{ hour: 9, minute: 0 }], tz: 'Asia/Shanghai' },
+    schedule: { slots: [{ hour: 9, minute: 0 }], tz: 'Asia/Shanghai' },
     ...over,
   }, 1);
 
@@ -67,7 +67,7 @@ describe('tick', () => {
   });
 
   it('one automation with an invalid tz does not starve the others', async () => {
-    seed({ name: 'broken', schedule: { times: [{ hour: 9, minute: 0 }], tz: 'Beijing' } }); // Intl throws RangeError
+    seed({ name: 'broken', schedule: { slots: [{ hour: 9, minute: 0 }], tz: 'Beijing' } }); // Intl throws RangeError
     const good = seed({ name: 'good' });
     const logs: string[] = [];
     await makeEngine({ log: msg => logs.push(msg) }).tick();

--- a/packages/gateway/src/automations/schedule.test.ts
+++ b/packages/gateway/src/automations/schedule.test.ts
@@ -5,7 +5,7 @@ import type { AutomationSchedule } from '@codey/core';
 // 2026-07-02T09:00:00 in Asia/Shanghai is 2026-07-02T01:00:00Z
 const SH_9AM = Date.UTC(2026, 6, 2, 1, 0, 0);
 const sched = (over: Partial<AutomationSchedule> = {}): AutomationSchedule =>
-  ({ times: [{ hour: 9, minute: 0 }], tz: 'Asia/Shanghai', ...over });
+  ({ slots: [{ hour: 9, minute: 0 }], tz: 'Asia/Shanghai', ...over });
 
 describe('localParts', () => {
   it('converts an instant into tz-local wall-clock parts', () => {
@@ -32,7 +32,7 @@ describe('shouldFire', () => {
     expect(shouldFire(sched(), SH_9AM, SH_9AM + 24 * 3600_000)).toBe(true);
   });
   it('fires at each time of a multi-time schedule, independently', () => {
-    const multi = sched({ times: [{ hour: 9, minute: 0 }, { hour: 18, minute: 0 }] });
+    const multi = sched({ slots: [{ hour: 9, minute: 0 }, { hour: 18, minute: 0 }] });
     const SH_6PM = SH_9AM + 9 * 3600_000;
     expect(shouldFire(multi, undefined, SH_9AM)).toBe(true);
     // The 09:00 fire does not consume the 18:00 slot of the same day.
@@ -43,10 +43,23 @@ describe('shouldFire', () => {
     // Process restarts at 12:00 having missed the 09:00 slot.
     expect(shouldFire(sched(), undefined, SH_9AM + 3 * 3600_000)).toBe(false);
   });
-  it('respects daysOfWeek', () => {
+  it('respects the weekdays linked to each slot', () => {
     // SH_9AM is a Thursday (4)
-    expect(shouldFire(sched({ daysOfWeek: [4] }), undefined, SH_9AM)).toBe(true);
-    expect(shouldFire(sched({ daysOfWeek: [0, 6] }), undefined, SH_9AM)).toBe(false);
+    expect(shouldFire(sched({ slots: [{ hour: 9, minute: 0, daysOfWeek: [4] }] }), undefined, SH_9AM)).toBe(true);
+    expect(shouldFire(sched({ slots: [{ hour: 9, minute: 0, daysOfWeek: [0, 6] }] }), undefined, SH_9AM)).toBe(false);
+  });
+  it('treats an empty daysOfWeek as daily defensively', () => {
+    expect(shouldFire(sched({ slots: [{ hour: 9, minute: 0, daysOfWeek: [] }] }), undefined, SH_9AM)).toBe(true);
+  });
+  it('does not cross a time onto another slot\'s weekdays', () => {
+    const linked = sched({ slots: [
+      { hour: 21, minute: 0, daysOfWeek: [1, 2, 3] },
+      { hour: 12, minute: 0, daysOfWeek: [4, 5] },
+    ] });
+    const thursdayNoon = Date.UTC(2026, 6, 2, 4, 0, 0);
+    const thursday9pm = Date.UTC(2026, 6, 2, 13, 0, 0);
+    expect(shouldFire(linked, undefined, thursdayNoon)).toBe(true);
+    expect(shouldFire(linked, undefined, thursday9pm)).toBe(false);
   });
   it('evaluates in the schedule tz, not UTC (DST-safe)', () => {
     // 09:00 NY on 2026-11-01 (fall back day) is 14:00Z.

--- a/packages/gateway/src/automations/schedule.ts
+++ b/packages/gateway/src/automations/schedule.ts
@@ -51,8 +51,10 @@ export function shouldFire(
   now: number,
 ): boolean {
   const p = localParts(now, schedule.tz);
-  if (!schedule.times.some(t => t.hour === p.hour && t.minute === p.minute)) return false;
-  if (schedule.daysOfWeek && !schedule.daysOfWeek.includes(p.dayOfWeek)) return false;
+  const matches = schedule.slots.some(slot =>
+    slot.hour === p.hour && slot.minute === p.minute
+    && (!slot.daysOfWeek?.length || slot.daysOfWeek.includes(p.dayOfWeek)));
+  if (!matches) return false;
   if (lastFiredAt !== undefined && slotId(lastFiredAt, schedule.tz) === slotId(now, schedule.tz)) return false;
   return true;
 }

--- a/packages/gateway/src/automations/store.test.ts
+++ b/packages/gateway/src/automations/store.test.ts
@@ -50,7 +50,24 @@ describe('definitions', () => {
 
   it('normalizes a legacy single-time schedule on read', () => {
     const a = store.create(draft({ schedule: { hour: 9, minute: 30, tz: 'UTC' } as any }), 111);
-    expect(store.get(a.id)?.schedule).toEqual({ times: [{ hour: 9, minute: 30 }], tz: 'UTC' });
+    expect(store.get(a.id)?.schedule).toEqual({ slots: [{ hour: 9, minute: 30 }], tz: 'UTC' });
+  });
+
+  it('canonicalizes empty/all weekdays to daily and deduplicates partial weekdays', () => {
+    const empty = store.create(draft({ schedule: { times: [{ hour: 9, minute: 0 }], daysOfWeek: [], tz: 'UTC' } as any }), 111);
+    const all = store.create(draft({ schedule: { times: [{ hour: 9, minute: 0 }], daysOfWeek: [6, 5, 4, 3, 2, 1, 0], tz: 'UTC' } as any }), 111);
+    const partial = store.create(draft({ schedule: { times: [{ hour: 9, minute: 0 }], daysOfWeek: [5, 1, 5], tz: 'UTC' } as any }), 111);
+    expect(store.get(empty.id)?.schedule?.slots[0].daysOfWeek).toBeUndefined();
+    expect(store.get(all.id)?.schedule?.slots[0].daysOfWeek).toBeUndefined();
+    expect(store.get(partial.id)?.schedule?.slots[0].daysOfWeek).toEqual([1, 5]);
+  });
+
+  it('refuses to treat corrupt storage as an empty first run', () => {
+    const file = path.join(dir, 'automations.json');
+    fs.writeFileSync(file, '{broken');
+    expect(() => store.list()).toThrow(/corrupt.*refusing to overwrite/i);
+    expect(() => store.create(draft(), 111)).toThrow(/corrupt.*refusing to overwrite/i);
+    expect(fs.readFileSync(file, 'utf8')).toBe('{broken');
   });
 
   it('update patches and bumps updatedAt', () => {
@@ -81,6 +98,14 @@ describe('definitions', () => {
     expect(fs.existsSync(path.join(dir, 'automation-runs', `${a.id}.jsonl`))).toBe(false);
   });
 
+  it('rejects unsafe or nonexistent ids before deleting files', () => {
+    const sibling = path.join(dir, 'keep-me');
+    fs.mkdirSync(sibling);
+    expect(() => store.delete('../keep-me')).toThrow(/Invalid.*id/);
+    expect(() => store.delete('not-a-real-id')).toThrow(/not found/);
+    expect(fs.existsSync(sibling)).toBe(true);
+  });
+
   it('setEnabled + recordLastFired persist', () => {
     const a = store.create(draft(), 111);
     store.setEnabled(a.id, false, 222);
@@ -92,6 +117,10 @@ describe('definitions', () => {
 });
 
 describe('run history', () => {
+  it('rejects path traversal ids', () => {
+    expect(() => store.listRuns('../outside')).toThrow(/Invalid.*id/);
+    expect(() => store.patchRun('../outside', 'run', { status: 'failed' })).toThrow(/Invalid.*id/);
+  });
   it('appends and lists newest-first with limit', () => {
     const a = store.create(draft(), 111);
     store.appendRun(a.id, run({ runId: 'r1', startedAt: 1 }));

--- a/packages/gateway/src/automations/store.ts
+++ b/packages/gateway/src/automations/store.ts
@@ -37,8 +37,14 @@ export class AutomationStore {
     try {
       const raw = JSON.parse(fs.readFileSync(this.file, 'utf8'));
       if (raw && Array.isArray(raw.automations)) return raw;
-    } catch { /* first run or unreadable — start fresh */ }
-    return { automations: [] };
+      throw new Error(`Automation store has an invalid root shape: ${this.file}`);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { automations: [] };
+      if (err instanceof SyntaxError) {
+        throw new Error(`Automation store is corrupt; refusing to overwrite ${this.file}: ${err.message}`);
+      }
+      throw err;
+    }
   }
 
   private writeRaw(raw: Record<string, unknown>): void {
@@ -78,7 +84,12 @@ export class AutomationStore {
 
   create(draft: AutomationDraft, now: number): Automation {
     return this.mutate(raw => {
-      const a = { ...draft, id: randomUUID(), createdAt: now, updatedAt: now } as Automation;
+      const normalizedSchedule = draft.schedule ? normalizeSchedule(draft.schedule) : undefined;
+      const a = {
+        ...draft,
+        schedule: normalizedSchedule,
+        id: randomUUID(), createdAt: now, updatedAt: now,
+      } as Automation;
       raw.automations.push(a as unknown as Record<string, unknown>);
       return a;
     });
@@ -88,13 +99,23 @@ export class AutomationStore {
     return this.mutate(raw => {
       const cur = raw.automations.find(a => a.id === id);
       if (!cur) throw new Error(`Automation not found: ${id}`);
+      if ('schedule' in patch) {
+        const normalized = patch.schedule ? normalizeSchedule(patch.schedule) : undefined;
+        patch = { ...patch, schedule: normalized };
+      } else if (cur.schedule) {
+        // Any write is also a migration opportunity, so changing an unrelated
+        // field on a legacy automation cannot return the old schedule shape.
+        cur.schedule = normalizeSchedule(cur.schedule);
+      }
       Object.assign(cur, patch, { updatedAt: now });
       return cur as unknown as Automation;
     });
   }
 
   delete(id: string): void {
+    AutomationStore.assertSafeId(id);
     this.mutate(raw => {
+      if (!raw.automations.some(a => a.id === id)) throw new Error(`Automation not found: ${id}`);
       raw.automations = raw.automations.filter(a => a.id !== id);
     });
     try { fs.unlinkSync(this.runFile(id)); } catch { /* no history yet */ }
@@ -117,6 +138,7 @@ export class AutomationStore {
   // ---- run history ----
 
   private runFile(id: string): string {
+    AutomationStore.assertSafeId(id);
     return path.join(this.runsDir, `${id}.jsonl`);
   }
 
@@ -127,6 +149,7 @@ export class AutomationStore {
 
   /** Newest-first. Skips unparseable lines. */
   listRuns(id: string, limit?: number): AutomationRun[] {
+    AutomationStore.assertSafeId(id);
     let text: string;
     try { text = fs.readFileSync(this.runFile(id), 'utf8'); } catch { return []; }
     const runs: AutomationRun[] = [];
@@ -150,7 +173,11 @@ export class AutomationStore {
 
   /** IDs come over IPC — refuse anything that could escape runsDir. */
   private static isSafeId(s: string): boolean {
-    return /^[\w-]+$/.test(s);
+    return typeof s === 'string' && /^[\w-]+$/.test(s);
+  }
+
+  private static assertSafeId(s: string): void {
+    if (!AutomationStore.isSafeId(s)) throw new Error(`Invalid automation or run id: ${String(s)}`);
   }
 
   /** Append one activity-log line. Failures are the caller's to swallow —
@@ -169,6 +196,8 @@ export class AutomationStore {
 
   /** Read-patch-rewrite (atomic). Caps retained history at MAX_HISTORY_REWRITE. */
   patchRun(id: string, runId: string, patch: Partial<AutomationRun>): void {
+    AutomationStore.assertSafeId(id);
+    AutomationStore.assertSafeId(runId);
     const oldestFirst = this.listRuns(id).reverse().slice(-MAX_HISTORY_REWRITE);
     let found = false;
     const lines = oldestFirst.map(r => {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -906,7 +906,7 @@ export class Codey {
     });
     this.automationEngine.start();
     this.automationDryRuns = new DryRunManager({
-      execute: (workspaceName, prompt) => this.runDryRunPrompt(workspaceName, prompt),
+      execute: (target, prompt) => this.runDryRunPrompt(target, prompt),
       classify: (output) => classifyDryRun(output, this.getAideOptions()),
       teamContext: (_workspaceName, teamName) => {
         const team = (this.configManager?.getTeams() ?? {})[teamName];
@@ -929,6 +929,8 @@ export class Codey {
       context: () => ({
         workspaces: this.getWorkspaceList(),
         teams: Object.keys(this.configManager?.getTeams() ?? {}),
+        agents: ['claude-code', 'opencode', 'codex'] as CodingAgent[],
+        models: (this.configManager?.listModels() ?? this.config.models ?? []).map(m => m.model),
         tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
         nowIso: new Date().toString(),
       }),
@@ -1021,7 +1023,8 @@ export class Codey {
    * suspenders - the agent can read the workspace but a stray write attempt
    * is refused rather than executed.
    */
-  private async runDryRunPrompt(workspaceName: string, prompt: string): Promise<string> {
+  private async runDryRunPrompt(target: Automation['target'], prompt: string): Promise<string> {
+    const workspaceName = target.workspaceName;
     // workspaceName is LLM output; a hallucinated name must fail visibly
     // (DryRunManager maps the throw to an 'error' verdict) instead of
     // silently dry-running against the gateway's own working dir.
@@ -1029,8 +1032,14 @@ export class Codey {
       throw new Error(`Unknown workspace: ${workspaceName}`);
     }
     const workingDir = this.resolveWorkspaceWorkingDir(workspaceName);
-    const agent = this.getDefaultAgent();
-    const model = this.getDefaultModelConfig(agent);
+    // A prompt automation may override both agent and model. The check must
+    // use that same execution configuration or its verdict is misleading.
+    // Team checks remain a no-act analysis run with the gateway default; the
+    // team definition is already inlined into the prompt above.
+    const agent = target.kind === 'prompt' && target.agent ? target.agent : this.getDefaultAgent();
+    const model = target.kind === 'prompt' && target.model
+      ? this.getModelConfig(agent, target.model)
+      : this.getDefaultModelConfig(agent);
     // Plain agentFactory.run, not runWithFallback: fallback churn is not
     // wanted for a background nicety - a failure just becomes an 'error'
     // verdict in the authoring panel.
@@ -1070,6 +1079,7 @@ export class Codey {
   listAutomations(): Automation[] { return this.automationStore?.list() ?? []; }
   getAutomation(id: string): Automation | undefined { return this.automationStore?.get(id); }
   createAutomation(draft: Parameters<AutomationStore['create']>[0]): Automation {
+    this.validateAutomationTargetReferences(draft.target);
     return this.requireAutomationStore().create(draft, Date.now());
   }
   updateAutomation(id: string, patch: Partial<Automation>): Automation {
@@ -1079,8 +1089,10 @@ export class Codey {
     // fresh one matching the new target. (store.update Object.assigns the
     // patch, so chatId becomes undefined and JSON.stringify drops the key
     // from the persisted document.)
-    if (patch.target) {
-      const prev = this.requireAutomationStore().get(id);
+    const prev = this.requireAutomationStore().get(id);
+    const targetChanged = !!patch.target && JSON.stringify(patch.target) !== JSON.stringify(prev?.target);
+    if (patch.target) this.validateAutomationTargetReferences(patch.target);
+    if (targetChanged) {
       if (prev?.chatId) {
         // reload first so a chat created by the other process is deletable.
         this.chatManager.reload(prev.chatId);
@@ -1088,9 +1100,20 @@ export class Codey {
       }
       patch = { ...patch, chatId: undefined };
     }
+    // Renderer edits commonly change only notification policy. Preserve a
+    // configured channel instead of replacing the entire report object.
+    if (patch.report && prev?.report) patch = { ...patch, report: { ...prev.report, ...patch.report } };
     return this.requireAutomationStore().update(id, patch, Date.now());
   }
-  deleteAutomation(id: string): void { this.requireAutomationStore().delete(id); }
+  deleteAutomation(id: string): void {
+    const a = this.requireAutomationStore().get(id);
+    if (!a) throw new Error(`Automation not found: ${id}`);
+    if (a.chatId) {
+      this.chatManager.reload(a.chatId);
+      try { this.chatManager.delete(a.chatId); } catch { /* already gone */ }
+    }
+    this.requireAutomationStore().delete(id);
+  }
   setAutomationEnabled(id: string, enabled: boolean): Automation {
     return this.requireAutomationStore().setEnabled(id, enabled, Date.now());
   }
@@ -1129,10 +1152,29 @@ export class Codey {
       notify: a.report.notify,
       brief: a.brief,
       params: a.params,
-    });
+    }, a.id);
   }
   sendAutomationChat(sessionId: string, text: string): Promise<ChatStep> {
     return this.requireAutomationChats().send(sessionId, text);
+  }
+  patchAutomationChat(sessionId: string, patch: Parameters<AutomationChatManager['patch']>[1]): ChatStep {
+    return this.requireAutomationChats().patch(sessionId, patch);
+  }
+  retryAutomationChatCheck(sessionId: string): ChatStep {
+    return this.requireAutomationChats().retryCheck(sessionId);
+  }
+  saveAutomationChat(sessionId: string, allowUnchecked = false): Automation {
+    const { mode, sourceAutomationId, draft } = this.requireAutomationChats().finalize(sessionId, allowUnchecked);
+    const payload = {
+      name: draft.name!.trim(), target: draft.target!, brief: draft.brief!.trim(),
+      params: draft.params ?? {}, schedule: draft.schedule,
+      report: { notify: draft.notify ?? 'none' },
+    };
+    const saved = mode === 'edit'
+      ? this.updateAutomation(sourceAutomationId!, payload)
+      : this.createAutomation({ ...payload, enabled: true });
+    this.cancelAutomationChat(sessionId);
+    return saved;
   }
   cancelAutomationChat(sessionId: string): void {
     this.automationChats?.cancel(sessionId);
@@ -1140,6 +1182,15 @@ export class Codey {
   }
   setAutomationEventListener(fn: (ev: AutomationEvent) => void): void {
     this.automationEventListener = fn;
+  }
+
+  private validateAutomationTargetReferences(target: Automation['target']): void {
+    if (!this.getWorkspaceList().includes(target.workspaceName)) {
+      throw new Error(`Unknown automation workspace: ${target.workspaceName}`);
+    }
+    if (target.kind === 'team' && !(target.teamName in (this.configManager?.getTeams() ?? {}))) {
+      throw new Error(`Unknown automation team: ${target.teamName}`);
+    }
   }
 
   private requireAutomationStore(): AutomationStore {


### PR DESCRIPTION
## Summary

- replace the conversational-only automation setup with a draft-first composer that keeps assistant guidance and deterministic fields in sync
- harden validation, persistence, dry runs, session saves, and run execution configuration across the Mac app, core, and gateway
- introduce linked time slots so each time owns its weekdays (for example Mon–Wed at 21:00 and Thu–Fri at 12:00)
- redesign automation detail and list views around health, next/last runs, target, notifications, compact run history, and clearer settings
- reduce the prominence of destructive controls and improve parked/failed run handling

## Why

The previous schedule schema applied every configured time to every configured weekday, so users could not express different times for different day groups. Automation creation also split state between conversation and UI, while list/detail pages made health and recent outcomes difficult to scan.

## Implementation notes

- schedules now persist as independently linked `slots`
- legacy single-time and `times + daysOfWeek` schedules normalize into the new schema on read/write
- scheduler matching and next-run calculations evaluate each slot's weekdays independently
- IPC validation accepts the new schema while retaining legacy compatibility
- authoring chat patches are server-owned, directly editable, and rechecked before save
- manual dry runs honor the selected agent/model overrides

## Validation

- `npm test -w packages/core -- src/aide-automation.test.ts` — 18 passed
- `npm test -w packages/gateway -- src/automations/schedule.test.ts src/automations/store.test.ts src/automations/chat.test.ts src/automations/dry-run.test.ts src/automations/engine.test.ts` — 72 passed
- `npm test -w codey-mac -- src/components/automationsModel.test.ts electron/automation-validate.test.ts electron/automation-notifications.test.ts` — 43 passed
- `npm run build -w packages/core`
- `npm run build -w packages/gateway`
- `npm exec -w codey-mac -- vite build`
- browser visual QA for creation, linked slot editing, detail overview/run history, and automation list layouts
