### PR TITLE
Preserve agent sessions and refine chat input

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2406,7 +2406,6 @@ app.whenReady().then(async () => {
       // through the normal clipboard. Sending Cmd+V via System Events
       // requires Accessibility permission; if denied, the clipboard fallback
       // still lets the user paste manually.
-      let pasted = false
       const codeyFocused = mainWindow?.isFocused() === true
       if (process.platform === 'darwin' && !codeyFocused) {
         try {
@@ -2417,27 +2416,19 @@ app.whenReady().then(async () => {
               'tell application "System Events" to keystroke "v" using command down',
             ])
             const t = setTimeout(() => { try { p.kill() } catch { /* gone */ } resolve() }, 2000)
-            p.on('close', (code) => { clearTimeout(t); if (code === 0) pasted = true; resolve() })
+            p.on('close', () => { clearTimeout(t); resolve() })
             p.on('error', () => { clearTimeout(t); resolve() })
           })
-        } catch { /* fall through to notification */ }
+        } catch { /* clipboard remains available */ }
       }
-      if (!pasted && Notification.isSupported()) {
-        const n = new Notification({
-          title: 'Voice transcribed (copied to clipboard)',
-          body: text.length > 120 ? text.slice(0, 117) + '…' : text,
-          silent: true,
-        })
-        n.show()
-      }
+      // The clipboard remains the fallback when auto-paste is unavailable.
+      // Voice input deliberately does not create a system notification.
     })
   )
 
   ipcMain.handle('voice:error', async (_e, message: string) =>
     wrap(async () => {
-      if (Notification.isSupported()) {
-        new Notification({ title: 'Voice input failed', body: String(message ?? 'Unknown error') }).show()
-      }
+      console.warn('Voice input failed:', String(message ?? 'Unknown error'))
     })
   )
 

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -33,6 +33,16 @@ import { TerminalPanel } from './TerminalPanel'
 import { splitWhiteboardMarkers, type WhiteboardMarker } from './teamWhiteboardFormat'
 import { groupTeamMessagesByMember, type TeamMemberMessageGroup } from './teamRunModel'
 import { ToolCallList } from './ToolCallList'
