### PR TITLE
Add MCP tab for external MCP servers

### DIFF
--- a/codey-mac/electron/external-mcp.test.ts
+++ b/codey-mac/electron/external-mcp.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { validateExternalMcp } from './external-mcp'
+
+describe('validateExternalMcp', () => {
+  it('accepts a valid stdio server and coerces enabled', () => {
+    const result = validateExternalMcp({
+      name: ' github ',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'server'],
+      env: { TOKEN: 't' },
+      enabled: 'yes' as any,
+    })
+    expect(result).toEqual({
+      ok: true,
+      name: 'github',
+      config: { transport: 'stdio', command: 'npx', args: ['-y', 'server'], env: { TOKEN: 't' }, enabled: false },
+    })
+  })
+
+  it('accepts a valid remote server', () => {
+    const result = validateExternalMcp({ name: 'linear', transport: 'remote', url: 'https://mcp.linear.app/sse', enabled: true })
+    expect(result).toEqual({
+      ok: true,
+      name: 'linear',
+      config: { transport: 'remote', url: 'https://mcp.linear.app/sse', enabled: true },
+    })
+  })
+
+  it('rejects bad names, reserved names, and missing fields', () => {
+    expect(validateExternalMcp({ name: '', transport: 'stdio', command: 'x' }).ok).toBe(false)
+    expect(validateExternalMcp({ name: 'has space', transport: 'stdio', command: 'x' }).ok).toBe(false)
+    expect(validateExternalMcp({ name: '-lead', transport: 'stdio', command: 'x' }).ok).toBe(false)
+    expect(validateExternalMcp({ name: 'codey-browser', transport: 'stdio', command: 'x' }).ok).toBe(false)
+    expect(validateExternalMcp({ name: 'a', transport: 'stdio', command: '  ' }).ok).toBe(false)
+    expect(validateExternalMcp({ name: 'a', transport: 'remote', url: 'ftp://x' }).ok).toBe(false)
+    expect(validateExternalMcp({ name: 'a', transport: 'remote', url: '' }).ok).toBe(false)
+    expect(validateExternalMcp({ name: 'a', transport: 'weird' as any }).ok).toBe(false)
+  })
+})

