### PR TITLE
Add skill usage counts/sorting, drop redundant "Inherit" labels

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -14,6 +14,8 @@ import { SKILL_FILE, resolveUserPath, samePath, scanClaudePluginSkills, scanSkil
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import type { ScannedSkill } from './skills'
+import { scanSkillUsage } from './skill-usage'
+import type { SkillUsageMap, UsageCacheEntry } from './skill-usage'
 import { BROWSER_PARTITION, BrowserController, type BrowserBounds } from './browser-controller'
 import { BrowserAgentBridge, type BrowserLoginWaitEvent } from './browser-agent-bridge'
 import { BrowserControlPermissionGate } from './browser-control-permission'
@@ -3327,6 +3329,27 @@ app.whenReady().then(async () => {
     wrap(async () => {
       const agentKey = agent ?? 'claude-code'
       return listAgentSkills(agentKey)
+    })
+  )
+
+  // Transcripts are large and append-only; the cache lives for the app session
+  // so re-opening the Skills tab only reads whatever grew since the last scan.
+  const skillUsageCache = new Map<string, UsageCacheEntry>()
+
+  ipcMain.handle('skills:usage', async (_e, agent?: string) =>
+    wrap(async () => {
+      const agentKey = agent ?? 'claude-code'
+      // Only Claude Code records skill invocations in a format we can read;
+      // for the others the Skills tab falls back to name ordering.
+      if (agentKey !== 'claude-code') return {} as SkillUsageMap
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const osMod = await import('os')
+      const env = coreConfigManager?.get().agents?.['claude-code']?.env ?? {}
+      const configRoot = env.CLAUDE_CONFIG_DIR
+        ? resolveUserPath(pathMod, env.CLAUDE_CONFIG_DIR, osMod.homedir())
+        : pathMod.join(osMod.homedir(), '.claude')
+      return scanSkillUsage(fsMod, pathMod, [pathMod.join(configRoot, 'projects')], skillUsageCache)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -125,6 +125,7 @@ contextBridge.exposeInMainWorld('codey', {
   },
   skills: {
     list: (agent?: string) => ipcRenderer.invoke('skills:list', agent),
+    usage: (agent?: string) => ipcRenderer.invoke('skills:usage', agent),
     install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) =>
       ipcRenderer.invoke('skills:install', payload),
     remove: (dir: string) => ipcRenderer.invoke('skills:remove', dir),

--- a/codey-mac/electron/skill-usage.test.ts
+++ b/codey-mac/electron/skill-usage.test.ts
@@ -1,0 +1,96 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { collectUsageFromTranscript, mergeUsage, scanSkillUsage } from './skill-usage'
+import type { UsageCacheEntry } from './skill-usage'
+
+const roots: string[] = []
+const temp = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-skill-usage-'))
+  roots.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+})
+
+const skillLine = (skill: string, timestamp: string) => JSON.stringify({
+  timestamp,
+  message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Skill', input: { skill } }] },
+})
+
+describe('collectUsageFromTranscript', () => {
+  it('counts invocations and keeps the latest timestamp', () => {
+    const text = [
+      skillLine('superpowers:brainstorming', '2026-07-01T00:00:00.000Z'),
+      skillLine('superpowers:brainstorming', '2026-07-03T00:00:00.000Z'),
+      skillLine('graphify', '2026-07-02T00:00:00.000Z'),
+    ].join('\n')
+    expect(collectUsageFromTranscript(text)).toEqual({
+      'superpowers:brainstorming': { count: 2, lastUsedAt: Date.parse('2026-07-03T00:00:00.000Z') },
+      'graphify': { count: 1, lastUsedAt: Date.parse('2026-07-02T00:00:00.000Z') },
+    })
+  })
+
+  it('lowercases ids and survives malformed or unrelated lines', () => {
+    const text = [
+      '{ not json',
+      JSON.stringify({ timestamp: 'nonsense', message: { content: [{ type: 'tool_use', name: 'Skill', input: { skill: 'GraphIfy' } }] } }),
+      JSON.stringify({ message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }] } }),
+      JSON.stringify({ message: { content: 'plain text mentioning "name":"Skill"' } }),
+    ].join('\n')
+    expect(collectUsageFromTranscript(text)).toEqual({ graphify: { count: 1, lastUsedAt: 0 } })
+  })
+
+  it('ignores a tool result echoing the tool name', () => {
+    const text = JSON.stringify({
+      message: { role: 'user', content: [{ type: 'tool_result', name: 'Skill', content: 'done' }] },
+    })
+    expect(collectUsageFromTranscript(text)).toEqual({})
+  })
+})
+
+describe('mergeUsage', () => {
+  it('sums counts and takes the newer timestamp', () => {
+    const target = { a: { count: 1, lastUsedAt: 500 } }
+    mergeUsage(target, { a: { count: 2, lastUsedAt: 100 }, b: { count: 1, lastUsedAt: 900 } })
+    expect(target).toEqual({ a: { count: 3, lastUsedAt: 500 }, b: { count: 1, lastUsedAt: 900 } })
+  })
+})
+
+describe('scanSkillUsage', () => {
+  it('aggregates nested transcripts and skips non-jsonl files', async () => {
+    const root = temp()
+    fs.mkdirSync(path.join(root, 'project-a'), { recursive: true })
+    fs.writeFileSync(path.join(root, 'project-a', 'one.jsonl'), skillLine('graphify', '2026-07-01T00:00:00.000Z'))
+    fs.writeFileSync(path.join(root, 'two.jsonl'), skillLine('graphify', '2026-07-05T00:00:00.000Z'))
+    fs.writeFileSync(path.join(root, 'notes.txt'), skillLine('ignored', '2026-07-05T00:00:00.000Z'))
+
+    expect(await scanSkillUsage(fs, path, [root, path.join(root, 'missing')], new Map())).toEqual({
+      graphify: { count: 2, lastUsedAt: Date.parse('2026-07-05T00:00:00.000Z') },
+    })
+  })
+
+  it('reuses the cache until a transcript changes', async () => {
+    const root = temp()
+    const file = path.join(root, 'session.jsonl')
+    fs.writeFileSync(file, skillLine('graphify', '2026-07-01T00:00:00.000Z'))
+    const cache = new Map<string, UsageCacheEntry>()
+
+    expect(await scanSkillUsage(fs, path, [root], cache)).toEqual({
+      graphify: { count: 1, lastUsedAt: Date.parse('2026-07-01T00:00:00.000Z') },
+    })
+    // Cached entries must not be mutated by the merge into the running total.
+    expect(cache.get(file)?.usage).toEqual({ graphify: { count: 1, lastUsedAt: Date.parse('2026-07-01T00:00:00.000Z') } })
+    expect(await scanSkillUsage(fs, path, [root], cache)).toEqual({
+      graphify: { count: 1, lastUsedAt: Date.parse('2026-07-01T00:00:00.000Z') },
+    })
+
+    fs.appendFileSync(file, '\n' + skillLine('graphify', '2026-07-09T00:00:00.000Z'))
+    expect(await scanSkillUsage(fs, path, [root], cache)).toEqual({
+      graphify: { count: 2, lastUsedAt: Date.parse('2026-07-09T00:00:00.000Z') },
+    })
+  })
+})

--- a/codey-mac/electron/skill-usage.ts
+++ b/codey-mac/electron/skill-usage.ts
@@ -1,0 +1,120 @@
+import type * as Fs from 'fs'
+import type * as Path from 'path'
+
+export interface SkillUsage {
+  /** How many times the skill was invoked across all recorded sessions. */
+  count: number
+  /** Epoch ms of the most recent invocation, or 0 when unknown. */
+  lastUsedAt: number
+}
+
+/** Usage keyed by the skill id as it was invoked, lowercased. */
+export type SkillUsageMap = Record<string, SkillUsage>
+
+export interface UsageCacheEntry {
+  mtimeMs: number
+  size: number
+  usage: SkillUsageMap
+}
+
+/** Cheap pre-filter so we only JSON.parse the handful of lines that matter. */
+const SKILL_TOOL_HINT = '"name":"Skill"'
+
+function record(into: SkillUsageMap, id: string, at: number): void {
+  const key = id.trim().toLowerCase()
+  if (!key) return
+  const prev = into[key]
+  if (prev) {
+    prev.count += 1
+    if (at > prev.lastUsedAt) prev.lastUsedAt = at
+  } else {
+    into[key] = { count: 1, lastUsedAt: at }
+  }
+}
+
+/**
+ * Extract Skill tool invocations from one agent transcript (JSONL).
+ *
+ * Agents log every tool call, so the transcripts are the only record of what a
+ * skill was actually used for — nothing in the app writes usage stats itself.
+ */
+export function collectUsageFromTranscript(text: string): SkillUsageMap {
+  const usage: SkillUsageMap = {}
+  for (const line of text.split('\n')) {
+    if (!line.includes(SKILL_TOOL_HINT)) continue
+    let entry: any
+    try { entry = JSON.parse(line) } catch { continue }
+    const content = entry?.message?.content
+    if (!Array.isArray(content)) continue
+    const at = Date.parse(entry?.timestamp ?? '')
+    for (const block of content) {
+      if (block?.type !== 'tool_use' || block?.name !== 'Skill') continue
+      const id = block?.input?.skill
+      if (typeof id === 'string') record(usage, id, Number.isNaN(at) ? 0 : at)
+    }
+  }
+  return usage
+}
+
+export function mergeUsage(target: SkillUsageMap, extra: SkillUsageMap): SkillUsageMap {
+  for (const [key, value] of Object.entries(extra)) {
+    const prev = target[key]
+    if (prev) {
+      prev.count += value.count
+      if (value.lastUsedAt > prev.lastUsedAt) prev.lastUsedAt = value.lastUsedAt
+    } else {
+      target[key] = { count: value.count, lastUsedAt: value.lastUsedAt }
+    }
+  }
+  return target
+}
+
+function collectTranscriptFiles(fsMod: typeof Fs, pathMod: typeof Path, root: string): string[] {
+  const files: string[] = []
+  const pending = [root]
+  const visited = new Set<string>()
+  while (pending.length > 0) {
+    const current = pending.pop()!
+    if (visited.has(current)) continue
+    visited.add(current)
+    let entries: Fs.Dirent[] = []
+    try { entries = fsMod.readdirSync(current, { withFileTypes: true }) } catch { continue }
+    for (const entry of entries) {
+      const child = pathMod.join(current, entry.name)
+      if (entry.isDirectory()) pending.push(child)
+      else if (entry.isFile() && entry.name.endsWith('.jsonl')) files.push(child)
+    }
+  }
+  return files
+}
+
+/**
+ * Aggregate skill usage across an agent's transcript roots. Transcripts are
+ * append-only, but a single history can run to hundreds of megabytes, so
+ * results are cached per file and only re-read when size or mtime moves.
+ */
+export async function scanSkillUsage(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  roots: string[],
+  cache: Map<string, UsageCacheEntry>,
+): Promise<SkillUsageMap> {
+  const total: SkillUsageMap = {}
+  for (const root of roots) {
+    for (const file of collectTranscriptFiles(fsMod, pathMod, root)) {
+      let stat: Fs.Stats
+      try { stat = fsMod.statSync(file) } catch { continue }
+      const cached = cache.get(file)
+      if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+        mergeUsage(total, cached.usage)
+        continue
+      }
+      let text: string
+      try { text = await fsMod.promises.readFile(file, 'utf-8') } catch { continue }
+      const usage = collectUsageFromTranscript(text)
+      cache.set(file, { mtimeMs: stat.mtimeMs, size: stat.size, usage })
+      mergeUsage(total, usage)
+    }
+  }
+  return total
+}

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -6,6 +6,7 @@ import type { ApiKeyEntry } from '../../packages/core/src/types/index'
 import type { UpdaterEvent } from './hooks/updaterState'
 import type { CoreState } from '../electron/core-state'
 import type { ScannedSkill } from '../electron/skills'
