### PR TITLE
Stop the distill fallback from undoing the distinctiveness gate

### DIFF
--- a/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
+++ b/docs/superpowers/specs/2026-07-28-playbook-induction-design.md
@@ -96,7 +96,14 @@ degrades the same way — so the design keeps the fallback below.
   `«topic»`) reaches the model.
 - **Suggestion stays opt-in.** Unchanged: detect -> propose -> user confirms.
   A computed cluster is stronger evidence, not a license to auto-save.
-- **The existing LLM-only path stays as a fallback**, not as the primary.
+- **The existing LLM-only path stays as a fallback**, not as the primary — and
+  only for what induction cannot see. Narrowed 2026-07-28: the fallback fires
+  when no run in the window observed a tool at all, not merely when clustering
+  found nothing. Clustering declining a candidate (too short, too generic, not
+  recurring yet) is a decision, and routing around it to the distiller would
+  re-propose exactly what the distinctiveness gate just rejected. Likewise,
+  "already a skill" and "couldn't name it" both mean stay quiet and retry on the
+  next window.
 
 ## 1. Trace schema v2
 

--- a/packages/core/src/playbook-induction.test.ts
+++ b/packages/core/src/playbook-induction.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   shapeOf, sameShape, stepsFrom, signatureOf, computeRarity, similarity, clusterProcedures,
-  induceTemplate, renderTemplate,
+  induceTemplate, renderTemplate, hasProcedureData,
   TEXT_LEN_MAX, MAX_STEPS, MAX_ARGS_PER_STEP, ProcedureInput,
 } from './playbook-induction';
 
@@ -350,5 +350,43 @@ describe('shapeOf, glob and directory values', () => {
     // as constants, so this is what lets "always this directory" be baked in.
     expect(shapeOf('/tmp/oc-probe')).toEqual({ kind: 'enum', value: '/tmp/oc-probe' });
     expect(sameShape(shapeOf('/tmp/a'), shapeOf('/tmp/b'))).toBe(false);
+  });
+});
+
+describe('hasProcedureData', () => {
+  it('is false only when nothing in the window observed a tool', () => {
+    const nothing = clusterProcedures([{ runId: 'a' }, { runId: 'b' }], { minMembers: 2 });
+    expect(nothing.considered).toBe(2);
+    expect(nothing.withoutSteps).toBe(2);
+    expect(hasProcedureData(nothing)).toBe(false);
+  });
+
+  it('is true when procedures were observed but declined', () => {
+    // The distinction the distill fallback turns on: these runs DID something,
+    // clustering just refused to crystallize it. Falling back to prose
+    // distillation here would re-propose what the gates rejected.
+    const tooGeneric = clusterProcedures([
+      run('a', ['Read', 'Edit', 'Bash']),
+      run('b', ['Read', 'Edit', 'Bash']),
+      run('c', ['Read', 'Edit', 'Bash']),
+    ], { minMembers: 2 });
+    expect(tooGeneric.clusters).toHaveLength(0);
+    expect(hasProcedureData(tooGeneric)).toBe(true);
+
+    const tooShort = clusterProcedures([run('a', ['Read', 'Edit'])], { minMembers: 2 });
+    expect(tooShort.clusters).toHaveLength(0);
+    expect(hasProcedureData(tooShort)).toBe(true);
+  });
+
+  it('is true when a mixed window has any observable run', () => {
+    const mixed = clusterProcedures([
+      { runId: 'a' },
+      run('b', ['browser_navigate', 'browser_read', 'browser_interact']),
+    ], { minMembers: 2 });
+    expect(hasProcedureData(mixed)).toBe(true);
+  });
+
+  it('is false for an empty window', () => {
+    expect(hasProcedureData(clusterProcedures([], { minMembers: 2 }))).toBe(false);
   });
 });

