### PR TITLE
Preserve case in derived workspace names

### DIFF
--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -282,10 +282,13 @@ export class WorkspaceManager {
       }
     }
 
-    let name = path.basename(dir).toLowerCase().replace(/[^a-z0-9-_]/g, '-');
-    if (workspaces.includes(name)) {
+    let name = path.basename(dir).replace(/[^a-zA-Z0-9-_]/g, '-');
+    // Case-insensitive collision check: workspace dirs live on a
+    // case-insensitive filesystem on macOS.
+    const taken = (n: string) => workspaces.some(ws => ws.toLowerCase() === n.toLowerCase());
+    if (taken(name)) {
       let i = 2;
-      while (workspaces.includes(`${name}-${i}`)) i++;
+      while (taken(`${name}-${i}`)) i++;
       name = `${name}-${i}`;
     }
 


### PR DESCRIPTION
## What & why

When a workspace name is derived from a directory basename, it was lowercased before use. This PR keeps the original casing so a directory like `MyProject` yields the workspace name `MyProject` instead of `myproject`.

Collision detection is changed to be **case-insensitive** (`ws.toLowerCase() === name.toLowerCase()`), matching the case-insensitive filesystem that workspaces live on (macOS). This prevents two names that differ only in case from silently clobbering each other and keeps the `-2`, `-3`, … disambiguation working.

## Tests
- `@codey/core` suite: 17 files / 206 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)