+import {
+  VOICE_RESULT_EVENT,
+  VOICE_LEVEL_EVENT,
+  VOICE_STATE_EVENT,
+  toggleVoiceInput,
+  type VoiceInputState,
+  type VoiceResultDetail,
+  type VoiceLevelDetail,
+  type VoiceStateDetail,
+} from './voiceInputEvents'
 
 const EDITOR_LOGOS: Partial<Record<string, string>> = {
   vscode: vscodeLogo,
@@ -87,6 +97,32 @@ const PaperclipIcon: React.FC<{ color: string }> = ({ color }) => (
   <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
     <path d="M21.44 11.05L12.25 20.24a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 11-2.83-2.83l8.49-8.48" />
   </svg>
+)
+
+const MicrophoneIcon: React.FC<{ color: string }> = ({ color }) => (
+  <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <rect x="9" y="2" width="6" height="12" rx="3" />
+    <path d="M5 10a7 7 0 0014 0M12 17v5M8 22h8" />
+  </svg>
+)
+
+const VoiceWaveform: React.FC<{ levels: number[] }> = ({ levels }) => (
+  <div
+    style={styles.voiceWaveform}
+    role="status"
+    aria-label="Recording"
+    title="Recording"
+  >
+    {levels.map((level, index) => (
+      <span
+        key={index}
+        style={{
+          ...styles.voiceWaveBar,
+          height: 3 + Math.round(level * 10),
+        }}
+      />
+    ))}
+  </div>
 )
 
 const UploadCloudIcon: React.FC<{ color: string; size?: number }> = ({ color, size = 32 }) => (
@@ -870,6 +906,60 @@ export const ChatTab: React.FC<Props> = ({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const taRef = useRef<HTMLTextAreaElement>(null)
+  const voiceTargetId = `chat-composer:${chatId}`
+  const voiceSelectionRef = useRef<{ start: number; end: number } | null>(null)
+  const [voiceState, setVoiceState] = useState<VoiceInputState>('idle')
+  const [voiceLevels, setVoiceLevels] = useState<number[]>(() => Array(11).fill(0.08))
+
+  useEffect(() => {
+    const onState = (event: Event) => {
+      const detail = (event as CustomEvent<VoiceStateDetail>).detail
+      if (detail.targetId === voiceTargetId) {
+        setVoiceState(detail.state)
+        if (detail.state !== 'recording') setVoiceLevels(Array(11).fill(0.08))
+      }
+    }
+    const onLevel = (event: Event) => {
+      const detail = (event as CustomEvent<VoiceLevelDetail>).detail
+      if (detail.targetId === voiceTargetId) setVoiceLevels(detail.levels)
+    }
+    const onResult = (event: Event) => {
+      const detail = (event as CustomEvent<VoiceResultDetail>).detail
+      if (detail.targetId !== voiceTargetId) return
+
+      let nextCursor = 0
+      setInput(current => {
+        const selection = voiceSelectionRef.current ?? { start: current.length, end: current.length }
+        const start = Math.min(selection.start, current.length)
+        const end = Math.min(Math.max(selection.end, start), current.length)
+        const spoken = detail.text.trim()
+        const leading = start > 0 && !/\s/.test(current[start - 1]) ? ' ' : ''
+        const trailing = end < current.length && !/\s/.test(current[end]) ? ' ' : ''
+        const inserted = `${leading}${spoken}${trailing}`
+        nextCursor = start + inserted.length
+        return current.slice(0, start) + inserted + current.slice(end)
+      })
+      setInputHistoryIndex(null)
+      requestAnimationFrame(() => {
+        const textarea = taRef.current
+        if (!textarea) return
+        textarea.focus()
+        textarea.setSelectionRange(nextCursor, nextCursor)
+        if (composerHeight == null) {
+          textarea.style.height = 'auto'
+          textarea.style.height = Math.min(textarea.scrollHeight, 120) + 'px'
+        }
+      })
+    }
+    window.addEventListener(VOICE_STATE_EVENT, onState)
+    window.addEventListener(VOICE_LEVEL_EVENT, onLevel)
+    window.addEventListener(VOICE_RESULT_EVENT, onResult)
+    return () => {
+      window.removeEventListener(VOICE_STATE_EVENT, onState)
+      window.removeEventListener(VOICE_LEVEL_EVENT, onLevel)
+      window.removeEventListener(VOICE_RESULT_EVENT, onResult)
+    }
+  }, [voiceTargetId, composerHeight])
 
   useEffect(() => {
     if (composerHeight != null) localStorage.setItem('codey.composerHeight', String(composerHeight))
@@ -2129,23 +2219,7 @@ export const ChatTab: React.FC<Props> = ({
               })}
             </div>
           )}
-          <div style={styles.composerRow}>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              accept="image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql"
-              style={{ display: 'none' }}
-              onChange={handleFilePick}
-            />
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              disabled={!isGatewayRunning || !!coreFailed || isSending}
-              style={styles.attachButton}
-              title="Attach file"
-            >
-              <PaperclipIcon color={isGatewayRunning && !isSending ? C.fg2 : C.fg3} />
-            </button>
+          <div style={styles.composerInputRow}>
             <textarea
               ref={taRef}
               value={input}
@@ -2164,23 +2238,71 @@ export const ChatTab: React.FC<Props> = ({
                 ? { ...styles.input, height: composerHeight, maxHeight: 'none' }
                 : styles.input}
             />
-            {isSending ? (
+          </div>
+          <div style={styles.composerToolbar}>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql"
+              style={{ display: 'none' }}
+              onChange={handleFilePick}
+            />
+            <div style={styles.composerTools}>
               <button
-                onClick={() => stopChat(chatId)}
-                style={{ ...styles.sendButton, background: C.red, cursor: 'pointer' }}
-                title="Stop (Esc)"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={!isGatewayRunning || !!coreFailed || isSending}
+                style={styles.attachButton}
+                title="Attach file"
               >
-                <StopIcon color="#fff" />
+                <PaperclipIcon color={isGatewayRunning && !isSending ? C.fg2 : C.fg3} />
               </button>
-            ) : (
+            </div>
+            <div style={styles.composerActions}>
+              {voiceState === 'recording' && <VoiceWaveform levels={voiceLevels} />}
               <button
-                onClick={send}
-                disabled={!canSend}
-                style={{ ...styles.sendButton, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
+                type="button"
+                onMouseDown={event => {
+                  // Keep the insertion point in the textarea when the button is clicked.
+                  event.preventDefault()
+                  const textarea = taRef.current
+                  voiceSelectionRef.current = textarea
+                    ? { start: textarea.selectionStart, end: textarea.selectionEnd }
+                    : { start: input.length, end: input.length }
+                }}
+                onClick={() => toggleVoiceInput(voiceTargetId)}
+                disabled={!isGatewayRunning || !!coreFailed}
+                style={{
+                  ...styles.voiceButton,
+                  color: voiceState === 'idle' ? C.fg2 : '#fff',
+                  background: voiceState === 'recording' ? C.red : voiceState === 'transcribing' ? C.accent : 'transparent',
+                  cursor: isGatewayRunning && !coreFailed ? 'pointer' : 'default',
+                }}
+                title={voiceState === 'recording' ? 'Stop dictation' : voiceState === 'transcribing' ? 'Transcribing…' : 'Start dictation'}
+                aria-label={voiceState === 'recording' ? 'Stop dictation' : 'Start dictation'}
               >
-                <SendIcon color={canSend ? C.onAccent : C.fg3} />
+                {voiceState === 'recording'
+                  ? <StopIcon color="#fff" />
+                  : <MicrophoneIcon color={voiceState === 'idle' ? (isGatewayRunning && !coreFailed ? C.fg2 : C.fg3) : '#fff'} />}
               </button>
-            )}
+              {isSending ? (
+                <button
+                  onClick={() => stopChat(chatId)}
+                  style={{ ...styles.sendButton, background: C.red, cursor: 'pointer' }}
+                  title="Stop (Esc)"
+                >
+                  <StopIcon color="#fff" />
+                </button>
+              ) : (
+                <button
+                  onClick={send}
+                  disabled={!canSend}
+                  style={{ ...styles.sendButton, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
+                >
+                  <SendIcon color={canSend ? C.onAccent : C.fg3} />
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -2449,16 +2571,35 @@ const styles: Record<string, React.CSSProperties> = {
     width: 26, height: 3, borderRadius: 2, background: C.fg3,
     transition: 'opacity 0.12s ease',
   },
-  composerRow: { display: 'flex', gap: 8, alignItems: 'flex-end', padding: 7 },
+  composerInputRow: { display: 'flex', padding: '12px 13px 4px' },
+  composerToolbar: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    gap: 8, padding: '4px 7px 7px',
+  },
+  composerTools: { display: 'flex', alignItems: 'center', gap: 4 },
+  composerActions: { display: 'flex', alignItems: 'center', gap: 4 },
   input: {
-    flex: 1, background: 'transparent', border: 'none', borderRadius: 8,
-    color: C.fg, fontSize: 13, padding: '11px 6px 9px', outline: 'none', resize: 'none',
+    width: '100%', background: 'transparent', border: 'none', borderRadius: 8,
+    color: C.fg, fontSize: 13, padding: '4px 2px', outline: 'none', resize: 'none',
     lineHeight: 1.5, maxHeight: 120, overflowY: 'auto',
   },
   sendButton: {
     width: 38, height: 38, borderRadius: 11, border: 'none',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     flexShrink: 0, transition: 'background 0.15s',
+  },
+  voiceButton: {
+    width: 36, height: 36, borderRadius: 9, border: 'none',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    flexShrink: 0, transition: 'background 0.15s',
+  },
+  voiceWaveform: {
+    height: 36, minWidth: 48, display: 'flex', alignItems: 'center',
+    justifyContent: 'center', gap: 2.5, flexShrink: 0,
+  },
+  voiceWaveBar: {
+    width: 2, minHeight: 3, maxHeight: 13, borderRadius: 2,
+    background: C.red, transition: 'height 45ms linear',
   },
   iconButtonPlus: { fontSize: 12, lineHeight: 1, marginLeft: 1, color: C.accent, fontWeight: 700 },
   orphanBanner: { padding: '8px 12px', background: C.warningBg, color: C.warningFg, fontSize: 12, borderTop: `1px solid ${C.border}` },

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -399,9 +399,17 @@ const FallbackList: React.FC<{
                 ))}
               </select>
               {i === 0 ? (
-                <span style={{ width: 28, fontSize: 10, color: C.fg3, textAlign: 'center' }} title="The default agent — drag a row above to replace it">—</span>
+                <span style={{
+                  width: 28, height: 28, flexShrink: 0,
+                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 10, color: C.fg3,
+                }} title="The default agent — drag a row above to replace it">—</span>
               ) : (
-                <button onClick={() => remove(i)} style={{ ...pillButton('danger'), display: 'inline-flex', alignItems: 'center' }} aria-label="Remove fallback"><UIIcon name="trash" size={13} /></button>
+                <button onClick={() => remove(i)} style={{
+                  ...pillButton('danger'),
+                  width: 28, height: 28, padding: 0, flexShrink: 0,
+                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                }} aria-label="Remove fallback"><UIIcon name="trash" size={13} /></button>
               )}
             </div>
             {dropIdx === order.length && i === order.length - 1 && dragIdx !== null && dragIdx !== i && (
@@ -521,46 +529,6 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
     <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
       {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
 
-      <Section title="Models" right={
-        <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
-      }/>
-      {creating && (
-        <ModelRow
-          entry={{ apiType: 'anthropic', model: '' }}
-          apis={apis}
-          isNew
-          onSave={saveModel}
-          onCancel={() => setCreating(false)}
-        />
-      )}
-      {models.length === 0 && !creating && (
-        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0' }}>No models yet. Click + Add to create one.</div>
-      )}
-      {[...models]
-        .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.model.localeCompare(b.model))
-        .map(m => <ModelRow key={m.model} entry={m} apis={apis} onSave={saveModel} onDelete={deleteModel}/>)}
-
-      <Section title="Agent priority" right={
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ color: C.fg3, fontSize: 11 }}>{fallback.enabled ? 'Enabled' : 'Disabled'}</span>
-          <Toggle on={fallback.enabled} onChange={enabled => updateFallback({ ...fallback, enabled })}/>
-        </div>
-      }/>
-      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
-        Row 1 is the default agent + model. When fallback is enabled and a request fails, the gateway tries each subsequent row in order. Drag to reorder.
-      </div>
-      <FallbackList
-        order={fallback.order}
-        models={models}
-        enabledAgents={enabledAgents}
-        onChange={next => updateFallback({ ...fallback, order: next })}
-      />
-      {!fallback.enabled && (
-        <div style={{ color: C.fg3, fontSize: 11, padding: '8px 0' }}>
-          Fallback is off — only Row 1 (the default) will run. Failures surface as errors instead of trying the rest of the list.
-        </div>
-      )}
-
       <Section title="Advisor"/>
       <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
         The advisor is the routing/orchestration model: it runs the <code>/team</code> advisor and picks workers for Auto-mode teams. Set a stronger model (e.g. Opus) here for better routing decisions. Leave both as <em>Use default</em> to fall back to the gateway default agent + model.
@@ -643,6 +611,47 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
           ))}
         </select>
       </div>
+
+      <Section title="Models" right={
+        <button onClick={() => setCreating(true)} style={pillButton('primary')} disabled={creating}>+ Add</button>
+      }/>
+      {creating && (
+        <ModelRow
+          entry={{ apiType: 'anthropic', model: '' }}
+          apis={apis}
+          isNew
+          onSave={saveModel}
+          onCancel={() => setCreating(false)}
+        />
+      )}
+      {models.length === 0 && !creating && (
+        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0' }}>No models yet. Click + Add to create one.</div>
+      )}
+      {[...models]
+        .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.model.localeCompare(b.model))
+        .map(m => <ModelRow key={m.model} entry={m} apis={apis} onSave={saveModel} onDelete={deleteModel}/>)}
+
+      <Section title="Agent priority" right={
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ color: C.fg3, fontSize: 11 }}>{fallback.enabled ? 'Enabled' : 'Disabled'}</span>
+          <Toggle on={fallback.enabled} onChange={enabled => updateFallback({ ...fallback, enabled })}/>
+        </div>
+      }/>
+      <div style={{ color: C.fg3, fontSize: 11, marginBottom: 8 }}>
+        Row 1 is the default agent + model. When fallback is enabled and a request fails, the gateway tries each subsequent row in order. Drag to reorder.
+      </div>
+      <FallbackList
+        order={fallback.order}
+        models={models}
+        enabledAgents={enabledAgents}
+        onChange={next => updateFallback({ ...fallback, order: next })}
+      />
+      {!fallback.enabled && (
+        <div style={{ color: C.fg3, fontSize: 11, padding: '8px 0' }}>
+          Fallback is off — only Row 1 (the default) will run. Failures surface as errors instead of trying the rest of the list.
+        </div>
+      )}
+
     </div>
   )
 }

