### PR TITLE
Turn playbook induction on by default

### DIFF
--- a/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
+++ b/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
@@ -1,7 +1,7 @@
 # Playbook Induction — Design
 
 Date: 2026-07-28
-Status: Implemented behind `skills.induction` (off by default); thresholds unfit
+Status: Implemented; on by default via `skills.induction`
 
 ## Problem
 

--- a/packages/core/src/skill-crystallizer.test.ts
+++ b/packages/core/src/skill-crystallizer.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { InducedTemplate } from './playbook-induction';
-import { SkillStore, RECENT_TRACES_MAX, TRACES_FILE_VERSION, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, bindParameter, nameTemplate, evolveSkill, isLowSignalTrace } from './skill-crystallizer';
+import { SkillStore, RECENT_TRACES_MAX, TRACES_FILE_VERSION, HISTORY_MAX, REJECTED_MAX, EVOLUTION_MAX, distillCandidate, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, SkillEntry, SkillEvolutionEvent, applySkill, bindParameter, nameTemplate, evolveSkill, isLowSignalTrace } from './skill-crystallizer';
 
 describe('SkillStore', () => {
   let tmp: string;
@@ -707,19 +707,21 @@ describe('nameTemplate', () => {
         name: 'x-outreach', description: 'Comment on AI posts', whenToUse: 'user asks to comment', steps: '1. open «comment»',
       }), error: null, tokens: { total: 10 } };
     });
-    const result = await nameTemplate(deps, template, [], []);
-    expect(result!.name).toBe('x-outreach');
-    expect(result!.parameters).toEqual(template.parameters);
-    expect(result!.inducedFrom).toEqual(['r1', 'r2']);
+    const result = await nameTemplate(deps, template, [], []) as DistillResult;
+    expect(result.name).toBe('x-outreach');
+    expect(result.parameters).toEqual(template.parameters);
+    expect(result.inducedFrom).toEqual(['r1', 'r2']);
     // The prompt states the recurrence rather than asking the model to judge it.
     expect(prompt).toContain('2 runs');
     expect(prompt).toContain('browser_navigate(url=x.com)');
     expect(prompt).toContain('comment=«comment»');
   });
 
