### PR TITLE
Stop swallowing opencode and codex tool events

### DIFF
--- a/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
+++ b/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
@@ -58,10 +58,29 @@ true for the default agent:
   The chat surface collects these into `ToolCallEntry[]` and persists them on
   the assistant message; the channel surface gets the same via
   `ContextManager.extractMeta`.
-- **opencode** and **codex** emit no tool events at all.
+- **opencode** emits `tool_use` events (`run --format json`).
+- **codex** emits `item.started` / `item.completed` (`exec --json`) whose item
+  types include `command_execution`, `file_change`, `mcp_tool_call` and
+  `web_search`.
 
-So tool observability is per-adapter, and the design must degrade rather than
-assume. See "Degradation" below.
+> Corrected 2026-07-28. This section first claimed opencode and codex emit no
+> tool events. They do; three gaps on our side were swallowing them, and all
+> three are now fixed:
+>
+> 1. Neither adapter called `request.onStatus`, so the chat/Mac surface — which
+>    builds `toolCalls` from that callback — saw nothing.
+> 2. `extractMeta` paired only `running` -> `done`. Both CLIs report
+>    `completed` / `failed`, matching neither branch, so the channel surface
+>    dropped them too.
+> 3. The codex adapter keyed on `tool_use` / `tool_call` / `shell_command`,
+>    which current codex does not emit.
+>
+> A shared `ToolCallCollector` now normalizes all three dialects. Both CLIs
+> report a tool once, already finished, so it synthesizes the start event that
+> downstream consumers key the procedure off.
+
+Tool observability is still per-adapter — any future CLI that reports nothing
+degrades the same way — so the design keeps the fallback below.
 
 ## Decisions
 
@@ -267,12 +286,18 @@ skills without parameters.
 
 ## 6. Degradation
 
-- **No tool events (opencode, codex):** traces have empty `steps`. Clustering
-  finds nothing, logs "no procedure data", and the existing LLM-only
-  `distillCandidate` runs as today. Users on those adapters keep current
-  behavior; users on claude-code get induction.
+- **No tool events:** traces have empty `steps`. Clustering finds nothing, logs
+  "no procedure data", and the existing LLM-only `distillCandidate` runs as
+  today. This is now the path for a CLI that reports nothing at all, rather
+  than for opencode and codex specifically.
 - **Mixed adapters in one workspace:** cluster only over traces that have
   steps. A trace with no steps never joins a cluster.
+- **Tool granularity differs by adapter.** claude-code names the tool
+  (`Read`, `Edit`); codex names the kind of work (`command_execution`,
+  `file_change`), keeping an MCP call's own `server.tool` identity. Procedures
+  therefore cluster within an adapter far more readily than across adapters.
+  Acceptable — a workspace usually has one — but it means the rarity
+  denominator mixes vocabularies when it does not.
 - **Team runs:** `workerSequence` is a procedure at a coarser grain. Treat a
   worker name as a pseudo-tool so team runs cluster on the same machinery.
 

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'crypto';
 import { AgentRequest, AgentResponse, AgentStateEntry } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
+import { ToolCallCollector } from './tool-events';
 import { codexMcpArgs } from './mcp-config';
 
 /**
@@ -30,6 +31,68 @@ interface CodexEvent {
     total_tokens?: number;
   };
   error?: { message?: string };
+  // item.started / item.updated / item.completed carry the work in `item`.
+  item?: CodexItem;
+}
+
+/** The unit of work in codex's current event stream. `type` names the kind of
+ *  work, which is what stands in for a tool name here. */
+export interface CodexItem {
+  id?: string;
+  type?: string;
+  status?: string;
+  // command_execution
+  command?: string;
+  aggregated_output?: string;
+  exit_code?: number;
+  // file_change
+  path?: string;
+  changes?: unknown;
+  // mcp_tool_call
+  server?: string;
+  tool?: string;
+  arguments?: Record<string, unknown>;
+  result?: unknown;
+  // web_search
+  query?: string;
+}
+
+/** Item types that represent the agent DOING something, as opposed to saying
+ *  something. Anything else on an item.* event is ignored. */
+export const CODEX_TOOL_ITEMS = new Set(['command_execution', 'file_change', 'mcp_tool_call', 'web_search']);
+
+/** Name, input: what a codex item looks like as a tool call. An mcp tool keeps
+ *  its own identity ("server.tool") — those are the distinctive ones for
+ *  procedure clustering, so collapsing them all to "mcp_tool_call" would throw
+ *  away the signal. */
+export function codexItemAsTool(item: CodexItem): { tool: string; input?: Record<string, unknown>; output?: unknown } | null {
+  switch (item.type) {
+    case 'command_execution':
+      return {
+        tool: 'command_execution',
+        ...(item.command ? { input: { command: item.command } } : {}),
+        output: item.aggregated_output,
+      };
+    case 'file_change':
+      return {
+        tool: 'file_change',
+        ...(item.path ? { input: { path: item.path } } : {}),
+        output: item.changes,
+      };
+    case 'mcp_tool_call':
+      return {
+        tool: item.server && item.tool ? `${item.server}.${item.tool}` : (item.tool ?? 'mcp_tool_call'),
+        ...(item.arguments ? { input: item.arguments } : {}),
+        output: item.result,
+      };
+    case 'web_search':
+      return {
+        tool: 'web_search',
+        ...(item.query ? { input: { query: item.query } } : {}),
+      };
+    default:
+      return null;
+  }
 }
 
 /**
@@ -99,8 +162,11 @@ export class CodexAdapter extends BaseAgentAdapter {
       let capturedThreadId: string | undefined;
       let streamedText = '';
       let errorMessage: string | undefined;
-      const statusUpdates: string[] = [];
-      const states: AgentStateEntry[] = [];
+      // codex reports finished work, so the collector synthesizes the
+      // tool_start the chat surface needs to see a procedure.
+      const tools = new ToolCallCollector(request.onStatus);
+      const statusUpdates = tools.statusUpdates;
+      const states = tools.states;
 
       const safeResolve = (response: AgentResponse) => {
         if (resolved) return;
@@ -127,13 +193,30 @@ export class CodexAdapter extends BaseAgentAdapter {
               request.onStream?.(event.text);
             }
             break;
+          case 'item.started':
+          case 'item.updated':
+          case 'item.completed': {
+            // The current codex surface: work is reported as items, and only
+            // some item types are tool activity.
+            if (!event.item || !CODEX_TOOL_ITEMS.has(event.item.type ?? '')) break;
+            const asTool = codexItemAsTool(event.item);
+            if (!asTool) break;
+            tools.record({
+              ...asTool,
+              key: event.item.id ?? asTool.tool,
+              phase: event.type === 'item.started' ? 'start' : 'end',
+              status: event.item.status,
+            });
+            break;
+          }
           case 'tool_use':
           case 'tool_call':
           case 'shell_command':
+            // Older codex builds. Kept because these event names shipped for a
+            // while and cost nothing to keep accepting.
             if (event.name || event.status) {
-              statusUpdates.push(`${event.name ?? 'tool'}: ${event.status ?? 'running'}`);
-              states.push({
-                source: event.name ?? 'tool',
+              tools.record({
+                tool: event.name ?? 'tool',
                 status: event.status,
                 input: event.input,
                 output: event.output,
@@ -168,6 +251,7 @@ export class CodexAdapter extends BaseAgentAdapter {
       });
 
       childProcess.on('close', (code: number | null) => {
+        tools.finish();
         // Drain any leftover line.
         if (buffer.trim().startsWith('{')) {
           try { handleEvent(JSON.parse(buffer.trim()) as CodexEvent); } catch { /* ignore */ }

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -29,6 +29,7 @@ interface CodexEvent {
     input_tokens?: number;
     output_tokens?: number;
     total_tokens?: number;
+    cached_input_tokens?: number;
   };
   error?: { message?: string };
   // item.started / item.updated / item.completed carry the work in `item`.