--- a/packages/core/src/playbook-induction.ts
+++ b/packages/core/src/playbook-induction.ts
@@ -248,6 +248,10 @@ export function similarity(a: string[], b: string[], rarity: Map<string, number>
  *  is answerable with a number instead of a shrug. */
 export interface ClusterReport {
   clusters: ProcedureCluster[];
+  /** How many runs were looked at. `considered === withoutSteps` means the
+   *  window holds no procedure data at all — the one case where prose
+   *  distillation is the only thing that could find anything. */
+  considered: number;
   /** Runs carrying no procedure data at all (adapter emits no tool events). */
   withoutSteps: number;
   /** Runs whose procedure was too short to mean anything. */
@@ -256,6 +260,13 @@ export interface ClusterReport {
   rejectedByDistinctiveness: number;
   /** Groups that were distinctive enough but haven't recurred yet. */
   tooFewMembers: number;
+}
+
+/** True when at least one run in the window left a procedure behind. Distinct
+ *  from "clustering found nothing": a window full of observed-but-unclusterable
+ *  runs has data, it just did not recur distinctively enough. */
+export function hasProcedureData(report: ClusterReport): boolean {
+  return report.considered > report.withoutSteps;
 }
 
 /** Group runs by the procedure they executed. Pure; no I/O, no LLM. */
@@ -268,7 +279,8 @@ export function clusterProcedures(
   const minDistinctiveness = opts.minDistinctiveness ?? DEFAULT_MIN_DISTINCTIVENESS;
 
   const report: ClusterReport = {
-    clusters: [], withoutSteps: 0, tooShort: 0, rejectedByDistinctiveness: 0, tooFewMembers: 0,
+    clusters: [], considered: inputs.length, withoutSteps: 0, tooShort: 0,
+    rejectedByDistinctiveness: 0, tooFewMembers: 0,
   };
 
   const eligible: { runId: string; sig: string[] }[] = [];

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ProcedureCluster, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -2289,7 +2289,7 @@ export class Codey {
    *  so it runs in log-only mode until there are real traces to fit them
    *  against. Pure computation over at most RECENT_TRACES_MAX traces.
    *  See docs/superpowers/specs/2026-07-28-playbook-induction-design.md. */
-  private logProcedureClusters(store: SkillStore, minMembers: number): ProcedureCluster | null {
+  private logProcedureClusters(store: SkillStore, minMembers: number): ClusterReport | null {
     try {
       const traces = store.getRecentTraces(RECENT_TRACES_MAX);
       const report = clusterProcedures(traces, { minMembers });
@@ -2298,7 +2298,7 @@ export class Codey {
           `[skills] induction: no cluster — ${report.withoutSteps} without steps, ` +
           `${report.tooShort} too short, ${report.tooFewMembers} not recurring yet, ` +
           `${report.rejectedByDistinctiveness} too generic`);
-        return null;
+        return report;
       }
       for (const cluster of report.clusters) {
         this.logger.info(
@@ -2306,7 +2306,7 @@ export class Codey {
           `${cluster.signature.join(' → ')} (distinctiveness ${cluster.distinctiveness.toFixed(2)}, ` +
           `score ${cluster.score.toFixed(2)})`);
       }
-      return report.clusters[0];
+      return report;
     } catch (err) {
       this.logger.warn(`[skills] induction pass failed: ${err}`);
       return null;
@@ -2391,7 +2391,7 @@ export class Codey {
       }
 
       store.recordTrace(opts.trace);
-      const cluster = this.logProcedureClusters(store, cfg.suggestOnRepeat);
+      const clusterReport = this.logProcedureClusters(store, cfg.suggestOnRepeat);
 
       this.skillRunCounter++;
       if (this.skillRunCounter % Codey.SKILL_GC_EVERY_N_RUNS === 1) {
@@ -2417,16 +2417,30 @@ export class Codey {
           }
           this.lastSkillDistillTime = now;
           // A clustered procedure is evidence; a prose pattern is an
-          // impression. Prefer the former, and fall back to distillation only
-          // when induction found nothing — NOT when it found a procedure that
-          // already has a skill, which is a reason to stay quiet.
-          const induced = cfg.induction && cluster
-            ? await this.induceSuggestion(store, cluster)
-            : null;
-          if (induced === 'duplicate') return;
-          const candidate = induced ?? await distillCandidate(
-            this.getSkillDistillDeps(), recent, store.getAll(), store.getRejected(), cfg.suggestOnRepeat,
-          );
+          // impression. When induction has something to say, it is the only
+          // one that speaks — including when what it says is "already a skill"
+          // or "I couldn't name it", both of which mean stay quiet and retry
+          // on the next window rather than propose something unrelated.
+          let candidate: DistillResult | null = null;
+          if (cfg.induction && clusterReport?.clusters.length) {
+            const induced = await this.induceSuggestion(store, clusterReport.clusters[0]);
+            if (induced === 'duplicate' || induced === null) return;
+            candidate = induced;
+          } else {
+            // Prose distillation is for runs induction CANNOT see: no tool
+            // activity anywhere in the window. When procedures were observed
+            // and clustering declined them — too short, too generic, not
+            // recurring yet — that decision stands. Falling through here would
+            // let the distiller re-propose exactly what the distinctiveness
+            // gate just rejected ("read a file, then edit it").
+            if (cfg.induction && clusterReport && hasProcedureData(clusterReport)) {
+              this.logger.debug('[skills] distill skipped — procedures observed but none clustered');
+              return;
+            }
+            candidate = await distillCandidate(
+              this.getSkillDistillDeps(), recent, store.getAll(), store.getRejected(), cfg.suggestOnRepeat,
+            );
+          }
           if (candidate) {
             opts.setPending(candidate);
             await opts.notify(


### PR DESCRIPTION
Follow-up to #196. Now that induction is on by default, the fallback's trigger condition is wrong.

## The problem

Prose distillation fired whenever clustering produced no cluster:

```ts
const induced = cfg.induction && cluster ? await this.induceSuggestion(...) : null;
const candidate = induced ?? await distillCandidate(...);   // cluster === null lands here
```

But "no cluster" covers two very different situations. One is *nothing was observed*. The other is *clustering looked at real procedures and deliberately declined them* — too short, too generic, not recurring yet.

In the second case the fallback undoes the decision that was just made. The distinctiveness gate exists specifically to stop `Read → Edit → Bash` — nearly every coding run — from becoming a playbook. When it rejects that, `cluster` is null, and the very next line asks a model to find a pattern in the same runs. It is free to propose "read a file, then edit it" in prose.

## The change

Prose distillation is now for what induction **cannot see**: a window where no run observed a tool at all. That still covers every case it's the only answer for:

- runs that used no tools (pure generation — "write a post about X")
- an adapter that reports nothing
- a CLI that changes its event format again, which codex just did

What it no longer does is overrule a decision clustering already made.

Naming failures join `'duplicate'` in staying quiet. If a procedure is established but the model couldn't name it, proposing something unrelated isn't a recovery — the cooldown lets the next window retry.

`ClusterReport` gains `considered` so callers can distinguish "nothing observed" from "nothing clustered", and `hasProcedureData` names that distinction.

## Worth noting

This also shrinks the privacy surface in the common case. The distill prompt embeds your prompt text and the agent's output; the induction prompt carries only tool names, argument keys, hosts and slot names. Narrowing the fallback means the text-carrying path runs only when there's genuinely no alternative.

## Testing

`npm test` — core 267, gateway 173, codey-mac 314, all passing. `tsc` clean, lint clean.

New tests cover `hasProcedureData` across the cases that matter: nothing observed, procedures observed but rejected as too generic, procedures observed but too short, a mixed window, and an empty window. The gateway wiring itself has no test harness (the pass is private and needs a full `Codey`), so it rests on typecheck plus the core-level distinction being tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)