--- a/codey-mac/src/components/VoiceRecorder.tsx
+++ b/codey-mac/src/components/VoiceRecorder.tsx
@@ -1,5 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { C } from '../theme'
+import {
+  VOICE_RESULT_EVENT,
+  VOICE_LEVEL_EVENT,
+  VOICE_STATE_EVENT,
+  VOICE_TOGGLE_EVENT,
+  type VoiceInputState,
+  type VoiceResultDetail,
+  type VoiceLevelDetail,
+  type VoiceStateDetail,
+  type VoiceToggleDetail,
+} from './voiceInputEvents'
 
 interface VoiceCfg {
   enabled?: boolean
@@ -9,24 +20,96 @@ interface VoiceCfg {
   apiModel?: string
 }
 
-type State = 'idle' | 'recording' | 'transcribing'
-
 export const VoiceRecorder: React.FC = () => {
-  const [state, setState] = useState<State>('idle')
+  const [state, setState] = useState<VoiceInputState>('idle')
+  const [globalLevels, setGlobalLevels] = useState<number[]>(() => Array(11).fill(0.08))
   const recorderRef = useRef<MediaRecorder | null>(null)
   const chunksRef = useRef<Blob[]>([])
   const streamRef = useRef<MediaStream | null>(null)
-  const stateRef = useRef<State>('idle')
+  const stateRef = useRef<VoiceInputState>('idle')
+  const targetRef = useRef<string | null>(null)
+  const audioContextRef = useRef<AudioContext | null>(null)
+  const levelFrameRef = useRef<number | null>(null)
   stateRef.current = state
 
+  function updateState(next: VoiceInputState) {
+    stateRef.current = next
+    setState(next)
+    window.dispatchEvent(new CustomEvent<VoiceStateDetail>(VOICE_STATE_EVENT, {
+      detail: { state: next, targetId: targetRef.current },
+    }))
+  }
+
+  function toggleRecording(targetId: string | null) {
+    if (stateRef.current === 'idle') {
+      targetRef.current = targetId
+      void startRecording()
+    } else if (stateRef.current === 'recording' && targetRef.current === targetId) {
+      stopRecording()
+    }
+    // Ignore unrelated targets and taps while transcribing.
+  }
+
   useEffect(() => {
-    const off = window.codey.voice.onHotkey(() => {
-      if (stateRef.current === 'idle') void startRecording()
-      else if (stateRef.current === 'recording') stopRecording()
-      // ignore taps while transcribing
-    })
-    return off
+    const off = window.codey.voice.onHotkey(() => toggleRecording(null))
+    const onToggle = (event: Event) => {
+      const { targetId } = (event as CustomEvent<VoiceToggleDetail>).detail
+      toggleRecording(targetId)
+    }
+    window.addEventListener(VOICE_TOGGLE_EVENT, onToggle)
+    return () => {
+      off()
+      window.removeEventListener(VOICE_TOGGLE_EVENT, onToggle)
+      stopLevelMeter()
+    }
   }, [])
+
+  function startLevelMeter(stream: MediaStream) {
+    stopLevelMeter()
+    const targetId = targetRef.current
+
+    const audioContext = new AudioContext()
+    const analyser = audioContext.createAnalyser()
+    analyser.fftSize = 512
+    analyser.smoothingTimeConstant = 0.72
+    audioContext.createMediaStreamSource(stream).connect(analyser)
+    audioContextRef.current = audioContext
+    void audioContext.resume()
+
+    const bins = new Uint8Array(analyser.frequencyBinCount)
+    // Log-ish bands covering the frequencies where speech carries most energy.
+    const ranges = [[1, 2], [2, 3], [3, 4], [4, 6], [6, 8], [8, 11], [11, 15], [15, 20], [20, 27], [27, 35], [35, 45]]
+    let lastSent = 0
+    const sample = (time: number) => {
+      if (time - lastSent >= 45) {
+        analyser.getByteFrequencyData(bins)
+        const levels = ranges.map(([start, end]) => {
+          let total = 0
+          for (let index = start; index < end; index++) total += bins[index]
+          const average = total / (end - start)
+          return Math.max(0.08, Math.min(1, (average - 8) / 92))
+        })
+        if (targetId) {
+          window.dispatchEvent(new CustomEvent<VoiceLevelDetail>(VOICE_LEVEL_EVENT, {
+            detail: { levels, targetId },
+          }))
+        } else {
+          setGlobalLevels(levels)
+        }
+        lastSent = time
+      }
+      levelFrameRef.current = requestAnimationFrame(sample)
+    }
+    levelFrameRef.current = requestAnimationFrame(sample)
+  }
+
+  function stopLevelMeter() {
+    if (levelFrameRef.current != null) cancelAnimationFrame(levelFrameRef.current)
+    levelFrameRef.current = null
+    const audioContext = audioContextRef.current
+    audioContextRef.current = null
+    if (audioContext) void audioContext.close().catch(() => {})
+  }
 
   async function startRecording() {
     try {
@@ -41,10 +124,13 @@ export const VoiceRecorder: React.FC = () => {
       rec.onstop = () => { void handleStop(mime) }
       rec.start()
       recorderRef.current = rec
-      setState('recording')
+      updateState('recording')
+      try { startLevelMeter(stream) } catch { stopLevelMeter() }
     } catch (err: any) {
+      stopLevelMeter()
       await window.codey.voice.showError(err?.message ?? 'Microphone unavailable')
-      setState('idle')
+      updateState('idle')
+      targetRef.current = null
     }
   }
 
@@ -53,7 +139,8 @@ export const VoiceRecorder: React.FC = () => {
   }
 
   async function handleStop(mime: string) {
-    setState('transcribing')
+    stopLevelMeter()
+    updateState('transcribing')
     streamRef.current?.getTracks().forEach(t => t.stop())
     streamRef.current = null
     const blob = new Blob(chunksRef.current, { type: mime })
@@ -65,7 +152,8 @@ export const VoiceRecorder: React.FC = () => {
 
       if (!voice.apiKey) {
         await window.codey.voice.showError('Add an API key in Settings → Whisper.')
-        setState('idle')
+        updateState('idle')
+        targetRef.current = null
         return
       }
 
@@ -86,32 +174,62 @@ export const VoiceRecorder: React.FC = () => {
       }
       const data = await resp.json()
       const text = (data?.text ?? '').trim()
-      if (text) await window.codey.voice.notifyTranscribed(text)
-      else await window.codey.voice.showError('No speech detected.')
+      if (text) {
+        const targetId = targetRef.current
+        if (targetId) {
+          window.dispatchEvent(new CustomEvent<VoiceResultDetail>(VOICE_RESULT_EVENT, {
+            detail: { text, targetId },
+          }))
+        } else {
+          await window.codey.voice.notifyTranscribed(text)
+        }
+      } else await window.codey.voice.showError('No speech detected.')
     } catch (err: any) {
       await window.codey.voice.showError(err?.message ?? String(err))
     } finally {
-      setState('idle')
+      updateState('idle')
+      targetRef.current = null
     }
   }
 
-  if (state === 'idle') return null
+  // Composer-triggered dictation renders inside that composer. The floating
+  // capsule is reserved for system-wide hotkey recording.
+  if (state === 'idle' || targetRef.current !== null) return null
   return (
-    <div style={{
-      position: 'fixed', bottom: 18, right: 18, zIndex: 9999,
-      display: 'flex', alignItems: 'center', gap: 8,
-      background: C.surface, border: `1px solid ${C.border2}`,
-      padding: '8px 12px', borderRadius: 8, fontSize: 12,
-      boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
-    }}>
-      <span style={{
-        width: 8, height: 8, borderRadius: '50%',
-        background: state === 'recording' ? C.red : C.accent,
-        animation: 'codey-pulse 1.2s ease-in-out infinite',
-      }}/>
-      <span style={{ color: C.fg }}>
-        {state === 'recording' ? 'Recording — press hotkey to stop' : 'Transcribing…'}
-      </span>
+    <div style={styles.capsule} role="status" aria-label={state === 'recording' ? 'Recording' : 'Transcribing'}>
+      {state === 'recording' ? (
+        <div style={styles.waveform} title="Recording">
+          {globalLevels.map((level, index) => (
+            <span key={index} style={{ ...styles.waveBar, height: 3 + Math.round(level * 11) }} />
+          ))}
+        </div>
+      ) : (
+        <>
+          <span style={styles.transcribingDot} />
+          <span style={{ color: C.fg }}>Transcribing…</span>
+        </>
+      )}
     </div>
   )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  capsule: {
+    position: 'fixed', bottom: 18, right: 18, zIndex: 9999,
+    minHeight: 40, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+    background: C.surface, border: `1px solid ${C.border2}`,
+    padding: '7px 12px', borderRadius: 999, fontSize: 12,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+  },
+  waveform: {
+    height: 24, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2,
+  },
+  waveBar: {
+    width: 2, minHeight: 3, maxHeight: 14, borderRadius: 2,
+    background: C.red, transition: 'height 45ms linear',
+  },
+  transcribingDot: {
+    width: 7, height: 7, borderRadius: '50%', background: C.accent,
+    animation: 'codey-pulse 1.2s ease-in-out infinite',
+  },
 }

--- a/codey-mac/src/components/voiceInputEvents.ts
+++ b/codey-mac/src/components/voiceInputEvents.ts
@@ -1,0 +1,31 @@
+export type VoiceInputState = 'idle' | 'recording' | 'transcribing'
+
+export const VOICE_TOGGLE_EVENT = 'codey:voice-toggle'
+export const VOICE_STATE_EVENT = 'codey:voice-state'
+export const VOICE_RESULT_EVENT = 'codey:voice-result'
+export const VOICE_LEVEL_EVENT = 'codey:voice-level'
+
+export interface VoiceToggleDetail {
+  targetId: string
+}
+
+export interface VoiceStateDetail {
+  state: VoiceInputState
+  targetId: string | null
+}
+
+export interface VoiceResultDetail {
+  text: string
+  targetId: string
+}
+
+export interface VoiceLevelDetail {
+  levels: number[]
+  targetId: string
+}
+
+export function toggleVoiceInput(targetId: string) {
+  window.dispatchEvent(new CustomEvent<VoiceToggleDetail>(VOICE_TOGGLE_EVENT, {
+    detail: { targetId },
+  }))
+}

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -165,14 +165,21 @@ export interface Chat {
     }[];
     inducedFrom?: string[];
   };
-  /**
-   * Warm CLI session for this chat. When set, the next turn for the same
-   * coding agent is sent via `--resume <sessionId>` (only the new user text is
-   * passed to the agent; the agent retrieves prior context from its own
-   * session store). Cleared on agent switch, selection-type change, /clear,
-   * or when a resume attempt fails.
-   */
-  sessionAnchor?: { agent: 'claude-code' | 'opencode' | 'codex'; sessionId: string };
+  /** Warm CLI sessions retained independently for each agent/model identity. */
+  sessionAnchors?: Array<{
+    agent: 'claude-code' | 'opencode' | 'codex';
+    model?: string;
+    sessionId: string;
+    /** Last Codey transcript message already visible inside this CLI session. */
+    syncedThroughMessageId?: string;
+  }>;
+  /** Legacy single-anchor field. Read for migration, never written by new code. */
+  sessionAnchor?: {
+    agent: 'claude-code' | 'opencode' | 'codex';
+    model?: string;
+    sessionId: string;
+    syncedThroughMessageId?: string;
+  };
   /**
    * Rolling LLM-generated summary of older messages. When set, the bootstrap
    * prompt prepends `summary` and only renders the transcript tail starting at

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -139,6 +139,39 @@ export function buildChatResumePrompt(
   return parts.join('\n\n');
 }
 
+/**
+ * Resume a previously used agent after another agent handled some turns.
+ * Only messages newer than this session's sync cursor are replayed, so an
+ * agent receives the gap exactly once instead of being polluted by the full
+ * transcript every time the user switches back.
+ */
+export function buildChatCatchupPrompt(
+  chat: Chat,
+  syncedThroughMessageId: string,
+  userText: string,
+  attachments?: FileAttachment[],
+): string {
+  const cursor = chat.messages.findIndex(message => message.id === syncedThroughMessageId);
+  if (cursor < 0 || cursor === chat.messages.length - 1) {
+    return buildChatResumePrompt(userText, attachments);
+  }
+
+  const parts: string[] = [];
+  if (attachments && attachments.length > 0) parts.push(formatAttachmentList(attachments));
+
+  const updates = chat.messages.slice(cursor + 1).map(message => {
+    if (message.role === 'user') return `[user]\n${message.content}`;
+    const identity = [message.agent, message.model].filter(Boolean).join(' / ');
+    return `[assistant${identity ? ` via ${identity}` : ''}]\n${message.content}`;
+  }).join('\n\n');
+
+  parts.push(
+    `[Codey conversation updates since this agent was last active — context only; do not repeat or fabricate turns]\n${updates}`,
+    `[Respond to this new user message]\n${userText}`,
+  );
+  return parts.join('\n\n');
+}
+
 export function assistantPrefixForSelection(chat: Chat): string {
   switch (chat.selection.type) {
     case 'worker': return `[worker:${chat.selection.name}]\n`;

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -214,26 +214,84 @@ export class ChatManager {
     const changedKind = chat.selection.type !== selection.type
       || (chat.selection.type === selection.type && (chat.selection as { name?: string }).name !== (selection as { name?: string }).name);
     chat.selection = selection;
-    if (changedKind) delete chat.sessionAnchor;
+    if (changedKind) {
+      delete chat.sessionAnchor;
+      delete chat.sessionAnchors;
+    }
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;
   }
 
-  /** Persist the warm CLI session for this chat. */
+  /** Find the warm CLI session belonging to one exact agent/model identity. */
+  getSessionAnchor(
+    chatId: string,
+    agent: NonNullable<Chat['sessionAnchor']>['agent'],
+    model?: string,
+  ): NonNullable<Chat['sessionAnchor']> | undefined {
+    const chat = this.get(chatId);
+    if (!chat) return undefined;
+
+    // Lazily migrate the pre-pool anchor before selecting an identity. Under
+    // the old single-anchor design it always represented the agent that had
+    // processed the current transcript tail, so the last persisted message is
+    // a safe initial sync cursor. This migration runs before a newly selected
+    // agent appends its first user turn.
+    if (chat.sessionAnchor) {
+      const legacy = {
+        ...chat.sessionAnchor,
+        syncedThroughMessageId: chat.sessionAnchor.syncedThroughMessageId
+          ?? chat.messages[chat.messages.length - 1]?.id,
+      };
+      const pooled = [...(chat.sessionAnchors ?? [])]
+        .filter(item => item.agent !== legacy.agent || item.model !== legacy.model)
+        .concat(legacy);
+      chat.sessionAnchors = pooled;
+      delete chat.sessionAnchor;
+      this.persist(chat);
+    }
+
+    const pooled = chat.sessionAnchors?.find(anchor => anchor.agent === agent && anchor.model === model);
+    return pooled;
+  }
+
+  /** Persist or advance the warm CLI session for one agent/model identity. */
   setSessionAnchor(chatId: string, anchor: NonNullable<Chat['sessionAnchor']>): void {
     const chat = this.cache.get(chatId);
     if (!chat) return;
-    chat.sessionAnchor = anchor;
+    const migrated = [...(chat.sessionAnchors ?? [])];
+    if (chat.sessionAnchor && !migrated.some(item =>
+      item.agent === chat.sessionAnchor!.agent && item.model === chat.sessionAnchor!.model
+    )) {
+      migrated.push(chat.sessionAnchor);
+    }
+    chat.sessionAnchors = migrated
+      .filter(item => item.agent !== anchor.agent || item.model !== anchor.model)
+      .concat(anchor);
+    delete chat.sessionAnchor;
     chat.updatedAt = Date.now();
     this.persist(chat);
   }
 
-  /** Drop the warm CLI session — next turn will bootstrap. */
-  clearSessionAnchor(chatId: string): void {
+  /** Drop one identity's session, or every session when no identity is given. */
+  clearSessionAnchor(
+    chatId: string,
+    agent?: NonNullable<Chat['sessionAnchor']>['agent'],
+    model?: string,
+  ): void {
     const chat = this.cache.get(chatId);
-    if (!chat || !chat.sessionAnchor) return;
-    delete chat.sessionAnchor;
+    if (!chat) return;
+    if (agent === undefined) {
+      if (!chat.sessionAnchor && !chat.sessionAnchors?.length) return;
+      delete chat.sessionAnchor;
+      delete chat.sessionAnchors;
+    } else {
+      const before = chat.sessionAnchors?.length ?? 0;
+      chat.sessionAnchors = chat.sessionAnchors?.filter(item => item.agent !== agent || item.model !== model);
+      if (chat.sessionAnchors?.length === 0) delete chat.sessionAnchors;
+      if (chat.sessionAnchor?.agent === agent && chat.sessionAnchor.model === model) delete chat.sessionAnchor;
+      if (before === (chat.sessionAnchors?.length ?? 0) && chat.sessionAnchor) return;
+    }
     chat.updatedAt = Date.now();
     this.persist(chat);
   }
@@ -244,12 +302,12 @@ export class ChatManager {
    */
   updateAgentModel(chatId: string, agent?: Chat['agent'] | null, model?: string | null): Chat {
     const chat = this.requireChat(chatId);
-    const prevAgent = chat.agent;
     if (agent === null || agent === undefined) delete chat.agent;
     else chat.agent = agent;
     if (model === null || model === undefined || model === '') delete chat.model;
     else chat.model = model;
-    if (chat.agent !== prevAgent) delete chat.sessionAnchor;
+    // Keep every agent/model session. The next turn selects the matching
+    // anchor and incrementally synchronizes only the messages it has missed.
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;

--- a/packages/gateway/src/chats.workingDirOverride.test.ts
+++ b/packages/gateway/src/chats.workingDirOverride.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { ChatManager } from './chats';
+import { buildChatCatchupPrompt } from './chat-runner';
 
 describe('ChatManager.setWorkingDirOverride', () => {
   let root: string;
@@ -20,5 +21,99 @@ describe('ChatManager.setWorkingDirOverride', () => {
     expect(set.workingDirOverride).toBe('/tmp/wt');
     const cleared = mgr.setWorkingDirOverride(chat.id, null);
     expect(cleared.workingDirOverride).toBeUndefined();
+  });
+});
+
+describe('ChatManager.updateAgentModel', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('retains the previous model session when the selection changes', () => {
+    const chat = mgr.create({ workspaceName: 'ws', agent: 'codex', model: 'model-a' });
+    mgr.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'session-a' });
+
+    const updated = mgr.updateAgentModel(chat.id, 'codex', 'model-b');
+
+    expect(updated.model).toBe('model-b');
+    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')?.sessionId).toBe('session-a');
+  });
+
+  it('stores independent warm sessions for each agent/model identity', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.setSessionAnchor(chat.id, {
+      agent: 'codex', model: 'model-a', sessionId: 'session-a', syncedThroughMessageId: 'a1',
+    });
+    mgr.setSessionAnchor(chat.id, {
+      agent: 'claude-code', model: 'model-b', sessionId: 'session-b', syncedThroughMessageId: 'b1',
+    });
+
+    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')).toMatchObject({
+      sessionId: 'session-a', syncedThroughMessageId: 'a1',
+    });
+    expect(mgr.getSessionAnchor(chat.id, 'claude-code', 'model-b')).toMatchObject({
+      sessionId: 'session-b', syncedThroughMessageId: 'b1',
+    });
+  });
+
+  it('clears only the failed identity while preserving other agents', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'session-a' });
+    mgr.setSessionAnchor(chat.id, { agent: 'claude-code', model: 'model-b', sessionId: 'session-b' });
+
+    mgr.clearSessionAnchor(chat.id, 'codex', 'model-a');
+
+    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')).toBeUndefined();
+    expect(mgr.getSessionAnchor(chat.id, 'claude-code', 'model-b')?.sessionId).toBe('session-b');
+  });
+
+  it('migrates a legacy anchor with the current transcript cursor', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'question', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'a1', role: 'assistant', content: 'answer', timestamp: 2, isComplete: true });
+    const stored = mgr.get(chat.id)!;
+    stored.sessionAnchor = { agent: 'codex', model: 'model-a', sessionId: 'legacy-session' };
+    delete stored.sessionAnchors;
+
+    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')).toMatchObject({
+      sessionId: 'legacy-session', syncedThroughMessageId: 'a1',
+    });
+    expect(mgr.get(chat.id)?.sessionAnchor).toBeUndefined();
+  });
+});
+
+describe('buildChatCatchupPrompt', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('replays only messages after the returning agent sync cursor', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'already known user turn', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'a1', role: 'assistant', content: 'already known answer', timestamp: 2, isComplete: true, agent: 'codex', model: 'model-a' });
+    mgr.appendMessage(chat.id, { id: 'u2', role: 'user', content: 'message handled while away', timestamp: 3, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'a2', role: 'assistant', content: 'other agent answer', timestamp: 4, isComplete: true, agent: 'claude-code', model: 'model-b' });
+
+    const prompt = buildChatCatchupPrompt(mgr.get(chat.id)!, 'a1', 'new question');
+
+    expect(prompt).toContain('message handled while away');
+    expect(prompt).toContain('other agent answer');
+    expect(prompt).toContain('new question');
+    expect(prompt).not.toContain('already known user turn');
+    expect(prompt).not.toContain('already known answer');
   });
 });

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -22,7 +22,7 @@ import { WorkerManager } from '@codey/core';
 import { ChatManager } from './chats';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
