### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -22,7 +22,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.10.3",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12251,7 +12251,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12263,7 +12263,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.10.3",
+  "version": "0.11.0",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codey/core",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codey/core",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
0.10.3 → 0.11.0 across the root, `@codey/core`, `@codey/gateway`, and `codey-mac`, with lockfiles synced.

Minor rather than patch because this cycle added a new subsystem rather than fixing things:

- **#194** — traces record what a run *did* (tool sequence), not just what was said, and every distill verdict is logged.
- **#195** — playbook induction: recurrence is decided by clustering tool procedures in code, templates are induced by diffing argument shapes, and playbooks gained parameters.
- **#196** — induction on by default.

## Note on scope

**#197 is not in this release** — it's still open, and it's what makes induction work for opencode and codex rather than claude-code only. If you'd rather 0.11.0 cover all three agents, merge #197 first and I'll rebase this.

The CHANGELOG is stale (last entry is 0.7.0; 0.8.x through 0.10.x were never recorded), so I left it alone rather than adding a lone 0.11.0 entry after a three-version gap. Happy to backfill it as its own PR if you want the file current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)