### PR TITLE
Revert "Render assistant messages as document flow" (#205)

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -388,9 +388,6 @@ ${paletteToCssVars(terminalLight)}
 ${paletteToCssVars(terminalDark)}
   }
   html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
-  /* Roomy headings open a section with a large top margin. The first block in a
-     turn has nothing above it to separate from, so that margin is dead space. */
-  .md-roomy > :first-child { margin-top: 0 !important; }
   body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
   * { box-sizing: border-box; }
   ::-webkit-scrollbar { width: 5px; height: 5px; }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1971,44 +1971,26 @@ export const ChatTab: React.FC<Props> = ({
               style={{
                 display: 'flex', flexDirection: 'column',
                 alignItems: isUser ? 'flex-end' : 'flex-start',
-                // Assistant turns have no bubble to bound them, so spacing is
-                // what keeps two consecutive replies from reading as one.
-                marginBottom: isUser ? 12 : 20,
+                marginBottom: 12,
                 cursor: isUser ? 'default' : 'pointer',
                 paddingLeft: !isUser ? 6 : 0,
                 transform: isSelected ? 'translateY(-3px)' : 'translateY(0)',
                 transition: 'transform 0.18s ease',
               }}
             >
-              <div style={isUser ? {
+              <div style={{
                 minWidth: 0, maxWidth: '72%', padding: '10px 14px',
-                borderRadius: '16px 16px 4px 16px',
-                background: C.userBg,
-                color: C.onAccent, fontSize: 13, lineHeight: 1.55,
+                borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
+                background: isUser ? C.userBg : C.aiBg,
+                color: isUser ? C.onAccent : C.fg, fontSize: 13, lineHeight: 1.55,
                 overflowWrap: 'anywhere', wordBreak: 'break-word',
-              } : {
-                // The bubble marks "what the user said". An assistant reply
-                // reads better as a document, and at length the bubble was the
-                // thing making it dense.
-                //
-                // `ch` resolves against this element's 13px font, so 78ch is
-                // ~562px — about 72 characters of the 14px roomy body text, or
-                // ~43 Chinese characters. Unlike the old 72%, it does not grow
-                // with the window.
-                minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
-                // The rail is always 3px, transparent when unselected, so
-                // selecting a turn never shifts the text column sideways.
-                // 6 (row) + 3 (rail) + 12 = 21px, exactly the old inset of
-                // 6 (row) + 1 (border) + 14 (bubble padding).
-                padding: '0 0 0 12px',
-                borderLeft: `3px solid ${isSelected ? C.accent : 'transparent'}`,
-                background: isSelected ? C.accentDim : 'transparent',
-                // fontSize/lineHeight stay compact: non-Markdown children
-                // (LiveActivity, tool chips) inherit them. The roomy metrics
-                // apply inside <Markdown layout="roomy"> only.
-                color: C.fg, fontSize: 13, lineHeight: 1.55,
-                overflowWrap: 'anywhere', wordBreak: 'break-word',
-                transition: 'border-color 0.18s ease, background 0.18s ease',
+                boxShadow: isUser
+                  ? 'none'
+                  : (isSelected
+                      ? `0 10px 24px ${C.accentDim}, 0 6px 14px ${C.accentDim}`
+                      : '0 1px 3px rgba(0,0,0,0.18)'),
+                border: isUser ? 'none' : `1px solid ${isSelected ? C.accent : C.border2}`,
+                transition: 'box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease',
               }}>
                 {!isUser && !!flight && msg === lastMsg && (
                   <LiveActivity toolCalls={msg.toolCalls} />
@@ -2027,7 +2009,7 @@ export const ChatTab: React.FC<Props> = ({
                           isComplete={msg.isComplete ?? false}
                         />
                       )}
-                      <Markdown variant="assistant" layout="roomy">{text}</Markdown>
+                      <Markdown variant="assistant">{text}</Markdown>
                     </div>
                   )
                   return (

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -6,62 +6,7 @@ import { C } from '../theme'
 interface MarkdownProps {
   children: string
   variant?: 'user' | 'assistant'
-  layout?: 'compact' | 'roomy'
 }
-
-/** Shape of one density's metrics; both entries must supply every field. */
-interface Metrics {
-  fontSize: number
-  lineHeight: number
-  /** Bottom margin for block-level elements (p, ul, ol, blockquote, code blocks). */
-  blockGap: number
-  /** Bottom margin for the table wrapper. */
-  tableGap: number
-  li: number
-  hr: string
-  h1: { fontSize: number; margin: string }
-  h2: { fontSize: number; margin: string }
-  h3: { fontSize: number; margin: string }
-  h4: { fontSize: number; margin: string }
-}
-
-/** Two typographic densities. `compact` is the historical chat metric and stays
- *  the default, so every secondary surface (team panels, automation, quick
- *  question) is untouched. `roomy` is for the main assistant turn, which renders
- *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
- *  (8px) was barely larger than the gap between its own lines (~7px), so the
- *  paragraph stopped reading as a unit. Heading margins are deliberately
- *  asymmetric — a heading belongs to the text below it, not midway between two
- *  blocks. */
-const METRICS = {
-  compact: {
-    fontSize: 13,
-    lineHeight: 1.55,
-    blockGap: 8,
-    tableGap: 10,
-    li: 2,
-    hr: '10px 0',
-    h1: { fontSize: 17, margin: '8px 0 6px' },
-    h2: { fontSize: 15, margin: '8px 0 6px' },
-    h3: { fontSize: 14, margin: '8px 0 4px' },
-    h4: { fontSize: 13, margin: '6px 0 4px' },
-  },
-  roomy: {
-    fontSize: 14,
-    // 1.7 rather than 1.55: Chinese has a high character-face ratio and no
-    // ascenders or descenders, so identical leading reads tighter than it does
-    // for Latin text.
-    lineHeight: 1.7,
-    blockGap: 14,
-    tableGap: 14,
-    li: 5,
-    hr: '18px 0',
-    h1: { fontSize: 20, margin: '22px 0 8px' },
-    h2: { fontSize: 17, margin: '20px 0 8px' },
-    h3: { fontSize: 15, margin: '18px 0 6px' },
-    h4: { fontSize: 14, margin: '16px 0 6px' },
-  },
-} as const satisfies Record<'compact' | 'roomy', Metrics>
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Monaco, "Courier New", monospace'
 
@@ -69,8 +14,7 @@ const CodeBlock: React.FC<{
   children: React.ReactNode
   background: string
   borderColor: string
-  blockMargin: number
-}> = ({ children, background, borderColor, blockMargin }) => {
+}> = ({ children, background, borderColor }) => {
   const [copied, setCopied] = React.useState(false)
   const resetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const child: any = React.Children.toArray(children)[0]
@@ -102,7 +46,7 @@ const CodeBlock: React.FC<{
         background,
         border: `1px solid ${borderColor}`,
         borderRadius: 8,
-        margin: `6px 0 ${blockMargin}px`,
+        margin: '6px 0 8px',
         position: 'relative',
         overflow: 'hidden',
       }}
@@ -213,9 +157,8 @@ function preserveLineBreaks(src: string): string {
   return out.join('\n')
 }
 
-const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant', layout = 'compact' }) => {
+const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant' }) => {
   const onUser = variant === 'user'
-  const M = METRICS[layout]
   const inlineCodeBg = onUser ? 'rgba(0,0,0,0.22)' : C.inlineCodeBg
   const inlineCodeFg = onUser ? C.onAccent : C.inlineCodeFg
   const codeBlockBg = onUser ? 'rgba(0,0,0,0.25)' : C.codeBg
@@ -228,14 +171,11 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
   const tableHeadBg = onUser ? 'rgba(0,0,0,0.2)' : C.surface3
 
   return (
-    <div
-      className={layout === 'roomy' ? 'md-roomy' : undefined}
-      style={{ minWidth: 0, maxWidth: '100%', fontSize: M.fontSize, lineHeight: M.lineHeight, overflowWrap: 'anywhere', wordBreak: 'break-word' }}
-    >
+    <div style={{ minWidth: 0, maxWidth: '100%', fontSize: 13, lineHeight: 1.55, overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          p: ({ children }) => <p style={{ margin: `0 0 ${M.blockGap}px 0` }}>{children}</p>,
+          p: ({ children }) => <p style={{ margin: '0 0 8px 0' }}>{children}</p>,
           a: ({ href, children }) => (
             <a
               href={href}
@@ -251,20 +191,20 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           strong: ({ children }) => <strong style={{ fontWeight: 700 }}>{children}</strong>,
           em: ({ children }) => <em style={{ fontStyle: 'italic' }}>{children}</em>,
           del: ({ children }) => <del style={{ opacity: 0.6 }}>{children}</del>,
-          h1: ({ children }) => <h1 style={{ fontSize: M.h1.fontSize, fontWeight: 700, margin: M.h1.margin }}>{children}</h1>,
-          h2: ({ children }) => <h2 style={{ fontSize: M.h2.fontSize, fontWeight: 700, margin: M.h2.margin }}>{children}</h2>,
-          h3: ({ children }) => <h3 style={{ fontSize: M.h3.fontSize, fontWeight: 700, margin: M.h3.margin }}>{children}</h3>,
-          h4: ({ children }) => <h4 style={{ fontSize: M.h4.fontSize, fontWeight: 700, margin: M.h4.margin }}>{children}</h4>,
-          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.blockGap}px 0`, paddingLeft: 20 }}>{children}</ul>,
-          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.blockGap}px 0`, paddingLeft: 20 }}>{children}</ol>,
-          li: ({ children }) => <li style={{ marginBottom: M.li }}>{children}</li>,
-          hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: M.hr }} />,
+          h1: ({ children }) => <h1 style={{ fontSize: 17, fontWeight: 700, margin: '8px 0 6px' }}>{children}</h1>,
+          h2: ({ children }) => <h2 style={{ fontSize: 15, fontWeight: 700, margin: '8px 0 6px' }}>{children}</h2>,
+          h3: ({ children }) => <h3 style={{ fontSize: 14, fontWeight: 700, margin: '8px 0 4px' }}>{children}</h3>,
+          h4: ({ children }) => <h4 style={{ fontSize: 13, fontWeight: 700, margin: '6px 0 4px' }}>{children}</h4>,
+          ul: ({ children }) => <ul style={{ margin: '0 0 8px 0', paddingLeft: 20 }}>{children}</ul>,
+          ol: ({ children }) => <ol style={{ margin: '0 0 8px 0', paddingLeft: 20 }}>{children}</ol>,
+          li: ({ children }) => <li style={{ marginBottom: 2 }}>{children}</li>,
+          hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: '10px 0' }} />,
           blockquote: ({ children }) => (
             <blockquote
               style={{
                 borderLeft: `3px solid ${quoteBorder}`,
                 paddingLeft: 10,
-                margin: `0 0 ${M.blockGap}px 0`,
+                margin: '0 0 8px 0',
                 color: quoteFg,
               }}
             >
@@ -272,7 +212,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
             </blockquote>
           ),
           table: ({ children }) => (
-            <div style={{ overflowX: 'auto', margin: `6px 0 ${M.tableGap}px`, maxWidth: '100%' }}>
+            <div style={{ overflowX: 'auto', margin: '6px 0 10px', maxWidth: '100%' }}>
               <table
                 style={{
                   borderCollapse: 'collapse',
@@ -316,7 +256,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           ),
           pre: ({ children }: any) => {
             return (
-              <CodeBlock background={codeBlockBg} borderColor={codeBlockBorder} blockMargin={M.blockGap}>
+              <CodeBlock background={codeBlockBg} borderColor={codeBlockBorder}>
                 {children}
               </CodeBlock>
             )


### PR DESCRIPTION
Reverts the source changes from #205. The spec and plan are kept — the work will be redone.

## Why

Removing the assistant bubble removed three things at once, and only two were accounted for in the design:

- background (grouping — which elements belong to this turn)
- border (replaced by the selected-state rail, as designed)
- **`padding: '10px 14px'` → `'0 0 0 12px'`, i.e. 10px of vertical padding, which was not considered**

The design preserved the horizontal text inset exactly (6 + 3 + 12 = 21px, matching the old 6 + 1 + 14) but silently dropped the vertical padding. A turn's first element is often 11px `C.fg3` secondary chrome, which then sits flush against the previous message with neither background nor space to mark it as part of this turn.

More seriously: the collapsed "Show thinking" toggle disappeared **entirely**, not just became hard to see. #205 touches no line of the `ThinkingBlock` render path (`git diff e35e536..3845b7a -- ChatTab.tsx` matches nothing containing "thinking"), so the diff does not explain the observation. That gap is unresolved and is the reason this is a revert rather than a follow-up patch — building the planned turn-header on top of an unexplained disappearance would inherit the same bug.

## What this restores

`codey-mac/` source is byte-identical to `e35e536`, the commit before #205. Verified with `git diff e35e536 HEAD -- codey-mac/` (empty).

tsc clean, 322/322 tests passing.

## What comes next

Redo the layout work with turn chrome designed in rather than bolted on: a header above each reply, separated by a thin rule, carrying model and elapsed time plus a disclosure control that expands the thinking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)