-import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
+import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildChatCatchupPrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
 import { resolveChoiceDigit } from './digit-mapping';
@@ -5277,16 +5277,19 @@ Example: /model gpt-4.1 write a Python script`;
     // resume) because team dispatch builds worker prompts internally.
     const selPrefix = assistantPrefixForSelection(chat);
     const canResume = chat.selection.type !== 'team';
-    const warmAnchor = canResume && chat.sessionAnchor && chat.sessionAnchor.agent === agent
-      ? chat.sessionAnchor
+    const warmAnchor = canResume
+      ? this.chatManager.getSessionAnchor(chatId, agent, model?.model)
       : undefined;
 
     let prompt: string;
     let resumeSessionId: string | undefined;
     let newSessionId: string | undefined;
     if (warmAnchor) {
-      // Resume turn: send only the new user text (+ attachments).
-      prompt = selPrefix + buildChatResumePrompt(userText, attachments);
+      // Resume the agent's own session. If other agents produced messages
+      // while it was inactive, replay only that unseen gap before the new turn.
+      prompt = selPrefix + (warmAnchor.syncedThroughMessageId
+        ? buildChatCatchupPrompt(chat, warmAnchor.syncedThroughMessageId, userText, attachments)
+        : buildChatResumePrompt(userText, attachments));
       resumeSessionId = warmAnchor.sessionId;
     } else {
       // Bootstrap turn: include prior history once. For claude-code, pre-allocate
@@ -5386,6 +5389,7 @@ Example: /model gpt-4.1 write a Python script`;
       let teamTurnId: string | undefined;
       let agentUserQuestion: AgentResponse['userQuestion'];
       let singleAgentResponse: AgentResponse | null | undefined;
