### PR TITLE
Playbook induction: cluster procedures, induce parameters

### DIFF
--- a/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
+++ b/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
@@ -1,7 +1,7 @@
 # Playbook Induction — Design
 
 Date: 2026-07-28
-Status: Draft (not implemented)
+Status: Steps 1-2 implemented (trace schema v2 + log-only clustering); 3-5 pending
 
 ## Problem
 
@@ -146,16 +146,31 @@ write" is not "write, read, navigate".
 **Step 3 — distinctiveness weighting.** This is what keeps the whole thing from
 firing on every coding run. `Read -> Edit -> Bash` is nearly universal and
 means nothing; `browser_navigate -> browser_interact -> Write` is a procedure.
-Weight each tool by inverse frequency across the trace store:
+Weight each tool by how *rare* it is across the window:
 
 ```
-idf(tool) = ln(totalTraces / (1 + tracesContaining(tool)))
+rarity(tool) = 1 - tracesContaining(tool) / totalRuns
 ```
 
-and weight LCS matches by `idf`, so a match on ubiquitous tools contributes
-little. Reject a cluster whose mean `idf` falls below a floor, and reject
-signatures shorter than `MIN_PROCEDURE_LEN` (3 distinct tools) regardless of
-similarity.
+LCS matches are weighted by `rarity`, so a match on ubiquitous tools
+contributes almost nothing. Reject a cluster whose mean rarity falls below
+`MIN_DISTINCTIVENESS`, and reject signatures shorter than `MIN_PROCEDURE_LEN`
+(3 distinct tools) regardless of similarity.
+
+> Revised during implementation. This started as `ln(total / (1 + containing))`
+> — textbook idf — which turns out to be unusable at these window sizes: a
+> procedure repeated twice in a 4-run window scores 0.29 and reads as "common",
+> so the very clusters worth finding were rejected. Plain `1 - frequency` means
+> the same thing at every window size and is directly interpretable ("absent
+> from at least 40% of runs"). Two related details:
+>
+> - `totalRuns` counts **every** run considered, including ones that observed
+>   no tools. Counting only runs with steps makes a procedure look ubiquitous
+>   at exactly the moment it is the only observable thing in the window.
+> - Distinctiveness still needs a corpus. Early on, with a handful of traces,
+>   real clusters will be withheld for looking too common. That is acceptable
+>   while the pass is log-only, and is itself a reason to keep it log-only
+>   until the window fills.
 
 **Step 4 — group.** Single-link agglomerative clustering at
 `SIMILARITY_THRESHOLD` (start at 0.7, tune against the real `traces.json`).

--- a/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
+++ b/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
@@ -1,7 +1,7 @@
 # Playbook Induction — Design
 
 Date: 2026-07-28
-Status: Steps 1-2 implemented (trace schema v2 + log-only clustering); 3-5 pending
+Status: Implemented behind `skills.induction` (off by default); thresholds unfit
 
 ## Problem
 
@@ -187,14 +187,19 @@ construction, so alignment is positional after collapsing).
 
 For each step, for each argument key, compare the shapes across members:
 
-- **Identical shape and identical value across all members** -> a **constant**.
-  Bake it into the step text: "open x.com".
-- **Same shape, differing values** -> a **slot**. Name it from the key and
-  shape (`url` -> `«target_url»`, `query` -> `«query»`); collisions get a
-  numeric suffix.
-- **Differing shapes** -> not part of the template. If a step disagrees on
-  shape across members, drop the step from the induced procedure rather than
-  guessing.
+- **Identical shape and identical value across all members** -> a **constant**,
+  baked into the step text: "open x.com".
+- **Same shape, differing values** -> a **slot**, named from the argument key;
+  collisions get a numeric suffix.
+- **Differing kinds** -> not part of the template. Where members disagree on
+  the tool called at a position, the step is dropped rather than guessed.
+
+> Sharpened during implementation: **only `url` and `enum` shapes can produce a
+> constant.** The other shapes don't retain an identifying value, so "same
+> shape" doesn't mean "same value" — two `text` arguments in the same length
+> bucket are not the same text, and two paths with the same extension are not
+> the same file. Treating those as constants would bake one run's content into
+> the playbook. They are always slots.
 
 Output:
 

--- a/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
+++ b/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
@@ -1,0 +1,298 @@
+# Playbook Induction — Design
+
+Date: 2026-07-28
+Status: Draft (not implemented)
+
+## Problem
+
+No playbook has ever crystallized. Every workspace under
+`~/.codey/workspaces/*/skills/` carries a `traces.json` and no `index.json`.
+
+The proximate causes were fixed in PR #194 (traces now carry a `toolSequence`,
+the distill prompt shows `Did:` and `Result:`, continuation turns no longer
+occupy window slots, automation runs contribute traces, and every distill
+verdict is logged). What that PR did **not** change is how recurrence is
+decided:
+
+```
+distillCandidate(deps, recentTraces, existing, rejected, minRecurrence)
+  -> one LLM call: "find a repeatable sub-process appearing in 2+ runs, else NONE"
+```
+
+Recurrence is a model's impression of a 7-item list. There is no comparison, no
+similarity measure, no clustering. The `steps` it returns are prose the model
+composed, not a procedure observed from the run. And because a playbook has no
+notion of a parameter, the best a distilled skill can express is one specific
+instance of the work.
+
+## The criterion
+
+From the user, and adopted here as the definition:
+
+> If several runs produce similar output through a similar procedure, and the
+> only thing that varies is the input, that is a playbook — and the varying
+> inputs are its parameters.
+
+This is decidable in code. It moves crystallization from "ask a model to notice
+something" to "compute the recurring procedure, then ask a model to name it."
+
+Consequences that follow directly:
+
+- **Procedure is the identity of a playbook.** Two runs with the same tool
+  sequence are the same work even when the requests are worded nothing alike.
+  This is the case that defeats the current design — the real traces show the
+  same social-media outreach procedure requested four different ways.
+- **Variance is not noise; it is the parameter list.** What differs across
+  members of a cluster is exactly what the playbook should take as input.
+- **The LLM's job shrinks** to naming, phrasing, and writing `whenToUse` — the
+  tasks it is good at — over a cluster that code has already established.
+
+## What Codey can observe (revised)
+
+The 2026-07-01 design assumed Codey sees only prompt-in / response-out for solo
+runs, and that real process was observable only in team runs. That is no longer
+true for the default agent:
+
+- **claude-code** emits `tool_start` / `tool_result` events with the tool name
+  **and its input object** (`packages/core/src/agents/claude-code.ts:277`).
+  The chat surface collects these into `ToolCallEntry[]` and persists them on
+  the assistant message; the channel surface gets the same via
+  `ContextManager.extractMeta`.
+- **opencode** and **codex** emit no tool events at all.
+
+So tool observability is per-adapter, and the design must degrade rather than
+assume. See "Degradation" below.
+
+## Decisions
+
+- **Detection moves into code.** Clustering by procedure is deterministic,
+  testable, and cheap. The LLM is called once per *confirmed* cluster, not once
+  per hopeful window.
+- **Store input shapes, never raw values, in `traces.json`.** Crystallizer
+  prompts embed user content and deliberately run on a tool-less runner
+  (`skill-crystallizer.ts:460`). Raw tool inputs are strictly more sensitive
+  than what already flows there.
+- **Diff locally, abstract before the prompt.** Slot discovery runs over values
+  held in memory during the run; only the resulting template (`«url»`,
+  `«topic»`) reaches the model.
+- **Suggestion stays opt-in.** Unchanged: detect -> propose -> user confirms.
+  A computed cluster is stronger evidence, not a license to auto-save.
+- **The existing LLM-only path stays as a fallback**, not as the primary.
+
+## 1. Trace schema v2
+
+`RunTrace.toolSequence: string[]` becomes a structured step list. `traces.json`
+goes to `version: 2`; a v1 file loads with `steps: []` on every trace rather
+than being migrated (traces roll over within ~20 runs anyway).
+
+```ts
+export interface TraceStep {
+  /** Tool name, e.g. "browser_navigate", "Edit". */
+  tool: string;
+  /** Argument shape — keys with abstracted values. Never raw content. */
+  args: Record<string, ArgShape>;
+}
+
+export type ArgShape =
+  | { kind: 'url'; host: string }          // https://x.com/foo -> host only
+  | { kind: 'path'; ext: string; depth: number }
+  | { kind: 'enum'; value: string }        // short, low-cardinality literals
+  | { kind: 'text'; len: number }          // free text: length bucket only
+  | { kind: 'number' }
+  | { kind: 'bool' }
+  | { kind: 'other' };
+```
+
+`toolSequence` remains as a derived convenience (`steps.map(s => s.tool)`) so
+nothing downstream of #194 breaks.
+
+**Shape extraction** (`shapeOf(value)`) is pure, synchronous, and lives in
+core. Rules, in order:
+
+1. String parses as a URL -> `{kind:'url', host}`. Host is retained because
+   "always x.com" vs "a different host each time" is exactly the constant-vs-
+   slot distinction; the path and query are dropped.
+2. String looks like a path -> `{kind:'path', ext, depth}`.
+3. String, `len <= 32`, matches `/^[\w.\-\/]+$/` -> `{kind:'enum', value}`.
+   Short identifier-ish values are the ones worth comparing literally.
+4. Any longer string -> `{kind:'text', len}` with `len` bucketed
+   (`<100`, `<1k`, `<10k`, `10k+`) so trivial length differences don't split a
+   cluster.
+5. Numbers, booleans, everything else -> the trivial shapes.
+
+Objects and arrays are walked one level; deeper structure collapses to
+`{kind:'other'}`. Step count per trace stays capped (`TOOL_SEQUENCE_MAX`).
+
+**Raw values** are held only for the duration of the run, passed to induction
+(§3) alongside the trace, and dropped. They are never written to
+`traces.json` and never placed in a prompt.
+
+## 2. Clustering
+
+Given the trace window (all 20, not the current 7 — clustering is cheap):
+
+**Step 1 — signature.** Each trace becomes its tool-name sequence with
+consecutive repeats collapsed (already the #194 behavior).
+
+**Step 2 — pairwise similarity.** LCS ratio over the two sequences:
+
+```
+sim(a, b) = 2 * |LCS(a, b)| / (|a| + |b|)
+```
+
+LCS rather than set overlap because order carries meaning — "navigate, read,
+write" is not "write, read, navigate".
+
+**Step 3 — distinctiveness weighting.** This is what keeps the whole thing from
+firing on every coding run. `Read -> Edit -> Bash` is nearly universal and
+means nothing; `browser_navigate -> browser_interact -> Write` is a procedure.
+Weight each tool by inverse frequency across the trace store:
+
+```
+idf(tool) = ln(totalTraces / (1 + tracesContaining(tool)))
+```
+
+and weight LCS matches by `idf`, so a match on ubiquitous tools contributes
+little. Reject a cluster whose mean `idf` falls below a floor, and reject
+signatures shorter than `MIN_PROCEDURE_LEN` (3 distinct tools) regardless of
+similarity.
+
+**Step 4 — group.** Single-link agglomerative clustering at
+`SIMILARITY_THRESHOLD` (start at 0.7, tune against the real `traces.json`).
+Take clusters with `>= suggestOnRepeat` members. If several qualify, take the
+one with the highest `members * meanIdf`.
+
+Every rejection reason is logged — cluster too small, procedure too short,
+`idf` below floor. "Why no playbook?" should be answerable with a number.
+
+## 3. Template induction
+
+For a cluster, align members by step position (members share a signature by
+construction, so alignment is positional after collapsing).
+
+For each step, for each argument key, compare the shapes across members:
+
+- **Identical shape and identical value across all members** -> a **constant**.
+  Bake it into the step text: "open x.com".
+- **Same shape, differing values** -> a **slot**. Name it from the key and
+  shape (`url` -> `«target_url»`, `query` -> `«query»`); collisions get a
+  numeric suffix.
+- **Differing shapes** -> not part of the template. If a step disagrees on
+  shape across members, drop the step from the induced procedure rather than
+  guessing.
+
+Output:
+
+```ts
+interface InducedTemplate {
+  steps: { tool: string; constants: Record<string, string>; slots: string[] }[];
+  parameters: { name: string; shape: ArgShape['kind']; examples: string[] }[];
+  memberRunIds: string[];
+}
+```
+
+`examples` holds up to 2 sample values **for the confirmation prompt shown to
+the user only** — they never enter an LLM prompt.
+
+## 4. The LLM's remaining job
+
+One call, over an already-established cluster:
+
+```
+Here is a procedure observed in N runs:
+  1. browser_navigate(host=x.com, url=«target_url»)
+  2. browser_read
+  3. browser_interact(«comment_text»)
+Parameters: target_url (url), comment_text (text)
+
+Name it, describe it in one line, say when to use it, and write the steps as
+prose a coding agent can follow. Refer to parameters by their «name».
+```
+
+No raw user content, no tool outputs, no prompt text from the runs. The model
+returns `{name, description, whenToUse, steps}` as today, so `tryParseDistill`
+and the name validation are reused unchanged.
+
+## 5. Parameterized skills
+
+```ts
+interface SkillParameter {
+  name: string;
+  shape: ArgShape['kind'];
+  /** Filled from the induced constant when the value never varied. */
+  default?: string;
+}
+
+interface SkillEntry {
+  // ...existing fields
+  parameters?: SkillParameter[];
+  /** Provenance: the runs the template was induced from. */
+  inducedFrom?: string[];
+}
+```
+
+`applySkill` (`skill-crystallizer.ts:740`) currently prepends free text. With
+parameters it must bind them:
+
+1. If the new task text plainly supplies a value (a URL when the slot is a
+   `url`), bind it directly — a cheap regex/heuristic pass, no LLM.
+2. Otherwise leave the slot as `«name»` in the injected steps and instruct the
+   agent to determine it from the task. **Do not** invent a value.
+3. Never block a run to ask. Asking the user for slot values is a possible
+   later refinement; the failure mode of a wrong auto-bound value is worse than
+   an unfilled slot the agent resolves itself.
+
+Rendering stays a banner plus steps, so the surface behavior is unchanged for
+skills without parameters.
+
+## 6. Degradation
+
+- **No tool events (opencode, codex):** traces have empty `steps`. Clustering
+  finds nothing, logs "no procedure data", and the existing LLM-only
+  `distillCandidate` runs as today. Users on those adapters keep current
+  behavior; users on claude-code get induction.
+- **Mixed adapters in one workspace:** cluster only over traces that have
+  steps. A trace with no steps never joins a cluster.
+- **Team runs:** `workerSequence` is a procedure at a coarser grain. Treat a
+  worker name as a pseudo-tool so team runs cluster on the same machinery.
+
+## 7. Testing
+
+Pure functions, so unit-testable without a gateway:
+
+- `shapeOf` — each rule, plus the bucketing boundaries and one-level walking.
+- `signature` / `lcsRatio` — order sensitivity, collapse behavior.
+- `idf` weighting — a `Read/Edit/Bash` corpus produces no cluster; a corpus with
+  a distinctive repeated sequence does.
+- `cluster` — threshold behavior, minimum size, tie-break by `members * meanIdf`.
+- `induce` — constant vs slot vs dropped-step, slot naming and collisions.
+- Redaction — property test: no raw value from a tool input appears in the
+  composed prompt.
+- End-to-end on a fixture built from the real `traces.json` shape: the
+  social-media runs cluster; the coding runs do not.
+
+## Open questions
+
+1. **Threshold tuning has no ground truth yet.** 0.7 / 3 tools / idf floor are
+   guesses. They should be fit against real traces once a few hundred
+   accumulate — which argues for shipping trace schema v2 first and letting
+   data collect before the clustering lands.
+2. **Cross-workspace clustering.** Procedures probably recur across
+   workspaces (the same outreach flow in `codey` and `default`), but skills are
+   per-workspace state today. Out of scope here; worth revisiting.
+3. **How much does `Result:` still matter?** Once procedure drives detection,
+   output similarity may add nothing. Keep it in the prompt, but it should not
+   enter the clustering math.
+4. **Retiring the LLM-only path.** If induction proves out on claude-code, the
+   fallback exists solely for adapters without tool events. Whether to invest
+   in a heuristic procedure extractor for those adapters is a separate call.
+
+## Sequencing
+
+1. Trace schema v2 + `shapeOf` + logging (no behavior change; starts collecting
+   the data everything else needs).
+2. Clustering + distinctiveness weighting, behind a config flag, logging what it
+   *would* have clustered without proposing anything.
+3. Template induction + the reduced LLM call, still flagged.
+4. Parameterized `SkillEntry` + binding in `applySkill`.
+5. Flip the default once (2) has been observed against real traces.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from './workers';
 export * from './workspace';
 export * from './worker-generator';
 export * from './skill-crystallizer';
+export * from './playbook-induction';
 export * from './memory';
 export * from './agents';
 export * from './errors';

--- a/packages/core/src/playbook-induction.test.ts
+++ b/packages/core/src/playbook-induction.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   shapeOf, sameShape, stepsFrom, signatureOf, computeRarity, similarity, clusterProcedures,
+  induceTemplate, renderTemplate,
   TEXT_LEN_MAX, MAX_STEPS, MAX_ARGS_PER_STEP, ProcedureInput,
 } from './playbook-induction';
 
