### PR TITLE
Show automation results when they happen, not on next launch

### DIFF
--- a/codey-mac/electron/automation-notifications.test.ts
+++ b/codey-mac/electron/automation-notifications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { decideAutomationNotification, findUnseenRuns } from './automation-notifications'
+import { decideAutomationNotification, findUnseenRuns, findUnnotifiedRuns } from './automation-notifications'
 
 const auto = (over: any = {}) => ({
   id: 'a1', name: 'Morning news', report: { notify: 'all' }, ...over,
@@ -47,5 +47,17 @@ describe('findUnseenRuns', () => {
       run({ runId: 'fresh', endedAt: now - 3600_000 }),
     ]
     expect(findUnseenRuns(runs, now).map(r => r.runId)).toEqual(['fresh'])
+  })
+})
+
+describe('findUnnotifiedRuns', () => {
+  it('drops unseen runs that already fired a notification live', () => {
+    const now = 100 * 3600_000
+    const runs = [
+      run({ runId: 'announced', endedAt: now - 3600_000, notifiedAt: now - 3600_000 }),
+      run({ runId: 'silent', endedAt: now - 1800_000 }),
+    ]
+    expect(findUnseenRuns(runs, now).map(r => r.runId)).toEqual(['announced', 'silent'])
+    expect(findUnnotifiedRuns(runs, now).map(r => r.runId)).toEqual(['silent'])
   })
 })

--- a/codey-mac/electron/automation-notifications.ts
+++ b/codey-mac/electron/automation-notifications.ts
@@ -24,6 +24,7 @@ export interface RunLike {
   error?: string
   question?: string
   seenAt?: number
+  notifiedAt?: number
 }
 export interface AutomationNotification { automationId: string; runId: string; title: string; body: string }
 
@@ -49,7 +50,14 @@ export function decideAutomationNotification(a: AutomationLike, run: RunLike): A
   return { automationId: a.id, runId: run.runId, title, body: truncate(mdToPlainText(raw), MAX_BODY) }
 }
 
-/** Runs that ended recently, unseen — surfaced (badge + notify) on app launch. */
+/** Runs that ended recently, unseen — surfaced as the launch-time badge count. */
 export function findUnseenRuns(runs: RunLike[], now: number): RunLike[] {
   return runs.filter(r => !r.seenAt && r.endedAt !== undefined && now - r.endedAt <= UNSEEN_WINDOW_MS)
+}
+
+/** Of those, the ones no OS notification has fired for yet. Unseen alone is the
+ *  wrong gate for notifying: a run announced live stays unseen until the user
+ *  opens it, so the launch scan would announce it again on the next start. */
+export function findUnnotifiedRuns(runs: RunLike[], now: number): RunLike[] {
+  return findUnseenRuns(runs, now).filter(r => !r.notifiedAt)
 }

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -7,7 +7,7 @@ import { findAvailablePort } from './portUtils'
 import { initAutoUpdater, registerUpdaterIpc } from './updater'
 import { createCoreStateStore } from './core-state'
 import { decideNotification, createTurnTracker } from './chat-notifications'
-import { decideAutomationNotification, findUnseenRuns } from './automation-notifications'
+import { decideAutomationNotification, findUnseenRuns, findUnnotifiedRuns } from './automation-notifications'
 import { validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
 import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, uniqueSkills } from './skills'
@@ -468,14 +468,14 @@ function sendToRenderer(channel: string, ...args: any[]) {
     if (pendingRendererMessages.length > 500) pendingRendererMessages.shift()
   }
 }
