### PR TITLE
Assistant turn header + document flow

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -388,6 +388,9 @@ ${paletteToCssVars(terminalLight)}
 ${paletteToCssVars(terminalDark)}
   }
   html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
+  /* Roomy headings open a section with a large top margin. The first block in a
+     turn has nothing above it to separate from, so that margin is dead space. */
+  .md-roomy > :first-child { margin-top: 0 !important; }
   body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
   * { box-sizing: border-box; }
   ::-webkit-scrollbar { width: 5px; height: 5px; }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -18,6 +18,7 @@ import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
 import { formatTokens } from './turnHeaderModel'
+import { TurnHeader } from './TurnHeader'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
 import { useGitStatus } from '../hooks/useGitStatus'
@@ -876,6 +877,11 @@ export const ChatTab: React.FC<Props> = ({
   const [multiChoice, setMultiChoice] = useState<string[]>([])
   const [selectedTurnIdState, setSelectedTurnIdState] = useState<string | null>(null)
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set())
+  // The turn header owns the thinking chevron, so the disclosure state has to
+  // live above it. Only a user's explicit toggle is stored; `undefined` means
+  // fall back to defaultThinkingExpanded, which auto-opens thinking while the
+  // agent is still working and has produced no answer yet.
+  const [thinkingToggles, setThinkingToggles] = useState<Record<string, boolean>>({})
   const [taskBriefLoading, setTaskBriefLoading] = useState(false)
   // This is a single app-wide display preference, not chat state. ChatTab is
   // remounted on chat switches, so seed it from localStorage and write changes
@@ -1965,27 +1971,64 @@ export const ChatTab: React.FC<Props> = ({
               style={{
                 display: 'flex', flexDirection: 'column',
                 alignItems: isUser ? 'flex-end' : 'flex-start',
-                marginBottom: 12,
+                marginBottom: isUser ? 12 : 20,
                 cursor: isUser ? 'default' : 'pointer',
                 paddingLeft: !isUser ? 6 : 0,
                 transform: isSelected ? 'translateY(-3px)' : 'translateY(0)',
                 transition: 'transform 0.18s ease',
               }}
             >
-              <div style={{
+              <div style={isUser ? {
                 minWidth: 0, maxWidth: '72%', padding: '10px 14px',
-                borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-                background: isUser ? C.userBg : C.aiBg,
-                color: isUser ? C.onAccent : C.fg, fontSize: 13, lineHeight: 1.55,
+                borderRadius: '16px 16px 4px 16px',
+                background: C.userBg,
+                color: C.onAccent, fontSize: 13, lineHeight: 1.55,
                 overflowWrap: 'anywhere', wordBreak: 'break-word',
-                boxShadow: isUser
-                  ? 'none'
-                  : (isSelected
-                      ? `0 10px 24px ${C.accentDim}, 0 6px 14px ${C.accentDim}`
-                      : '0 1px 3px rgba(0,0,0,0.18)'),
-                border: isUser ? 'none' : `1px solid ${isSelected ? C.accent : C.border2}`,
-                transition: 'box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease',
+              } : {
+                // The bubble marks "what the user said". An assistant reply
+                // reads as a document; the header rule below carries the
+                // boundary the bubble used to provide.
+                //
+                // `ch` resolves against this element's 13px font, so 78ch is
+                // ~562px — about 72 characters of the 14px roomy body text, or
+                // ~43 Chinese characters. Unlike the old 72%, it does not grow
+                // with the window.
+                minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
+                // 6px top is the vertical padding the first attempt at this
+                // silently dropped when it replaced the bubble's '10px 14px'.
+                // Left: 3 (rail) + 12 = the old 1 (border) + 14 (bubble).
+                padding: '6px 0 0 12px',
+                // The rail is always 3px, transparent when unselected, so
+                // selecting a turn never shifts the text column sideways.
+                borderLeft: `3px solid ${isSelected ? C.accent : 'transparent'}`,
+                background: isSelected ? C.accentDim : 'transparent',
+                // fontSize/lineHeight stay compact: non-Markdown children
+                // inherit them. Roomy applies inside <Markdown layout="roomy">.
+                color: C.fg, fontSize: 13, lineHeight: 1.55,
+                overflowWrap: 'anywhere', wordBreak: 'break-word',
+                transition: 'border-color 0.18s ease, background 0.18s ease',
               }}>
+                {!isUser && (() => {
+                  const thinking = msg.thinking?.trim() ?? ''
+                  const expanded = thinkingToggles[msg.id]
+                    ?? defaultThinkingExpanded({
+                      hasAnswer: !!msg.content.trim(),
+                      isComplete: msg.isComplete ?? false,
+                    })
+                  return (
+                    <>
+                      <TurnHeader
+                        msg={msg}
+                        hasThinking={!!thinking}
+                        expanded={expanded}
+                        onToggle={() => setThinkingToggles(p => ({ ...p, [msg.id]: !expanded }))}
+                      />
+                      {!!thinking && expanded && (
+                        <div style={styles.thinkingBody}>{thinking}</div>
+                      )}
+                    </>
+                  )
+                })()}
                 {!isUser && !!flight && msg === lastMsg && (
                   <LiveActivity toolCalls={msg.toolCalls} />
                 )}
@@ -1996,14 +2039,7 @@ export const ChatTab: React.FC<Props> = ({
                   const isStreaming = !!flight && msg === lastMsg
                   if (!parsed) return (
                     <div>
-                      {msg.thinking && (
-                        <ThinkingBlock
-                          thinking={msg.thinking}
-                          hasAnswer={!!text.trim()}
-                          isComplete={msg.isComplete ?? false}
-                        />
-                      )}
-                      <Markdown variant="assistant">{text}</Markdown>
+                      <Markdown variant="assistant" layout="roomy">{text}</Markdown>
                     </div>
                   )
                   return (
@@ -2147,38 +2183,11 @@ export const ChatTab: React.FC<Props> = ({
                   </div>
                 )
               }
+              {/* Model, fallback, tokens and duration now live in TurnHeader.
+                  The timestamp stays here so it does not compete with the
+                  turn's identity for the reader's attention. */}
               <div style={styles.tsLabel}>
                 <span>{fmtTime(msg.timestamp)}</span>
-                <span style={styles.tsRight}>
-                  {msg.role === 'assistant' && msg.model && (
-                    <span
-                      style={styles.modelBadge}
-                      title={`${msg.agent ?? 'Agent'} model`}
-                    >
-                      {msg.model}
-                    </span>
-                  )}
-                  {msg.fallback && (
-                    <span
-                      style={styles.fallbackBadge}
-                      title={`Primary ${msg.fallback.from} failed — answered by fallback ${msg.fallback.to}`}
-                    >
-                      ⤷ {msg.fallback.to}
-                    </span>
-                  )}
-                  {(() => {
-                    const tokStr = msg.tokens != null ? formatTokens(msg.tokens) : null
-                    const durStr = msg.durationSec != null && Number.isFinite(msg.durationSec) ? `${msg.durationSec}s` : null
-                    if (!tokStr && !durStr) return null
-                    return (
-                      <span style={styles.tsMeta}>
-                        {tokStr && `${tokStr} tok`}
-                        {tokStr && durStr && ' · '}
-                        {durStr}
-                      </span>
-                    )
-                  })()}
-                </span>
               </div>
             </div>
           )
@@ -2620,17 +2629,12 @@ const styles: Record<string, React.CSSProperties> = {
   messages: { flex: 1, overflowY: 'auto', padding: '22px max(22px, 5%)', background: C.bg },
   typingRow: { display: 'flex', alignItems: 'center', gap: 8, color: C.fg3, fontSize: 13, marginBottom: 12 },
   tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, paddingLeft: 4, paddingRight: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
-  tsMeta: { color: C.fg3, opacity: 0.55, fontVariantNumeric: 'tabular-nums' },
-  tsRight: { display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 },
+  // modelBadge is still used by team worker messages; tsRight, tsMeta and
+  // fallbackBadge moved into TurnHeader with the metadata they styled.
   modelBadge: {
     color: C.fg3, background: C.surface3, border: `1px solid ${C.border2}`,
     borderRadius: 5, padding: '1px 6px', fontSize: 10,
     fontFamily: 'SF Mono, Menlo, monospace',
-    maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-  },
-  fallbackBadge: {
-    color: C.warningFg, background: C.warningBg,
-    borderRadius: 6, padding: '1px 6px', fontSize: 10,
     maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
   inputContainer: { padding: '12px max(16px, 4%) 16px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 6, flexShrink: 0, background: C.surface },

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -17,6 +17,7 @@ import { isTaskBriefStale, extractSidecarBrief } from './taskHudView'
 import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
+import { formatTokens } from './turnHeaderModel'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
 import { useGitStatus } from '../hooks/useGitStatus'
@@ -72,13 +73,6 @@ const StopIcon: React.FC<{ color: string }> = ({ color }) => (
 
 const fmtTime = (ts: number) =>
   new Date(ts).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
-
-const formatTokens = (n: number): string | null => {
-  if (!Number.isFinite(n) || n < 0) return null
-  if (n < 1000) return String(n)
-  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`
-  return `${Math.round(n / 1000)}k`
-}
 
 const TypingDots: React.FC = () => {
   const [n, setN] = useState(0)

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -17,11 +17,24 @@ interface MarkdownProps {
  *  paragraph stopped reading as a unit. Heading margins are deliberately
  *  asymmetric — a heading belongs to the text below it, not midway between two
  *  blocks. */
+interface Metrics {
+  fontSize: number
+  lineHeight: number
+  /** Bottom margin for block-level elements (p, ul, ol, blockquote, code blocks, tables). */
+  blockGap: number
+  li: number
+  hr: string
+  h1: { fontSize: number; margin: string }
+  h2: { fontSize: number; margin: string }
+  h3: { fontSize: number; margin: string }
+  h4: { fontSize: number; margin: string }
+}
+
 const METRICS = {
   compact: {
     fontSize: 13,
     lineHeight: 1.55,
-    block: 8,
+    blockGap: 8,
     li: 2,
     hr: '10px 0',
     h1: { fontSize: 17, margin: '8px 0 6px' },
@@ -30,12 +43,12 @@ const METRICS = {
     h4: { fontSize: 13, margin: '6px 0 4px' },
   },
   roomy: {
+    fontSize: 14,
     // 1.7 rather than 1.55: Chinese has a high character-face ratio and no
     // ascenders or descenders, so identical leading reads tighter than it does
     // for Latin text.
-    fontSize: 14,
     lineHeight: 1.7,
-    block: 14,
+    blockGap: 14,
     li: 5,
     hr: '18px 0',
     h1: { fontSize: 20, margin: '22px 0 8px' },
@@ -43,7 +56,7 @@ const METRICS = {
     h3: { fontSize: 15, margin: '18px 0 6px' },
     h4: { fontSize: 14, margin: '16px 0 6px' },
   },
-} as const
+} as const satisfies Record<'compact' | 'roomy', Metrics>
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Monaco, "Courier New", monospace'
 
@@ -51,7 +64,8 @@ const CodeBlock: React.FC<{
   children: React.ReactNode
   background: string
   borderColor: string
-}> = ({ children, background, borderColor }) => {
+  blockMargin: number
+}> = ({ children, background, borderColor, blockMargin }) => {
   const [copied, setCopied] = React.useState(false)
   const resetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const child: any = React.Children.toArray(children)[0]
@@ -83,7 +97,7 @@ const CodeBlock: React.FC<{
         background,
         border: `1px solid ${borderColor}`,
         borderRadius: 8,
-        margin: '6px 0 8px',
+        margin: `6px 0 ${blockMargin}px`,
         position: 'relative',
         overflow: 'hidden',
       }}
@@ -216,7 +230,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          p: ({ children }) => <p style={{ margin: `0 0 ${M.block}px 0` }}>{children}</p>,
+          p: ({ children }) => <p style={{ margin: `0 0 ${M.blockGap}px 0` }}>{children}</p>,
           a: ({ href, children }) => (
             <a
               href={href}
@@ -236,8 +250,8 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           h2: ({ children }) => <h2 style={{ fontSize: M.h2.fontSize, fontWeight: 700, margin: M.h2.margin }}>{children}</h2>,
           h3: ({ children }) => <h3 style={{ fontSize: M.h3.fontSize, fontWeight: 700, margin: M.h3.margin }}>{children}</h3>,
           h4: ({ children }) => <h4 style={{ fontSize: M.h4.fontSize, fontWeight: 700, margin: M.h4.margin }}>{children}</h4>,
-          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ul>,
-          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ol>,
+          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.blockGap}px 0`, paddingLeft: 20 }}>{children}</ul>,
+          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.blockGap}px 0`, paddingLeft: 20 }}>{children}</ol>,
           li: ({ children }) => <li style={{ marginBottom: M.li }}>{children}</li>,
           hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: M.hr }} />,
           blockquote: ({ children }) => (
@@ -245,7 +259,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
               style={{
                 borderLeft: `3px solid ${quoteBorder}`,
                 paddingLeft: 10,
-                margin: `0 0 ${M.block}px 0`,
+                margin: `0 0 ${M.blockGap}px 0`,
                 color: quoteFg,
               }}
             >
@@ -253,7 +267,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
             </blockquote>
           ),
           table: ({ children }) => (
-            <div style={{ overflowX: 'auto', margin: '6px 0 10px', maxWidth: '100%' }}>
+            <div style={{ overflowX: 'auto', margin: `6px 0 ${M.blockGap}px`, maxWidth: '100%' }}>
               <table
                 style={{
                   borderCollapse: 'collapse',
@@ -297,7 +311,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           ),
           pre: ({ children }: any) => {
             return (
-              <CodeBlock background={codeBlockBg} borderColor={codeBlockBorder}>
+              <CodeBlock background={codeBlockBg} borderColor={codeBlockBorder} blockMargin={M.blockGap}>
                 {children}
               </CodeBlock>
             )

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -6,7 +6,44 @@ import { C } from '../theme'
 interface MarkdownProps {
   children: string
   variant?: 'user' | 'assistant'
+  layout?: 'compact' | 'roomy'
 }
+
+/** Two typographic densities. `compact` is the historical chat metric and stays
+ *  the default, so every secondary surface (team panels, automation, quick
+ *  question) is untouched. `roomy` is for the main assistant turn, which renders
+ *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
+ *  (8px) was barely larger than the gap between its own lines (~7px), so the
+ *  paragraph stopped reading as a unit. Heading margins are deliberately
+ *  asymmetric — a heading belongs to the text below it, not midway between two
+ *  blocks. */
+const METRICS = {
+  compact: {
+    fontSize: 13,
+    lineHeight: 1.55,
+    block: 8,
+    li: 2,
+    hr: '10px 0',
+    h1: { fontSize: 17, margin: '8px 0 6px' },
+    h2: { fontSize: 15, margin: '8px 0 6px' },
+    h3: { fontSize: 14, margin: '8px 0 4px' },
+    h4: { fontSize: 13, margin: '6px 0 4px' },
+  },
+  roomy: {
+    // 1.7 rather than 1.55: Chinese has a high character-face ratio and no
+    // ascenders or descenders, so identical leading reads tighter than it does
+    // for Latin text.
+    fontSize: 14,
+    lineHeight: 1.7,
+    block: 14,
+    li: 5,
+    hr: '18px 0',
+    h1: { fontSize: 20, margin: '22px 0 8px' },
+    h2: { fontSize: 17, margin: '20px 0 8px' },
+    h3: { fontSize: 15, margin: '18px 0 6px' },
+    h4: { fontSize: 14, margin: '16px 0 6px' },
+  },
+} as const
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Monaco, "Courier New", monospace'
 
@@ -157,8 +194,9 @@ function preserveLineBreaks(src: string): string {
   return out.join('\n')
 }
 
-const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant' }) => {
+const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant', layout = 'compact' }) => {
   const onUser = variant === 'user'
+  const M = METRICS[layout]
   const inlineCodeBg = onUser ? 'rgba(0,0,0,0.22)' : C.inlineCodeBg
   const inlineCodeFg = onUser ? C.onAccent : C.inlineCodeFg
   const codeBlockBg = onUser ? 'rgba(0,0,0,0.25)' : C.codeBg
@@ -171,11 +209,14 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
   const tableHeadBg = onUser ? 'rgba(0,0,0,0.2)' : C.surface3
 
   return (
-    <div style={{ minWidth: 0, maxWidth: '100%', fontSize: 13, lineHeight: 1.55, overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
+    <div
+      className={layout === 'roomy' ? 'md-roomy' : undefined}
+      style={{ minWidth: 0, maxWidth: '100%', fontSize: M.fontSize, lineHeight: M.lineHeight, overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          p: ({ children }) => <p style={{ margin: '0 0 8px 0' }}>{children}</p>,
+          p: ({ children }) => <p style={{ margin: `0 0 ${M.block}px 0` }}>{children}</p>,
           a: ({ href, children }) => (
             <a
               href={href}
@@ -191,20 +232,20 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
           strong: ({ children }) => <strong style={{ fontWeight: 700 }}>{children}</strong>,
           em: ({ children }) => <em style={{ fontStyle: 'italic' }}>{children}</em>,
           del: ({ children }) => <del style={{ opacity: 0.6 }}>{children}</del>,
-          h1: ({ children }) => <h1 style={{ fontSize: 17, fontWeight: 700, margin: '8px 0 6px' }}>{children}</h1>,
-          h2: ({ children }) => <h2 style={{ fontSize: 15, fontWeight: 700, margin: '8px 0 6px' }}>{children}</h2>,
-          h3: ({ children }) => <h3 style={{ fontSize: 14, fontWeight: 700, margin: '8px 0 4px' }}>{children}</h3>,
-          h4: ({ children }) => <h4 style={{ fontSize: 13, fontWeight: 700, margin: '6px 0 4px' }}>{children}</h4>,
-          ul: ({ children }) => <ul style={{ margin: '0 0 8px 0', paddingLeft: 20 }}>{children}</ul>,
-          ol: ({ children }) => <ol style={{ margin: '0 0 8px 0', paddingLeft: 20 }}>{children}</ol>,
-          li: ({ children }) => <li style={{ marginBottom: 2 }}>{children}</li>,
-          hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: '10px 0' }} />,
+          h1: ({ children }) => <h1 style={{ fontSize: M.h1.fontSize, fontWeight: 700, margin: M.h1.margin }}>{children}</h1>,
+          h2: ({ children }) => <h2 style={{ fontSize: M.h2.fontSize, fontWeight: 700, margin: M.h2.margin }}>{children}</h2>,
+          h3: ({ children }) => <h3 style={{ fontSize: M.h3.fontSize, fontWeight: 700, margin: M.h3.margin }}>{children}</h3>,
+          h4: ({ children }) => <h4 style={{ fontSize: M.h4.fontSize, fontWeight: 700, margin: M.h4.margin }}>{children}</h4>,
+          ul: ({ children }) => <ul style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ul>,
+          ol: ({ children }) => <ol style={{ margin: `0 0 ${M.block}px 0`, paddingLeft: 20 }}>{children}</ol>,
+          li: ({ children }) => <li style={{ marginBottom: M.li }}>{children}</li>,
+          hr: () => <hr style={{ border: 'none', borderTop: `1px solid ${ruleColor}`, margin: M.hr }} />,
           blockquote: ({ children }) => (
             <blockquote
               style={{
                 borderLeft: `3px solid ${quoteBorder}`,
                 paddingLeft: 10,
-                margin: '0 0 8px 0',
+                margin: `0 0 ${M.block}px 0`,
                 color: quoteFg,
               }}
             >

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -20,8 +20,10 @@ interface MarkdownProps {
 interface Metrics {
   fontSize: number
   lineHeight: number
-  /** Bottom margin for block-level elements (p, ul, ol, blockquote, code blocks, tables). */
+  /** Bottom margin for block-level elements (p, ul, ol, blockquote, code blocks). */
   blockGap: number
+  /** Bottom margin for the table wrapper. */
+  tableGap: number
   li: number
   hr: string
   h1: { fontSize: number; margin: string }
@@ -35,6 +37,7 @@ const METRICS = {
     fontSize: 13,
     lineHeight: 1.55,
     blockGap: 8,
+    tableGap: 10,
     li: 2,
     hr: '10px 0',
     h1: { fontSize: 17, margin: '8px 0 6px' },
@@ -49,6 +52,7 @@ const METRICS = {
     // for Latin text.
     lineHeight: 1.7,
     blockGap: 14,
+    tableGap: 14,
     li: 5,
     hr: '18px 0',
     h1: { fontSize: 20, margin: '22px 0 8px' },
@@ -267,7 +271,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
             </blockquote>
           ),
           table: ({ children }) => (
-            <div style={{ overflowX: 'auto', margin: `6px 0 ${M.blockGap}px`, maxWidth: '100%' }}>
+            <div style={{ overflowX: 'auto', margin: `6px 0 ${M.tableGap}px`, maxWidth: '100%' }}>
               <table
                 style={{
                   borderCollapse: 'collapse',

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -9,14 +9,7 @@ interface MarkdownProps {
   layout?: 'compact' | 'roomy'
 }
 
-/** Two typographic densities. `compact` is the historical chat metric and stays
- *  the default, so every secondary surface (team panels, automation, quick
- *  question) is untouched. `roomy` is for the main assistant turn, which renders
- *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
- *  (8px) was barely larger than the gap between its own lines (~7px), so the
- *  paragraph stopped reading as a unit. Heading margins are deliberately
- *  asymmetric — a heading belongs to the text below it, not midway between two
- *  blocks. */
+/** Shape of one density's metrics; both entries must supply every field. */
 interface Metrics {
   fontSize: number
   lineHeight: number
@@ -32,6 +25,14 @@ interface Metrics {
   h4: { fontSize: number; margin: string }
 }
 
+/** Two typographic densities. `compact` is the historical chat metric and stays
+ *  the default, so every secondary surface (team panels, automation, quick
+ *  question) is untouched. `roomy` is for the main assistant turn, which renders
+ *  as a document rather than a bubble: at 13px/1.55 a paragraph's bottom margin
+ *  (8px) was barely larger than the gap between its own lines (~7px), so the
+ *  paragraph stopped reading as a unit. Heading margins are deliberately
+ *  asymmetric — a heading belongs to the text below it, not midway between two
+ *  blocks. */
 const METRICS = {
   compact: {
     fontSize: 13,

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { C } from '../theme'
+import { turnHeaderMeta } from './turnHeaderModel'
+import type { ChatMessage } from '../types'
+
+interface Props {
+  msg: ChatMessage
+  /** Rendered only when the turn has thinking to disclose. */
+  hasThinking: boolean
+  expanded: boolean
+  onToggle: () => void
+}
+
+/** Identifies an assistant turn and bounds it.
+ *
+ *  The bubble used to do both jobs. When it was removed, the boundary fell to
+ *  spacing alone — an implicit signal competing with the reply's own paragraph
+ *  spacing — and the turn's secondary chrome lost the surface that marked it as
+ *  belonging to this turn. A rule is an explicit boundary that does not compete,
+ *  and the header gives the thinking disclosure a permanent home instead of
+ *  leaving it as an unanchored 11px line above the reply.
+ *
+ *  The rule always renders; the metadata row renders only when there is
+ *  something to put in it, so a turn with no metadata is a bare hairline rather
+ *  than a blank row. */
+export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle }) => {
+  const meta = turnHeaderMeta(msg)
+  if (meta.isEmpty && !hasThinking) return <div style={styles.rule} />
+
+  return (
+    <div>
+      <div style={styles.row}>
+        <div style={styles.left}>
+          {meta.identity && (
+            <span style={styles.identity} title={meta.identity}>{meta.identity}</span>
+          )}
+          {hasThinking && (
+            <span
+              style={styles.chevron}
+              onClick={onToggle}
+              role="button"
+              aria-expanded={expanded}
+              title={expanded ? 'Hide thinking' : 'Show thinking'}
+            >
+              {expanded ? '▾' : '▸'}
+            </span>
+          )}
+        </div>
+        <div style={styles.right}>
+          {meta.fallback && (
+            <span
+              style={styles.fallback}
+              title={`Primary ${meta.fallback.from} failed — answered by fallback ${meta.fallback.to}`}
+            >
+              ⤷ {meta.fallback.to}
+            </span>
+          )}
+          {meta.stats.length > 0 && (
+            <span style={styles.stats}>{meta.stats.join(' · ')}</span>
+          )}
+        </div>
+      </div>
+      <div style={styles.rule} />
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  row: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    gap: 8, fontSize: 11, color: C.fg3, marginBottom: 4,
+  },
+  left: { display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 },
+  right: { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 },
+  identity: {
+    fontFamily: 'SF Mono, Menlo, monospace',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  chevron: { cursor: 'pointer', fontSize: 9, userSelect: 'none', flexShrink: 0 },
+  stats: { fontVariantNumeric: 'tabular-nums', opacity: 0.55 },
+  fallback: {
+    color: C.warningFg, background: C.warningBg,
+    borderRadius: 6, padding: '1px 6px', fontSize: 10,
+    maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
+  rule: { borderTop: `1px solid ${C.border2}`, marginBottom: 8 },
+}

--- a/codey-mac/src/components/turnHeaderModel.test.ts
+++ b/codey-mac/src/components/turnHeaderModel.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { turnHeaderMeta } from './turnHeaderModel'
+import type { ChatMessage } from '../types'
+
+const msg = (over: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: 'm1', role: 'assistant', content: 'hi', timestamp: 0, ...over,
+})
+
+describe('turnHeaderMeta', () => {
+  it('joins agent and model as the identity', () => {
+    expect(turnHeaderMeta(msg({ agent: 'claude-code', model: 'opus' })).identity)
+      .toBe('claude-code · opus')
+  })
+
+  it('uses whichever of agent or model is present', () => {
+    expect(turnHeaderMeta(msg({ model: 'opus' })).identity).toBe('opus')
+    expect(turnHeaderMeta(msg({ agent: 'codex' })).identity).toBe('codex')
+  })
+
+  it('reports no identity when neither is known', () => {
+    expect(turnHeaderMeta(msg()).identity).toBeNull()
+  })
+
+  it('orders stats as duration then tokens', () => {
+    expect(turnHeaderMeta(msg({ durationSec: 12, tokens: 3400 })).stats)
+      .toEqual(['12s', '3.4k tok'])
+  })
+
+  // The orphaned-separator bug: stats are returned as items, never as a
+  // pre-joined string, so a missing field cannot leave a dangling '·'.
+  it('omits absent stats without leaving a gap', () => {
+    expect(turnHeaderMeta(msg({ durationSec: 12 })).stats).toEqual(['12s'])
+    expect(turnHeaderMeta(msg({ tokens: 3400 })).stats).toEqual(['3.4k tok'])
+    expect(turnHeaderMeta(msg()).stats).toEqual([])
+  })
+
+  it('drops a non-finite duration', () => {
+    expect(turnHeaderMeta(msg({ durationSec: NaN })).stats).toEqual([])
+    expect(turnHeaderMeta(msg({ durationSec: Infinity })).stats).toEqual([])
+  })
+
+  it('keeps a zero token count', () => {
+    expect(turnHeaderMeta(msg({ tokens: 0 })).stats).toEqual(['0 tok'])
+  })
+
+  // formatTokens switches formatting at 10k. Pin both sides so the move out of
+  // ChatTab cannot silently change how the count reads.
+  it('formats token counts the way the footer did', () => {
+    expect(turnHeaderMeta(msg({ tokens: 950 })).stats).toEqual(['950 tok'])
+    expect(turnHeaderMeta(msg({ tokens: 3400 })).stats).toEqual(['3.4k tok'])
+    expect(turnHeaderMeta(msg({ tokens: 45_000 })).stats).toEqual(['45k tok'])
+  })
+
+  it('passes the fallback through', () => {
+    const f = { from: 'claude-code(opus)', to: 'codex(gpt-5)' }
+    expect(turnHeaderMeta(msg({ fallback: f })).fallback).toEqual(f)
+  })
+
+  // Drives the spec's "empty case": nothing to show means the metadata row is
+  // not rendered at all, leaving only the rule.
+  it('is empty when the message carries no metadata', () => {
+    expect(turnHeaderMeta(msg()).isEmpty).toBe(true)
+    expect(turnHeaderMeta(msg({ model: 'opus' })).isEmpty).toBe(false)
+  })
+})

--- a/codey-mac/src/components/turnHeaderModel.ts
+++ b/codey-mac/src/components/turnHeaderModel.ts
@@ -1,0 +1,46 @@
+import type { ChatMessage } from '../types'
+
+/** Compact token count: 1200 -> "1.2k", 45000 -> "45k". Moved verbatim from
+ *  ChatTab so the header formats exactly as the footer used to. */
+export const formatTokens = (n: number): string | null => {
+  if (!Number.isFinite(n) || n < 0) return null
+  if (n < 1000) return String(n)
+  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`
+  return `${Math.round(n / 1000)}k`
+}
+
+export interface TurnHeaderMeta {
+  /** `agent · model`, whichever is known, or null when neither is. */
+  identity: string | null
+  /** Right-side items, already ordered. Returned as items rather than a joined
+   *  string so an absent field cannot leave an orphaned separator. */
+  stats: string[]
+  fallback?: { from: string; to: string }
+  /** Nothing to show — the caller renders the rule without a metadata row. */
+  isEmpty: boolean
+}
+
+/** The metadata identifying one assistant turn, ready to render.
+ *
+ *  Every field on a ChatMessage that this reads is optional: older messages
+ *  predate the model/token bookkeeping, and duration and tokens are only set
+ *  once a turn completes, so a streaming turn legitimately has neither. */
+export function turnHeaderMeta(msg: ChatMessage): TurnHeaderMeta {
+  const identity = [msg.agent, msg.model].filter(Boolean).join(' · ') || null
+
+  const stats: string[] = []
+  if (msg.durationSec != null && Number.isFinite(msg.durationSec)) {
+    stats.push(`${msg.durationSec}s`)
+  }
+  if (msg.tokens != null) {
+    const tok = formatTokens(msg.tokens)
+    if (tok) stats.push(`${tok} tok`)
+  }
+
+  return {
+    identity,
+    stats,
+    fallback: msg.fallback,
+    isEmpty: !identity && stats.length === 0 && !msg.fallback,
+  }
+}

--- a/docs/superpowers/plans/2026-08-07-assistant-turn-header.md
+++ b/docs/superpowers/plans/2026-08-07-assistant-turn-header.md
@@ -1,0 +1,557 @@
+# Assistant Turn Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each assistant turn a metadata header above a hairline rule, and render the reply as document flow — so long replies stop reading as a dense wall without losing the turn's identity and boundary, which is what the reverted first attempt got wrong.
+
+**Architecture:** Three pieces. `turnHeaderModel.ts` holds the pure formatting logic and is unit-tested. `TurnHeader.tsx` is the presentational component. `ChatTab.tsx` swaps the assistant bubble for document flow, mounts the header, moves `tsRight` out of the footer, and hands the thinking disclosure to the header. `Markdown.tsx` regains the two typographic densities by cherry-pick from the reverted branch.
+
+**Tech Stack:** React 18 + TypeScript, inline styles, `react-markdown` + `remark-gfm`, Vite, Vitest, Electron.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-assistant-turn-header-design.md`
+
+**Node version:** this repo needs nvm's v22.17.1. Prefix every command with
+`export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 22.17.1 >/dev/null`.
+The system default v16 cannot run vitest or tsc here.
+
+**Worktree:** `/Users/jackou/Documents/projects/codey/.worktrees/turn-header`, branch `feat/assistant-turn-header`, cut from the post-revert main (`493b844`).
+
+---
+
+## What is different from last time
+
+The previous attempt shipped on "typecheck clean, 322 tests passing" and was reverted hours later for a defect no automated check could catch. Two concrete changes:
+
+1. **There is real logic here, and it gets real tests.** `turnHeaderMeta` is pure with concrete failure modes. Task 3 is genuine TDD — failing test first.
+2. **Task 7 is a blocking human review, not a formality.** The plan is not complete until it is done. Do not report success on the strength of the test suite.
+
+Still true from last time: no tests asserting that a style constant equals itself.
+
+## File Structure
+
+- **Create** `codey-mac/src/components/turnHeaderModel.ts` — pure formatting: `turnHeaderMeta()` and `formatTokens()`. No React. Follows the house pattern (`automationsModel.ts`, `notificationLogic.ts`, `flowEditorModel.ts`: logic extracted from a component into a `*Model`-style module so it can be tested).
+- **Create** `codey-mac/src/components/turnHeaderModel.test.ts` — its tests.
+- **Create** `codey-mac/src/components/TurnHeader.tsx` — the presentational header row + rule.
+- **Modify** `codey-mac/src/components/Markdown.tsx` — restored by cherry-pick, not rewritten.
+- **Modify** `codey-mac/src/components/ChatTab.tsx` — container split, header mount, footer slimming, `LiveActivity` move, thinking disclosure handover.
+- **Modify** `codey-mac/src/App.tsx` — one CSS rule.
+
+`ChatTab.tsx` is 3265 lines and does too much. New code goes in new files; splitting the rest is out of scope.
+
+---
+
+### Task 1: Recover the typographic densities
+
+The `Markdown.tsx` work from the reverted attempt was reviewed twice, verified byte-equivalent on the `compact` path, and was **not** the reason for the revert. Recover it rather than retyping it.
+
+**Files:**
+- Modify: `codey-mac/src/components/Markdown.tsx`
+
+- [ ] **Step 1: Cherry-pick the four commits**
+
+```bash
+git cherry-pick 81cd2d1 1203888 483eb23 81519e9
+```
+
+In order these are: add `layout` prop + `METRICS`; fix code-review findings (`blockGap` rename, `satisfies`, `CodeBlock` and table margins threaded); give the table its own `tableGap` so `compact` stays byte-equivalent; move the density doc comment onto `METRICS`.
+
+If any conflicts: `Markdown.tsx` at `493b844` is identical to `e35e536`, which is what these commits were written against, so there should be none. If one appears, stop and report rather than resolving creatively.
+
+- [ ] **Step 2: Confirm compact is unchanged**
+
+```bash
+git diff e35e536 HEAD -- codey-mac/src/components/Markdown.tsx | grep -E '^\-' | grep -E '1\.55|fontSize: 13|8px|10px'
+```
+
+Read the output. Every removed hardcoded value must reappear in `METRICS.compact`: `fontSize: 13`, `lineHeight: 1.55`, `blockGap: 8`, `tableGap: 10`, `li: 2`, `hr: '10px 0'`, h1 `17/'8px 0 6px'`, h2 `15/'8px 0 6px'`, h3 `14/'8px 0 4px'`, h4 `13/'6px 0 4px'`, `CodeBlock` `6px 0 8px`. This invariant is what lets the other sixteen `<Markdown>` call sites go unverified.
+
+- [ ] **Step 3: Verify**
+
+```
+cd codey-mac && npx tsc --noEmit && npm test
+```
+Expected: tsc silent, `41 passed`, `322 passed`.
+
+No commit step — the cherry-picks are the commits.
+
+---
+
+### Task 2: Zero the top margin of a turn's first block
+
+**Files:**
+- Modify: `codey-mac/src/App.tsx`
+
+Roomy headings carry a 16-22px top margin to open a section. A reply that starts with a heading has nothing above it to separate from, so that margin is dead space. Inline styles cannot express `:first-child`.
+
+- [ ] **Step 1: Add the rule**
+
+In the existing global `<style>` template literal, immediately after:
+
+```
+  html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
+```
+
+add:
+
+```
+  /* Roomy headings open a section with a large top margin. The first block in a
+     turn has nothing above it to separate from, so that margin is dead space. */
+  .md-roomy > :first-child { margin-top: 0 !important; }
+```
+
+`!important` is required — it overrides an inline style. The selector must be the direct-child form `>`; a descendant selector would also zero the first item of nested lists and blockquotes.
+
+Take care not to introduce a backtick or `${` that breaks the template literal.
+
+- [ ] **Step 2: Verify and commit**
+
+```
+cd codey-mac && npx tsc --noEmit && npm test
+git add codey-mac/src/App.tsx
+git commit -m "style(mac): collapse leading heading margin in roomy markdown"
+```
+
+---
+
+### Task 3: The header model (TDD — tests first)
+
+This is the one part of the change with real logic and real failure modes. Write the failing test before the implementation.
+
+**Files:**
+- Create: `codey-mac/src/components/turnHeaderModel.ts`
+- Create: `codey-mac/src/components/turnHeaderModel.test.ts`
+- Modify: `codey-mac/src/components/ChatTab.tsx` (remove its now-duplicate `formatTokens`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `codey-mac/src/components/turnHeaderModel.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { turnHeaderMeta } from './turnHeaderModel'
+import type { ChatMessage } from '../types'
+
+const msg = (over: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: 'm1', role: 'assistant', content: 'hi', timestamp: 0, ...over,
+})
+
+describe('turnHeaderMeta', () => {
+  it('joins agent and model as the identity', () => {
+    expect(turnHeaderMeta(msg({ agent: 'claude-code', model: 'opus' })).identity)
+      .toBe('claude-code · opus')
+  })
+
+  it('uses whichever of agent or model is present', () => {
+    expect(turnHeaderMeta(msg({ model: 'opus' })).identity).toBe('opus')
+    expect(turnHeaderMeta(msg({ agent: 'codex' })).identity).toBe('codex')
+  })
+
+  it('reports no identity when neither is known', () => {
+    expect(turnHeaderMeta(msg()).identity).toBeNull()
+  })
+
+  it('orders stats as duration then tokens', () => {
+    expect(turnHeaderMeta(msg({ durationSec: 12, tokens: 3400 })).stats)
+      .toEqual(['12s', '3.4k tok'])
+  })
+
+  // The orphaned-separator bug: stats are returned as items, never as a
+  // pre-joined string, so a missing field cannot leave a dangling '·'.
+  it('omits absent stats without leaving a gap', () => {
+    expect(turnHeaderMeta(msg({ durationSec: 12 })).stats).toEqual(['12s'])
+    expect(turnHeaderMeta(msg({ tokens: 3400 })).stats).toEqual(['3.4k tok'])
+    expect(turnHeaderMeta(msg()).stats).toEqual([])
+  })
+
+  it('drops a non-finite duration', () => {
+    expect(turnHeaderMeta(msg({ durationSec: NaN })).stats).toEqual([])
+    expect(turnHeaderMeta(msg({ durationSec: Infinity })).stats).toEqual([])
+  })
+
+  it('keeps a zero token count', () => {
+    expect(turnHeaderMeta(msg({ tokens: 0 })).stats).toEqual(['0 tok'])
+  })
+
+  // formatTokens switches formatting at 10k. Pin both sides so the move out of
+  // ChatTab cannot silently change how the count reads.
+  it('formats token counts the way the footer did', () => {
+    expect(turnHeaderMeta(msg({ tokens: 950 })).stats).toEqual(['950 tok'])
+    expect(turnHeaderMeta(msg({ tokens: 3400 })).stats).toEqual(['3.4k tok'])
+    expect(turnHeaderMeta(msg({ tokens: 45_000 })).stats).toEqual(['45k tok'])
+  })
+
+  it('passes the fallback through', () => {
+    const f = { from: 'claude-code(opus)', to: 'codex(gpt-5)' }
+    expect(turnHeaderMeta(msg({ fallback: f })).fallback).toEqual(f)
+  })
+
+  // Drives the spec's "empty case": nothing to show means the metadata row is
+  // not rendered at all, leaving only the rule.
+  it('is empty when the message carries no metadata', () => {
+    expect(turnHeaderMeta(msg()).isEmpty).toBe(true)
+    expect(turnHeaderMeta(msg({ model: 'opus' })).isEmpty).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```
+cd codey-mac && npx vitest run src/components/turnHeaderModel.test.ts
+```
+Expected: FAIL — cannot resolve `./turnHeaderModel`.
+
+- [ ] **Step 3: Implement the model**
+
+Create `codey-mac/src/components/turnHeaderModel.ts`:
+
+```ts
+import type { ChatMessage } from '../types'
+
+/** Compact token count: 1200 -> "1.2k", 45000 -> "45k". Moved verbatim from
+ *  ChatTab so the header formats exactly as the footer used to. */
+export const formatTokens = (n: number): string | null => {
+  if (!Number.isFinite(n) || n < 0) return null
+  if (n < 1000) return String(n)
+  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`
+  return `${Math.round(n / 1000)}k`
+}
+
+export interface TurnHeaderMeta {
+  /** `agent · model`, whichever is known, or null when neither is. */
+  identity: string | null
+  /** Right-side items, already ordered. Returned as items rather than a joined
+   *  string so an absent field cannot leave an orphaned separator. */
+  stats: string[]
+  fallback?: { from: string; to: string }
+  /** Nothing to show — the caller renders the rule without a metadata row. */
+  isEmpty: boolean
+}
+
+export function turnHeaderMeta(msg: ChatMessage): TurnHeaderMeta {
+  const identity = [msg.agent, msg.model].filter(Boolean).join(' · ') || null
+
+  const stats: string[] = []
+  if (msg.durationSec != null && Number.isFinite(msg.durationSec)) {
+    stats.push(`${msg.durationSec}s`)
+  }
+  if (msg.tokens != null) {
+    const tok = formatTokens(msg.tokens)
+    if (tok) stats.push(`${tok} tok`)
+  }
+
+  return {
+    identity,
+    stats,
+    fallback: msg.fallback,
+    isEmpty: !identity && stats.length === 0 && !msg.fallback,
+  }
+}
+```
+
+Note: `formatTokens` here is moved from `ChatTab.tsx:76`, not copied. `ChatContextPanel.tsx:58` has a third copy; leave it alone — deduplicating it is unrelated to this goal.
+
+- [ ] **Step 4: Run the test again**
+
+```
+cd codey-mac && npx vitest run src/components/turnHeaderModel.test.ts
+```
+Expected: PASS, 10 tests.
+
+If `formatTokens` behaves differently from `ChatTab.tsx:76` — read that function and match it exactly rather than adjusting the test. The header must format tokens the same way the footer did.
+
+- [ ] **Step 5: Point ChatTab at the moved function**
+
+Delete `formatTokens` from `ChatTab.tsx:76` and import it instead:
+
+```ts
+import { formatTokens, turnHeaderMeta } from './turnHeaderModel'
+```
+
+`ChatTab.tsx:497` still uses `formatTokens`; `:2176` is removed in Task 5. No import cycle: `ChatTab` → `turnHeaderModel`, and `turnHeaderModel` imports only types.
+
+- [ ] **Step 6: Verify and commit**
+
+```
+cd codey-mac && npx tsc --noEmit && npm test
+git add codey-mac/src/components/turnHeaderModel.ts codey-mac/src/components/turnHeaderModel.test.ts codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): add turn header model with token and duration formatting"
+```
+Expected: `41 passed` becomes `42 passed`, `322 passed` becomes `332 passed`.
+
+---
+
+### Task 4: The header component
+
+**Files:**
+- Create: `codey-mac/src/components/TurnHeader.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import React from 'react'
+import { C } from '../theme'
+import { turnHeaderMeta } from './turnHeaderModel'
+import type { ChatMessage } from '../types'
+
+interface Props {
+  msg: ChatMessage
+  /** Rendered only when the turn has thinking to disclose. */
+  hasThinking: boolean
+  expanded: boolean
+  onToggle: () => void
+}
+
+/** Identifies an assistant turn and bounds it.
+ *
+ *  The bubble used to do both jobs. When it was removed, the boundary fell to
+ *  spacing alone — an implicit signal competing with the reply's own paragraph
+ *  spacing — and the turn's secondary chrome lost the surface that marked it as
+ *  belonging to this turn. The rule is an explicit boundary that does not
+ *  compete, and the header gives the thinking disclosure a permanent home.
+ *
+ *  The rule always renders; the metadata row renders only when there is
+ *  something to put in it, so a turn with no metadata is a bare hairline rather
+ *  than a blank line. */
+export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle }) => {
+  const meta = turnHeaderMeta(msg)
+  if (meta.isEmpty && !hasThinking) return <div style={styles.rule} />
+
+  return (
+    <div>
+      <div style={styles.row}>
+        <div style={styles.left}>
+          {meta.identity && <span style={styles.identity}>{meta.identity}</span>}
+          {hasThinking && (
+            <span
+              style={styles.chevron}
+              onClick={onToggle}
+              role="button"
+              title={expanded ? 'Hide thinking' : 'Show thinking'}
+            >
+              {expanded ? '▾' : '▸'}
+            </span>
+          )}
+        </div>
+        <div style={styles.right}>
+          {meta.fallback && (
+            <span
+              style={styles.fallback}
+              title={`Primary ${meta.fallback.from} failed — answered by fallback ${meta.fallback.to}`}
+            >
+              ⤷ {meta.fallback.to}
+            </span>
+          )}
+          {meta.stats.length > 0 && <span style={styles.stats}>{meta.stats.join(' · ')}</span>}
+        </div>
+      </div>
+      <div style={styles.rule} />
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  row: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    gap: 8, fontSize: 11, color: C.fg3, marginBottom: 4,
+  },
+  left: { display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 },
+  right: { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 },
+  identity: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  chevron: { cursor: 'pointer', fontSize: 9, userSelect: 'none', flexShrink: 0 },
+  stats: { fontVariantNumeric: 'tabular-nums', opacity: 0.55 },
+  fallback: { color: C.yellow },
+  rule: { borderTop: `1px solid ${C.border2}`, marginBottom: 8 },
+}
+```
+
+The chevron sits to the right of the identity, per the design.
+
+- [ ] **Step 2: Verify and commit**
+
+```
+cd codey-mac && npx tsc --noEmit && npm test
+git add codey-mac/src/components/TurnHeader.tsx
+git commit -m "feat(mac): add assistant turn header component"
+```
+
+No test for this file — it is markup and style objects, the category the spec explicitly excludes. Its logic lives in `turnHeaderModel`, which is tested.
+
+---
+
+### Task 5: Wire it into ChatTab
+
+The largest task, and the one that failed last time. Work through it in order.
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx`
+
+- [ ] **Step 1: Hoist the thinking disclosure state**
+
+The header owns the chevron, so the expanded state can no longer live inside `ThinkingBlock`. Next to the existing `expandedSteps` state in the `ChatTab` component, add:
+
+```tsx
+const [expandedThinking, setExpandedThinking] = useState<Record<string, boolean>>({})
+```
+
+Keyed by message id. `ThinkingBlock` at `:256` and its team-context uses at `:509` and `:701` are **not** touched — only the single-agent main path at `:2006` is replaced.
+
+- [ ] **Step 2: Split the message container**
+
+Replace the inner `div` opening tag at `ChatTab.tsx:1981-1994` (it begins `minWidth: 0, maxWidth: '72%', padding: '10px 14px',`):
+
+```tsx
+              <div style={isUser ? {
+                minWidth: 0, maxWidth: '72%', padding: '10px 14px',
+                borderRadius: '16px 16px 4px 16px',
+                background: C.userBg,
+                color: C.onAccent, fontSize: 13, lineHeight: 1.55,
+                overflowWrap: 'anywhere', wordBreak: 'break-word',
+              } : {
+                // The bubble marks "what the user said". An assistant reply
+                // reads as a document; the header rule below carries the
+                // boundary the bubble used to provide.
+                //
+                // `ch` resolves against this element's 13px font, so 78ch is
+                // ~562px — about 72 characters of the 14px roomy body text, or
+                // ~43 Chinese characters. Unlike the old 72%, it does not grow
+                // with the window.
+                minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
+                // 6px top is the vertical padding the previous attempt dropped
+                // when it replaced the bubble's '10px 14px'. Left: 3 (rail) +
+                // 12 = the old 1 (border) + 14 (bubble padding).
+                padding: '6px 0 0 12px',
+                // The rail is always 3px, transparent when unselected, so
+                // selecting a turn never shifts the text column sideways.
+                borderLeft: `3px solid ${isSelected ? C.accent : 'transparent'}`,
+                background: isSelected ? C.accentDim : 'transparent',
+                // fontSize/lineHeight stay compact: non-Markdown children
+                // inherit them. Roomy applies inside <Markdown layout="roomy">.
+                color: C.fg, fontSize: 13, lineHeight: 1.55,
+                overflowWrap: 'anywhere', wordBreak: 'break-word',
+                transition: 'border-color 0.18s ease, background 0.18s ease',
+              }}>
+```
+
+Also change `marginBottom: 12,` at `:1974` to `marginBottom: isUser ? 12 : 20,`.
+
+- [ ] **Step 3: Mount the header and move LiveActivity below the rule**
+
+Replace the `LiveActivity` block at `:1995-1997`:
+
+```tsx
+                {!isUser && (
+                  <TurnHeader
+                    msg={msg}
+                    hasThinking={!!msg.thinking?.trim()}
+                    expanded={!!expandedThinking[msg.id]}
+                    onToggle={() => setExpandedThinking(p => ({ ...p, [msg.id]: !p[msg.id] }))}
+                  />
+                )}
+                {!isUser && !!msg.thinking?.trim() && expandedThinking[msg.id] && (
+                  <div style={styles.thinkingBody}>{msg.thinking}</div>
+                )}
+                {!isUser && !!flight && msg === lastMsg && (
+                  <LiveActivity toolCalls={msg.toolCalls} />
+                )}
+```
+
+The header comes first, then the disclosed thinking, then live activity — activity is turn *content*, not turn identity.
+
+Add the import at the top of the file:
+
+```tsx
+import { TurnHeader } from './TurnHeader'
+```
+
+- [ ] **Step 4: Remove the old inline ThinkingBlock from the main path**
+
+At `:2005-2011` (inside `if (!parsed) return (`), delete the `{msg.thinking && (<ThinkingBlock ... />)}` block, leaving:
+
+```tsx
+                  if (!parsed) return (
+                    <div>
+                      <Markdown variant="assistant" layout="roomy">{text}</Markdown>
+                    </div>
+                  )
+```
+
+Leave the `ThinkingBlock` component definition and its two team-context uses in place.
+
+- [ ] **Step 5: Slim the footer**
+
+At `:2156`, `tsLabel` currently holds the timestamp plus the whole `tsRight` span (model badge, fallback badge, `tokens · duration`). Every item in `tsRight` is assistant-only and now lives in the header. Delete the `tsRight` span entirely, leaving:
+
+```tsx
+              <div style={styles.tsLabel}>
+                <span>{fmtTime(msg.timestamp)}</span>
+              </div>
+```
+
+The timestamp stays in the footer by design. Remove the now-unused `tsRight`, `tsMeta`, `modelBadge`, and `fallbackBadge` style entries **only if** nothing else references them — check with `grep -n 'tsRight\|tsMeta\|modelBadge\|fallbackBadge' ChatTab.tsx` first and leave any that are still used.
+
+- [ ] **Step 6: Verify and commit**
+
+```
+cd codey-mac && npx tsc --noEmit && npm test
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "feat(mac): render assistant turns as document flow under a turn header"
+```
+
+Expected: tsc silent, all tests pass. `tsc` will catch a missed reference to a deleted style or the removed `formatTokens`.
+
+---
+
+### Task 6: Settle the thinking question
+
+The spec leaves open why the "Show thinking" toggle vanished entirely under the reverted attempt. That must be settled before the visual review can interpret an absent chevron.
+
+**Files:** none unless a defect is found.
+
+- [ ] **Step 1: Establish whether thinking data exists at all**
+
+Run the app, send a prompt to an agent that produces extended thinking, and check whether the chevron appears next to the model in the header.
+
+- [ ] **Step 2: If the chevron does not appear, trace the data**
+
+Do not conclude "the model does not emit thinking" without checking. The chain is: gateway emits a `thinking` stream event → `useChats.tsx:576` dispatches `thinkingToken` → the reducer at `:225-241` accumulates it onto `inFlight` and copies it to the message → the message is persisted with `thinking` (`packages/core/src/types/chat.ts:57`).
+
+Add a temporary `console.log` at `useChats.tsx:576` reporting whether any `thinking` event arrives, and one where the message is finalised reporting whether `thinking` survived. Run once, read the output, then remove the logging.
+
+Report which link is broken. Do not fix it inside this task — if it is a data bug it is a separate change with its own scope.
+
+- [ ] **Step 3: If the chevron appears, say so explicitly**
+
+Then the vanishing was a layout artefact of the reverted attempt and is fixed by construction. Record that, and close the open question in the spec.
+
+---
+
+### Task 7: Visual verification — blocking
+
+**Files:** none.
+
+The previous attempt was reverted for a defect that typecheck and 322 tests could not see. This task is the gate. Do not report the plan complete without it.
+
+```
+cd codey-mac && npm run dev
+```
+
+(The gateway binds port 3000 — quit a running Codey.app first.)
+
+- [ ] **Step 1: Long reply, dark theme.** Ask for 800+ words with headings, a bulleted list, a fenced code block, and a table. Confirm: the text column stops widening past ~600px; paragraph breaks read as larger than line breaks; headings group with the text below them; the code block and table are wider than before, not clipped.
+- [ ] **Step 2: The header itself.** Model and agent on the left, duration and tokens on the right, hairline under them, timestamp still at the bottom. Nothing appears in both header and footer.
+- [ ] **Step 3: Streaming.** Watch a turn arrive. The header shows the model immediately; duration and tokens appear on completion without shifting the left side.
+- [ ] **Step 4: Thinking.** The chevron sits to the right of the model. Clicking it discloses the thinking between the rule and the reply, and collapses it again.
+- [ ] **Step 5: Short reply.** Send something answered in one line. **This is the risk the spec flags** — the header may outweigh the content. Judge honestly.
+- [ ] **Step 6: Light theme.** Assistant text now sits on `#f6f7fb` with no white bubble. Confirm the column still reads as anchored and the hairline is visible without being harsh.
+- [ ] **Step 7: Selection and boundaries.** Double-click an assistant turn: the accent rail appears and the text does **not** shift sideways. Two consecutive assistant turns read as separate.
+- [ ] **Step 8: Untouched surfaces.** Team run panels and the quick-question view are unchanged in size and spacing — that is what the `compact` default protects. Team messages still show their own thinking blocks.
+- [ ] **Step 9: A turn with no metadata.** An older message with no model or tokens shows a bare hairline, not a blank row.
+
+- [ ] **Step 10: Report what you saw**, per step, including anything that read poorly. If step 5 or 6 is bad, the spec's fallback is a very subtle background on the assistant column — not restoring the bubble. Raise it rather than applying it unilaterally.
+
+---
+
+## Rollback
+
+Each task is a separate commit. Reverting Task 5's commit restores bubbles while keeping the header component, the model, and its tests on the branch.

--- a/docs/superpowers/specs/2026-08-07-assistant-turn-header-design.md
+++ b/docs/superpowers/specs/2026-08-07-assistant-turn-header-design.md
@@ -1,0 +1,162 @@
+# Assistant turn header + document flow
+
+**Date:** 2026-08-07
+**Surface:** `codey-mac` chat tab
+**Supersedes:** `2026-08-07-assistant-document-layout-design.md`, whose implementation
+(PR #205, commit `3845b7a`) was reverted by PR #208.
+
+## Why this exists
+
+The previous design removed the assistant bubble so long replies would read as a document.
+The typography half of it was right. The structural half was not: the bubble had been carrying
+information, and only two of its three jobs were replaced.
+
+What went wrong, precisely:
+
+- The design preserved the horizontal text inset exactly (row 6 + rail 3 + padding 12 = 21px,
+  matching the old row 6 + border 1 + bubble padding 14) but silently dropped **10px of
+  vertical padding** when `padding: '10px 14px'` became `'0 0 0 12px'`.
+- A turn's first element is often 11px `C.fg3` secondary chrome — the collapsed "Show thinking"
+  toggle. With no background and no space above it, it sat flush against the previous message.
+- Message boundaries were left to `marginBottom: 20`. Spacing alone is a weak boundary; it
+  competes with the paragraph spacing inside the reply, which the same change had just
+  increased to 14px.
+
+Reported symptom: the collapsed "Show thinking" toggle disappeared **entirely**. That is not
+explained by the diff — `git diff e35e536..3845b7a -- ChatTab.tsx` matches no line containing
+"thinking", and the `ThinkingBlock` render path was untouched. **This discrepancy is
+unresolved.** See "Open question" below; the design does not depend on the answer, but the
+implementation must not assume the answer either.
+
+## Decision
+
+Keep the document flow. Give each assistant turn an explicit header — a metadata row above a
+hairline rule — and let that header be the boundary the bubble used to provide.
+
+This is not decoration. Spacing is an implicit boundary that competes with the content's own
+spacing; a rule is an explicit one that does not. The previous design's weakest point becomes
+the new design's structural element.
+
+The header also gives the thinking disclosure a permanent home. Previously it was a floating
+11px line above the reply with nothing to anchor it.
+
+## Design
+
+### 1. Anatomy
+
+```
+claude-code · opus  ▸                    12s · 3.4k tok
+──────────────────────────────────────────────────────
+(thinking body, when expanded)
+
+Reply body, 14px / 1.7, capped at 78ch
+
+                                                 10:42
+```
+
+- **Header left:** `agent · model`, then the disclosure chevron immediately to its right.
+  The chevron renders only when the message has thinking.
+- **Header right:** `durationSec` and `tokens`, plus the fallback badge when present.
+- **Rule:** 1px `C.border2`, spanning the text column (the same 78ch cap as the body).
+- **Timestamp:** stays in the footer, where it is today. It is not part of the header.
+
+### 2. The empty case
+
+The rule renders for every assistant turn. The metadata row renders only when it has something
+to show.
+
+A message with no model, no thinking, no duration and no tokens therefore produces a bare
+hairline rather than an empty text line. The boundary still exists — which is the invariant that
+matters, and the one the previous design failed to hold — but there is no blank row.
+
+### 3. What moves out of the footer
+
+`ChatTab.tsx:2156` currently renders `tsLabel`: timestamp on the left, and in `tsRight` the
+model badge, the fallback badge, and `tokens · duration`. Every item in `tsRight` is
+assistant-only. The whole span moves to the header.
+
+The footer therefore becomes timestamp-only for both roles — a simplification, not just a move.
+Nothing is shown in two places; duplicated metadata reads as two different facts.
+
+### 4. Streaming
+
+`durationSec` and `tokens` are set when the turn completes. During streaming the header shows
+`agent · model` and nothing on the right; the values appear on completion. Both live on the
+right edge and grow leftward, so the left side never shifts.
+
+`LiveActivity` (`ChatTab.tsx:1996`) moves from the top of the container to **below** the rule.
+It is content belonging to the turn, not identification of it.
+
+### 5. Container
+
+The assistant container is as the reverted design specified, with the padding bug fixed:
+
+- no background, border, shadow, or radius
+- `maxWidth: 'min(100%, 78ch)'` — `ch` resolves against the container's 13px font, so 78ch
+  ≈ 562px ≈ 72 characters of 14px body text, or ~43 Chinese characters
+- `padding: '6px 0 0 12px'` — the 6px top is the previously-dropped vertical padding
+- selected state: 3px left accent rail, always present and transparent when unselected, so
+  selecting a turn does not shift the text column
+
+User messages keep the bubble untouched.
+
+### 6. Typography
+
+Unchanged from the reverted design, which was not the problem: `Markdown.tsx` gains
+`layout?: 'compact' | 'roomy'`, `compact` stays the default so the other sixteen call sites do
+not move, and only the main assistant body passes `roomy`. That work is recoverable verbatim
+from commits `81cd2d1`, `1203888`, `483eb23`, `81519e9` on the reverted branch, including the
+`tableGap` fix and the `Metrics` interface.
+
+## Components
+
+**New file** `codey-mac/src/components/TurnHeader.tsx`. `ChatTab.tsx` is 3265 lines and already
+does too much; new code has no reason to go into it.
+
+It exports two things:
+
+- `turnHeaderMeta(msg)` — a **pure function** producing the right-side items from a
+  `ChatMessage`. This is the part with real failure modes: a missing field must not leave an
+  orphaned `·` separator, `durationSec` may be `undefined` or non-finite, `tokens` may be
+  absent, and the fallback badge is conditional.
+- `TurnHeader` — the presentational component.
+
+## Testing
+
+Unlike the previous change, this one has genuinely testable logic, and it gets real tests:
+`turnHeaderMeta` is pure, and its failure modes are concrete (orphaned separators, non-finite
+duration, all-fields-absent producing an empty row rather than a stray `·`).
+
+The layout itself remains presentation-only and is verified by typecheck, the existing suite as
+a regression check, and human visual review. No tests will be written asserting that a style
+constant equals itself.
+
+**Visual review must actually be performed this time.** The previous round shipped on
+"typecheck clean, 322 tests passing", which proved only that nothing else broke — and the
+change was reverted a few hours later for a defect no automated check could have caught.
+
+## Open question
+
+Why the "Show thinking" toggle vanished completely under #205 is not established. The two
+possibilities:
+
+- **Layout.** Then it is fixed by construction here: the chevron lives in a header that is
+  always rendered, not in a floating unanchored line.
+- **Data** — `msg.thinking` is empty. Then the chevron will never appear and this design
+  changes nothing about it. The path to check is `useChats.tsx:225` (`thinkingToken`) through
+  to persistence; `thinking` is declared on `ChatMessage` (`packages/core/src/types/chat.ts:57`)
+  so it is expected to survive a reload.
+
+The implementation must verify which, and must not treat an absent chevron during review as
+"working as designed".
+
+## Risks
+
+- Removing the assistant background reduces figure/ground separation against the chat backdrop.
+  The header rule now provides most of that structure. If it still reads flat, the fallback is
+  a very subtle background on the assistant column — not restoring the bubble.
+- The header adds chrome to every turn, including one-line replies where it may outweigh the
+  content. This is the case to look at hardest during visual review.
+- Nested Markdown inside team and thinking blocks stays `compact` while the surrounding turn is
+  `roomy`, so a size step is visible at that boundary. Accepted: those blocks are deliberately
+  secondary.


### PR DESCRIPTION
Second attempt at making long assistant replies readable. The first (#205) was reverted by #208; this one fixes what that got wrong rather than repeating it.

## What the first attempt got wrong

Removing the bubble removed three things, and only two were replaced:

- background (grouping — which elements belong to this turn)
- border (replaced by the selected-state rail, as designed)
- **`padding: '10px 14px'` → `'0 0 0 12px'` — 10px of vertical padding, dropped without noticing**

The horizontal inset was preserved to the pixel (row 6 + rail 3 + padding 12 = the old row 6 + border 1 + bubble 14). The vertical was not considered at all. A turn's first element is often 11px `C.fg3` secondary chrome, which then sat flush against the previous message with neither background nor space marking it as part of this turn.

Boundaries were left to `marginBottom: 20`. Spacing is an implicit boundary, and it competes with the reply's own paragraph spacing — which the same change had just raised to 14px.

## What this does instead

Each assistant turn gets a header row over a hairline rule. The rule is an explicit boundary that does not compete with the content's spacing, and the header gives the thinking disclosure a permanent home instead of leaving it as an unanchored line above the reply.

```
claude-code · opus  ▸                    12s · 3.4k tok
──────────────────────────────────────────────────────
(thinking, when expanded)

Reply body, 14px / 1.7, capped at 78ch

                                                 10:42
```

- Model, fallback, tokens and duration move up from the footer; the footer keeps only the timestamp. Nothing appears in two places.
- The rule always renders; the metadata row renders only when it has content, so a turn with no metadata is a bare hairline rather than a blank line.
- `LiveActivity` moves below the rule — it is turn content, not turn identity.
- Container regains the dropped vertical padding: `'6px 0 0 12px'`.

Typography is unchanged from the reverted attempt, which was not the problem, and is recovered by cherry-pick (`81cd2d1`, `1203888`, `483eb23`, `81519e9`) rather than retyped — including the `tableGap` fix that keeps `compact` byte-equivalent.

## Notes for review

- `turnHeaderMeta` returns `stats: string[]` rather than a joined string, so an absent field cannot leave an orphaned `·`. That bug is prevented structurally, not by a guard.
- `formatTokens` moves verbatim out of `ChatTab`; tests pin both sides of its 10k formatting threshold so the move cannot silently change how counts read. (`ChatContextPanel.tsx:58` has a third copy — deduplicating it is unrelated to this goal and was left alone.)
- The thinking disclosure state is hoisted to `ChatTab` but stores **only explicit user toggles**. `defaultThinkingExpanded` still auto-opens thinking while the agent is working with no answer yet — that behaviour lived inside `ThinkingBlock` and would have been silently lost by a naive hoist.
- `ThinkingBlock` and its two team-context uses are untouched; only the single-agent path moved.
- `modelBadge` is kept — team worker messages still use it. `tsRight`, `tsMeta` and `fallbackBadge` were removed after confirming nothing else referenced them.

## Testing

`tsc` clean; **332 tests passing** (322 existing + 10 new for `turnHeaderMeta`).

Unlike #205, there is real logic here and it has real tests: identity assembly, stat ordering, absent and non-finite fields, zero token counts, and the empty case that drives the bare-hairline branch.

## Not yet verified — do not merge on the test count alone

**Visual review is outstanding.** #205 shipped on "typecheck clean, 322 tests passing" and was reverted hours later for a defect no automated check could see. The three things to look at:

1. **Does the thinking chevron appear?** #205's reported symptom was that "Show thinking" vanished entirely, which its diff does not explain — it touched no line of the `ThinkingBlock` render path. If the chevron appears here, that was a layout artefact and is fixed by construction. If it does not, `msg.thinking` is empty and the cause is in the data path (`useChats.tsx:576` → reducer → persistence), which is a separate change.
2. **Short replies.** A one-line answer may be outweighed by its own header. This is the risk the design knowingly takes.
3. **Light theme.** Assistant text now sits on `#f6f7fb` with no white bubble; the hairline must be visible without being harsh.

If 2 or 3 read poorly, the intended fallback is a very subtle background on the assistant column — not restoring the bubble.

Spec: `docs/superpowers/specs/2026-08-07-assistant-turn-header-design.md`
Plan: `docs/superpowers/plans/2026-08-07-assistant-turn-header.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)