@@ -44,7 +45,7 @@ export interface CodexItem {
   // command_execution
   command?: string;
   aggregated_output?: string;
-  exit_code?: number;
+  exit_code?: number | null;
   // file_change
   path?: string;
   changes?: unknown;
@@ -162,6 +163,7 @@ export class CodexAdapter extends BaseAgentAdapter {
       let capturedThreadId: string | undefined;
       let streamedText = '';
       let errorMessage: string | undefined;
+      let tokens: AgentResponse['tokens'];
       // codex reports finished work, so the collector synthesizes the
       // tool_start the chat surface needs to see a procedure.
       const tools = new ToolCallCollector(request.onStatus);
@@ -223,11 +225,19 @@ export class CodexAdapter extends BaseAgentAdapter {
               });
             }
             break;
+          case 'turn.completed':
+            // Observed on a real run: usage carries input/output (and
+            // cached_input_tokens) but no total, so total is derived.
+            if (event.usage) {
+              const input = event.usage.input_tokens ?? 0;
+              const output = event.usage.output_tokens ?? 0;
+              tokens = { input, output, total: event.usage.total_tokens ?? input + output };
+            }
+            break;
           case 'turn.failed':
           case 'error':
             errorMessage = event.error?.message ?? event.message ?? 'Codex turn failed';
             break;
-          // 'turn.started' / 'turn.completed' carry no text we need here.
         }
       };
 
@@ -274,6 +284,7 @@ export class CodexAdapter extends BaseAgentAdapter {
           output,
           error: errorMessage ?? (code !== 0 ? (stderr.trim() || `Codex exited with code ${code}`) : undefined),
           duration,
+          tokens,
           statusUpdates,
           states,
           sessionId: capturedThreadId,

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -3,9 +3,9 @@ import { AgentRequest, AgentResponse } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
 import { writeOpenCodeMcpConfig } from './mcp-config';
-import { ToolCallCollector } from './tool-events';
+import { ObservedToolEvent, ToolCallCollector } from './tool-events';
 
-interface OpenCodeEvent {
+export interface OpenCodeEvent {
   type: string;
   sessionID?: string;
   part?: {
@@ -30,6 +30,24 @@ interface OpenCodeEvent {
         write: number;
       };
     };
+  };
+}
+
+/** Map one opencode `tool_use` part onto an observed tool event.
+ *
+ *  Verified against a real `run --format json` stream (opencode 1.14.18):
+ *  the part carries `tool`, `callID`, and a `state` holding status, input and
+ *  output. Only terminal states are reported — there is no "running" event —
+ *  which is why ToolCallCollector synthesizes the start. */
+export function opencodeToolEvent(part: NonNullable<OpenCodeEvent['part']>): ObservedToolEvent | null {
+  if (!part.state) return null;
+  return {
+    tool: part.tool || 'tool_use',
+    // callID identifies the call; `id` is absent on tool parts.
+    key: part.callID ?? part.id ?? part.tool,
+    status: part.state.status,
+    input: part.state.input,
+    output: part.state.output,
   };
 }
 
@@ -138,14 +156,9 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
               request.onStream?.(event.part.text);
             }
 
