### PR TITLE
Keep the automation list in place and show schedule times on the row

### DIFF
--- a/codey-mac/src/components/AutomationOnePager.tsx
+++ b/codey-mac/src/components/AutomationOnePager.tsx
@@ -8,6 +8,7 @@ import {
   scheduleSummary, slotsToSchedule, nextRunAt, humanizeDelta,
   knobsFrom, knobsEqual, NOTIFY_OPTIONS, type Knobs, type NotifyMode,
 } from './automationsModel'
+import { isScheduled } from '../../../packages/core/src/types/automation'
 import type { Automation, AutomationRun } from '../../../packages/core/src/types/automation'
 import { UIIcon, type IconName } from './UIIcons'
 import { Markdown } from './Markdown'
@@ -193,7 +194,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
 
   if (!a) return <div style={{ color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 24 }}>Loading…</div>
 
-  const scheduled = !!a.schedule && a.enabled
+  const scheduled = isScheduled(a)
   const next = scheduled ? nextRunAt(a.schedule, Date.now()) : null
   const latest = runs[0]
   const health = automationHealth(a, latest)

--- a/codey-mac/src/components/AutomationsView.tsx
+++ b/codey-mac/src/components/AutomationsView.tsx
@@ -2,10 +2,11 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
 import { OverlayWindow } from './OverlayWindow'
 import { pillButton, unwrap } from './settingsAtoms'
-import { humanizeDelta, nextRunAt } from './automationsModel'
+import { humanizeDelta, nextRunAt, scheduleChipLabel, scheduleSummary } from './automationsModel'
 import { AutomationChatCreate } from './AutomationChatCreate'
 import { AutomationOnePager } from './AutomationOnePager'
 import { UIIcon } from './UIIcons'
+import { isScheduled } from '../../../packages/core/src/types/automation'
 import type { Automation, AutomationRun, AutomationTarget } from '../../../packages/core/src/types/automation'
 
 const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -38,7 +39,10 @@ export const AutomationsView: React.FC<Props> = ({ onClose, onOpenRunChat }) => 
     }
   }, [])
 
-  useEffect(() => { void refresh() }, [refresh])
+  // Also re-lists on every return to the list, so edits made on the one-pager
+  // (schedule, notify, params) are reflected the moment the user comes back —
+  // those go through `update`, which fires no automation event.
+  useEffect(() => { if (panel.kind === 'list') void refresh() }, [panel.kind, refresh])
 
   // The view is open and the user is looking at it - mark finished/parked
   // runs seen as their events arrive, so they don't re-notify on next launch.
