### PR TITLE
Capture what runs did, so playbooks can crystallize

### DIFF
--- a/packages/core/src/skill-crystallizer.test.ts
+++ b/packages/core/src/skill-crystallizer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { SkillStore, RECENT_TRACES_MAX, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, evolveSkill, isLowSignalPrompt } from './skill-crystallizer';
+import { SkillStore, RECENT_TRACES_MAX, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, evolveSkill, isLowSignalTrace, toolSequenceFrom, TOOL_SEQUENCE_MAX } from './skill-crystallizer';
 
 describe('SkillStore', () => {
   let tmp: string;
@@ -394,6 +394,22 @@ describe('distillCandidate', () => {
     expect(calledPrompt).not.toContain('\n  Result:');
   });
 
+  it('puts the tool sequence in the prompt as a Did line', async () => {
+    let calledPrompt = '';
+    const deps = fakeDeps(async (req) => {
+      calledPrompt = req.prompt;
+      return { success: true, output: 'NONE', error: null, tokens: { total: 10 } };
+    });
+    const traces: RunTrace[] = [
+      { runId: '1', promptSummary: 'ok', outputPreview: 'posted', toolSequence: ['browser_navigate', 'browser_interact'], timestamp: 1, mode: 'solo' },
+      { runId: '2', promptSummary: 'go ahead', outputPreview: 'posted', timestamp: 2, mode: 'solo' },
+    ];
+    await distillCandidate(deps, traces, [], [], 2);
+    expect(calledPrompt).toContain('Did: browser_navigate → browser_interact');
+    // A trace without tool activity contributes no Did line.
+    expect(calledPrompt.match(/\n {2}Did:/g)).toHaveLength(1);
+  });
+
   it('logs a verdict for every outcome', async () => {
     const lines: string[] = [];
     const logger = { info: (m: string) => lines.push(m), warn: (m: string) => lines.push(m), error: (m: string) => lines.push(m) };
@@ -422,8 +438,45 @@ describe('distillCandidate', () => {
   });
 });
 
-describe('isLowSignalPrompt', () => {
-  it('flags bare acknowledgements and option picks', () => {
+function traceWith(over: Partial<RunTrace>): RunTrace {
+  return { runId: 'r', promptSummary: 'x', outputPreview: '', timestamp: 0, mode: 'solo', ...over };
+}
+
+describe('toolSequenceFrom', () => {
+  it('keeps call order, drops the tool_end half of each pair', () => {
+    expect(toolSequenceFrom([
+      { type: 'tool_start', tool: 'browser_navigate' },
+      { type: 'tool_end', tool: 'browser_navigate' },
+      { type: 'tool_start', tool: 'browser_read' },
+      { type: 'tool_end', tool: 'browser_read' },
+    ])).toEqual(['browser_navigate', 'browser_read']);
+  });
+
+  it('accepts records with no type (the channel surface shape)', () => {
+    expect(toolSequenceFrom([{ tool: 'Read' }, { tool: 'Write' }])).toEqual(['Read', 'Write']);
+  });
+
+  it('collapses consecutive repeats but keeps a later revisit', () => {
+    expect(toolSequenceFrom([
+      { tool: 'Read' }, { tool: 'Read' }, { tool: 'Read' }, { tool: 'Edit' }, { tool: 'Read' },
+    ])).toEqual(['Read', 'Edit', 'Read']);
+  });
+
+  it('skips info entries and entries with no tool name, and caps length', () => {
+    expect(toolSequenceFrom([{ type: 'info', tool: 'x', message: 'hi' } as any, { tool: undefined }, { tool: 'Read' }]))
+      .toEqual(['Read']);
+    const many = Array.from({ length: 40 }, (_, i) => ({ tool: `tool-${i}` }));
+    expect(toolSequenceFrom(many)).toHaveLength(TOOL_SEQUENCE_MAX);
+  });
+
+  it('returns an empty list for missing or empty input', () => {
+    expect(toolSequenceFrom(undefined)).toEqual([]);
+    expect(toolSequenceFrom([])).toEqual([]);
+  });
+});
+
+describe('isLowSignalTrace', () => {
+  it('flags turns that neither said nor did anything', () => {
     const acks = [
       '2', 'ok', 'Yes!', 'try again', 'it is ready', 'looks good', '   ',
       '好', // lint-allow-non-english
@@ -432,7 +485,7 @@ describe('isLowSignalPrompt', () => {
       '对的。', // lint-allow-non-english
     ];
     for (const text of acks) {
-      expect(isLowSignalPrompt(text), text).toBe(true);
+      expect(isLowSignalTrace(traceWith({ promptSummary: text })), text).toBe(true);
     }
   });
 
@@ -444,8 +497,19 @@ describe('isLowSignalPrompt', () => {
       '发布 hackernews reddit 的推广帖', // lint-allow-non-english
     ];
     for (const text of work) {
-      expect(isLowSignalPrompt(text), text).toBe(false);
+      expect(isLowSignalTrace(traceWith({ promptSummary: text })), text).toBe(false);
     }
+  });
+
+  it('keeps a bare acknowledgement that drove real tool work', () => {
+    expect(isLowSignalTrace(traceWith({
+      promptSummary: 'ok',
+      toolSequence: ['browser_navigate', 'browser_interact', 'Write'],
+    }))).toBe(false);
+    expect(isLowSignalTrace(traceWith({
+      promptSummary: 'ok',
+      workerSequence: ['researcher', 'writer'],
+    }))).toBe(false);
   });
 });
 
@@ -597,6 +661,19 @@ describe('evolveSkill', () => {
     const result = await evolveSkill(deps, skill, trace);
     expect(result).not.toBeNull();
     expect(result).toContain('add links');
+  });
+
+  it('shows the run tool sequence to the evolve prompt', async () => {
+    let calledPrompt = '';
+    const deps = fakeDeps(async (req) => {
+      calledPrompt = req.prompt;
+      return { success: true, output: JSON.stringify({ improved: false }), error: null, tokens: { total: 10 } };
+    });
+    await evolveSkill(deps, skill, { ...trace, toolSequence: ['Bash', 'Read', 'Write'] });
+    expect(calledPrompt).toContain('- Tools called: Bash → Read → Write');
+    calledPrompt = '';
+    await evolveSkill(deps, skill, trace);
+    expect(calledPrompt).not.toContain('Tools called');
   });
 
   it('returns null when no improvement needed', async () => {

--- a/packages/core/src/skill-crystallizer.test.ts
+++ b/packages/core/src/skill-crystallizer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { SkillStore, RECENT_TRACES_MAX, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, evolveSkill } from './skill-crystallizer';
+import { SkillStore, RECENT_TRACES_MAX, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, evolveSkill, isLowSignalPrompt } from './skill-crystallizer';
 
 describe('SkillStore', () => {
   let tmp: string;
@@ -360,6 +360,92 @@ describe('distillCandidate', () => {
       error: null, tokens: { total: 10 },
     }));
     expect(await distillCandidate(tooShort, traces, [], [], 2)).toBeNull();
+  });
+
+  it('puts each trace output preview in the prompt, truncated', async () => {
+    let calledPrompt = '';
+    const deps = fakeDeps(async (req) => {
+      calledPrompt = req.prompt;
+      return { success: true, output: 'NONE', error: null, tokens: { total: 10 } };
+    });
+    const traces: RunTrace[] = [
+      { runId: '1', promptSummary: 'do it again', outputPreview: 'Posted 3 comments on AI threads', timestamp: 1, mode: 'solo' },
+      { runId: '2', promptSummary: 'same as before', outputPreview: 'x'.repeat(300), timestamp: 2, mode: 'solo' },
+    ];
+    await distillCandidate(deps, traces, [], [], 2);
+    expect(calledPrompt).toContain('Result: Posted 3 comments on AI threads');
+    expect(calledPrompt).toContain(`Result: ${'x'.repeat(200)}\n`);
+    expect(calledPrompt).not.toContain('x'.repeat(201));
+  });
+
+  it('omits the Result line when a trace has no output preview', async () => {
+    let calledPrompt = '';
+    const deps = fakeDeps(async (req) => {
+      calledPrompt = req.prompt;
+      return { success: true, output: 'NONE', error: null, tokens: { total: 10 } };
+    });
+    const traces: RunTrace[] = [
+      { runId: '1', promptSummary: 'draft release notes', outputPreview: '', timestamp: 1, mode: 'solo' },
+      { runId: '2', promptSummary: 'draft changelog', outputPreview: '   ', timestamp: 2, mode: 'solo' },
+    ];
+    await distillCandidate(deps, traces, [], [], 2);
+    // The instructions mention "Result: ..."; what must be absent is the
+    // indented per-trace line.
+    expect(calledPrompt).not.toContain('\n  Result:');
+  });
+
+  it('logs a verdict for every outcome', async () => {
+    const lines: string[] = [];
+    const logger = { info: (m: string) => lines.push(m), warn: (m: string) => lines.push(m), error: (m: string) => lines.push(m) };
+    const traces: RunTrace[] = [
+      { runId: '1', promptSummary: 'x', outputPreview: 'y', timestamp: 0, mode: 'solo' },
+      { runId: '2', promptSummary: 'z', outputPreview: 'y', timestamp: 1, mode: 'solo' },
+    ];
+
+    const none = { ...fakeDeps(async () => ({ success: true, output: 'NONE', error: null, tokens: { total: 10 } })), logger };
+    await distillCandidate(none, traces, [], [], 2);
+    expect(lines.some(l => l.includes('no recurring pattern'))).toBe(true);
+
+    lines.length = 0;
+    const garbage = { ...fakeDeps(async () => ({ success: true, output: 'garbage', error: null, tokens: { total: 10 } })), logger };
+    await distillCandidate(garbage, traces, [], [], 2);
+    expect(lines.some(l => l.includes('no usable output'))).toBe(true);
+
+    lines.length = 0;
+    const hit = { ...fakeDeps(async () => ({
+      success: true,
+      output: JSON.stringify({ name: 'release-notes', description: 'd', whenToUse: 'w', steps: '1. x' }),
+      error: null, tokens: { total: 10 },
+    })), logger };
+    await distillCandidate(hit, traces, [], [], 2);
+    expect(lines.some(l => l.includes('candidate "release-notes"'))).toBe(true);
+  });
+});
+
+describe('isLowSignalPrompt', () => {
+  it('flags bare acknowledgements and option picks', () => {
+    const acks = [
+      '2', 'ok', 'Yes!', 'try again', 'it is ready', 'looks good', '   ',
+      '好', // lint-allow-non-english
+      '好的', // lint-allow-non-english
+      '继续', // lint-allow-non-english
+      '对的。', // lint-allow-non-english
+    ];
+    for (const text of acks) {
+      expect(isLowSignalPrompt(text), text).toBe(true);
+    }
+  });
+
+  it('keeps prompts that describe work', () => {
+    const work = [
+      'write a post based on most recent AI news, keep it short',
+      'Analyze my Xiaohongshu account and give me some tips.',
+      '帮我找一下 twitter 上别人 ai 相关的项目，写一些评论', // lint-allow-non-english
+      '发布 hackernews reddit 的推广帖', // lint-allow-non-english
+    ];
+    for (const text of work) {
+      expect(isLowSignalPrompt(text), text).toBe(false);
+    }
   });
 });
 

--- a/packages/core/src/skill-crystallizer.ts
+++ b/packages/core/src/skill-crystallizer.ts
@@ -52,6 +52,10 @@ export interface RunTrace {
   /** First ~300 chars of the agent's output. A preview, not a structural analysis. */
   outputPreview: string;
   workerSequence?: string[];
+  /** Tool names in call order, consecutive repeats collapsed, capped at
+   *  TOOL_SEQUENCE_MAX. A skill IS a procedure, so what the run did is the
+   *  signal the distiller actually needs — the message text is context. */
+  toolSequence?: string[];
   timestamp: number;
   mode: 'solo' | 'team-sequential' | 'team-parallel' | 'team-auto';
 }
@@ -85,6 +89,7 @@ export interface SkillMatch {
 }
 
 export const RECENT_TRACES_MAX = 20;
+export const TOOL_SEQUENCE_MAX = 12;
 export const HISTORY_MAX = 5;
 export const REJECTED_MAX = 20;
 export const EVOLUTION_MAX = 20;
@@ -485,9 +490,10 @@ const DISTILL_PROMPT = `You analyze coding-agent runs to find recurring work pat
 
 Given these recent run traces and existing skills, identify a repeatable sub-process that appears in 2+ runs. If you find one, describe it as a reusable skill. If none, return exactly "NONE".
 
-Each trace lists what the user asked ("- <request> [mode]") and, where available, what
-the run produced ("Result: ..."). Judge recurrence on the work itself, not on wording —
-two runs that phrase the request differently but do the same job still count as a repeat.
+Each trace lists what the user asked ("- <request> [mode]"), the tools the run actually
+called in order ("Did: ..."), and what it produced ("Result: ..."). Weigh "Did" most
+heavily — a skill is a procedure, so two runs that ran the same tool sequence are the
+same work even when the requests are worded nothing alike.
 
 Recent traces:
 %TRACES%
@@ -521,6 +527,9 @@ function formatTracesForPrompt(traces: RunTrace[]): string {
     if (t.workerSequence && t.workerSequence.length > 0) {
       parts.push(`  Steps: ${t.workerSequence.join(' → ')}`);
     }
+    if (t.toolSequence && t.toolSequence.length > 0) {
+      parts.push(`  Did: ${t.toolSequence.join(' → ')}`);
+    }
     // The request alone is often just "do the thing again" — what the run
     // PRODUCED is what makes two runs recognizably the same work.
     const preview = (t.outputPreview || '').replace(/\s+/g, ' ').trim();
@@ -553,6 +562,30 @@ function tryParseDistill(raw: string): DistillResult | null {
            whenToUse: p.whenToUse as string, steps: p.steps as string };
 }
 
+/** Collapse a run's tool activity into an ordered list of tool NAMES.
+ *
+ *  Names only, deliberately: tool inputs and outputs carry user content and
+ *  file contents, and every crystallizer prompt goes to a tool-less runner
+ *  precisely so that material stays out of a tool-capable session.
+ *
+ *  Accepts both shapes the gateway has on hand — the chat surface's
+ *  ToolCallEntry (paired 'tool_start'/'tool_end' records) and the channel
+ *  surface's ContextManager ToolCallRecord (one record per call, no `type`).
+ *  Only the start half of a pair is counted so calls aren't doubled. */
+export function toolSequenceFrom(entries: { tool?: string; type?: string }[] | undefined): string[] {
+  if (!entries || entries.length === 0) return [];
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (!entry.tool) continue;
+    if (entry.type === 'tool_end' || entry.type === 'info') continue;
+    // A loop over 20 files is one step in a procedure, not 20.
+    if (names[names.length - 1] === entry.tool) continue;
+    names.push(entry.tool);
+    if (names.length >= TOOL_SEQUENCE_MAX) break;
+  }
+  return names;
+}
+
 /** Bare acknowledgements, matched after trailing punctuation is stripped. */
 const ACK_REPLY_EN = /^(y|yes|yep|yeah|ok|okay|k|sure|please|go|go ahead|continue|next|again|try again|do it|redo|retry|looks good|lgtm|perfect|great|nice|good|done|ready|it is ready|no|nope|nah|stop)$/i;
 /** The same, in the other language this gateway sees day to day. */
@@ -566,11 +599,7 @@ const CJK_CHAR = /[一-鿿]/g; // lint-allow-non-english
 const MIN_CONTENT_WORDS = 4;
 const MIN_CJK_CHARS = 4;
 
-/** True for turns that continue a conversation instead of describing work —
- *  "ok", "2", "try again". They are real runs, but as distillation input they
- *  are noise, and the trace window is small enough (suggestOnRepeat + 5) that
- *  a handful of them crowds out every trace the distiller could pattern-match. */
-export function isLowSignalPrompt(text: string): boolean {
+function isLowSignalPrompt(text: string): boolean {
   const normalized = (text || '').trim().replace(/\s+/g, ' ');
   if (!normalized) return true;
   const bare = normalized.replace(TRAILING_PUNCT, '');
@@ -581,6 +610,20 @@ export function isLowSignalPrompt(text: string): boolean {
   if (cjkChars > 0) return cjkChars < MIN_CJK_CHARS;
   const words = normalized.split(' ').filter(w => /[a-z0-9]/i.test(w));
   return words.length < MIN_CONTENT_WORDS;
+}
+
+/** True for turns that continue a conversation instead of doing work — "ok",
+ *  "2", "try again" with nothing behind them. The trace window is small
+ *  (suggestOnRepeat + 5), so a handful of these crowds out every trace the
+ *  distiller could pattern-match on.
+ *
+ *  Tool activity outranks the prompt: a bare "ok" that drove six tool calls is
+ *  a full procedure and among the most useful traces there is. Only a turn
+ *  that both says nothing and did nothing is dropped. */
+export function isLowSignalTrace(trace: RunTrace): boolean {
+  if (trace.toolSequence && trace.toolSequence.length > 0) return false;
+  if (trace.workerSequence && trace.workerSequence.length > 0) return false;
+  return isLowSignalPrompt(trace.promptSummary);
 }
 
 export async function distillCandidate(
@@ -712,7 +755,7 @@ Run context:
 - Task: %TASK_SUMMARY%
 - Output preview: %OUTPUT_PREVIEW%
 - Mode: %MODE%
-%WORKER_STEPS%
+%WORKER_STEPS%%TOOL_STEPS%
 
 Does the run suggest a better version of the steps? If yes, return improved steps. If the current steps are fine, say no change. Only propose a change when the run clearly revealed a missing, wrong, or better step — do not rephrase working steps.
 
@@ -732,6 +775,11 @@ export async function evolveSkill(
   if (trace.workerSequence && trace.workerSequence.length > 0) {
     workerPart = `- Worker sequence: ${trace.workerSequence.join(' → ')}`;
   }
+  // What the run DID is the strongest evidence that a step is missing or wrong.
+  let toolPart = '';
+  if (trace.toolSequence && trace.toolSequence.length > 0) {
+    toolPart = `${workerPart ? '\n' : ''}- Tools called: ${trace.toolSequence.join(' → ')}`;
+  }
   const composed = fillPrompt(EVOLVE_PROMPT, {
     '%SKILL_NAME%': skill.name,
     '%SKILL_DESC%': skill.description,
@@ -741,6 +789,7 @@ export async function evolveSkill(
     '%OUTPUT_PREVIEW%': trace.outputPreview,
     '%MODE%': trace.mode,
     '%WORKER_STEPS%': workerPart,
+    '%TOOL_STEPS%': toolPart,
   });
 
   const output = await runCrystallizerLLM(deps, composed);

--- a/packages/core/src/skill-crystallizer.ts
+++ b/packages/core/src/skill-crystallizer.ts
@@ -65,6 +65,9 @@ export interface DistillDeps {
   runner: AideRunner;
   /** Hard timeout per call in ms. Defaults to the Aide's 30s. */
   timeoutMs?: number;
+  /** Optional — distillation returning nothing is the normal case, so without
+   *  a logger here "why has no playbook appeared?" is unanswerable from logs. */
+  logger?: CoreLogger;
 }
 
 export interface DistillResult {
@@ -482,6 +485,10 @@ const DISTILL_PROMPT = `You analyze coding-agent runs to find recurring work pat
 
 Given these recent run traces and existing skills, identify a repeatable sub-process that appears in 2+ runs. If you find one, describe it as a reusable skill. If none, return exactly "NONE".
 
+Each trace lists what the user asked ("- <request> [mode]") and, where available, what
+the run produced ("Result: ..."). Judge recurrence on the work itself, not on wording —
+two runs that phrase the request differently but do the same job still count as a repeat.
+
 Recent traces:
 %TRACES%
 
@@ -503,12 +510,21 @@ Rules:
 - name must match /^[a-z][a-z0-9-]*$/ and be 3-30 chars.
 - Output ONLY the JSON or "NONE". No markdown fences, no prose.`;
 
+/** How much of each trace's output preview reaches the distill prompt. The
+ *  preview is stored at 300 chars; trimming here keeps a full trace window
+ *  from crowding out the instructions. */
+const TRACE_PREVIEW_CHARS = 200;
+
 function formatTracesForPrompt(traces: RunTrace[]): string {
   return traces.map(t => {
     const parts = [`- ${t.promptSummary} [${t.mode}]`];
     if (t.workerSequence && t.workerSequence.length > 0) {
       parts.push(`  Steps: ${t.workerSequence.join(' → ')}`);
     }
+    // The request alone is often just "do the thing again" — what the run
+    // PRODUCED is what makes two runs recognizably the same work.
+    const preview = (t.outputPreview || '').replace(/\s+/g, ' ').trim();
+    if (preview) parts.push(`  Result: ${preview.slice(0, TRACE_PREVIEW_CHARS)}`);
     return parts.join('\n');
   }).join('\n');
 }
@@ -537,6 +553,36 @@ function tryParseDistill(raw: string): DistillResult | null {
            whenToUse: p.whenToUse as string, steps: p.steps as string };
 }
 
+/** Bare acknowledgements, matched after trailing punctuation is stripped. */
+const ACK_REPLY_EN = /^(y|yes|yep|yeah|ok|okay|k|sure|please|go|go ahead|continue|next|again|try again|do it|redo|retry|looks good|lgtm|perfect|great|nice|good|done|ready|it is ready|no|nope|nah|stop)$/i;
+/** The same, in the other language this gateway sees day to day. */
+const ACK_REPLY_ZH = new Set(['好', '好的', '好吧', '可以', '继续', '再来', '重来', '对', '对的', '是', '是的', '行', '嗯', '不错', '谢谢', '完成']); // lint-allow-non-english
+/** ASCII plus CJK sentence-final punctuation. */
+const TRAILING_PUNCT = /[.!?~,、。！？，]+$/; // lint-allow-non-english
+const CJK_CHAR = /[一-鿿]/g; // lint-allow-non-english
+
+/** Minimum content words (Latin script) / ideographs (CJK) a prompt needs
+ *  before it describes work rather than continuing a conversation. */
+const MIN_CONTENT_WORDS = 4;
+const MIN_CJK_CHARS = 4;
+
+/** True for turns that continue a conversation instead of describing work —
+ *  "ok", "2", "try again". They are real runs, but as distillation input they
+ *  are noise, and the trace window is small enough (suggestOnRepeat + 5) that
+ *  a handful of them crowds out every trace the distiller could pattern-match. */
+export function isLowSignalPrompt(text: string): boolean {
+  const normalized = (text || '').trim().replace(/\s+/g, ' ');
+  if (!normalized) return true;
+  const bare = normalized.replace(TRAILING_PUNCT, '');
+  if (ACK_REPLY_EN.test(bare) || ACK_REPLY_ZH.has(bare)) return true;
+  // CJK writes far more meaning per character, so it gets its own threshold
+  // instead of being judged by whitespace-delimited word count.
+  const cjkChars = (normalized.match(CJK_CHAR) || []).length;
+  if (cjkChars > 0) return cjkChars < MIN_CJK_CHARS;
+  const words = normalized.split(' ').filter(w => /[a-z0-9]/i.test(w));
+  return words.length < MIN_CONTENT_WORDS;
+}
+
 export async function distillCandidate(
   deps: DistillDeps,
   traces: RunTrace[],
@@ -556,15 +602,24 @@ export async function distillCandidate(
     const prompt = attempt === 0 ? composed
       : `${composed}\n\nReminder: return ONLY the JSON object or the word "NONE". No markdown.`;
     const output = await runCrystallizerLLM(deps, prompt);
-    if (output === null) continue;
+    if (output === null) {
+      deps.logger?.warn(`[skills] distill: LLM call failed or timed out (attempt ${attempt + 1})`);
+      continue;
+    }
     const parsed = tryParseDistill(output);
     if (parsed) {
       if (/^[a-z][a-z0-9-]*$/.test(parsed.name) && parsed.name.length >= 3 && parsed.name.length <= 30) {
+        deps.logger?.info(`[skills] distill: candidate "${parsed.name}" from ${traces.length} trace(s)`);
         return parsed;
       }
+      deps.logger?.warn(`[skills] distill: rejected candidate name "${parsed.name}"`);
     }
-    if (output.trim() === 'NONE') return null;
+    if (output.trim() === 'NONE') {
+      deps.logger?.info(`[skills] distill: no recurring pattern across ${traces.length} trace(s)`);
+      return null;
+    }
   }
+  deps.logger?.warn(`[skills] distill: no usable output after 2 attempts over ${traces.length} trace(s)`);
   return null;
 }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalPrompt, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -2252,6 +2252,7 @@ export class Codey {
       // and never with permissions skipped — crystallizer prompts embed user
       // text and agent output, so they must not reach a tool-capable session.
       runner: this.advisorRunner,
+      logger: this.logger,
     };
   }
 
@@ -2327,6 +2328,13 @@ export class Codey {
 
       if (!opts.clean) return; // failed runs contribute a correction signal, not a trace
 
+      // "ok", "2", "try again" — a real run, but as distillation input it is
+      // noise that pushes describable work out of the small trace window.
+      if (isLowSignalPrompt(opts.trace.promptSummary)) {
+        this.logger.debug(`[skills] trace skipped — continuation turn: "${opts.trace.promptSummary.slice(0, 40)}"`);
+        return;
+      }
+
       store.recordTrace(opts.trace);
 
       this.skillRunCounter++;
@@ -2342,10 +2350,15 @@ export class Codey {
 
       try {
         const now = Date.now();
-        if (now - this.lastSkillDistillTime > Codey.SKILL_DISTILL_COOLDOWN_MS) {
+        if (now - this.lastSkillDistillTime <= Codey.SKILL_DISTILL_COOLDOWN_MS) {
+          this.logger.debug('[skills] distill skipped — cooldown');
+        } else {
           const recent = store.getRecentTraces(cfg.suggestOnRepeat + 5);
           // Nothing to distill yet — skip WITHOUT consuming the cooldown.
-          if (recent.length < cfg.suggestOnRepeat) return;
+          if (recent.length < cfg.suggestOnRepeat) {
+            this.logger.debug(`[skills] distill skipped — ${recent.length}/${cfg.suggestOnRepeat} traces`);
+            return;
+          }
           this.lastSkillDistillTime = now;
           const candidate = await distillCandidate(
             this.getSkillDistillDeps(), recent, store.getAll(), store.getRejected(), cfg.suggestOnRepeat,
@@ -5421,9 +5434,12 @@ Example: /model gpt-4.1 write a Python script`;
       // with the team's question on the next user turn), and no use/success
       // bookkeeping for an applied skill either — the run isn't finished yet.
       const pausedAfterRun = !!this.chatManager.get(chatId)?.pendingTeam;
-      // Automation chats skip the pass entirely — unattended runs must not
-      // generate skill suggestions (nobody is there to answer them).
-      if (skillsCfg?.enabled && !pausedAfterRun && chat.kind !== 'automation') {
+      // Automation chats still contribute traces — scheduled work is the most
+      // repetitive work there is, so excluding it starves the distiller of its
+      // best signal. Only the SUGGESTION is suppressed: an unattended run has
+      // nobody there to answer "save this as a skill?".
+      const unattended = chat.kind === 'automation';
+      if (skillsCfg?.enabled && !pausedAfterRun) {
         // Real success signal: the solo path exposes it on singleAgentResponse
         // (a failed run reaches here with success:false and output = streamed
         // partial text or ''). Team paths have no structured flag — they throw
@@ -5457,7 +5473,7 @@ Example: /model gpt-4.1 write a Python script`;
           // a structured AskUserQuestion) must not get a skill suggestion
           // stacked on top — the user's "yes" would resolve the suggestion
           // instead of the agent's question. Trace/evolve still run.
-          suppressSuggestion: !!surfacedChoices || !!agentUserQuestion,
+          suppressSuggestion: unattended || !!surfacedChoices || !!agentUserQuestion,
           notify: (text) => { sink({ type: 'info', chatId, message: text, skillNotice: true }); },
           setPending: (s) => { this.chatManager.setPendingSkillSuggestion(chatId, s); },
         });

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalPrompt, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, toolSequenceFrom, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -1745,6 +1745,8 @@ export class Codey {
         runId: `solo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         promptSummary: parsed.prompt.slice(0, 200),
         outputPreview: (response.output || '').slice(0, 300),
+        // What the run DID — the procedure the distiller pattern-matches on.
+        toolSequence: toolSequenceFrom(meta.toolCalls),
         timestamp: Date.now(),
         mode: 'solo',
       };
@@ -2328,9 +2330,10 @@ export class Codey {
 
       if (!opts.clean) return; // failed runs contribute a correction signal, not a trace
 
-      // "ok", "2", "try again" — a real run, but as distillation input it is
-      // noise that pushes describable work out of the small trace window.
-      if (isLowSignalPrompt(opts.trace.promptSummary)) {
+      // A turn that neither said nor did anything ("ok", "2") is noise that
+      // pushes real procedures out of the small trace window. Tool activity
+      // overrides this — see isLowSignalTrace.
+      if (isLowSignalTrace(opts.trace)) {
         this.logger.debug(`[skills] trace skipped — continuation turn: "${opts.trace.promptSummary.slice(0, 40)}"`);
         return;
       }
@@ -5459,6 +5462,8 @@ Example: /model gpt-4.1 write a Python script`;
           promptSummary: userText.slice(0, 200),
           outputPreview: (output || '').slice(0, 300),
           workerSequence: workerSequence && workerSequence.length > 0 ? workerSequence : undefined,
+          // What the run DID — the procedure the distiller pattern-matches on.
+          toolSequence: toolSequenceFrom(toolCalls),
           timestamp: Date.now(),
           mode: teamTurnId ? 'team-sequential' : 'solo',
         };


### PR DESCRIPTION
## Why

No playbook has ever crystallized. Live data confirms the pipeline runs but never produces a skill: every workspace under `~/.codey/workspaces/*/skills/` has a `traces.json` and no `index.json`, and the logs contain zero `[skills]` lines — consistent with `distillCandidate` returning `NONE` every time, which logs nothing today.

The root cause is what a trace contained. A playbook is a *procedure*, but `RunTrace` only carried the conversation surface — the user's text and the agent's reply — and `formatTracesForPrompt` sent even less, dropping the stored `outputPreview`. The tool calls were already captured per assistant message (`ChatMessage.toolCalls`) and simply never read by the crystallizer. So the distiller was asked to infer a procedure from a chat transcript, then judged for returning `NONE`.

Two runs that both did `browser_navigate → browser_read → browser_interact → Write` are obviously the same work at the action level and can look unrelated at the message level — which is exactly the repeated social-media outreach visible in the real traces.

## What changed

**Actions (`skill-crystallizer.ts`)**
- `RunTrace.toolSequence` — tool names in call order, consecutive repeats collapsed, capped at `TOOL_SEQUENCE_MAX`. Names only: inputs and outputs carry user content and file contents, and crystallizer prompts deliberately run on a tool-less runner.
- `toolSequenceFrom()` reads both shapes the gateway has on hand — the chat surface's paired `tool_start`/`tool_end` entries and the channel surface's `ContextManager` records.
- Distill and evolve prompts show it (`Did:` / `- Tools called:`), and the distiller is told to weigh it above wording.

**Messages**
- Traces now carry a `Result:` line (200 of the stored 300 chars, whitespace-collapsed, omitted when empty) — `outputPreview` was written to disk and never used.

**Window hygiene**
- `isLowSignalTrace()` drops turns that neither said nor did anything (`ok`, `2`, `try again`), which otherwise fill a 7-slot window. Tool or worker activity overrides the prompt text, so a bare `ok` that drove six tool calls is kept.
- Automation chats run the post-run pass again; only the suggestion is suppressed via `suppressSuggestion: unattended`. That flag returns before the cooldown check, so unattended runs contribute traces without burning the window an interactive run needs.

**Observability**
- A verdict is logged for every distill outcome (candidate, `NONE`, rejected name, LLM failure, no usable output) and every skip reason (cooldown, `n/N traces`, continuation turn). Diagnosing this required reading the source because all of it was silent.

## Testing

`npm test` — core 219, gateway 173, codey-mac 314, all passing. `tsc` clean for core and gateway. `npm run lint` clean (CJK literals use the repo's `lint-allow-non-english` marker).

New unit tests cover `toolSequenceFrom` (pair de-duplication, both record shapes, consecutive collapse with later revisits, cap, empty input), the `Did:` and `Result:` lines reaching both prompts, `isLowSignalTrace` including the acknowledgement-with-tool-calls case, and a logged verdict for each outcome.

## Not included

Two related issues found in the same audit, left for a follow-up: the distill cooldown and GC counter are process-global rather than per-workspace (a run in one workspace consumes the other's distill window), and channel-path pending suggestions live in an in-memory `Map` that a restart drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)