@@ -250,5 +251,87 @@ describe('clusterProcedures', () => {
     ], { minMembers: 2 });
     expect(report.clusters).toHaveLength(1);
     expect(report.clusters[0].runIds.sort()).toEqual(['a', 'b']);
+  });
+});
+
+function member(runId: string, calls: { tool: string; input?: Record<string, unknown> }[]): ProcedureInput {
+  return { runId, steps: stepsFrom(calls) };
+}
+
+describe('induceTemplate', () => {
+  it('splits constants from slots across a cluster', () => {
+    const template = induceTemplate([
+      member('a', [
+        { tool: 'browser_navigate', input: { url: 'https://x.com/alice/status/1' } },
+        { tool: 'browser_interact', input: { text: 'a'.repeat(200) } },
+      ]),
+      member('b', [
+        { tool: 'browser_navigate', input: { url: 'https://x.com/bob/status/2' } },
+        { tool: 'browser_interact', input: { text: 'b'.repeat(240) } },
+      ]),
+    ])!;
+    // Same host every run -> constant. Same text bucket -> still a slot.
+    expect(template.steps[0]).toEqual({ tool: 'browser_navigate', constants: { url: 'x.com' }, slots: [] });
+    expect(template.steps[1]).toEqual({ tool: 'browser_interact', constants: {}, slots: ['text'] });
+    expect(template.parameters).toEqual([{ name: 'text', kind: 'text' }]);
+  });
+
+  it('makes a differing host a slot', () => {
+    const template = induceTemplate([
+      member('a', [{ tool: 'fetch', input: { url: 'https://x.com/a' } }, { tool: 'Write', input: { n: 1 } }]),
+      member('b', [{ tool: 'fetch', input: { url: 'https://reddit.com/b' } }, { tool: 'Write', input: { n: 2 } }]),
+    ])!;
+    expect(template.steps[0].slots).toEqual(['url']);
+    expect(template.steps[0].constants).toEqual({});
+    expect(template.parameters.map(p => p.name)).toEqual(['url', 'n']);
+  });
+
+  it('never treats same-length text or same-extension paths as constant', () => {
+    const template = induceTemplate([
+      member('a', [{ tool: 'Write', input: { file_path: 'src/one.ts', content: 'x'.repeat(50) } }]),
+      member('b', [{ tool: 'Write', input: { file_path: 'src/two.ts', content: 'y'.repeat(60) } }]),
+    ])!;
+    expect(template.steps[0].constants).toEqual({});
+    expect(template.steps[0].slots.sort()).toEqual(['content', 'file_path']);
+    expect(template.parameters.find(p => p.name === 'file_path')).toEqual({ name: 'file_path', kind: 'path', ext: 'ts' });
+  });
+
+  it('drops a step where members called different tools', () => {
+    const template = induceTemplate([
+      member('a', [{ tool: 'Read' }, { tool: 'Edit' }, { tool: 'Bash' }]),
+      member('b', [{ tool: 'Read' }, { tool: 'Grep' }, { tool: 'Bash' }]),
+    ])!;
+    expect(template.steps.map(s => s.tool)).toEqual(['Read', 'Bash']);
+  });
+
+  it('ignores arguments only some members supplied', () => {
+    const template = induceTemplate([
+      member('a', [{ tool: 'Bash', input: { command: 'x'.repeat(50), timeout: 1000 } }]),
+      member('b', [{ tool: 'Bash', input: { command: 'y'.repeat(50) } }]),
+    ])!;
+    expect(template.steps[0].slots).toEqual(['command']);
+  });
+
+  it('disambiguates repeated slot names', () => {
+    const template = induceTemplate([
+      member('a', [{ tool: 'fetch', input: { url: 'https://one.com/x' } }, { tool: 'post', input: { url: 'https://two.com/y' } }]),
+      member('b', [{ tool: 'fetch', input: { url: 'https://three.com/x' } }, { tool: 'post', input: { url: 'https://four.com/y' } }]),
+    ])!;
+    expect(template.parameters.map(p => p.name)).toEqual(['url', 'url_2']);
+  });
+
+  it('returns null without at least two members or any steps', () => {
+    expect(induceTemplate([member('a', [{ tool: 'Read' }])])).toBeNull();
+    expect(induceTemplate([{ runId: 'a' }, { runId: 'b' }])).toBeNull();
+  });
+
+  it('renders a template without any user content', () => {
+    const template = induceTemplate([
+      member('a', [{ tool: 'browser_navigate', input: { url: 'https://x.com/secret-handle/status/1' } }]),
+      member('b', [{ tool: 'browser_navigate', input: { url: 'https://x.com/other-handle/status/2' } }]),
+    ])!;
+    const rendered = renderTemplate(template);
+    expect(rendered).toBe('1. browser_navigate(url=x.com)');
+    expect(rendered).not.toContain('secret-handle');
   });
 });

