### PR TITLE
Turn header: align the timestamp, defer the rule, keep done-event thinking

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -20,6 +20,7 @@ import { defaultThinkingExpanded } from './thinkingState'
 import { formatTokens } from './turnHeaderModel'
 import {
   TurnHeader, MESSAGE_ROW_INSET, TURN_RAIL_WIDTH, TURN_TEXT_PADDING, TURN_TEXT_INSET,
+  USER_BUBBLE_PADDING_X,
 } from './TurnHeader'
 import { ACTIVITY_LABEL } from './agentActivity'
 import { statusLine } from './checklistView'
@@ -2030,7 +2031,7 @@ export const ChatTab: React.FC<Props> = ({
               }}
             >
               <div style={isUser ? {
-                minWidth: 0, maxWidth: '72%', padding: '10px 14px',
+                minWidth: 0, maxWidth: '72%', padding: `10px ${USER_BUBBLE_PADDING_X}px`,
                 borderRadius: '16px 16px 4px 16px',
                 background: C.userBg,
                 color: C.onAccent, fontSize: 13, lineHeight: 1.55,
@@ -2247,10 +2248,13 @@ export const ChatTab: React.FC<Props> = ({
               <div
                 style={{
                   ...styles.tsLabel,
-                  // The footer sits inside the message row, which already
-                  // carries MESSAGE_ROW_INSET, so only the remainder is needed
-                  // to line the timestamp up with the reply above it.
-                  paddingLeft: isUser ? 4 : TURN_TEXT_INSET - MESSAGE_ROW_INSET,
+                  // A user turn is right-aligned, so its timestamp lines up on
+                  // the bubble's right text edge; an assistant turn is
+                  // left-aligned, so its timestamp lines up on the left. The
+                  // footer sits inside the message row, which already carries
+                  // MESSAGE_ROW_INSET, so only the remainder is needed there.
+                  paddingLeft: isUser ? 0 : TURN_TEXT_INSET - MESSAGE_ROW_INSET,
+                  paddingRight: isUser ? USER_BUBBLE_PADDING_X : 0,
                 }}
               >
                 <span>{fmtTime(msg.timestamp)}</span>
@@ -2701,9 +2705,10 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', gap: 8, color: C.fg3, fontSize: 13,
     marginBottom: 12, paddingLeft: TURN_TEXT_INSET,
   },
-  // paddingLeft is set per role at the render site — it has to line up with the
-  // reply above it, which is inset differently for user and assistant.
-  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, paddingRight: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  // Horizontal padding is set per role at the render site — the timestamp has to
+  // line up with the reply above it, which is inset differently (and from the
+  // opposite edge) for user and assistant.
+  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
   // modelBadge is still used by team worker messages; tsRight, tsMeta and
   // fallbackBadge moved into TurnHeader with the metadata they styled.
   modelBadge: {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -18,7 +18,9 @@ import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
 import { formatTokens } from './turnHeaderModel'
-import { TurnHeader } from './TurnHeader'
+import {
+  TurnHeader, MESSAGE_ROW_INSET, TURN_RAIL_WIDTH, TURN_TEXT_PADDING, TURN_TEXT_INSET,
+} from './TurnHeader'
 import { ACTIVITY_LABEL } from './agentActivity'
 import { statusLine } from './checklistView'
 import { composerPlaceholder } from './coreOfflineView'
@@ -2022,7 +2024,7 @@ export const ChatTab: React.FC<Props> = ({
                 alignItems: isUser ? 'flex-end' : 'flex-start',
                 marginBottom: isUser ? 12 : 20,
                 cursor: isUser ? 'default' : 'pointer',
-                paddingLeft: !isUser ? 6 : 0,
+                paddingLeft: !isUser ? MESSAGE_ROW_INSET : 0,
                 transform: isSelected ? 'translateY(-3px)' : 'translateY(0)',
                 transition: 'transform 0.18s ease',
               }}
@@ -2045,11 +2047,10 @@ export const ChatTab: React.FC<Props> = ({
                 minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
                 // 6px top is the vertical padding the first attempt at this
                 // silently dropped when it replaced the bubble's '10px 14px'.
-                // Left: 3 (rail) + 12 = the old 1 (border) + 14 (bubble).
-                padding: '6px 0 0 12px',
-                // The rail is always 3px, transparent when unselected, so
+                padding: `6px 0 0 ${TURN_TEXT_PADDING}px`,
+                // The rail is always present, transparent when unselected, so
                 // selecting a turn never shifts the text column sideways.
-                borderLeft: `3px solid ${isSelected ? C.accent : 'transparent'}`,
+                borderLeft: `${TURN_RAIL_WIDTH}px solid ${isSelected ? C.accent : 'transparent'}`,
                 background: isSelected ? C.accentDim : 'transparent',
                 // fontSize/lineHeight stay compact: non-Markdown children
                 // inherit them. Roomy applies inside <Markdown layout="roomy">.
@@ -2235,7 +2236,15 @@ export const ChatTab: React.FC<Props> = ({
               {/* Model, fallback, tokens and duration now live in TurnHeader.
                   The timestamp stays here so it does not compete with the
                   turn's identity for the reader's attention. */}
-              <div style={styles.tsLabel}>
+              <div
+                style={{
+                  ...styles.tsLabel,
+                  // The footer sits inside the message row, which already
+                  // carries MESSAGE_ROW_INSET, so only the remainder is needed
+                  // to line the timestamp up with the reply above it.
+                  paddingLeft: isUser ? 4 : TURN_TEXT_INSET - MESSAGE_ROW_INSET,
+                }}
+              >
                 <span>{fmtTime(msg.timestamp)}</span>
               </div>
             </div>
@@ -2677,8 +2686,15 @@ const styles: Record<string, React.CSSProperties> = {
   editorOpeningLabel: { color: C.fg2, fontSize: 11, whiteSpace: 'nowrap' },
   editorMenuEmpty: { color: C.fg3, fontSize: 11, lineHeight: 1.4, padding: '8px 9px', maxWidth: 220 },
   messages: { flex: 1, overflowY: 'auto', padding: '22px max(22px, 5%)', background: C.bg },
-  typingRow: { display: 'flex', alignItems: 'center', gap: 8, color: C.fg3, fontSize: 13, marginBottom: 12 },
-  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, paddingLeft: 4, paddingRight: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  // The status row is a direct child of `messages`, not of a message row, so it
+  // carries the full inset rather than the remainder.
+  typingRow: {
+    display: 'flex', alignItems: 'center', gap: 8, color: C.fg3, fontSize: 13,
+    marginBottom: 12, paddingLeft: TURN_TEXT_INSET,
+  },
+  // paddingLeft is set per role at the render site — it has to line up with the
+  // reply above it, which is inset differently for user and assistant.
+  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, paddingRight: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
   // modelBadge is still used by team worker messages; tsRight, tsMeta and
   // fallbackBadge moved into TurnHeader with the metadata they styled.
   modelBadge: {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2060,6 +2060,10 @@ export const ChatTab: React.FC<Props> = ({
               }}>
                 {!isUser && (() => {
                   const thinking = msg.thinking?.trim() ?? ''
+                  // Keyed off the in-flight turn rather than msg.isComplete:
+                  // messages persisted before isComplete existed would
+                  // otherwise lose their rule and timestamp for good.
+                  const streaming = !!flight && msg === lastMsg
                   const expanded = thinkingToggles[msg.id]
                     ?? defaultThinkingExpanded({
                       hasAnswer: !!msg.content.trim(),
@@ -2070,6 +2074,7 @@ export const ChatTab: React.FC<Props> = ({
                       <TurnHeader
                         msg={msg}
                         hasThinking={!!thinking}
+                        turnComplete={!streaming}
                         expanded={expanded}
                         onToggle={() => setThinkingToggles(p => ({ ...p, [msg.id]: !expanded }))}
                       />
@@ -2236,6 +2241,9 @@ export const ChatTab: React.FC<Props> = ({
               {/* Model, fallback, tokens and duration now live in TurnHeader.
                   The timestamp stays here so it does not compete with the
                   turn's identity for the reader's attention. */}
+              {/* The timestamp records when the turn landed, so it waits until
+                  the turn has landed. */}
+              {!(!isUser && !!flight && msg === lastMsg) && (
               <div
                 style={{
                   ...styles.tsLabel,
@@ -2247,6 +2255,7 @@ export const ChatTab: React.FC<Props> = ({
               >
                 <span>{fmtTime(msg.timestamp)}</span>
               </div>
+              )}
             </div>
           )
         })}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2042,22 +2042,34 @@ export const ChatTab: React.FC<Props> = ({
                 // boundary the bubble used to provide.
                 //
                 // `ch` resolves against this element's 13px font, so 78ch is
-                // ~562px — about 72 characters of the 14px roomy body text, or
-                // ~43 Chinese characters. Unlike the old 72%, it does not grow
-                // with the window.
+                // ~562px. box-sizing is border-box, so the rail and the 27px of
+                // horizontal padding come out of that, leaving ~535px of text —
+                // about 68 characters of the 14px roomy body, or ~41 Chinese
+                // characters. Unlike the old 72%, it does not grow with the
+                // window.
                 minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
-                // 6px top is the vertical padding the first attempt at this
-                // silently dropped when it replaced the bubble's '10px 14px'.
-                padding: `6px 0 0 ${TURN_TEXT_PADDING}px`,
+                // Padding on all four sides so the selected highlight reads as a
+                // card rather than a rectangle cut through the text. It is
+                // unconditional — applying it only when selected would shift the
+                // whole reply the moment you click it.
+                //
+                // Right padding equals rail + left padding, so the text sits the
+                // same distance from both inner edges of the highlight.
+                padding: `8px ${TURN_RAIL_WIDTH + TURN_TEXT_PADDING}px 10px ${TURN_TEXT_PADDING}px`,
                 // The rail is always present, transparent when unselected, so
                 // selecting a turn never shifts the text column sideways.
                 borderLeft: `${TURN_RAIL_WIDTH}px solid ${isSelected ? C.accent : 'transparent'}`,
+                borderRadius: 10,
                 background: isSelected ? C.accentDim : 'transparent',
+                // Same treatment the rest of the app gives an active card
+                // (teamStepCardActive, teamRoundTableMemberActive): a tint plus a
+                // 1px accent ring, which defines the edge without a hard border.
+                boxShadow: isSelected ? `0 0 0 1px ${C.accentDim}` : 'none',
                 // fontSize/lineHeight stay compact: non-Markdown children
                 // inherit them. Roomy applies inside <Markdown layout="roomy">.
                 color: C.fg, fontSize: 13, lineHeight: 1.55,
                 overflowWrap: 'anywhere', wordBreak: 'break-word',
-                transition: 'border-color 0.18s ease, background 0.18s ease',
+                transition: 'border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease',
               }}>
                 {!isUser && (() => {
                   const thinking = msg.thinking?.trim() ?? ''

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -3,6 +3,21 @@ import { C } from '../theme'
 import { turnHeaderMeta } from './turnHeaderModel'
 import type { ChatMessage } from '../types'
 
+/** Left inset applied to a whole message row. */
+export const MESSAGE_ROW_INSET = 6
+/** Width of the selection rail down the left of an assistant turn. */
+export const TURN_RAIL_WIDTH = 3
+/** Gap between the rail and the text. Chosen so the text column lands exactly
+ *  where the old bubble put it: rail 3 + 12 == the bubble's border 1 + padding 14. */
+export const TURN_TEXT_PADDING = 12
+
+/** Left inset of an assistant turn's text column, measured from the messages
+ *  container. Everything that belongs to the turn — the header, the reply, the
+ *  timestamp footer, the status row — aligns to this one value. They used to
+ *  carry independent numbers (21, 10 and 0), which read as three ragged left
+ *  edges. */
+export const TURN_TEXT_INSET = MESSAGE_ROW_INSET + TURN_RAIL_WIDTH + TURN_TEXT_PADDING
+
 interface Props {
   msg: ChatMessage
   /** Rendered only when the turn has thinking to disclose. */

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -18,6 +18,10 @@ export const TURN_TEXT_PADDING = 12
  *  edges. */
 export const TURN_TEXT_INSET = MESSAGE_ROW_INSET + TURN_RAIL_WIDTH + TURN_TEXT_PADDING
 
+/** Horizontal padding inside the user bubble. A user turn is right-aligned, so
+ *  its timestamp lines up on the right edge and needs this, not TURN_TEXT_INSET. */
+export const USER_BUBBLE_PADDING_X = 14
+
 interface Props {
   msg: ChatMessage
   /** Rendered only when the turn has thinking to disclose. */

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -24,6 +24,10 @@ interface Props {
   hasThinking: boolean
   expanded: boolean
   onToggle: () => void
+  /** The rule closes a finished turn. While one is still streaming there is
+   *  nothing below it to bound, and a line drawn under a growing reply reads as
+   *  a separator in the wrong place. */
+  turnComplete: boolean
 }
 
 /** Identifies an assistant turn and bounds it.
@@ -38,13 +42,15 @@ interface Props {
  *  The rule always renders; the metadata row renders only when there is
  *  something to put in it, so a turn with no metadata is a bare hairline rather
  *  than a blank row. */
-export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle }) => {
+export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete }) => {
   const meta = turnHeaderMeta(msg)
-  if (meta.isEmpty && !hasThinking) return <div style={styles.rule} />
+  const rule = turnComplete ? <div style={styles.rule} /> : null
+  if (meta.isEmpty && !hasThinking) return rule
 
   return (
     <div>
-      <div style={styles.row}>
+      {/* Without the rule below it, the row supplies its own bottom gap. */}
+      <div style={{ ...styles.row, marginBottom: turnComplete ? 4 : 12 }}>
         <div style={styles.left}>
           {meta.identity && (
             <span style={styles.identity} title={meta.identity}>{meta.identity}</span>
@@ -75,7 +81,7 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
           )}
         </div>
       </div>
-      <div style={styles.rule} />
+      {rule}
     </div>
   )
 }

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -44,7 +44,7 @@ type Action =
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: AgentActivity; messageId?: string }
   | { type: 'patchChecklist'; chatId: string; items: ChecklistItem[] }
   | { type: 'queued'; chatId: string; position: number }
-  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; tokens?: number; durationSec?: number; agent?: ChatMessage['agent']; model?: string; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion']; fallback?: ChatMessage['fallback']; teamTurnId?: string }
+  | { type: 'completeSend'; chatId: string; assistantMessageId: string; content: string; thinking?: string; tokens?: number; durationSec?: number; agent?: ChatMessage['agent']; model?: string; title?: string; choices?: string[]; userQuestion?: ChatMessage['userQuestion']; fallback?: ChatMessage['fallback']; teamTurnId?: string }
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
   | { type: 'stoppedSend'; chatId: string; text: string }
   | { type: 'clearRestore'; chatId: string }
@@ -376,7 +376,10 @@ export function reducer(state: State, action: Action): State {
       } else {
         messages = chat.messages.map(m =>
           m.id === action.assistantMessageId
-            ? { ...m, content: action.content, tokens: action.tokens, durationSec: action.durationSec, agent: action.agent, model: action.model, isComplete: true, choices: action.choices, userQuestion: action.userQuestion, fallback: action.fallback }
+            // `?? m.thinking` rather than a plain assignment: thinking that
+            // already streamed in through thinkingToken must not be wiped by a
+            // done event that carries none.
+            ? { ...m, content: action.content, thinking: action.thinking ?? m.thinking, tokens: action.tokens, durationSec: action.durationSec, agent: action.agent, model: action.model, isComplete: true, choices: action.choices, userQuestion: action.userQuestion, fallback: action.fallback }
             : m
         )
       }
@@ -618,6 +621,12 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               chatId: ev.chatId,
               assistantMessageId: asstId,
               content: ev.response,
+              // The agent may report thinking only at the end rather than
+              // streaming it (claude-code does exactly that when the deltas
+              // arrive as whole assistant blocks). Without this the renderer
+              // has no thinking for those turns even though the gateway
+              // persisted it, so the disclosure never appears until refetch.
+              thinking: ev.thinking,
               tokens: ev.tokens,
               durationSec: ev.durationSec,
               agent: ev.agent,


### PR DESCRIPTION
Follow-ups to #209, which was merged before these landed. Three fixes found by looking at the shipped UI.

## 1. A turn read as three ragged left edges

The reply, the timestamp and the status row each carried an independent left inset:

| | composition | inset |
|---|---|---|
| reply text | row 6 + rail 3 + padding 12 | **21px** |
| timestamp | row 6 + `tsLabel` 4 | **10px** |
| status row | direct child of `messages`, no padding | **0px** |

Measured off a screenshot of the shipped build, the gaps came out at 10.5px and 10px — matching those numbers.

They now derive from one `TURN_TEXT_INSET`, which is itself composed from `MESSAGE_ROW_INSET + TURN_RAIL_WIDTH + TURN_TEXT_PADDING` rather than being a fourth magic number. Change the rail width or the text padding and the timestamp and status row follow.

Note the two call sites intentionally use *different* numbers: the timestamp lives inside the message row, which already carries `MESSAGE_ROW_INSET`, so it gets the remainder; the status row is a direct child of `messages` and gets the full inset. That asymmetry is commented, because it looks like a typo otherwise.

## 2. The user turn's timestamp was misaligned too, on the other edge

The first pass fixed only the assistant side. A user turn is right-aligned, so its timestamp lines up on the right: the bubble's text sits 14px from the row's right edge, the timestamp sat 4px from it. Both now derive from `USER_BUBBLE_PADDING_X`, which also feeds the bubble's own padding so they cannot drift apart again.

## 3. The rule and timestamp appeared mid-turn

A hairline drawn under a still-growing reply reads as a separator in the wrong place, and a timestamp should record when the turn landed. Both now wait for the turn to finish.

Keyed off the in-flight turn rather than `msg.isComplete`: messages persisted before `isComplete` existed would otherwise lose their rule and timestamp permanently. Without a rule below it the header row supplies its own bottom gap, so the body does not ride up.

## 4. The thinking chevron could never appear for some turns

`chat-runner` puts `thinking` on the `done` event and the gateway persists it, but `useChats`' `done` handler never passed it to `completeSend`. Meanwhile `claude-code` only calls `onThinking` for delta-shaped thinking (`claude-code.ts:237` accumulates whole-block thinking without notifying — asymmetric with the text branch right below it, which does call `onStream`).

So a turn whose thinking arrived as whole assistant blocks had thinking on disk and none in the renderer, and the disclosure never appeared until the chat was refetched. Fixed in the renderer, which covers both shapes without changing adapter behaviour.

Merged with `??` rather than assigned: a `done` event carrying no thinking must not wipe thinking that already streamed in through `thinkingToken`.

## Testing

`tsc` clean; **372 tests passing**. No new tests — these are style constants plus one field passed through a reducer; the header's actual logic is already covered by the 10 `turnHeaderMeta` tests from #209.

## Still not verified

The alignment and the deferred rule are geometry I have reasoned about and measured off a screenshot, not seen rendered. The thinking fix is traced through the code end to end but has not been observed working — if a completed turn still shows no chevron after this, the remaining possibility is that the turn genuinely produced no thinking.

Note when testing: build from this branch. The previously shipped `Codey.app` bundles #209 without these commits — `strings -a <app>/Contents/Resources/app.asar | grep -c turnComplete` returns 0 for a build that predates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)