### PR TITLE
Improve Tools search and MCP server UI

### DIFF
--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/McpTab.tsx
+++ b/codey-mac/src/components/McpTab.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { C } from '../theme'
 import { inputStyle, pillButton, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { parseArgsLine, parseEnvLines } from './mcp-form'
+import { matchesToolSearch } from './tools-search'
 import type { ExternalMcpServer } from '../codey-api'
 
 // Matches the toggle idiom already used by AppearanceTab / PluginsTab.
@@ -41,7 +42,7 @@ const toForm = (server: ExternalMcpServer): FormState => ({
   url: server.url ?? '',
 })
 
-export const McpTab: React.FC = () => {
+export const McpTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [servers, setServers] = useState<ExternalMcpServer[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -49,6 +50,14 @@ export const McpTab: React.FC = () => {
   const [form, setForm] = useState<FormState | null>(null)
   const [editing, setEditing] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const filteredServers = useMemo(
+    () => servers.filter(server => matchesToolSearch(
+      searchQuery,
+      server.name,
+      server.transport === 'remote' ? server.url : [server.command, ...(server.args ?? [])].join(' '),
+    )),
+    [servers, searchQuery],
+  )
 
   const reload = useCallback(async () => {
     setLoading(true)
@@ -133,7 +142,7 @@ export const McpTab: React.FC = () => {
       </div>
       {error && <div style={styles.errorBanner}>{error}</div>}
 
-      {servers.map(server => (
+      {filteredServers.map(server => (
         <div key={server.name} style={styles.card}>
           <div style={styles.cardIcon}><UIIcon name="server" size={18} /></div>
           <div style={styles.cardBody}>
@@ -161,67 +170,74 @@ export const McpTab: React.FC = () => {
           </div>
         </div>
       ))}
+      {servers.length > 0 && filteredServers.length === 0 && !form && (
+        <div style={styles.emptySearch}>No MCP servers match that name or configuration.</div>
+      )}
 
       {form ? (
         <div style={styles.form}>
           <div style={styles.formTitle}>{editing ? `Edit ${editing}` : 'Add MCP server'}</div>
-          <label style={styles.label}>Name
-            <input
-              style={inputStyle}
-              value={form.name}
-              disabled={!!editing}
-              placeholder="github"
-              onChange={e => setForm({ ...form, name: e.target.value })}
-            />
-          </label>
-          <label style={styles.label}>Transport
-            <div style={styles.transportRow}>
-              {(['stdio', 'remote'] as const).map(t => (
-                <button
-                  key={t}
-                  style={{ ...styles.transportBtn, ...(form.transport === t ? styles.transportBtnActive : null) }}
-                  onClick={() => setForm({ ...form, transport: t })}
-                >{t === 'stdio' ? 'Local (stdio)' : 'Remote (URL)'}</button>
-              ))}
-            </div>
-          </label>
-          {form.transport === 'stdio' ? (
-            <>
-              <label style={styles.label}>Command
-                <input
-                  style={inputStyle}
-                  value={form.command}
-                  placeholder="npx"
-                  onChange={e => setForm({ ...form, command: e.target.value })}
-                />
-              </label>
-              <label style={styles.label}>Arguments (space-separated)
-                <input
-                  style={inputStyle}
-                  value={form.args}
-                  placeholder="-y @modelcontextprotocol/server-github"
-                  onChange={e => setForm({ ...form, args: e.target.value })}
-                />
-              </label>
-              <label style={styles.label}>Environment (one KEY=VALUE per line)
-                <textarea
-                  style={{ ...inputStyle, minHeight: 64, resize: 'vertical', fontFamily: 'monospace' }}
-                  value={form.env}
-                  placeholder={'GITHUB_TOKEN=ghp_...'}
-                  onChange={e => setForm({ ...form, env: e.target.value })}
-                />
-              </label>
-            </>
-          ) : (
-            <label style={styles.label}>URL
+          <div style={styles.formGrid}>
+            <label style={styles.label}>Name
               <input
-                style={inputStyle}
-                value={form.url}
-                placeholder="https://mcp.example.com/sse"
-                onChange={e => setForm({ ...form, url: e.target.value })}
+                style={styles.formInput}
+                value={form.name}
+                disabled={!!editing}
+                placeholder="github"
+                onChange={e => setForm({ ...form, name: e.target.value })}
               />
             </label>
-          )}
+            <label style={styles.label}>Transport
+              <div style={styles.transportRow}>
+                {(['stdio', 'remote'] as const).map(t => (
+                  <button
+                    key={t}
+                    type="button"
+                    aria-pressed={form.transport === t}
+                    style={{ ...styles.transportBtn, ...(form.transport === t ? styles.transportBtnActive : null) }}
+                    onClick={() => setForm({ ...form, transport: t })}
+                  >{t === 'stdio' ? 'Local (stdio)' : 'Remote (URL)'}</button>
+                ))}
+              </div>
+            </label>
+            {form.transport === 'stdio' ? (
+              <>
+                <label style={styles.label}>Command
+                  <input
+                    style={styles.formInput}
+                    value={form.command}
+                    placeholder="npx"
+                    onChange={e => setForm({ ...form, command: e.target.value })}
+                  />
+                </label>
+                <label style={styles.label}>Arguments (space-separated)
+                  <input
+                    style={styles.formInput}
+                    value={form.args}
+                    placeholder="-y @modelcontextprotocol/server-github"
+                    onChange={e => setForm({ ...form, args: e.target.value })}
+                  />
+                </label>
+                <label style={{ ...styles.label, ...styles.fullWidthField }}>Environment (one KEY=VALUE per line)
+                  <textarea
+                    style={styles.formTextarea}
+                    value={form.env}
+                    placeholder={'GITHUB_TOKEN=ghp_...'}
+                    onChange={e => setForm({ ...form, env: e.target.value })}
+                  />
+                </label>
+              </>
+            ) : (
+              <label style={{ ...styles.label, ...styles.fullWidthField }}>URL
+                <input
+                  style={styles.formInput}
+                  value={form.url}
+                  placeholder="https://mcp.example.com/sse"
+                  onChange={e => setForm({ ...form, url: e.target.value })}
+                />
+              </label>
+            )}
+          </div>
           <div style={styles.formActions}>
             <button style={pillButton('primary')} disabled={saving} onClick={() => void save()}>
               {saving ? 'Saving…' : 'Save'}
@@ -263,13 +279,25 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.fg3, border: `1px solid ${C.border2}`, borderRadius: 5, padding: '1px 6px',
   },
   toggleBusy: { opacity: 0.5, cursor: 'wait', pointerEvents: 'none' },
+  emptySearch: { color: C.fg3, fontSize: 12, textAlign: 'center', padding: '30px 16px' },
   form: {
     border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface2,
-    padding: '14px 16px', marginTop: 4, display: 'flex', flexDirection: 'column', gap: 10,
+    padding: '16px', marginTop: 4, display: 'flex', flexDirection: 'column', gap: 14,
+    maxWidth: 720, boxSizing: 'border-box',
   },
   formTitle: { color: C.fg, fontSize: 13, fontWeight: 700 },
-  label: { color: C.fg2, fontSize: 11.5, display: 'flex', flexDirection: 'column', gap: 4 },
-  transportRow: { display: 'flex', gap: 8 },
+  formGrid: {
+    display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+    gap: '12px 14px', alignItems: 'end',
+  },
+  label: { color: C.fg2, fontSize: 11.5, display: 'flex', flexDirection: 'column', gap: 5, minWidth: 0 },
+  fullWidthField: { gridColumn: '1 / -1' },
+  formInput: { ...inputStyle, width: '100%', boxSizing: 'border-box' },
+  formTextarea: {
+    ...inputStyle, width: '100%', minHeight: 76, resize: 'vertical',
+    boxSizing: 'border-box', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  },
+  transportRow: { display: 'flex', gap: 8, minHeight: 34 },
   transportBtn: {
     padding: '6px 12px', borderRadius: 8, border: `1px solid ${C.border2}`,
     background: 'transparent', color: C.fg2, cursor: 'pointer', fontSize: 12,

--- a/codey-mac/src/components/PlaybooksTab.tsx
+++ b/codey-mac/src/components/PlaybooksTab.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { C } from '../theme'
 import { pillButton, unwrap } from './settingsAtoms'
 import { timelineRows, playbookActions, relativeTime, TimelineRow } from './playbooksModel'
 import { UIIcon } from './UIIcons'
+import { matchesToolSearch } from './tools-search'
 
 interface Summary {
   name: string
@@ -16,13 +17,17 @@ interface Summary {
   canRollback: boolean
 }
 
-export const PlaybooksTab: React.FC = () => {
+export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [playbooks, setPlaybooks] = useState<Summary[]>([])
   const [expanded, setExpanded] = useState<string | null>(null)
   const [trail, setTrail] = useState<TimelineRow[]>([])
   const [openSteps, setOpenSteps] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const filteredPlaybooks = useMemo(
+    () => playbooks.filter(playbook => matchesToolSearch(searchQuery, playbook.name, playbook.description)),
+    [playbooks, searchQuery],
+  )
 
   const reload = useCallback(async () => {
     setLoading(true)
@@ -199,9 +204,14 @@ export const PlaybooksTab: React.FC = () => {
           <div style={{ fontWeight: 500, color: C.fg2, marginBottom: 4 }}>No playbooks yet</div>
           <div style={{ fontSize: 12 }}>Playbooks crystallize from your repeated work patterns.</div>
         </div>
+      ) : filteredPlaybooks.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: '36px 20px', color: C.fg3, fontSize: 13 }}>
+          <div style={{ fontWeight: 600, color: C.fg2, marginBottom: 4 }}>No matching playbooks</div>
+          <div style={{ fontSize: 12 }}>Try a different name or description keyword.</div>
+        </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {playbooks.map(renderCard)}
+          {filteredPlaybooks.map(renderCard)}
         </div>
       )}
     </div>

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { C } from '../theme'
 import { unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
+import { matchesToolSearch } from './tools-search'
 import type { PluginInfo } from '../codey-api'
 
 // Matches the toggle idiom already used by AppearanceTab / ChannelsSection.
@@ -20,11 +21,15 @@ const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on,
   </div>
 )
 
-export const PluginsTab: React.FC = () => {
+export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [plugins, setPlugins] = useState<PluginInfo[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
+  const filteredPlugins = useMemo(
+    () => plugins.filter(plugin => matchesToolSearch(searchQuery, plugin.name, plugin.description)),
+    [plugins, searchQuery],
+  )
 
   const reload = useCallback(async () => {
     setLoading(true)
@@ -62,7 +67,7 @@ export const PluginsTab: React.FC = () => {
         changes apply to the next agent run.
       </div>
       {error && <div style={styles.errorBanner}>{error}</div>}
-      {plugins.map(plugin => (
+      {filteredPlugins.map(plugin => (
         <div key={plugin.id} style={styles.card}>
           <div style={styles.cardIcon}><UIIcon name="tools" size={18} /></div>
           <div style={styles.cardBody}>
@@ -74,6 +79,9 @@ export const PluginsTab: React.FC = () => {
           </div>
         </div>
       ))}
+      {plugins.length > 0 && filteredPlugins.length === 0 && (
+        <div style={styles.emptySearch}>No plugins match that name or description.</div>
+      )}
     </div>
   )
 }
@@ -94,4 +102,5 @@ const styles: Record<string, React.CSSProperties> = {
   cardName: { color: C.fg, fontSize: 13, fontWeight: 700, marginBottom: 3 },
   cardDesc: { color: C.fg3, fontSize: 11.5, lineHeight: 1.45 },
   toggleBusy: { opacity: 0.5, cursor: 'wait', pointerEvents: 'none' },
+  emptySearch: { color: C.fg3, fontSize: 12, textAlign: 'center', padding: '30px 16px' },
 }

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { C } from '../theme'
 import { pillButton, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
+import { matchesToolSearch } from './tools-search'
 import type { SkillEntry, SkillsListResult } from '../codey-api'
 
 type AgentFilter = 'claude-code' | 'opencode' | 'codex'
@@ -17,7 +18,7 @@ const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
   'opencode': '~/.config/opencode/skills/',
 }
 
-export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 }) => {
+export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> = ({ addRequest = 0, searchQuery = '' }) => {
   const [data, setData] = useState<SkillsListResult>({ skills: [], projectDir: null })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -33,6 +34,10 @@ export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 })
   const [copyMenuOpen, setCopyMenuOpen] = useState(false)
   const copyRef = useRef<HTMLDivElement>(null)
   const initDone = useRef(false)
+  const filteredSkills = useMemo(
+    () => data.skills.filter(skill => matchesToolSearch(searchQuery, skill.name, skill.qualifiedName, skill.description)),
+    [data.skills, searchQuery],
+  )
 
   // The primary action lives in the parent Tools tab bar; this counter gives
   // that button a clean way to open the existing install form without a second
@@ -301,7 +306,9 @@ export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 })
           </div>
         </div>
         <div style={styles.agentMeta}>
-          <span>{loading ? 'Scanning…' : `${data.skills.length} skill${data.skills.length === 1 ? '' : 's'}`}</span>
+          <span>{loading ? 'Scanning…' : searchQuery.trim()
+            ? `${filteredSkills.length} of ${data.skills.length} skills`
+            : `${data.skills.length} skill${data.skills.length === 1 ? '' : 's'}`}</span>
           <button
             onClick={() => void reload(agentFilter)}
             disabled={loading}
@@ -418,9 +425,14 @@ export const SkillsTab: React.FC<{ addRequest?: number }> = ({ addRequest = 0 })
             Add a skill or place one in <code style={styles.inlineCode}>{AGENT_SKILL_HINTS[agentFilter]}</code>
           </div>
         </div>
+      ) : filteredSkills.length === 0 ? (
+        <div style={styles.emptyState}>
+          <div style={{ fontWeight: 650, color: C.fg, marginBottom: 5 }}>No matching skills</div>
+          <div style={{ fontSize: 12 }}>Try a different name or description keyword.</div>
+        </div>
       ) : (
         <div style={styles.skillGrid}>
-          {data.skills.map(renderCard)}
+          {filteredSkills.map(renderCard)}
         </div>
       )}
     </div>

--- a/codey-mac/src/components/ToolsView.tsx
+++ b/codey-mac/src/components/ToolsView.tsx
@@ -21,6 +21,7 @@ const TABS: { key: Tab; label: string; icon: IconName }[] = [
 export const ToolsView: React.FC<Props> = ({ onClose }) => {
   const [tab, setTab] = useState<Tab>('skills')
   const [addSkillRequest, setAddSkillRequest] = useState(0)
+  const [searchQuery, setSearchQuery] = useState('')
 
   return (
     <OverlayWindow title="Tools" icon="tools" onClose={onClose}>
@@ -39,6 +40,27 @@ export const ToolsView: React.FC<Props> = ({ onClose }) => {
           )
         })}
         <span style={styles.tabSpacer} />
+        <div style={styles.searchBox}>
+          <span style={styles.searchIcon}><UIIcon name="search" size={14} /></span>
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Escape') setSearchQuery('') }}
+            placeholder="Search tools…"
+            aria-label="Search tools by name or description"
+            style={styles.searchInput}
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              aria-label="Clear search"
+              title="Clear search"
+              style={styles.clearSearch}
+            ><UIIcon name="close" size={12} /></button>
+          )}
+        </div>
         {tab === 'skills' && (
           <button style={styles.addSkillBtn} onClick={() => setAddSkillRequest(v => v + 1)}>
             <UIIcon name="add" size={15} />Add skill
@@ -46,10 +68,10 @@ export const ToolsView: React.FC<Props> = ({ onClose }) => {
         )}
       </div>
       <div style={styles.body}>
-        {tab === 'skills'  && <SkillsTab addRequest={addSkillRequest} />}
-        {tab === 'playbooks' && <PlaybooksTab />}
-        {tab === 'plugins' && <PluginsTab />}
-        {tab === 'mcp' && <McpTab />}
+        {tab === 'skills'  && <SkillsTab addRequest={addSkillRequest} searchQuery={searchQuery} />}
+        {tab === 'playbooks' && <PlaybooksTab searchQuery={searchQuery} />}
+        {tab === 'plugins' && <PluginsTab searchQuery={searchQuery} />}
+        {tab === 'mcp' && <McpTab searchQuery={searchQuery} />}
       </div>
     </OverlayWindow>
   )
@@ -69,6 +91,20 @@ const styles: Record<string, React.CSSProperties> = {
     background: C.accentDim, color: C.fg, border: `1px solid ${C.accent}`,
   },
   tabSpacer: { flex: 1 },
+  searchBox: {
+    width: 220, minWidth: 140, height: 34, boxSizing: 'border-box',
+    display: 'flex', alignItems: 'center', gap: 6, padding: '0 8px',
+    border: `1px solid ${C.border2}`, borderRadius: 9, background: C.bg,
+  },
+  searchIcon: { display: 'inline-flex', color: C.fg3, flexShrink: 0 },
+  searchInput: {
+    flex: 1, minWidth: 0, border: 'none', outline: 'none', background: 'transparent',
+    color: C.fg, fontSize: 12, fontFamily: 'inherit', padding: 0,
+  },
+  clearSearch: {
+    width: 22, height: 22, padding: 0, display: 'grid', placeItems: 'center', flexShrink: 0,
+    border: 'none', borderRadius: 6, background: 'transparent', color: C.fg3, cursor: 'pointer',
+  },
   addSkillBtn: { display: 'inline-flex', alignItems: 'center', gap: 6, border: 'none', borderRadius: 9, padding: '9px 12px', color: C.onAccent, background: C.accent, cursor: 'pointer', fontSize: 12, fontWeight: 700, boxShadow: `0 5px 13px ${C.accentDim}` },
   body: { flex: 1, overflowY: 'auto', padding: 20, background: C.bg },
 }

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 export type IconName =
   | 'activity' | 'add' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
   | 'clock' | 'code' | 'copy' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
-  | 'globe' | 'overview' | 'refresh' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
+  | 'globe' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
   | 'telegram' | 'discord' | 'imessage'
 
 interface Props {
@@ -46,6 +46,7 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     play: <path {...common} d="M8 5l11 7-11 7z" />,
     plus: <path {...common} d="M12 5v14M5 12h14" />,
     refresh: <><path {...common} d="M20 11a8 8 0 00-14.7-4.4L3 9" /><path {...common} d="M3 4v5h5M4 13a8 8 0 0014.7 4.4L21 15" /><path {...common} d="M21 20v-5h-5" /></>,
+    search: <><circle {...common} cx="11" cy="11" r="7" /><path {...common} d="M16.5 16.5L21 21" /></>,
     server: <><rect {...common} x="3" y="4" width="18" height="6" rx="2" /><rect {...common} x="3" y="14" width="18" height="6" rx="2" /><path {...common} d="M7 7h.01M7 17h.01" /></>,
     settings: <><path {...common} d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.09a2 2 0 011 1.74v.5a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.38a2 2 0 00-.73-2.73l-.15-.09a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z" /><circle {...common} cx="12" cy="12" r="3" /></>,
     sparkle: <path {...common} d="M12 3l1.5 5.5L19 10l-5.5 1.5L12 17l-1.5-5.5L5 10l5.5-1.5L12 3zM19 16l.7 2.3L22 19l-2.3.7L19 22l-.7-2.3L16 19l2.3-.7L19 16z" />,

--- a/codey-mac/src/components/tools-search.test.ts
+++ b/codey-mac/src/components/tools-search.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { matchesToolSearch } from './tools-search'
+
+describe('matchesToolSearch', () => {
+  it('matches names and descriptions without regard to case', () => {
+    expect(matchesToolSearch('GITHUB', 'github-mcp', 'Repository tools')).toBe(true)
+    expect(matchesToolSearch('repository', 'github-mcp', 'Repository tools')).toBe(true)
+  })
+
+  it('trims the query and ignores missing values', () => {
+    expect(matchesToolSearch('  deploy  ', 'release', undefined, 'Deploy to production')).toBe(true)
+  })
+
+  it('shows every item for an empty query', () => {
+    expect(matchesToolSearch('   ', 'anything')).toBe(true)
+  })
+})

--- a/codey-mac/src/components/tools-search.ts
+++ b/codey-mac/src/components/tools-search.ts
@@ -1,0 +1,5 @@
+export function matchesToolSearch(query: string, ...values: Array<string | null | undefined>): boolean {
+  const needle = query.trim().toLocaleLowerCase()
+  if (!needle) return true
+  return values.some(value => value?.toLocaleLowerCase().includes(needle))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -22,7 +22,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.11.1",
+      "version": "0.11.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12251,7 +12251,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12263,7 +12263,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codey/core",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codey/core",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What changed

- add a Tools search field that filters Skills, Playbooks, Plugins, and MCP servers by name and description/configuration
- add clear and Escape-key behavior plus empty-result states
- rework the MCP server editor into a compact responsive grid with full-width fields
- add accessible pressed state to the MCP transport controls
- bump the monorepo, core, gateway, and macOS app versions to 0.11.2

## Why

The MCP editor stretched across the Tools window while its fields stayed in a narrow vertical column, leaving a large unused area and truncating useful input hints. Tools also lacked a quick way to find entries as the lists grew.

## Impact

Users can find tools with case-insensitive keywords and configure MCP servers in a denser, more readable layout. Narrow windows fall back to a single-column form.

## Validation

- `vitest run src/components/tools-search.test.ts src/components/mcp-form.test.ts` — 7 tests passed
- Vite production build completed for the renderer, Electron main process, and preload script
- `git diff --check` passed
