### PR TITLE
Add an on/off switch to each skill

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -10,7 +10,7 @@ import { decideNotification, createTurnTracker } from './chat-notifications'
 import { decideAutomationNotification, findUnseenRuns, findUnnotifiedRuns } from './automation-notifications'
 import { validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
-import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
+import { SKILL_FILE, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import type { ScannedSkill } from './skills'
@@ -3295,6 +3295,9 @@ app.whenReady().then(async () => {
         description: 'Quick Question — ask about this chat without affecting it',
         source: 'gateway',
       }
+      // Filter before mapping: `skillAliases` below is derived from this array,
+      // so a disabled skill left in would still suppress the agent's own
+      // command of the same bare name.
       const skills: SlashCommand[] = skillResult.skills
         .filter(skill => skill.enabled)
         .map(skill => ({
@@ -3357,7 +3360,7 @@ app.whenReady().then(async () => {
         if (samePath(fsMod, pathMod, src, targetRoot)) {
           return { name: pathMod.basename(targetRoot), dir: targetRoot }
         }
-        const rootSkillFile = pathMod.join(src, 'SKILL.md')
+        const rootSkillFile = pathMod.join(src, SKILL_FILE)
 
         const discovered = fsMod.existsSync(rootSkillFile)
           ? []
@@ -3414,6 +3417,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('skills:setEnabled', async (_e, dir: string, enabled: boolean) =>
     wrap(async () => {
       if (typeof dir !== 'string' || !dir) throw new Error('Invalid path')
+      if (typeof enabled !== 'boolean') throw new Error('Invalid enabled flag')
       const fsMod = await import('fs')
       const pathMod = await import('path')
       setSkillEnabled(fsMod, pathMod, dir, enabled)

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -10,7 +10,7 @@ import { decideNotification, createTurnTracker } from './chat-notifications'
 import { decideAutomationNotification, findUnseenRuns, findUnnotifiedRuns } from './automation-notifications'
 import { validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
-import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, uniqueSkills } from './skills'
+import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import type { ScannedSkill } from './skills'
@@ -3295,11 +3295,13 @@ app.whenReady().then(async () => {
         description: 'Quick Question — ask about this chat without affecting it',
         source: 'gateway',
       }
-      const skills: SlashCommand[] = skillResult.skills.map(skill => ({
-        name: skill.qualifiedName,
-        description: skill.description || 'Agent skill',
-        source: 'skill',
-      }))
+      const skills: SlashCommand[] = skillResult.skills
+        .filter(skill => skill.enabled)
+        .map(skill => ({
+          name: skill.qualifiedName,
+          description: skill.description || 'Agent skill',
+          source: 'skill',
+        }))
       // Gateway commands take precedence, then installed skills, then the
       // agent's own commands. A Set keeps the menu stable when a skill and an
       // agent command happen to share a name.
@@ -3406,6 +3408,15 @@ app.whenReady().then(async () => {
       }
 
       throw new Error('Either localDir or gitUrl is required')
+    })
+  )
+
+  ipcMain.handle('skills:setEnabled', async (_e, dir: string, enabled: boolean) =>
+    wrap(async () => {
+      if (typeof dir !== 'string' || !dir) throw new Error('Invalid path')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      setSkillEnabled(fsMod, pathMod, dir, enabled)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -128,6 +128,7 @@ contextBridge.exposeInMainWorld('codey', {
     install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) =>
       ipcRenderer.invoke('skills:install', payload),
     remove: (dir: string) => ipcRenderer.invoke('skills:remove', dir),
+    setEnabled: (dir: string, enabled: boolean) => ipcRenderer.invoke('skills:setEnabled', dir, enabled),
     reveal: (dir: string) => ipcRenderer.invoke('skills:reveal', dir),
   },
   playbooks: {

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -179,7 +179,7 @@ describe('setSkillEnabled', () => {
 
   it('throws when the directory holds no skill file', () => {
     const root = temp()
-    expect(() => setSkillEnabled(fs, path, root, false)).toThrow(/SKILL\.md/)
+    expect(() => setSkillEnabled(fs, path, root, false)).toThrow(/No SKILL\.md found/)
   })
 
   it('refuses to disable over an existing disabled file, and keeps both intact', () => {

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -73,6 +73,24 @@ describe('agent skill discovery', () => {
     ])
   })
 
+  it('keeps the collection prefix on a disabled nested skill', () => {
+    const root = temp()
+    const skill = path.join(root, 'superpowers', 'skills', 'brainstorming')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md.disabled'), '---\nname: brainstorming\ndescription: Explore ideas\n---\n')
+
+    expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
+      {
+        name: 'brainstorming',
+        qualifiedName: 'superpowers:brainstorming',
+        description: 'Explore ideas',
+        scope: 'user',
+        dir: skill,
+        enabled: false,
+      },
+    ])
+  })
+
   it('does not duplicate an explicit namespace from frontmatter', () => {
     expect(qualifySkillName(path, '/skills', '/skills/superpowers/brainstorming', 'superpowers:brainstorming'))
       .toBe('superpowers:brainstorming')

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -174,10 +174,24 @@ describe('setSkillEnabled', () => {
     setSkillEnabled(fs, path, skill, false)
     setSkillEnabled(fs, path, skill, false)
     expect(fs.existsSync(path.join(skill, 'SKILL.md.disabled'))).toBe(true)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md'))).toBe(false)
   })
 
   it('throws when the directory holds no skill file', () => {
     const root = temp()
     expect(() => setSkillEnabled(fs, path, root, false)).toThrow(/SKILL\.md/)
+  })
+
+  it('refuses to disable over an existing disabled file, and keeps both intact', () => {
+    const skill = makeSkill()
+    const active = path.join(skill, 'SKILL.md')
+    const disabled = path.join(skill, 'SKILL.md.disabled')
+    fs.writeFileSync(disabled, '---\nname: one\ndescription: A backup\n---\n')
+
+    expect(() => setSkillEnabled(fs, path, skill, false)).toThrow(/already exists/)
+    expect(() => setSkillEnabled(fs, path, skill, true)).not.toThrow()
+
+    expect(fs.readFileSync(active, 'utf-8')).toBe('---\nname: one\ndescription: A skill\n---\n')
+    expect(fs.readFileSync(disabled, 'utf-8')).toBe('---\nname: one\ndescription: A backup\n---\n')
   })
 })

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -27,7 +27,31 @@ describe('agent skill discovery', () => {
     fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\r\nname: "Image Gen"\r\ndescription: Makes images\r\n---\r\n')
     fs.writeFileSync(path.join(skill, 'references', 'SKILL.md'), '---\nname: wrong\n---\n')
     expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
-      { name: 'Image Gen', qualifiedName: 'Image Gen', description: 'Makes images', scope: 'user', dir: skill },
+      { name: 'Image Gen', qualifiedName: 'Image Gen', description: 'Makes images', scope: 'user', dir: skill, enabled: true },
+    ])
+  })
+
+  it('lists a disabled skill and stops descending into it', () => {
+    const root = temp()
+    const skill = path.join(root, 'noisy')
+    fs.mkdirSync(path.join(skill, 'references'), { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md.disabled'), '---\nname: noisy\ndescription: Too chatty\n---\n')
+    fs.writeFileSync(path.join(skill, 'references', 'SKILL.md'), '---\nname: wrong\n---\n')
+
+    expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
+      { name: 'noisy', qualifiedName: 'noisy', description: 'Too chatty', scope: 'user', dir: skill, enabled: false },
+    ])
+  })
+
+  it('prefers the active SKILL.md when a stale disabled copy is left behind', () => {
+    const root = temp()
+    const skill = path.join(root, 'both')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: both\ndescription: Live\n---\n')
+    fs.writeFileSync(path.join(skill, 'SKILL.md.disabled'), '---\nname: both\ndescription: Stale\n---\n')
+
+    expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
+      { name: 'both', qualifiedName: 'both', description: 'Live', scope: 'user', dir: skill, enabled: true },
     ])
   })
 
@@ -44,6 +68,7 @@ describe('agent skill discovery', () => {
         description: 'Explore ideas',
         scope: 'user',
         dir: skill,
+        enabled: true,
       },
     ])
   })
@@ -74,6 +99,7 @@ describe('agent skill discovery', () => {
         description: '',
         scope: 'user',
         dir: skill,
+        enabled: true,
       },
     ])
   })

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { qualifySkillName, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, uniqueSkills } from './skills'
+import { qualifySkillName, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 
 const roots: string[] = []
 const temp = () => {
@@ -133,5 +133,51 @@ describe('agent skill discovery', () => {
       ...scanSkillsDir(fs, path, `${root}${path.sep}`, 'user'),
     ]
     expect(uniqueSkills(fs, path, twice)).toHaveLength(1)
+  })
+})
+
+describe('setSkillEnabled', () => {
+  const makeSkill = (): string => {
+    const root = temp()
+    const skill = path.join(root, 'one')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: one\ndescription: A skill\n---\n')
+    return skill
+  }
+
+  it('round-trips a skill from enabled to disabled and back', () => {
+    const skill = makeSkill()
+
+    setSkillEnabled(fs, path, skill, false)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md'))).toBe(false)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md.disabled'))).toBe(true)
+    expect(scanSkillsDir(fs, path, skill, 'user')[0]?.enabled).toBe(false)
+
+    setSkillEnabled(fs, path, skill, true)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md'))).toBe(true)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md.disabled'))).toBe(false)
+    expect(scanSkillsDir(fs, path, skill, 'user')[0]?.enabled).toBe(true)
+  })
+
+  it('preserves the skill body across the rename', () => {
+    const skill = makeSkill()
+    setSkillEnabled(fs, path, skill, false)
+    expect(fs.readFileSync(path.join(skill, 'SKILL.md.disabled'), 'utf-8'))
+      .toBe('---\nname: one\ndescription: A skill\n---\n')
+  })
+
+  it('is a no-op when the skill is already in the requested state', () => {
+    const skill = makeSkill()
+    setSkillEnabled(fs, path, skill, true)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md'))).toBe(true)
+
+    setSkillEnabled(fs, path, skill, false)
+    setSkillEnabled(fs, path, skill, false)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md.disabled'))).toBe(true)
+  })
+
+  it('throws when the directory holds no skill file', () => {
+    const root = temp()
+    expect(() => setSkillEnabled(fs, path, root, false)).toThrow(/SKILL\.md/)
   })
 })

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -3,8 +3,9 @@ import type * as Path from 'path'
 
 export type SkillScope = 'user' | 'project'
 