--- a/packages/core/src/playbook-induction.test.ts
+++ b/packages/core/src/playbook-induction.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shapeOf, sameShape, stepsFrom, signatureOf, computeRarity, similarity, clusterProcedures,
+  TEXT_LEN_MAX, MAX_STEPS, MAX_ARGS_PER_STEP, ProcedureInput,
+} from './playbook-induction';
+
+describe('shapeOf', () => {
+  it('keeps only the host of a URL', () => {
+    expect(shapeOf('https://x.com/someone/status/12345?s=20')).toEqual({ kind: 'url', host: 'x.com' });
+    // Same host, wildly different path — the same shape, so a constant.
+    expect(sameShape(shapeOf('https://x.com/a'), shapeOf('https://x.com/b/c/d'))).toBe(true);
+    // Different host — a slot.
+    expect(sameShape(shapeOf('https://x.com/a'), shapeOf('https://reddit.com/a'))).toBe(false);
+  });
+
+  it('falls back to string rules for a malformed URL', () => {
+    expect(shapeOf('https://').kind).not.toBe('url');
+  });
+
+  it('describes paths by extension and depth', () => {
+    expect(shapeOf('src/agents/claude-code.ts')).toEqual({ kind: 'path', ext: 'ts', depth: 3 });
+    expect(shapeOf('/tmp/out.json')).toEqual({ kind: 'path', ext: 'json', depth: 2 });
+  });
+
+  it('compares short identifier-ish values literally', () => {
+    expect(shapeOf('main')).toEqual({ kind: 'enum', value: 'main' });
+    expect(sameShape(shapeOf('main'), shapeOf('main'))).toBe(true);
+    expect(sameShape(shapeOf('main'), shapeOf('develop'))).toBe(false);
+  });
+
+  it('reduces free text to a bucketed length', () => {
+    expect(shapeOf('x'.repeat(50))).toEqual({ kind: 'text', len: 100 });
+    expect(shapeOf('x'.repeat(500))).toEqual({ kind: 'text', len: 1_000 });
+    expect(shapeOf('x'.repeat(50_000))).toEqual({ kind: 'text', len: TEXT_LEN_MAX });
+  });
+
+  it('treats near-identical long text as the same shape', () => {
+    // 300 vs 500 chars is the same step, not two different ones.
+    expect(sameShape(shapeOf('a'.repeat(300)), shapeOf('b'.repeat(500)))).toBe(true);
+  });
+
+  it('handles non-strings and collapses structures', () => {
+    expect(shapeOf(42)).toEqual({ kind: 'number' });
+    expect(shapeOf(true)).toEqual({ kind: 'bool' });
+    expect(shapeOf({ a: 1 })).toEqual({ kind: 'other' });
+    expect(shapeOf([1, 2])).toEqual({ kind: 'other' });
+    expect(shapeOf(null)).toEqual({ kind: 'other' });
+  });
+});
+
+describe('stepsFrom', () => {
+  it('abstracts arguments and keeps call order', () => {
+    expect(stepsFrom([
+      { type: 'tool_start', tool: 'browser_navigate', input: { url: 'https://x.com/home' } },
+      { type: 'tool_end', tool: 'browser_navigate' },
+      { type: 'tool_start', tool: 'Write', input: { file_path: 'out/post.md', content: 'x'.repeat(400) } },
+    ])).toEqual([
+      { tool: 'browser_navigate', args: { url: { kind: 'url', host: 'x.com' } } },
+      { tool: 'Write', args: { file_path: { kind: 'path', ext: 'md', depth: 2 }, content: { kind: 'text', len: 1_000 } } },
+    ]);
+  });
+
+  it('never retains a raw argument value', () => {
+    const secret = 'https://internal.example.com/very/secret/path?token=abcdef';
+    const json = JSON.stringify(stepsFrom([{ tool: 'fetch', input: { url: secret, body: 'hunter2 hunter2 hunter2 hunter2 hunter2' } }]));
+    expect(json).not.toContain('secret');
+    expect(json).not.toContain('abcdef');
+    expect(json).not.toContain('hunter2');
+    expect(json).toContain('internal.example.com'); // host is deliberate
+  });
+
+  it('accepts records with no type, collapses repeats, and caps', () => {
+    expect(stepsFrom([{ tool: 'Read' }, { tool: 'Read' }, { tool: 'Edit' }]).map(s => s.tool))
+      .toEqual(['Read', 'Edit']);
+    const many = Array.from({ length: 40 }, (_, i) => ({ tool: `tool-${i}` }));
+    expect(stepsFrom(many)).toHaveLength(MAX_STEPS);
+  });
+
+  it('caps arguments per step and skips info entries and missing names', () => {
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 20; i++) wide[`k${i}`] = i;
+    expect(Object.keys(stepsFrom([{ tool: 'x', input: wide }])[0].args)).toHaveLength(MAX_ARGS_PER_STEP);
+    expect(stepsFrom([{ type: 'info', tool: 'x' }, { tool: undefined }, { tool: 'Read' }]).map(s => s.tool))
+      .toEqual(['Read']);
+    expect(stepsFrom(undefined)).toEqual([]);
+  });
+
+  it('gives a step with no usable input an empty arg map', () => {
+    expect(stepsFrom([{ tool: 'Bash', input: 'not-an-object' }])).toEqual([{ tool: 'Bash', args: {} }]);
+  });
+});
+
+describe('signatureOf', () => {
+  it('collapses consecutive repeats', () => {
+    expect(signatureOf({ runId: 'r', steps: [
+      { tool: 'Read', args: {} }, { tool: 'Read', args: {} }, { tool: 'Edit', args: {} }, { tool: 'Read', args: {} },
+    ] })).toEqual(['Read', 'Edit', 'Read']);
+  });
+
+  it('falls back to worker names for team runs', () => {
+    expect(signatureOf({ runId: 'r', workerSequence: ['researcher', 'writer'] }))
+      .toEqual(['researcher', 'writer']);
+  });
+
+  it('is empty when a run observed nothing', () => {
+    expect(signatureOf({ runId: 'r' })).toEqual([]);
+  });
+});
+
+describe('similarity', () => {
+  const flat = new Map<string, number>();
+
+  it('is order-sensitive', () => {
+    const forward = similarity(['a', 'b', 'c'], ['a', 'b', 'c'], flat);
+    const reversed = similarity(['a', 'b', 'c'], ['c', 'b', 'a'], flat);
+    expect(forward).toBe(1);
+    expect(reversed).toBeLessThan(forward);
+  });
+
+  it('scores a shared prefix between 0 and 1', () => {
+    const score = similarity(['a', 'b', 'c'], ['a', 'b', 'd'], flat);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1);
+  });
+
+  it('weights distinctive tools above ubiquitous ones', () => {
+    const rarity = new Map([['common', 0.01], ['rare', 0.9]]);
+    const rareMatch = similarity(['rare', 'common'], ['rare', 'other'], rarity);
+    const commonMatch = similarity(['common', 'rare'], ['common', 'other'], rarity);
+    expect(rareMatch).toBeGreaterThan(commonMatch);
+  });
+
+  it('returns 0 for an empty sequence', () => {
+    expect(similarity([], ['a'], flat)).toBe(0);
+  });
+});
+
+describe('computeRarity', () => {
+  it('scores a tool in every run at zero and a rare tool high', () => {
+    const rarity = computeRarity([['Read', 'Edit'], ['Read', 'Bash'], ['Read', 'browser_interact']], 3);
+    expect(rarity.get('Read')).toBe(0);
+    expect(rarity.get('browser_interact')).toBeCloseTo(2 / 3);
+  });
+
+  it('counts runs that observed no tools in the denominator', () => {
+    // Two browser runs among ten is distinctive, even if the other eight
+    // observed nothing at all.
+    const rarity = computeRarity([['browser_navigate'], ['browser_navigate']], 10);
+    expect(rarity.get('browser_navigate')).toBeCloseTo(0.8);
+  });
+});
+
+function run(runId: string, tools: string[]): ProcedureInput {
+  return { runId, steps: tools.map(tool => ({ tool, args: {} })) };
+}
+
+describe('clusterProcedures', () => {
+  it('clusters runs that executed the same distinctive procedure', () => {
+    const report = clusterProcedures([
+      run('a', ['browser_navigate', 'browser_read', 'browser_interact']),
+      run('b', ['browser_navigate', 'browser_read', 'browser_interact']),
+      run('c', ['Read', 'Edit', 'Bash']),
+      run('d', ['Grep', 'Read', 'Write']),
+    ], { minMembers: 2 });
+    expect(report.clusters).toHaveLength(1);
+    expect(report.clusters[0].runIds.sort()).toEqual(['a', 'b']);
+    expect(report.clusters[0].signature).toEqual(['browser_navigate', 'browser_read', 'browser_interact']);
+  });
+
+  it('does not crystallize a procedure made of ubiquitous tools', () => {
+    // Read -> Edit -> Bash in every run: recurring, but meaningless.
+    const report = clusterProcedures([
+      run('a', ['Read', 'Edit', 'Bash']),
+      run('b', ['Read', 'Edit', 'Bash']),
+      run('c', ['Read', 'Edit', 'Bash']),
+      run('d', ['Read', 'Edit', 'Bash']),
+    ], { minMembers: 2 });
+    expect(report.clusters).toHaveLength(0);
+    expect(report.rejectedByDistinctiveness).toBe(1);
+  });
+
+  it('rejects procedures that are too short to mean anything', () => {
+    const report = clusterProcedures([
+      run('a', ['Read', 'Edit']),
+      run('b', ['Read', 'Edit']),
+    ], { minMembers: 2 });
+    expect(report.clusters).toHaveLength(0);
+    expect(report.tooShort).toBe(2);
+  });
+
+  it('counts runs with no procedure data separately', () => {
+    const report = clusterProcedures([
+      { runId: 'a' }, { runId: 'b' },
+      run('c', ['browser_navigate', 'browser_read', 'browser_interact']),
+      run('d', ['browser_navigate', 'browser_read', 'browser_interact']),
+    ], { minMembers: 2 });
+    expect(report.withoutSteps).toBe(2);
+    expect(report.clusters).toHaveLength(1);
+  });
+
+  it('reports a distinctive procedure that has not recurred yet', () => {
+    const report = clusterProcedures([
+      run('a', ['browser_navigate', 'browser_read', 'browser_interact']),
+      run('b', ['Grep', 'Read', 'Write']),
+      run('c', ['Bash', 'Read', 'Edit']),
+    ], { minMembers: 2 });
+    expect(report.clusters).toHaveLength(0);
+    expect(report.tooFewMembers).toBeGreaterThan(0);
+  });
+
+  it('prefers a small distinctive cluster over a larger generic one', () => {
+    const report = clusterProcedures([
+      run('a', ['Read', 'browser_navigate', 'browser_interact', 'browser_files']),
+      run('b', ['Read', 'browser_navigate', 'browser_interact', 'browser_files']),
+      run('c', ['Read', 'Edit', 'Write', 'Bash']),
+      run('d', ['Read', 'Edit', 'Write', 'Bash']),
+      run('e', ['Read', 'Edit', 'Write', 'Bash']),
+      run('f', ['Read', 'Edit', 'Write', 'Grep']),
+      run('g', ['Read', 'Edit', 'Write', 'Grep']),
+    ], { minMembers: 2 });
+    // The Read/Edit/Write group is bigger, but it is what almost every run
+    // does — it must not outrank the browser procedure by size alone.
+    expect(report.clusters[0].runIds.sort()).toEqual(['a', 'b']);
+    expect(report.rejectedByDistinctiveness).toBeGreaterThan(0);
+  });
+
+  it('scores a cluster as members * distinctiveness', () => {
+    const report = clusterProcedures([
+      run('a', ['browser_navigate', 'browser_read', 'browser_interact']),
+      run('b', ['browser_navigate', 'browser_read', 'browser_interact']),
+      run('c', ['Grep', 'Bash', 'Write']),
+      run('d', ['Curl', 'Deploy', 'Notify']),
+    ], { minMembers: 2 });
+    const cluster = report.clusters[0];
+    expect(cluster.score).toBeCloseTo(cluster.runIds.length * cluster.distinctiveness);
+  });
+
+  it('returns an empty report when there is nothing to compare', () => {
+    expect(clusterProcedures([], { minMembers: 2 }).clusters).toEqual([]);
+    expect(clusterProcedures([run('a', ['x', 'y', 'z'])], { minMembers: 2 }).clusters).toEqual([]);
+  });
+
+  it('clusters team runs on their worker sequence', () => {
+    const report = clusterProcedures([
+      { runId: 'a', workerSequence: ['scout', 'writer', 'editor'] },
+      { runId: 'b', workerSequence: ['scout', 'writer', 'editor'] },
+      { runId: 'c', workerSequence: ['auditor', 'fixer', 'verifier'] },
+      run('d', ['Read', 'Edit', 'Bash']),
+      run('e', ['Grep', 'Write', 'Bash']),
+    ], { minMembers: 2 });
+    expect(report.clusters).toHaveLength(1);
+    expect(report.clusters[0].runIds.sort()).toEqual(['a', 'b']);
+  });
+});