-            if (event.type === 'tool_use' && event.part?.state) {
-              tools.record({
-                tool: event.part.tool || 'tool_use',
-                key: event.part.id ?? event.part.callID ?? event.part.tool,
-                status: event.part.state.status,
-                input: event.part.state.input,
-                output: event.part.state.output,
-              });
+            if (event.type === 'tool_use' && event.part) {
+              const observed = opencodeToolEvent(event.part);
+              if (observed) tools.record(observed);
             }
           } catch {
             // Not JSON, skip

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -3,6 +3,7 @@ import { AgentRequest, AgentResponse } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
 import { writeOpenCodeMcpConfig } from './mcp-config';
+import { ToolCallCollector } from './tool-events';
 
 interface OpenCodeEvent {
   type: string;
@@ -12,6 +13,8 @@ interface OpenCodeEvent {
     text?: string;
     reason?: string;
     tool?: string;
+    id?: string;
+    callID?: string;
     state?: {
       status?: string;
       input?: Record<string, unknown>;
@@ -94,8 +97,11 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       let resolved = false;
       let allData = '';
       let stderr = '';
-      const statusUpdates: string[] = [];
-      const states: NonNullable<AgentResponse['states']> = [];
+      // opencode reports a tool once it has finished, so the collector
+      // synthesizes the tool_start the chat surface needs to see a procedure.
+      const tools = new ToolCallCollector(request.onStatus);
+      const statusUpdates = tools.statusUpdates;
+      const states = tools.states;
       // Captured from the top-level `sessionID` field present on every event
       // (e.g. `step_start`, `text`, `step_finish`). The first event we see
       // tells us which session OpenCode opened so the gateway can resume it.
@@ -133,12 +139,9 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
             }
 
             if (event.type === 'tool_use' && event.part?.state) {
-              const toolName = event.part.tool || 'tool_use';
-              if (event.part.state.status) {
-                statusUpdates.push(`${toolName}: ${event.part.state.status}`);
-              }
-              states.push({
-                source: toolName,
+              tools.record({
+                tool: event.part.tool || 'tool_use',
+                key: event.part.id ?? event.part.callID ?? event.part.tool,
                 status: event.part.state.status,
                 input: event.part.state.input,
                 output: event.part.state.output,
@@ -156,6 +159,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
 
       // Process close - collect remaining buffer and resolve
       childProcess.on('close', (code: number | null) => {
+        tools.finish();
         // Process remaining buffer
         if (buffer.trim()) {
           try {

--- a/packages/core/src/agents/tool-events.test.ts
+++ b/packages/core/src/agents/tool-events.test.ts
@@ -136,3 +136,50 @@ describe('codexItemAsTool', () => {
     expect(codexItemAsTool({})).toBeNull();
   });
 });
+
+describe('codex item events, against a real captured stream', () => {
+  // Verbatim from `codex exec --json` (codex-cli 0.145.0, 2026-07-28) for the
+  // prompt "Run the shell command 'ls -la' and then read note.txt". Trimmed
+  // only in aggregated_output length.
+  const CAPTURED = [
+    { type: 'thread.started', thread_id: '019fab77-6d2d-7690-927f-85d56a0f8816' },
+    { type: 'turn.started' },
+    { type: 'item.completed', item: { id: 'item_0', type: 'agent_message', text: 'I will inspect the directory.' } },
+    { type: 'item.started', item: { id: 'item_1', type: 'command_execution', command: '/bin/zsh -lc "ls -la"', aggregated_output: '', exit_code: null, status: 'in_progress' } },
+    { type: 'item.completed', item: { id: 'item_1', type: 'command_execution', command: '/bin/zsh -lc "ls -la"', aggregated_output: 'total 24\ndrwxr-xr-x 7 ...', exit_code: 0, status: 'completed' } },
+    { type: 'item.completed', item: { id: 'item_2', type: 'agent_message', text: 'The directory contains seven entries.' } },
+    { type: 'turn.completed', usage: { input_tokens: 40554, output_tokens: 139 } },
+  ];
+
+  it('yields exactly one paired tool call and ignores agent messages', () => {
+    const updates: StatusUpdate[] = [];
+    const tools = new ToolCallCollector(u => updates.push(u));
+    for (const event of CAPTURED) {
+      if (!event.type.startsWith('item.')) continue;
+      const item = event.item!;
+      if (!CODEX_TOOL_ITEMS.has(item.type ?? '')) continue;
+      const asTool = codexItemAsTool(item);
+      if (!asTool) continue;
+      tools.record({
+        ...asTool,
+        key: item.id ?? asTool.tool,
+        phase: event.type === 'item.started' ? 'start' : 'end',
+        status: item.status,
+      });
+    }
+    tools.finish();
+
+    // Two agent_message items must not become tool calls.
+    expect(updates.map(u => u.type)).toEqual(['tool_start', 'tool_end']);
+    expect(updates[0].tool).toBe('command_execution');
+    expect(updates[0].input).toEqual({ command: '/bin/zsh -lc "ls -la"' });
+    expect(updates[1].output).toContain('total 24');
+    expect(tools.states.map(s => s.status)).toEqual(['running', 'done']);
+  });
+
+  it('gives the trace a procedure the crystallizer can read', () => {
+    // "in_progress" must resolve to a start, or the pairing collapses.
+    expect(toolPhaseOf('in_progress')).toBe('start');
+    expect(toolPhaseOf('completed')).toBe('end');
+  });
+});

--- a/packages/core/src/agents/tool-events.test.ts
+++ b/packages/core/src/agents/tool-events.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { toolPhaseOf, isFailureStatus, ToolCallCollector } from './tool-events';
+import { codexItemAsTool, CODEX_TOOL_ITEMS } from './codex';
+import { StatusUpdate } from '../types';
+
+describe('toolPhaseOf', () => {
+  it('maps the dialects the three CLIs actually use', () => {
+    for (const status of ['running', 'pending', 'in_progress', 'started']) {
+      expect(toolPhaseOf(status), status).toBe('start');
+    }
+    for (const status of ['done', 'completed', 'success', 'failed', 'error', 'cancelled']) {
+      expect(toolPhaseOf(status), status).toBe('end');
+    }
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(toolPhaseOf(' Running ')).toBe('start');
+    expect(toolPhaseOf('COMPLETED')).toBe('end');
+  });
+
+  it('treats an unknown status as terminal and no status as nothing', () => {
+    // A tool heard about exactly once is likelier finished than still running.
+    expect(toolPhaseOf('weird-new-word')).toBe('end');
+    expect(toolPhaseOf(undefined)).toBeNull();
+  });
+
+  it('recognizes failure separately from completion', () => {
+    expect(isFailureStatus('failed')).toBe(true);
+    expect(isFailureStatus('error')).toBe(true);
+    expect(isFailureStatus('completed')).toBe(false);
+    expect(isFailureStatus(undefined)).toBe(false);
+  });
+});
+
+describe('ToolCallCollector', () => {
+  function collect(): { updates: StatusUpdate[]; tools: ToolCallCollector } {
+    const updates: StatusUpdate[] = [];
+    return { updates, tools: new ToolCallCollector(u => updates.push(u)) };
+  }
+
+  it('synthesizes a start for a CLI that only reports finished tools', () => {
+    // This is the opencode/codex case, and the whole reason induction saw
+    // nothing from them: consumers key a procedure off tool_start.
+    const { updates, tools } = collect();
+    tools.record({ tool: 'read', status: 'completed', input: { filePath: 'note.txt' }, output: 'hello' });
+    expect(updates.map(u => u.type)).toEqual(['tool_start', 'tool_end']);
+    expect(updates[0].tool).toBe('read');
+    expect(updates[0].input).toEqual({ filePath: 'note.txt' });
+    expect(tools.states.map(s => s.status)).toEqual(['running', 'done']);
+  });
+
+  it('does not double-count a tool reported at both ends', () => {
+    const { updates, tools } = collect();
+    tools.record({ tool: 'bash', status: 'running', key: 'call-1', input: { command: 'ls' } });
+    tools.record({ tool: 'bash', status: 'completed', key: 'call-1', output: 'note.txt' });
+    expect(updates.map(u => u.type)).toEqual(['tool_start', 'tool_end']);
+    expect(tools.states).toHaveLength(2);
+  });
+
+  it('keeps concurrent calls to the same tool apart by key', () => {
+    const { updates, tools } = collect();
+    tools.record({ tool: 'read', status: 'running', key: 'a' });
+    tools.record({ tool: 'read', status: 'running', key: 'b' });
+    tools.record({ tool: 'read', status: 'completed', key: 'a' });
+    tools.record({ tool: 'read', status: 'completed', key: 'b' });
+    expect(updates.map(u => u.type)).toEqual(['tool_start', 'tool_start', 'tool_end', 'tool_end']);
+  });
+
+  it('respects an explicit phase over the status word', () => {
+    const { updates, tools } = collect();
+    // codex item.started can carry status "in_progress" or nothing at all.
+    tools.record({ tool: 'command_execution', phase: 'start', key: 'i1' });
+    expect(updates.map(u => u.type)).toEqual(['tool_start']);
+  });
+
+  it('marks a failed tool in the end message', () => {
+    const { updates, tools } = collect();
+    tools.record({ tool: 'bash', status: 'failed', output: 'boom' });
+    expect(updates[1].message).toContain('failed');
+  });
+
+  it('summarizes scalar input into the start message and skips structures', () => {
+    const { updates, tools } = collect();
+    tools.record({ tool: 'edit', status: 'completed', input: { path: 'a.ts', nested: { x: 1 }, n: 3 } });
+    expect(updates[0].message).toBe('edit(path=a.ts, n=3)');
+  });
+
+  it('stringifies a non-string output for the status update but keeps states raw', () => {
+    const { updates, tools } = collect();
+    tools.record({ tool: 'fetch', status: 'completed', output: { ok: true } });
+    expect(updates[1].output).toBe('{"ok":true}');
+    expect(tools.states[1].output).toEqual({ ok: true });
+  });
+
+  it('closes tools still open when the process exits', () => {
+    const { tools } = collect();
+    tools.record({ tool: 'sleep', status: 'running', key: 'x' });
+    tools.finish();
+    expect(tools.states.map(s => s.status)).toEqual(['running', 'done']);
+  });
+
+  it('works with no onStatus listener (the channel surface)', () => {
+    const tools = new ToolCallCollector();
+    expect(() => tools.record({ tool: 'read', status: 'completed' })).not.toThrow();
+    expect(tools.states).toHaveLength(2);
+  });
+});
+
+describe('codexItemAsTool', () => {
+  it('maps the item types that represent doing something', () => {
+    expect([...CODEX_TOOL_ITEMS].sort())
+      .toEqual(['command_execution', 'file_change', 'mcp_tool_call', 'web_search']);
+
+    expect(codexItemAsTool({ type: 'command_execution', command: 'ls -la', aggregated_output: 'a\nb' }))
+      .toEqual({ tool: 'command_execution', input: { command: 'ls -la' }, output: 'a\nb' });
+
+    expect(codexItemAsTool({ type: 'file_change', path: 'src/x.ts', changes: [{ kind: 'edit' }] }))
+      .toEqual({ tool: 'file_change', input: { path: 'src/x.ts' }, output: [{ kind: 'edit' }] });
+
+    expect(codexItemAsTool({ type: 'web_search', query: 'codex json events' }))
+      .toEqual({ tool: 'web_search', input: { query: 'codex json events' } });
+  });
+
+  it('keeps an MCP tool call\'s own identity', () => {
+    // "server.tool" is the distinctive name; collapsing every MCP call to
+    // "mcp_tool_call" would erase what makes the procedure recognizable.
+    expect(codexItemAsTool({ type: 'mcp_tool_call', server: 'browser', tool: 'navigate', arguments: { url: 'https://x.com' } }))
+      .toEqual({ tool: 'browser.navigate', input: { url: 'https://x.com' }, output: undefined });
+    expect(codexItemAsTool({ type: 'mcp_tool_call', tool: 'navigate' })!.tool).toBe('navigate');
+    expect(codexItemAsTool({ type: 'mcp_tool_call' })!.tool).toBe('mcp_tool_call');
+  });
+
+  it('ignores items that are not tool activity', () => {
+    expect(codexItemAsTool({ type: 'agent_message' })).toBeNull();
+    expect(codexItemAsTool({ type: 'reasoning' })).toBeNull();
+    expect(codexItemAsTool({})).toBeNull();
+  });
+});

--- a/packages/core/src/agents/tool-events.test.ts
+++ b/packages/core/src/agents/tool-events.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { toolPhaseOf, isFailureStatus, ToolCallCollector } from './tool-events';
 import { codexItemAsTool, CODEX_TOOL_ITEMS } from './codex';
+import { opencodeToolEvent } from './opencode';
 import { StatusUpdate } from '../types';
+import { stepsFrom, signatureOf } from '../playbook-induction';
 
 describe('toolPhaseOf', () => {
   it('maps the dialects the three CLIs actually use', () => {
@@ -181,5 +183,88 @@ describe('codex item events, against a real captured stream', () => {
     // "in_progress" must resolve to a start, or the pairing collapses.
     expect(toolPhaseOf('in_progress')).toBe('start');
     expect(toolPhaseOf('completed')).toBe('end');
+  });
+});
+
+describe('opencode tool_use events, against a real captured stream', () => {
+  // Verbatim from `opencode run --format json` (opencode 1.14.18, 2026-07-28)
+  // for the prompt "Read the file note.txt and tell me what it says."
+  // Note what is NOT here: any event with a "running" status. opencode reports
+  // a tool once, already completed.
+  const CAPTURED_PARTS = [
+    {
+      type: 'tool', tool: 'read', callID: 'call_00_BaGBWjXewyuRz9fSIpJN6271',
+      state: {
+        status: 'completed',
+        input: { filePath: '/private/tmp/oc-probe/note.txt' },
+        output: '<path>/private/tmp/oc-probe/note.txt</path>\n<content>\n1: hello from probe\n',
+      },
+    },
+    {
+      type: 'tool', tool: 'glob', callID: 'call_01_7G7qL5AZ50oFOiauKKRZ6950',
+      state: {
+        status: 'completed',
+        input: { pattern: '**/note.txt', path: '/private/tmp/oc-probe' },
+        output: 'Found 1 file(s)\n\n/private/tmp/oc-probe/note.txt',
+      },
+    },
+  ];
+
+  it('reads the call identity, input and output off the part', () => {
+    expect(opencodeToolEvent(CAPTURED_PARTS[0])).toEqual({
+      tool: 'read',
+      key: 'call_00_BaGBWjXewyuRz9fSIpJN6271',
+      status: 'completed',
+      input: { filePath: '/private/tmp/oc-probe/note.txt' },
+      output: expect.stringContaining('hello from probe'),
+    });
+  });
+
+  it('produces a two-step procedure the crystallizer can cluster on', () => {
+    const updates: StatusUpdate[] = [];
+    const tools = new ToolCallCollector(u => updates.push(u));
+    for (const part of CAPTURED_PARTS) {
+      const observed = opencodeToolEvent(part);
+      if (observed) tools.record(observed);
+    }
+    tools.finish();
+
+    // Two completed tools -> two synthesized starts, in order. Before this
+    // fix the run contributed nothing at all.
+    expect(updates.map(u => `${u.type}:${u.tool}`)).toEqual([
+      'tool_start:read', 'tool_end:read', 'tool_start:glob', 'tool_end:glob',
+    ]);
+    expect(updates[0].input).toEqual({ filePath: '/private/tmp/oc-probe/note.txt' });
+    expect(tools.states.map(s => `${s.source}:${s.status}`)).toEqual([
+      'read:running', 'read:done', 'glob:running', 'glob:done',
+    ]);
+  });
+
+  it('ignores a part with no state', () => {
+    expect(opencodeToolEvent({ type: 'tool', tool: 'read' })).toBeNull();
+  });
+
+  it('reaches the crystallizer as a procedure with argument shapes', () => {
+    // End to end: what the chat surface collects from onStatus is what
+    // stepsFrom reads. This is the whole point of the fix — before it, an
+    // opencode run produced an empty signature and could never cluster.
+    const updates: StatusUpdate[] = [];
+    const tools = new ToolCallCollector(u => updates.push(u));
+    for (const part of CAPTURED_PARTS) {
+      const observed = opencodeToolEvent(part);
+      if (observed) tools.record(observed);
+    }
+    const steps = stepsFrom(updates.map(u => ({ tool: u.tool, type: u.type, input: u.input })));
+    expect(signatureOf({ runId: 'r', steps })).toEqual(['read', 'glob']);
+    expect(steps[0].args).toEqual({ filePath: { kind: 'path', ext: 'txt', depth: 4 } });
+    expect(steps[1].args).toEqual({
+      // A glob keeps its literal value: "**/note.txt" and "**/*.test.ts" are
+      // different searches, and a length bucket would hide that.
+      pattern: { kind: 'enum', value: '**/note.txt' },
+      // An extensionless directory lands on 'enum', not 'path' — deliberately.
+      // Only url and enum can be induced as CONSTANTS, so this is what lets
+      // "always the same directory" be baked into a playbook step.
+      path: { kind: 'enum', value: '/private/tmp/oc-probe' },
+    });
   });
 });

--- a/packages/core/src/agents/tool-events.ts
+++ b/packages/core/src/agents/tool-events.ts
@@ -1,0 +1,125 @@
+// packages/core/src/agents/tool-events.ts
+//
+// Shared normalization for the tool activity CLIs report, so every adapter
+// feeds the same two consumers the same way:
+//
+//   request.onStatus(...)  — the chat/Mac surface's live tool timeline
+//   AgentResponse.states   — the channel surface, via ContextManager.extractMeta
+//
+// Adapters differ in both vocabulary and timing. claude-code reports a tool
+// twice ('running' then 'done'); opencode and codex report it once, already
+// finished ('completed' / 'failed'). Downstream consumers key a run's
+// procedure off START events, so a report that only ever arrives at the end
+// must still produce one — otherwise the run looks like it did nothing.
+
+import { AgentStateEntry, StatusUpdate } from '../types';
+
+export type ToolPhase = 'start' | 'end';
+
+const START_STATUSES = new Set(['running', 'pending', 'in_progress', 'started', 'start', 'active']);
+const END_STATUSES = new Set([
+  'done', 'completed', 'complete', 'success', 'succeeded', 'ok',
+  'failed', 'failure', 'error', 'cancelled', 'canceled', 'aborted',
+]);
+
+/** Map a CLI's status word onto a phase, or null when it means nothing to us.
+ *  Unknown words are treated as terminal: a tool we heard about exactly once
+ *  is more likely finished than perpetually running. */
+export function toolPhaseOf(status?: string): ToolPhase | null {
+  if (!status) return null;
+  const normalized = status.toLowerCase().trim();
+  if (START_STATUSES.has(normalized)) return 'start';
+  if (END_STATUSES.has(normalized)) return 'end';
+  return 'end';
+}
+
+/** True for statuses that report the tool did not succeed. */
+export function isFailureStatus(status?: string): boolean {
+  if (!status) return false;
+  const normalized = status.toLowerCase().trim();
+  return normalized.startsWith('fail') || normalized === 'error'
+    || normalized === 'cancelled' || normalized === 'canceled' || normalized === 'aborted';
+}
+
+function summarizeInput(input?: Record<string, unknown>): string {
+  if (!input) return '';
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') continue;
+    const text = String(value);
+    parts.push(`${key}=${text.length > 40 ? `${text.slice(0, 40)}…` : text}`);
+    if (parts.length >= 2) break;
+  }
+  return parts.join(', ');
+}
+
+export interface ObservedToolEvent {
+  tool: string;
+  /** Explicit phase when the event name carries it (codex item.started /
+   *  item.completed). Omit to derive it from `status`. */
+  phase?: ToolPhase;
+  status?: string;
+  /** Stable id for pairing start with end. Falls back to the tool name. */
+  key?: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+}
+
+/** Collects a run's tool activity into the shapes the rest of the gateway
+ *  expects. `states` carries normalized 'running'/'done' statuses so
+ *  ContextManager.extractMeta can pair them without knowing any CLI's dialect. */
+export class ToolCallCollector {
+  readonly states: AgentStateEntry[] = [];
+  readonly statusUpdates: string[] = [];
+  private open = new Set<string>();
+
+  constructor(private readonly onStatus?: (update: StatusUpdate) => void) {}
+
+  record(event: ObservedToolEvent): void {
+    const key = event.key ?? event.tool;
+    const phase = event.phase ?? toolPhaseOf(event.status) ?? 'end';
+
+    if (phase === 'start') {
+      if (this.open.has(key)) return; // duplicate start — one call, not two
+      this.open.add(key);
+      this.emitStart(event);
+      return;
+    }
+
+    // Terminal event. Synthesize the start we never saw, so a CLI that only
+    // reports finished tools still contributes a procedure.
+    if (!this.open.has(key)) this.emitStart(event);
+    this.open.delete(key);
+
+    const output = typeof event.output === 'string'
+      ? event.output
+      : event.output !== undefined ? JSON.stringify(event.output) : undefined;
+    this.states.push({ source: event.tool, status: 'done', input: event.input, output: event.output });
+    if (event.status) this.statusUpdates.push(`${event.tool}: ${event.status}`);
+    this.onStatus?.({
+      type: 'tool_end',
+      tool: event.tool,
+      message: isFailureStatus(event.status) ? `${event.tool} failed` : event.tool,
+      ...(output !== undefined ? { output: output.slice(0, 500) } : {}),
+    });
+  }
+
+  private emitStart(event: ObservedToolEvent): void {
+    const summary = summarizeInput(event.input);
+    this.states.push({ source: event.tool, status: 'running', input: event.input });
+    this.onStatus?.({
+      type: 'tool_start',
+      tool: event.tool,
+      message: summary ? `${event.tool}(${summary})` : event.tool,
+      ...(event.input ? { input: event.input } : {}),
+    });
+  }
+
+  /** Close out anything still open when the process exits. */
+  finish(): void {
+    for (const key of this.open) {
+      this.states.push({ source: key, status: 'done' });
+    }
+    this.open.clear();
+  }
+}

--- a/packages/core/src/context.extract-meta.test.ts
+++ b/packages/core/src/context.extract-meta.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { ContextManager } from './context';
+
+describe('ContextManager.extractMeta', () => {
+  it('pairs the running/done states adapters normalize to', () => {
+    const meta = ContextManager.extractMeta({
+      states: [
+        { source: 'Read', status: 'running', input: { file_path: 'a.ts' } },
+        { source: 'Read', status: 'done', output: 'contents' },
+      ],
+    }, 'claude-code');
+    expect(meta.toolCalls).toEqual([
+      { tool: 'Read', input: { file_path: 'a.ts' }, status: 'success', output: 'contents' },
+    ]);
+  });
+
+  it('accepts a CLI dialect leaking through rather than dropping the call', () => {
+    // opencode reports "completed"; before this it matched neither branch and
+    // the tool call vanished, leaving the run looking like it did nothing.
+    const meta = ContextManager.extractMeta({
+      states: [
+        { source: 'read', status: 'pending', input: { filePath: 'note.txt' } },
+        { source: 'read', status: 'completed', output: 'hello' },
+      ],
+    }, 'opencode');
+    expect(meta.toolCalls).toHaveLength(1);
+    expect(meta.toolCalls![0].tool).toBe('read');
+  });
+
+  it('records a tool that never reported completion as an error', () => {
+    const meta = ContextManager.extractMeta({
+      states: [{ source: 'bash', status: 'running', input: { command: 'sleep 100' } }],
+    }, 'codex');
+    expect(meta.toolCalls).toEqual([
+      { tool: 'bash', input: { command: 'sleep 100' }, status: 'error' },
+    ]);
+  });
+
+  it('derives file changes from the tools that touch files', () => {
+    const meta = ContextManager.extractMeta({
+      states: [
+        { source: 'Write', status: 'running', input: { file_path: 'out/post.md' } },
+        { source: 'Write', status: 'completed' },
+      ],
+    }, 'claude-code');
+    expect(meta.filesChanged).toEqual([{ path: 'out/post.md', action: 'create' }]);
+  });
+
+  it('leaves toolCalls unset when a run observed nothing', () => {
+    expect(ContextManager.extractMeta({}, 'opencode').toolCalls).toBeUndefined();
+    expect(ContextManager.extractMeta({ states: [] }, 'opencode').toolCalls).toBeUndefined();
+  });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { estimateTokens } from './utils/tokens';
+import { toolPhaseOf } from './agents/tool-events';
 
 // ── Structured turn types ──────────────────────────────────────────
 
@@ -561,13 +562,17 @@ export class ContextManager {
       // Group by tool call pairs (running -> done)
       const seen = new Map<string, ToolCallRecord>();
       for (const state of response.states) {
-        if (state.status === 'running') {
+        // Adapters normalize to running/done via ToolCallCollector, but tolerate
+        // a CLI dialect leaking through ('completed', 'failed', ...) rather than
+        // silently dropping the tool call.
+        const phase = toolPhaseOf(state.status);
+        if (phase === 'start') {
           seen.set(state.source, {
             tool: state.source,
             input: state.input,
             status: 'success',
           });
-        } else if (state.status === 'done') {
+        } else if (phase === 'end') {
           const record = seen.get(state.source) || { tool: state.source, status: 'success' as const };
           if (state.output) {
             record.output = typeof state.output === 'string'
@@ -580,7 +585,12 @@ export class ContextManager {
           // Detect file changes from tool names
           const fileTools = ['Write', 'Edit', 'Create', 'Delete', 'Read', 'write', 'edit', 'create', 'delete', 'read'];
           if (fileTools.some(ft => state.source.toLowerCase().includes(ft.toLowerCase()))) {
-            const filePath = state.input?.file_path || state.input?.path || state.input?.file;
+            // The path arrives with the START event; this is the END one, so
+            // fall back to what the paired record already captured. Without
+            // this, filesChanged stayed empty for every adapter that reports
+            // arguments once, at the start.
+            const args = state.input ?? record.input;
+            const filePath = args?.file_path || args?.path || args?.file;
             if (filePath && typeof filePath === 'string') {
               const action = state.source.toLowerCase().includes('read') ? 'read'
                 : state.source.toLowerCase().includes('delete') ? 'delete'

--- a/packages/core/src/playbook-induction.test.ts
+++ b/packages/core/src/playbook-induction.test.ts
@@ -335,3 +335,20 @@ describe('induceTemplate', () => {
     expect(rendered).not.toContain('secret-handle');
   });
 });
+
+describe('shapeOf, glob and directory values', () => {
+  it('keeps a glob pattern literal instead of bucketing it', () => {
+    // From a real opencode run: glob(pattern: "**/note.txt"). As bucketed text
+    // every glob of similar length looks identical.
+    expect(shapeOf('**/note.txt')).toEqual({ kind: 'enum', value: '**/note.txt' });
+    expect(sameShape(shapeOf('**/note.txt'), shapeOf('**/*.test.ts'))).toBe(false);
+    expect(shapeOf('src/**/{a,b}.ts').kind).toBe('enum');
+  });
+
+  it('treats an extensionless directory as a comparable value', () => {
+    // 'enum' rather than 'path' on purpose: only url and enum can be induced
+    // as constants, so this is what lets "always this directory" be baked in.
+    expect(shapeOf('/tmp/oc-probe')).toEqual({ kind: 'enum', value: '/tmp/oc-probe' });
+    expect(sameShape(shapeOf('/tmp/a'), shapeOf('/tmp/b'))).toBe(false);
+  });
+});

--- a/packages/core/src/playbook-induction.ts
+++ b/packages/core/src/playbook-induction.ts
@@ -39,7 +39,11 @@ export const TEXT_LEN_MAX = 100_000;
 /** Values at or below this length are compared literally (kind 'enum').
  *  Longer ones are reduced to a length bucket. */
 const ENUM_MAX_LEN = 32;
-const ENUM_PATTERN = /^[\w.\-/]+$/;
+// Glob and brace characters are included deliberately: a search pattern like
+// "**/*.test.ts" is an identifying value, and reducing it to a length bucket
+// would make two unrelated searches look like the same argument. Observed on a
+// real opencode run (glob(pattern: "**/note.txt")).
+const ENUM_PATTERN = /^[\w.\-/*?[\]{},]+$/;  // comma: brace expansion, e.g. src/**/{a,b}.ts
 const PATH_PATTERN = /^[~.]?\/|^[\w\-./]+\.[a-z]{1,5}$/i;
 
 function bucketLen(len: number): number {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
       'src/judge.test.ts',
       'src/skill-crystallizer.test.ts',
       'src/playbook-induction.test.ts',
+      'src/agents/tool-events.test.ts',
+      'src/context.extract-meta.test.ts',
       'src/aide-automation.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],


### PR DESCRIPTION
Follow-up to #195. Induction only ever worked for claude-code — this is why, and it isn't what the spec said.

## The claim I got wrong

#195's spec stated that opencode and codex "emit no tool events at all", so induction degrading to prose distillation for them was framed as an upstream limitation. That was wrong about the cause. Both CLIs report tool activity today; three gaps on our side were swallowing it.

## The three gaps

1. **Neither adapter called `request.onStatus`.** Both collected events into `AgentResponse.states`, but the chat/Mac surface builds `toolCalls` from the `onStatus` callback — so on the surface you actually work in, these agents produced no tool calls at all.
2. **`extractMeta` paired only `running` → `done`** (`context.ts:564`). Both CLIs report `completed` / `failed`, matching neither branch, so `seen` stayed empty and the channel surface dropped the calls too.
3. **The codex adapter keyed on `tool_use` / `tool_call` / `shell_command`**, which current codex does not emit. Its own comment already noted that field names drift between versions; they had drifted.

## What changed

A shared `ToolCallCollector` (`agents/tool-events.ts`) normalizes the dialects into one shape, feeding both `onStatus` and `states`.

The load-bearing detail: **claude-code reports a tool twice (`running`, then `done`); opencode and codex report it once, already finished.** Downstream consumers key a run's procedure off *start* events — `stepsFrom` explicitly skips `tool_end` — so a terminal-only report produces an empty procedure. The collector synthesizes the missing start, carrying the input with it.

codex items map to tool names by kind (`command_execution`, `file_change`), except `mcp_tool_call`, which keeps its own `server.tool` identity — those are the distinctive names, and collapsing them all would erase exactly the signal clustering depends on.

## Both CLIs verified against real runs

**codex** (codex-cli 0.145.0), prompt that runs a shell command and reads a file:

```
item.started   { id: item_1, type: command_execution, command: "...", exit_code: null, status: "in_progress" }
item.completed { id: item_1, type: command_execution, aggregated_output: "total 24...", exit_code: 0, status: "completed" }
item.completed { id: item_0, type: agent_message, text: "..." }      <- must not become a tool call
turn.completed { usage: { input_tokens: 40554, output_tokens: 139, cached_input_tokens: 19200 } }
```

**opencode** (1.14.18), file-read prompt:

```
tool_use { part: { type: tool, tool: "read", callID: "call_00_...", state: { status: "completed", input: {...}, output: "..." } } }
tool_use { part: { type: tool, tool: "glob", callID: "call_01_...", state: { status: "completed", input: { pattern: "**/note.txt", path: "..." } } } }
step_finish { part: { reason: "tool-calls", tokens: {...} } }
```

**Note the absence:** neither stream contains a "running" event. That confirms the synthesized start isn't defensive padding — it's the thing that makes these runs contribute a procedure at all.

Both captures are now fixture tests, and the opencode one asserts end-to-end that the run reaches `stepsFrom` as `read → glob` with argument shapes.

### Four corrections the live data forced

- **codex `exit_code` is `null` while a command is in flight**, not absent — the declared type was wrong.
- **codex `turn.completed` carries usage that nothing read**, so every codex run reported no tokens at all. There is no `total_tokens`, so total is derived from input + output.
- **`shapeOf` bucketed glob patterns as free text.** `**/note.txt` contains characters the enum pattern rejected, so every same-length glob looked like the same argument. Globs and brace expansion now compare literally.
- **The earlier opencode "hang" was my probe, not the CLI.** `opencode run` reads stdin; my shell invocation left it open. The adapter already spawns with stdio `'ignore'`, so it was never affected. Retracting that as a possible problem in your setup.

## Bonus fix

`filesChanged` was empty for every paired-event adapter, including claude-code: it read the path off the END state, but arguments arrive with the START one. It now falls back to the paired record.

## An asymmetry worth reviewing

An extensionless directory (`/tmp/oc-probe`) lands on shape `enum`, not `path`. That's deliberate: only `url` and `enum` can be induced as *constants*, so this is what lets "always this directory" be baked into a step rather than becoming a slot. The cost is that a directory path over 32 chars falls through to bucketed text and loses that identity.

## Testing

`npm test` — core 292, gateway 173, codey-mac 314, all passing. `tsc` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)