### PR TITLE
Render assistant messages as document flow

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -388,6 +388,9 @@ ${paletteToCssVars(terminalLight)}
 ${paletteToCssVars(terminalDark)}
   }
   html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
+  /* Roomy headings open a section with a large top margin. The first block in a
+     turn has nothing above it to separate from, so that margin is dead space. */
+  .md-roomy > :first-child { margin-top: 0 !important; }
   body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
   * { box-sizing: border-box; }
   ::-webkit-scrollbar { width: 5px; height: 5px; }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1971,26 +1971,44 @@ export const ChatTab: React.FC<Props> = ({
               style={{
                 display: 'flex', flexDirection: 'column',
                 alignItems: isUser ? 'flex-end' : 'flex-start',
-                marginBottom: 12,
+                // Assistant turns have no bubble to bound them, so spacing is
+                // what keeps two consecutive replies from reading as one.
+                marginBottom: isUser ? 12 : 20,
                 cursor: isUser ? 'default' : 'pointer',
                 paddingLeft: !isUser ? 6 : 0,
                 transform: isSelected ? 'translateY(-3px)' : 'translateY(0)',
                 transition: 'transform 0.18s ease',
               }}
             >
-              <div style={{
+              <div style={isUser ? {
                 minWidth: 0, maxWidth: '72%', padding: '10px 14px',
-                borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-                background: isUser ? C.userBg : C.aiBg,
-                color: isUser ? C.onAccent : C.fg, fontSize: 13, lineHeight: 1.55,
+                borderRadius: '16px 16px 4px 16px',
+                background: C.userBg,
+                color: C.onAccent, fontSize: 13, lineHeight: 1.55,
                 overflowWrap: 'anywhere', wordBreak: 'break-word',
-                boxShadow: isUser
-                  ? 'none'
-                  : (isSelected
-                      ? `0 10px 24px ${C.accentDim}, 0 6px 14px ${C.accentDim}`
-                      : '0 1px 3px rgba(0,0,0,0.18)'),
-                border: isUser ? 'none' : `1px solid ${isSelected ? C.accent : C.border2}`,
-                transition: 'box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease',
+              } : {
+                // The bubble marks "what the user said". An assistant reply
+                // reads better as a document, and at length the bubble was the
+                // thing making it dense.
+                //
+                // `ch` resolves against this element's 13px font, so 78ch is
+                // ~562px — about 72 characters of the 14px roomy body text, or
+                // ~43 Chinese characters. Unlike the old 72%, it does not grow
+                // with the window.
+                minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
+                // The rail is always 3px, transparent when unselected, so
+                // selecting a turn never shifts the text column sideways.
+                // 6 (row) + 3 (rail) + 12 = 21px, exactly the old inset of
+                // 6 (row) + 1 (border) + 14 (bubble padding).
+                padding: '0 0 0 12px',
+                borderLeft: `3px solid ${isSelected ? C.accent : 'transparent'}`,
+                background: isSelected ? C.accentDim : 'transparent',
+                // fontSize/lineHeight stay compact: non-Markdown children
+                // (LiveActivity, tool chips) inherit them. The roomy metrics
+                // apply inside <Markdown layout="roomy"> only.
+                color: C.fg, fontSize: 13, lineHeight: 1.55,
+                overflowWrap: 'anywhere', wordBreak: 'break-word',
+                transition: 'border-color 0.18s ease, background 0.18s ease',
               }}>
                 {!isUser && !!flight && msg === lastMsg && (
                   <LiveActivity toolCalls={msg.toolCalls} />

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2027,7 +2027,7 @@ export const ChatTab: React.FC<Props> = ({
                           isComplete={msg.isComplete ?? false}
                         />
                       )}
-                      <Markdown variant="assistant">{text}</Markdown>
+                      <Markdown variant="assistant" layout="roomy">{text}</Markdown>
                     </div>
                   )
                   return (

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -17,11 +17,24 @@ interface MarkdownProps {
  *  paragraph stopped reading as a unit. Heading margins are deliberately
  *  asymmetric — a heading belongs to the text below it, not midway between two
  *  blocks. */
+interface Metrics {
+  fontSize: number
+  lineHeight: number
+  /** Bottom margin for block-level elements (p, ul, ol, blockquote, code blocks, tables). */
+  blockGap: number
+  li: number
+  hr: string
+  h1: { fontSize: number; margin: string }
+  h2: { fontSize: number; margin: string }
+  h3: { fontSize: number; margin: string }
+  h4: { fontSize: number; margin: string }
+}
+
 const METRICS = {
   compact: {
     fontSize: 13,
     lineHeight: 1.55,
-    block: 8,
+    blockGap: 8,
     li: 2,
     hr: '10px 0',
     h1: { fontSize: 17, margin: '8px 0 6px' },
@@ -30,12 +43,12 @@ const METRICS = {
     h4: { fontSize: 13, margin: '6px 0 4px' },
   },
   roomy: {
+    fontSize: 14,
     // 1.7 rather than 1.55: Chinese has a high character-face ratio and no
     // ascenders or descenders, so identical leading reads tighter than it does
     // for Latin text.
-    fontSize: 14,
     lineHeight: 1.7,
-    block: 14,
+    blockGap: 14,
     li: 5,
     hr: '18px 0',
     h1: { fontSize: 20, margin: '22px 0 8px' },
@@ -43,7 +56,7 @@ const METRICS = {
     h3: { fontSize: 15, margin: '18px 0 6px' },
     h4: { fontSize: 14, margin: '16px 0 6px' },
   },
-} as const
+} as const satisfies Record<'compact' | 'roomy', Metrics>
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Monaco, "Courier New", monospace'
 
@@ -51,7 +64,8 @@ const CodeBlock: React.FC<{
   children: React.ReactNode
   background: string
   borderColor: string
-}> = ({ children, background, borderColor }) => {
+  blockMargin: number
+}> = ({ children, background, borderColor, blockMargin }) => {
   const [copied, setCopied] = React.useState(false)
   const resetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const child: any = React.Children.toArray(children)[0]
@@ -83,7 +97,7 @@ const CodeBlock: React.FC<{
         background,
         border: `1px solid ${borderColor}`,
         borderRadius: 8,
-        margin: '6px 0 8px',
+        margin: `6px 0 ${blockMargin}px`,
         position: 'relative',
         overflow: 'hidden',
       }}
@@ -216,7 +230,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          p: ({ children }) => <p style={{ margin: `0 0 ${M.block}px 0` }}>{children}</p>,
+          p: ({ children }) => <p style={{ margin: `0 0 ${M.blockGap}px 0` }}>{children}</p>,
           a: ({ href, children }) => (
             <a
               href={href}
@@ -236,8 +250,8 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           h2: ({ children }) => <h2 style={{ fontSize: M.h2.fontSize, fontWeight: 700, margin: M.h2.margin }}>{children}</h2>,
           h3: ({ children }) => <h3 style={{ fontSize: M.h3.fontSize, fontWeight: 700, margin: M.h3.margin }}>{children}</h3>,
           h4: ({ children }) => <h4 style={{ fontSize: M.h4.fontSize, fontWeight: 700, margin: M.h4.margin }}>{children}</h4>,
-          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ul>,
-          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ol>,
+          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.blockGap}px 0`, paddingLeft: 20 }}>{children}</ul>,
+          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.blockGap}px 0`, paddingLeft: 20 }}>{children}</ol>,
           li: ({ children }) => <li style={{ marginBottom: M.li }}>{children}</li>,
           hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: M.hr }} />,
           blockquote: ({ children }) => (
@@ -245,7 +259,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
               style={{
                 borderLeft: `3px solid ${quoteBorder}`,
                 paddingLeft: 10,
-                margin: `0 0 ${M.block}px 0`,
+                margin: `0 0 ${M.blockGap}px 0`,
                 color: quoteFg,
               }}
             >
@@ -253,7 +267,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
             </blockquote>
           ),
           table: ({ children }) => (
-            <div style={{ overflowX: 'auto', margin: '6px 0 10px', maxWidth: '100%' }}>
+            <div style={{ overflowX: 'auto', margin: `6px 0 ${M.blockGap}px`, maxWidth: '100%' }}>
               <table
                 style={{
                   borderCollapse: 'collapse',
@@ -297,7 +311,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           ),
           pre: ({ children }: any) => {
             return (
-              <CodeBlock background={codeBlockBg} borderColor={codeBlockBorder}>
+              <CodeBlock background={codeBlockBg} borderColor={codeBlockBorder} blockMargin={M.blockGap}>
                 {children}
               </CodeBlock>
             )

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -6,7 +6,44 @@ import { C } from '../theme'
 interface MarkdownProps {
   children: string
   variant?: 'user' | 'assistant'
+  layout?: 'compact' | 'roomy'
 }
+
+/** Two typographic densities. `compact` is the historical chat metric and stays
+ *  the default, so every secondary surface (team panels, automation, quick
+ *  question) is untouched. `roomy` is for the main assistant turn, which renders
+ *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
+ *  (8px) was barely larger than the gap between its own lines (~7px), so the
+ *  paragraph stopped reading as a unit. Heading margins are deliberately
+ *  asymmetric — a heading belongs to the text below it, not midway between two
+ *  blocks. */
+const METRICS = {
+  compact: {
+    fontSize: 13,
+    lineHeight: 1.55,
+    block: 8,
+    li: 2,
+    hr: '10px 0',
+    h1: { fontSize: 17, margin: '8px 0 6px' },
+    h2: { fontSize: 15, margin: '8px 0 6px' },
+    h3: { fontSize: 14, margin: '8px 0 4px' },
+    h4: { fontSize: 13, margin: '6px 0 4px' },
+  },
+  roomy: {
+    // 1.7 rather than 1.55: Chinese has a high character-face ratio and no
+    // ascenders or descenders, so identical leading reads tighter than it does
+    // for Latin text.
+    fontSize: 14,
+    lineHeight: 1.7,
+    block: 14,
+    li: 5,
+    hr: '18px 0',
+    h1: { fontSize: 20, margin: '22px 0 8px' },
+    h2: { fontSize: 17, margin: '20px 0 8px' },
+    h3: { fontSize: 15, margin: '18px 0 6px' },
+    h4: { fontSize: 14, margin: '16px 0 6px' },
+  },
+} as const
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Monaco, "Courier New", monospace'
 
@@ -157,8 +194,9 @@ function preserveLineBreaks(src: string): string {
   return out.join('\n')
 }
 
-const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant' }) => {
+const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant', layout = 'compact' }) => {
   const onUser = variant === 'user'
+  const M = METRICS[layout]
   const inlineCodeBg = onUser ? 'rgba(0,0,0,0.22)' : C.inlineCodeBg
   const inlineCodeFg = onUser ? C.onAccent : C.inlineCodeFg
   const codeBlockBg = onUser ? 'rgba(0,0,0,0.25)' : C.codeBg
@@ -171,11 +209,14 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
   const tableHeadBg = onUser ? 'rgba(0,0,0,0.2)' : C.surface3
 
   return (
-    <div style={{ minWidth: 0, maxWidth: '100%', fontSize: 13, lineHeight: 1.55, overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
+    <div
+      className={layout === 'roomy' ? 'md-roomy' : undefined}
+      style={{ minWidth: 0, maxWidth: '100%', fontSize: M.fontSize, lineHeight: M.lineHeight, overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          p: ({ children }) => <p style={{ margin: '0 0 8px 0' }}>{children}</p>,
+          p: ({ children }) => <p style={{ margin: `0 0 ${M.block}px 0` }}>{children}</p>,
           a: ({ href, children }) => (
             <a
               href={href}
@@ -191,20 +232,20 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           strong: ({ children }) => <strong style={{ fontWeight: 700 }}>{children}</strong>,
           em: ({ children }) => <em style={{ fontStyle: 'italic' }}>{children}</em>,
           del: ({ children }) => <del style={{ opacity: 0.6 }}>{children}</del>,
-          h1: ({ children }) => <h1 style={{ fontSize: 17, fontWeight: 700, margin: '8px 0 6px' }}>{children}</h1>,
-          h2: ({ children }) => <h2 style={{ fontSize: 15, fontWeight: 700, margin: '8px 0 6px' }}>{children}</h2>,
-          h3: ({ children }) => <h3 style={{ fontSize: 14, fontWeight: 700, margin: '8px 0 4px' }}>{children}</h3>,
-          h4: ({ children }) => <h4 style={{ fontSize: 13, fontWeight: 700, margin: '6px 0 4px' }}>{children}</h4>,
-          ul: ({ children }) => <ul style={{ margin: '0 0 8px 0', paddingLeft: 20 }}>{children}</ul>,
-          ol: ({ children }) => <ol style={{ margin: '0 0 8px 0', paddingLeft: 20 }}>{children}</ol>,
-          li: ({ children }) => <li style={{ marginBottom: 2 }}>{children}</li>,
-          hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: '10px 0' }} />,
+          h1: ({ children }) => <h1 style={{ fontSize: M.h1.fontSize, fontWeight: 700, margin: M.h1.margin }}>{children}</h1>,
+          h2: ({ children }) => <h2 style={{ fontSize: M.h2.fontSize, fontWeight: 700, margin: M.h2.margin }}>{children}</h2>,
+          h3: ({ children }) => <h3 style={{ fontSize: M.h3.fontSize, fontWeight: 700, margin: M.h3.margin }}>{children}</h3>,
+          h4: ({ children }) => <h4 style={{ fontSize: M.h4.fontSize, fontWeight: 700, margin: M.h4.margin }}>{children}</h4>,
+          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ul>,
+          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ol>,
+          li: ({ children }) => <li style={{ marginBottom: M.li }}>{children}</li>,
+          hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: M.hr }} />,
           blockquote: ({ children }) => (
             <blockquote
               style={{
                 borderLeft: `3px solid ${quoteBorder}`,
                 paddingLeft: 10,
-                margin: '0 0 8px 0',
+                margin: `0 0 ${M.block}px 0`,
                 color: quoteFg,
               }}
             >

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -20,8 +20,10 @@ interface MarkdownProps {
 interface Metrics {
   fontSize: number
   lineHeight: number
-  /** Bottom margin for block-level elements (p, ul, ol, blockquote, code blocks, tables). */
+  /** Bottom margin for block-level elements (p, ul, ol, blockquote, code blocks). */
   blockGap: number
+  /** Bottom margin for the table wrapper. */
+  tableGap: number
   li: number
   hr: string
   h1: { fontSize: number; margin: string }
@@ -35,6 +37,7 @@ const METRICS = {
     fontSize: 13,
     lineHeight: 1.55,
     blockGap: 8,
+    tableGap: 10,
     li: 2,
     hr: '10px 0',
     h1: { fontSize: 17, margin: '8px 0 6px' },
@@ -49,6 +52,7 @@ const METRICS = {
     // for Latin text.
     lineHeight: 1.7,
     blockGap: 14,
+    tableGap: 14,
     li: 5,
     hr: '18px 0',
     h1: { fontSize: 20, margin: '22px 0 8px' },
@@ -267,7 +271,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
             </blockquote>
           ),
           table: ({ children }) => (
-            <div style={{ overflowX: 'auto', margin: `6px 0 ${M.blockGap}px`, maxWidth: '100%' }}>
+            <div style={{ overflowX: 'auto', margin: `6px 0 ${M.tableGap}px`, maxWidth: '100%' }}>
               <table
                 style={{
                   borderCollapse: 'collapse',

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -9,14 +9,7 @@ interface MarkdownProps {
   layout?: 'compact' | 'roomy'
 }
 
-/** Two typographic densities. `compact` is the historical chat metric and stays
- *  the default, so every secondary surface (team panels, automation, quick
- *  question) is untouched. `roomy` is for the main assistant turn, which renders
- *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
- *  (8px) was barely larger than the gap between its own lines (~7px), so the
- *  paragraph stopped reading as a unit. Heading margins are deliberately
- *  asymmetric — a heading belongs to the text below it, not midway between two
- *  blocks. */
+/** Shape of one density's metrics; both entries must supply every field. */
 interface Metrics {
   fontSize: number
   lineHeight: number
@@ -32,6 +25,14 @@ interface Metrics {
   h4: { fontSize: number; margin: string }
 }
 
+/** Two typographic densities. `compact` is the historical chat metric and stays
+ *  the default, so every secondary surface (team panels, automation, quick
+ *  question) is untouched. `roomy` is for the main assistant turn, which renders
+ *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
+ *  (8px) was barely larger than the gap between its own lines (~7px), so the
+ *  paragraph stopped reading as a unit. Heading margins are deliberately
+ *  asymmetric — a heading belongs to the text below it, not midway between two
+ *  blocks. */
 const METRICS = {
   compact: {
     fontSize: 13,

--- a/docs/superpowers/plans/2026-08-07-assistant-document-layout.md
+++ b/docs/superpowers/plans/2026-08-07-assistant-document-layout.md
@@ -1,0 +1,454 @@
+# Assistant Document Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render assistant messages in the Mac app's chat tab as document flow instead of chat bubbles, so long replies stop reading as a dense wall.
+
+**Architecture:** Two changes. `Markdown.tsx` gains a `layout` prop selecting between two typographic metric sets (`compact`, today's values, stays the default so no other surface moves; `roomy`, looser, for the main assistant turn). `ChatTab.tsx` splits its message container on `isUser`: user messages keep the bubble untouched, assistant messages lose background/border/shadow/radius, gain a `ch`-based width cap, and replace the bubble's selected-state border with a left accent rail.
+
+**Tech Stack:** React 18 + TypeScript, inline styles, `react-markdown` + `remark-gfm`, Vite, Vitest, Electron.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-assistant-document-layout-design.md`
+
+**Node version:** this repo needs nvm's v22.17.1. Run `nvm use 22.17.1` before any npm command; the system default v16 cannot run vitest or tsc here.
+
+---
+
+## A note on tests
+
+This change is presentation-only. There is no branching logic, no data transformation, and no
+new pure function — the entire diff is style objects and one prop. A unit test here would
+assert that a constant equals itself, which is worse than no test because it implies coverage
+that does not exist. So this plan uses TDD's verification discipline without fabricating unit
+tests: every task ends with a typecheck and the existing suite, and Task 6 is a real visual
+verification against both themes that must be performed, not assumed.
+
+Do not add tests asserting the contents of `METRICS`.
+
+## File Structure
+
+- **Modify** `codey-mac/src/components/Markdown.tsx` — add the `layout` prop and the `METRICS`
+  table; replace hardcoded typographic values with lookups. Responsibility unchanged: render a
+  Markdown string with app theming.
+- **Modify** `codey-mac/src/components/ChatTab.tsx:1997-2020` — split the message container on
+  `isUser`; pass `layout="roomy"` at the assistant body call site (currently line 2038).
+- **Modify** `codey-mac/src/App.tsx:365` — add one CSS rule to the existing global `<style>`
+  block, zeroing the top margin of a turn's first block.
+
+No new files. `ChatTab.tsx` is 3265 lines and doing too much, but splitting it is unrelated to
+this goal and out of scope.
+
+---
+
+### Task 1: Two typographic densities in Markdown
+
+**Files:**
+- Modify: `codey-mac/src/components/Markdown.tsx:6-9` (props), `:160-201` (metrics use)
+
+- [ ] **Step 1: Add the `layout` prop**
+
+Replace lines 6-9:
+
+```tsx
+interface MarkdownProps {
+  children: string
+  variant?: 'user' | 'assistant'
+  layout?: 'compact' | 'roomy'
+}
+```
+
+- [ ] **Step 2: Add the METRICS table**
+
+Insert directly below the `interface MarkdownProps` block, above the `MONO` constant on line 11:
+
+```tsx
+/** Two typographic densities. `compact` is the historical chat metric and stays
+ *  the default, so every secondary surface (team panels, automation, quick
+ *  question) is untouched. `roomy` is for the main assistant turn, which renders
+ *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
+ *  (8px) was barely larger than the gap between its own lines (~7px), so the
+ *  paragraph stopped reading as a unit. Heading margins are deliberately
+ *  asymmetric — a heading belongs to the text below it, not midway between two
+ *  blocks. */
+const METRICS = {
+  compact: {
+    fontSize: 13,
+    lineHeight: 1.55,
+    block: 8,
+    li: 2,
+    hr: '10px 0',
+    h1: { fontSize: 17, margin: '8px 0 6px' },
+    h2: { fontSize: 15, margin: '8px 0 6px' },
+    h3: { fontSize: 14, margin: '8px 0 4px' },
+    h4: { fontSize: 13, margin: '6px 0 4px' },
+  },
+  roomy: {
+    // 1.7 rather than 1.55: Chinese has a high character-face ratio and no
+    // ascenders or descenders, so identical leading reads tighter than it does
+    // for Latin text.
+    fontSize: 14,
+    lineHeight: 1.7,
+    block: 14,
+    li: 5,
+    hr: '18px 0',
+    h1: { fontSize: 20, margin: '22px 0 8px' },
+    h2: { fontSize: 17, margin: '20px 0 8px' },
+    h3: { fontSize: 15, margin: '18px 0 6px' },
+    h4: { fontSize: 14, margin: '16px 0 6px' },
+  },
+} as const
+```
+
+- [ ] **Step 3: Read the metrics in the component**
+
+Change the signature on line 160 from:
+
+```tsx
+const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant' }) => {
+  const onUser = variant === 'user'
+```
+
+to:
+
+```tsx
+const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant', layout = 'compact' }) => {
+  const onUser = variant === 'user'
+  const M = METRICS[layout]
+```
+
+- [ ] **Step 4: Apply the metrics to the wrapper and block elements**
+
+Change the wrapper `div` on line 174 from:
+
+```tsx
+    <div style={{ minWidth: 0, maxWidth: '100%', fontSize: 13, lineHeight: 1.55, overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
+```
+
+to (the `className` is consumed by the CSS rule added in Task 2):
+
+```tsx
+    <div
+      className={layout === 'roomy' ? 'md-roomy' : undefined}
+      style={{ minWidth: 0, maxWidth: '100%', fontSize: M.fontSize, lineHeight: M.lineHeight, overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+    >
+```
+
+Then replace these six component overrides. Line 178:
+
+```tsx
+          p: ({ children }) => <p style={{ margin: `0 0 ${M.block}px 0` }}>{children}</p>,
+```
+
+Lines 194-197:
+
+```tsx
+          h1: ({ children }) => <h1 style={{ fontSize: M.h1.fontSize, fontWeight: 700, margin: M.h1.margin }}>{children}</h1>,
+          h2: ({ children }) => <h2 style={{ fontSize: M.h2.fontSize, fontWeight: 700, margin: M.h2.margin }}>{children}</h2>,
+          h3: ({ children }) => <h3 style={{ fontSize: M.h3.fontSize, fontWeight: 700, margin: M.h3.margin }}>{children}</h3>,
+          h4: ({ children }) => <h4 style={{ fontSize: M.h4.fontSize, fontWeight: 700, margin: M.h4.margin }}>{children}</h4>,
+```
+
+Lines 198-201:
+
+```tsx
+          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ul>,
+          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ol>,
+          li: ({ children }) => <li style={{ marginBottom: M.li }}>{children}</li>,
+          hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: M.hr }} />,
+```
+
+Lines 202-213, the `blockquote` margin only — leave `borderLeft`, `paddingLeft`, and `color` as they are:
+
+```tsx
+                margin: `0 0 ${M.block}px 0`,
+```
+
+Leave `preserveLineBreaks` on line 292 alone. It exists because LLM output relies on single
+newlines; changing its semantics is out of scope. At 14px × 1.7 the line gap is ~10px, so a
+14px paragraph margin now reads as a real break even with hard breaks present.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd codey-mac && npx tsc --noEmit`
+Expected: exits 0, no output.
+
+If `tsc` reports that `M.h1.margin` is not assignable to `margin`, the `as const` on `METRICS`
+made it a string literal type — that is compatible with `React.CSSProperties['margin']` and the
+real error is elsewhere. Read the message rather than deleting `as const`.
+
+- [ ] **Step 6: Run the existing suite**
+
+Run: `cd codey-mac && npm test`
+Expected: PASS. Nothing tests `Markdown.tsx`; this confirms no unrelated breakage.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add codey-mac/src/components/Markdown.tsx
+git commit -m "feat(mac): add roomy typographic density to Markdown"
+```
+
+---
+
+### Task 2: Zero the top margin of a turn's first block
+
+**Files:**
+- Modify: `codey-mac/src/App.tsx:390` (inside the existing global `<style>` block)
+
+Roomy headings carry a 16-22px top margin to open a section. When a reply *starts* with a
+heading — which is common — that margin adds dead space above the first line, because there is
+nothing above it to separate from. Inline styles cannot express `:first-child`, so this needs a
+real CSS rule.
+
+- [ ] **Step 1: Add the rule**
+
+In `App.tsx`, immediately after the line:
+
+```
+  html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
+```
+
+add:
+
+```
+  /* Roomy headings open a section with a large top margin. The first block in a
+     turn has nothing above it to separate from, so that margin is dead space. */
+  .md-roomy > :first-child { margin-top: 0 !important; }
+```
+
+`!important` is required: the margin it overrides is an inline style, which otherwise wins.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd codey-mac && npx tsc --noEmit`
+Expected: exits 0, no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/App.tsx
+git commit -m "style(mac): collapse leading heading margin in roomy markdown"
+```
+
+---
+
+### Task 3: Assistant messages render as document flow
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx:1997-2020`
+
+- [ ] **Step 1: Widen the gap between assistant turns**
+
+Without bubbles, consecutive assistant turns merge into each other. Spacing is what separates
+them now. In the outer row style at line 1997-2005, change:
+
+```tsx
+                marginBottom: 12,
+```
+
+to:
+
+```tsx
+                marginBottom: isUser ? 12 : 20,
+```
+
+Leave everything else in that style object — including `transform` and `paddingLeft` — as is.
+
+- [ ] **Step 2: Split the container style on `isUser`**
+
+Replace the whole inner `div` opening tag at lines 2007-2020:
+
+```tsx
+              <div style={isUser ? {
+                minWidth: 0, maxWidth: '72%', padding: '10px 14px',
+                borderRadius: '16px 16px 4px 16px',
+                background: C.userBg,
+                color: C.onAccent, fontSize: 13, lineHeight: 1.55,
+                overflowWrap: 'anywhere', wordBreak: 'break-word',
+              } : {
+                // No bubble: the bubble marks "what the user said", and an
+                // assistant reply of any length reads better as a document.
+                // `ch` resolves against this element's 13px font, so 78ch is
+                // ~562px — about 72 characters of the 14px roomy body text, or
+                // ~43 Chinese characters. Unlike the old 72%, it does not grow
+                // with the window.
+                minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
+                // The rail is always 3px, transparent when unselected, so
+                // selecting a turn never shifts the text column sideways.
+                // 6 (row) + 3 (rail) + 12 = 21px, exactly today's inset of
+                // 6 (row) + 1 (border) + 14 (bubble padding).
+                padding: '0 0 0 12px',
+                borderLeft: `3px solid ${isSelected ? C.accent : 'transparent'}`,
+                background: isSelected ? C.accentDim : 'transparent',
+                // fontSize/lineHeight stay at the compact values: non-Markdown
+                // children (LiveActivity, tool chips) inherit them. The roomy
+                // metrics apply inside <Markdown layout="roomy"> only.
+                color: C.fg, fontSize: 13, lineHeight: 1.55,
+                overflowWrap: 'anywhere', wordBreak: 'break-word',
+                transition: 'border-color 0.18s ease, background 0.18s ease',
+              }}>
+```
+
+Three things are deliberately gone from the assistant branch: `boxShadow` (it needed a surface
+to cast from), `border` (replaced by the rail), and `borderRadius` (nothing to round). The
+user branch is byte-for-byte equivalent to what the ternaries produced before — verify that in
+review by reading the old and new user styles side by side.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd codey-mac && npx tsc --noEmit`
+Expected: exits 0, no output.
+
+- [ ] **Step 4: Run the existing suite**
+
+Run: `cd codey-mac && npm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): render assistant messages as document flow"
+```
+
+---
+
+### Task 4: Use the roomy metrics for the assistant body
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx:2038`
+
+- [ ] **Step 1: Pass the prop**
+
+Change line 2038 from:
+
+```tsx
+                      <Markdown variant="assistant">{text}</Markdown>
+```
+
+to:
+
+```tsx
+                      <Markdown variant="assistant" layout="roomy">{text}</Markdown>
+```
+
+This is the only call site that changes. The other twelve `<Markdown variant="assistant">` uses
+— `AutomationOnePager.tsx:288,418`, `TeamRunFlow.tsx:99`, `ChatTab.tsx:334,352,368,372,436,724,734`,
+`AutomationChatCreate.tsx:283`, `QuickQuestionView.tsx:168` — keep the `compact` default and must
+not be edited. Confirm with:
+
+Run: `cd codey-mac/src && grep -rn 'layout="roomy"' components/`
+Expected: exactly one line, `components/ChatTab.tsx`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd codey-mac && npx tsc --noEmit`
+Expected: exits 0, no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): use roomy typography for assistant replies"
+```
+
+---
+
+### Task 5: Re-seat the blocks that were sitting on the bubble background
+
+**Files:**
+- Inspect: `codey-mac/src/components/ChatTab.tsx` — `LiveActivity`, `ThinkingBlock`, `TeamMessage`, tool-call chips
+- Modify: only those that turn out to need it
+
+`C.aiBg` was the assistant bubble's background and is now gone from that container. In the
+light theme `aiBg` is `#ffffff` against a `bg` of `#f6f7fb`, so anything that relied on sitting
+on white now sits on light grey; in dark, `#1b2030` becomes `#10131b`. Sub-blocks that set
+their own surface are fine. Ones that assumed the bubble's are not.
+
+This task is an inspection with a conditional fix, not a predetermined edit. Do not guess.
+
+- [ ] **Step 1: Find the sub-blocks' own backgrounds**
+
+Run: `cd codey-mac/src && grep -n 'background' components/ChatTab.tsx | grep -iE 'thinking|activity|toolchip|toolCall|teamRun|teamGroup'`
+Expected: a list of style entries. Any entry already setting `background` to a theme surface is fine.
+
+- [ ] **Step 2: Launch the app and look**
+
+Run: `cd codey-mac && nvm use 22.17.1 && npm run dev`
+
+Send a prompt that produces thinking, several tool calls, and a long reply. Check whether the
+thinking block, live activity row, and tool chips still read as distinct elements now that the
+backdrop behind them changed.
+
+- [ ] **Step 3: Fix only what actually reads wrong**
+
+For any block that now blends into the backdrop, give it `background: C.surface` (dark) /
+`C.surface` (light) — the theme's card surface — plus its existing border if it has one. Do not
+restore `C.aiBg` on the message container; that reinstates the bubble.
+
+If everything reads fine, change nothing and record that in the commit message.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "style(mac): re-seat assistant sub-blocks after bubble removal"
+```
+
+If no change was needed, skip the commit entirely and note it when reporting the task.
+
+---
+
+### Task 6: Visual verification
+
+**Files:** none — this task changes nothing.
+
+The spec's whole justification is readability, which no assertion in this repo can check. This
+step is the verification. Do not mark the plan complete without performing it.
+
+- [ ] **Step 1: Run the app**
+
+Run: `cd codey-mac && nvm use 22.17.1 && npm run dev`
+
+- [ ] **Step 2: Check a long reply in the dark theme**
+
+Ask for something that produces 800+ words with headings, a bulleted list, a fenced code block,
+and a table. Confirm:
+  - Line length stops growing when the window widens past ~600px of text column.
+  - Paragraph breaks are visibly larger than line breaks.
+  - Headings group with the text below them, not floating between blocks.
+  - The code block and table are wider than before, not clipped.
+
+- [ ] **Step 3: Check the light theme**
+
+Switch themes. Confirm assistant text on `#f6f7fb` still has adequate contrast, and that the
+loss of the white bubble does not make the column feel unanchored.
+
+- [ ] **Step 4: Check selection and boundaries**
+
+Double-click an assistant turn to select it. Confirm the accent rail appears and the text does
+**not** jump sideways. Then confirm two consecutive assistant turns read as separate messages.
+
+- [ ] **Step 5: Check a short reply**
+
+Send something answered in one line. Confirm it does not look stranded without its bubble — this
+is the case option C trades away, and it is the one most likely to need a follow-up adjustment.
+
+- [ ] **Step 6: Check the untouched surfaces**
+
+Open a team run panel and the quick-question view. Confirm their text is unchanged in size and
+spacing — that is what the `compact` default protects.
+
+- [ ] **Step 7: Report**
+
+Report which of steps 2-6 passed and which did not, with what you saw. If step 3 or step 5 reads
+poorly, the spec's stated fallback is a very subtle background on the assistant column — not
+restoring the bubble. Raise it rather than applying it unilaterally.
+
+---
+
+## Rollback
+
+Every task is a separate commit touching one file. If the result reads worse than the bubble
+did, `git revert` the Task 3 and Task 4 commits to restore bubbles while keeping the `roomy`
+metrics available for later use.

--- a/docs/superpowers/plans/2026-08-07-assistant-document-layout.md
+++ b/docs/superpowers/plans/2026-08-07-assistant-document-layout.md
@@ -30,8 +30,8 @@ Do not add tests asserting the contents of `METRICS`.
 - **Modify** `codey-mac/src/components/Markdown.tsx` — add the `layout` prop and the `METRICS`
   table; replace hardcoded typographic values with lookups. Responsibility unchanged: render a
   Markdown string with app theming.
-- **Modify** `codey-mac/src/components/ChatTab.tsx:1997-2020` — split the message container on
-  `isUser`; pass `layout="roomy"` at the assistant body call site (currently line 2038).
+- **Modify** `codey-mac/src/components/ChatTab.tsx:1971-1994` — split the message container on
+  `isUser`; pass `layout="roomy"` at the assistant body call site (currently line 2012).
 - **Modify** `codey-mac/src/App.tsx:365` — add one CSS rule to the existing global `<style>`
   block, zeroing the top margin of a turn's first block.
 
@@ -235,12 +235,12 @@ git commit -m "style(mac): collapse leading heading margin in roomy markdown"
 ### Task 3: Assistant messages render as document flow
 
 **Files:**
-- Modify: `codey-mac/src/components/ChatTab.tsx:1997-2020`
+- Modify: `codey-mac/src/components/ChatTab.tsx:1971-1994`
 
 - [ ] **Step 1: Widen the gap between assistant turns**
 
 Without bubbles, consecutive assistant turns merge into each other. Spacing is what separates
-them now. In the outer row style at line 1997-2005, change:
+them now. In the outer row style at line 1971-1979, change:
 
 ```tsx
                 marginBottom: 12,
@@ -256,7 +256,8 @@ Leave everything else in that style object — including `transform` and `paddin
 
 - [ ] **Step 2: Split the container style on `isUser`**
 
-Replace the whole inner `div` opening tag at lines 2007-2020:
+Replace the whole inner `div` opening tag at lines 1981-1994 (it starts with the line
+`minWidth: 0, maxWidth: '72%', padding: '10px 14px',`):
 
 ```tsx
               <div style={isUser ? {
@@ -316,11 +317,11 @@ git commit -m "feat(mac): render assistant messages as document flow"
 ### Task 4: Use the roomy metrics for the assistant body
 
 **Files:**
-- Modify: `codey-mac/src/components/ChatTab.tsx:2038`
+- Modify: `codey-mac/src/components/ChatTab.tsx:2012`
 
 - [ ] **Step 1: Pass the prop**
 
-Change line 2038 from:
+Change line 2012 from:
 
 ```tsx
                       <Markdown variant="assistant">{text}</Markdown>
@@ -333,7 +334,7 @@ to:
 ```
 
 This is the only call site that changes. The other twelve `<Markdown variant="assistant">` uses
-— `AutomationOnePager.tsx:288,418`, `TeamRunFlow.tsx:99`, `ChatTab.tsx:334,352,368,372,436,724,734`,
+— `AutomationOnePager.tsx:288,418`, `TeamRunFlow.tsx:99`, `ChatTab.tsx:307,325,341,345,409,697,707`,
 `AutomationChatCreate.tsx:283`, `QuickQuestionView.tsx:168` — keep the `compact` default and must
 not be edited. Confirm with:
 

--- a/docs/superpowers/specs/2026-08-07-assistant-document-layout-design.md
+++ b/docs/superpowers/specs/2026-08-07-assistant-document-layout-design.md
@@ -7,7 +7,7 @@
 
 Long assistant replies read as a dense wall. Five causes, all located:
 
-1. **Line length.** `ChatTab.tsx:2008` caps the bubble at `maxWidth: '72%'`. On a wide
+1. **Line length.** `ChatTab.tsx:1982` caps the bubble at `maxWidth: '72%'`. On a wide
    window a line reaches 100+ characters; comfortable measure is 45–75. Longer lines
    cost a return sweep on every line.
 2. **No paragraph rhythm.** `Markdown.tsx:178` gives `p` a `margin-bottom` of 8px, while
@@ -39,7 +39,7 @@ A single unconditional rule has no threshold, no latch, and no mid-stream reshap
 
 ### 1. Structure
 
-Split the message container at `ChatTab.tsx:2007` on `isUser`.
+Split the message container at `ChatTab.tsx:1981` on `isUser`.
 
 - **User:** unchanged — right-aligned, `maxWidth: '72%'`, `C.userBg`, asymmetric radius.
 - **Assistant:** drop `background`, `border`, `boxShadow`, `borderRadius`; padding becomes
@@ -58,7 +58,7 @@ Code blocks and tables gain width — today they are squeezed into 72% minus bub
 The bubble had two jobs beyond decoration. Both must be replaced or this is a net regression.
 
 - **Selected state.** Today `isSelected` draws an accent border plus glow
-  (`ChatTab.tsx:2015-2018`), which needs a bubble to live on. Replace with a left accent
+  (`ChatTab.tsx:1989-1992`), which needs a bubble to live on. Replace with a left accent
   rail: `borderLeft: 3px solid C.accent`. The unselected state reserves the same 3px as
   transparent so selecting a turn does not shift text horizontally. The existing
   `translateY(-3px)` lift stays.
@@ -92,7 +92,7 @@ semantics are out of scope here.
 
 ### 4. Scope
 
-Only the main chat assistant body (`ChatTab.tsx:2038`) passes `layout="roomy"`. The other
+Only the main chat assistant body (`ChatTab.tsx:2012`) passes `layout="roomy"`. The other
 twelve `<Markdown variant="assistant">` call sites — team panels, `AutomationOnePager`,
 `TeamRunFlow`, `QuickQuestionView` — keep the `compact` default and are not edited, so the
 change cannot leak into surfaces nobody asked about.

--- a/docs/superpowers/specs/2026-08-07-assistant-document-layout-design.md
+++ b/docs/superpowers/specs/2026-08-07-assistant-document-layout-design.md
@@ -1,0 +1,119 @@
+# Assistant messages as document flow
+
+**Date:** 2026-08-07
+**Surface:** `codey-mac` chat tab
+
+## Problem
+
+Long assistant replies read as a dense wall. Five causes, all located:
+
+1. **Line length.** `ChatTab.tsx:2008` caps the bubble at `maxWidth: '72%'`. On a wide
+   window a line reaches 100+ characters; comfortable measure is 45–75. Longer lines
+   cost a return sweep on every line.
+2. **No paragraph rhythm.** `Markdown.tsx:178` gives `p` a `margin-bottom` of 8px, while
+   13px × 1.55 leading already leaves ~7px between lines. Paragraph spacing and line
+   spacing are nearly equal, so the paragraph stops being a visual unit.
+3. **Hard breaks amplify it.** `Markdown.tsx:292` runs `preserveLineBreaks`, turning the
+   single newlines that fill LLM output into hard breaks — a block of evenly packed lines.
+4. **No section anchors.** `Markdown.tsx:194-197`: h3 is 14px and h4 is 13px against 13px
+   body text, with 6–8px top margins. Nothing signals "new section" when scanning.
+5. **CJK is hit harder.** 1.55 leading is acceptable for Latin text but cramped for Chinese,
+   which has a high character-face ratio and no ascenders/descenders to create air.
+
+## Decision
+
+The bubble becomes the marker for *what the user said*. Assistant output renders as a
+document.
+
+Considered and rejected:
+
+- **Tune typography inside the bubble.** Smallest change, but a very long reply stays one
+  enormous bubble.
+- **Fork on length.** Short replies keep the bubble, long ones go document. Rejected for the
+  threshold: a streaming reply would change shape mid-flight, and the threshold itself is a
+  parameter with no principled value.
+
+A single unconditional rule has no threshold, no latch, and no mid-stream reshaping.
+
+## Design
+
+### 1. Structure
+
+Split the message container at `ChatTab.tsx:2007` on `isUser`.
+
+- **User:** unchanged — right-aligned, `maxWidth: '72%'`, `C.userBg`, asymmetric radius.
+- **Assistant:** drop `background`, `border`, `boxShadow`, `borderRadius`; padding becomes
+  `0 0 0 12px`, which with the 3px rail below reproduces today's text inset exactly
+  (row padding 6 + border 1 + bubble padding 14 = 21 → 6 + 3 + 12 = 21), so the text
+  column does not move; width becomes `maxWidth: 'min(100%, 78ch)'`.
+
+`ch` resolves against the container's own 13px font, so 78ch ≈ 562px ≈ 72 characters of the
+14px roomy body text, or ~43 Chinese characters — both inside the comfortable range.
+
+The `ch` cap is what fixes cause (1): ~640px at 14px, and it does not grow with the window.
+Code blocks and tables gain width — today they are squeezed into 72% minus bubble padding.
+
+### 2. Restore what the bubble was carrying
+
+The bubble had two jobs beyond decoration. Both must be replaced or this is a net regression.
+
+- **Selected state.** Today `isSelected` draws an accent border plus glow
+  (`ChatTab.tsx:2015-2018`), which needs a bubble to live on. Replace with a left accent
+  rail: `borderLeft: 3px solid C.accent`. The unselected state reserves the same 3px as
+  transparent so selecting a turn does not shift text horizontally. The existing
+  `translateY(-3px)` lift stays.
+- **Message boundary.** Without bubbles, consecutive assistant turns merge. Raise the
+  assistant row's `marginBottom` from 12 to 20 and let the existing `tsLabel` timestamp row
+  act as the divider. No rule element — it would collide with Markdown's own `hr`.
+
+### 3. Typography
+
+Add `layout?: 'compact' | 'roomy'` to `MarkdownProps`, defaulting to `compact`. It is
+orthogonal to `variant`, which stays responsible for color only. `roomy` overrides:
+
+| | compact (today) | roomy |
+|---|---|---|
+| fontSize | 13 | 14 |
+| lineHeight | 1.55 | 1.7 |
+| `p` margin-bottom | 8 | 14 |
+| `li` margin-bottom | 2 | 5 |
+| `ul` / `ol` margin-bottom | 8 | 14 |
+| h1 | 17, margins 8/6 | 20, margins 22/8 |
+| h2 | 15, margins 8/6 | 17, margins 20/8 |
+| h3 | 14, margins 8/4 | 15, margins 18/6 |
+| h4 | 13, margins 6/4 | 14, margins 16/6 |
+
+Asymmetric heading margins are what make sections legible: a heading should sit against the
+body text it governs rather than float midway between two blocks.
+
+At 14px × 1.7 the line gap is ~10px, so a 14px paragraph margin reads as a real break. That
+resolves cause (2) without touching `preserveLineBreaks` — it exists for a reason and its
+semantics are out of scope here.
+
+### 4. Scope
+
+Only the main chat assistant body (`ChatTab.tsx:2038`) passes `layout="roomy"`. The other
+twelve `<Markdown variant="assistant">` call sites — team panels, `AutomationOnePager`,
+`TeamRunFlow`, `QuickQuestionView` — keep the `compact` default and are not edited, so the
+change cannot leak into surfaces nobody asked about.
+
+## Verification
+
+This is presentation-only; there is no pure logic worth a unit test, and none will be
+invented to look thorough. Verification is running the app and reading a long reply, in both
+light and dark themes.
+
+One open item to confirm during implementation: `ThinkingBlock`, `LiveActivity`, and the
+tool-call chips currently sit on `C.aiBg` supplied by the bubble. Once that background is
+gone they land directly on the chat backdrop and may each need their own surface. Check
+before deciding whether to add one.
+
+## Risks
+
+- Removing the assistant background reduces figure/ground separation against the chat
+  backdrop. Mitigated by the width cap and larger inter-message spacing; if it still reads
+  flat, the fallback is a very subtle background on the assistant column rather than
+  restoring the bubble.
+- Nested Markdown inside team/thinking blocks inherits `compact` while the surrounding turn
+  is `roomy`, so a size step is visible at that boundary. Accepted: those blocks are
+  deliberately secondary content.


### PR DESCRIPTION
Long assistant replies read as a dense wall. The bubble was a large part of why, so it now marks only what the *user* said; assistant output renders as a document.

## The five causes

All located before changing anything:

1. **Line length** — the bubble capped at `maxWidth: '72%'`, so on a wide window a line reached 100+ characters. Comfortable measure is 45–75.
2. **No paragraph rhythm** — `p` had an 8px bottom margin while 13px × 1.55 leading already left ~7px between lines. Paragraph spacing and line spacing were nearly equal, so the paragraph stopped being a visual unit.
3. **Hard breaks amplified it** — `preserveLineBreaks` turns the single newlines that fill LLM output into hard breaks, producing evenly packed lines.
4. **No section anchors** — h3 was 14px and h4 13px against 13px body text, with 6–8px top margins. Nothing signalled "new section" when scanning.
5. **CJK is hit harder** — 1.55 leading is fine for Latin but cramped for Chinese, which has a high character-face ratio and no ascenders or descenders.

## What changed

**`Markdown.tsx`** gains a `layout?: 'compact' | 'roomy'` prop, orthogonal to `variant` (which stays responsible for colour only). `compact` is today's values and stays the **default**, so all sixteen other `<Markdown>` call sites are untouched. `roomy` runs 14px/1.7 with a 14px paragraph gap and asymmetric heading margins — a heading belongs to the text below it, not midway between two blocks.

**`ChatTab.tsx`** splits the message container on `isUser`:

- User: unchanged.
- Assistant: no background, border, shadow, or radius; `maxWidth: 'min(100%, 78ch)'`; row spacing 12 → 20.

The bubble was carrying two jobs beyond decoration, both replaced:

- **Selected state** was an accent border plus glow, which needs a surface to live on → a 3px left accent rail, always present and transparent when unselected, so selecting a turn never shifts the text column sideways. The inset is preserved exactly: 6 + 3 + 12 = 21px, matching the old 6 + 1 + 14.
- **Message boundary** → row spacing plus the existing timestamp row. No rule element; it would collide with Markdown's own `hr`.

**`App.tsx`** gets one CSS rule. Roomy headings carry a 16–22px top margin to open a section, but a reply that *starts* with a heading has nothing above it to separate from. Inline styles cannot express `:first-child`, so this needs real CSS.

## Notes for review

- `ch` resolves against the container's 13px font, so 78ch ≈ 562px ≈ 72 characters of the 14px roomy body, or ~43 Chinese characters.
- `METRICS` is `as const satisfies Record<'compact' | 'roomy', Metrics>`. The interface stops the two entries desyncing on field *type*; `as const` keeps `METRICS[layout]` a literal union so a key present in only one entry is a compile error at the use site. Both were verified empirically, not assumed.
- The table keeps its own `tableGap` rather than folding into `blockGap`, because its historical compact margin is 10px, not 8px. Every compact value is byte-identical to before — that invariant is what lets this ship without re-verifying the other call sites.
- `preserveLineBreaks` is deliberately untouched. It exists because LLM output relies on single newlines; at 14px × 1.7 the line gap is ~10px, so a 14px paragraph margin reads as a real break even with hard breaks present.
- No sub-block needed re-seating after the bubble background went away: `liveActivity` and `liveActivityDetail` bring their own background and border, and `thinkingBody` uses a left border rather than a background.

## Testing

**tsc clean, 322/322 tests passing** at every commit.

That only proves nothing else broke. This change is presentation-only — no branching logic, no data transformation, no new pure function — so there is no unit test worth writing here; one would assert a constant equals itself and imply coverage that does not exist. The reasoning is recorded in the plan.

**Visual verification is still outstanding and is the real acceptance gate.** Specifically worth a look:

- Light theme: the white bubble is gone, so assistant text now sits on `#f6f7fb`. Does the column still feel anchored?
- Short replies: a one-line answer without a bubble is the case this design trades away.
- `thinkingBody` uses a left border and the new selected-state rail is also a left bar. They are offset by `marginLeft: 17` and should not collide, but nested left rules want a human eye.

If light theme or short replies read poorly, the intended fallback is a very subtle background on the assistant column — not restoring the bubble.

Design doc: `docs/superpowers/specs/2026-08-07-assistant-document-layout-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)