--- a/packages/core/src/playbook-induction.ts
+++ b/packages/core/src/playbook-induction.ts
@@ -330,3 +330,120 @@ export function clusterProcedures(
   report.clusters.sort((a, b) => b.score - a.score);
   return report;
 }
+
+// ── Template induction ─────────────────────────────────────────────
+
+export interface InducedStep {
+  tool: string;
+  /** Arguments that held the same identifying value in every member. */
+  constants: Record<string, string>;
+  /** Arguments that varied — the playbook's inputs. Names index into
+   *  InducedTemplate.parameters. */
+  slots: string[];
+}
+
+export interface TemplateParameter {
+  name: string;
+  kind: ArgShape['kind'];
+  /** Extension seen for path parameters — "a .ts file" is a better prompt than
+   *  "a path". Absent for other kinds. */
+  ext?: string;
+}
+
+export interface InducedTemplate {
+  steps: InducedStep[];
+  parameters: TemplateParameter[];
+  memberRunIds: string[];
+}
+
+/** Only two shapes retain a value identifying enough to call an argument
+ *  constant. Two `text` arguments in the same length bucket are NOT the same
+ *  text, and two paths with the same extension are not the same file — those
+ *  are slots, however similar their shapes look. */
+function constantValue(shape: ArgShape): string | null {
+  if (shape.kind === 'url') return shape.host;
+  if (shape.kind === 'enum') return shape.value;
+  return null;
+}
+
+/** Collapsed step list, matching what signatureOf produces. */
+function collapsedSteps(input: ProcedureInput): TraceStep[] {
+  const steps: TraceStep[] = [];
+  for (const step of input.steps ?? []) {
+    if (steps[steps.length - 1]?.tool === step.tool) continue;
+    steps.push(step);
+  }
+  return steps;
+}
+
+/** Turn a cluster into a procedure with holes.
+ *
+ *  Runs over the persisted SHAPES, not raw values — `sameShape` already
+ *  encodes the distinction the diff needs, so induction never requires the
+ *  values to have been stored.
+ *
+ *  Positional alignment: a step is induced only where every member called the
+ *  same tool at that index. A member that diverges mid-procedure contributes
+ *  its agreeing prefix and suffix positions, never a guess. */
+export function induceTemplate(members: ProcedureInput[]): InducedTemplate | null {
+  if (members.length < 2) return null;
+  const stepLists = members.map(collapsedSteps);
+  const length = Math.min(...stepLists.map(s => s.length));
+  if (length === 0) return null;
+
+  const steps: InducedStep[] = [];
+  const parameters: TemplateParameter[] = [];
+  const takenNames = new Set<string>();
+
+  for (let i = 0; i < length; i++) {
+    const tool = stepLists[0][i].tool;
+    if (!stepLists.every(list => list[i].tool === tool)) continue;
+
+    const constants: Record<string, string> = {};
+    const slots: string[] = [];
+    // Only arguments every member supplied can be reasoned about.
+    const keys = Object.keys(stepLists[0][i].args)
+      .filter(key => stepLists.every(list => list[i].args[key] !== undefined));
+
+    for (const key of keys) {
+      const shapes = stepLists.map(list => list[i].args[key]);
+      const first = shapes[0];
+      if (!shapes.every(shape => shape.kind === first.kind)) continue; // disagreeing kinds: not part of the template
+
+      const constant = constantValue(first);
+      if (constant !== null && shapes.every(shape => sameShape(shape, first))) {
+        constants[key] = constant;
+        continue;
+      }
+
+      let name = key;
+      let suffix = 2;
+      while (takenNames.has(name)) name = `${key}_${suffix++}`;
+      takenNames.add(name);
+      slots.push(name);
+      parameters.push({
+        name,
+        kind: first.kind,
+        ...(first.kind === 'path' ? { ext: first.ext } : {}),
+      });
+    }
+
+    steps.push({ tool, constants, slots });
+  }
+
+  if (steps.length === 0) return null;
+  return { steps, parameters, memberRunIds: members.map(m => m.runId) };
+}
+
+/** Render a template for a prompt or a confirmation. Contains only tool names,
+ *  argument keys, constants (hosts and short literals), and slot names — never
+ *  user content. */
+export function renderTemplate(template: InducedTemplate): string {
+  return template.steps.map((step, i) => {
+    const args = [
+      ...Object.entries(step.constants).map(([key, value]) => `${key}=${value}`),
+      ...step.slots.map(slot => `${slot}=«${slot}»`),
+    ];
+    return `${i + 1}. ${step.tool}${args.length ? `(${args.join(', ')})` : ''}`;
+  }).join('\n');
+}