@@ -143,7 +147,7 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
 
   const toggleRunMode = async (a: Automation) => {
     if (switchingIds[a.id]) return
-    const scheduled = !!a.schedule && a.enabled
+    const scheduled = isScheduled(a)
     setSwitchingIds(prev => ({ ...prev, [a.id]: true }))
     try {
       if (scheduled) {
@@ -188,13 +192,12 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
     const status = lastStatus[a.id]?.status
     return status === 'failed' || status === 'parked'
   }).length
-  const scheduledCount = automations.filter(a => a.enabled && a.schedule).length
+  const scheduledCount = automations.filter(isScheduled).length
   const manualCount = automations.length - scheduledCount
-  const ordered = [...automations].sort((a, b) => {
-    const attention = (automation: Automation) => ['failed', 'parked'].includes(lastStatus[automation.id]?.status ?? '') ? 1 : 0
-    const scheduled = (automation: Automation) => Number(!!automation.schedule && automation.enabled)
-    return attention(b) - attention(a) || scheduled(b) - scheduled(a) || b.updatedAt - a.updatedAt
-  })
+  // Ordered by creation only. Sorting on run state or updatedAt made rows jump
+  // whenever a mode toggle or a finished run landed, which loses the user's
+  // place; status is carried by the rail colour and pill instead.
+  const ordered = [...automations].sort((a, b) => b.createdAt - a.createdAt)
 
   return (
     <div style={styles.list}>
@@ -224,7 +227,7 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
           {ordered.map(a => {
             const last = lastStatus[a.id]
             const health = listHealth(a, last)
-            const scheduled = !!a.schedule && a.enabled
+            const scheduled = isScheduled(a)
             const next = scheduled ? nextRunAt(a.schedule, Date.now()) : null
             return (
               <div key={a.id} style={rowStyle}>
@@ -236,21 +239,32 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
                       <strong style={automationName}>{a.name}</strong>
                       <span style={statusPill(health.color)}><span style={{ ...statusDot, background: health.color }} />{health.label}</span>
                     </span>
-                    <span style={targetLine}>{targetLabel(a.target)}</span>
+                    <span style={metaRow}>
+                      {scheduled ? (
+                        <span style={schedulePill} title={`${scheduleSummary(a.schedule)} · ${a.schedule!.tz}`}>
+                          <UIIcon name="clock" size={10} strokeWidth={2} />
+                          {scheduleChipLabel(a.schedule)}
+                          {next && <span style={nextHint}>· {humanizeDelta(next - Date.now())}</span>}
+                        </span>
+                      ) : (
+                        <span style={manualPill} title="Runs only when you start it">Manual</span>
+                      )}
+                      <span style={targetLine}>{targetLabel(a.target)}</span>
+                    </span>
                   </span>
                 </button>
                 <div style={cardAside}>
                   <div style={runRecency}>
-                    <span style={runRecencyLabel}>{last ? 'Last run' : next ? 'Next run' : 'Run history'}</span>
+                    <span style={runRecencyLabel}>{last ? 'Last run' : 'Run history'}</span>
                     <strong style={{ color: last?.status === 'failed' ? C.red : C.fg2, fontSize: 10.5 }}>
-                      {last ? runStatusText(last) : next ? humanizeDelta(next - Date.now()) : 'Not run yet'}
+                      {last ? runStatusText(last) : 'Not run yet'}
                     </strong>
                     {last && <span style={runDate}>{new Date(last.startedAt).toLocaleString()}</span>}
                   </div>
                   <button
                     type="button" role="switch" aria-label={`${a.name} run mode`}
-                    aria-checked={scheduled} style={modeToggle} disabled={!!switchingIds[a.id]}
-                    title={scheduled ? 'Switch to manual runs' : 'Run automatically on a schedule'}
+                    aria-checked={scheduled} style={modeToggle(scheduled)} disabled={!!switchingIds[a.id]}
+                    title={scheduled ? `Runs ${scheduleSummary(a.schedule)} — click for manual runs` : 'Run automatically on a schedule'}
                     onClick={() => void toggleRunMode(a)}
                   >
                     {scheduled ? 'Scheduled' : 'Manual'}
@@ -300,16 +314,28 @@ const nameRow: React.CSSProperties = { display: 'flex', alignItems: 'center', ga
 const automationName: React.CSSProperties = { color: C.fg, fontSize: 13, fontWeight: 720, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
 const statusPill = (color: string): React.CSSProperties => ({ display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0, padding: '2px 6px', borderRadius: 999, color, background: C.surface3, fontSize: 9, fontWeight: 700 })
 const statusDot: React.CSSProperties = { width: 5, height: 5, borderRadius: 999 }
-const targetLine: React.CSSProperties = { color: C.fg3, fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+const targetLine: React.CSSProperties = { color: C.fg3, fontSize: 10, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+const metaRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }
+const schedulePill: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0,
+  padding: '2px 7px', borderRadius: 999, background: C.accentDim, color: C.accent,
+  fontSize: 9.5, fontWeight: 700, whiteSpace: 'nowrap',
+}
+const manualPill: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', flexShrink: 0, padding: '2px 7px', borderRadius: 999,
+  background: C.surface3, color: C.fg3, fontSize: 9.5, fontWeight: 700,
+}
+const nextHint: React.CSSProperties = { color: C.fg3, fontWeight: 600 }
 const cardAside: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7, flexShrink: 0, padding: '10px 11px 10px 6px' }
 const runRecency: React.CSSProperties = { width: 130, display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 1, paddingRight: 5 }
 const runRecencyLabel: React.CSSProperties = { color: C.fg3, fontSize: 8.5, fontWeight: 750, textTransform: 'uppercase', letterSpacing: .45 }
 const runDate: React.CSSProperties = { color: C.fg3, fontSize: 8.5, whiteSpace: 'nowrap' }
-const modeToggle: React.CSSProperties = {
-  padding: '6px 8px', border: `1px solid ${C.border}`, borderRadius: 8,
-  background: C.surface3, color: C.fg2, fontSize: 9.5, fontWeight: 650,
-  cursor: 'pointer',
-}
+const modeToggle = (scheduled: boolean): React.CSSProperties => ({
+  padding: '6px 8px', borderRadius: 8, fontSize: 9.5, fontWeight: 650, cursor: 'pointer',
+  border: `1px solid ${scheduled ? C.accent : C.border}`,
+  background: scheduled ? C.accentDim : C.surface3,
+  color: scheduled ? C.accent : C.fg2,
+})
 const runButton: React.CSSProperties = { ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 4, padding: '6px 9px', fontSize: 10.5 }
 const openButton: React.CSSProperties = { width: 28, height: 28, display: 'grid', placeItems: 'center', border: 'none', borderRadius: 8, background: 'transparent', color: C.fg3, cursor: 'pointer' }
 const listStat: React.CSSProperties = { display: 'flex', alignItems: 'baseline', gap: 6, color: C.fg3, fontSize: 10.5, padding: '7px 11px', borderRight: `1px solid ${C.border}` }

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export type IconName =
   | 'activity' | 'add' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
-  | 'code' | 'copy' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
+  | 'clock' | 'code' | 'copy' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
   | 'globe' | 'overview' | 'refresh' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
   | 'telegram' | 'discord' | 'imessage'
 
@@ -27,6 +27,7 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     chat: <><path {...common} d="M20 11.5a7.5 7.5 0 01-8 7.5 8.7 8.7 0 01-3.3-.65L4 20l1.55-3.9A7.3 7.3 0 014 11.5 7.5 7.5 0 0112 4a7.5 7.5 0 018 7.5z" /></>,
     check: <path {...common} d="M5 12.5l4.2 4.2L19 7" />,
     chevron: <path {...common} d="M9 18l6-6-6-6" />,
+    clock: <><circle {...common} cx="12" cy="12" r="9" /><path {...common} d="M12 7.5V12l3.2 2.2" /></>,
     close: <path {...common} d="M6 6l12 12M18 6L6 18" />,
     disclosure: <path fill="currentColor" stroke="none" d="M9 6.5L16 12l-7 5.5z" />,
     code: <><path {...common} d="M8 9l-3 3 3 3M16 9l3 3-3 3M14 6l-4 12" /></>,

--- a/codey-mac/src/components/automationsModel.test.ts
+++ b/codey-mac/src/components/automationsModel.test.ts
@@ -1,6 +1,6 @@
 // codey-mac/src/components/automationsModel.test.ts
 import { describe, it, expect } from 'vitest'
-import { scheduleSummary, slotsToSchedule, nextRunAt, humanizeDelta, draftComplete, formatHHMM, knobsFrom, knobsEqual, checkLabel } from './automationsModel'
+import { scheduleSummary, scheduleChipLabel, slotsToSchedule, nextRunAt, humanizeDelta, draftComplete, formatHHMM, knobsFrom, knobsEqual, checkLabel } from './automationsModel'
 
 const t = (hour: number, minute: number, daysOfWeek?: number[]) => ({ hour, minute, ...(daysOfWeek ? { daysOfWeek } : {}) })
 
@@ -18,6 +18,26 @@ describe('scheduleSummary', () => {
   it('keeps each time connected to its own weekdays', () => {
     expect(scheduleSummary({ slots: [t(21, 0, [1, 2, 3]), t(12, 0, [4, 5])], tz: 'UTC' }))
       .toBe('Mon–Wed 21:00 · Thu–Fri 12:00')
+  })
+})
+
+describe('scheduleChipLabel', () => {
+  it('capitalizes the compact label and falls back to Manual', () => {
+    expect(scheduleChipLabel({ slots: [t(9, 0)], tz: 'UTC' })).toBe('Daily 09:00')
+    expect(scheduleChipLabel({ slots: [t(18, 30, [1, 2, 3, 4, 5])], tz: 'UTC' })).toBe('Mon–Fri 18:30')
+    expect(scheduleChipLabel(undefined)).toBe('Manual')
+  })
+  it('caps the times listed per day-set', () => {
+    expect(scheduleChipLabel({ slots: [t(1, 0), t(2, 0), t(3, 0), t(4, 0)], tz: 'UTC' }))
+      .toBe('Daily 01:00, 02:00, 03:00 +1')
+  })
+  it('collapses many day-sets sharing one clock time', () => {
+    const slots = [t(9, 0, [0, 3, 4, 6]), t(9, 0, [1, 5])]
+    expect(scheduleChipLabel({ slots, tz: 'UTC' })).toBe('09:00 · 6 days/wk')
+  })
+  it('collapses many day-sets with differing times to a cadence', () => {
+    const slots = [t(1, 0, [1]), t(2, 0, [2, 3]), t(3, 0, [4])]
+    expect(scheduleChipLabel({ slots, tz: 'UTC' })).toBe('4 runs/wk · 3 times')
   })
 })
 

--- a/codey-mac/src/components/automationsModel.ts
+++ b/codey-mac/src/components/automationsModel.ts
@@ -1,6 +1,8 @@
 // codey-mac/src/components/automationsModel.ts
 // Pure helpers for the Automations view — kept separate for unit tests.
 
+import { isScheduled } from '../../../packages/core/src/types/automation'
+
 export interface ScheduleSlotLike { hour: number; minute: number; daysOfWeek?: number[] }
 export interface ScheduleLike { slots: ScheduleSlotLike[]; tz: string }
 export interface ScheduleSlotInput { time: string; days: number[] }
@@ -8,8 +10,8 @@ export interface ScheduleSlotInput { time: string; days: number[] }
 const DAY = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const pad = (n: number) => String(n).padStart(2, '0')
 
-export function scheduleSummary(s: ScheduleLike | undefined): string {
-  if (!s) return 'manual'
+/** Slots collapsed into one label per distinct day-set, e.g. ["daily 09:00"]. */
+function scheduleGroupLabels(s: ScheduleLike, maxTimes = Infinity): string[] {
   const groups = new Map<string, { days: number[]; times: string[] }>()
   for (const slot of s.slots) {
     const days = [...(slot.daysOfWeek ?? [])].sort((a, b) => a - b)
@@ -18,7 +20,38 @@ export function scheduleSummary(s: ScheduleLike | undefined): string {
     group.times.push(`${pad(slot.hour)}:${pad(slot.minute)}`)
     groups.set(key, group)
   }
-  return [...groups.values()].map(group => `${dayLabel(group.days)} ${group.times.join(', ')}`).join(' · ')
+  return [...groups.values()].map(group => {
+    const shown = group.times.slice(0, maxTimes)
+    const extra = group.times.length - shown.length
+    return `${dayLabel(group.days)} ${shown.join(', ')}${extra ? ` +${extra}` : ''}`
+  })
+}
+
+export function scheduleSummary(s: ScheduleLike | undefined): string {
+  if (!s) return 'manual'
+  return scheduleGroupLabels(s).join(' · ')
+}
+
+/** One-line schedule label for a list row. A single day-set is spelled out
+ *  ("Mon–Fri 09:00"); anything more elaborate would be truncated mid-word, so
+ *  it collapses to a cadence instead and leaves the detail to the tooltip and
+ *  the one-pager. */
+export function scheduleChipLabel(s: ScheduleLike | undefined, maxTimes = 3): string {
+  if (!s) return 'Manual'
+  const labels = scheduleGroupLabels(s, maxTimes)
+  if (labels.length === 1) return labels[0].charAt(0).toUpperCase() + labels[0].slice(1)
+  const days = new Set<number>()
+  const times = new Set<string>()
+  let runsPerWeek = 0
+  for (const slot of s.slots) {
+    const slotDays = slot.daysOfWeek?.length ? slot.daysOfWeek : [0, 1, 2, 3, 4, 5, 6]
+    for (const day of slotDays) days.add(day)
+    times.add(`${pad(slot.hour)}:${pad(slot.minute)}`)
+    runsPerWeek += slotDays.length
+  }
+  // Same clock time on an irregular set of days is common enough to name.
+  if (times.size === 1) return `${[...times][0]} · ${days.size} days/wk`
+  return `${runsPerWeek} runs/wk · ${times.size} times`
 }
 
 function dayLabel(days: number[]): string {
@@ -149,7 +182,7 @@ interface KnobSource {
 export function knobsFrom(a: KnobSource): Knobs {
   return {
     params: { ...a.params },
-    scheduleOn: !!a.schedule && a.enabled !== false,
+    scheduleOn: isScheduled(a),
     slots: a.schedule
       ? a.schedule.slots.map(slot => ({ time: formatHHMM(slot.hour, slot.minute), days: [...(slot.daysOfWeek ?? [])].sort((x, y) => x - y) }))
       : [{ time: '09:00', days: [] }],
@@ -160,7 +193,7 @@ export function knobsFrom(a: KnobSource): Knobs {
 /** True when the staged knobs match the automation (nothing to save). */
 export function knobsEqual(k: Knobs, a: KnobSource): boolean {
   if (JSON.stringify(k.params) !== JSON.stringify(a.params)) return false
-  if (k.scheduleOn !== (!!a.schedule && a.enabled !== false)) return false
+  if (k.scheduleOn !== isScheduled(a)) return false
   if (k.scheduleOn) {
     const canonical = (slots: ScheduleSlotInput[]) => slots
       .map(slot => ({ time: slot.time, days: [...slot.days].sort((x, y) => x - y) }))

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -108,6 +108,20 @@ export interface Automation {
   updatedAt: number;
 }
 
+/** How an automation is triggered. Derived from `enabled` + `schedule` rather
+ *  than stored: 'manual' with a schedule present means the times are kept but
+ *  disarmed, so switching back restores them. */
+export type AutomationRunMode = 'scheduled' | 'manual';
+
+export function runMode(a: { enabled?: boolean; schedule?: AutomationSchedule }): AutomationRunMode {
+  return a.schedule && a.enabled !== false ? 'scheduled' : 'manual';
+}
+
+/** True when the scheduler will fire this automation on its own. */
+export function isScheduled(a: { enabled?: boolean; schedule?: AutomationSchedule }): boolean {
+  return runMode(a) === 'scheduled';
+}
+
 export type AutomationRunStatus = 'success' | 'failed' | 'parked' | 'resumed';
 
 export interface AutomationRun {

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -117,8 +117,11 @@ export function runMode(a: { enabled?: boolean; schedule?: AutomationSchedule })
   return a.schedule && a.enabled !== false ? 'scheduled' : 'manual';
 }
 
-/** True when the scheduler will fire this automation on its own. */
-export function isScheduled(a: { enabled?: boolean; schedule?: AutomationSchedule }): boolean {
+/** True when the scheduler will fire this automation on its own. Narrows
+ *  `schedule` to present, since that is half of what makes it scheduled. */
+export function isScheduled<T extends { enabled?: boolean; schedule?: AutomationSchedule }>(
+  a: T,
+): a is T & { schedule: AutomationSchedule } {
   return runMode(a) === 'scheduled';
 }
 

--- a/packages/gateway/src/automations/engine.ts
+++ b/packages/gateway/src/automations/engine.ts
@@ -1,5 +1,6 @@
 // packages/gateway/src/automations/engine.ts
 import { randomUUID } from 'crypto';
+import { isScheduled } from '@codey/core';
 import type { Automation, AutomationEvent, AutomationRun } from '@codey/core';
 import { AutomationStore } from './store';
 import { SchedulerLease } from './lease';
@@ -72,7 +73,7 @@ export class AutomationEngine {
       // a RangeError inside shouldFire) must not abort the whole tick and
       // starve every other schedule.
       try {
-        if (!a.enabled || !a.schedule) continue;
+        if (!isScheduled(a)) continue;
         if (!shouldFire(a.schedule, a.lastFiredAt, now)) continue;
         // Record the slot BEFORE running so a crash mid-run can't re-fire it.
         this.deps.store.recordLastFired(a.id, now);


### PR DESCRIPTION
Three fixes to the Automations list, from using it.

### The list reordered itself on every toggle

Rows were sorted by `attention -> scheduled -> updatedAt` — all three mutable, and switching a row between Manual and Scheduled flips two of them, so the row you just touched jumped somewhere else. Sorted by `createdAt` only now; nothing mutates it, so neither a mode toggle nor a finished run moves anything. Status is still legible from the rail colour, the pill, and the "Need attention" count.

### Rows didn't say when they fire

A schedule chip sits next to the target line, with the next firing time on it:

- one day-set — spelled out: `Daily 09:00`, `Mon-Fri 09:00, 18:30` (times capped at 3, then `+N`)
- many day-sets, one clock time — `09:00 · 6 days/wk`
- many day-sets, differing times — `4 runs/wk · 3 times`
- no schedule — a grey `Manual` chip

The compact forms exist because the spelled-out version of a complex schedule gets truncated mid-word and takes the next-run hint down with it; the full schedule stays in the chip tooltip (with tz) and on the one-pager. The aside column no longer alternates between last-run and next-run — it always means last run.

### Schedule edits didn't show up until relaunch

The one-pager saves through `automations.update`, which emits no automation event, and the list only re-fetched on mount and on events. It now re-lists whenever the list panel comes back into view.

### Drive-by

`!!a.schedule && a.enabled` was written out six times, and inconsistently — with `enabled` missing, the Mac side read the automation as scheduled and the engine read it as manual. Collapsed into `isScheduled()` / `runMode()` in `@codey/core`. No schema change: `enabled` still means "is the schedule armed", and Manual deliberately keeps the schedule so switching back restores the times.

## Testing

- `npm test` — gateway 173, codey-mac 314, all passing
- `tsc --noEmit` clean on codey-mac; `npm run lint` clean
- 4 new `scheduleChipLabel` unit tests covering each display tier
- Not yet exercised in the running Mac app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5LgnectbhpJYkUuPxtVqq