+      let detachedSoloAdvisorRun = false;
       if (pendingTeam && !isSlashTurn) {
         // This turn answers a paused team's question. Resume regardless of the
         // chat's current selection — a paused team can outlive a selection change.
@@ -5476,7 +5480,7 @@ Example: /model gpt-4.1 write a Python script`;
         // drop the anchor and retry once with a full bootstrap prompt.
         if (resumeSessionId && !response?.success && !abortController.signal.aborted) {
           this.logger.warn(`[chat ${chatId}] resume of ${resumeSessionId} failed; bootstrapping`);
-          this.chatManager.clearSessionAnchor(chatId);
+          this.chatManager.clearSessionAnchor(chatId, agent, model?.model);
           streamedText = '';
           resumeSessionId = undefined;
           newSessionId = canResume && agent === 'claude-code' ? randomUUID() : undefined;
@@ -5530,6 +5534,7 @@ Example: /model gpt-4.1 write a Python script`;
           // Intentionally no resumeSessionId/newSessionId — each re-run bootstraps
           // fresh (the prior attempt + guidance are inlined in the followup prompt)
           // so this works uniformly across all agent types, not just claude-code.
+          detachedSoloAdvisorRun = true;
           response = await this.runWithFallback(agent, {
             prompt: followup,
             agent,
@@ -5548,13 +5553,7 @@ Example: /model gpt-4.1 write a Python script`;
         output = response?.success ? this.formatAgentResponse(response) : (streamedText || '');
         if (chat.soloAdvisor) output = stripAskAdvisor(output);
         tokens = (response as any)?.tokens?.total;
-        // Persist the anchor on success for next-turn resume.
-        if (canResume && response?.success) {
-          const anchorId = newSessionId ?? (response as any)?.sessionId;
-          if (anchorId) {
-            this.chatManager.setSessionAnchor(chatId, { agent, sessionId: anchorId });
-          }
-        }
+        // The cursor is advanced after the assistant message is persisted.
         // Surface permission denials so the UI can offer to add them to the allow list.
         if (response?.permissionDenials && response.permissionDenials.length > 0) {
           sink({ type: 'permission_denials', chatId, denials: response.permissionDenials });
@@ -5632,6 +5631,22 @@ Example: /model gpt-4.1 write a Python script`;
       let teamSummaryMessageId: string | undefined;
       if (!teamTurnId) {
         const updated = this.chatManager.appendMessage(chatId, assistantMessage);
+
+        if (canResume && singleAgentResponse?.success && !detachedSoloAdvisorRun) {
+          // A fallback response belongs to the fallback adapter's emitted
+          // session, never the primary adapter's resume/new session id.
+          const anchorId = singleAgentResponse.fallback
+            ? (singleAgentResponse as any)?.sessionId
+            : resumeSessionId ?? newSessionId ?? (singleAgentResponse as any)?.sessionId;
+          if (anchorId) {
+            this.chatManager.setSessionAnchor(chatId, {
+              agent: responseAgent,
+              model: responseModel,
+              sessionId: anchorId,
+              syncedThroughMessageId: assistantMessage.id,
+            });
+          }
+        }
 
         // Persist lastAskedOptions on non-team chats so the next user reply can
         // be digit-mapped. Team flows track this via pendingTeam.options.


### PR DESCRIPTION
## Summary

- retain independent CLI sessions for each agent/model identity
- synchronize Codey's cached transcript into a newly selected agent on first use
- resume previously used agents with only the messages added since their last sync cursor
- avoid advancing or misassigning session cursors during fallback and detached advisor runs
- reorganize the chat composer into a Codex-style input area with a lower toolbar
- add composer dictation controls, live audio levels, and quieter clipboard fallback behavior
- refine model/agent settings layout

## Why

Codey previously kept a single warm session anchor and validated it incompletely. Switching models could resume the prior model, while switching agents discarded the previous agent's position. Repeated switches could therefore route turns incorrectly or replay too much history into an existing agent session.

The new session pool keys anchors by agent and model and tracks the last Codey message synchronized into each session. A returning agent receives only the unseen transcript gap, preserving continuity without duplicating prior context.

## Validation

- `npm run build:core`
- `npm run build:gateway`
- `npx tsc -p codey-mac/tsconfig.json --noEmit`
- targeted gateway regression tests: 6/6 passed
- Mac component tests: 143/143 passed
- full gateway assertions: 189/189 passed; Vitest still exits non-zero because the existing parallel-team file watchers hit the macOS `EMFILE` limit
