### PR TITLE
Drop a dead thinking helper, tighten the gap before the timestamp

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -391,6 +391,9 @@ ${paletteToCssVars(terminalDark)}
   /* Roomy headings open a section with a large top margin. The first block in a
      turn has nothing above it to separate from, so that margin is dead space. */
   .md-roomy > :first-child { margin-top: 0 !important; }
+  /* Same argument at the other end: the last block's bottom margin separates it
+     from nothing, and it was the largest part of the gap before the timestamp. */
+  .md-roomy > :last-child { margin-bottom: 0 !important; }
   body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
   * { box-sizing: border-box; }
   ::-webkit-scrollbar { width: 5px; height: 5px; }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2055,7 +2055,7 @@ export const ChatTab: React.FC<Props> = ({
                 //
                 // Right padding equals rail + left padding, so the text sits the
                 // same distance from both inner edges of the highlight.
-                padding: `8px ${TURN_RAIL_WIDTH + TURN_TEXT_PADDING}px 10px ${TURN_TEXT_PADDING}px`,
+                padding: `8px ${TURN_RAIL_WIDTH + TURN_TEXT_PADDING}px 6px ${TURN_TEXT_PADDING}px`,
                 // The rail is always present, transparent when unselected, so
                 // selecting a turn never shifts the text column sideways.
                 borderLeft: `${TURN_RAIL_WIDTH}px solid ${isSelected ? C.accent : 'transparent'}`,
@@ -2720,7 +2720,7 @@ const styles: Record<string, React.CSSProperties> = {
   // Horizontal padding is set per role at the render site — the timestamp has to
   // line up with the reply above it, which is inset differently (and from the
   // opposite edge) for user and assistant.
-  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 4, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
   // modelBadge is still used by team worker messages; tsRight, tsMeta and
   // fallbackBadge moved into TurnHeader with the metadata they styled.
   modelBadge: {

--- a/packages/core/src/agents/thinking-stream.test.ts
+++ b/packages/core/src/agents/thinking-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { thinkingDeltaFrom, isThinkingBlockStart } from './thinking-stream';
+import { thinkingDeltaFrom } from './thinking-stream';
 
 describe('thinkingDeltaFrom', () => {
   it('extracts text from a thinking_delta', () => {
@@ -26,28 +26,5 @@ describe('thinkingDeltaFrom', () => {
 
   it('returns null for non-delta events', () => {
     expect(thinkingDeltaFrom({ type: 'assistant' })).toBeNull();
-  });
-});
-
-describe('isThinkingBlockStart', () => {
-  it('is true for a thinking content_block_start', () => {
-    expect(isThinkingBlockStart({
-      type: 'stream_event',
-      event: { type: 'content_block_start', content_block: { type: 'thinking' } },
-    })).toBe(true);
-  });
-
-  it('is false for a tool_use start', () => {
-    expect(isThinkingBlockStart({
-      type: 'stream_event',
-      event: { type: 'content_block_start', content_block: { type: 'tool_use', name: 'Read' } },
-    })).toBe(false);
-  });
-
-  it('ignores redacted_thinking (no plaintext to show)', () => {
-    expect(isThinkingBlockStart({
-      type: 'stream_event',
-      event: { type: 'content_block_start', content_block: { type: 'redacted_thinking' } },
-    })).toBe(false);
   });
 });

--- a/packages/core/src/agents/thinking-stream.ts
+++ b/packages/core/src/agents/thinking-stream.ts
@@ -4,7 +4,6 @@ export interface ThinkingProbe {
   event?: {
     type?: string;
     delta?: { type?: string; thinking?: string; text?: string };
-    content_block?: { type?: string; name?: string };
   };
 }
 
@@ -17,11 +16,4 @@ export function thinkingDeltaFrom(event: ThinkingProbe): string | null {
     return delta.thinking;
   }
   return null;
-}
-
-/** True when this event opens a (non-redacted) thinking content block. */
-export function isThinkingBlockStart(event: ThinkingProbe): boolean {
-  if (event.type !== 'stream_event') return false;
-  if (event.event?.type !== 'content_block_start') return false;
-  return event.event.content_block?.type === 'thinking';
 }


### PR DESCRIPTION
Two small follow-ups to #212.

## Dead code

`isThinkingBlockStart` was referenced only by its own test — `claude-code` captures thinking through `thinkingDeltaFrom` alone (`claude-code.ts:203`). Removing it also retires the `content_block` field on `ThinkingProbe`, which existed only to feed it; left in place it reads as "this shape still needs handling here".

Its three tests go with it. `@codey/core` drops from 348 to 345 tests, which is exactly those three and nothing else.

## The gap between a reply and its timestamp

Measured off a screenshot: **37px** from the last line's ink to the timestamp's. Broken down:

| source | px |
|---|---|
| last line's half-leading | ~6 |
| trailing `<p>` bottom margin (roomy `blockGap`) | **14** |
| container `padding-bottom` | 10 |
| `tsLabel` `marginTop` | 4 |
| timestamp's own leading | ~2 |

The largest piece was dead space: the last block's bottom margin separates it from nothing. A `.md-roomy > :last-child { margin-bottom: 0 }` rule zeroes it — the same argument as the existing `:first-child { margin-top: 0 }` rule at the other end of the turn, which exists for exactly this reason. Container bottom padding 10 → 6 and `tsLabel` margin 4 → 2 take the rest.

Result is about **17px**.

Deliberately not smaller: the gap *below* the timestamp is 20px (the message row's `marginBottom`). Keeping the gap above clearly smaller is what makes the timestamp read as belonging to the turn above it rather than floating between two turns. Compressing both would trade one spacing problem for another.

## Testing

`tsc` clean. `@codey/core` 345, `@codey/gateway` 238, `codey-mac` 378 — all passing.

The 17px is arithmetic plus a pixel measurement of the previous state, not something I have seen rendered. If it reads tight, the number to move is the container's `padding-bottom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)