### PR TITLE
Show the agent's task list and what it is working on

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -19,6 +19,8 @@ import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolForm
 import { defaultThinkingExpanded } from './thinkingState'
 import { formatTokens } from './turnHeaderModel'
 import { TurnHeader } from './TurnHeader'
+import { ACTIVITY_LABEL } from './agentActivity'
+import { statusLine } from './checklistView'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
 import { useGitStatus } from '../hooks/useGitStatus'
@@ -75,11 +77,38 @@ const StopIcon: React.FC<{ color: string }> = ({ color }) => (
 const fmtTime = (ts: number) =>
   new Date(ts).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 
-const TypingDots: React.FC = () => {
-  const [n, setN] = useState(0)
-  useEffect(() => { const t = setInterval(() => setN(v => (v + 1) % 4), 400); return () => clearInterval(t) }, [])
-  return <span style={{ letterSpacing: 2 }}>{'●'.repeat(n + 1).padEnd(3, '○')}</span>
-}
+/** The live status word ("Thinking", "Reading", …). The motion is a light
+ *  sweeping across the letters — no marching dots beside it, so the word alone
+ *  carries "still running" without pulling the eye off the transcript. */
+const ShimmerStatus: React.FC<{ label: string }> = ({ label }) => (
+  <>
+    <style>{`
+      @keyframes codey-status-shimmer {
+        0%   { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .codey-status-shimmer { animation: none !important; }
+      }
+    `}</style>
+    <span
+      className="codey-status-shimmer"
+      aria-live="polite"
+      style={{
+        backgroundImage: `linear-gradient(90deg, ${C.fg3} 0%, ${C.fg3} 35%, ${C.fg} 50%, ${C.fg3} 65%, ${C.fg3} 100%)`,
+        backgroundSize: '200% 100%',
+        WebkitBackgroundClip: 'text',
+        backgroundClip: 'text',
+        color: 'transparent',
+        WebkitTextFillColor: 'transparent',
+        animation: 'codey-status-shimmer 2s linear infinite',
+        fontWeight: 600,
+      }}
+    >
+      {label}
+    </span>
+  </>
+)
 
 /** Elapsed recording time. A counter answers "is it still listening?" without
  *  a sentence of prose, and reassures during a long dictation. */
@@ -1656,11 +1685,25 @@ export const ChatTab: React.FC<Props> = ({
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
   const canSend = isGatewayRunning && !coreFailed && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
+  // Three layers when the agent gave us its task list: what it is on, the tool
+  // it is running right now, and how far through it is — a bare "Editing…"
+  // withholds information we already have in hand.
+  const flightToolCalls = flight
+    ? chat.messages.find(m => m.id === flight.assistantMessageId)?.toolCalls
+    : undefined
+  const live = flight && flight.agentStatus !== 'idle'
+    ? statusLine({
+        checklist: chat.checklist,
+        entries: flightToolCalls,
+        format: formatHeadline,
+        fallback: ACTIVITY_LABEL[flight.agentStatus],
+      })
+    : null
   const statusLabel = flight?.queuedPosition
     ? `Queued (#${flight.queuedPosition})`
-    : flight?.agentStatus === 'thinking' ? 'Thinking…'
-    : flight?.agentStatus === 'working'  ? 'Working…'
-    : flight?.agentStatus === 'writing'  ? 'Writing…'
+    // The trailing ellipsis is the "still going" cue for a lone verb; with real
+    // detail the shimmer already says that, and the dots just add noise.
+    : live ? (live.parts.length > 1 ? live.parts.join(' · ') : `${live.parts[0]}…`)
     : ''
 
   const openChatTerminal = () => {
@@ -2200,8 +2243,7 @@ export const ChatTab: React.FC<Props> = ({
         })}
         {statusLabel && (
           <div style={styles.typingRow}>
-            <TypingDots />
-            <span>{statusLabel}</span>
+            <ShimmerStatus label={statusLabel} />
           </div>
         )}
         <div ref={messagesEndRef} />
@@ -2529,6 +2571,7 @@ export const ChatTab: React.FC<Props> = ({
         return (
           <StatusSidecar
             view={extractSidecarBrief(chat.taskBrief)}
+            checklist={chat.checklist}
             loading={taskBriefLoading}
             compact={statusSidecarHidden}
             width={SIDECAR_W}

--- a/codey-mac/src/components/NotificationCenter.tsx
+++ b/codey-mac/src/components/NotificationCenter.tsx
@@ -3,13 +3,11 @@ import { C } from '../theme'
 import { useChats } from '../hooks/useChats'
 import { deriveNotifications, type InFlightLike } from './notificationLogic'
 import { UIIcon } from './UIIcons'
+import { ACTIVITY_LABEL } from './agentActivity'
 
-const STATUS_LABEL: Record<InFlightLike['agentStatus'], string> = {
-  idle: 'Idle',
-  thinking: 'Thinking…',
-  working: 'Working…',
-  writing: 'Writing…',
-}
+const STATUS_LABEL: Record<InFlightLike['agentStatus'], string> = Object.fromEntries(
+  Object.entries(ACTIVITY_LABEL).map(([k, v]) => [k, k === 'idle' ? v : `${v}…`]),
+) as Record<InFlightLike['agentStatus'], string>
 
 export const NotificationCenter: React.FC = () => {
   const { state, selectChat } = useChats()

--- a/codey-mac/src/components/StatusSidecar.tsx
+++ b/codey-mac/src/components/StatusSidecar.tsx
@@ -3,9 +3,15 @@ import { C } from '../theme'
 import { statusMeta, formatAgo, type SidecarView, type StatusTone } from './taskHudView'
 import { createPrButtonState } from './createPrModel'
 import { UIIcon } from './UIIcons'
+import { checklistProgress, checklistWindow, currentChecklistItem, currentItemLabel } from './checklistView'
+import type { ChecklistItem } from '../types'
 
 interface Props {
   view: SidecarView
+  /** The agent's own task list for this turn, when it reported one. It
+   *  outranks view.progress: the brief's percentage is an LLM's guess about
+   *  the conversation, this is the agent stating what it has finished. */
+  checklist?: ChecklistItem[]
   /** True while a (re)generation of the brief is in flight. */
   loading: boolean
   /** Render only the global, right-edge status control. */
@@ -33,9 +39,13 @@ const clamp = (lines: number): React.CSSProperties => ({
 const COLLAPSE_KEY = 'codey.statusSidecarCollapsed'
 
 export const StatusSidecar: React.FC<Props> = ({
-  view, loading, compact = false, onOpen, onHide, onRestore, width, branchAhead, onCreatePr,
+  view, checklist, loading, compact = false, onOpen, onHide, onRestore, width, branchAhead, onCreatePr,
 }) => {
   const sm = statusMeta(view.status)
+  const tasks = checklist?.length ? checklist : undefined
+  const counted = tasks ? checklistProgress(tasks) : null
+  const progress = counted ? counted.percent : view.progress
+  const current = tasks ? currentChecklistItem(tasks) : null
   const prState = createPrButtonState(view.status, !!branchAhead)
   const [collapsed, setCollapsed] = React.useState<boolean>(() => localStorage.getItem(COLLAPSE_KEY) === '1')
   React.useEffect(() => { localStorage.setItem(COLLAPSE_KEY, collapsed ? '1' : '0') }, [collapsed])
@@ -47,7 +57,7 @@ export const StatusSidecar: React.FC<Props> = ({
         style={styles.compactRoot}
         onClick={onRestore}
         title="Show status panel"
-        aria-label={`Show status panel: ${sm.label}, ${view.progress}%`}
+        aria-label={`Show status panel: ${sm.label}, ${progress}%`}
       >
         <span
           style={{
@@ -57,7 +67,7 @@ export const StatusSidecar: React.FC<Props> = ({
           }}
         />
         <span style={styles.compactStatus}>{sm.label}</span>
-        <span style={styles.compactProgress}>{view.progress}%</span>
+        <span style={styles.compactProgress}>{progress}%</span>
         <UIIcon name="chevron" size={11} />
       </button>
     )
@@ -111,7 +121,7 @@ export const StatusSidecar: React.FC<Props> = ({
       {collapsed ? (
         <div style={styles.statusRow}>
           {pill}
-          <span style={styles.progress}>{view.progress}%</span>
+          <span style={styles.progress}>{progress}%</span>
         </div>
       ) : (
         <>
@@ -119,11 +129,52 @@ export const StatusSidecar: React.FC<Props> = ({
 
           <div style={styles.statusRow}>
             {pill}
-            <span style={styles.progress}>{view.progress}%</span>
+            <span style={styles.progress}>{progress}%</span>
           </div>
           <div style={styles.barTrack}>
-            <div style={{ ...styles.barFill, width: `${view.progress}%` }} />
+            <div style={{ ...styles.barFill, width: `${progress}%` }} />
           </div>
+
+          {tasks && counted && (
+            <div style={styles.nextBox}>
+              <div style={styles.tasksHeader}>
+                <span style={styles.sectionLabel}>Tasks</span>
+                <span style={styles.tasksCount}>{counted.label}</span>
+              </div>
+              {(() => {
+                const w = checklistWindow(tasks)
+                return (
+                  <>
+                    {w.hiddenBefore > 0 && <div style={styles.taskElided}>+{w.hiddenBefore} earlier</div>}
+                    {w.shown.map((t, i) => {
+                      const isCurrent = current?.item === t
+                      // An inferred current item gets the pending marker: only
+                      // the agent's own in_progress earns the active one.
+                      const active = isCurrent && !current?.inferred
+                      return (
+                        <div key={`${i}-${t.text}`} style={styles.taskRow}>
+                          <span style={{ ...styles.taskMark, color: t.status === 'completed' ? C.green : active ? C.accent : C.fg3 }}>
+                            {t.status === 'completed' ? '✓' : active ? '◐' : '○'}
+                          </span>
+                          <span
+                            style={{
+                              ...styles.taskText,
+                              color: t.status === 'completed' ? C.fg3 : isCurrent ? C.fg : C.fg2,
+                              fontWeight: active ? 600 : 400,
+                              textDecoration: t.status === 'completed' ? 'line-through' : 'none',
+                            }}
+                          >
+                            {active ? currentItemLabel(t) : t.text}
+                          </span>
+                        </div>
+                      )
+                    })}
+                    {w.hiddenAfter > 0 && <div style={styles.taskElided}>+{w.hiddenAfter} more</div>}
+                  </>
+                )
+              })()}
+            </div>
+          )}
 
           {view.nextActionText && (
             <div style={styles.nextBox}>
@@ -210,6 +261,12 @@ const styles: Record<string, React.CSSProperties> = {
   progress: { fontSize: 12, fontWeight: 600, color: C.fg, fontVariantNumeric: 'tabular-nums' },
   barTrack: { height: 4, background: C.surface3, borderRadius: 2, overflow: 'hidden' },
   barFill: { height: '100%', background: C.accent, borderRadius: 2 },
+  tasksHeader: { display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' },
+  tasksCount: { fontSize: 11, fontWeight: 600, color: C.fg3, fontVariantNumeric: 'tabular-nums' },
+  taskRow: { display: 'flex', alignItems: 'flex-start', gap: 6, padding: '2px 0' },
+  taskMark: { flex: 'none', width: 10, fontSize: 11, lineHeight: '17px', textAlign: 'center' },
+  taskText: { flex: 1, minWidth: 0, fontSize: 12, lineHeight: 1.4, ...clamp(2) },
+  taskElided: { fontSize: 10, color: C.fg3, padding: '2px 0 2px 16px' },
   nextBox: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 8, padding: '8px 9px' },
   sectionLabel: { fontSize: 10, fontWeight: 600, letterSpacing: 0.5, textTransform: 'uppercase', color: C.fg3, marginBottom: 5 },
   nextText: { fontSize: 12, fontWeight: 600, color: C.fg, lineHeight: 1.4, ...clamp(2) },

--- a/codey-mac/src/components/agentActivity.test.ts
+++ b/codey-mac/src/components/agentActivity.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { activityForTool, ACTIVITY_LABEL, type AgentActivity } from './agentActivity'
+
+describe('activityForTool', () => {
+  it('maps claude-code tool names', () => {
+    expect(activityForTool('Read')).toBe('reading')
+    expect(activityForTool('Edit')).toBe('editing')
+    expect(activityForTool('Write')).toBe('editing')
+    expect(activityForTool('Bash')).toBe('running')
+    expect(activityForTool('Grep')).toBe('searching')
+    expect(activityForTool('Glob')).toBe('searching')
+    expect(activityForTool('WebFetch')).toBe('browsing')
+    expect(activityForTool('WebSearch')).toBe('searching')
+    expect(activityForTool('Task')).toBe('delegating')
+  })
+
+  it('maps lowercased opencode/codex tool names', () => {
+    expect(activityForTool('read')).toBe('reading')
+    expect(activityForTool('glob')).toBe('searching')
+    expect(activityForTool('shell')).toBe('running')
+  })
+
+  it('maps MCP-prefixed browser tools', () => {
+    expect(activityForTool('mcp__codey-browser__browser_open')).toBe('browsing')
+    expect(activityForTool('mcp__codey-browser__browser_navigate')).toBe('browsing')
+  })
+
+  it('falls back to working for unknown or missing tools', () => {
+    expect(activityForTool(undefined)).toBe('working')
+    expect(activityForTool('')).toBe('working')
+    expect(activityForTool('SomeNovelTool')).toBe('working')
+  })
+
+  it('labels every activity', () => {
+    const all: AgentActivity[] = ['idle', 'thinking', 'reading', 'searching', 'editing', 'running', 'browsing', 'delegating', 'working', 'writing']
+    for (const a of all) expect(ACTIVITY_LABEL[a]).toBeTruthy()
+  })
+})

--- a/codey-mac/src/components/agentActivity.ts
+++ b/codey-mac/src/components/agentActivity.ts
@@ -1,0 +1,42 @@
+/** What the agent is doing right now, as shown in the shimmering status line.
+ *  Finer than "working": the tool a turn is currently running says far more
+ *  about the wait than a generic spinner does. */
+export type AgentActivity =
+  | 'idle'
+  | 'thinking'
+  | 'reading'
+  | 'searching'
+  | 'editing'
+  | 'running'
+  | 'browsing'
+  | 'delegating'
+  | 'working'
+  | 'writing'
+
+export const ACTIVITY_LABEL: Record<AgentActivity, string> = {
+  idle: 'Idle',
+  thinking: 'Thinking',
+  reading: 'Reading',
+  searching: 'Searching',
+  editing: 'Editing',
+  running: 'Running',
+  browsing: 'Browsing',
+  delegating: 'Delegating',
+  working: 'Working',
+  writing: 'Writing',
+}
+
+/** Tool names differ per agent (`Read` in claude-code, `read` in opencode,
+ *  `mcp__codey-browser__browser_open` for MCP), so match loosely on substrings
+ *  rather than an exact table that silently degrades to "Working". */
+export function activityForTool(tool?: string): AgentActivity {
+  const t = (tool ?? '').toLowerCase()
+  if (!t) return 'working'
+  if (t.includes('browser') || t.includes('webfetch') || t.includes('fetch')) return 'browsing'
+  if (t.includes('websearch') || t.includes('grep') || t.includes('glob') || t.includes('search')) return 'searching'
+  if (t.includes('edit') || t.includes('write') || t.includes('patch') || t.includes('apply')) return 'editing'
+  if (t.includes('read') || t.includes('view') || t.includes('cat')) return 'reading'
+  if (t.includes('bash') || t.includes('shell') || t.includes('exec') || t.includes('command') || t.includes('terminal')) return 'running'
+  if (t.includes('task') || t.includes('agent') || t.includes('worker')) return 'delegating'
+  return 'working'
+}

--- a/codey-mac/src/components/checklistView.test.ts
+++ b/codey-mac/src/components/checklistView.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import type { ChecklistItem, ToolCallEntry } from '../types'
+import {
+  activeToolHeadline,
+  checklistProgress,
+  checklistWindow,
+  currentChecklistItem,
+  currentItemLabel,
+  statusLine,
+} from './checklistView'
+
+const item = (text: string, status: ChecklistItem['status'], activeForm?: string): ChecklistItem =>
+  ({ text, status, ...(activeForm ? { activeForm } : {}) })
+
+const start = (tool: string, input?: Record<string, unknown>): ToolCallEntry =>
+  ({ id: `s-${tool}`, type: 'tool_start', tool, message: '', input })
+const end = (tool: string): ToolCallEntry =>
+  ({ id: `e-${tool}`, type: 'tool_end', tool, message: '' })
+const info = (): ToolCallEntry => ({ id: 'i', type: 'info', message: 'note' })
+
+const headline = (tool: string, input?: Record<string, unknown>) =>
+  input?.file_path ? `${tool}(${input.file_path})` : tool
+
+describe('checklistProgress', () => {
+  it('counts only completed items', () => {
+    const p = checklistProgress([
+      item('a', 'completed'), item('b', 'in_progress'), item('c', 'pending'),
+    ])
+    expect(p).toEqual({ done: 1, total: 3, percent: 33, label: '1/3' })
+  })
+
+  it('reports 0% rather than dividing by zero on an empty list', () => {
+    expect(checklistProgress([])).toEqual({ done: 0, total: 0, percent: 0, label: '0/0' })
+  })
+
+  it('reaches 100% only when every item is done', () => {
+    expect(checklistProgress([item('a', 'completed'), item('b', 'completed')]).percent).toBe(100)
+  })
+})
+
+describe('currentChecklistItem', () => {
+  it('takes the declared in_progress item as fact', () => {
+    const items = [item('a', 'completed'), item('b', 'in_progress'), item('c', 'pending')]
+    expect(currentChecklistItem(items)).toEqual({ item: items[1], index: 1, inferred: false })
+  })
+
+  it('falls back to the first unfinished item and marks it a guess', () => {
+    // Codex's shape: booleans only, so nothing is ever in_progress.
+    const items = [item('a', 'completed'), item('b', 'pending'), item('c', 'pending')]
+    expect(currentChecklistItem(items)).toEqual({ item: items[1], index: 1, inferred: true })
+  })
+
+  it('returns null when the list is finished', () => {
+    expect(currentChecklistItem([item('a', 'completed')])).toBeNull()
+  })
+
+  it('prefers a declared in_progress item even when an earlier one is pending', () => {
+    const items = [item('a', 'pending'), item('b', 'in_progress')]
+    expect(currentChecklistItem(items)?.index).toBe(1)
+  })
+})
+
+describe('currentItemLabel', () => {
+  it('uses activeForm when the agent wrote one', () => {
+    expect(currentItemLabel(item('Implement it', 'in_progress', 'Implementing it'))).toBe('Implementing it')
+  })
+
+  it('falls back to the imperative content rather than rewriting the tense', () => {
+    expect(currentItemLabel(item('Implement it', 'in_progress'))).toBe('Implement it')
+  })
+})
+
+describe('activeToolHeadline', () => {
+  it('names the tool that is still running', () => {
+    expect(activeToolHeadline([start('Edit', { file_path: 'a.ts' })], headline)).toBe('Edit(a.ts)')
+  })
+
+  it('goes quiet once the tool finished', () => {
+    expect(activeToolHeadline([start('Edit'), end('Edit')], headline)).toBeUndefined()
+  })
+
+  it('ignores info entries when deciding what is running', () => {
+    expect(activeToolHeadline([start('Read'), info()], headline)).toBe('Read')
+  })
+
+  it('handles no entries at all', () => {
+    expect(activeToolHeadline(undefined, headline)).toBeUndefined()
+  })
+})
+
+describe('checklistWindow', () => {
+  const many = (n: number, currentAt: number) =>
+    Array.from({ length: n }, (_, i) =>
+      item(`t${i}`, i === currentAt ? 'in_progress' : i < currentAt ? 'completed' : 'pending'))
+
+  it('shows a short list whole', () => {
+    const items = many(4, 1)
+    expect(checklistWindow(items)).toEqual({ shown: items, hiddenBefore: 0, hiddenAfter: 0 })
+  })
+
+  it('keeps one finished line above the current item', () => {
+    const w = checklistWindow(many(12, 5))
+    expect(w.shown.map(i => i.text)).toEqual(['t4', 't5', 't6', 't7', 't8', 't9'])
+    expect(w).toMatchObject({ hiddenBefore: 4, hiddenAfter: 2 })
+  })
+
+  it('does not scroll past the end for a current item near the tail', () => {
+    const w = checklistWindow(many(10, 9))
+    expect(w.shown.map(i => i.text)).toEqual(['t4', 't5', 't6', 't7', 't8', 't9'])
+    expect(w.hiddenAfter).toBe(0)
+  })
+
+  it('anchors on the last item when the list is finished', () => {
+    const done = Array.from({ length: 9 }, (_, i) => item(`t${i}`, 'completed'))
+    const w = checklistWindow(done)
+    expect(w.shown.map(i => i.text)).toEqual(['t3', 't4', 't5', 't6', 't7', 't8'])
+    expect(w.hiddenAfter).toBe(0)
+  })
+})
+
+describe('statusLine', () => {
+  const items = [
+    item('Set up', 'completed'),
+    item('Implement the reducer', 'in_progress', 'Implementing the reducer'),
+    item('Test it', 'pending'),
+  ]
+
+  it('joins what, how and how far', () => {
+    const line = statusLine({
+      checklist: items, entries: [start('Edit', { file_path: 'sessionReducer.ts' })],
+      format: headline, fallback: 'Working',
+    })
+    expect(line.parts).toEqual(['Implementing the reducer', 'Edit(sessionReducer.ts)', '1/3'])
+    expect(line.inferred).toBe(false)
+  })
+
+  it('keeps the item and count when no tool is running', () => {
+    const line = statusLine({ checklist: items, entries: [start('Edit'), end('Edit')], format: headline, fallback: 'Working' })
+    expect(line.parts).toEqual(['Implementing the reducer', '1/3'])
+  })
+
+  it('flags an inferred current item', () => {
+    const line = statusLine({
+      checklist: [item('a', 'completed'), item('b', 'pending')],
+      format: headline, fallback: 'Working',
+    })
+    expect(line.parts).toEqual(['b', '1/2'])
+    expect(line.inferred).toBe(true)
+  })
+
+  it('falls back to the activity word when there is no checklist', () => {
+    const line = statusLine({ entries: [start('Read')], format: headline, fallback: 'Reading' })
+    expect(line.parts).toEqual(['Reading', 'Read'])
+    expect(line.inferred).toBe(false)
+  })
+
+  it('is just the activity word with neither checklist nor tool', () => {
+    expect(statusLine({ format: headline, fallback: 'Thinking' }).parts).toEqual(['Thinking'])
+  })
+
+  it('still shows the count once every item is done', () => {
+    const done = [item('a', 'completed'), item('b', 'completed')]
+    const line = statusLine({ checklist: done, format: headline, fallback: 'Writing' })
+    expect(line.parts).toEqual(['Writing', '2/2'])
+    expect(line.inferred).toBe(false)
+  })
+})

--- a/codey-mac/src/components/checklistView.ts
+++ b/codey-mac/src/components/checklistView.ts
@@ -1,0 +1,128 @@
+// codey-mac/src/components/checklistView.ts
+//
+// Renderer-side derivations over the agent's own task list. The gateway
+// normalizes the three CLIs into ChecklistItem before this sees anything, so
+// the only difference left to honour is that codex never marks an item
+// in_progress — the current item there is our guess, and is flagged as one.
+//
+// Deliberately free of React and of @codey/core's runtime: this file is pure
+// so it can be tested directly, and the renderer only ever imports core types.
+
+import type { ChecklistItem, ToolCallEntry } from '../types'
+
+export interface ChecklistProgress {
+  done: number
+  total: number
+  /** Rounded percentage, for the same bar the LLM-estimated brief drives. */
+  percent: number
+  /** "3/7" — the compact form shown beside the current item. */
+  label: string
+}
+
+export function checklistProgress(items: ChecklistItem[]): ChecklistProgress {
+  const total = items.length
+  const done = items.filter(i => i.status === 'completed').length
+  return {
+    done,
+    total,
+    percent: total === 0 ? 0 : Math.round((done / total) * 100),
+    label: `${done}/${total}`,
+  }
+}
+
+export interface CurrentItem {
+  item: ChecklistItem
+  index: number
+  /** True when nothing was marked in_progress and we picked the first
+   *  unfinished item instead. Callers must not render a guess as a claim. */
+  inferred: boolean
+}
+
+/** The item the agent is on, or null when the list is finished. */
+export function currentChecklistItem(items: ChecklistItem[]): CurrentItem | null {
+  const active = items.findIndex(i => i.status === 'in_progress')
+  if (active >= 0) return { item: items[active], index: active, inferred: false }
+  const next = items.findIndex(i => i.status !== 'completed')
+  if (next >= 0) return { item: items[next], index: next, inferred: true }
+  return null
+}
+
+/** claude-code writes activeForm ("Implementing the reducer") for exactly this
+ *  line; the other two only have the imperative content. Using it verbatim
+ *  beats a round-trip to a model just to fix the tense. */
+export function currentItemLabel(item: ChecklistItem): string {
+  return item.activeForm || item.text
+}
+
+/** The tool running right now, or undefined once it has finished.
+ *  Only a trailing tool_start counts: after tool_end the agent is deciding what
+ *  to do next, and holding the last tool's name there would claim activity that
+ *  has already stopped. */
+export function activeToolHeadline(
+  entries: ToolCallEntry[] | undefined,
+  format: (tool: string, input?: Record<string, unknown>) => string,
+): string | undefined {
+  const last = [...(entries ?? [])].reverse().find(e => e.type === 'tool_start' || e.type === 'tool_end')
+  if (!last || last.type !== 'tool_start' || !last.tool) return undefined
+  return format(last.tool, last.input) || undefined
+}
+
+export interface ChecklistWindow {
+  shown: ChecklistItem[]
+  /** Items elided before/after the window, so the panel can say so rather
+   *  than quietly truncating a list the user is using to track progress. */
+  hiddenBefore: number
+  hiddenAfter: number
+}
+
+/** A long plan would push everything else out of the sidecar, so show a window
+ *  around the current item — the finished tail above it is the least useful
+ *  part to keep on screen. */
+export function checklistWindow(items: ChecklistItem[], max = 6): ChecklistWindow {
+  if (items.length <= max) return { shown: items, hiddenBefore: 0, hiddenAfter: 0 }
+  const current = currentChecklistItem(items)
+  const focus = current ? current.index : items.length - 1
+  // Keep one line of finished context above the current item where possible.
+  const start = Math.min(Math.max(0, focus - 1), items.length - max)
+  const end = start + max
+  return { shown: items.slice(start, end), hiddenBefore: start, hiddenAfter: items.length - end }
+}
+
+export interface StatusLineInput {
+  /** The agent's task list, when it reported one. */
+  checklist?: ChecklistItem[]
+  /** Tool calls on the in-flight assistant message. */
+  entries?: ToolCallEntry[]
+  format: (tool: string, input?: Record<string, unknown>) => string
+  /** What to say when there is no checklist — the existing activity word. */
+  fallback: string
+}
+
+export interface StatusLine {
+  /** Rendered joined by " · ": what, how, how far. */
+  parts: string[]
+  /** The leading item is a guess (codex). Render it without the in-progress
+   *  marker so a supposition doesn't read as the agent's own statement. */
+  inferred: boolean
+}
+
+/** Three layers, each dropped when its source has nothing to say:
+ *  "Implementing the reducer · Edit(sessionReducer.ts) · 3/7". */
+export function statusLine({ checklist, entries, format, fallback }: StatusLineInput): StatusLine {
+  const tool = activeToolHeadline(entries, format)
+  const items = checklist ?? []
+  const current = items.length ? currentChecklistItem(items) : null
+
+  if (!items.length) {
+    return { parts: [fallback, ...(tool ? [tool] : [])], inferred: false }
+  }
+
+  const progress = checklistProgress(items).label
+  // A finished list still deserves its count: "3/3" beats silently reverting
+  // to a generic verb while the agent writes up the result.
+  const head = current ? currentItemLabel(current.item) : fallback
+  return {
+    parts: [head, ...(tool ? [tool] : []), progress],
+    inferred: current?.inferred ?? false,
+  }
+}

--- a/codey-mac/src/components/notificationLogic.ts
+++ b/codey-mac/src/components/notificationLogic.ts
@@ -1,8 +1,9 @@
 import type { Chat } from '../types'
+import type { AgentActivity } from './agentActivity'
 
 /** Subset of useChats' internal InFlight needed to render a notification. */
 export interface InFlightLike {
-  agentStatus: 'idle' | 'thinking' | 'working' | 'writing'
+  agentStatus: AgentActivity
   queuedPosition?: number
 }
 

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -1,12 +1,13 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef } from 'react'
 import { apiService } from '../services/api'
-import type { Chat, ChatSelection, ChatMessage, ToolCallEntry, FileAttachment, TaskBrief, TeamRunSummary } from '../types'
+import type { Chat, ChatSelection, ChatMessage, ChecklistItem, ToolCallEntry, FileAttachment, TaskBrief, TeamRunSummary } from '../types'
 import type { ChatStreamEvent } from '../../../packages/gateway/src/chat-runner'
+import { activityForTool, type AgentActivity } from '../components/agentActivity'
 
 interface InFlight {
   assistantMessageId: string
   userMessageId: string
-  agentStatus: 'idle' | 'thinking' | 'working' | 'writing'
+  agentStatus: AgentActivity
   queuedPosition?: number
   thinking?: string
   thinkingByStep?: Record<number, string>
@@ -40,7 +41,8 @@ type Action =
   | { type: 'startSend'; chatId: string; userMessage: ChatMessage; assistantMessageId: string }
   | { type: 'streamToken'; chatId: string; token: string; messageId?: string }
   | { type: 'thinkingToken'; chatId: string; token: string; step?: number; messageId?: string }
-  | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: 'working' | 'writing'; messageId?: string }
+  | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: AgentActivity; messageId?: string }
+  | { type: 'patchChecklist'; chatId: string; items: ChecklistItem[] }
   | { type: 'queued'; chatId: string; position: number }
   | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; agent?: ChatMessage['agent']; model?: string; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion']; fallback?: ChatMessage['fallback']; teamTurnId?: string }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
@@ -158,6 +160,16 @@ export function reducer(state: State, action: Action): State {
       const updated: Chat = { ...chat, soloAdvisor: action.enabled ? true : undefined }
       return { ...state, chats: { ...state.chats, [chat.id]: updated } }
     }
+    case 'patchChecklist': {
+      const chat = state.chats[action.chatId]
+      if (!chat) return state
+      // The agent restates its whole list on every revision, so replace rather
+      // than merge. updatedAt is left alone: the chat list orders by real
+      // conversation activity, and a plan revision is not a new message.
+      const updated: Chat = action.items.length ? { ...chat, checklist: action.items } : { ...chat }
+      if (!action.items.length) delete updated.checklist
+      return { ...state, chats: { ...state.chats, [chat.id]: updated } }
+    }
     case 'patchTaskBrief': {
       const chat = state.chats[action.chatId]
       if (!chat) return state
@@ -208,6 +220,9 @@ export function reducer(state: State, action: Action): State {
         messages: [...chat.messages, action.userMessage, assistantStub],
         updatedAt: Date.now(),
       }
+      // Last turn's task list describes last turn's task. Showing it against a
+      // new prompt would report progress on work nobody asked for again.
+      delete updated.checklist
       return {
         ...state,
         chats: { ...state.chats, [chat.id]: updated },
@@ -540,7 +555,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             type: 'toolCall',
             chatId: ev.chatId,
             entry: { id: `tc-${Date.now()}-${Math.random()}`, type: 'tool_start', tool: ev.tool, message: ev.message, input: ev.input },
-            status: 'working',
+            status: activityForTool(ev.tool),
             messageId: ev.messageId,
           })
           break
@@ -549,9 +564,15 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             type: 'toolCall',
             chatId: ev.chatId,
             entry: { id: `tc-${Date.now()}-${Math.random()}`, type: 'tool_end', tool: ev.tool, message: ev.message, output: ev.output },
-            status: 'working',
+            // Hold the tool's own activity rather than snapping back to
+            // "Working": the label would flicker between every paired event.
+            status: activityForTool(ev.tool),
             messageId: ev.messageId,
           })
+          break
+        case 'checklist':
+          // State, not a tool row: it never enters the message transcript.
+          dispatch({ type: 'patchChecklist', chatId: ev.chatId, items: ev.items })
           break
         case 'info':
           if (ev.skillNotice) {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -1,6 +1,6 @@
 // IPC proxy — all calls go through window.codey.* (Electron preload)
 
-import type { Chat, ChatSelection, TaskBrief, TeamRunSummary } from '../types'
+import type { Chat, ChatSelection, ChecklistItem, TaskBrief, TeamRunSummary } from '../types'
 import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
 
 // Inline ChatStreamEvent to avoid cross-package import
@@ -9,6 +9,7 @@ export type ChatStreamEvent =
   | { type: 'tool_start'; chatId: string; tool?: string; message: string; input?: Record<string, unknown>; messageId?: string; step?: number }
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string; messageId?: string; step?: number }
   | { type: 'info'; chatId: string; message: string }
+  | { type: 'checklist'; chatId: string; message: string; items: ChecklistItem[] }
   | { type: 'stream'; chatId: string; token: string; messageId?: string; step?: number }
   | { type: 'thinking'; chatId: string; token: string; step?: number; messageId?: string }
   | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string }> }

--- a/codey-mac/src/types/index.ts
+++ b/codey-mac/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { ChatMessage, ToolCallEntry, Chat, ChatSelection, FileAttachment, ChatRoute, TaskBrief, TaskEvent, TeamRunSummary, TeamRunSummaryEntry } from '@codey/core';
+export type { ChatMessage, ToolCallEntry, Chat, ChatSelection, ChecklistItem, FileAttachment, ChatRoute, TaskBrief, TaskEvent, TeamRunSummary, TeamRunSummaryEntry } from '@codey/core';
 
 export interface GatewayStatus {
   status: string;

--- a/packages/core/src/agents/checklist.test.ts
+++ b/packages/core/src/agents/checklist.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isChecklistTool,
+  checklistFromTodos,
+  checklistFromCodexTodoList,
+  currentChecklistItem,
+  checklistFromCodexItem,
+  ChecklistTracker,
+} from './checklist';
+import { CODEX_TOOL_ITEMS } from './codex';
+import { StatusUpdate } from '../types';
+
+describe('isChecklistTool', () => {
+  it('recognizes the todo tools claude-code and opencode expose', () => {
+    // Verified against real streams: claude-code emits `TodoWrite`,
+    // opencode emits `todowrite` (both lowercase-compared here).
+    expect(isChecklistTool('TodoWrite')).toBe(true);
+    expect(isChecklistTool('todowrite')).toBe(true);
+    expect(isChecklistTool('TodoRead')).toBe(true);
+  });
+
+  it('does not claim unrelated tools', () => {
+    expect(isChecklistTool('Read')).toBe(false);
+    expect(isChecklistTool('bash')).toBe(false);
+    expect(isChecklistTool(undefined)).toBe(false);
+  });
+});
+
+describe('checklistFromTodos', () => {
+  it('normalizes a claude-code TodoWrite input, keeping activeForm', () => {
+    const items = checklistFromTodos({
+      todos: [
+        { content: 'Implement the reducer', status: 'in_progress', activeForm: 'Implementing the reducer' },
+        { content: 'Write the tests', status: 'pending' },
+      ],
+    });
+    expect(items).toEqual([
+      { text: 'Implement the reducer', status: 'in_progress', activeForm: 'Implementing the reducer' },
+      { text: 'Write the tests', status: 'pending' },
+    ]);
+  });
+
+  it('normalizes an opencode todowrite input, which has no activeForm', () => {
+    // Real opencode 1.14.18 payload shape: content/status/priority.
+    const items = checklistFromTodos({
+      todos: [
+        { content: 'Step 1', status: 'completed', priority: 'medium' },
+        { content: 'Step 2', status: 'pending', priority: 'medium' },
+      ],
+    });
+    expect(items).toEqual([
+      { text: 'Step 1', status: 'completed' },
+      { text: 'Step 2', status: 'pending' },
+    ]);
+  });
+
+  it('treats an unknown status word as pending rather than dropping the item', () => {
+    const items = checklistFromTodos({ todos: [{ content: 'Step 1', status: 'queued' }] });
+    expect(items).toEqual([{ text: 'Step 1', status: 'pending' }]);
+  });
+
+  it('returns null when there is nothing usable to show', () => {
+    expect(checklistFromTodos(undefined)).toBeNull();
+    expect(checklistFromTodos({})).toBeNull();
+    expect(checklistFromTodos({ todos: [] })).toBeNull();
+    expect(checklistFromTodos({ todos: 'nope' })).toBeNull();
+  });
+
+  it('skips entries with no text at all', () => {
+    const items = checklistFromTodos({ todos: [{ status: 'pending' }, { content: 'Real', status: 'pending' }] });
+    expect(items).toEqual([{ text: 'Real', status: 'pending' }]);
+  });
+});
+
+describe('recorded CLI payloads', () => {
+  it('reads a real opencode 1.14.18 todowrite part', () => {
+    // Captured verbatim from `opencode run --format json`.
+    const part = {
+      type: 'tool',
+      tool: 'todowrite',
+      callID: 'call_00_xWUclb4HvHEK7hIvf2A22700',
+      state: {
+        status: 'completed',
+        input: {
+          todos: [
+            { content: 'Step 1', status: 'pending', priority: 'medium' },
+            { content: 'Step 2', status: 'pending', priority: 'medium' },
+          ],
+        },
+      },
+    };
+    expect(isChecklistTool(part.tool)).toBe(true);
+    expect(checklistFromTodos(part.state.input)).toEqual([
+      { text: 'Step 1', status: 'pending' },
+      { text: 'Step 2', status: 'pending' },
+    ]);
+  });
+
+  it('reads a real codex 0.145.0 todo_list item', () => {
+    // Captured verbatim from `codex exec --json`.
+    const item = {
+      id: 'item_1',
+      type: 'todo_list',
+      items: [
+        { text: 'Define the task scope', completed: true },
+        { text: 'Carry out the task', completed: false },
+      ],
+    };
+    expect(checklistFromCodexItem(item)).toEqual([
+      { text: 'Define the task scope', status: 'completed' },
+      { text: 'Carry out the task', status: 'pending' },
+    ]);
+  });
+
+  it('ignores codex items that are not the todo list', () => {
+    const command = { id: 'x', type: 'command_execution', command: 'ls' };
+    expect(checklistFromCodexItem(command)).toBeNull();
+    expect(checklistFromCodexItem(undefined)).toBeNull();
+  });
+
+  it('keeps todo_list out of the codex tool items, so it never becomes a tool row', () => {
+    // codex reports its list as an item, not a tool call. Routing it through
+    // the tool collector would invent a tool row per plan revision.
+    expect(CODEX_TOOL_ITEMS.has('todo_list')).toBe(false);
+  });
+});
+
+describe('checklistFromCodexTodoList', () => {
+  it('maps codex booleans onto the shared tri-state', () => {
+    // Real codex 0.145.0 payload: {text, completed} — there is no in_progress.
+    const items = checklistFromCodexTodoList([
+      { text: 'Define the task scope', completed: true },
+      { text: 'Carry out the task', completed: false },
+    ]);
+    expect(items).toEqual([
+      { text: 'Define the task scope', status: 'completed' },
+      { text: 'Carry out the task', status: 'pending' },
+    ]);
+  });
+
+  it('returns null for an empty or malformed list', () => {
+    expect(checklistFromCodexTodoList([])).toBeNull();
+    expect(checklistFromCodexTodoList(undefined)).toBeNull();
+  });
+});
+
+describe('currentChecklistItem', () => {
+  it('reports an explicitly marked in_progress item', () => {
+    const current = currentChecklistItem([
+      { text: 'a', status: 'completed' },
+      { text: 'b', status: 'in_progress', activeForm: 'Doing b' },
+      { text: 'c', status: 'pending' },
+    ]);
+    expect(current).toEqual({
+      item: { text: 'b', status: 'in_progress', activeForm: 'Doing b' },
+      index: 1,
+      inferred: false,
+    });
+  });
+
+  it('infers the first unfinished item when nothing is marked in_progress', () => {
+    // codex never marks in_progress, so the current item is a guess and must
+    // say so — the UI styles an inferred item differently.
+    const current = currentChecklistItem([
+      { text: 'a', status: 'completed' },
+      { text: 'b', status: 'pending' },
+      { text: 'c', status: 'pending' },
+    ]);
+    expect(current).toEqual({ item: { text: 'b', status: 'pending' }, index: 1, inferred: true });
+  });
+
+  it('has no current item once everything is done', () => {
+    expect(currentChecklistItem([{ text: 'a', status: 'completed' }])).toBeNull();
+    expect(currentChecklistItem([])).toBeNull();
+  });
+});
+
+describe('ChecklistTracker', () => {
+  const capture = () => {
+    const seen: StatusUpdate[] = [];
+    return { seen, tracker: new ChecklistTracker(u => seen.push(u)) };
+  };
+
+  it('emits a checklist update summarizing progress and the current item', () => {
+    const { seen, tracker } = capture();
+    tracker.record([
+      { text: 'a', status: 'completed' },
+      { text: 'b', status: 'in_progress', activeForm: 'Doing b' },
+      { text: 'c', status: 'pending' },
+    ]);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe('checklist');
+    expect(seen[0].message).toBe('1/3 · Doing b');
+    expect(seen[0].checklist).toHaveLength(3);
+  });
+
+  it('falls back to the plain text when the CLI has no activeForm', () => {
+    const { seen, tracker } = capture();
+    tracker.record([{ text: 'Step 1', status: 'pending' }, { text: 'Step 2', status: 'pending' }]);
+    expect(seen[0].message).toBe('0/2 · Step 1');
+  });
+
+  it('reports a finished list without a current item', () => {
+    const { seen, tracker } = capture();
+    tracker.record([{ text: 'a', status: 'completed' }]);
+    expect(seen[0].message).toBe('1/1');
+  });
+
+  it('stays silent when the list has not changed', () => {
+    // codex emits item.started and item.completed with an identical payload;
+    // re-announcing the same list would add noise and no information.
+    const { seen, tracker } = capture();
+    const items: Array<{ text: string; status: 'pending' }> = [{ text: 'a', status: 'pending' }];
+    tracker.record(items);
+    tracker.record([{ text: 'a', status: 'pending' }]);
+    expect(seen).toHaveLength(1);
+  });
+
+  it('emits again once any item changes state', () => {
+    const { seen, tracker } = capture();
+    tracker.record([{ text: 'a', status: 'pending' }]);
+    tracker.record([{ text: 'a', status: 'completed' }]);
+    expect(seen).toHaveLength(2);
+  });
+
+  it('ignores an empty list rather than announcing an empty checklist', () => {
+    const { seen, tracker } = capture();
+    tracker.record(null);
+    tracker.record([]);
+    expect(seen).toHaveLength(0);
+  });
+
+  it('exposes the latest list so the run can report it when it ends', () => {
+    const { tracker } = capture();
+    expect(tracker.latest()).toBeNull();
+    tracker.record([{ text: 'a', status: 'completed' }]);
+    expect(tracker.latest()).toEqual([{ text: 'a', status: 'completed' }]);
+  });
+});

--- a/packages/core/src/agents/checklist.ts
+++ b/packages/core/src/agents/checklist.ts
@@ -1,0 +1,131 @@
+// packages/core/src/agents/checklist.ts
+//
+// The three CLIs all track a task list, and all three describe it differently.
+// Verified against real streams:
+//
+//   claude-code  TodoWrite tool  -> input.todos = [{content, status, activeForm}]
+//   opencode     todowrite tool  -> state.input.todos = [{content, status, priority}]
+//   codex        todo_list item  -> item.items = [{text, completed}]
+//
+// The first two share a tri-state status word; codex has only a boolean and
+// never reports which item is in flight. Normalizing here keeps that difference
+// in one place, so the UI renders one shape and only has to know that an
+// inferred current item is a guess rather than a claim.
+
+import { ChecklistItem, ChecklistStatus, StatusUpdate } from '../types';
+
+const CHECKLIST_TOOLS = new Set(['todowrite', 'todoread']);
+
+/** True for the tool names claude-code and opencode use to write a task list. */
+export function isChecklistTool(tool?: string): boolean {
+  return CHECKLIST_TOOLS.has((tool ?? '').toLowerCase());
+}
+
+/** An unknown status word means "not started": claiming completion we were
+ *  never told about would overstate progress, which is the one error the
+ *  panel must not make. */
+function statusOf(raw: unknown): ChecklistStatus {
+  const word = typeof raw === 'string' ? raw.toLowerCase().trim() : '';
+  if (word === 'completed' || word === 'complete' || word === 'done') return 'completed';
+  if (word === 'in_progress' || word === 'in-progress' || word === 'active') return 'in_progress';
+  return 'pending';
+}
+
+/** Normalize the `todos` array claude-code and opencode both pass as tool input.
+ *  Returns null when there is no list worth showing. */
+export function checklistFromTodos(input?: Record<string, unknown>): ChecklistItem[] | null {
+  const todos = input?.todos;
+  if (!Array.isArray(todos) || todos.length === 0) return null;
+
+  const items: ChecklistItem[] = [];
+  for (const raw of todos) {
+    if (!raw || typeof raw !== 'object') continue;
+    const todo = raw as Record<string, unknown>;
+    const text = typeof todo.content === 'string' ? todo.content
+      : typeof todo.text === 'string' ? todo.text
+      : '';
+    if (!text) continue;
+    // activeForm is claude-code's present-tense phrasing of the same item
+    // ("Implementing the reducer"), written for exactly this display.
+    const activeForm = typeof todo.activeForm === 'string' && todo.activeForm ? todo.activeForm : undefined;
+    items.push({ text, status: statusOf(todo.status), ...(activeForm ? { activeForm } : {}) });
+  }
+  return items.length ? items : null;
+}
+
+/** Normalize a codex `todo_list` item payload. Its booleans collapse onto
+ *  completed/pending — codex has no in_progress to report. */
+export function checklistFromCodexTodoList(
+  items?: Array<{ text?: string; completed?: boolean }>,
+): ChecklistItem[] | null {
+  if (!Array.isArray(items) || items.length === 0) return null;
+  const normalized: ChecklistItem[] = [];
+  for (const entry of items) {
+    const text = typeof entry?.text === 'string' ? entry.text : '';
+    if (!text) continue;
+    normalized.push({ text, status: entry.completed ? 'completed' : 'pending' });
+  }
+  return normalized.length ? normalized : null;
+}
+
+/** Pull the checklist out of a codex stream item, or null when the item is
+ *  anything else. Codex reports its list as a `todo_list` item — never a tool
+ *  call — so this is the only hook for it. */
+export function checklistFromCodexItem(item?: {
+  type?: string;
+  items?: Array<{ text?: string; completed?: boolean }>;
+}): ChecklistItem[] | null {
+  if (item?.type !== 'todo_list') return null;
+  return checklistFromCodexTodoList(item.items);
+}
+
+export interface CurrentChecklistItem {
+  item: ChecklistItem;
+  index: number;
+  /** True when no item was marked in_progress and we picked the first
+   *  unfinished one instead. The UI must not present a guess as a fact. */
+  inferred: boolean;
+}
+
+/** The item the agent is working on, or null when the list is finished. */
+export function currentChecklistItem(items: ChecklistItem[]): CurrentChecklistItem | null {
+  const active = items.findIndex(i => i.status === 'in_progress');
+  if (active >= 0) return { item: items[active], index: active, inferred: false };
+  const next = items.findIndex(i => i.status !== 'completed');
+  if (next >= 0) return { item: items[next], index: next, inferred: true };
+  return null;
+}
+
+/** One-line summary for surfaces that get text rather than structure
+ *  (channels, logs): "1/3 · Implementing the reducer". */
+export function summarizeChecklist(items: ChecklistItem[]): string {
+  const done = items.filter(i => i.status === 'completed').length;
+  const progress = `${done}/${items.length}`;
+  const current = currentChecklistItem(items);
+  if (!current) return progress;
+  return `${progress} · ${current.item.activeForm ?? current.item.text}`;
+}
+
+/** Holds a run's task list and announces it only when it actually changes.
+ *  Codex restates an identical list on both item.started and item.completed,
+ *  and any CLI may rewrite a list without moving anything in it. */
+export class ChecklistTracker {
+  private current: ChecklistItem[] | null = null;
+  private lastKey = '';
+
+  constructor(private readonly onStatus?: (update: StatusUpdate) => void) {}
+
+  record(items: ChecklistItem[] | null): void {
+    if (!items || items.length === 0) return;
+    const key = items.map(i => `${i.status}:${i.text}`).join(' ');
+    if (key === this.lastKey) return;
+    this.lastKey = key;
+    this.current = items;
+    this.onStatus?.({ type: 'checklist', message: summarizeChecklist(items), checklist: items });
+  }
+
+  /** The list as last reported, for the run's final response. */
+  latest(): ChecklistItem[] | null {
+    return this.current;
+  }
+}

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -4,6 +4,7 @@ import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
 import { thinkingDeltaFrom } from './thinking-stream';
 import { writeClaudeMcpConfig } from './mcp-config';
+import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
 
 interface StreamEvent {
   type: string;
@@ -165,6 +166,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       const states: AgentStateEntry[] = [];
       // Track pending tool_use calls by id so we can pair them with tool_result
       const pendingTools = new Map<string, { name: string; input?: Record<string, unknown> }>();
+      const checklist = new ChecklistTracker(request.onStatus);
       let permissionDenials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> = [];
       let userQuestion: AgentResponse['userQuestion'];
       let askUserInputJson = '';
@@ -273,6 +275,10 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
                     return `${k}: ${val && val.length > 80 ? val.substring(0, 80) + '...' : val}`;
                   }).join(', ')
                 : '';
+              if (isChecklistTool(toolName)) {
+                checklist.record(checklistFromTodos(block.input));
+              }
+
               statusUpdates.push(`${toolName}: running`);
               states.push({
                 source: toolName,

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -7,6 +7,7 @@ import { AgentRequest, AgentResponse, AgentStateEntry } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
 import { ToolCallCollector } from './tool-events';
+import { ChecklistTracker, checklistFromCodexItem } from './checklist';
 import { codexMcpArgs } from './mcp-config';
 
 /**
@@ -56,6 +57,8 @@ export interface CodexItem {
   result?: unknown;
   // web_search
   query?: string;
+  // todo_list — codex's task list, restated in full on every revision.
+  items?: Array<{ text?: string; completed?: boolean }>;
 }
 
 /** Item types that represent the agent DOING something, as opposed to saying
@@ -169,6 +172,7 @@ export class CodexAdapter extends BaseAgentAdapter {
       const tools = new ToolCallCollector(request.onStatus);
       const statusUpdates = tools.statusUpdates;
       const states = tools.states;
+      const checklist = new ChecklistTracker(request.onStatus);
 
       const safeResolve = (response: AgentResponse) => {
         if (resolved) return;
@@ -198,6 +202,10 @@ export class CodexAdapter extends BaseAgentAdapter {
           case 'item.started':
           case 'item.updated':
           case 'item.completed': {
+            // The task list arrives as its own item type, not a tool call.
+            // The tracker de-dupes the identical payload codex sends on both
+            // item.started and item.completed.
+            checklist.record(checklistFromCodexItem(event.item));
             // The current codex surface: work is reported as items, and only
             // some item types are tool activity.
             if (!event.item || !CODEX_TOOL_ITEMS.has(event.item.type ?? '')) break;

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -4,6 +4,7 @@ import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
 import { writeOpenCodeMcpConfig } from './mcp-config';
 import { ObservedToolEvent, ToolCallCollector } from './tool-events';
+import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
 
 export interface OpenCodeEvent {
   type: string;
@@ -120,6 +121,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       const tools = new ToolCallCollector(request.onStatus);
       const statusUpdates = tools.statusUpdates;
       const states = tools.states;
+      const checklist = new ChecklistTracker(request.onStatus);
       // Captured from the top-level `sessionID` field present on every event
       // (e.g. `step_start`, `text`, `step_finish`). The first event we see
       // tells us which session OpenCode opened so the gateway can resume it.
@@ -159,6 +161,9 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
             if (event.type === 'tool_use' && event.part) {
               const observed = opencodeToolEvent(event.part);
               if (observed) tools.record(observed);
+              if (isChecklistTool(event.part.tool)) {
+                checklist.record(checklistFromTodos(event.part.state?.input));
+              }
             }
           } catch {
             // Not JSON, skip

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -1,6 +1,21 @@
 import { ChatRoute } from './route';
 import { PendingTeamState } from './pending-team';
 
+/** The three CLIs report task lists in three shapes; the adapters normalize
+ *  onto this one. codex has only a completed boolean, so it never produces
+ *  'in_progress' — a list with no in-progress item means "not stated", not
+ *  "nothing is running". */
+export type ChecklistStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface ChecklistItem {
+  text: string;
+  status: ChecklistStatus;
+  /** claude-code's present-tense phrasing of the same item ("Implementing the
+   *  reducer"), written by the model for exactly this display. The other two
+   *  agents supply only the imperative text. */
+  activeForm?: string;
+}
+
 export interface FileAttachment {
   id: string;
   name: string;        // original filename
@@ -191,6 +206,10 @@ export interface Chat {
    *  and the cached value is stale; never bumps Chat.updatedAt (see
    *  ChatManager.setTaskBrief) so staleness can compare updatedAt vs generatedAt. */
   taskBrief?: TaskBrief;
+  /** The agent's own task list for the current turn, as last reported. Unlike
+   *  taskBrief this is not inferred by an LLM — the agent stated it — so the
+   *  status panel prefers it for progress. Cleared when a new turn starts. */
+  checklist?: ChecklistItem[];
   /** Set when this chat is hosting a parallel-team (roundtable) discussion. */
   discussion?: DiscussionMeta;
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -182,12 +182,20 @@ export interface AgentRequest {
   mcpServers?: Record<string, McpServerSpec>;
 }
 
+import { ChecklistItem } from './chat';
+
 export interface StatusUpdate {
-  type: 'tool_start' | 'tool_end' | 'info';
+  /** 'checklist' carries the agent's whole task list, restated. It is not a
+   *  tool event: codex reports its list as a `todo_list` item rather than a
+   *  tool call, so routing it through tool_start would invent tool rows that
+   *  never happened. Consumers replace their stored list wholesale. */
+  type: 'tool_start' | 'tool_end' | 'info' | 'checklist';
   tool?: string;
   message: string;
   input?: Record<string, unknown>;
   output?: string;
+  /** Set on 'checklist' updates only. */
+  checklist?: ChecklistItem[];
 }
 
 export interface AgentStateEntry {

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -1,4 +1,4 @@
-import { Chat, ChatMessage, CodingAgent, FileAttachment, TaskBrief, TeamRunSummary, ToolCallEntry } from '@codey/core';
+import { Chat, ChatMessage, ChecklistItem, CodingAgent, FileAttachment, TaskBrief, TeamRunSummary, ToolCallEntry } from '@codey/core';
 
 export const MAX_CONCURRENT_AGENTS = 4;
 export const CHAT_CONTEXT_WINDOW = 40;
@@ -19,6 +19,9 @@ export type ChatStreamEvent =
   | { type: 'tool_start'; chatId: string; tool?: string; message: string; input?: Record<string, unknown>; messageId?: string; step?: number }
   | { type: 'tool_end'; chatId: string; tool?: string; message: string; output?: string; messageId?: string; step?: number }
   | { type: 'info'; chatId: string; message: string; skillNotice?: boolean }
+  // The agent's own task list, restated in full. Consumers replace whatever
+  // they were showing; the list is authoritative, not incremental.
+  | { type: 'checklist'; chatId: string; message: string; items: ChecklistItem[] }
   | { type: 'stream'; chatId: string; token: string; messageId?: string; step?: number }
   | { type: 'thinking'; chatId: string; token: string; step?: number; messageId?: string }
   | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: CodingAgent; model?: string }> }

--- a/packages/gateway/src/chat-status-events.test.ts
+++ b/packages/gateway/src/chat-status-events.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
+
+describe('chatStreamEventForStatus', () => {
+  it('maps a checklist update onto its own event carrying the items', () => {
+    const event = chatStreamEventForStatus('c1', {
+      type: 'checklist',
+      message: '1/2 · Doing b',
+      checklist: [
+        { text: 'a', status: 'completed' },
+        { text: 'b', status: 'in_progress', activeForm: 'Doing b' },
+      ],
+    });
+    expect(event).toEqual({
+      type: 'checklist',
+      chatId: 'c1',
+      message: '1/2 · Doing b',
+      items: [
+        { text: 'a', status: 'completed' },
+        { text: 'b', status: 'in_progress', activeForm: 'Doing b' },
+      ],
+    });
+  });
+
+  it('drops a checklist update with no items instead of emitting an empty list', () => {
+    // An empty list would blank the panel mid-run for no reason.
+    expect(chatStreamEventForStatus('c1', { type: 'checklist', message: '', checklist: [] })).toBeNull();
+    expect(chatStreamEventForStatus('c1', { type: 'checklist', message: '' })).toBeNull();
+  });
+
+  it('still maps the tool events unchanged', () => {
+    expect(chatStreamEventForStatus('c1', { type: 'tool_start', tool: 'Read', message: 'Read(a.ts)', input: { file_path: 'a.ts' } }))
+      .toEqual({ type: 'tool_start', chatId: 'c1', tool: 'Read', message: 'Read(a.ts)', input: { file_path: 'a.ts' } });
+    expect(chatStreamEventForStatus('c1', { type: 'tool_end', tool: 'Read', message: 'done', output: 'x' }))
+      .toEqual({ type: 'tool_end', chatId: 'c1', tool: 'Read', message: 'done', output: 'x' });
+  });
+
+  it('treats anything else as an info notice', () => {
+    expect(chatStreamEventForStatus('c1', { type: 'info', message: 'hello' }))
+      .toEqual({ type: 'info', chatId: 'c1', message: 'hello' });
+    expect(chatStreamEventForStatus('c1', { message: 'no type' }))
+      .toEqual({ type: 'info', chatId: 'c1', message: 'no type' });
+  });
+});
+
+describe('isPersistableToolCall', () => {
+  it('keeps real tool activity in the message transcript', () => {
+    expect(isPersistableToolCall('tool_start')).toBe(true);
+    expect(isPersistableToolCall('tool_end')).toBe(true);
+    expect(isPersistableToolCall('info')).toBe(true);
+  });
+
+  it('excludes checklist updates, which are state and not a tool call', () => {
+    // The list is restated in full on every revision; recording each one would
+    // bury the transcript under duplicate rows that never were tool calls.
+    expect(isPersistableToolCall('checklist')).toBe(false);
+  });
+});

--- a/packages/gateway/src/chat-status-events.ts
+++ b/packages/gateway/src/chat-status-events.ts
@@ -1,0 +1,41 @@
+// packages/gateway/src/chat-status-events.ts
+//
+// Turns an adapter's StatusUpdate into the chat surface's stream event.
+// Split out from the gateway's inline handler so the routing — in particular
+// that a checklist is state rather than a tool call — is testable on its own.
+
+import { ChecklistItem } from '@codey/core';
+import { ChatStreamEvent } from './chat-runner';
+
+interface ParsedStatus {
+  type?: string;
+  tool?: string;
+  message?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  checklist?: ChecklistItem[];
+}
+
+export function chatStreamEventForStatus(chatId: string, parsed: ParsedStatus): ChatStreamEvent | null {
+  const message = parsed.message ?? '';
+  switch (parsed.type) {
+    case 'tool_start':
+      return { type: 'tool_start', chatId, tool: parsed.tool, message, input: parsed.input };
+    case 'tool_end':
+      return { type: 'tool_end', chatId, tool: parsed.tool, message, output: parsed.output };
+    case 'checklist':
+      // No items means nothing to show; emitting it would blank a panel that
+      // is currently displaying a perfectly good list.
+      if (!parsed.checklist?.length) return null;
+      return { type: 'checklist', chatId, message, items: parsed.checklist };
+    default:
+      return { type: 'info', chatId, message };
+  }
+}
+
+/** Whether a status update belongs in the message's saved tool transcript.
+ *  A checklist restates the whole list on every revision — recording each
+ *  restatement would fill the transcript with rows that were never tools. */
+export function isPersistableToolCall(type?: string): boolean {
+  return type !== 'checklist';
+}

--- a/packages/gateway/src/chats.checklist.test.ts
+++ b/packages/gateway/src/chats.checklist.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+import type { ChecklistItem } from '@codey/core';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function tmpManager(): ChatManager {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+  roots.push(root);
+  fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+  return new ChatManager(root);
+}
+
+const items: ChecklistItem[] = [
+  { text: 'a', status: 'completed' },
+  { text: 'b', status: 'in_progress', activeForm: 'Doing b' },
+];
+
+describe('ChatManager.setChecklist', () => {
+  it('stores the list so a client adopting the run mid-flight can show it', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', title: 't' });
+    mgr.setChecklist(chat.id, items);
+    expect(mgr.get(chat.id)!.checklist).toEqual(items);
+  });
+
+  it('does not bump updatedAt, which orders the chat list by real activity', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', title: 't' });
+    const before = mgr.get(chat.id)!.updatedAt;
+    mgr.setChecklist(chat.id, items);
+    expect(mgr.get(chat.id)!.updatedAt).toBe(before);
+  });
+
+  it('replaces the previous list wholesale rather than merging', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', title: 't' });
+    mgr.setChecklist(chat.id, items);
+    mgr.setChecklist(chat.id, [{ text: 'only', status: 'pending' }]);
+    expect(mgr.get(chat.id)!.checklist).toEqual([{ text: 'only', status: 'pending' }]);
+  });
+
+  it('clears the list, so a new turn does not inherit the last one', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', title: 't' });
+    mgr.setChecklist(chat.id, items);
+    mgr.clearChecklist(chat.id);
+    expect(mgr.get(chat.id)!.checklist).toBeUndefined();
+  });
+
+  it('is a no-op for an unknown chat', () => {
+    const mgr = tmpManager();
+    expect(() => mgr.setChecklist('nope', items)).not.toThrow();
+    expect(() => mgr.clearChecklist('nope')).not.toThrow();
+  });
+});

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { Chat, ChatCompaction, ChatMessage, ChatSelection, ChatRoute, ChannelKind, TaskBrief } from '@codey/core';
+import { Chat, ChatCompaction, ChatMessage, ChatSelection, ChatRoute, ChannelKind, ChecklistItem, TaskBrief } from '@codey/core';
 import { Logger } from './logger';
 
 const log = Logger.getInstance();
@@ -360,6 +360,24 @@ export class ChatManager {
     const chat = this.cache.get(chatId);
     if (!chat) return;
     chat.taskBrief = brief;
+    this.persist(chat);
+  }
+
+  /** Store the agent's current task list. Like setTaskBrief this leaves
+   *  updatedAt alone — the chat list is ordered by real conversation activity,
+   *  and an agent revising its own plan is not that. */
+  setChecklist(chatId: string, items: ChecklistItem[]): void {
+    const chat = this.cache.get(chatId);
+    if (!chat) return;
+    chat.checklist = items;
+    this.persist(chat);
+  }
+
+  /** Drop the list so a new turn starts without inheriting the last one. */
+  clearChecklist(chatId: string): void {
+    const chat = this.cache.get(chatId);
+    if (!chat || !chat.checklist) return;
+    delete chat.checklist;
     this.persist(chat);
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -24,6 +24,7 @@ import { WorkerManager } from '@codey/core';
 import { ChatManager } from './chats';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
+import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
 import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildChatCatchupPrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
@@ -5781,22 +5782,23 @@ Example: /model gpt-4.1 write a Python script`;
     const onStatus = (update: any) => {
       try {
         const parsed = typeof update === 'string' ? JSON.parse(update) : update;
-        const entry: ToolCallEntry = {
-          id: randomUUID(),
-          type: parsed.type ?? 'info',
-          tool: parsed.tool,
-          message: parsed.message ?? '',
-          input: parsed.input,
-          output: parsed.output,
-        };
-        toolCalls.push(entry);
-        if (entry.type === 'tool_start') {
-          sink({ type: 'tool_start', chatId, tool: entry.tool, message: entry.message, input: entry.input });
-        } else if (entry.type === 'tool_end') {
-          sink({ type: 'tool_end', chatId, tool: entry.tool, message: entry.message, output: entry.output });
-        } else {
-          sink({ type: 'info', chatId, message: entry.message });
+        if (isPersistableToolCall(parsed.type)) {
+          toolCalls.push({
+            id: randomUUID(),
+            type: parsed.type ?? 'info',
+            tool: parsed.tool,
+            message: parsed.message ?? '',
+            input: parsed.input,
+            output: parsed.output,
+          });
         }
+        if (parsed.type === 'checklist' && parsed.checklist?.length) {
+          // Persist so a client that adopts this run mid-flight (or reloads)
+          // sees the list without waiting for the agent's next revision.
+          this.chatManager.setChecklist(chatId, parsed.checklist);
+        }
+        const event = chatStreamEventForStatus(chatId, parsed);
+        if (event) sink(event);
       } catch { /* non-JSON status */ }
     };
 


### PR DESCRIPTION
The status line said `Working…` while the data for something far more useful was already flowing past. Every agent reports a task list, and the tool it is running right now says more about the wait than a spinner does.

## The three agents disagree, so core normalizes them

| agent | shape | before |
|---|---|---|
| claude-code | `TodoWrite` tool → `input.todos[{content, status, activeForm}]` | reached the UI, drawn once as a tool row and discarded |
| opencode | `todowrite` tool → `state.input.todos[{content, status, priority}]` | same |
| codex | `todo_list` **item** → `items[{text, completed}]` | **dropped entirely** — not in `CODEX_TOOL_ITEMS`, so the adapter `break`ed on it |

All three land on one `ChecklistItem { text, status, activeForm? }` (`packages/core/src/agents/checklist.ts`). Event shapes were verified against real CLI streams (codex 0.145.0, opencode 1.14.18), not from docs.

Codex has only a boolean, so it never states which item is in flight. That difference survives to the UI as an `inferred` flag rather than being papered over: an inferred current item gets the pending marker (`○`), never the active one (`◐`). A guess must not read as the agent's own claim.

Codex also restates an identical payload on both `item.started` and `item.completed`; `ChecklistTracker` de-dupes on content so an unchanged list emits nothing.

## A checklist is state, not a tool call

It travels as its own `StatusUpdate` type. Routing codex's list through `tool_start` would invent tool rows for work that was never a tool call — one per plan revision — and `isPersistableToolCall` keeps those restatements out of the saved transcript.

## Progress comes from the list when there is one

`view.progress` was the LLM's guess while generating the task brief. `completed/total` is the agent stating what it finished, so it takes over the sidecar's percentage and bar. No checklist → the brief's estimate still stands.

## The status line gets three layers

```
Implementing the reducer · Edit(sessionReducer.ts) · 3/7
```

What it is on (claude-code's `activeForm` is the model's own present-tense phrasing, written for exactly this; the other two supply the imperative text verbatim — a model round-trip to fix the tense isn't worth the latency), how it is doing it, and how far along. Each layer disappears when its source has nothing to say.

The tool layer clears on `tool_end` rather than holding the last tool's name. The old behaviour avoided flicker between paired events but left `Editing…` on screen while the model was deciding what to do next — a claim that an edit was still running. With a checklist anchor underneath it, the quiet stretch now reads `Implementing the reducer · 3/7`.

A long plan shows a window around the current item with the elided count stated (`+4 earlier`), rather than silently truncating a list someone is using to track progress.

## Also fixed

`ChecklistItem` / `ChecklistStatus` were referenced across core, gateway and all three adapters but **never defined**. Vitest doesn't typecheck, so a green suite hid it — `npm run build` failed outright. Now defined in `packages/core/src/types/chat.ts`, along with two missing imports in `gateway.ts` and `chats.ts`.

`codey-mac`'s `checklistView.ts` imports only types from core, never runtime code — pulling core's runtime into the renderer drags in Node builtins and blanks the packaged window.

## Verification

- `@codey/core` 348 ✅ · `@codey/gateway` 238 ✅ · `codey-mac` 350 ✅ (936 total, 0 failures)
- `tsc` clean across core, gateway and `codey-mac --noEmit`
- `npm run lint` clean

**Not verified:** no live agent turn was run against this. The panel's feel with a real list, and how codex's inferred item reads in practice, are still on paper. The sidecar also renders only once `chat.taskBrief` exists, so a checklist arriving before the brief is generated waits those few seconds — worth revisiting if it's noticeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)