+import type { SkillUsage, SkillUsageMap } from '../electron/skill-usage'
 import type { Automation, AutomationRun, AutomationEvent } from '../../packages/core/src/types/automation'
 import type { AutomationDraft } from '../../packages/core/src/aide-automation'
 import type { ChatStep } from '../../packages/gateway/src/automations/chat'
@@ -13,6 +14,7 @@ import type { ChatStep } from '../../packages/gateway/src/automations/chat'
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
 export type SkillEntry = ScannedSkill
+export type { SkillUsage, SkillUsageMap }
 
 export interface SkillsListResult {
   skills: SkillEntry[]
@@ -246,6 +248,7 @@ declare global {
       }
       skills: {
         list: (agent?: string) => Promise<IpcResult<SkillsListResult>>
+        usage: (agent?: string) => Promise<IpcResult<SkillUsageMap>>
         install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) => Promise<IpcResult<{ name: string; dir: string }>>
         remove: (dir: string) => Promise<IpcResult<void>>
         setEnabled: (dir: string, enabled: boolean) => Promise<IpcResult<void>>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1862,7 +1862,7 @@ export const ChatTab: React.FC<Props> = ({
                         style={styles.runSettingSelect}
                         title={`Agent: ${effectiveAgent}${chat.agent ? ' (override)' : workerAgent ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
                       >
-                        <option value="">Inherit ({effectiveAgent})</option>
+                        <option value="">{effectiveAgent}</option>
                         {AGENT_NAMES.filter(n => enabledAgents.includes(n) || n === chat.agent).map(n => (
                           <option key={n} value={n}>{n}</option>
                         ))}
@@ -1877,7 +1877,7 @@ export const ChatTab: React.FC<Props> = ({
                         title={`Model: ${effectiveModel ?? 'unset'}${chat.model ? ' (override)' : workerModel ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
                         disabled={modelsForAgent.length === 0}
                       >
-                        <option value="">Inherit ({effectiveModel ?? 'agent default'})</option>
+                        <option value="">{effectiveModel ?? 'agent default'}</option>
                         {modelsForAgent.map(m => (
                           <option key={m.model} value={m.model}>{m.model}</option>
                         ))}

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -3,7 +3,9 @@ import { C } from '../theme'
 import { pillButton, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
-import type { SkillEntry, SkillsListResult } from '../codey-api'
+import { SKILL_SORT_MODES, sortSkills, usageFor, usageLabel } from './skillsSort'
+import type { SkillSortMode } from './skillsSort'
+import type { SkillEntry, SkillUsageMap, SkillsListResult } from '../codey-api'
 
 type AgentFilter = 'claude-code' | 'opencode' | 'codex'
 const AGENTS: { key: AgentFilter; label: string }[] = [
@@ -49,12 +51,20 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   const [copyState, setCopyState] = useState<{ label: string; status: 'copying' | 'done' | 'error'; msg?: string } | null>(null)
   const [copyMenuOpen, setCopyMenuOpen] = useState(false)
   const [busyDirs, setBusyDirs] = useState<Set<string>>(new Set())
+  const [usage, setUsage] = useState<SkillUsageMap>({})
+  const [sortMode, setSortMode] = useState<SkillSortMode>('name')
   const copyRef = useRef<HTMLDivElement>(null)
   const initDone = useRef(false)
+  const usageToken = useRef(0)
   const filteredSkills = useMemo(
-    () => data.skills.filter(skill => matchesToolSearch(searchQuery, skill.name, skill.qualifiedName, skill.description)),
-    [data.skills, searchQuery],
+    () => sortSkills(
+      data.skills.filter(skill => matchesToolSearch(searchQuery, skill.name, skill.qualifiedName, skill.description)),
+      sortMode,
+      usage,
+    ),
+    [data.skills, searchQuery, sortMode, usage],
   )
+  const now = Date.now()
 
   // The primary action lives in the parent Tools tab bar; this counter gives
   // that button a clean way to open the existing install form without a second
@@ -75,6 +85,16 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
       setError(e?.message ?? String(e))
     } finally {
       setLoading(false)
+    }
+    // Usage comes from scanning agent transcripts, which is slower than the
+    // skill scan and non-essential: let the list paint, then fill counts in.
+    // The token drops a slow scan whose agent is no longer the selected one.
+    const token = ++usageToken.current
+    try {
+      const next = unwrap(await window.codey.skills.usage(agent))
+      if (token === usageToken.current) setUsage(next)
+    } catch {
+      if (token === usageToken.current) setUsage({})
     }
   }, [])
 
@@ -184,7 +204,9 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     else setCopyState({ label, status: 'done' })
   }
 
-  const renderCard = (skill: SkillEntry) => (
+  const renderCard = (skill: SkillEntry) => {
+    const meta = usageLabel(usageFor(usage, skill), now)
+    return (
     <button
       key={skill.dir}
       onClick={() => { setSelected(skill); setCopyState(null); setCopyMenuOpen(false); setError(null) }}
@@ -231,8 +253,12 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           {skill.description}
         </div>
       )}
+      {meta && (
+        <div style={{ color: C.fg3, fontSize: 10, opacity: 0.85, marginTop: 'auto', paddingTop: 6 }}>{meta}</div>
+      )}
     </button>
-  )
+    )
+  }
 
   const renderDetail = (skill: SkillEntry) => (
     <div
@@ -385,6 +411,20 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           </div>
         </div>
         <div style={styles.agentMeta}>
+          <div style={styles.smallSwitcher} role="tablist" aria-label="Sort skills">
+            {SKILL_SORT_MODES.map(mode => (
+              <button
+                key={mode.key}
+                role="tab"
+                aria-selected={sortMode === mode.key}
+                onClick={() => setSortMode(mode.key)}
+                title={mode.title}
+                style={{ ...styles.smallSwitchButton, ...(sortMode === mode.key ? styles.smallSwitchButtonSelected : undefined) }}
+              >
+                {mode.label}
+              </button>
+            ))}
+          </div>
           <span>{loading ? 'Scanning…' : searchQuery.trim()
             ? `${filteredSkills.length} of ${data.skills.length} skills`
             : `${data.skills.length} skill${data.skills.length === 1 ? '' : 's'}`}</span>

--- a/codey-mac/src/components/skillsSort.ts
+++ b/codey-mac/src/components/skillsSort.ts
@@ -1,0 +1,60 @@
+import type { SkillEntry, SkillUsage, SkillUsageMap } from '../codey-api'
+
+export type SkillSortMode = 'name' | 'recent' | 'frequent'
+
+export const SKILL_SORT_MODES: { key: SkillSortMode; label: string; title: string }[] = [
+  { key: 'name',     label: 'Name',          title: 'Alphabetical by name' },
+  { key: 'recent',   label: 'Recently used', title: 'Most recently used first (LRU)' },
+  { key: 'frequent', label: 'Most used',     title: 'Most frequently used first (LFU)' },
+]
+
+const NO_USAGE: SkillUsage = { count: 0, lastUsedAt: 0 }
+
+/**
+ * A skill is invoked by its qualified name (`superpowers:brainstorming`), but
+ * transcripts from before a skill was namespaced — and skills installed
+ * outside a collection — carry the bare name, so both are worth checking.
+ */
+export function usageFor(usage: SkillUsageMap, skill: SkillEntry): SkillUsage {
+  return usage[skill.qualifiedName.toLowerCase()] ?? usage[skill.name.toLowerCase()] ?? NO_USAGE
+}
+
+const byName = (a: SkillEntry, b: SkillEntry) => a.qualifiedName.localeCompare(b.qualifiedName)
+
+/** Sort a copy of `skills`; ties and never-used skills fall back to name order. */
+export function sortSkills(skills: SkillEntry[], mode: SkillSortMode, usage: SkillUsageMap): SkillEntry[] {
+  const sorted = [...skills]
+  if (mode === 'name') return sorted.sort(byName)
+  return sorted.sort((a, b) => {
+    const ua = usageFor(usage, a)
+    const ub = usageFor(usage, b)
+    if (mode === 'recent') {
+      if (ub.lastUsedAt !== ua.lastUsedAt) return ub.lastUsedAt - ua.lastUsedAt
+      if (ub.count !== ua.count) return ub.count - ua.count
+    } else {
+      if (ub.count !== ua.count) return ub.count - ua.count
+      if (ub.lastUsedAt !== ua.lastUsedAt) return ub.lastUsedAt - ua.lastUsedAt
+    }
+    return byName(a, b)
+  })
+}
+
+/** Compact "used 4× · 3d ago" line for a card; empty when never used. */
+export function usageLabel(usage: SkillUsage, now: number): string {
+  if (usage.count === 0) return ''
+  const times = `used ${usage.count}×`
+  if (!usage.lastUsedAt) return times
+  return `${times} · ${relativeTime(usage.lastUsedAt, now)}`
+}
+
+function relativeTime(at: number, now: number): string {
+  const seconds = Math.max(0, Math.round((now - at) / 1000))
+  if (seconds < 60) return 'just now'
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return `${Math.round(days / 30)}mo ago`
+}


### PR DESCRIPTION
## Summary
- Skills tab: scan Claude Code transcripts for skill invocations and add a usage-based sort (recent/frequent) alongside name sort
- Chat agent/model dropdowns: show the effective value directly instead of "Inherit (value)"

## Test plan
- [x] `vitest run electron/skill-usage.test.ts` passes
- [ ] Manual: open Skills tab, verify usage counts populate and sort toggles work
- [ ] Manual: verify chat agent/model dropdowns show plain values with no "Inherit" wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)