--- a/codey-mac/electron/external-mcp.ts
+++ b/codey-mac/electron/external-mcp.ts
@@ -1,0 +1,51 @@
+export interface ExternalMcpDraft {
+  name: string
+  transport: 'stdio' | 'remote'
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  enabled?: boolean
+}
+
+export type ExternalMcpValidation =
+  | { ok: true; name: string; config: { transport: 'stdio' | 'remote'; command?: string; args?: string[]; env?: Record<string, string>; url?: string; enabled: boolean } }
+  | { ok: false; error: string }
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]*$/i
+/** Names Codey's own plugins claim; user servers may not shadow them. */
+const RESERVED_NAMES = new Set(['codey-browser'])
+
+/** Validate a renderer-submitted external MCP server before it reaches config. */
+export function validateExternalMcp(draft: ExternalMcpDraft): ExternalMcpValidation {
+  const name = (draft.name ?? '').trim()
+  if (!NAME_PATTERN.test(name)) {
+    return { ok: false, error: 'Name must start with a letter or digit and use only letters, digits, - and _' }
+  }
+  if (RESERVED_NAMES.has(name)) {
+    return { ok: false, error: `"${name}" is reserved for Codey's built-in plugins` }
+  }
+  if (draft.transport === 'stdio') {
+    const command = (draft.command ?? '').trim()
+    if (!command) return { ok: false, error: 'A command is required for stdio servers' }
+    return {
+      ok: true,
+      name,
+      config: {
+        transport: 'stdio',
+        command,
+        args: (draft.args ?? []).map(String),
+        env: draft.env ?? {},
+        enabled: draft.enabled === true,
+      },
+    }
+  }
+  if (draft.transport === 'remote') {
+    const url = (draft.url ?? '').trim()
+    if (!/^https?:\/\/.+/i.test(url)) {
+      return { ok: false, error: 'Remote servers need an http(s) URL' }
+    }
+    return { ok: true, name, config: { transport: 'remote', url, enabled: draft.enabled === true } }
+  }
+  return { ok: false, error: 'Transport must be stdio or remote' }
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2527,7 +2527,10 @@ app.whenReady().then(async () => {
   ipcMain.handle('mcp:list', async () =>
     wrap(async () => {
       const servers = (coreConfigManager?.get() as any)?.mcpServers ?? {}
-      return Object.entries(servers).map(([name, cfg]) => ({ name, ...(cfg as object) }))
+      return Object.entries(servers)
+        // A hand-edited codey-browser entry can never reach agents; hide it here too.
+        .filter(([name]) => name !== 'codey-browser')
+        .map(([name, cfg]) => ({ name, ...(cfg as object) }))
     })
   )
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -11,6 +11,7 @@ import { validateAutomationChatPatch, validateAutomationDraft, validateAutomatio
 import { applyEvent, clearAttention, summarize } from './tray-state'
 import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
+import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import type { ScannedSkill } from './skills'
 import { BROWSER_PARTITION, BrowserController, type BrowserBounds } from './browser-controller'
 import { BrowserAgentBridge, type BrowserLoginWaitEvent } from './browser-agent-bridge'
@@ -2519,6 +2520,39 @@ app.whenReady().then(async () => {
       if (!coreConfigManager) throw new Error('Config manager not initialized')
       if (!isKnownPlugin(id)) throw new Error(`Unknown plugin: ${id}`)
       coreConfigManager.update({ plugins: { [id]: { enabled: enabled === true } } } as any)
+    })
+  )
+
+  // ── External MCP servers IPC ──────────────────────────────────────
+  ipcMain.handle('mcp:list', async () =>
+    wrap(async () => {
+      const servers = (coreConfigManager?.get() as any)?.mcpServers ?? {}
+      return Object.entries(servers).map(([name, cfg]) => ({ name, ...(cfg as object) }))
+    })
+  )
+
+  ipcMain.handle('mcp:save', async (_e, draft: ExternalMcpDraft) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      const result = validateExternalMcp(draft)
+      if (!result.ok) throw new Error(result.error)
+      coreConfigManager.setExternalMcpServer(result.name, result.config)
+    })
+  )
+
+  ipcMain.handle('mcp:remove', async (_e, name: string) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      coreConfigManager.removeExternalMcpServer(String(name))
+    })
+  )
+
+  ipcMain.handle('mcp:setEnabled', async (_e, name: string, enabled: boolean) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      const existing = coreConfigManager.get().mcpServers?.[String(name)]
+      if (!existing) throw new Error(`Unknown MCP server: ${name}`)
+      coreConfigManager.setExternalMcpServer(String(name), { ...existing, enabled: enabled === true })
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -117,6 +117,12 @@ contextBridge.exposeInMainWorld('codey', {
     list: () => ipcRenderer.invoke('plugins:list'),
     setEnabled: (id: string, enabled: boolean) => ipcRenderer.invoke('plugins:setEnabled', id, enabled),
   },
+  mcp: {
+    list: () => ipcRenderer.invoke('mcp:list'),
+    save: (draft: any) => ipcRenderer.invoke('mcp:save', draft),
+    remove: (name: string) => ipcRenderer.invoke('mcp:remove', name),
+    setEnabled: (name: string, enabled: boolean) => ipcRenderer.invoke('mcp:setEnabled', name, enabled),
+  },
   skills: {
     list: (agent?: string) => ipcRenderer.invoke('skills:list', agent),
     install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) =>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -32,6 +32,16 @@ export interface PluginInfo {
   enabled: boolean
 }
 
+export interface ExternalMcpServer {
+  name: string
+  transport: 'stdio' | 'remote'
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  enabled: boolean
+}
+
 export interface ModelEntry {
   apiType: 'anthropic' | 'openai'
   model: string
@@ -233,6 +243,12 @@ declare global {
       plugins: {
         list: () => Promise<IpcResult<PluginInfo[]>>
         setEnabled: (id: string, enabled: boolean) => Promise<IpcResult<void>>
+      }
+      mcp: {
+        list: () => Promise<IpcResult<ExternalMcpServer[]>>
+        save: (draft: Omit<ExternalMcpServer, 'enabled'> & { enabled?: boolean }) => Promise<IpcResult<void>>
+        remove: (name: string) => Promise<IpcResult<void>>
+        setEnabled: (name: string, enabled: boolean) => Promise<IpcResult<void>>
       }
       skills: {
         list: (agent?: string) => Promise<IpcResult<SkillsListResult>>

--- a/codey-mac/src/components/McpTab.tsx
+++ b/codey-mac/src/components/McpTab.tsx
@@ -1,0 +1,290 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { C } from '../theme'
+import { inputStyle, pillButton, unwrap } from './settingsAtoms'
+import { UIIcon } from './UIIcons'
+import { parseArgsLine, parseEnvLines } from './mcp-form'
+import type { ExternalMcpServer } from '../codey-api'
+
+// Matches the toggle idiom already used by AppearanceTab / PluginsTab.
+const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
+  <div onClick={() => onChange(!on)} style={{
+    width: 36, height: 20, borderRadius: 10, flexShrink: 0,
+    background: on ? C.accent : C.surface3,
+    border: `1px solid ${on ? C.accent : C.border2}`,
+    cursor: 'pointer', position: 'relative', transition: 'all 0.2s',
+  }}>
+    <div style={{
+      position: 'absolute', top: 1, left: on ? 17 : 1,
+      width: 16, height: 16, borderRadius: '50%', background: '#fff',
+      transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.3)',
+    }}/>
+  </div>
+)
+
+interface FormState {
+  name: string
+  transport: 'stdio' | 'remote'
+  command: string
+  args: string
+  env: string
+  url: string
+}
+
+const EMPTY_FORM: FormState = { name: '', transport: 'stdio', command: '', args: '', env: '', url: '' }
+
+const toForm = (server: ExternalMcpServer): FormState => ({
+  name: server.name,
+  transport: server.transport,
+  command: server.command ?? '',
+  args: (server.args ?? []).join(' '),
+  env: Object.entries(server.env ?? {}).map(([k, v]) => `${k}=${v}`).join('\n'),
+  url: server.url ?? '',
+})
+
+export const McpTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 }) => {
+  const [servers, setServers] = useState<ExternalMcpServer[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [form, setForm] = useState<FormState | null>(null)
+  const [editing, setEditing] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setServers(unwrap(await window.codey.mcp.list()))
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void reload() }, [reload])
+
+  useEffect(() => {
+    if (addRequest > 0) {
+      setForm(EMPTY_FORM)
+      setEditing(null)
+    }
+  }, [addRequest])
+
+  const toggle = async (server: ExternalMcpServer) => {
+    setBusy(server.name)
+    setError(null)
+    try {
+      unwrap(await window.codey.mcp.setEnabled(server.name, !server.enabled))
+      await reload()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const remove = async (server: ExternalMcpServer) => {
+    if (!window.confirm(`Remove MCP server "${server.name}"?`)) return
+    setBusy(server.name)
+    setError(null)
+    try {
+      unwrap(await window.codey.mcp.remove(server.name))
+      await reload()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const save = async () => {
+    if (!form) return
+    setSaving(true)
+    setError(null)
+    try {
+      const env = parseEnvLines(form.env)
+      const existing = editing ? servers.find(s => s.name === editing) : undefined
+      unwrap(await window.codey.mcp.save({
+        name: form.name.trim(),
+        transport: form.transport,
+        command: form.command,
+        args: parseArgsLine(form.args),
+        env,
+        url: form.url,
+        enabled: existing?.enabled ?? false,
+      }))
+      setForm(null)
+      setEditing(null)
+      await reload()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading && servers.length === 0) return <div style={styles.note}>Loading MCP servers…</div>
+
+  return (
+    <div>
+      <div style={styles.intro}>
+        External MCP servers give agents extra tools. Enabled servers are passed to every
+        task-performing agent run. Remote servers are not passed to Codex (no remote MCP support).
+      </div>
+      {error && <div style={styles.errorBanner}>{error}</div>}
+
+      {servers.map(server => (
+        <div key={server.name} style={styles.card}>
+          <div style={styles.cardIcon}><UIIcon name="server" size={18} /></div>
+          <div style={styles.cardBody}>
+            <div style={styles.cardName}>
+              {server.name}
+              <span style={styles.badge}>{server.transport}</span>
+            </div>
+            <div style={styles.cardDesc}>
+              {server.transport === 'remote'
+                ? server.url
+                : [server.command, ...(server.args ?? [])].join(' ')}
+            </div>
+          </div>
+          <button
+            style={pillButton('ghost')}
+            onClick={() => { setForm(toForm(server)); setEditing(server.name) }}
+          >Edit</button>
+          <button
+            style={pillButton('danger')}
+            disabled={busy === server.name}
+            onClick={() => void remove(server)}
+          ><UIIcon name="trash" size={13} /></button>
+          <div style={busy === server.name ? styles.toggleBusy : undefined}>
+            <Toggle on={server.enabled} onChange={() => { if (busy !== server.name) void toggle(server) }} />
+          </div>
+        </div>
+      ))}
+
+      {servers.length === 0 && !form && (
+        <div style={styles.empty}>No external MCP servers yet. Add one to get started.</div>
+      )}
+
+      {form ? (
+        <div style={styles.form}>
+          <div style={styles.formTitle}>{editing ? `Edit ${editing}` : 'Add MCP server'}</div>
+          <label style={styles.label}>Name
+            <input
+              style={inputStyle}
+              value={form.name}
+              disabled={!!editing}
+              placeholder="github"
+              onChange={e => setForm({ ...form, name: e.target.value })}
+            />
+          </label>
+          <label style={styles.label}>Transport
+            <div style={styles.transportRow}>
+              {(['stdio', 'remote'] as const).map(t => (
+                <button
+                  key={t}
+                  style={{ ...styles.transportBtn, ...(form.transport === t ? styles.transportBtnActive : null) }}
+                  onClick={() => setForm({ ...form, transport: t })}
+                >{t === 'stdio' ? 'Local (stdio)' : 'Remote (URL)'}</button>
+              ))}
+            </div>
+          </label>
+          {form.transport === 'stdio' ? (
+            <>
+              <label style={styles.label}>Command
+                <input
+                  style={inputStyle}
+                  value={form.command}
+                  placeholder="npx"
+                  onChange={e => setForm({ ...form, command: e.target.value })}
+                />
+              </label>
+              <label style={styles.label}>Arguments (space-separated)
+                <input
+                  style={inputStyle}
+                  value={form.args}
+                  placeholder="-y @modelcontextprotocol/server-github"
+                  onChange={e => setForm({ ...form, args: e.target.value })}
+                />
+              </label>
+              <label style={styles.label}>Environment (one KEY=VALUE per line)
+                <textarea
+                  style={{ ...inputStyle, minHeight: 64, resize: 'vertical', fontFamily: 'monospace' }}
+                  value={form.env}
+                  placeholder={'GITHUB_TOKEN=ghp_...'}
+                  onChange={e => setForm({ ...form, env: e.target.value })}
+                />
+              </label>
+            </>
+          ) : (
+            <label style={styles.label}>URL
+              <input
+                style={inputStyle}
+                value={form.url}
+                placeholder="https://mcp.example.com/sse"
+                onChange={e => setForm({ ...form, url: e.target.value })}
+              />
+            </label>
+          )}
+          <div style={styles.formActions}>
+            <button style={pillButton('primary')} disabled={saving} onClick={() => void save()}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button style={pillButton('ghost')} disabled={saving} onClick={() => { setForm(null); setEditing(null) }}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button style={styles.addBtn} onClick={() => { setForm(EMPTY_FORM); setEditing(null) }}>
+          <UIIcon name="add" size={15} /> Add MCP server
+        </button>
+      )}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  note: { color: C.fg3, fontSize: 12, padding: 8 },
+  intro: { color: C.fg2, fontSize: 12, marginBottom: 14 },
+  errorBanner: {
+    background: C.dangerBg, color: C.dangerFg, border: `1px solid ${C.dangerBorder}`,
+    padding: '9px 11px', borderRadius: 9, marginBottom: 14, fontSize: 12,
+  },
+  card: {
+    display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px',
+    border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface2, marginBottom: 10,
+  },
+  cardIcon: { color: C.accent, flexShrink: 0 },
+  cardBody: { flex: 1, minWidth: 0 },
+  cardName: { color: C.fg, fontSize: 13, fontWeight: 700, marginBottom: 3, display: 'flex', alignItems: 'center', gap: 8 },
+  cardDesc: {
+    color: C.fg3, fontSize: 11.5, lineHeight: 1.45, fontFamily: 'monospace',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  badge: {
+    fontSize: 9.5, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5,
+    color: C.fg3, border: `1px solid ${C.border2}`, borderRadius: 5, padding: '1px 6px',
+  },
+  toggleBusy: { opacity: 0.5, cursor: 'wait', pointerEvents: 'none' },
+  empty: { color: C.fg3, fontSize: 12, padding: '18px 0', textAlign: 'center' },
+  form: {
+    border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface2,
+    padding: '14px 16px', marginTop: 4, display: 'flex', flexDirection: 'column', gap: 10,
+  },
+  formTitle: { color: C.fg, fontSize: 13, fontWeight: 700 },
+  label: { color: C.fg2, fontSize: 11.5, display: 'flex', flexDirection: 'column', gap: 4 },
+  transportRow: { display: 'flex', gap: 8 },
+  transportBtn: {
+    padding: '6px 12px', borderRadius: 8, border: `1px solid ${C.border2}`,
+    background: 'transparent', color: C.fg2, cursor: 'pointer', fontSize: 12,
+  },
+  transportBtnActive: { background: C.accentDim, color: C.fg, border: `1px solid ${C.accent}` },
+  formActions: { display: 'flex', gap: 8, marginTop: 4 },
+  addBtn: {
+    display: 'inline-flex', alignItems: 'center', gap: 6, marginTop: 4,
+    border: `1px dashed ${C.border2}`, borderRadius: 10, padding: '9px 14px',
+    background: 'transparent', color: C.fg2, cursor: 'pointer', fontSize: 12, fontWeight: 650,
+  },
+}

--- a/codey-mac/src/components/McpTab.tsx
+++ b/codey-mac/src/components/McpTab.tsx
@@ -41,7 +41,7 @@ const toForm = (server: ExternalMcpServer): FormState => ({
   url: server.url ?? '',
 })
 
-export const McpTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 }) => {
+export const McpTab: React.FC = () => {
   const [servers, setServers] = useState<ExternalMcpServer[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -63,13 +63,6 @@ export const McpTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 }) =>
   }, [])
 
   useEffect(() => { void reload() }, [reload])
-
-  useEffect(() => {
-    if (addRequest > 0) {
-      setForm(EMPTY_FORM)
-      setEditing(null)
-    }
-  }, [addRequest])
 
   const toggle = async (server: ExternalMcpServer) => {
     setBusy(server.name)
@@ -100,13 +93,19 @@ export const McpTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 }) =>
 
   const save = async () => {
     if (!form) return
+    const name = form.name.trim()
+    // Adding under an existing name would silently overwrite (and disable) it.
+    if (!editing && servers.some(s => s.name === name)) {
+      setError(`A server named "${name}" already exists — edit it instead.`)
+      return
+    }
     setSaving(true)
     setError(null)
     try {
       const env = parseEnvLines(form.env)
       const existing = editing ? servers.find(s => s.name === editing) : undefined
       unwrap(await window.codey.mcp.save({
-        name: form.name.trim(),
+        name,
         transport: form.transport,
         command: form.command,
         args: parseArgsLine(form.args),

--- a/codey-mac/src/components/ToolsView.tsx
+++ b/codey-mac/src/components/ToolsView.tsx
@@ -4,16 +4,18 @@ import { OverlayWindow } from './OverlayWindow'
 import { SkillsTab } from './SkillsTab'
 import { PlaybooksTab } from './PlaybooksTab'
 import { PluginsTab } from './PluginsTab'
+import { McpTab } from './McpTab'
 import { UIIcon, type IconName } from './UIIcons'
 
 interface Props { onClose: () => void }
 
-type Tab = 'skills' | 'playbooks' | 'plugins'
+type Tab = 'skills' | 'playbooks' | 'plugins' | 'mcp'
 
 const TABS: { key: Tab; label: string; icon: IconName }[] = [
   { key: 'skills',  label: 'Skills',  icon: 'sparkle' },
   { key: 'playbooks', label: 'Playbooks', icon: 'archive' },
   { key: 'plugins', label: 'Plugins', icon: 'tools' },
+  { key: 'mcp', label: 'MCP', icon: 'server' },
 ]
 
 export const ToolsView: React.FC<Props> = ({ onClose }) => {
@@ -47,6 +49,7 @@ export const ToolsView: React.FC<Props> = ({ onClose }) => {
         {tab === 'skills'  && <SkillsTab addRequest={addSkillRequest} />}
         {tab === 'playbooks' && <PlaybooksTab />}
         {tab === 'plugins' && <PluginsTab />}
+        {tab === 'mcp' && <McpTab />}
       </div>
     </OverlayWindow>
   )

--- a/codey-mac/src/components/ToolsView.tsx
+++ b/codey-mac/src/components/ToolsView.tsx
@@ -15,7 +15,7 @@ const TABS: { key: Tab; label: string; icon: IconName }[] = [
   { key: 'skills',  label: 'Skills',  icon: 'sparkle' },
   { key: 'playbooks', label: 'Playbooks', icon: 'archive' },
   { key: 'plugins', label: 'Plugins', icon: 'tools' },
-  { key: 'mcp', label: 'MCP', icon: 'server' },
+  { key: 'mcp', label: 'MCPs', icon: 'server' },
 ]
 
 export const ToolsView: React.FC<Props> = ({ onClose }) => {

--- a/codey-mac/src/components/mcp-form.test.ts
+++ b/codey-mac/src/components/mcp-form.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { parseArgsLine, parseEnvLines } from './mcp-form'
+
+describe('parseEnvLines', () => {
+  it('parses KEY=VALUE lines, skipping blanks and trimming', () => {
+    expect(parseEnvLines('A=1\n\n  B = two words \nC=x=y')).toEqual({
+      A: '1',
+      B: 'two words',
+      C: 'x=y',
+    })
+  })
+
+  it('returns empty for empty input', () => {
+    expect(parseEnvLines('')).toEqual({})
+    expect(parseEnvLines('  \n ')).toEqual({})
+  })
+
+  it('throws on lines without a key', () => {
+    expect(() => parseEnvLines('novalue')).toThrow(/KEY=VALUE/)
+    expect(() => parseEnvLines('=leading')).toThrow(/KEY=VALUE/)
+  })
+})
+
+describe('parseArgsLine', () => {
+  it('splits on whitespace and handles empty input', () => {
+    expect(parseArgsLine(' -y  @scope/pkg ')).toEqual(['-y', '@scope/pkg'])
+    expect(parseArgsLine('')).toEqual([])
+    expect(parseArgsLine('   ')).toEqual([])
+  })
+})

--- a/codey-mac/src/components/mcp-form.ts
+++ b/codey-mac/src/components/mcp-form.ts
@@ -1,0 +1,18 @@
+/** "KEY=VALUE" lines → env record. Blank lines are skipped; bad lines throw. */
+export function parseEnvLines(text: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const raw of text.split('\n')) {
+    const line = raw.trim()
+    if (!line) continue
+    const eq = line.indexOf('=')
+    if (eq <= 0) throw new Error(`Env lines must look like KEY=VALUE (got "${line}")`)
+    env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim()
+  }
+  return env
+}
+
+/** Space-separated args line → argv array. */
+export function parseArgsLine(text: string): string[] {
+  const trimmed = text.trim()
+  return trimmed ? trimmed.split(/\s+/) : []
+}

--- a/docs/superpowers/specs/2026-07-21-external-mcp-servers-design.md
+++ b/docs/superpowers/specs/2026-07-21-external-mcp-servers-design.md
@@ -1,0 +1,83 @@
+# External MCP Servers (MCP tab) — Design
+
+Date: 2026-07-21
+Status: Approved
+Builds on: 2026-07-21-plugins-browser-mcp-design.md (branch `external-mcp-servers` off `plugins-browser-mcp`)
+
+## Goal
+
+Let users register external MCP servers (beyond Codey's built-in plugins) in a
+new **Tools → MCP** tab, and expose the enabled ones to every task-performing
+agent turn through the existing `AgentRequest.mcpServers` seam.
+
+## Decisions (user)
+
+- Transports: **local stdio AND remote URLs** in v1.
+- Add UX: **form fields only** (name, transport, command, args, env, url) — no
+  JSON paste/import.
+- Tools tab subtitles removed (shipped separately on PR #180's branch).
+
+## Config (`gateway.json`)
+
+```json
+"mcpServers": {
+  "github": { "transport": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"], "env": { "GITHUB_TOKEN": "..." }, "enabled": true },
+  "linear": { "transport": "remote", "url": "https://mcp.linear.app/sse", "enabled": false }
+}
+```
+
+- Record keyed by server name. `enabled` defaults false and is coerced
+  strictly (same posture as `plugins`).
+- `ConfigManager` gains `setExternalMcpServer(name, cfg)`,
+  `removeExternalMcpServer(name)` (merge-based `update()` cannot delete keys),
+  and `getEnabledExternalMcpServers(): Record<string, McpServerSpec>` which
+  skips disabled/invalid entries and the reserved name `codey-browser`.
+- Env values are plaintext in `gateway.json` — consistent with the existing
+  `apiKeys` handling.
+
+## Core seam
+
+- `McpServerSpec` gains optional `url?: string`. Remote entries carry
+  `command: ''`, `args: []`, `env: {}` plus `url`.
+- New `addExternalMcpServers(request, servers)` in `packages/core/src/agents`:
+  merges entries into `request.mcpServers` under the same task-performing-turn
+  gate as the browser plugin (`browserTools === true`, workingDir, no
+  `allowedTools` — the flag doubles as the "tools-capable turn" marker);
+  filters the reserved `codey-browser` name; existing request entries win
+  conflicts. `AgentFactory` gains `setExternalMcpProvider(fn)`; the gateway
+  wires it to `getEnabledExternalMcpServers()` (live config read).
+
+## Adapter serialization
+
+- **claude-code** (`writeClaudeMcpConfig`): stdio entries as today; url
+  entries serialize as `{ "type": "http", "url": ... }`.
+- **opencode** (`writeOpenCodeMcpConfig`): url entries as
+  `{ "type": "remote", "url": ..., "enabled": true }`.
+- **codex** (`codexMcpArgs`): **skips url entries** — codex's `-c` MCP config
+  has no reliable remote support. The MCP tab notes this limitation.
+
+## Electron / IPC
+
+- `codey-mac/electron/external-mcp.ts`: `validateExternalMcp(draft)` pure
+  helper — name `^[a-z0-9][a-z0-9_-]*$/i` and not `codey-browser`; stdio
+  requires `command`; remote requires an http(s) `url`; `enabled` coerced.
+- IPC: `mcp:list` (array of `{ name, ...cfg }`), `mcp:save` (validated
+  add/update), `mcp:remove`, `mcp:setEnabled`. Exposed via preload as
+  `window.codey.mcp.*` with the `IpcResult` envelope; types in
+  `codey-api.d.ts`.
+
+## UI
+
+- Fourth tab `MCP` in ToolsView (icon `server`).
+- `McpTab.tsx`: card list (name, transport badge, command/url summary, Toggle
+  with busy affordance, trash delete) + add/edit form with the five fields;
+  args entered as one space-separated line, env as KEY=VALUE lines (parsed in
+  the renderer before `mcp:save`). A footnote states remote servers are not
+  passed to Codex. Deleting asks confirm().
+
+## Testing
+
+- gateway: config round-trip incl. set/remove/getEnabled mapping + coercion.
+- core: `addExternalMcpServers` gate matrix, reserved-name filter, conflict
+  precedence; remote serialization in claude/opencode helpers; codex skip.
+- codey-mac: `validateExternalMcp` cases; renderer arg/env parsing helpers.

--- a/packages/core/src/agents/external-mcp.test.ts
+++ b/packages/core/src/agents/external-mcp.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { addExternalMcpServers } from './index';
+import { AgentRequest, McpServerSpec } from '../types';
+
+const base = (): AgentRequest => ({
+  prompt: 'do the thing',
+  context: { workingDir: '/tmp/work' },
+  browserTools: true,
+} as AgentRequest);
+
+const servers: Record<string, McpServerSpec> = {
+  github: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'], env: { GITHUB_TOKEN: 'tok' } },
+  linear: { command: '', args: [], env: {}, url: 'https://mcp.linear.app/sse' },
+};
+
+describe('addExternalMcpServers', () => {
+  it('merges enabled external servers into the request', () => {
+    const request = addExternalMcpServers(base(), servers);
+    expect(request.mcpServers?.github).toEqual(servers.github);
+    expect(request.mcpServers?.linear).toEqual(servers.linear);
+  });
+
+  it('does nothing when no servers are provided', () => {
+    expect(addExternalMcpServers(base(), undefined).mcpServers).toBeUndefined();
+    expect(addExternalMcpServers(base(), {}).mcpServers).toBeUndefined();
+  });
+
+  it('excludes coordination turns (browserTools not set)', () => {
+    const request = addExternalMcpServers({ ...base(), browserTools: false }, servers);
+    expect(request.mcpServers).toBeUndefined();
+  });
+
+  it('excludes turns with no working directory', () => {
+    const request = addExternalMcpServers({ ...base(), context: {} as any }, servers);
+    expect(request.mcpServers).toBeUndefined();
+  });
+
+  it('excludes tool-restricted turns (allowedTools set)', () => {
+    const request = addExternalMcpServers({ ...base(), allowedTools: ['Read'] }, servers);
+    expect(request.mcpServers).toBeUndefined();
+  });
+
+  it('filters the reserved codey-browser name', () => {
+    const request = addExternalMcpServers(base(), {
+      'codey-browser': { command: '/evil', args: [], env: {} },
+    });
+    expect(request.mcpServers).toBeUndefined();
+  });
+
+  it('never overwrites servers already on the request', () => {
+    const browser: McpServerSpec = { command: '/app/Codey', args: ['/app/server.cjs'], env: {} };
+    const withBrowser = { ...base(), mcpServers: { 'codey-browser': browser, github: browser } };
+    const request = addExternalMcpServers(withBrowser, servers);
+    expect(request.mcpServers?.['codey-browser']).toEqual(browser);
+    expect(request.mcpServers?.github).toEqual(browser);
+    expect(request.mcpServers?.linear).toEqual(servers.linear);
+  });
+
+  it('never touches the prompt', () => {
+    expect(addExternalMcpServers(base(), servers).prompt).toBe('do the thing');
+  });
+});

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -47,11 +47,35 @@ export function addCodeyBrowserMcp(
   };
 }
 
+/**
+ * Merge user-configured external MCP servers into a task-performing agent
+ * turn. Uses the same turn gate as the browser plugin — `browserTools` doubles
+ * as the "tools-capable turn" marker, so advisor/housekeeping/tool-restricted
+ * turns get nothing. The reserved `codey-browser` name is filtered, and
+ * servers already on the request always win name conflicts.
+ */
+export function addExternalMcpServers(
+  request: AgentRequest,
+  servers: Record<string, McpServerSpec> | undefined,
+): AgentRequest {
+  if (!servers) return request;
+  if (request.browserTools !== true || !request.context?.workingDir || request.allowedTools) {
+    return request;
+  }
+  const entries = Object.entries(servers).filter(([name]) => name !== 'codey-browser');
+  if (entries.length === 0) return request;
+  return {
+    ...request,
+    mcpServers: { ...Object.fromEntries(entries), ...(request.mcpServers ?? {}) },
+  };
+}
+
 // Agent factory
 export class AgentFactory {
   private agents: Map<CodingAgent, CodingAgentAdapter> = new Map();
   private envProvider?: (agent: CodingAgent) => Record<string, string> | undefined;
   private pluginEnabledProvider?: (plugin: string) => boolean;
+  private externalMcpProvider?: () => Record<string, McpServerSpec> | undefined;
 
   constructor() {
     this.register('claude-code', new ClaudeCodeAdapter());
@@ -82,6 +106,14 @@ export class AgentFactory {
    */
   setPluginEnabledProvider(provider: (plugin: string) => boolean): void {
     this.pluginEnabledProvider = provider;
+  }
+
+  /**
+   * Inject a callback that returns the user's enabled external MCP servers
+   * from the live config, so edits in the renderer apply on the next request.
+   */
+  setExternalMcpProvider(provider: () => Record<string, McpServerSpec> | undefined): void {
+    this.externalMcpProvider = provider;
   }
 
   resetSessions(): void {
@@ -116,6 +148,7 @@ export class AgentFactory {
     }
 
     request = addCodeyBrowserMcp(request, this.pluginEnabledProvider?.('browser') === true);
+    request = addExternalMcpServers(request, this.externalMcpProvider?.());
 
     return adapter.run(request);
   }

--- a/packages/core/src/agents/mcp-config.test.ts
+++ b/packages/core/src/agents/mcp-config.test.ts
@@ -11,6 +11,8 @@ const servers: Record<string, McpServerSpec> = {
   },
 };
 
+const remote: McpServerSpec = { command: '', args: [], env: {}, url: 'https://mcp.linear.app/sse' };
+
 const cleanups: Array<() => void> = [];
 afterEach(() => { while (cleanups.length) cleanups.pop()!(); });
 
@@ -27,6 +29,13 @@ describe('writeClaudeMcpConfig', () => {
     const { args, cleanup } = writeClaudeMcpConfig(servers);
     cleanup();
     expect(fs.existsSync(args[1])).toBe(false);
+  });
+
+  it('serializes remote servers as http url entries', () => {
+    const { args, cleanup } = writeClaudeMcpConfig({ linear: remote });
+    cleanups.push(cleanup);
+    const parsed = JSON.parse(fs.readFileSync(args[1], 'utf-8'));
+    expect(parsed.mcpServers.linear).toEqual({ type: 'http', url: remote.url });
   });
 });
 
@@ -48,6 +57,12 @@ describe('codexMcpArgs', () => {
     expect(args).toContain('mcp_servers."bare".args=[]');
     expect(args).toContain('mcp_servers."bare".tool_timeout_sec=600');
   });
+
+  it('skips remote servers (codex has no remote MCP config)', () => {
+    const args = codexMcpArgs({ linear: remote, ...servers });
+    expect(args.join(' ')).not.toContain('linear');
+    expect(args.join(' ')).toContain('codey-browser');
+  });
 });
 
 describe('writeOpenCodeMcpConfig', () => {
@@ -61,5 +76,12 @@ describe('writeOpenCodeMcpConfig', () => {
       enabled: true,
       environment: servers['codey-browser'].env,
     });
+  });
+
+  it('serializes remote servers as remote url entries', () => {
+    const { env, cleanup } = writeOpenCodeMcpConfig({ linear: remote });
+    cleanups.push(cleanup);
+    const parsed = JSON.parse(fs.readFileSync(env.OPENCODE_CONFIG, 'utf-8'));
+    expect(parsed.mcp.linear).toEqual({ type: 'remote', url: remote.url, enabled: true });
   });
 });

--- a/packages/core/src/agents/mcp-config.ts
+++ b/packages/core/src/agents/mcp-config.ts
@@ -5,15 +5,23 @@ import { McpServerSpec } from '../types';
 
 /**
  * Write a Claude Code MCP config file and return the CLI args referencing it.
- * The temp dir is per-spawn; callers invoke cleanup() after the CLI exits.
+ * Remote entries (spec.url) serialize as `{ type: 'http', url }`; stdio
+ * entries pass command/args/env through. The temp dir is per-spawn; callers
+ * invoke cleanup() after the CLI exits.
  */
 export function writeClaudeMcpConfig(
   servers: Record<string, McpServerSpec>,
 ): { args: string[]; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-mcp-'));
   const file = path.join(dir, 'mcp.json');
+  const mcpServers: Record<string, unknown> = {};
+  for (const [name, spec] of Object.entries(servers)) {
+    mcpServers[name] = spec.url
+      ? { type: 'http', url: spec.url }
+      : { command: spec.command, args: spec.args, env: spec.env };
+  }
   try {
-    fs.writeFileSync(file, JSON.stringify({ mcpServers: servers }));
+    fs.writeFileSync(file, JSON.stringify({ mcpServers }));
   } catch (error) {
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
     throw error;
@@ -44,6 +52,8 @@ export function writeClaudeMcpConfig(
 export function codexMcpArgs(servers: Record<string, McpServerSpec>): string[] {
   const args: string[] = [];
   for (const [name, spec] of Object.entries(servers)) {
+    // Codex's -c MCP config is stdio-only; remote servers are skipped.
+    if (spec.url) continue;
     const key = `mcp_servers."${name}"`;
     args.push('-c', `${key}.command=${JSON.stringify(spec.command)}`);
     args.push('-c', `${key}.args=${JSON.stringify(spec.args)}`);
@@ -70,12 +80,14 @@ export function writeOpenCodeMcpConfig(
   const file = path.join(dir, 'opencode.json');
   const mcp: Record<string, unknown> = {};
   for (const [name, spec] of Object.entries(servers)) {
-    mcp[name] = {
-      type: 'local',
-      command: [spec.command, ...spec.args],
-      enabled: true,
-      environment: spec.env,
-    };
+    mcp[name] = spec.url
+      ? { type: 'remote', url: spec.url, enabled: true }
+      : {
+          type: 'local',
+          command: [spec.command, ...spec.args],
+          enabled: true,
+          environment: spec.env,
+        };
   }
   try {
     fs.writeFileSync(file, JSON.stringify({ mcp }));

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -104,6 +104,12 @@ export interface McpServerSpec {
   command: string;
   args: string[];
   env: Record<string, string>;
+  /**
+   * Remote server URL. When set, adapters that support remote MCP serialize
+   * the url and ignore command/args/env (which are empty for remote entries);
+   * adapters without remote support (codex) skip the server entirely.
+   */
+  url?: string;
 }
 
 export interface AgentRequest {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       'src/agents/thinking-stream.test.ts',
       'src/agents/browser-mcp.test.ts',
       'src/agents/mcp-config.test.ts',
+      'src/agents/external-mcp.test.ts',
       'src/solo-advisor.test.ts',
       'src/team-graph.test.ts',
       'src/judge.test.ts',

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,9 +1,19 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { EventEmitter } from 'events';
-import { ApiKeyEntry, CodingAgent, FallbackConfig, FallbackEntry, ModelEntry, TeamConfigRaw } from '@codey/core';
+import { ApiKeyEntry, CodingAgent, FallbackConfig, FallbackEntry, McpServerSpec, ModelEntry, TeamConfigRaw } from '@codey/core';
 
 // ── Configuration types ─────────────────────────────────────────────
+
+/** One user-configured external MCP server as stored in gateway.json. */
+export interface ExternalMcpServerConfig {
+  transport: 'stdio' | 'remote';
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  enabled: boolean;
+}
 
 export interface GatewayConfigJson {
   gateway: {
@@ -97,6 +107,12 @@ export interface GatewayConfigJson {
   plugins?: {
     browser?: { enabled: boolean };
   };
+  /**
+   * User-configured external MCP servers, keyed by server name. Enabled
+   * entries are exposed to every task-performing agent turn alongside plugin
+   * servers. Env values are stored in plaintext, same as `apiKeys`.
+   */
+  mcpServers?: Record<string, ExternalMcpServerConfig>;
   notifications?: { enabled?: boolean };
   capture?: { hotkey?: string };
   ui?: { launchAtLogin?: boolean; dockless?: boolean };
@@ -202,6 +218,9 @@ export class ConfigManager extends EventEmitter {
     if (partial.teams !== undefined) this.config.teams = partial.teams;
     if (partial.plugins !== undefined) {
       this.config.plugins = { ...this.config.plugins, ...partial.plugins };
+    }
+    if (partial.mcpServers !== undefined) {
+      this.config.mcpServers = { ...this.config.mcpServers, ...partial.mcpServers };
     }
     if (partial.voice !== undefined) this.config.voice = partial.voice;
     if (partial.notifications !== undefined) {
@@ -422,6 +441,41 @@ export class ConfigManager extends EventEmitter {
     return this.config.plugins?.[name]?.enabled === true;
   }
 
+  // ── External MCP servers ───────────────────────────────────────────
+  /** Add or replace one external MCP server entry. Saves and emits change. */
+  setExternalMcpServer(name: string, cfg: ExternalMcpServerConfig): void {
+    this.config.mcpServers = { ...this.config.mcpServers, [name]: cfg };
+    this.save();
+  }
+
+  /** Delete one external MCP server entry (merge-based update() cannot). */
+  removeExternalMcpServer(name: string): void {
+    if (!this.config.mcpServers || !(name in this.config.mcpServers)) return;
+    const { [name]: _removed, ...rest } = this.config.mcpServers;
+    this.config.mcpServers = rest;
+    this.save();
+  }
+
+  /**
+   * Enabled external servers mapped to the core McpServerSpec shape. Skips
+   * disabled entries, entries missing their transport's required field, and
+   * the reserved `codey-browser` name.
+   */
+  getEnabledExternalMcpServers(): Record<string, McpServerSpec> {
+    const out: Record<string, McpServerSpec> = {};
+    for (const [name, cfg] of Object.entries(this.config.mcpServers ?? {})) {
+      if (!cfg.enabled || name === 'codey-browser') continue;
+      if (cfg.transport === 'remote') {
+        if (!cfg.url) continue;
+        out[name] = { command: '', args: [], env: {}, url: cfg.url };
+      } else if (cfg.transport === 'stdio') {
+        if (!cfg.command) continue;
+        out[name] = { command: cfg.command, args: cfg.args ?? [], env: cfg.env ?? {} };
+      }
+    }
+    return out;
+  }
+
   // ── Channels ───────────────────────────────────────────────────────
   getTelegramConfig() { return this.config.channels.telegram; }
   getDiscordConfig() { return this.config.channels.discord; }
@@ -628,6 +682,25 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
     out.plugins = {
       browser: { enabled: raw.plugins.browser?.enabled === true },
     };
+  }
+  if (raw.mcpServers && typeof raw.mcpServers === 'object') {
+    const servers: Record<string, ExternalMcpServerConfig> = {};
+    for (const [name, value] of Object.entries(raw.mcpServers as Record<string, any>)) {
+      if (!value || typeof value !== 'object') continue;
+      const transport = value.transport === 'remote' ? 'remote' : value.transport === 'stdio' ? 'stdio' : null;
+      if (!transport) continue; // unknown transports are dropped, not guessed
+      servers[name] = {
+        transport,
+        command: typeof value.command === 'string' ? value.command : undefined,
+        args: Array.isArray(value.args) ? value.args.map(String) : undefined,
+        env: value.env && typeof value.env === 'object'
+          ? Object.fromEntries(Object.entries(value.env).map(([k, v]) => [k, String(v)]))
+          : undefined,
+        url: typeof value.url === 'string' ? value.url : undefined,
+        enabled: value.enabled === true,
+      };
+    }
+    out.mcpServers = servers;
   }
   if (raw.voice && typeof raw.voice === 'object') {
     out.voice = raw.voice;

--- a/packages/gateway/src/external-mcp-config.test.ts
+++ b/packages/gateway/src/external-mcp-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ConfigManager } from './config';
+
+describe('external MCP server config', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-mcp-cfg-'));
+    file = path.join(dir, 'gateway.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('defaults to no external servers', () => {
+    const mgr = new ConfigManager(file);
+    expect(mgr.getEnabledExternalMcpServers()).toEqual({});
+  });
+
+  it('set + persist + reload round-trip', () => {
+    const mgr = new ConfigManager(file);
+    mgr.setExternalMcpServer('github', {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-github'],
+      env: { GITHUB_TOKEN: 'tok' },
+      enabled: true,
+    });
+    const reloaded = new ConfigManager(file);
+    expect(reloaded.getEnabledExternalMcpServers()).toEqual({
+      github: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-github'], env: { GITHUB_TOKEN: 'tok' } },
+    });
+  });
+
+  it('maps remote entries to url specs', () => {
+    const mgr = new ConfigManager(file);
+    mgr.setExternalMcpServer('linear', {
+      transport: 'remote',
+      url: 'https://mcp.linear.app/sse',
+      enabled: true,
+    });
+    expect(mgr.getEnabledExternalMcpServers()).toEqual({
+      linear: { command: '', args: [], env: {}, url: 'https://mcp.linear.app/sse' },
+    });
+  });
+
+  it('excludes disabled servers and invalid entries', () => {
+    const mgr = new ConfigManager(file);
+    mgr.setExternalMcpServer('off', { transport: 'stdio', command: '/bin/x', enabled: false });
+    mgr.setExternalMcpServer('nocmd', { transport: 'stdio', command: '', enabled: true });
+    mgr.setExternalMcpServer('nourl', { transport: 'remote', url: '', enabled: true });
+    expect(mgr.getEnabledExternalMcpServers()).toEqual({});
+  });
+
+  it('never returns the reserved codey-browser name', () => {
+    const mgr = new ConfigManager(file);
+    mgr.setExternalMcpServer('codey-browser', { transport: 'stdio', command: '/evil', enabled: true });
+    expect(mgr.getEnabledExternalMcpServers()).toEqual({});
+  });
+
+  it('removeExternalMcpServer deletes and persists', () => {
+    const mgr = new ConfigManager(file);
+    mgr.setExternalMcpServer('github', { transport: 'stdio', command: 'npx', enabled: true });
+    mgr.removeExternalMcpServer('github');
+    expect(mgr.getEnabledExternalMcpServers()).toEqual({});
+    const reloaded = new ConfigManager(file);
+    expect(reloaded.get().mcpServers?.github).toBeUndefined();
+  });
+
+  it('coerces non-boolean enabled and bad shapes on load', () => {
+    fs.writeFileSync(file, JSON.stringify({
+      mcpServers: {
+        a: { transport: 'stdio', command: '/bin/a', enabled: 'yes' },
+        b: { transport: 'weird', command: '/bin/b', enabled: true },
+      },
+    }));
+    const mgr = new ConfigManager(file);
+    expect(mgr.getEnabledExternalMcpServers()).toEqual({});
+    expect(mgr.get().mcpServers?.a?.enabled).toBe(false);
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -561,6 +561,10 @@ export class Codey {
     this.agentFactory.setPluginEnabledProvider((plugin) =>
       plugin === 'browser' && this.configManager?.isPluginEnabled('browser') === true
     );
+    // User-configured external MCP servers ride the same live-read pattern.
+    this.agentFactory.setExternalMcpProvider(() =>
+      this.configManager?.getEnabledExternalMcpServers()
+    );
     this.logger = logger || Logger.getInstance();
     this.contextManager = new ContextManager({
       maxTokenBudget: config.context?.maxTokenBudget ?? 12000,

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     include: [
       'src/config.test.ts',
       'src/plugins-config.test.ts',
+      'src/external-mcp-config.test.ts',
       'src/gateway.network-retry.test.ts',
       'src/digit-mapping.test.ts',
       'src/team-pause.test.ts',


### PR DESCRIPTION
## Summary
- Stacked on #180. New **Tools → MCP** tab where users register external MCP servers — local stdio (command/args/env) and remote URLs — stored in `gateway.json` `mcpServers`, off by default with per-server enable toggles.
- Enabled servers ride the existing `AgentRequest.mcpServers` seam into every task-performing agent turn (advisor/housekeeping turns excluded); the `codey-browser` name is reserved and filtered at three layers.
- Remote entries serialize as `{ type: "http", url }` for claude-code and `{ type: "remote", url }` for opencode; **codex receives stdio servers only** (no reliable remote MCP config) — noted in the tab.
- Also removes the tab subtitles in the Tools view (Skills/Playbooks/Plugins/MCP now show label + icon only).

Design spec: `docs/superpowers/specs/2026-07-21-external-mcp-servers-design.md`

## Test Plan
- [x] 205 core + 172 gateway + 292 codey-mac tests pass (25 new: gate matrix + reserved-name + precedence, remote serialization per adapter, config round-trip/remove/coercion, IPC validation, env/args parsing)
- [x] Renderer bundles; zero new tsc errors vs pre-existing electron-typing baseline
- [ ] Manual: add a stdio server (e.g. `npx -y @modelcontextprotocol/server-github`), enable it, confirm the agent sees its tools; add a remote server and confirm claude/opencode receive it while codex does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)