### PR TITLE
Bump version to 0.12.1

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -22,7 +22,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.12.0",
+      "version": "0.12.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12251,7 +12251,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -12263,7 +12263,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps `0.12.0` → `0.12.1` across the root package, `codey-mac`, `@codey/core` and `@codey/gateway`, plus the matching workspace entries in `package-lock.json`.

Version only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)