-  it('returns null when the model says the template duplicates a skill', async () => {
+  it('reports a duplicate distinctly from having nothing to offer', async () => {
+    // 'duplicate' must not read as "induction failed" — the caller uses it to
+    // stay quiet rather than fall back to prose distillation.
     const deps = fakeDeps(async () => ({ success: true, output: 'NONE', error: null, tokens: { total: 5 } }));
-    expect(await nameTemplate(deps, template, [], [])).toBeNull();
+    expect(await nameTemplate(deps, template, [], [])).toBe('duplicate');
   });
 
   it('returns null on an invalid name after retrying', async () => {

--- a/packages/core/src/skill-crystallizer.ts
+++ b/packages/core/src/skill-crystallizer.ts
@@ -720,7 +720,7 @@ export async function nameTemplate(
   template: InducedTemplate,
   existing: SkillEntry[],
   rejected: RejectedSuggestion[],
-): Promise<DistillResult | null> {
+): Promise<DistillResult | 'duplicate' | null> {
   const params = template.parameters.length
     ? template.parameters.map(p => `- ${p.name}: ${p.ext ? `${p.kind} (.${p.ext})` : p.kind}`).join('\n')
     : '(none — the procedure takes no varying input)';
@@ -747,8 +747,11 @@ export async function nameTemplate(
       return { ...parsed, parameters: template.parameters, inducedFrom: template.memberRunIds };
     }
     if (output.trim() === 'NONE') {
+      // Distinct from null: the procedure IS established, it just already has
+      // a skill. Falling back to prose distillation here would propose
+      // something else in spite of that signal.
       deps.logger?.info('[skills] induction: template duplicates an existing skill');
-      return null;
+      return 'duplicate';
     }
   }
   deps.logger?.warn('[skills] induction: no usable name after 2 attempts');

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -76,7 +76,7 @@ export interface GatewayConfigJson {
     /** Model override for distillation. Falls back to advisor.model. */
     distillModel?: string;
     /** Suggest playbooks from clustered procedures instead of from an LLM's
-     *  impression of recent prompts. Off by default while thresholds settle. */
+     *  impression of recent prompts. On by default; set false to disable. */
     induction?: boolean;
   };
   /**
@@ -390,10 +390,12 @@ export class ConfigManager extends EventEmitter {
       staleDays: raw?.staleDays ?? 30,
       weakSkillDays: raw?.weakSkillDays ?? 7,
       distillModel: raw?.distillModel,
-      // Off by default: clustering thresholds are unfit guesses until they
-      // have been observed against real traces. Off still logs would-be
-      // clusters; on lets an induced template become a suggestion.
-      induction: raw?.induction ?? false,
+      // On by default. The gates (3+ distinct tools, 2+ members, 0.4
+      // distinctiveness) all err toward finding nothing, the suggestion still
+      // needs the user's "yes", and a "no" is remembered — so the cost of a
+      // bad cluster is one dismissed message. Set false to fall back to prose
+      // distillation; clustering still logs either way.
+      induction: raw?.induction ?? true,
     };
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2319,7 +2319,7 @@ export class Codey {
   private async induceSuggestion(
     store: SkillStore,
     cluster: ProcedureCluster,
-  ): Promise<DistillResult | null> {
+  ): Promise<DistillResult | 'duplicate' | null> {
     const byId = new Map(store.getRecentTraces(RECENT_TRACES_MAX).map(t => [t.runId, t]));
     const members = cluster.runIds.map(id => byId.get(id)).filter((t): t is RunTrace => !!t);
     const template = induceTemplate(members);
@@ -2417,13 +2417,16 @@ export class Codey {
           }
           this.lastSkillDistillTime = now;
           // A clustered procedure is evidence; a prose pattern is an
-          // impression. Prefer the former when induction is on, and fall back
-          // to distillation when there is no cluster or naming came up empty.
-          const candidate =
-            (cfg.induction && cluster ? await this.induceSuggestion(store, cluster) : null)
-            ?? await distillCandidate(
-              this.getSkillDistillDeps(), recent, store.getAll(), store.getRejected(), cfg.suggestOnRepeat,
-            );
+          // impression. Prefer the former, and fall back to distillation only
+          // when induction found nothing — NOT when it found a procedure that
+          // already has a skill, which is a reason to stay quiet.
+          const induced = cfg.induction && cluster
+            ? await this.induceSuggestion(store, cluster)
+            : null;
+          if (induced === 'duplicate') return;
+          const candidate = induced ?? await distillCandidate(
+            this.getSkillDistillDeps(), recent, store.getAll(), store.getRejected(), cfg.suggestOnRepeat,
+          );
           if (candidate) {
             opts.setPending(candidate);
             await opts.notify(


### PR DESCRIPTION
Follow-up to #195, which shipped induction behind `skills.induction` defaulting to **off**.

## Default flipped to on

A flag nobody flips means the feature doesn't exist for anyone who doesn't read the source — and the original reason for keeping it off (thresholds are unfit guesses) argues for a cheap failure mode, not for silence. The failure mode is cheap:

- Every gate errs toward finding nothing (3+ distinct tools, 2+ members, 0.4 distinctiveness). A bad threshold produces silence, not noise.
- A suggestion still needs the user's explicit "yes" before anything is saved.
- A "no" goes into the `rejected` list and is fed back to the prompt, so it isn't re-proposed.
- Prose distillation remains the fallback, so the worst case is the behavior we already had.

The flag stays as an off switch rather than being removed: if a cluster does turn noisy, the remedy shouldn't be a code change.

## Also: stay quiet on a duplicate

`nameTemplate` returning `NONE` means "this procedure already has a skill". The gateway was treating that identically to "induction found nothing" and falling back to prose distillation — proposing something else in spite of the signal it had just received.

`nameTemplate` now returns `'duplicate'` distinctly from `null`, and the caller returns without suggesting. Fallback to distillation happens only when induction genuinely found nothing.

## Testing

`npm test` — core 263, gateway 173, codey-mac 314, all passing. `tsc` clean, lint clean. The `nameTemplate` duplicate test now asserts the distinct return value rather than `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)