### PR TITLE
Humanize in-app browser input; keep it painting when unfocused

### DIFF
--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -62,18 +62,59 @@ describe('BrowserController agent controls', () => {
           : command === 'DOM.querySelector' ? { nodeId: 2 } : {}),
       },
     }
-    const controller = new BrowserController(() => null, vi.fn())
+    const controller = new BrowserController(
+      () => null,
+      vi.fn(),
+      undefined,
+      undefined,
+      undefined,
+      { random: () => 0.5, sleep: async () => {} },
+    )
     ;(controller as any).view = { webContents: contents }
     return { controller, contents }
   }
 
-  it('performs a trusted click at the snapshotted element center', async () => {
+  it('approaches and clicks the snapshotted element center along a human path', async () => {
     const { controller, contents } = setup({ x: 120, y: 80 })
     await expect(controller.click('e2')).resolves.toMatchObject({ ok: true, message: 'Clicked e2' })
-    expect(contents.sendInputEvent.mock.calls.map(call => call[0].type)).toEqual([
-      'mouseMove', 'mouseDown', 'mouseUp',
-    ])
+    const events = contents.sendInputEvent.mock.calls.map(call => call[0])
+    const moves = events.filter(event => event.type === 'mouseMove')
+    // A curved approach means many samples, not a single jump to the target.
+    expect(moves.length).toBeGreaterThan(1)
+    expect(moves[moves.length - 1]).toMatchObject({ x: 120, y: 80 })
+    expect(events.slice(-2).map(event => event.type)).toEqual(['mouseDown', 'mouseUp'])
+    expect(events.find(event => event.type === 'mouseDown')).toMatchObject({ x: 120, y: 80 })
     expect(contents.sendInputEvent).toHaveBeenLastCalledWith(expect.objectContaining({ x: 120, y: 80 }))
+  })
+
+  it('bows the pointer path off the straight line between endpoints', async () => {
+    const contents = {
+      isDestroyed: vi.fn(() => false),
+      getURL: vi.fn(() => 'https://example.com/form'),
+      getTitle: vi.fn(() => 'Example'),
+      executeJavaScript: vi.fn(async () => ({ x: 200, y: 200 })),
+      sendInputEvent: vi.fn(),
+    }
+    const controller = new BrowserController(
+      () => null,
+      vi.fn(),
+      undefined,
+      undefined,
+      undefined,
+      { random: () => 0.9, sleep: async () => {} },
+    )
+    ;(controller as any).view = { webContents: contents }
+    await controller.click('e1')
+    const moves = contents.sendInputEvent.mock.calls.map(call => call[0]).filter(event => event.type === 'mouseMove')
+    const start = moves[0]
+    const end = moves[moves.length - 1]
+    const mid = moves[Math.floor(moves.length / 2)]
+    const dx = end.x - start.x
+    const dy = end.y - start.y
+    // Perpendicular distance of the midpoint from the start→end line proves the arc.
+    const deviation = Math.abs((mid.x - start.x) * dy - (mid.y - start.y) * dx) / (Math.hypot(dx, dy) || 1)
+    expect(deviation).toBeGreaterThan(1)
+    expect(end).toMatchObject({ x: 200, y: 200 })
   })
 
   it('follows a safe page link directly without dispatching its click handler', async () => {
@@ -137,14 +178,24 @@ describe('BrowserController agent controls', () => {
     expect(script).not.toContain('sessionStorage')
   })
 
-  it('fills through Chromium native editing so stateful editors receive the text', async () => {
+  it('types into the focused field character by character with native keystrokes', async () => {
     const { controller, contents } = setup(true)
     await controller.fill('e4', `Jack's "post"`)
     const script = contents.executeJavaScript.mock.calls[0][0]
     expect(script).toContain('range.selectNodeContents(el)')
     expect(script).toContain('el.select()')
+    // The text is never embedded in the executed page script.
     expect(script).not.toContain(`Jack's`)
-    expect(contents.insertText).toHaveBeenCalledWith(`Jack's "post"`)
+    expect(contents.insertText).not.toHaveBeenCalled()
+    // Each character arrives as a full keydown/char/keyup keystroke.
+    expect(contents.sendInputEvent.mock.calls.slice(0, 3).map(call => call[0].type)).toEqual([
+      'keyDown', 'char', 'keyUp',
+    ])
+    const typed = contents.sendInputEvent.mock.calls
+      .filter(call => call[0].type === 'char')
+      .map(call => call[0].keyCode)
+      .join('')
+    expect(typed).toBe(`Jack's "post"`)
   })
 
   it('sends a character event for the space key', async () => {
@@ -170,9 +221,9 @@ describe('BrowserController agent controls', () => {
   it('supports coordinate clicks and drag gestures for maps and canvases', async () => {
     const { controller, contents } = setup(true)
     await controller.clickAt(20.4, 30.6, 2)
-    expect(contents.sendInputEvent.mock.calls.map(call => call[0].type)).toEqual([
-      'mouseMove', 'mouseDown', 'mouseUp', 'mouseDown', 'mouseUp',
-    ])
+    const clickEvents = contents.sendInputEvent.mock.calls.map(call => call[0])
+    expect(clickEvents.filter(event => event.type === 'mouseMove').length).toBeGreaterThan(1)
+    expect(clickEvents.slice(-4).map(event => event.type)).toEqual(['mouseDown', 'mouseUp', 'mouseDown', 'mouseUp'])
     expect(contents.sendInputEvent).toHaveBeenLastCalledWith(expect.objectContaining({ x: 20, y: 31, clickCount: 2 }))
 
     contents.sendInputEvent.mockClear()

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -70,6 +70,12 @@ export interface BrowserActionResult {
   message: string
 }
 
+/** Seams for deterministic, fast tests of the humanized input timing. */
+export interface HumanInputOptions {
+  random?: () => number
+  sleep?: (ms: number) => Promise<void>
+}
+
 export interface BrowserWaitRequest {
   kind: 'ref' | 'text' | 'url' | 'title'
   value: string
@@ -201,6 +207,10 @@ export class BrowserController {
   private downloadWaiters: Array<(download: BrowserDownload) => void> = []
   private downloadSequence = 0
   private sitePermissionManager: BrowserSitePermissionManager | null = null
+  /** Last synthesized cursor position, so each move starts where the last ended. */
+  private pointer: { x: number; y: number } | null = null
+  private readonly random: () => number
+  private readonly sleep: (ms: number) => Promise<void>
 
   constructor(
     private readonly getWindow: () => BrowserWindow | null,
@@ -208,7 +218,11 @@ export class BrowserController {
     private readonly onDownload: (download: BrowserDownload) => void = () => {},
     private readonly getDownloadDirectory: () => string = () => path.join(os.tmpdir(), 'codey-downloads'),
     private readonly getBrowserSession: () => Session = () => session.fromPartition(BROWSER_PARTITION, { cache: true }),
-  ) {}
+    options: HumanInputOptions = {},
+  ) {
+    this.random = options.random ?? Math.random
+    this.sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
+  }
 
   setSitePermissionManager(manager: BrowserSitePermissionManager): void {
     this.sitePermissionManager = manager
@@ -561,9 +575,7 @@ export class BrowserController {
   async click(ref: string): Promise<BrowserActionResult> {
     const contents = this.requirePage()
     const point = await this.elementPoint(ref)
-    contents.sendInputEvent({ type: 'mouseMove', x: point.x, y: point.y })
-    contents.sendInputEvent({ type: 'mouseDown', x: point.x, y: point.y, button: 'left', clickCount: 1 })
-    contents.sendInputEvent({ type: 'mouseUp', x: point.x, y: point.y, button: 'left', clickCount: 1 })
+    await this.humanClick(contents, point)
     return this.actionResult(`Clicked ${ref}`)
   }
 
@@ -571,11 +583,7 @@ export class BrowserController {
     const contents = this.requirePage()
     const point = this.validatePoint(x, y)
     const count = Math.max(1, Math.min(3, Math.round(clickCount) || 1))
-    contents.sendInputEvent({ type: 'mouseMove', ...point })
-    for (let index = 1; index <= count; index += 1) {
-      contents.sendInputEvent({ type: 'mouseDown', ...point, button: 'left', clickCount: index })
-      contents.sendInputEvent({ type: 'mouseUp', ...point, button: 'left', clickCount: index })
-    }
+    await this.humanClick(contents, point, count)
     return this.actionResult(`Clicked at ${point.x}, ${point.y}${count > 1 ? ` (${count} times)` : ''}`)
   }
 
@@ -602,23 +610,25 @@ export class BrowserController {
       })
     }
     contents.sendInputEvent({ type: 'mouseUp', ...to, button: 'left', clickCount: 1 })
+    this.pointer = { x: to.x, y: to.y }
     return this.actionResult(`Dragged from ${from.x}, ${from.y} to ${to.x}, ${to.y}`)
   }
 
   async hover(ref: string): Promise<BrowserActionResult> {
     const contents = this.requirePage()
     const point = await this.elementPoint(ref)
-    contents.sendInputEvent({ type: 'mouseMove', x: point.x, y: point.y })
+    await this.humanMove(contents, point)
     return this.actionResult(`Hovered ${ref}`)
   }
 
   async fill(ref: string, value: string): Promise<BrowserActionResult> {
     this.assertRef(ref)
     const contents = this.requirePage()
-    // Select through the DOM, then insert through Chromium's native editing
-    // pipeline. Assigning textContent/value only changes the rendered DOM and
-    // leaves stateful editors (Draft.js, ProseMirror, X's composer, etc.)
-    // unaware of the new text.
+    // Select through the DOM, then type through Chromium's native key pipeline.
+    // Assigning textContent/value only changes the rendered DOM and leaves
+    // stateful editors (Draft.js, ProseMirror, X's composer, etc.) unaware of
+    // the new text; real keystrokes drive their editing model and also emit the
+    // keydown/keyup cadence that anti-bot heuristics look for.
     await contents.executeJavaScript(`(() => {
       const el = document.querySelector('[data-codey-ref="${ref}"]')
       if (!el) throw new Error('Element ${ref} is no longer available; take a new snapshot')
@@ -638,10 +648,12 @@ export class BrowserController {
       return true
     })()`, true)
     if (value) {
-      contents.insertText(value)
+      // Typing over the existing selection replaces it, just like a person
+      // does after the field is selected above.
+      await this.humanType(contents, value)
     } else {
-      // insertText('') does not replace the active selection, so preserve the
-      // expected "fill with empty text" behavior through the same native path.
+      // Nothing to type, so clear the active selection through the same native
+      // path to preserve the expected "fill with empty text" behavior.
       contents.sendInputEvent({ type: 'keyDown', keyCode: 'Backspace' })
       contents.sendInputEvent({ type: 'keyUp', keyCode: 'Backspace' })
     }
@@ -902,6 +914,99 @@ export class BrowserController {
     })()`, true) as { x: number; y: number }
   }
 
+  /**
+   * Emit a curved, variable-speed pointer path from the last known cursor
+   * position to the target. A straight line traversed at a constant rate is a
+   * strong automation tell, so the synthesized motion arcs off-axis, eases in
+   * and out, and jitters between samples the way a real hand does.
+   */
+  private async humanMove(contents: WebContents, target: { x: number; y: number }): Promise<void> {
+    const from = this.pointer ?? {
+      x: Math.max(0, target.x - 40 - Math.round(this.random() * 40)),
+      y: Math.max(0, target.y - 30 - Math.round(this.random() * 30)),
+    }
+    for (const point of this.buildPointerPath(from, target)) {
+      contents.sendInputEvent({ type: 'mouseMove', x: point.x, y: point.y })
+      await this.sleep(this.humanDelay(6, 10))
+    }
+    this.pointer = { x: target.x, y: target.y }
+  }
+
+  /** Approach the target, settle, then press and release with human-scale gaps. */
+  private async humanClick(
+    contents: WebContents,
+    target: { x: number; y: number },
+    clickCount = 1,
+  ): Promise<void> {
+    await this.humanMove(contents, target)
+    await this.sleep(this.humanDelay(40, 90))
+    const count = Math.max(1, Math.min(3, Math.round(clickCount) || 1))
+    for (let index = 1; index <= count; index += 1) {
+      contents.sendInputEvent({ type: 'mouseDown', x: target.x, y: target.y, button: 'left', clickCount: index })
+      await this.sleep(this.humanDelay(55, 70))
+      contents.sendInputEvent({ type: 'mouseUp', x: target.x, y: target.y, button: 'left', clickCount: index })
+      if (index < count) await this.sleep(this.humanDelay(70, 90))
+    }
+  }
+
+  private buildPointerPath(
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+  ): Array<{ x: number; y: number }> {
+    const dx = to.x - from.x
+    const dy = to.y - from.y
+    const distance = Math.hypot(dx, dy)
+    const steps = Math.max(8, Math.min(40, Math.round(distance / 12) + 8))
+    const length = distance || 1
+    // Perpendicular unit vector used to bow the straight line into a gentle arc.
+    const perpX = -dy / length
+    const perpY = dx / length
+    const bow = (this.random() * 2 - 1) * Math.min(60, distance * 0.2)
+    const controlX = from.x + dx / 2 + perpX * bow
+    const controlY = from.y + dy / 2 + perpY * bow
+    const points: Array<{ x: number; y: number }> = []
+    for (let index = 1; index <= steps; index += 1) {
+      const progress = index / steps
+      // Ease-in-out clusters samples near the endpoints, like a real hand.
+      const eased = progress < 0.5 ? 2 * progress * progress : 1 - Math.pow(-2 * progress + 2, 2) / 2
+      const inverse = 1 - eased
+      const last = index === steps
+      // Quadratic Bézier through the bowed control point.
+      const x = inverse * inverse * from.x + 2 * inverse * eased * controlX + eased * eased * to.x
+      const y = inverse * inverse * from.y + 2 * inverse * eased * controlY + eased * eased * to.y
+      // Land exactly on the target; only intermediate samples carry jitter.
+      const jitterX = last ? 0 : (this.random() * 2 - 1) * 1.2
+      const jitterY = last ? 0 : (this.random() * 2 - 1) * 1.2
+      points.push({ x: Math.round(x + jitterX), y: Math.round(y + jitterY) })
+    }
+    return points
+  }
+
+  /**
+   * Type a string one character at a time as full keydown/char/keyup
+   * keystrokes with a jittered inter-key delay. `Array.from` keeps multi-code-
+   * unit characters (emoji, combined glyphs) intact, and newlines are sent as
+   * Return so multi-line fields receive the break a real keyboard would insert.
+   */
+  private async humanType(contents: WebContents, value: string): Promise<void> {
+    for (const char of Array.from(value)) {
+      if (char === '\n' || char === '\r') {
+        contents.sendInputEvent({ type: 'keyDown', keyCode: 'Return' })
+        contents.sendInputEvent({ type: 'char', keyCode: '\r' })
+        contents.sendInputEvent({ type: 'keyUp', keyCode: 'Return' })
+      } else {
+        contents.sendInputEvent({ type: 'keyDown', keyCode: char })
+        contents.sendInputEvent({ type: 'char', keyCode: char })
+        contents.sendInputEvent({ type: 'keyUp', keyCode: char })
+      }
+      await this.sleep(this.humanDelay(40, 90))
+    }
+  }
+
+  private humanDelay(base: number, spread: number): number {
+    return Math.max(0, Math.round(base + this.random() * spread))
+  }
+
   private actionResult(message: string): BrowserActionResult {
     return { ok: true, url: this.view?.webContents.getURL() || '', message }
   }
@@ -929,6 +1034,10 @@ export class BrowserController {
         nodeIntegration: false,
         sandbox: true,
         webSecurity: true,
+        // Keep the page compositing and running timers even when the Codey
+        // window is backgrounded or occluded, so agent screenshots
+        // (capturePage) stay fresh without forcing the window to the front.
+        backgroundThrottling: false,
       },
     })
     view.setBackgroundColor('#141414')


### PR DESCRIPTION
## What & why

Two related improvements to the Mac app's in-app browser (`browser-controller.ts`), aimed at letting agent-driven browsing run without hijacking the user's machine and without looking like a naive bot.

### 1. Keep painting in the background
Tab `WebContentsView`s are created with `backgroundThrottling: false`. When the Codey window is unfocused or occluded, the page keeps compositing and running timers, so `capturePage()` returns fresh frames — the agent no longer has to pull the window to the front just to screenshot the page.

### 2. Humanized pointer input
`click` / `clickAt` / `hover` now approach the target along a curved, variable-speed path instead of jumping in one step:
- eased quadratic Bézier bowed off the straight line, sampled with per-step jitter
- pointer position tracked across actions (and updated by `drag`), so moves are continuous rather than teleporting from the same spot
- human-scale settle-before-press and randomized press/release gaps

### 3. Humanized typing
`fill` types one character at a time as full `keyDown → char → keyUp` keystrokes with a jittered inter-key delay, replacing the single `insertText`. It keeps the existing focus/select step (so typing replaces the selection), keeps the empty-value Backspace path, handles multi-code-unit characters via `Array.from`, and sends newlines as Return.

All three still use trusted `sendInputEvent`, so they work while the window is unfocused — pairing naturally with change #1.

### Testing seams
The constructor takes optional `{ random, sleep }` (defaulting to `Math.random` / `setTimeout`) so timing is deterministic and instant in tests.

## Scope / expectations
This reduces friction against simple bot checks and keeps day-to-day automation smoother. It is **not** a CAPTCHA bypass — reCAPTCHA Enterprise / Turnstile weigh IP reputation and fingerprint far more than pointer realism, so hard challenges should still fall back to a human handoff (`[ASK_USER]`).

## Tests
- `codey-mac` electron suite: 18 files / 153 tests pass (added curved-path and per-character-typing assertions; updated the two that expected the old single-jump / bulk-insert behavior)
- `tsc --noEmit` clean

Runtime note: the background-screenshot behavior (#1) still wants a manual smoke test in the running app — unit tests mock `WebContentsView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)