--- a/packages/core/src/playbook-induction.ts
+++ b/packages/core/src/playbook-induction.ts
@@ -1,0 +1,332 @@
+// packages/core/src/playbook-induction.ts
+//
+// Deciding whether runs repeat is a computation, not an impression. This
+// module holds the parts that run in plain code, before any LLM is involved:
+//
+//   shapeOf / stepsFrom  — abstract a run's tool calls into a comparable shape
+//   clusterProcedures    — group runs that ran the same procedure
+//
+// Design note (see docs/superpowers/specs/2026-07-28-playbook-induction-design.md):
+// argument VALUES never leave the run. What persists is their shape, which is
+// enough to tell a constant from a slot without putting user content into a
+// trace file or a prompt.
+//
+// Deliberately free of imports from skill-crystallizer.ts: the clustering
+// entry points take structural types so the dependency runs one way only.
+
+// ── Argument shapes ────────────────────────────────────────────────
+
+export type ArgShape =
+  | { kind: 'url'; host: string }
+  | { kind: 'path'; ext: string; depth: number }
+  | { kind: 'enum'; value: string }
+  | { kind: 'text'; len: number }
+  | { kind: 'number' }
+  | { kind: 'bool' }
+  | { kind: 'other' };
+
+export interface TraceStep {
+  tool: string;
+  args: Record<string, ArgShape>;
+}
+
+/** Upper bounds of the length buckets for free text. A run that writes 300
+ *  chars and one that writes 500 are the same step; bucketing keeps trivial
+ *  differences from splitting a cluster. TEXT_LEN_MAX marks "10k or more". */
+export const TEXT_LEN_BUCKETS = [100, 1_000, 10_000];
+export const TEXT_LEN_MAX = 100_000;
+
+/** Values at or below this length are compared literally (kind 'enum').
+ *  Longer ones are reduced to a length bucket. */
+const ENUM_MAX_LEN = 32;
+const ENUM_PATTERN = /^[\w.\-/]+$/;
+const PATH_PATTERN = /^[~.]?\/|^[\w\-./]+\.[a-z]{1,5}$/i;
+
+function bucketLen(len: number): number {
+  for (const bucket of TEXT_LEN_BUCKETS) {
+    if (len < bucket) return bucket;
+  }
+  return TEXT_LEN_MAX;
+}
+
+/** Abstract one argument value. Pure and synchronous — no value it is given
+ *  is retained anywhere. */
+export function shapeOf(value: unknown): ArgShape {
+  if (typeof value === 'boolean') return { kind: 'bool' };
+  if (typeof value === 'number') return { kind: 'number' };
+  if (typeof value !== 'string') return { kind: 'other' };
+
+  const text = value.trim();
+  if (!text) return { kind: 'text', len: bucketLen(0) };
+
+  // Host is kept because "always the same site" versus "a different site each
+  // run" is exactly the constant-versus-slot question. Path and query are not.
+  if (/^https?:\/\//i.test(text)) {
+    try {
+      return { kind: 'url', host: new URL(text).host };
+    } catch {
+      // Malformed URL — fall through to the string rules.
+    }
+  }
+
+  if (text.length <= ENUM_MAX_LEN && PATH_PATTERN.test(text) && text.includes('.')) {
+    const base = text.slice(text.lastIndexOf('/') + 1);
+    const dot = base.lastIndexOf('.');
+    return {
+      kind: 'path',
+      ext: dot > 0 ? base.slice(dot + 1).toLowerCase() : '',
+      depth: text.split('/').filter(Boolean).length,
+    };
+  }
+
+  if (text.length <= ENUM_MAX_LEN && ENUM_PATTERN.test(text)) {
+    return { kind: 'enum', value: text };
+  }
+
+  return { kind: 'text', len: bucketLen(text.length) };
+}
+
+/** True when two shapes are the same kind AND the same value — i.e. this
+ *  argument was constant across the runs being compared. Slot discovery is
+ *  the inverse: same kind, different value. */
+export function sameShape(a: ArgShape, b: ArgShape): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'url' && b.kind === 'url') return a.host === b.host;
+  if (a.kind === 'enum' && b.kind === 'enum') return a.value === b.value;
+  if (a.kind === 'path' && b.kind === 'path') return a.ext === b.ext && a.depth === b.depth;
+  if (a.kind === 'text' && b.kind === 'text') return a.len === b.len;
+  return true;
+}
+
+/** How many arguments of one tool call are abstracted. A tool with 30
+ *  parameters contributes noise, not signal. */
+export const MAX_ARGS_PER_STEP = 8;
+/** Steps kept per trace. Matches TOOL_SEQUENCE_MAX in skill-crystallizer. */
+export const MAX_STEPS = 12;
+
+/** Build the persisted step list from a run's tool calls.
+ *
+ *  Accepts both shapes the gateway has on hand — the chat surface's
+ *  ToolCallEntry (paired 'tool_start'/'tool_end' records) and the channel
+ *  surface's ContextManager ToolCallRecord (one record per call, no `type`).
+ *  Only the start half of a pair is counted so calls aren't doubled. */
+export function stepsFrom(
+  entries: { tool?: string; type?: string; input?: unknown }[] | undefined,
+): TraceStep[] {
+  if (!entries || entries.length === 0) return [];
+  const steps: TraceStep[] = [];
+  for (const entry of entries) {
+    if (!entry.tool) continue;
+    if (entry.type === 'tool_end' || entry.type === 'info') continue;
+    // A loop over 20 files is one step in a procedure, not 20.
+    if (steps[steps.length - 1]?.tool === entry.tool) continue;
+
+    const args: Record<string, ArgShape> = {};
+    const input = entry.input;
+    if (input && typeof input === 'object' && !Array.isArray(input)) {
+      for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+        if (Object.keys(args).length >= MAX_ARGS_PER_STEP) break;
+        args[key] = shapeOf(value);
+      }
+    }
+    steps.push({ tool: entry.tool, args });
+    if (steps.length >= MAX_STEPS) break;
+  }
+  return steps;
+}
+
+// ── Clustering ─────────────────────────────────────────────────────
+
+/** A run reduced to what clustering needs. Structural on purpose — callers
+ *  pass RunTrace values directly without this module importing that type. */
+export interface ProcedureInput {
+  runId: string;
+  steps?: TraceStep[];
+  /** Team runs observe process at a coarser grain; worker names stand in for
+   *  tools so both kinds cluster on the same machinery. */
+  workerSequence?: string[];
+}
+
+export interface ProcedureCluster {
+  runIds: string[];
+  /** The shared tool sequence, taken from the cluster's longest member. */
+  signature: string[];
+  /** Mean rarity of the signature's tools, in [0, 1). Low means the procedure
+   *  is built from tools that appear in nearly every recent run. */
+  distinctiveness: number;
+  /** members * distinctiveness — ranks a big cluster of common tools below a
+   *  smaller cluster of distinctive ones. */
+  score: number;
+}
+
+export interface ClusterOptions {
+  /** Minimum runs before a procedure counts as recurring. */
+  minMembers: number;
+  /** Weighted-LCS ratio above which two runs are the same procedure. */
+  similarityThreshold?: number;
+  /** Distinct tools a procedure needs before it is a procedure at all. */
+  minProcedureLen?: number;
+  /** Distinctiveness floor. Read -> Edit -> Bash is in nearly every coding run
+   *  and must not crystallize into a playbook. */
+  minDistinctiveness?: number;
+}
+
+// Unfit guesses — no ground truth exists yet. The spec's sequencing runs
+// clustering in log-only mode precisely so these can be tuned against real
+// traces before anything is proposed to a user.
+export const DEFAULT_SIMILARITY_THRESHOLD = 0.7;
+export const DEFAULT_MIN_PROCEDURE_LEN = 3;
+export const DEFAULT_MIN_DISTINCTIVENESS = 0.4;
+
+/** Tool sequence with consecutive repeats collapsed. */
+export function signatureOf(input: ProcedureInput): string[] {
+  const names = (input.steps ?? []).map(s => s.tool);
+  if (names.length === 0 && input.workerSequence) names.push(...input.workerSequence);
+  const collapsed: string[] = [];
+  for (const name of names) {
+    if (collapsed[collapsed.length - 1] !== name) collapsed.push(name);
+  }
+  return collapsed;
+}
+
+/** Fraction of runs a tool did NOT appear in, in [0, 1).
+ *
+ *  Plain rarity rather than a log-scaled idf: idf is unstable at the sizes
+ *  this operates on (a procedure repeated twice in a 4-run window scores as
+ *  "common"), while `1 - frequency` reads the same at every window size and
+ *  is directly interpretable — 0.4 means "absent from at least 40% of runs".
+ *
+ *  `totalRuns` counts every run considered, including ones that observed no
+ *  tools at all. A workspace where two runs used the browser and eight did
+ *  nothing observable should still see the browser as distinctive. */
+export function computeRarity(signatures: string[][], totalRuns: number): Map<string, number> {
+  const total = Math.max(totalRuns, signatures.length, 1);
+  const containing = new Map<string, number>();
+  for (const sig of signatures) {
+    for (const tool of new Set(sig)) {
+      containing.set(tool, (containing.get(tool) ?? 0) + 1);
+    }
+  }
+  const rarity = new Map<string, number>();
+  for (const [tool, count] of containing) {
+    rarity.set(tool, 1 - count / total);
+  }
+  return rarity;
+}
+
+function weightOf(tool: string, rarity: Map<string, number>): number {
+  // Floor at a small positive value: a tool present in every run should
+  // contribute almost nothing, but never zero (which would make a sequence
+  // of ubiquitous tools score 0/0 rather than "similar but worthless").
+  return Math.max(rarity.get(tool) ?? 0, 0.01);
+}
+
+/** Weighted longest-common-subsequence ratio. Subsequence rather than set
+ *  overlap because order is part of a procedure: navigate -> read -> write is
+ *  not write -> read -> navigate. */
+export function similarity(a: string[], b: string[], rarity: Map<string, number>): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const table: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      table[i][j] = a[i - 1] === b[j - 1]
+        ? table[i - 1][j - 1] + weightOf(a[i - 1], rarity)
+        : Math.max(table[i - 1][j], table[i][j - 1]);
+    }
+  }
+  const matched = table[a.length][b.length];
+  const totalWeight = a.reduce((sum, t) => sum + weightOf(t, rarity), 0)
+    + b.reduce((sum, t) => sum + weightOf(t, rarity), 0);
+  return totalWeight === 0 ? 0 : (2 * matched) / totalWeight;
+}
+
+/** Why a run or group didn't produce a cluster. Logged so "no playbook yet"
+ *  is answerable with a number instead of a shrug. */
+export interface ClusterReport {
+  clusters: ProcedureCluster[];
+  /** Runs carrying no procedure data at all (adapter emits no tool events). */
+  withoutSteps: number;
+  /** Runs whose procedure was too short to mean anything. */
+  tooShort: number;
+  /** Groups that recurred but are built from ubiquitous tools. */
+  rejectedByDistinctiveness: number;
+  /** Groups that were distinctive enough but haven't recurred yet. */
+  tooFewMembers: number;
+}
+
+/** Group runs by the procedure they executed. Pure; no I/O, no LLM. */
+export function clusterProcedures(
+  inputs: ProcedureInput[],
+  opts: ClusterOptions,
+): ClusterReport {
+  const threshold = opts.similarityThreshold ?? DEFAULT_SIMILARITY_THRESHOLD;
+  const minLen = opts.minProcedureLen ?? DEFAULT_MIN_PROCEDURE_LEN;
+  const minDistinctiveness = opts.minDistinctiveness ?? DEFAULT_MIN_DISTINCTIVENESS;
+
+  const report: ClusterReport = {
+    clusters: [], withoutSteps: 0, tooShort: 0, rejectedByDistinctiveness: 0, tooFewMembers: 0,
+  };
+
+  const eligible: { runId: string; sig: string[] }[] = [];
+  for (const input of inputs) {
+    const sig = signatureOf(input);
+    if (sig.length === 0) { report.withoutSteps++; continue; }
+    if (new Set(sig).size < minLen) { report.tooShort++; continue; }
+    eligible.push({ runId: input.runId, sig });
+  }
+  if (eligible.length < opts.minMembers) return report;
+
+  // Rarity is measured against every run considered, not just the eligible
+  // ones: "common" means common in THIS workspace's recent work. Counting only
+  // eligible runs would make a procedure look ubiquitous precisely when it is
+  // the only observable thing in the window.
+  const rarity = computeRarity(eligible.map(e => e.sig), inputs.length);
+
+  // Single-link agglomerative clustering via union-find over the pairs that
+  // clear the threshold.
+  const parent = eligible.map((_, i) => i);
+  const find = (i: number): number => {
+    while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; }
+    return i;
+  };
+  const union = (i: number, j: number) => { parent[find(i)] = find(j); };
+
+  for (let i = 0; i < eligible.length; i++) {
+    for (let j = i + 1; j < eligible.length; j++) {
+      if (similarity(eligible[i].sig, eligible[j].sig, rarity) >= threshold) union(i, j);
+    }
+  }
+
+  const groups = new Map<number, number[]>();
+  for (let i = 0; i < eligible.length; i++) {
+    const root = find(i);
+    const group = groups.get(root);
+    if (group) group.push(i); else groups.set(root, [i]);
+  }
+
+  for (const members of groups.values()) {
+    // The longest member is the fullest observation of the procedure; shorter
+    // members are runs where a step was skipped or the cap truncated.
+    const signature = members
+      .map(i => eligible[i].sig)
+      .reduce((longest, sig) => (sig.length > longest.length ? sig : longest), [] as string[]);
+    const tools = [...new Set(signature)];
+    const distinctiveness = tools.reduce((sum, t) => sum + weightOf(t, rarity), 0) / tools.length;
+
+    if (members.length < opts.minMembers) {
+      if (distinctiveness >= minDistinctiveness) report.tooFewMembers++;
+      continue;
+    }
+    if (distinctiveness < minDistinctiveness) { report.rejectedByDistinctiveness++; continue; }
+
+    report.clusters.push({
+      runIds: members.map(i => eligible[i].runId),
+      signature,
+      distinctiveness,
+      score: members.length * distinctiveness,
+    });
+  }
+
+  report.clusters.sort((a, b) => b.score - a.score);
+  return report;
+}