-// Same gate the chat path applies inside decideNotification (via maybeNotify's
-// ctx): global notifications toggle off → no OS notification; window focused →
-// the user is already looking at the app, so skip the OS notification (the
-// renderer still receives the underlying event either way).
-function osNotificationsAllowed(): boolean {
-  const enabled = ((coreConfigManager?.get() as any)?.notifications?.enabled ?? true) as boolean
-  const focused = mainWindow?.isFocused() ?? false
-  return enabled && !focused
+// Gate for automation-run notifications: only the global notifications toggle.
+// Deliberately NOT focus-gated, unlike the chat path (decideNotification via
+// maybeNotify's ctx). Automations run in the background, so a finished/parked
+// run is news even while the user is in the app — and a suppressed one is not
+// marked seen, so it used to resurface only via the launch scan on next start,
+// which read as "notifications are delayed until I restart".
+function automationNotificationsAllowed(): boolean {
+  return ((coreConfigManager?.get() as any)?.notifications?.enabled ?? true) as boolean
 }
 // Native macOS notifications for background chats. Decisions are pure
 // (chat-notifications.ts); this is the impure shell: focus check, config
@@ -953,16 +953,22 @@ async function bootInProcessCore() {
       // from being mislabeled as a gateway.start failure below.
       try {
         for (const a of inProcessGateway!.listAutomations()) {
-          const unseen = findUnseenRuns(inProcessGateway!.listAutomationRuns(a.id, 20) as any, Date.now())
+          const runs = inProcessGateway!.listAutomationRuns(a.id, 20) as any
+          const unseen = findUnseenRuns(runs, Date.now())
           if (unseen.length === 0) continue
           sendToRenderer('automation-unseen', { automationId: a.id, runIds: unseen.map((r: any) => r.runId) })
-          if (!osNotificationsAllowed()) continue
-          const d = decideAutomationNotification(a as any, unseen[0] as any)
+          if (!automationNotificationsAllowed()) continue
+          // Notify only about runs that were never announced live (e.g. fired by
+          // the daemon while the app was closed) — not every unseen one.
+          const fresh = findUnnotifiedRuns(runs, Date.now())
+          if (fresh.length === 0) continue
+          const d = decideAutomationNotification(a as any, fresh[0] as any)
           if (d) {
             new Notification({
               title: d.title,
-              body: unseen.length > 1 ? `${d.body} (+${unseen.length - 1} more)` : d.body,
+              body: fresh.length > 1 ? `${d.body} (+${fresh.length - 1} more)` : d.body,
             }).show()
+            for (const r of fresh) inProcessGateway!.markAutomationRunNotified(a.id, (r as any).runId)
           }
         }
       } catch (err: any) {
@@ -1012,11 +1018,14 @@ async function bootInProcessCore() {
     // report.notify (decision logic lives in automation-notifications.ts).
     inProcessGateway.setAutomationEventListener((ev: any) => {
       sendToRenderer('automation-event', ev)
-      if ((ev.type === 'run-finished' || ev.type === 'run-parked') && ev.run && osNotificationsAllowed()) {
+      if ((ev.type === 'run-finished' || ev.type === 'run-parked') && ev.run && automationNotificationsAllowed()) {
         const a = inProcessGateway?.getAutomation(ev.automationId)
         if (a) {
           const d = decideAutomationNotification(a as any, ev.run)
-          if (d) new Notification({ title: d.title, body: d.body }).show()
+          if (d) {
+            new Notification({ title: d.title, body: d.body }).show()
+            inProcessGateway?.markAutomationRunNotified(ev.automationId, ev.runId)
+          }
         }
       }
     })

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -194,10 +194,17 @@ const Shell: React.FC = () => {
 
   // Addition 3: the nav badge must not rely solely on the one-shot
   // 'automation-unseen' push (missed if it fires before this mounts, or if
-  // the app was relaunched) — also recompute from history on mount. Both
-  // paths merge into the same Set, whichever arrives.
+  // the app was relaunched) — also recompute from history on mount, and
+  // listen for live run completions. Without the live path the badge only
+  // appeared after a relaunch, since the mount scan was its only source for
+  // runs that finished while the app was open. All three paths merge into
+  // the same Set, whichever arrives.
   useEffect(() => {
     let cancelled = false
+    const offEvent = window.codey.automations.onEvent((ev) => {
+      if (ev.type !== 'run-finished' && ev.type !== 'run-parked') return
+      setUnseenRunKeys(prev => new Set(prev).add(`${ev.automationId}:${ev.runId}`))
+    })
     const off = window.codey.automations.onUnseen((msg) => {
       setUnseenRunKeys(prev => {
         const next = new Set(prev)
@@ -226,7 +233,7 @@ const Shell: React.FC = () => {
         // gateway not ready yet — the push will still arrive when it fires
       }
     })()
-    return () => { cancelled = true; off() }
+    return () => { cancelled = true; off(); offEvent() }
   }, [])
 
   const openAutomations = () => {

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -129,6 +129,10 @@ export interface AutomationRun {
   reportFailure?: string;
   /** Set when the Mac app has surfaced this result. */
   seenAt?: number;
+  /** Set once an OS notification has been fired for this run, so the
+   *  launch-time unseen scan doesn't re-notify what was already announced
+   *  live. Distinct from seenAt: notified ≠ read, the badge still counts it. */
+  notifiedAt?: number;
 }
 
 /** Status of the authoring-time dry-run check for a chat session. */

--- a/packages/gateway/src/automations/store.ts
+++ b/packages/gateway/src/automations/store.ts
@@ -213,4 +213,8 @@ export class AutomationStore {
   markSeen(id: string, runId: string, now: number): void {
     this.patchRun(id, runId, { seenAt: now });
   }
+
+  markNotified(id: string, runId: string, now: number): void {
+    this.patchRun(id, runId, { notifiedAt: now });
+  }
 }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1147,6 +1147,11 @@ export class Codey {
   markAutomationRunSeen(id: string, runId: string): void {
     this.automationStore?.markSeen(id, runId, Date.now());
   }
+  /** Records that an OS notification was fired, so a relaunch inside the
+   *  unseen window doesn't announce the same run twice. */
+  markAutomationRunNotified(id: string, runId: string): void {
+    this.automationStore?.markNotified(id, runId, Date.now());
+  }
   /** Per-run activity log (tool calls, worker steps), or undefined if none. */
   getAutomationRunLog(id: string, runId: string): string | undefined {
     return this.automationStore?.readRunLog(id, runId);


### PR DESCRIPTION
A finished automation only surfaced after restarting the app. Two independent bugs on the "while the app is open" path, plus one latent duplicate that fixing the second would have exposed.

## 1. Sidebar badge never moved live

`unseenRunKeys` in `App.tsx` had exactly two writers: the on-mount history scan and the one-shot `automation-unseen` push from the launch scan. The live `automation-event` stream was forwarded to the renderer but nothing fed it back into the badge — so the count only changed on remount, i.e. after a relaunch.

Now subscribes to `automations.onEvent` and adds `${automationId}:${runId}` on `run-finished` / `run-parked`.

## 2. OS notification suppressed whenever the window was focused

`osNotificationsAllowed()` returned `enabled && !focused`. That's the right rule for chat (the user is already looking at the conversation) and the wrong one for automations, which run in the background — a finished run is news even when you're using the app.

Worse, suppressing didn't mark the run seen, so the launch scan announced it on the next start. That is the "notifications are delayed until I restart" symptom.

Split into `automationNotificationsAllowed()`, which honors only the global `notifications.enabled` toggle. The chat path (`maybeNotify` → `decideNotification`) keeps its focus check, untouched.

## 3. Duplicate notification across relaunch

A run announced live stays unseen until the user opens it, so a relaunch inside the 24h window would announce it a second time. Previously masked by the focus gate; unmasked by #2.

`AutomationRun` gains `notifiedAt` — deliberately distinct from `seenAt`, since notified ≠ read and the badge must still count it. Both notification paths stamp it via `Codey.markAutomationRunNotified` → `AutomationStore.markNotified`. The launch scan picks what to announce with the new `findUnnotifiedRuns`; the badge count still uses `findUnseenRuns`.

## Verification

- `npm test` green across all three workspaces (206 / 173 / 310).
- `tsc --noEmit` clean in `codey-mac` after rebuilding `@codey/core` + `@codey/gateway`.
- New unit test covers `findUnnotifiedRuns` dropping already-announced runs while `findUnseenRuns` keeps them.
- **Not yet smoke-tested on a real Mac build.** Worth checking by hand: run an automation with the window focused → notification fires immediately and the badge appears immediately; then relaunch → the same run does not notify again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5LgnectbhpJYkUuPxtVqq