-/** Renaming SKILL.md to this hides the skill from every agent CLI's scan. */
-export const DISABLED_SKILL_FILE = 'SKILL.md.disabled'
+export const SKILL_FILE = 'SKILL.md'
+/** Renaming to this hides the skill from CLIs that discover skills by SKILL.md. */
+export const DISABLED_SKILL_FILE = `${SKILL_FILE}.disabled`
 
 export interface ScannedSkill {
   name: string
@@ -61,8 +62,9 @@ export function qualifySkillName(
 
 /**
  * Discover skills below an agent's configured root. Nested roots are supported
- * (for example Codex's .system skills); once SKILL.md is found, that directory
- * is treated as the skill boundary and its internals are not scanned again.
+ * (for example Codex's .system skills); once a SKILL.md, or a disabled one, is
+ * found, that directory is treated as the skill boundary and its internals are
+ * not scanned again.
  */
 export function scanSkillsDir(
   fsMod: typeof Fs,
@@ -85,7 +87,7 @@ export function scanSkillsDir(
 
     // A disabled skill is still a skill: it marks the boundary so we neither
     // lose it from the list nor walk its internals as if they were roots.
-    const activePath = pathMod.join(current, 'SKILL.md')
+    const activePath = pathMod.join(current, SKILL_FILE)
     const disabledPath = pathMod.join(current, DISABLED_SKILL_FILE)
     const enabled = fsMod.existsSync(activePath)
     const skillMdPath = enabled ? activePath : disabledPath

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -150,6 +150,26 @@ export function scanClaudePluginSkills(
   return result.sort((a, b) => a.qualifiedName.localeCompare(b.qualifiedName))
 }
 
+/**
+ * Toggle a skill by renaming its SKILL.md. Agent CLIs only load a directory
+ * whose skill file is named exactly SKILL.md, so the rename is what actually
+ * disables it — there is no separate state to keep in sync.
+ */
+export function setSkillEnabled(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  dir: string,
+  enabled: boolean,
+): void {
+  const activePath = pathMod.join(dir, SKILL_FILE)
+  const disabledPath = pathMod.join(dir, DISABLED_SKILL_FILE)
+  const target = enabled ? activePath : disabledPath
+  const source = enabled ? disabledPath : activePath
+  if (fsMod.existsSync(target)) return
+  if (!fsMod.existsSync(source)) throw new Error(`No SKILL.md found in ${dir}`)
+  fsMod.renameSync(source, target)
+}
+
 export function samePath(fsMod: typeof Fs, pathMod: typeof Path, a: string, b: string): boolean {
   const resolvedA = pathMod.resolve(a)
   const resolvedB = pathMod.resolve(b)

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -3,6 +3,9 @@ import type * as Path from 'path'
 
 export type SkillScope = 'user' | 'project'
 
+/** Renaming SKILL.md to this hides the skill from every agent CLI's scan. */
+export const DISABLED_SKILL_FILE = 'SKILL.md.disabled'
+
 export interface ScannedSkill {
   name: string
   qualifiedName: string
@@ -10,6 +13,7 @@ export interface ScannedSkill {
   description: string
   scope: SkillScope
   dir: string
+  enabled: boolean
 }
 
 export function parseSkillFrontmatter(md: string): { name: string; description: string } {
@@ -79,8 +83,13 @@ export function scanSkillsDir(
     if (visited.has(real)) continue
     visited.add(real)
 
-    const skillMdPath = pathMod.join(current, 'SKILL.md')
-    if (fsMod.existsSync(skillMdPath)) {
+    // A disabled skill is still a skill: it marks the boundary so we neither
+    // lose it from the list nor walk its internals as if they were roots.
+    const activePath = pathMod.join(current, 'SKILL.md')
+    const disabledPath = pathMod.join(current, DISABLED_SKILL_FILE)
+    const enabled = fsMod.existsSync(activePath)
+    const skillMdPath = enabled ? activePath : disabledPath
+    if (enabled || fsMod.existsSync(disabledPath)) {
       try {
         const md = fsMod.readFileSync(skillMdPath, 'utf-8')
         const { name, description } = parseSkillFrontmatter(md)
@@ -91,6 +100,7 @@ export function scanSkillsDir(
           description,
           scope,
           dir: current,
+          enabled,
         })
       } catch { /* skip unreadable skill */ }
       continue

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -154,6 +154,10 @@ export function scanClaudePluginSkills(
  * Toggle a skill by renaming its SKILL.md. Agent CLIs only load a directory
  * whose skill file is named exactly SKILL.md, so the rename is what actually
  * disables it — there is no separate state to keep in sync.
+ *
+ * Never renames over an existing target: a directory holding both files (an
+ * installed collection can carry one in) may hold a hand-written backup, so
+ * disabling that reports an error rather than silently clobbering it.
  */
 export function setSkillEnabled(
   fsMod: typeof Fs,
@@ -165,8 +169,11 @@ export function setSkillEnabled(
   const disabledPath = pathMod.join(dir, DISABLED_SKILL_FILE)
   const target = enabled ? activePath : disabledPath
   const source = enabled ? disabledPath : activePath
-  if (fsMod.existsSync(target)) return
-  if (!fsMod.existsSync(source)) throw new Error(`No SKILL.md found in ${dir}`)
+  if (fsMod.existsSync(target)) {
+    if (enabled || !fsMod.existsSync(source)) return   // already in the requested state
+    throw new Error(`Cannot disable: ${DISABLED_SKILL_FILE} already exists in: ${dir}`)
+  }
+  if (!fsMod.existsSync(source)) throw new Error(`No SKILL.md found in: ${dir}`)
   fsMod.renameSync(source, target)
 }
 

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -158,6 +158,8 @@ export function scanClaudePluginSkills(
  * Never renames over an existing target: a directory holding both files (an
  * installed collection can carry one in) may hold a hand-written backup, so
  * disabling that reports an error rather than silently clobbering it.
+ * Enabling with both present is deliberately a no-op rather than an error —
+ * the skill genuinely is enabled, and the disabled copy is only litter.
  */
 export function setSkillEnabled(
   fsMod: typeof Fs,
@@ -170,8 +172,8 @@ export function setSkillEnabled(
   const target = enabled ? activePath : disabledPath
   const source = enabled ? disabledPath : activePath
   if (fsMod.existsSync(target)) {
-    if (enabled || !fsMod.existsSync(source)) return   // already in the requested state
-    throw new Error(`Cannot disable: ${DISABLED_SKILL_FILE} already exists in: ${dir}`)
+    if (enabled || !fsMod.existsSync(source)) return // already in the requested state
+    throw new Error(`Cannot disable: ${DISABLED_SKILL_FILE} already exists in ${dir} — remove or rename it first`)
   }
   if (!fsMod.existsSync(source)) throw new Error(`No SKILL.md found in: ${dir}`)
   fsMod.renameSync(source, target)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -18,6 +18,7 @@ export interface SkillEntry {
   description: string
   scope: 'user' | 'project'
   dir: string
+  enabled: boolean
 }
 
 export interface SkillsListResult {
@@ -254,6 +255,7 @@ declare global {
         list: (agent?: string) => Promise<IpcResult<SkillsListResult>>
         install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) => Promise<IpcResult<{ name: string; dir: string }>>
         remove: (dir: string) => Promise<IpcResult<void>>
+        setEnabled: (dir: string, enabled: boolean) => Promise<IpcResult<void>>
         reveal: (dir: string) => Promise<IpcResult<void>>
       }
       playbooks: {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -5,21 +5,14 @@ import type { TeamConfigRaw } from '../../packages/core/src/workspace'
 import type { ApiKeyEntry } from '../../packages/core/src/types/index'
 import type { UpdaterEvent } from './hooks/updaterState'
 import type { CoreState } from '../electron/core-state'
+import type { ScannedSkill } from '../electron/skills'
 import type { Automation, AutomationRun, AutomationEvent } from '../../packages/core/src/types/automation'
 import type { AutomationDraft } from '../../packages/core/src/aide-automation'
 import type { ChatStep } from '../../packages/gateway/src/automations/chat'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
-export interface SkillEntry {
-  name: string
-  qualifiedName: string
-  managedBy?: string
-  description: string
-  scope: 'user' | 'project'
-  dir: string
-  enabled: boolean
-}
+export type SkillEntry = ScannedSkill
 
 export interface SkillsListResult {
   skills: SkillEntry[]

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -222,15 +222,6 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
         </span>
       </div>
-      {!skill.enabled && (
-        <span style={{
-          fontSize: 9, fontWeight: 700, letterSpacing: 0.4, textTransform: 'uppercase',
-          padding: '2px 6px', borderRadius: 4, marginBottom: 2,
-          background: C.surface3, color: C.fg3,
-        }}>
-          Off
-        </span>
-      )}
       {skill.description && (
         <div style={{
           color: C.fg3, fontSize: 12, lineHeight: '1.5', width: '100%',

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -20,7 +20,7 @@ const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
 
 // Matches the toggle idiom already used by PluginsTab / AppearanceTab.
 const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
-  <div onClick={() => onChange(!on)} style={{
+  <div onClick={() => onChange(!on)} role="switch" aria-checked={on} style={{
     width: 32, height: 18, borderRadius: 9, flexShrink: 0,
     background: on ? C.accent : C.surface3,
     border: `1px solid ${on ? C.accent : C.border2}`,
@@ -138,7 +138,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   }
 
   const handleSetEnabled = async (skill: SkillEntry, enabled: boolean) => {
-    if (busyDir) return
+    if (busyDir === skill.dir) return
     setBusyDir(skill.dir)
     setError(null)
     const apply = (value: boolean) => {
@@ -195,11 +195,11 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           {skill.qualifiedName}
         </span>
         <span
-          onClick={e => { e.stopPropagation(); void handleSetEnabled(skill, !skill.enabled) }}
+          onClick={e => e.stopPropagation()}
           style={{ display: 'inline-flex', opacity: busyDir === skill.dir ? 0.5 : 1 }}
           title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}
         >
-          <Toggle on={skill.enabled} onChange={() => {}} />
+          <Toggle on={skill.enabled} onChange={value => void handleSetEnabled(skill, value)} />
         </span>
         <span style={{
           fontSize: 9, fontWeight: 600, letterSpacing: 0.3,
@@ -280,6 +280,8 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           <div style={{ fontWeight: 600, marginBottom: 2, opacity: 0.7 }}>Location</div>
           <div style={{ wordBreak: 'break-all', fontFamily: 'monospace' }}>{skill.dir}</div>
         </div>
+
+        {error && <div style={{ ...styles.errorBanner, marginBottom: 12 }}>{error}</div>}
 
         {copyState && (
           <div style={{
@@ -375,8 +377,8 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
             : `${data.skills.length} skill${data.skills.length === 1 ? '' : 's'}`}</span>
           <button
             onClick={() => void reload(agentFilter)}
-            disabled={loading}
-            style={{ ...styles.iconButton, opacity: loading ? 0.5 : 1 }}
+            disabled={loading || !!busyDir}
+            style={{ ...styles.iconButton, opacity: loading || busyDir ? 0.5 : 1 }}
             title="Rescan skills"
             aria-label="Rescan skills"
           ><UIIcon name="refresh" size={14} /></button>

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -19,8 +19,8 @@ const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
 }
 
 // Matches the toggle idiom already used by PluginsTab / AppearanceTab.
-const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
-  <div onClick={() => onChange(!on)} role="switch" aria-checked={on} style={{
+const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void; label?: string }> = ({ on, onChange, label }) => (
+  <div onClick={() => onChange(!on)} role="switch" aria-checked={on} aria-label={label} style={{
     width: 32, height: 18, borderRadius: 9, flexShrink: 0,
     background: on ? C.accent : C.surface3,
     border: `1px solid ${on ? C.accent : C.border2}`,
@@ -48,7 +48,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   const [selected, setSelected] = useState<SkillEntry | null>(null)
   const [copyState, setCopyState] = useState<{ label: string; status: 'copying' | 'done' | 'error'; msg?: string } | null>(null)
   const [copyMenuOpen, setCopyMenuOpen] = useState(false)
-  const [busyDir, setBusyDir] = useState<string | null>(null)
+  const [busyDirs, setBusyDirs] = useState<Set<string>>(new Set())
   const copyRef = useRef<HTMLDivElement>(null)
   const initDone = useRef(false)
   const filteredSkills = useMemo(
@@ -138,8 +138,8 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   }
 
   const handleSetEnabled = async (skill: SkillEntry, enabled: boolean) => {
-    if (busyDir === skill.dir) return
-    setBusyDir(skill.dir)
+    if (busyDirs.has(skill.dir)) return
+    setBusyDirs(prev => new Set(prev).add(skill.dir))
     setError(null)
     const apply = (value: boolean) => {
       setData(prev => ({
@@ -155,7 +155,11 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
       apply(!enabled)
       setError(e?.message ?? String(e))
     } finally {
-      setBusyDir(null)
+      setBusyDirs(prev => {
+        const next = new Set(prev)
+        next.delete(skill.dir)
+        return next
+      })
     }
   }
 
@@ -183,7 +187,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   const renderCard = (skill: SkillEntry) => (
     <button
       key={skill.dir}
-      onClick={() => { setSelected(skill); setCopyState(null); setCopyMenuOpen(false) }}
+      onClick={() => { setSelected(skill); setCopyState(null); setCopyMenuOpen(false); setError(null) }}
       style={{ ...cardStyle, opacity: skill.enabled ? 1 : 0.55 }}
       title={skill.description || skill.name}
     >
@@ -196,10 +200,18 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
         </span>
         <span
           onClick={e => e.stopPropagation()}
-          style={{ display: 'inline-flex', opacity: busyDir === skill.dir ? 0.5 : 1 }}
+          style={{
+            display: 'inline-flex',
+            opacity: busyDirs.has(skill.dir) ? 0.5 : 1,
+            pointerEvents: busyDirs.has(skill.dir) ? 'none' : undefined,
+          }}
           title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}
         >
-          <Toggle on={skill.enabled} onChange={value => void handleSetEnabled(skill, value)} />
+          <Toggle
+            on={skill.enabled}
+            onChange={value => void handleSetEnabled(skill, value)}
+            label={skill.enabled ? 'Disable this skill' : 'Enable this skill'}
+          />
         </span>
         <span style={{
           fontSize: 9, fontWeight: 600, letterSpacing: 0.3,
@@ -250,8 +262,18 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
           <span style={{ color: C.fg, fontSize: 15, fontWeight: 700, flex: 1, minWidth: 0 }}>{skill.qualifiedName}</span>
-          <div style={{ opacity: busyDir === skill.dir ? 0.5 : 1 }} title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}>
-            <Toggle on={skill.enabled} onChange={value => void handleSetEnabled(skill, value)} />
+          <div
+            style={{
+              opacity: busyDirs.has(skill.dir) ? 0.5 : 1,
+              pointerEvents: busyDirs.has(skill.dir) ? 'none' : undefined,
+            }}
+            title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}
+          >
+            <Toggle
+              on={skill.enabled}
+              onChange={value => void handleSetEnabled(skill, value)}
+              label={skill.enabled ? 'Disable this skill' : 'Enable this skill'}
+            />
           </div>
           <span style={{
             fontSize: 10, fontWeight: 600, letterSpacing: 0.3,
@@ -377,8 +399,8 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
             : `${data.skills.length} skill${data.skills.length === 1 ? '' : 's'}`}</span>
           <button
             onClick={() => void reload(agentFilter)}
-            disabled={loading || !!busyDir}
-            style={{ ...styles.iconButton, opacity: loading || busyDir ? 0.5 : 1 }}
+            disabled={loading || busyDirs.size > 0}
+            style={{ ...styles.iconButton, opacity: loading || busyDirs.size > 0 ? 0.5 : 1 }}
             title="Rescan skills"
             aria-label="Rescan skills"
           ><UIIcon name="refresh" size={14} /></button>

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -18,6 +18,22 @@ const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
   'opencode': '~/.config/opencode/skills/',
 }
 
+// Matches the toggle idiom already used by PluginsTab / AppearanceTab.
+const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
+  <div onClick={() => onChange(!on)} style={{
+    width: 32, height: 18, borderRadius: 9, flexShrink: 0,
+    background: on ? C.accent : C.surface3,
+    border: `1px solid ${on ? C.accent : C.border2}`,
+    cursor: 'pointer', position: 'relative', transition: 'all 0.2s',
+  }}>
+    <div style={{
+      position: 'absolute', top: 1, left: on ? 15 : 1,
+      width: 14, height: 14, borderRadius: '50%', background: '#fff',
+      transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.3)',
+    }}/>
+  </div>
+)
+
 export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> = ({ addRequest = 0, searchQuery = '' }) => {
   const [data, setData] = useState<SkillsListResult>({ skills: [], projectDir: null })
   const [loading, setLoading] = useState(true)
@@ -32,6 +48,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   const [selected, setSelected] = useState<SkillEntry | null>(null)
   const [copyState, setCopyState] = useState<{ label: string; status: 'copying' | 'done' | 'error'; msg?: string } | null>(null)
   const [copyMenuOpen, setCopyMenuOpen] = useState(false)
+  const [busyDir, setBusyDir] = useState<string | null>(null)
   const copyRef = useRef<HTMLDivElement>(null)
   const initDone = useRef(false)
   const filteredSkills = useMemo(
@@ -120,6 +137,28 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     }
   }
 
+  const handleSetEnabled = async (skill: SkillEntry, enabled: boolean) => {
+    if (busyDir) return
+    setBusyDir(skill.dir)
+    setError(null)
+    const apply = (value: boolean) => {
+      setData(prev => ({
+        ...prev,
+        skills: prev.skills.map(s => (s.dir === skill.dir ? { ...s, enabled: value } : s)),
+      }))
+      setSelected(prev => (prev && prev.dir === skill.dir ? { ...prev, enabled: value } : prev))
+    }
+    apply(enabled)
+    try {
+      unwrap(await window.codey.skills.setEnabled(skill.dir, enabled))
+    } catch (e: any) {
+      apply(!enabled)
+      setError(e?.message ?? String(e))
+    } finally {
+      setBusyDir(null)
+    }
+  }
+
   const handleReveal = (dir: string) => {
     void window.codey.skills.reveal(dir)
   }
@@ -145,7 +184,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     <button
       key={skill.dir}
       onClick={() => { setSelected(skill); setCopyState(null); setCopyMenuOpen(false) }}
-      style={cardStyle}
+      style={{ ...cardStyle, opacity: skill.enabled ? 1 : 0.55 }}
       title={skill.description || skill.name}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2, width: '100%' }}>
@@ -154,6 +193,13 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: 1,
         }}>
           {skill.qualifiedName}
+        </span>
+        <span
+          onClick={e => { e.stopPropagation(); void handleSetEnabled(skill, !skill.enabled) }}
+          style={{ display: 'inline-flex', opacity: busyDir === skill.dir ? 0.5 : 1 }}
+          title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}
+        >
+          <Toggle on={skill.enabled} onChange={() => {}} />
         </span>
         <span style={{
           fontSize: 9, fontWeight: 600, letterSpacing: 0.3,
@@ -164,6 +210,15 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
         </span>
       </div>
+      {!skill.enabled && (
+        <span style={{
+          fontSize: 9, fontWeight: 700, letterSpacing: 0.4, textTransform: 'uppercase',
+          padding: '2px 6px', borderRadius: 4, marginBottom: 2,
+          background: C.surface3, color: C.fg3,
+        }}>
+          Off
+        </span>
+      )}
       {skill.description && (
         <div style={{
           color: C.fg3, fontSize: 12, lineHeight: '1.5', width: '100%',
@@ -195,6 +250,9 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
           <span style={{ color: C.fg, fontSize: 15, fontWeight: 700, flex: 1, minWidth: 0 }}>{skill.qualifiedName}</span>
+          <div style={{ opacity: busyDir === skill.dir ? 0.5 : 1 }} title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}>
+            <Toggle on={skill.enabled} onChange={value => void handleSetEnabled(skill, value)} />
+          </div>
           <span style={{
             fontSize: 10, fontWeight: 600, letterSpacing: 0.3,
             padding: '2px 6px', borderRadius: 4,
@@ -209,6 +267,12 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
         {skill.description && (
           <div style={{ color: C.fg2, fontSize: 13, lineHeight: '1.55', marginBottom: 16, whiteSpace: 'pre-wrap' }}>
             {skill.description}
+          </div>
+        )}
+
+        {skill.managedBy && !skill.enabled && (
+          <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.5, marginBottom: 14 }}>
+            Plugin updates may restore this skill.
           </div>
         )}
 

--- a/docs/superpowers/plans/2026-08-06-skill-toggle.md
+++ b/docs/superpowers/plans/2026-08-06-skill-toggle.md
@@ -1,0 +1,624 @@
+# Skill On/Off Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user switch any agent skill off and back on from the Codey Mac app's Skills tab, where "off" means the agent CLI no longer loads it.
+
+**Architecture:** Codey does not load skills — each agent CLI scans its own roots for directories containing `SKILL.md`. Disabling therefore renames `SKILL.md` to `SKILL.md.disabled`; enabling renames it back. The disk is the only state. The scanner learns to recognize both filenames so a disabled skill still shows up in Codey's own list (flagged `enabled: false`), while the chat slash-command palette filters it out.
+
+**Tech Stack:** TypeScript, Electron (main + preload + IPC), React 18, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-08-06-skill-toggle-design.md`
+
+**Before you start — Node version.** This repo's default `node` (v16) cannot run Vitest or `tsc`. Use nvm's v22.17.1 in every shell:
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+node -v   # must print v22.17.1
+```
+
+All test commands below are run from the `codey-mac/` directory.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `codey-mac/electron/skills.ts` | Pure skill discovery + on-disk mutation helpers. No Electron imports; `fs`/`path` are injected so it is unit-testable. | Modify: add `enabled` to `ScannedSkill`, teach `scanSkillsDir` about `SKILL.md.disabled`, add `setSkillEnabled`. |
+| `codey-mac/electron/skills.test.ts` | Vitest suite for the above, using real temp directories. | Modify: update three existing assertions, add five cases. |
+| `codey-mac/electron/main.ts` | IPC handlers. | Modify: add `skills:setEnabled`; filter disabled skills out of `agents:slashCommands`. |
+| `codey-mac/electron/preload.ts` | Renderer-facing bridge. | Modify: add `skills.setEnabled`. |
+| `codey-mac/src/codey-api.d.ts` | Renderer type declarations. | Modify: add `enabled` to `SkillEntry`, declare `skills.setEnabled`. |
+| `codey-mac/src/components/SkillsTab.tsx` | Skills tab UI. | Modify: `Toggle` component, card toggle, modal toggle, disabled styling. |
+
+---
+
+## Task 1: Scanner recognizes a disabled skill
+
+**Files:**
+- Modify: `codey-mac/electron/skills.ts:6-13` (the `ScannedSkill` interface), `codey-mac/electron/skills.ts:63-109` (`scanSkillsDir`), `codey-mac/electron/skills.ts:111-139` (`scanClaudePluginSkills` — no logic change, but its spread must carry the new field, which it already does)
+- Test: `codey-mac/electron/skills.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two cases inside the existing `describe('agent skill discovery', ...)` block in `codey-mac/electron/skills.test.ts`:
+
+```ts
+  it('lists a disabled skill and stops descending into it', () => {
+    const root = temp()
+    const skill = path.join(root, 'noisy')
+    fs.mkdirSync(path.join(skill, 'references'), { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md.disabled'), '---\nname: noisy\ndescription: Too chatty\n---\n')
+    fs.writeFileSync(path.join(skill, 'references', 'SKILL.md'), '---\nname: wrong\n---\n')
+
+    expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
+      { name: 'noisy', qualifiedName: 'noisy', description: 'Too chatty', scope: 'user', dir: skill, enabled: false },
+    ])
+  })
+
+  it('prefers the active SKILL.md when a stale disabled copy is left behind', () => {
+    const root = temp()
+    const skill = path.join(root, 'both')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: both\ndescription: Live\n---\n')
+    fs.writeFileSync(path.join(skill, 'SKILL.md.disabled'), '---\nname: both\ndescription: Stale\n---\n')
+
+    expect(scanSkillsDir(fs, path, root, 'user')).toEqual([
+      { name: 'both', qualifiedName: 'both', description: 'Live', scope: 'user', dir: skill, enabled: true },
+    ])
+  })
+```
+
+The three existing tests assert whole objects with `toEqual`, so they now need the new field. Make exactly these edits:
+
+- In `'finds nested configured skills and treats a skill as a boundary'`, change the expected object to:
+  ```ts
+      { name: 'Image Gen', qualifiedName: 'Image Gen', description: 'Makes images', scope: 'user', dir: skill, enabled: true },
+  ```
+- In `'keeps a nested skill collection prefix in its command name'`, add `enabled: true,` as the last property of the expected object (after `dir: skill,`).
+- In `'uses the Claude plugin id as the skill collection namespace'`, add `enabled: true,` as the last property of the expected object (after `dir: skill,`).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+cd codey-mac && npx vitest run electron/skills.test.ts
+```
+
+Expected: FAIL. The two new cases fail because a directory holding only `SKILL.md.disabled` is not recognized as a skill (the disabled case returns `[]`, or returns the nested `references` skill instead). The three edited cases fail on the missing `enabled` property.
+
+- [ ] **Step 3: Write the implementation**
+
+In `codey-mac/electron/skills.ts`, export the filename constant and add the field. Replace the `ScannedSkill` interface (lines 6-13) with:
+
+```ts
+/** Renaming SKILL.md to this hides the skill from every agent CLI's scan. */
+export const DISABLED_SKILL_FILE = 'SKILL.md.disabled'
+
+export interface ScannedSkill {
+  name: string
+  qualifiedName: string
+  managedBy?: string
+  description: string
+  scope: SkillScope
+  dir: string
+  enabled: boolean
+}
+```
+
+Then, inside `scanSkillsDir`, replace this block:
+
+```ts
+    const skillMdPath = pathMod.join(current, 'SKILL.md')
+    if (fsMod.existsSync(skillMdPath)) {
+      try {
+        const md = fsMod.readFileSync(skillMdPath, 'utf-8')
+        const { name, description } = parseSkillFrontmatter(md)
+        const resolvedName = name || pathMod.basename(current)
+        result.push({
+          name: resolvedName,
+          qualifiedName: qualifySkillName(pathMod, root, current, resolvedName),
+          description,
+          scope,
+          dir: current,
+        })
+      } catch { /* skip unreadable skill */ }
+      continue
+    }
+```
+
+with:
+
+```ts
+    // A disabled skill is still a skill: it marks the boundary so we neither
+    // lose it from the list nor walk its internals as if they were roots.
+    const activePath = pathMod.join(current, 'SKILL.md')
+    const disabledPath = pathMod.join(current, DISABLED_SKILL_FILE)
+    const enabled = fsMod.existsSync(activePath)
+    const skillMdPath = enabled ? activePath : disabledPath
+    if (enabled || fsMod.existsSync(disabledPath)) {
+      try {
+        const md = fsMod.readFileSync(skillMdPath, 'utf-8')
+        const { name, description } = parseSkillFrontmatter(md)
+        const resolvedName = name || pathMod.basename(current)
+        result.push({
+          name: resolvedName,
+          qualifiedName: qualifySkillName(pathMod, root, current, resolvedName),
+          description,
+          scope,
+          dir: current,
+          enabled,
+        })
+      } catch { /* skip unreadable skill */ }
+      continue
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd codey-mac && npx vitest run electron/skills.test.ts
+```
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/electron/skills.ts codey-mac/electron/skills.test.ts
+git commit -m "feat(skills): report enabled state when scanning skill dirs"
+```
+
+---
+
+## Task 2: `setSkillEnabled` renames SKILL.md
+
+**Files:**
+- Modify: `codey-mac/electron/skills.ts` (append after `scanClaudePluginSkills`, before `samePath`)
+- Test: `codey-mac/electron/skills.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block at the end of `codey-mac/electron/skills.test.ts`, after the closing `})` of `describe('agent skill discovery', ...)`:
+
+```ts
+describe('setSkillEnabled', () => {
+  const makeSkill = (): string => {
+    const root = temp()
+    const skill = path.join(root, 'one')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: one\ndescription: A skill\n---\n')
+    return skill
+  }
+
+  it('round-trips a skill from enabled to disabled and back', () => {
+    const skill = makeSkill()
+
+    setSkillEnabled(fs, path, skill, false)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md'))).toBe(false)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md.disabled'))).toBe(true)
+    expect(scanSkillsDir(fs, path, skill, 'user')[0]?.enabled).toBe(false)
+
+    setSkillEnabled(fs, path, skill, true)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md'))).toBe(true)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md.disabled'))).toBe(false)
+    expect(scanSkillsDir(fs, path, skill, 'user')[0]?.enabled).toBe(true)
+  })
+
+  it('preserves the skill body across the rename', () => {
+    const skill = makeSkill()
+    setSkillEnabled(fs, path, skill, false)
+    expect(fs.readFileSync(path.join(skill, 'SKILL.md.disabled'), 'utf-8'))
+      .toBe('---\nname: one\ndescription: A skill\n---\n')
+  })
+
+  it('is a no-op when the skill is already in the requested state', () => {
+    const skill = makeSkill()
+    setSkillEnabled(fs, path, skill, true)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md'))).toBe(true)
+
+    setSkillEnabled(fs, path, skill, false)
+    setSkillEnabled(fs, path, skill, false)
+    expect(fs.existsSync(path.join(skill, 'SKILL.md.disabled'))).toBe(true)
+  })
+
+  it('throws when the directory holds no skill file', () => {
+    const root = temp()
+    expect(() => setSkillEnabled(fs, path, root, false)).toThrow(/SKILL\.md/)
+  })
+})
+```
+
+Extend the import on line 5 of the same file so it reads:
+
+```ts
+import { qualifySkillName, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd codey-mac && npx vitest run electron/skills.test.ts
+```
+
+Expected: FAIL with `setSkillEnabled is not a function` (or a TypeScript "no exported member" error) on all four new cases.
+
+- [ ] **Step 3: Write the implementation**
+
+In `codey-mac/electron/skills.ts`, insert this function immediately before `export function samePath(...)`:
+
+```ts
+/**
+ * Toggle a skill by renaming its SKILL.md. Agent CLIs only load a directory
+ * whose skill file is named exactly SKILL.md, so the rename is what actually
+ * disables it — there is no separate state to keep in sync.
+ */
+export function setSkillEnabled(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  dir: string,
+  enabled: boolean,
+): void {
+  const activePath = pathMod.join(dir, 'SKILL.md')
+  const disabledPath = pathMod.join(dir, DISABLED_SKILL_FILE)
+  const target = enabled ? activePath : disabledPath
+  const source = enabled ? disabledPath : activePath
+  if (fsMod.existsSync(target)) return
+  if (!fsMod.existsSync(source)) throw new Error(`No SKILL.md found in ${dir}`)
+  fsMod.renameSync(source, target)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd codey-mac && npx vitest run electron/skills.test.ts
+```
+
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/electron/skills.ts codey-mac/electron/skills.test.ts
+git commit -m "feat(skills): add setSkillEnabled disk toggle"
+```
+
+---
+
+## Task 3: IPC wiring and slash-command filtering
+
+No unit test here: these are thin Electron IPC bindings with no logic of their own (the logic they call is already covered by Tasks 1-2), and the repo has no harness that boots the Electron main process. The verification step is a type check plus the manual smoke test in Task 5.
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts:3298` (slash-command mapping), `codey-mac/electron/main.ts:3412` (add handler above `skills:remove`)
+- Modify: `codey-mac/electron/preload.ts:126-132`
+- Modify: `codey-mac/src/codey-api.d.ts:14-21`
+
+- [ ] **Step 1: Filter disabled skills out of the slash-command palette**
+
+In `codey-mac/electron/main.ts`, inside the `agents:slashCommands` handler, replace:
+
+```ts
+      const skills: SlashCommand[] = skillResult.skills.map(skill => ({
+        name: skill.qualifiedName,
+        description: skill.description || 'Agent skill',
+        source: 'skill',
+      }))
+```
+
+with:
+
+```ts
+      const skills: SlashCommand[] = skillResult.skills
+        .filter(skill => skill.enabled)
+        .map(skill => ({
+          name: skill.qualifiedName,
+          description: skill.description || 'Agent skill',
+          source: 'skill',
+        }))
+```
+
+- [ ] **Step 2: Add the IPC handler**
+
+In `codey-mac/electron/main.ts`, add this immediately above the existing `ipcMain.handle('skills:remove', ...)` block:
+
+```ts
+  ipcMain.handle('skills:setEnabled', async (_e, dir: string, enabled: boolean) =>
+    wrap(async () => {
+      if (typeof dir !== 'string' || !dir) throw new Error('Invalid path')
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      setSkillEnabled(fsMod, pathMod, dir, enabled)
+    })
+  )
+```
+
+Then extend the import on line 13 so `setSkillEnabled` is in scope:
+
+```ts
+import { resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
+```
+
+- [ ] **Step 3: Expose it on the preload bridge**
+
+In `codey-mac/electron/preload.ts`, inside the `skills:` object, add the new method after `remove`:
+
+```ts
+    setEnabled: (dir: string, enabled: boolean) => ipcRenderer.invoke('skills:setEnabled', dir, enabled),
+```
+
+- [ ] **Step 4: Update the renderer types**
+
+In `codey-mac/src/codey-api.d.ts`, add `enabled` to `SkillEntry`:
+
+```ts
+export interface SkillEntry {
+  name: string
+  qualifiedName: string
+  managedBy?: string
+  description: string
+  scope: 'user' | 'project'
+  dir: string
+  enabled: boolean
+}
+```
+
+Then, in the window API declaration further down the same file, add a line to the `skills:` block (`codey-mac/src/codey-api.d.ts:253-258`) directly after `remove`:
+
+```ts
+        setEnabled: (dir: string, enabled: boolean) => Promise<IpcResult<void>>
+```
+
+For reference, that block should end up reading:
+
+```ts
+      skills: {
+        list: (agent?: string) => Promise<IpcResult<SkillsListResult>>
+        install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) => Promise<IpcResult<{ name: string; dir: string }>>
+        remove: (dir: string) => Promise<IpcResult<void>>
+        setEnabled: (dir: string, enabled: boolean) => Promise<IpcResult<void>>
+        reveal: (dir: string) => Promise<IpcResult<void>>
+      }
+```
+
+- [ ] **Step 5: Type check**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+cd codey-mac && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. If `tsconfig.json` does not cover `electron/`, run `npx tsc --noEmit -p tsconfig.node.json` as well — check which config files exist with `ls codey-mac/tsconfig*.json` and run every one that exists.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/electron/main.ts codey-mac/electron/preload.ts codey-mac/src/codey-api.d.ts
+git commit -m "feat(skills): expose setEnabled over IPC and hide disabled skills from /"
+```
+
+---
+
+## Task 4: Toggle in the Skills tab UI
+
+**Files:**
+- Modify: `codey-mac/src/components/SkillsTab.tsx`
+
+- [ ] **Step 1: Add the Toggle component**
+
+`SkillsTab.tsx` has no toggle yet. Copy the idiom already used by `PluginsTab.tsx:9-22` — do not import it from there, since it is a private const in that file and the two tabs are otherwise independent. Add this just below the `AGENT_SKILL_HINTS` const (after line 19):
+
+```tsx
+// Matches the toggle idiom already used by PluginsTab / AppearanceTab.
+const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
+  <div onClick={() => onChange(!on)} style={{
+    width: 32, height: 18, borderRadius: 9, flexShrink: 0,
+    background: on ? C.accent : C.surface3,
+    border: `1px solid ${on ? C.accent : C.border2}`,
+    cursor: 'pointer', position: 'relative', transition: 'all 0.2s',
+  }}>
+    <div style={{
+      position: 'absolute', top: 1, left: on ? 15 : 1,
+      width: 14, height: 14, borderRadius: '50%', background: '#fff',
+      transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.3)',
+    }}/>
+  </div>
+)
+```
+
+- [ ] **Step 2: Add the toggle handler**
+
+In the `SkillsTab` component, add a `busyDir` state next to the other `useState` calls (after the `copyMenuOpen` state on line 34):
+
+```tsx
+  const [busyDir, setBusyDir] = useState<string | null>(null)
+```
+
+Then add this handler immediately after `handleRemove` (after line 121). It updates local state optimistically and rolls back on failure, so the toggle never sits in a state the disk does not agree with:
+
+```tsx
+  const handleSetEnabled = async (skill: SkillEntry, enabled: boolean) => {
+    if (busyDir) return
+    setBusyDir(skill.dir)
+    setError(null)
+    const apply = (value: boolean) => {
+      setData(prev => ({
+        ...prev,
+        skills: prev.skills.map(s => (s.dir === skill.dir ? { ...s, enabled: value } : s)),
+      }))
+      setSelected(prev => (prev && prev.dir === skill.dir ? { ...prev, enabled: value } : prev))
+    }
+    apply(enabled)
+    try {
+      unwrap(await window.codey.skills.setEnabled(skill.dir, enabled))
+    } catch (e: any) {
+      apply(!enabled)
+      setError(e?.message ?? String(e))
+    } finally {
+      setBusyDir(null)
+    }
+  }
+```
+
+- [ ] **Step 3: Put the toggle on the card**
+
+In `renderCard`, the card is a `<button>`, so the toggle must swallow its own click or it would also open the detail modal. Replace the card's header row (lines 151-166, the `<div>` containing the name span and the scope badge) with:
+
+```tsx
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2, width: '100%' }}>
+        <span style={{
+          color: C.fg, fontSize: 13, fontWeight: 600,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: 1,
+        }}>
+          {skill.qualifiedName}
+        </span>
+        <span
+          onClick={e => { e.stopPropagation(); void handleSetEnabled(skill, !skill.enabled) }}
+          style={{ display: 'inline-flex', opacity: busyDir === skill.dir ? 0.5 : 1 }}
+          title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}
+        >
+          <Toggle on={skill.enabled} onChange={() => {}} />
+        </span>
+        <span style={{
+          fontSize: 9, fontWeight: 600, letterSpacing: 0.3,
+          padding: '2px 6px', borderRadius: 4, flexShrink: 0,
+          background: skill.scope === 'user' ? C.accentDim : C.surface3,
+          color: skill.scope === 'user' ? C.accent : C.fg3,
+        }}>
+          {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
+        </span>
+      </div>
+```
+
+The wrapping `<span>` owns the click; `Toggle`'s own `onChange` is a no-op here so the action fires exactly once.
+
+- [ ] **Step 4: Dim a disabled card and label it**
+
+Still in `renderCard`, change the opening `<button>` tag's `style` prop so a disabled skill reads as off at a glance:
+
+```tsx
+      style={{ ...cardStyle, opacity: skill.enabled ? 1 : 0.55 }}
+```
+
+Then, directly below the header row `</div>` and above the `{skill.description && (` block, add the off label:
+
+```tsx
+      {!skill.enabled && (
+        <span style={{
+          fontSize: 9, fontWeight: 700, letterSpacing: 0.4, textTransform: 'uppercase',
+          padding: '2px 6px', borderRadius: 4, marginBottom: 2,
+          background: C.surface3, color: C.fg3,
+        }}>
+          Off
+        </span>
+      )}
+```
+
+- [ ] **Step 5: Put the toggle in the detail modal**
+
+In `renderDetail`, replace the modal header row (lines 196-207) with a version carrying its own toggle. No `stopPropagation` is needed here — the modal body already stops propagation on its wrapper:
+
+```tsx
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+          <span style={{ color: C.fg, fontSize: 15, fontWeight: 700, flex: 1, minWidth: 0 }}>{skill.qualifiedName}</span>
+          <div style={{ opacity: busyDir === skill.dir ? 0.5 : 1 }} title={skill.enabled ? 'Disable this skill' : 'Enable this skill'}>
+            <Toggle on={skill.enabled} onChange={value => void handleSetEnabled(skill, value)} />
+          </div>
+          <span style={{
+            fontSize: 10, fontWeight: 600, letterSpacing: 0.3,
+            padding: '2px 6px', borderRadius: 4,
+            background: skill.scope === 'user' ? C.accentDim : C.surface3,
+            color: skill.scope === 'user' ? C.accent : C.fg3,
+          }}>
+            {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
+          </span>
+          <button onClick={() => setSelected(null)} style={{ ...iconBtn, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }} title="Close" aria-label="Close"><UIIcon name="close" size={14} /></button>
+        </div>
+```
+
+- [ ] **Step 6: Warn that a plugin update can undo the switch**
+
+Still in `renderDetail`, add this directly above the `Location` block (before the `<div style={{ color: C.fg3, fontSize: 11, marginBottom: 18 }}>` on line 215):
+
+```tsx
+        {skill.managedBy && !skill.enabled && (
+          <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.5, marginBottom: 14 }}>
+            Plugin updates may restore this skill.
+          </div>
+        )}
+```
+
+- [ ] **Step 7: Type check and run the full app test suite**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+cd codey-mac && npx tsc --noEmit -p tsconfig.json && npm test
+```
+
+Expected: no type errors, and the whole `codey-mac` Vitest suite passes.
+
+- [ ] **Step 8: Check for non-English characters**
+
+The repo lints against non-English characters in source. All strings added above are English; run the check to confirm nothing slipped in:
+
+```bash
+cd .. && npm run lint
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add codey-mac/src/components/SkillsTab.tsx
+git commit -m "feat(skills): add on/off switch to skill cards and detail modal"
+```
+
+---
+
+## Task 5: Manual smoke test
+
+The renderer has no component-test harness, and the whole point of the feature is an effect on a different process's view of the filesystem. Verify it by hand.
+
+**Files:** none — this task changes nothing.
+
+- [ ] **Step 1: Launch the app**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+cd codey-mac && npm run dev
+```
+
+- [ ] **Step 2: Disable a skill and confirm the disk changed**
+
+Open the Tools → Skills tab, pick a user-scope skill, and click its card toggle off. The card should dim and show an `Off` badge. Then confirm on disk, substituting the skill's own directory:
+
+```bash
+ls ~/.claude/skills/<the-skill>/
+```
+
+Expected: `SKILL.md.disabled` is present and `SKILL.md` is gone.
+
+- [ ] **Step 3: Confirm it left the slash-command palette**
+
+Open a chat, type `/`, and search for that skill's name. Expected: it is not listed.
+
+- [ ] **Step 4: Re-enable it from the detail modal**
+
+Click the dimmed card to open its detail modal, toggle it back on, and confirm `SKILL.md` is restored:
+
+```bash
+ls ~/.claude/skills/<the-skill>/
+```
+
+Expected: `SKILL.md` is back and `SKILL.md.disabled` is gone. The card is no longer dimmed, and the skill reappears in the `/` palette.
+
+- [ ] **Step 5: Check a plugin skill**
+
+Switch the toggle off on a `Plugin`-badged skill (for example one under `superpowers:`). Open its detail modal and confirm the line `Plugin updates may restore this skill.` is shown. Toggle it back on.
+
+- [ ] **Step 6: Confirm the count and search still behave**
+
+The header count must still include disabled skills (disabling never removes a skill from its own tab), and typing the disabled skill's name in the Tools search must still find it.

--- a/docs/superpowers/plans/2026-08-06-skill-toggle.md
+++ b/docs/superpowers/plans/2026-08-06-skill-toggle.md
@@ -161,7 +161,7 @@ with:
 cd codey-mac && npx vitest run electron/skills.test.ts
 ```
 
-Expected: PASS, 7 tests.
+Expected: PASS. (The file has 6 pre-existing tests, so 8 after this task.)
 
 - [ ] **Step 5: Commit**
 
@@ -276,7 +276,7 @@ export function setSkillEnabled(
 cd codey-mac && npx vitest run electron/skills.test.ts
 ```
 
-Expected: PASS, 11 tests.
+Expected: PASS, with four more tests than Task 1 left behind.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-08-06-skill-toggle-design.md
+++ b/docs/superpowers/specs/2026-08-06-skill-toggle-design.md
@@ -37,6 +37,15 @@ skill Codey disabled stays disabled for every agent that scans that directory.
 - New pure function `setSkillEnabled(fsMod, pathMod, dir, enabled)`: performs the
   rename, is a no-op when the directory is already in the requested state, and
   throws when neither file exists.
+- One ambiguous case needs a decision, because a directory can end up holding
+  *both* files — `skills:install` copies a source tree wholesale, so importing a
+  folder where someone had hand-disabled a skill lands both files in a managed
+  root. The rename must never overwrite, since the existing `SKILL.md.disabled`
+  may be a hand-written backup. Enabling from that state is a correct no-op: the
+  skill really is enabled and the stale file is just litter. Disabling from it
+  throws, rather than returning success without renaming — a silent success there
+  is the one outcome that leaves the UI showing "off" for a skill the agent still
+  loads.
 
 ### 3. IPC and the slash-command palette
 
@@ -72,6 +81,8 @@ special handling.
 - `setSkillEnabled` round-trips a skill disabled and enabled again.
 - Repeated calls in the same direction are a no-op rather than an error.
 - A directory with neither file throws.
+- A directory holding both files: disabling throws, enabling is a no-op, and both
+  files survive with their original content.
 - Plugin skill scanning preserves `enabled`.
 
 ## Out of scope

--- a/docs/superpowers/specs/2026-08-06-skill-toggle-design.md
+++ b/docs/superpowers/specs/2026-08-06-skill-toggle-design.md
@@ -1,0 +1,82 @@
+# Skill on/off toggle (Mac app)
+
+**Date:** 2026-08-06
+**Status:** Approved, ready for planning
+
+## Problem
+
+The Skills tab in the Codey Mac app can install, reveal, copy and remove skills, but
+there is no way to temporarily silence one. Users who want a noisy skill out of the
+way today, without losing it, have to delete the folder and reinstall it later.
+
+## Constraint that shapes the design
+
+Codey does not load skills. Each coding agent CLI (Claude Code, Codex, OpenCode)
+scans its own skill roots and picks up any directory containing `SKILL.md`. A
+"disabled" flag stored only in Codey config would change the Codey UI and nothing
+else — the agent would keep loading the skill. Disabling therefore has to make the
+skill invisible to that scan.
+
+## Design
+
+### 1. Disk representation
+
+Disabled means the skill directory's `SKILL.md` is renamed to `SKILL.md.disabled`.
+Enabling renames it back. There is no side-car state file: the disk is the single
+source of truth, so a skill a user disabled by hand is reported correctly, and a
+skill Codey disabled stays disabled for every agent that scans that directory.
+
+### 2. `codey-mac/electron/skills.ts`
+
+- `ScannedSkill` gains `enabled: boolean`.
+- `scanSkillsDir` checks `SKILL.md` first, then `SKILL.md.disabled`. **Either file
+  marks the skill boundary** — scanning must stop descending there, and the skill
+  must still appear in the list, otherwise disabling would make it vanish from the
+  UI entirely and its internals would be walked as if they were skill roots.
+  Frontmatter is parsed from whichever file exists; `enabled` is set accordingly.
+- New pure function `setSkillEnabled(fsMod, pathMod, dir, enabled)`: performs the
+  rename, is a no-op when the directory is already in the requested state, and
+  throws when neither file exists.
+
+### 3. IPC and the slash-command palette
+
+- New `skills:setEnabled` handler in `codey-mac/electron/main.ts`, exposed as
+  `skills.setEnabled(dir, enabled)` in `electron/preload.ts` and typed in
+  `src/codey-api.d.ts`.
+- The slash-command list built from `skills:list` in `main.ts` filters out skills
+  with `enabled === false`, so a disabled skill no longer appears in the chat `/`
+  palette.
+
+### 4. UI — `codey-mac/src/components/SkillsTab.tsx`
+
+- A small toggle sits in the card header, left of the scope badge. It calls
+  `stopPropagation` so it does not open the detail modal.
+- The detail modal carries a second toggle for the same skill.
+- Disabled cards render at `opacity: 0.55` with an `Off` badge. They stay in the
+  list and in the skill count; disabling never hides a skill from its own tab.
+- Toggling updates local state optimistically and reverts on failure, surfacing the
+  error through the existing error banner.
+- Plugin-managed skills can be toggled like any other. Their detail modal shows a
+  note: `Plugin updates may restore this skill.`
+
+### 5. Interaction with install
+
+Copying a disabled skill through `skills:install` carries the `SKILL.md.disabled`
+file along, so the copy arrives disabled. This is the expected outcome and needs no
+special handling.
+
+### 6. Tests — `codey-mac/electron/skills.test.ts`
+
+- A directory holding only `SKILL.md.disabled` is reported with `enabled: false`,
+  and its subdirectories are not scanned.
+- `setSkillEnabled` round-trips a skill disabled and enabled again.
+- Repeated calls in the same direction are a no-op rather than an error.
+- A directory with neither file throws.
+- Plugin skill scanning preserves `enabled`.
+
+## Out of scope
+
+- Bulk enable/disable of many skills at once.
+- Reconciling a plugin update that restores a `SKILL.md` the user had disabled.
+- Any disable mechanism that is specific to one agent, such as Claude Code
+  `settings.json` deny rules.


### PR DESCRIPTION
## What

Each skill in the Mac app's Skills tab now has a switch. Turning it off stops the coding agent from loading that skill; turning it back on restores it.

## How

Codey does not load skills — each agent CLI (Claude Code, Codex, OpenCode) scans its own roots for directories containing `SKILL.md`. A flag stored in Codey config would change the UI and nothing else, so disabling has to make the skill invisible to that scan.

Disabling renames `SKILL.md` to `SKILL.md.disabled`; enabling renames it back. There is no side-car state file — the disk is the single source of truth, so a skill disabled by hand reports correctly, and one disabled here stays disabled for every agent that scans that directory.

## Changes

- **`electron/skills.ts`** — `ScannedSkill` gains `enabled`. `scanSkillsDir` treats *either* filename as a skill boundary, so a disabled skill still appears in its own tab instead of vanishing, and its internals are not walked as if they were skill roots. New `setSkillEnabled` performs the rename.
- **`electron/main.ts` / `preload.ts` / `codey-api.d.ts`** — `skills:setEnabled` over IPC. `SkillEntry` is now an alias of `ScannedSkill` rather than a hand-maintained copy that had already drifted.
- **`agents:slashCommands`** — disabled skills are filtered out before the `.map`, which also fixes an existing latent bug: a `skillAliases` set built from that array suppresses an agent's own command when a skill shares its bare name, so without the filter, disabling a skill would silently remove an unrelated *working* command from the `/` menu.
- **`SkillsTab.tsx`** — toggle on each card and in the detail modal. Disabled cards dim with an `Off` badge but stay in the list, the header count and search results. Optimistic update reverts on failure, with the error shown inside the modal too. Plugin-managed skills are toggleable and note that a plugin update may restore them.

## Notable decisions

- **Never overwrite.** If a directory somehow holds both files, disabling throws rather than renaming over what may be a hand-written backup. Enabling from that state is a correct no-op. The state is reachable in normal use because `skills:install` copies a source tree wholesale.
- **No rescan after toggling.** Optimistic update plus rollback on `ok:false`; in-flight renames are tracked per directory so one skill's completion cannot unlatch another's guard.

## Testing

14 unit tests cover the scanner's disabled handling and every `setSkillEnabled` path including both-files-exist and body preservation. Full suite: 330 tests across 41 files. Both `tsc` projects and `npm run lint` are clean.

The IPC bindings and the UI have no automated coverage — there is no harness that boots the Electron main process and no renderer component-test harness in this repo. **Manual smoke test is still pending:** disable a skill, confirm `SKILL.md.disabled` on disk, confirm it leaves the `/` palette, re-enable from the detail modal.

## Known gap

The toggle is not keyboard-operable. It has `role="switch"`, `aria-checked` and `aria-label`, so a screen reader announces its state, but there is no keyboard path to activating it. On the card the toggle sits inside a `<button>`, so adding a focusable control there would be an invalid nested-interactive element — fixing it properly means restructuring the card to a `<div role="button">`, which was out of scope here.

Design spec and implementation plan are in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)