--- a/packages/core/src/skill-crystallizer.test.ts
+++ b/packages/core/src/skill-crystallizer.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { SkillStore, RECENT_TRACES_MAX, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, evolveSkill, isLowSignalTrace } from './skill-crystallizer';
+import { InducedTemplate } from './playbook-induction';
+import { SkillStore, RECENT_TRACES_MAX, TRACES_FILE_VERSION, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, bindParameter, nameTemplate, evolveSkill, isLowSignalTrace } from './skill-crystallizer';
 
 describe('SkillStore', () => {
   let tmp: string;
@@ -171,6 +172,42 @@ describe('SkillStore', () => {
     const traces = store2.getRecentTraces(10);
     expect(traces.length).toBe(2);
     expect(traces[0].runId).toBe('r2');
+  });
+
+  it('loads a v1 traces file and rewrites it as v2', async () => {
+    const skillsDir = path.join(tmp, 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, 'traces.json'), JSON.stringify({
+      version: 1,
+      traces: [{ runId: 'old', promptSummary: 'p', outputPreview: 'o', timestamp: 1, mode: 'solo' }],
+    }));
+    const store2 = new SkillStore(tmp);
+    await store2.load();
+    // v1 traces load as-is; they simply have no steps.
+    expect(store2.getRecentTraces(10)[0].runId).toBe('old');
+    expect(store2.getRecentTraces(10)[0].steps).toBeUndefined();
+    store2.recordTrace({
+      runId: 'new', promptSummary: 'p', outputPreview: 'o', timestamp: 2, mode: 'solo',
+      steps: [{ tool: 'Read', args: {} }],
+    });
+    await store2.flush();
+    const written = JSON.parse(fs.readFileSync(path.join(skillsDir, 'traces.json'), 'utf-8'));
+    expect(written.version).toBe(TRACES_FILE_VERSION);
+    expect(written.traces[0].steps).toEqual([{ tool: 'Read', args: {} }]);
+  });
+
+  it('persists parameters and provenance on an induced skill', async () => {
+    store.add({
+      name: 'x-outreach', description: 'd', whenToUse: 'w', steps: 's',
+      parameters: [{ name: 'comment', kind: 'text' }],
+      inducedFrom: ['r1', 'r2'],
+    });
+    await store.flush();
+    const store2 = new SkillStore(tmp);
+    await store2.load();
+    const entry = store2.get('x-outreach')!;
+    expect(entry.parameters).toEqual([{ name: 'comment', kind: 'text' }]);
+    expect(entry.inducedFrom).toEqual(['r1', 'r2']);
   });
 
   it('getRecentTraces returns most recent first', () => {
@@ -605,6 +642,93 @@ describe('applySkill', () => {
   it('handles empty task', () => {
     const result = applySkill('', skill);
     expect(result).toContain('using skill: release-notes');
+  });
+
+  it('binds a parameter the task plainly supplies', () => {
+    const parameterized = makeSkill({
+      ...skill,
+      parameters: [{ name: 'target_url', kind: 'url' }, { name: 'file_path', kind: 'path', ext: 'ts' }],
+    });
+    const result = applySkill('comment on https://x.com/someone/status/9 and patch src/gateway.ts', parameterized);
+    expect(result).toContain('«target_url» = https://x.com/someone/status/9');
+    expect(result).toContain('«file_path» = src/gateway.ts');
+  });
+
+  it('leaves a slot unfilled rather than inventing a value', () => {
+    const parameterized = makeSkill({
+      ...skill,
+      parameters: [{ name: 'topic', kind: 'text' }, { name: 'target_url', kind: 'url' }],
+    });
+    const result = applySkill('write something about agents', parameterized);
+    expect(result).toContain('«topic» — determine from the task (text)');
+    expect(result).toContain('«target_url» — determine from the task (url)');
+    expect(result).not.toContain('«topic» =');
+  });
+
+  it('says nothing about inputs for a skill without parameters', () => {
+    expect(applySkill('do the thing', skill)).not.toContain('Inputs:');
+  });
+});
+
+describe('bindParameter', () => {
+  it('extracts a URL, stopping at surrounding punctuation', () => {
+    expect(bindParameter('see https://x.com/a/b?x=1 for details', { name: 'u', kind: 'url' }))
+      .toBe('https://x.com/a/b?x=1');
+    expect(bindParameter('(https://x.com/a)', { name: 'u', kind: 'url' })).toBe('https://x.com/a');
+  });
+
+  it('prefers a path with the expected extension', () => {
+    expect(bindParameter('edit src/gateway.ts and README.md', { name: 'p', kind: 'path', ext: 'md' }))
+      .toBe('README.md');
+  });
+
+  it('returns null when the task supplies nothing usable', () => {
+    expect(bindParameter('no links here', { name: 'u', kind: 'url' })).toBeNull();
+    expect(bindParameter('anything', { name: 't', kind: 'text' })).toBeNull();
+    expect(bindParameter('anything', { name: 'n', kind: 'number' })).toBeNull();
+  });
+});
+
+describe('nameTemplate', () => {
+  const template: InducedTemplate = {
+    steps: [
+      { tool: 'browser_navigate', constants: { url: 'x.com' }, slots: [] },
+      { tool: 'browser_interact', constants: {}, slots: ['comment'] },
+    ],
+    parameters: [{ name: 'comment', kind: 'text' }],
+    memberRunIds: ['r1', 'r2'],
+  };
+
+  it('names the template and carries its parameters onto the result', async () => {
+    let prompt = '';
+    const deps = fakeDeps(async (req) => {
+      prompt = req.prompt;
+      return { success: true, output: JSON.stringify({
+        name: 'x-outreach', description: 'Comment on AI posts', whenToUse: 'user asks to comment', steps: '1. open «comment»',
+      }), error: null, tokens: { total: 10 } };
+    });
+    const result = await nameTemplate(deps, template, [], []);
+    expect(result!.name).toBe('x-outreach');
+    expect(result!.parameters).toEqual(template.parameters);
+    expect(result!.inducedFrom).toEqual(['r1', 'r2']);
+    // The prompt states the recurrence rather than asking the model to judge it.
+    expect(prompt).toContain('2 runs');
+    expect(prompt).toContain('browser_navigate(url=x.com)');
+    expect(prompt).toContain('comment=«comment»');
+  });
+
+  it('returns null when the model says the template duplicates a skill', async () => {
+    const deps = fakeDeps(async () => ({ success: true, output: 'NONE', error: null, tokens: { total: 5 } }));
+    expect(await nameTemplate(deps, template, [], [])).toBeNull();
+  });
+
+  it('returns null on an invalid name after retrying', async () => {
+    const deps = fakeDeps(async () => ({
+      success: true,
+      output: JSON.stringify({ name: 'Bad Name', description: 'd', whenToUse: 'w', steps: '1. x' }),
+      error: null, tokens: { total: 5 },
+    }));
+    expect(await nameTemplate(deps, template, [], [])).toBeNull();
   });
 });
 

--- a/packages/core/src/skill-crystallizer.test.ts
+++ b/packages/core/src/skill-crystallizer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { SkillStore, RECENT_TRACES_MAX, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, evolveSkill, isLowSignalTrace, toolSequenceFrom, TOOL_SEQUENCE_MAX } from './skill-crystallizer';
+import { SkillStore, RECENT_TRACES_MAX, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, evolveSkill, isLowSignalTrace } from './skill-crystallizer';
 
 describe('SkillStore', () => {
   let tmp: string;
@@ -441,39 +441,6 @@ describe('distillCandidate', () => {
 function traceWith(over: Partial<RunTrace>): RunTrace {
   return { runId: 'r', promptSummary: 'x', outputPreview: '', timestamp: 0, mode: 'solo', ...over };
 }
-
-describe('toolSequenceFrom', () => {
-  it('keeps call order, drops the tool_end half of each pair', () => {
-    expect(toolSequenceFrom([
-      { type: 'tool_start', tool: 'browser_navigate' },
-      { type: 'tool_end', tool: 'browser_navigate' },
-      { type: 'tool_start', tool: 'browser_read' },
-      { type: 'tool_end', tool: 'browser_read' },
-    ])).toEqual(['browser_navigate', 'browser_read']);
-  });
-
-  it('accepts records with no type (the channel surface shape)', () => {
-    expect(toolSequenceFrom([{ tool: 'Read' }, { tool: 'Write' }])).toEqual(['Read', 'Write']);
-  });
-
-  it('collapses consecutive repeats but keeps a later revisit', () => {
-    expect(toolSequenceFrom([
-      { tool: 'Read' }, { tool: 'Read' }, { tool: 'Read' }, { tool: 'Edit' }, { tool: 'Read' },
-    ])).toEqual(['Read', 'Edit', 'Read']);
-  });
-
-  it('skips info entries and entries with no tool name, and caps length', () => {
-    expect(toolSequenceFrom([{ type: 'info', tool: 'x', message: 'hi' } as any, { tool: undefined }, { tool: 'Read' }]))
-      .toEqual(['Read']);
-    const many = Array.from({ length: 40 }, (_, i) => ({ tool: `tool-${i}` }));
-    expect(toolSequenceFrom(many)).toHaveLength(TOOL_SEQUENCE_MAX);
-  });
-
-  it('returns an empty list for missing or empty input', () => {
-    expect(toolSequenceFrom(undefined)).toEqual([]);
-    expect(toolSequenceFrom([])).toEqual([]);
-  });
-});
 
 describe('isLowSignalTrace', () => {
   it('flags turns that neither said nor did anything', () => {

--- a/packages/core/src/skill-crystallizer.ts
+++ b/packages/core/src/skill-crystallizer.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { AideRunner, runAide } from './aide';
-import { TraceStep } from './playbook-induction';
+import { ArgShape, InducedTemplate, TraceStep, renderTemplate } from './playbook-induction';
 import { CodingAgent, CoreLogger, ModelConfig } from './types';
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -32,6 +32,17 @@ export interface SkillEntry {
   /** Promoted playbooks are backed by a durable agent SKILL.md and are never
    *  archived by either garbage collection or the playbook UI. */
   promotedToSkill?: boolean;
+  /** Inputs the procedure takes, discovered by diffing a cluster of runs.
+   *  Absent on skills distilled from prose rather than induced. */
+  parameters?: SkillParameter[];
+  /** Run ids the template was induced from — provenance for "why this?". */
+  inducedFrom?: string[];
+}
+
+export interface SkillParameter {
+  name: string;
+  kind: ArgShape['kind'];
+  ext?: string;
 }
 
 export interface RejectedSuggestion {
@@ -85,6 +96,10 @@ export interface DistillResult {
   description: string;
   whenToUse: string;
   steps: string;
+  /** Present when the suggestion came from an induced template rather than
+   *  from prose distillation. */
+  parameters?: SkillParameter[];
+  inducedFrom?: string[];
 }
 
 export interface SkillMatch {
@@ -199,6 +214,8 @@ export class SkillStore {
     steps: string;
     sourceRunId?: string;
     trigger?: { runId: string; promptSummary: string };
+    parameters?: SkillParameter[];
+    inducedFrom?: string[];
   }): SkillEntry {
     const now = Date.now();
     const existing = this.index.entries.find(e => e.name === params.name);
@@ -218,6 +235,10 @@ export class SkillStore {
       }
       existing.description = params.description;
       existing.whenToUse = params.whenToUse;
+      // A re-induction sees more runs than the first one did, so its parameter
+      // list supersedes the old one.
+      if (params.parameters) existing.parameters = params.parameters;
+      if (params.inducedFrom) existing.inducedFrom = params.inducedFrom;
       if (params.sourceRunId && !existing.sourceRunIds.includes(params.sourceRunId)) {
         existing.sourceRunIds.push(params.sourceRunId);
       }
@@ -238,6 +259,8 @@ export class SkillStore {
       sourceRunIds: params.sourceRunId ? [params.sourceRunId] : [],
       createdAt: now,
       archived: false,
+      ...(params.parameters?.length ? { parameters: params.parameters } : {}),
+      ...(params.inducedFrom?.length ? { inducedFrom: params.inducedFrom } : {}),
     };
     this.index.entries.push(entry);
     this.markIndexDirty();
@@ -655,6 +678,83 @@ export async function distillCandidate(
   return null;
 }
 
+// ── nameTemplate ───────────────────────────────────────────────────
+
+const NAME_TEMPLATE_PROMPT = `A recurring procedure was detected across %COUNT% runs by comparing what those runs actually did. Your job is only to NAME and DESCRIBE it — the recurrence is already established, so do not judge whether it is real.
+
+The procedure (tool calls in order; «name» marks an input that varied between runs):
+%TEMPLATE%
+
+Inputs it takes:
+%PARAMS%
+
+Existing skills (don't duplicate):
+%SKILLS%
+
+Previously rejected suggestions (the user said no — do NOT re-propose these or close variants):
+%REJECTED%
+
+Write the steps as prose a coding agent can follow, referring to inputs by their «name».
+
+Return ONE JSON object (no markdown, no prose) or the literal word "NONE" if this
+duplicates an existing skill:
+{
+  "name": "kebab-case",
+  "description": "one line describing what this skill does",
+  "whenToUse": "when the user asks to...",
+  "steps": "1. ...\\n2. ...\\n3. ..."
+}
+
+Rules:
+- name must match /^[a-z][a-z0-9-]*$/ and be 3-30 chars.
+- Output ONLY the JSON or "NONE". No markdown fences, no prose.`;
+
+/** Name a template that clustering already established.
+ *
+ *  The prompt carries tool names, argument keys, hosts, short literals and
+ *  slot names — no prompt text, no tool output, no user content. That is the
+ *  whole point of inducing the template first: the model sees an abstraction,
+ *  not the runs. */
+export async function nameTemplate(
+  deps: DistillDeps,
+  template: InducedTemplate,
+  existing: SkillEntry[],
+  rejected: RejectedSuggestion[],
+): Promise<DistillResult | null> {
+  const params = template.parameters.length
+    ? template.parameters.map(p => `- ${p.name}: ${p.ext ? `${p.kind} (.${p.ext})` : p.kind}`).join('\n')
+    : '(none — the procedure takes no varying input)';
+
+  const composed = fillPrompt(NAME_TEMPLATE_PROMPT, {
+    '%COUNT%': String(template.memberRunIds.length),
+    '%TEMPLATE%': renderTemplate(template),
+    '%PARAMS%': params,
+    '%SKILLS%': formatSkillsForPrompt(existing.filter(s => !s.archived)),
+    '%REJECTED%': formatRejectedForPrompt(rejected),
+  });
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const prompt = attempt === 0 ? composed
+      : `${composed}\n\nReminder: return ONLY the JSON object or the word "NONE". No markdown.`;
+    const output = await runCrystallizerLLM(deps, prompt);
+    if (output === null) {
+      deps.logger?.warn(`[skills] induction: naming call failed (attempt ${attempt + 1})`);
+      continue;
+    }
+    const parsed = tryParseDistill(output);
+    if (parsed && /^[a-z][a-z0-9-]*$/.test(parsed.name) && parsed.name.length >= 3 && parsed.name.length <= 30) {
+      deps.logger?.info(`[skills] induction: named "${parsed.name}" from ${template.memberRunIds.length} run(s)`);
+      return { ...parsed, parameters: template.parameters, inducedFrom: template.memberRunIds };
+    }
+    if (output.trim() === 'NONE') {
+      deps.logger?.info('[skills] induction: template duplicates an existing skill');
+      return null;
+    }
+  }
+  deps.logger?.warn('[skills] induction: no usable name after 2 attempts');
+  return null;
+}
+
 export function matchSkill(task: string, skills: SkillEntry[]): SkillMatch | null {
   const active = skills.filter(s => !s.archived);
   if (active.length === 0) return null;
@@ -726,8 +826,38 @@ export async function confirmMatch(
   return output.trim().toUpperCase() === 'YES';
 }
 
+/** Pull a value for one parameter out of the task text, or null.
+ *
+ *  Deliberately a cheap syntactic pass — no LLM. A wrong auto-bound value is
+ *  worse than an unfilled slot, because the agent can resolve the latter from
+ *  the task itself but will act confidently on the former. */
+export function bindParameter(task: string, param: SkillParameter): string | null {
+  if (param.kind === 'url') {
+    return task.match(/https?:\/\/[^\s<>"')]+/)?.[0] ?? null;
+  }
+  if (param.kind === 'path') {
+    const pattern = param.ext
+      ? new RegExp(`[\\w./-]+\\.${param.ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`)
+      : /[\w./-]*\/[\w./-]+/;
+    return task.match(pattern)?.[0] ?? null;
+  }
+  return null;
+}
+
+/** Prefix a task with the skill's procedure. Parameters the task plainly
+ *  supplies are bound; the rest stay as «name» for the agent to resolve. */
 export function applySkill(task: string, skill: SkillEntry): string {
-  const banner = `⚙︎ using skill: ${skill.name} (v${skill.version})\n\nFollow this procedure:\n${skill.steps}\n\n---\nNow execute this task:`;
+  let params = '';
+  if (skill.parameters?.length) {
+    const lines = skill.parameters.map(param => {
+      const bound = bindParameter(task, param);
+      return bound
+        ? `- «${param.name}» = ${bound}`
+        : `- «${param.name}» — determine from the task (${param.ext ? `${param.kind}, .${param.ext}` : param.kind})`;
+    });
+    params = `\n\nInputs:\n${lines.join('\n')}`;
+  }
+  const banner = `⚙︎ using skill: ${skill.name} (v${skill.version})\n\nFollow this procedure:\n${skill.steps}${params}\n\n---\nNow execute this task:`;
   return task ? `${banner} ${task}` : `${banner}\n\nProceed with the procedure above.`;
 }
 

--- a/packages/core/src/skill-crystallizer.ts
+++ b/packages/core/src/skill-crystallizer.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { AideRunner, runAide } from './aide';
+import { TraceStep } from './playbook-induction';
 import { CodingAgent, CoreLogger, ModelConfig } from './types';
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -56,6 +57,11 @@ export interface RunTrace {
    *  TOOL_SEQUENCE_MAX. A skill IS a procedure, so what the run did is the
    *  signal the distiller actually needs — the message text is context. */
   toolSequence?: string[];
+  /** The same calls with their arguments abstracted to shapes — the input to
+   *  procedure clustering. Values never appear here; see playbook-induction.ts.
+   *  Absent on traces recorded before schema v2 and on adapters that emit no
+   *  tool events (opencode, codex). */
+  steps?: TraceStep[];
   timestamp: number;
   mode: 'solo' | 'team-sequential' | 'team-parallel' | 'team-auto';
 }
@@ -89,6 +95,8 @@ export interface SkillMatch {
 }
 
 export const RECENT_TRACES_MAX = 20;
+/** Kept as the cap on the derived `toolSequence`; step extraction enforces the
+ *  same bound via MAX_STEPS. */
 export const TOOL_SEQUENCE_MAX = 12;
 export const HISTORY_MAX = 5;
 export const REJECTED_MAX = 20;
@@ -107,8 +115,13 @@ export interface SkillEvolutionEvent {
   steps: string;
 }
 
+/** v2 adds RunTrace.steps. v1 files load as-is — their traces simply have no
+ *  `steps`, and the window rolls over within RECENT_TRACES_MAX runs anyway, so
+ *  there is nothing worth migrating. */
+export const TRACES_FILE_VERSION = 2;
+
 interface TracesFile {
-  version: 1;
+  version: 1 | 2;
   traces: RunTrace[];
 }
 
@@ -161,7 +174,7 @@ export class SkillStore {
     if (fs.existsSync(this.tracesPath)) {
       try {
         const parsed = JSON.parse(fs.readFileSync(this.tracesPath, 'utf-8')) as TracesFile;
-        if (parsed && parsed.version === 1 && Array.isArray(parsed.traces)) {
+        if (parsed && (parsed.version === 1 || parsed.version === 2) && Array.isArray(parsed.traces)) {
           this.runTraces = parsed.traces.slice(0, RECENT_TRACES_MAX);
         }
       } catch { /* start with empty traces */ }
@@ -397,7 +410,7 @@ export class SkillStore {
     this.tracesDirty = false;
     // Serialize synchronously so later mutations in this tick can't tear the snapshot.
     const indexJson = writeIndex ? JSON.stringify(this.index, null, 2) : null;
-    const tracesPayload: TracesFile = { version: 1, traces: this.runTraces };
+    const tracesPayload: TracesFile = { version: TRACES_FILE_VERSION, traces: this.runTraces };
     const tracesJson = writeTraces ? JSON.stringify(tracesPayload, null, 2) : null;
     try {
       await fsp.mkdir(this.skillsDir, { recursive: true });
@@ -560,30 +573,6 @@ function tryParseDistill(raw: string): DistillResult | null {
   }
   return { name: p.name as string, description: p.description as string,
            whenToUse: p.whenToUse as string, steps: p.steps as string };
-}
-
-/** Collapse a run's tool activity into an ordered list of tool NAMES.
- *
- *  Names only, deliberately: tool inputs and outputs carry user content and
- *  file contents, and every crystallizer prompt goes to a tool-less runner
- *  precisely so that material stays out of a tool-capable session.
- *
- *  Accepts both shapes the gateway has on hand — the chat surface's
- *  ToolCallEntry (paired 'tool_start'/'tool_end' records) and the channel
- *  surface's ContextManager ToolCallRecord (one record per call, no `type`).
- *  Only the start half of a pair is counted so calls aren't doubled. */
-export function toolSequenceFrom(entries: { tool?: string; type?: string }[] | undefined): string[] {
-  if (!entries || entries.length === 0) return [];
-  const names: string[] = [];
-  for (const entry of entries) {
-    if (!entry.tool) continue;
-    if (entry.type === 'tool_end' || entry.type === 'info') continue;
-    // A loop over 20 files is one step in a procedure, not 20.
-    if (names[names.length - 1] === entry.tool) continue;
-    names.push(entry.tool);
-    if (names.length >= TOOL_SEQUENCE_MAX) break;
-  }
-  return names;
 }
 
 /** Bare acknowledgements, matched after trailing punctuation is stripped. */

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -127,11 +127,22 @@ export interface Chat {
   lastAskedOptions?: { messageId: string; options: string[] };
   /** Set when the skill distiller has proposed a new skill and is waiting for
    *  the user's "yes" / "no" / "rename <name>" reply. Cleared on any resolution. */
+  /** Mirrors DistillResult (skill-crystallizer). Inlined rather than imported
+   *  so this type module stays dependency-free; `parameters`/`inducedFrom` are
+   *  present only when the suggestion came from an induced template. */
   pendingSkillSuggestion?: {
     name: string;
     description: string;
     whenToUse: string;
     steps: string;
+    parameters?: {
+      name: string;
+      /** Mirrors ArgShape['kind'] — kept literal so a drift shows up as a type
+       *  error at the store.add call site rather than silently widening. */
+      kind: 'url' | 'path' | 'enum' | 'text' | 'number' | 'bool' | 'other';
+      ext?: string;
+    }[];
+    inducedFrom?: string[];
   };
   /**
    * Warm CLI session for this chat. When set, the next turn for the same

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'src/team-graph.test.ts',
       'src/judge.test.ts',
       'src/skill-crystallizer.test.ts',
+      'src/playbook-induction.test.ts',
       'src/aide-automation.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -75,6 +75,9 @@ export interface GatewayConfigJson {
     weakSkillDays?: number;
     /** Model override for distillation. Falls back to advisor.model. */
     distillModel?: string;
+    /** Suggest playbooks from clustered procedures instead of from an LLM's
+     *  impression of recent prompts. Off by default while thresholds settle. */
+    induction?: boolean;
   };
   /**
    * Global team library. Each entry maps a team name to its members + dispatch
@@ -377,6 +380,7 @@ export class ConfigManager extends EventEmitter {
   getSkillsConfig(): {
     enabled: boolean; suggestOnRepeat: number; autoApply: boolean;
     staleDays: number; weakSkillDays: number; distillModel: string | undefined;
+    induction: boolean;
   } {
     const raw = this.config.skills;
     return {
@@ -386,6 +390,10 @@ export class ConfigManager extends EventEmitter {
       staleDays: raw?.staleDays ?? 30,
       weakSkillDays: raw?.weakSkillDays ?? 7,
       distillModel: raw?.distillModel,
+      // Off by default: clustering thresholds are unfit guesses until they
+      // have been observed against real traces. Off still logs would-be
+      // clusters; on lets an induced template become a suggestion.
+      induction: raw?.induction ?? false,
     };
   }
 
@@ -656,6 +664,7 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
       staleDays: raw.skills.staleDays,
       weakSkillDays: raw.skills.weakSkillDays,
       distillModel: raw.skills.distillModel,
+      induction: raw.skills.induction,
     };
   }
   if (raw.advisor && typeof raw.advisor === 'object') {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ProcedureCluster, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -1422,6 +1422,9 @@ export class Codey {
             // If this upserts an existing skill (evolving its steps), record
             // what the user confirmed as the evolution's trigger.
             trigger: { runId: 'user-confirmed', promptSummary: pendingSkill.description },
+            // Present only when the suggestion came from an induced template.
+            parameters: pendingSkill.parameters,
+            inducedFrom: pendingSkill.inducedFrom,
           });
           this.pendingSkillSuggestions.delete(pendingSkillKey);
           await this.sendResponse({
@@ -2286,25 +2289,45 @@ export class Codey {
    *  so it runs in log-only mode until there are real traces to fit them
    *  against. Pure computation over at most RECENT_TRACES_MAX traces.
    *  See docs/superpowers/specs/2026-07-28-playbook-induction-design.md. */
-  private logProcedureClusters(store: SkillStore, minMembers: number): void {
+  private logProcedureClusters(store: SkillStore, minMembers: number): ProcedureCluster | null {
     try {
-      const report = clusterProcedures(store.getRecentTraces(RECENT_TRACES_MAX), { minMembers });
+      const traces = store.getRecentTraces(RECENT_TRACES_MAX);
+      const report = clusterProcedures(traces, { minMembers });
       if (report.clusters.length === 0) {
         this.logger.debug(
           `[skills] induction: no cluster — ${report.withoutSteps} without steps, ` +
           `${report.tooShort} too short, ${report.tooFewMembers} not recurring yet, ` +
           `${report.rejectedByDistinctiveness} too generic`);
-        return;
+        return null;
       }
       for (const cluster of report.clusters) {
         this.logger.info(
-          `[skills] induction: would cluster ${cluster.runIds.length} run(s) — ` +
+          `[skills] induction: clustered ${cluster.runIds.length} run(s) — ` +
           `${cluster.signature.join(' → ')} (distinctiveness ${cluster.distinctiveness.toFixed(2)}, ` +
           `score ${cluster.score.toFixed(2)})`);
       }
+      return report.clusters[0];
     } catch (err) {
       this.logger.warn(`[skills] induction pass failed: ${err}`);
+      return null;
     }
+  }
+
+  /** Turn the winning cluster into a named, parameterized suggestion. Returns
+   *  null whenever induction has nothing to offer, so the caller falls back to
+   *  prose distillation. */
+  private async induceSuggestion(
+    store: SkillStore,
+    cluster: ProcedureCluster,
+  ): Promise<DistillResult | null> {
+    const byId = new Map(store.getRecentTraces(RECENT_TRACES_MAX).map(t => [t.runId, t]));
+    const members = cluster.runIds.map(id => byId.get(id)).filter((t): t is RunTrace => !!t);
+    const template = induceTemplate(members);
+    if (!template) {
+      this.logger.debug('[skills] induction: cluster produced no template');
+      return null;
+    }
+    return nameTemplate(this.getSkillDistillDeps(), template, store.getAll(), store.getRejected());
   }
 
   /** Shared post-run skill pass for both surfaces. Never rejects — every LLM
@@ -2368,7 +2391,7 @@ export class Codey {
       }
 
       store.recordTrace(opts.trace);
-      this.logProcedureClusters(store, cfg.suggestOnRepeat);
+      const cluster = this.logProcedureClusters(store, cfg.suggestOnRepeat);
 
       this.skillRunCounter++;
       if (this.skillRunCounter % Codey.SKILL_GC_EVERY_N_RUNS === 1) {
@@ -2393,9 +2416,14 @@ export class Codey {
             return;
           }
           this.lastSkillDistillTime = now;
-          const candidate = await distillCandidate(
-            this.getSkillDistillDeps(), recent, store.getAll(), store.getRejected(), cfg.suggestOnRepeat,
-          );
+          // A clustered procedure is evidence; a prose pattern is an
+          // impression. Prefer the former when induction is on, and fall back
+          // to distillation when there is no cluster or naming came up empty.
+          const candidate =
+            (cfg.induction && cluster ? await this.induceSuggestion(store, cluster) : null)
+            ?? await distillCandidate(
+              this.getSkillDistillDeps(), recent, store.getAll(), store.getRejected(), cfg.suggestOnRepeat,
+            );
           if (candidate) {
             opts.setPending(candidate);
             await opts.notify(
@@ -4984,7 +5012,9 @@ Example: /model gpt-4.1 write a Python script`;
                       steps: s.steps, sourceRunId: 'user-confirmed',
                       // If this upserts an existing skill (evolving its steps),
                       // record what the user confirmed as the trigger.
-                      trigger: { runId: 'user-confirmed', promptSummary: s.description } });
+                      trigger: { runId: 'user-confirmed', promptSummary: s.description },
+                      // Present only when the suggestion came from an induced template.
+                      parameters: s.parameters, inducedFrom: s.inducedFrom });
           responseText = `✅ Skill **${name}** saved. It will be auto-applied on matching tasks.`;
         }
         this.chatManager.setPendingSkillSuggestion(chatId, null);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, toolSequenceFrom, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -1741,12 +1741,15 @@ export class Codey {
 
     // ── Skills: post-run pass (fire-and-forget — never blocks the reply) ──
     if (skillsCfg?.enabled) {
+      // What the run DID — the procedure clustering and the distiller work on.
+      // Argument VALUES stay here; only their shapes reach the trace file.
+      const steps = stepsFrom(meta.toolCalls);
       const trace: RunTrace = {
         runId: `solo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         promptSummary: parsed.prompt.slice(0, 200),
         outputPreview: (response.output || '').slice(0, 300),
-        // What the run DID — the procedure the distiller pattern-matches on.
-        toolSequence: toolSequenceFrom(meta.toolCalls),
+        steps,
+        toolSequence: steps.map(s => s.tool),
         timestamp: Date.now(),
         mode: 'solo',
       };
@@ -2278,6 +2281,32 @@ export class Codey {
     return codeyChatId ? this.chatManager.get(codeyChatId)?.workspaceName : undefined;
   }
 
+  /** Procedure clustering, observation only — it proposes nothing and changes
+   *  no behavior. Its thresholds are guesses with no ground truth behind them,
+   *  so it runs in log-only mode until there are real traces to fit them
+   *  against. Pure computation over at most RECENT_TRACES_MAX traces.
+   *  See docs/superpowers/specs/2026-07-28-playbook-induction-design.md. */
+  private logProcedureClusters(store: SkillStore, minMembers: number): void {
+    try {
+      const report = clusterProcedures(store.getRecentTraces(RECENT_TRACES_MAX), { minMembers });
+      if (report.clusters.length === 0) {
+        this.logger.debug(
+          `[skills] induction: no cluster — ${report.withoutSteps} without steps, ` +
+          `${report.tooShort} too short, ${report.tooFewMembers} not recurring yet, ` +
+          `${report.rejectedByDistinctiveness} too generic`);
+        return;
+      }
+      for (const cluster of report.clusters) {
+        this.logger.info(
+          `[skills] induction: would cluster ${cluster.runIds.length} run(s) — ` +
+          `${cluster.signature.join(' → ')} (distinctiveness ${cluster.distinctiveness.toFixed(2)}, ` +
+          `score ${cluster.score.toFixed(2)})`);
+      }
+    } catch (err) {
+      this.logger.warn(`[skills] induction pass failed: ${err}`);
+    }
+  }
+
   /** Shared post-run skill pass for both surfaces. Never rejects — every LLM
    *  stage is isolated in its own try/catch so call sites can be a bare
    *  `void this.afterRunSkillPass(...)` without a `.catch`. */
@@ -2339,6 +2368,7 @@ export class Codey {
       }
 
       store.recordTrace(opts.trace);
+      this.logProcedureClusters(store, cfg.suggestOnRepeat);
 
       this.skillRunCounter++;
       if (this.skillRunCounter % Codey.SKILL_GC_EVERY_N_RUNS === 1) {
@@ -5457,13 +5487,16 @@ Example: /model gpt-4.1 write a Python script`;
               .filter(m => m.teamTurnId === teamTurnId && m.worker)
               .map(m => m.worker as string)
           : undefined;
+        // What the run DID — the procedure clustering and the distiller work
+        // on. Argument VALUES stay here; only their shapes reach the trace file.
+        const steps = stepsFrom(toolCalls);
         const chatTrace: RunTrace = {
           runId: `chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
           promptSummary: userText.slice(0, 200),
           outputPreview: (output || '').slice(0, 300),
           workerSequence: workerSequence && workerSequence.length > 0 ? workerSequence : undefined,
-          // What the run DID — the procedure the distiller pattern-matches on.
-          toolSequence: toolSequenceFrom(toolCalls),
+          steps,
+          toolSequence: steps.map(s => s.tool),
           timestamp: Date.now(),
           mode: teamTurnId ? 'team-sequential' : 'solo',
         };


### PR DESCRIPTION
Follow-up to #194. Design doc plus its full implementation, behind `skills.induction` (off by default).

## Why

#194 fixed what the distiller could *see*. It did not change how recurrence is *decided*: one LLM call is shown a 7-item list and asked whether anything repeats — no comparison, no similarity measure, no clustering. And since `SkillEntry` had no parameter concept, a distilled skill could only describe one specific instance of the work.

## The criterion

> If several runs produce similar output through a similar procedure, and the only thing that varies is the input, that is a playbook — and the varying inputs are its parameters.

Decidable in code. Detection becomes a computation; the LLM is left to name a cluster that code already established.

## What's implemented

**Trace schema v2** — `RunTrace.steps` records each tool call with arguments abstracted to *shapes*: a URL keeps only its host, a path keeps extension and depth, short identifiers are compared literally, long text becomes a bucketed length. Raw values never reach `traces.json` or a prompt — the boundary that exists because crystallizer prompts run on a tool-less runner. A test asserts no raw value survives serialization. v1 files load unchanged.

**Clustering** — weighted-LCS over tool sequences (subsequence, not set overlap: order is part of a procedure), gated on procedure length, cluster size, and distinctiveness. Reports *why* nothing clustered, so "no playbook yet" has a number behind it.

**Template induction** — diffs a cluster's argument shapes: constants bake into the step, varying arguments become named slots. It runs over what's already persisted, so raw values turned out never to be needed — the shapes carry the distinction.

**Naming** — one LLM call over an established procedure ("name this", not "spot a pattern"). The prompt carries tool names, argument keys, hosts and slot names. No prompt text, no tool output, no user content.

**Parameterized skills** — `SkillEntry.parameters` + `inducedFrom`. `applySkill` binds a slot the task plainly supplies (URL, path by extension) with a cheap syntactic pass, and otherwise leaves `«name»` for the agent to resolve. It never invents a value: a wrong auto-bound value is worse than an unfilled slot, because the agent can resolve the latter from the task but will act confidently on the former.

## Two deviations from the spec, both worth a look

**Distinctiveness uses rarity (`1 - frequency`), not idf.** The spec said `ln(total / (1 + containing))`, which is unusable at these window sizes: a procedure repeated twice in a 4-run window scores 0.29 and reads as "common" — rejecting exactly the clusters worth finding. Rarity means the same thing at every window size. Its denominator counts every run considered, including ones that observed no tools, so a procedure isn't judged ubiquitous for being the only observable thing in the window.

**Only `url` and `enum` shapes can produce a constant.** The other shapes don't retain an identifying value, so "same shape" is not "same value" — two `text` arguments in the same length bucket are not the same text, and two `.ts` paths are not the same file. Treating those as constants would bake one run's content into the playbook. They are always slots.

The spec was updated in place with both, rather than left to diverge.

## Rollout

`skills.induction` defaults to **off**: the thresholds (0.7 similarity, 3-tool minimum, 0.4 distinctiveness) are guesses with no ground truth. Off still logs would-be clusters, so they can be fit against real traces first. Turning it on makes an induced template the suggestion, with prose distillation as the fallback when there's no cluster or no usable name.

Note that distinctiveness needs a corpus: early on, real clusters will be withheld for looking too common. That's expected, and is itself the argument for observing before enabling.

## Testing

`npm test` — core 263, gateway 173, codey-mac 314, all passing. `tsc` clean, lint clean.

New tests cover shape extraction and its redaction guarantee; clustering (distinctive procedures cluster, `Read → Edit → Bash` in every run does not, short procedures rejected, a small distinctive cluster outranks a larger generic one, team runs cluster on worker names); induction (constants vs slots, same-length text and same-extension paths stay slots, steps dropped where tools disagree, slot-name collisions, arguments only some members supplied); naming (parameters carried onto the result, `NONE` handling, invalid names); parameter binding (bound when supplied, left unfilled otherwise); and v1→v2 trace persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)