### PR TITLE
Add customizable automation icons

### DIFF
--- a/codey-mac/electron/automation-validate.test.ts
+++ b/codey-mac/electron/automation-validate.test.ts
@@ -50,6 +50,9 @@ describe('validateAutomationDraft / validateAutomationPatch', () => {
 
   it('requires a complete valid definition on create', () => {
     expect(() => validateAutomationDraft(validDraft())).not.toThrow()
+    expect(() => validateAutomationDraft(validDraft({ icon: { emoji: '📰', backgroundColor: '#6d5efc' } }))).not.toThrow()
+    expect(() => validateAutomationDraft(validDraft({ icon: { emoji: '', backgroundColor: '#6d5efc' } }))).toThrow(/emoji/)
+    expect(() => validateAutomationDraft(validDraft({ icon: { emoji: '📰', backgroundColor: 'purple' } }))).toThrow(/backgroundColor/)
     expect(() => validateAutomationDraft(validDraft({ report: { notify: true } }))).toThrow(/report\.notify/) // booleans are not modes
     for (const mode of ['all', 'failure', 'success', 'none']) {
       expect(() => validateAutomationDraft(validDraft({ report: { notify: mode } }))).not.toThrow()
@@ -63,6 +66,7 @@ describe('validateAutomationDraft / validateAutomationPatch', () => {
 
   it('allows only mutable, valid fields on update', () => {
     expect(() => validateAutomationPatch({ name: 'x' })).not.toThrow() // no schedule on the patch
+    expect(() => validateAutomationPatch({ icon: { emoji: '🚀', backgroundColor: '#123ABC' } })).not.toThrow()
     expect(() => validateAutomationPatch({ schedule: { hour: 9, minute: 0, tz: 'Beijing' } })).toThrow(/time zone/)
     expect(() => validateAutomationPatch({ report: { notify: 'failure' } })).not.toThrow()
     expect(() => validateAutomationPatch({ report: { notify: 'sometimes' } })).toThrow(/report\.notify/)

--- a/codey-mac/electron/automation-validate.ts
+++ b/codey-mac/electron/automation-validate.ts
@@ -77,8 +77,8 @@ function validateReport(report: unknown): void {
   }
 }
 
-const CREATE_FIELDS = new Set(['name', 'enabled', 'target', 'brief', 'params', 'schedule', 'report'])
-const UPDATE_FIELDS = new Set(['name', 'target', 'brief', 'params', 'schedule', 'report'])
+const CREATE_FIELDS = new Set(['name', 'icon', 'enabled', 'target', 'brief', 'params', 'schedule', 'report'])
+const UPDATE_FIELDS = new Set(['name', 'icon', 'target', 'brief', 'params', 'schedule', 'report'])
 const CHAT_FIELDS = new Set(['name', 'target', 'brief', 'params', 'schedule', 'notify'])
 const AGENTS = new Set(['claude-code', 'opencode', 'codex'])
 
@@ -108,6 +108,16 @@ function validateParams(value: unknown): void {
   }
 }
 
+function validateIcon(value: unknown): void {
+  validateObject(value, 'icon')
+  if (typeof value.emoji !== 'string' || !value.emoji.trim() || value.emoji.length > 16) {
+    throw new Error('invalid automation: icon.emoji must be a short emoji')
+  }
+  if (typeof value.backgroundColor !== 'string' || !/^#[0-9a-f]{6}$/i.test(value.backgroundColor)) {
+    throw new Error('invalid automation: icon.backgroundColor must be a six-digit hex color')
+  }
+}
+
 function validateTarget(value: unknown): void {
   validateObject(value, 'target')
   if (typeof value.workspaceName !== 'string' || !value.workspaceName.trim()) {
@@ -128,6 +138,7 @@ function validateTarget(value: unknown): void {
 
 function validateMutableFields(value: Record<string, unknown>): void {
   if ('name' in value) validateName(value.name)
+  if ('icon' in value) validateIcon(value.icon)
   if ('target' in value) validateTarget(value.target)
   if ('brief' in value) validateBrief(value.brief)
   if ('params' in value) validateParams(value.params)
@@ -140,6 +151,7 @@ export function validateAutomationDraft(draft: any): void {
   validateObject(draft, 'draft')
   validateFields(draft, CREATE_FIELDS)
   validateName(draft.name)
+  if (draft.icon !== undefined) validateIcon(draft.icon)
   validateTarget(draft.target)
   validateBrief(draft.brief)
   validateParams(draft.params)

--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/AutomationIconPicker.tsx
+++ b/codey-mac/src/components/AutomationIconPicker.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useRef, useState } from 'react'
+import type { AutomationIcon as AutomationIconValue } from '../../../packages/core/src/types/automation'
+import { C } from '../theme'
+import { pillButton } from './settingsAtoms'
+
+const EMOJIS = ['⚡️', '✨', '🚀', '📰', '🤖', '📊', '🔔', '🧪', '🛠️', '📅', '💡', '✅']
+const COLORS = ['#6D5EF7', '#2563EB', '#0891B2', '#059669', '#65A30D', '#D97706', '#E11D48', '#DB2777', '#7C3AED', '#475569']
+
+export const DEFAULT_AUTOMATION_ICON: AutomationIconValue = {
+  emoji: '⚡️',
+  backgroundColor: '#6D5EF7',
+}
+
+export const AutomationIconBadge: React.FC<{
+  icon?: AutomationIconValue
+  size?: number
+  fallback?: React.ReactNode
+  fallbackBackground?: string
+}> = ({ icon, size = 34, fallback, fallbackBackground }) => (
+  <span style={{
+    width: size,
+    height: size,
+    flexShrink: 0,
+    display: 'grid',
+    placeItems: 'center',
+    borderRadius: Math.round(size * .29),
+    background: icon?.backgroundColor ?? fallbackBackground ?? C.surface3,
+    color: C.fg3,
+    fontSize: Math.round(size * .47),
+    lineHeight: 1,
+  }}>
+    {icon ? icon.emoji : fallback}
+  </span>
+)
+
+interface PickerProps {
+  icon?: AutomationIconValue
+  saving?: boolean
+  onSave: (icon: AutomationIconValue) => void
+}
+
+export const AutomationIconPicker: React.FC<PickerProps> = ({ icon, saving, onSave }) => {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState<AutomationIconValue>(icon ?? DEFAULT_AUTOMATION_ICON)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) setDraft(icon ?? DEFAULT_AUTOMATION_ICON)
+  }, [icon, open])
+
+  useEffect(() => {
+    if (!open) return
+    const close = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', close)
+    return () => document.removeEventListener('mousedown', close)
+  }, [open])
+
+  const valid = !!draft.emoji.trim()
+
+  return (
+    <div ref={rootRef} style={{ position: 'relative', flexShrink: 0 }}>
+      <button
+        type="button"
+        aria-label="Change automation icon"
+        title="Change icon"
+        style={iconButton}
+        onClick={() => setOpen(value => !value)}
+      >
+        <AutomationIconBadge icon={icon ?? DEFAULT_AUTOMATION_ICON} size={44} />
+        <span style={editMark}>✎</span>
+      </button>
+      {open && (
+        <div style={popover}>
+          <div style={pickerTitle}>Automation icon</div>
+          <div style={pickerHint}>Choose an emoji and background color.</div>
+          <div style={emojiGrid}>
+            {EMOJIS.map(emoji => (
+              <button
+                type="button"
+                key={emoji}
+                aria-label={`Use ${emoji}`}
+                style={emojiChoice(draft.emoji === emoji)}
+                onClick={() => setDraft(value => ({ ...value, emoji }))}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+          <label style={fieldLabel}>
+            Emoji
+            <input
+              aria-label="Custom emoji"
+              style={emojiInput}
+              value={draft.emoji}
+              maxLength={16}
+              onChange={event => setDraft(value => ({ ...value, emoji: event.target.value }))}
+            />
+          </label>
+          <div style={fieldLabel}>
+            Background
+            <div style={colorRow}>
+              {COLORS.map(color => (
+                <button
+                  type="button"
+                  key={color}
+                  aria-label={`Use color ${color}`}
+                  style={colorChoice(color, draft.backgroundColor === color)}
+                  onClick={() => setDraft(value => ({ ...value, backgroundColor: color }))}
+                />
+              ))}
+              <label style={customColor} title="Custom color">
+                <input
+                  type="color"
+                  aria-label="Custom background color"
+                  value={draft.backgroundColor}
+                  onChange={event => setDraft(value => ({ ...value, backgroundColor: event.target.value.toUpperCase() }))}
+                />
+              </label>
+            </div>
+          </div>
+          <div style={previewRow}>
+            <AutomationIconBadge icon={draft} size={36} />
+            <span style={{ flex: 1, color: C.fg2, fontSize: 11 }}>Preview</span>
+            <button
+              type="button"
+              style={pillButton('primary')}
+              disabled={!valid || saving}
+              onClick={() => {
+                onSave({ ...draft, emoji: draft.emoji.trim() })
+                setOpen(false)
+              }}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const iconButton: React.CSSProperties = {
+  position: 'relative', display: 'grid', padding: 0, border: 'none',
+  borderRadius: 13, background: 'transparent', cursor: 'pointer',
+}
+const editMark: React.CSSProperties = {
+  position: 'absolute', right: -3, bottom: -3, width: 16, height: 16,
+  display: 'grid', placeItems: 'center', borderRadius: 999,
+  border: `2px solid ${C.bg}`, background: C.surface3, color: C.fg2,
+  fontSize: 9, fontWeight: 800,
+}
+const popover: React.CSSProperties = {
+  position: 'absolute', zIndex: 20, top: 52, left: 0, width: 248,
+  padding: 13, borderRadius: 12, border: `1px solid ${C.border}`,
+  background: C.surface, boxShadow: '0 14px 35px rgba(0,0,0,.28)',
+}
+const pickerTitle: React.CSSProperties = { color: C.fg, fontSize: 12.5, fontWeight: 750 }
+const pickerHint: React.CSSProperties = { color: C.fg3, fontSize: 10.5, marginTop: 2, marginBottom: 11 }
+const emojiGrid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 5 }
+const emojiChoice = (active: boolean): React.CSSProperties => ({
+  height: 31, borderRadius: 8, border: `1px solid ${active ? C.accent : C.border}`,
+  background: active ? C.accentDim : C.surface3, cursor: 'pointer', fontSize: 16,
+})
+const fieldLabel: React.CSSProperties = {
+  display: 'flex', flexDirection: 'column', gap: 5, color: C.fg2,
+  fontSize: 10.5, fontWeight: 650, marginTop: 11,
+}
+const emojiInput: React.CSSProperties = {
+  height: 30, boxSizing: 'border-box', padding: '4px 8px',
+  border: `1px solid ${C.border}`, borderRadius: 8,
+  background: C.surface3, color: C.fg, fontSize: 15, outline: 'none',
+}
+const colorRow: React.CSSProperties = { display: 'flex', gap: 6, flexWrap: 'wrap' }
+const colorChoice = (color: string, active: boolean): React.CSSProperties => ({
+  width: 22, height: 22, padding: 0, borderRadius: 7, cursor: 'pointer',
+  background: color, border: `2px solid ${active ? C.fg : 'transparent'}`,
+  boxShadow: active ? `0 0 0 1px ${C.bg}` : 'none',
+})
+const customColor: React.CSSProperties = {
+  width: 22, height: 22, overflow: 'hidden', borderRadius: 7,
+  border: `1px solid ${C.border}`, cursor: 'pointer',
+}
+const previewRow: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 9, marginTop: 13,
+  paddingTop: 11, borderTop: `1px solid ${C.border}`,
+}

--- a/codey-mac/src/components/AutomationOnePager.tsx
+++ b/codey-mac/src/components/AutomationOnePager.tsx
@@ -12,6 +12,7 @@ import { isScheduled } from '../../../packages/core/src/types/automation'
 import type { Automation, AutomationRun } from '../../../packages/core/src/types/automation'
 import { UIIcon, type IconName } from './UIIcons'
 import { Markdown } from './Markdown'
+import { AutomationIconPicker } from './AutomationIconPicker'
 
 const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
 const DAY = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -65,6 +66,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
   const [knobs, setKnobs] = useState<Knobs | null>(null)
   const [running, setRunning] = useState(false)
   const [savingKnobs, setSavingKnobs] = useState(false)
+  const [savingIcon, setSavingIcon] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [resuming, setResuming] = useState<Record<string, boolean>>({})
@@ -192,6 +194,20 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
     }
   }
 
+  const saveIcon = async (icon: NonNullable<Automation['icon']>) => {
+    if (savingIcon) return
+    setSavingIcon(true)
+    try {
+      const fresh: Automation = unwrap(await window.codey.automations.update(id, { icon }))
+      setA(fresh)
+      aRef.current = fresh
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    } finally {
+      setSavingIcon(false)
+    }
+  }
+
   if (!a) return <div style={{ color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 24 }}>Loading…</div>
 
   const scheduled = isScheduled(a)
@@ -207,6 +223,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
   return (
     <div style={pageStyle}>
       <header style={heroStyle}>
+        <AutomationIconPicker icon={a.icon} saving={savingIcon} onSave={icon => void saveIcon(icon)} />
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={eyebrow}>AUTOMATION</div>
           <div style={titleRow}>

--- a/codey-mac/src/components/AutomationsView.tsx
+++ b/codey-mac/src/components/AutomationsView.tsx
@@ -6,6 +6,7 @@ import { humanizeDelta, nextRunAt, scheduleChipLabel, scheduleSummary } from './
 import { AutomationChatCreate } from './AutomationChatCreate'
 import { AutomationOnePager } from './AutomationOnePager'
 import { UIIcon } from './UIIcons'
+import { AutomationIconBadge } from './AutomationIconPicker'
 import { isScheduled } from '../../../packages/core/src/types/automation'
 import type { Automation, AutomationRun, AutomationTarget } from '../../../packages/core/src/types/automation'
 
@@ -233,7 +234,11 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
               <div key={a.id} style={rowStyle}>
                 <span style={{ ...statusRail, background: health.color }} />
                 <button style={cardMain} onClick={() => onOpen(a.id)}>
-                  <span style={automationIcon(scheduled)}><UIIcon name={a.target.kind === 'team' ? 'users' : 'activity'} size={16} /></span>
+                  <AutomationIconBadge
+                    icon={a.icon}
+                    fallbackBackground={scheduled ? C.accentDim : C.surface3}
+                    fallback={<span style={automationIconFallback(scheduled)}><UIIcon name={a.target.kind === 'team' ? 'users' : 'activity'} size={16} /></span>}
+                  />
                   <span style={cardCopy}>
                     <span style={nameRow}>
                       <strong style={automationName}>{a.name}</strong>
@@ -308,7 +313,7 @@ const rowStyle: React.CSSProperties = {
 }
 const statusRail: React.CSSProperties = { width: 3, flexShrink: 0 }
 const cardMain: React.CSSProperties = { flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 11, padding: '13px 14px', border: 'none', background: 'transparent', textAlign: 'left', cursor: 'pointer', color: 'inherit' }
-const automationIcon = (enabled: boolean): React.CSSProperties => ({ width: 34, height: 34, flexShrink: 0, display: 'grid', placeItems: 'center', borderRadius: 10, background: enabled ? C.accentDim : C.surface3, color: enabled ? C.accent : C.fg3 })
+const automationIconFallback = (enabled: boolean): React.CSSProperties => ({ color: enabled ? C.accent : C.fg3, display: 'grid', placeItems: 'center' })
 const cardCopy: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0 }
 const nameRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }
 const automationName: React.CSSProperties = { color: C.fg, fontSize: 13, fontWeight: 720, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }

--- a/codey-mac/src/components/McpTab.tsx
+++ b/codey-mac/src/components/McpTab.tsx
@@ -162,10 +162,6 @@ export const McpTab: React.FC = () => {
         </div>
       ))}
 
-      {servers.length === 0 && !form && (
-        <div style={styles.empty}>No external MCP servers yet. Add one to get started.</div>
-      )}
-
       {form ? (
         <div style={styles.form}>
           <div style={styles.formTitle}>{editing ? `Edit ${editing}` : 'Add MCP server'}</div>
@@ -267,7 +263,6 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.fg3, border: `1px solid ${C.border2}`, borderRadius: 5, padding: '1px 6px',
   },
   toggleBusy: { opacity: 0.5, cursor: 'wait', pointerEvents: 'none' },
-  empty: { color: C.fg3, fontSize: 12, padding: '18px 0', textAlign: 'center' },
   form: {
     border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface2,
     padding: '14px 16px', marginTop: 4, display: 'flex', flexDirection: 'column', gap: 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -22,7 +22,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.11.0",
+      "version": "0.11.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12251,7 +12251,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12263,7 +12263,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codey/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codey/core",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -87,9 +87,18 @@ export interface AutomationReport {
   channel?: { platform: string; target: string };
 }
 
+/** User-selected visual shown beside an automation's title. */
+export interface AutomationIcon {
+  emoji: string;
+  /** Six-digit CSS hex color, including the leading #. */
+  backgroundColor: string;
+}
+
 export interface Automation {
   id: string;
   name: string;
+  /** Absent for older/default automations, which use the activity glyph. */
+  icon?: AutomationIcon;
   enabled: boolean;
   target: AutomationTarget;
   /** Frozen, self-contained instruction block synthesized by the authoring chat.

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What changed

- Add a persisted automation icon setting with emoji and background color.
- Add an icon picker with presets, custom inputs, and preview on the automation details page.
- Render customized icons in automation list cards while preserving the legacy fallback for existing automations.
- Validate icon updates at the Electron IPC boundary and cover valid and invalid values.
- Remove the empty-state wording for external MCP servers.
- Bump the monorepo, Mac app, core, and gateway versions to 0.11.1.

## Why

Automation cards previously used a fixed activity or team glyph. This lets users visually distinguish automations while keeping existing definitions backward compatible.

## Validation

- `npm exec -- tsc -p codey-mac/tsconfig.json --noEmit`
- `npm run test -w codey-mac -- --run electron/automation-validate.test.ts` (9 tests passed)
- `npm run build:core`
- `npm run build:gateway`
- `npm exec -w codey-mac vite build`
- `git diff --check`
