### PR TITLE
fix(core): honor is_error on the claude CLI result event so fallback engages

### DIFF
--- a/packages/core/src/agents/claude-code.test.ts
+++ b/packages/core/src/agents/claude-code.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { classifyClaudeRunResult } from './claude-code';
+
+// The claude CLI reports API-level failures (402 Insufficient Balance, session
+// limits, unknown models) as a stream-json `result` event with `is_error: true`
+// and the message in `result`. Some of those (session limits, billing errors)
+// still exit with code 0, so the adapter must treat the `is_error` flag as the
+// authoritative failure signal — otherwise the gateway's runWithFallback chain
+// never engages and the user just sees the raw API error as a "success".
+
+describe('classifyClaudeRunResult', () => {
+  it('classifies an API error result as failure even when the CLI exits 0', () => {
+    const cls = classifyClaudeRunResult({
+      code: 0,
+      result: 'API Error: 402 Insufficient Balance',
+      streamedText: '',
+      stderr: '',
+      resultIsError: true,
+      hasUserQuestion: false,
+    });
+
+    expect(cls.success).toBe(false);
+    expect(cls.error).toContain('402 Insufficient Balance');
+  });
+
+  it('keeps a clean result a success', () => {
+    const cls = classifyClaudeRunResult({
+      code: 0,
+      result: 'ok',
+      streamedText: '',
+      stderr: '',
+      resultIsError: false,
+      hasUserQuestion: false,
+    });
+
+    expect(cls.success).toBe(true);
+    expect(cls.output).toBe('ok');
+  });
+
+  it('falls back to streamed text when there is no result event', () => {
+    const cls = classifyClaudeRunResult({
+      code: 0,
+      result: '',
+      streamedText: 'ok',
+      stderr: '',
+      resultIsError: false,
+      hasUserQuestion: false,
+    });
+
+    expect(cls.success).toBe(true);
+    expect(cls.output).toBe('ok');
+  });
+
+  it('prefers the API error message over stderr noise for a flagged error', () => {
+    const cls = classifyClaudeRunResult({
+      code: 1,
+      result: 'API Error: 402 Insufficient Balance',
+      streamedText: '',
+      stderr: '⚠ claude.ai connectors are disabled…',
+      resultIsError: true,
+      hasUserQuestion: false,
+    });
+
+    expect(cls.success).toBe(false);
+    expect(cls.error).toContain('402 Insufficient Balance');
+    expect(cls.error).not.toContain('connectors');
+  });
+
+  it('still treats a non-zero exit without an is_error flag as a failure', () => {
+    const cls = classifyClaudeRunResult({
+      code: 2,
+      result: 'partial output',
+      streamedText: '',
+      stderr: '',
+      resultIsError: false,
+      hasUserQuestion: false,
+    });
+
+    expect(cls.success).toBe(false);
+    expect(cls.error).toContain('code 2');
+  });
+
+  it('keeps an AskUserQuestion result a success', () => {
+    const cls = classifyClaudeRunResult({
+      code: 0,
+      result: '{"question":"Continue?"}',
+      streamedText: '',
+      stderr: '',
+      resultIsError: false,
+      hasUserQuestion: true,
+    });
+
+    expect(cls.success).toBe(true);
+  });
+});

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -51,6 +51,40 @@ interface StreamEvent {
   permission_denials?: Array<{ tool_name: string; tool_input?: Record<string, unknown> }>;
 }
 
+export interface ClaudeRunClassification {
+  success: boolean;
+  output: string;
+  error?: string;
+}
+
+/**
+ * Classify a finished `claude` process into a success or failure response.
+ *
+ * The CLI reports API-level failures (402 Insufficient Balance, session
+ * limits, unknown models) as a stream-json `result` event with `is_error:
+ * true` and the message in `result` — and it can exit 0 for those. Exit code
+ * alone is therefore not a reliable failure signal; the result event's
+ * `is_error` flag must win. When it is set, the API message is also preferred
+ * over stderr, which may only hold an auth-source warning.
+ */
+export function classifyClaudeRunResult(input: {
+  code: number | null;
+  result: string;
+  streamedText: string;
+  stderr: string;
+  resultIsError: boolean;
+  hasUserQuestion: boolean;
+}): ClaudeRunClassification {
+  const { code, result, streamedText, stderr, resultIsError, hasUserQuestion } = input;
+  const output = result || streamedText;
+  if (hasUserQuestion) return { success: true, output };
+  if (code === 0 && output && !resultIsError) return { success: true, output };
+  const error = resultIsError
+    ? (output || stderr || `Claude Code exited with code ${code}`)
+    : (stderr || (code !== 0 ? `Claude Code exited with code ${code}` : 'Claude Code returned empty response'));
+  return { success: false, output, error };
+}
+
 export class ClaudeCodeAdapter extends BaseAgentAdapter {
   name = 'claude-code';
   private sessionId?: string;
@@ -160,6 +194,10 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       let streamedText = '';
       let buffer = '';
       let stderr = '';
+      // The CLI reports API failures (402, session limit, unknown model) as a
+      // `result` event with is_error:true — sometimes with a 0 exit code.
+      // Track it so the close handler can classify the run as a failure.
+      let resultIsError = false;
       let tokens: AgentResponse['tokens'];
       let durationSec: number | undefined;
       const statusUpdates: string[] = [];
@@ -325,6 +363,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
           if (event.result) {
             result = event.result;
           }
+          if (event.is_error) {
+            resultIsError = true;
+          }
           if (event.usage) {
             const input = event.usage.input_tokens;
             const output = event.usage.output_tokens;
@@ -396,20 +437,29 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
           if (parsed) userQuestion = parsed;
         }
 
+        const cls = classifyClaudeRunResult({
+          code,
+          result,
+          streamedText,
+          stderr,
+          resultIsError,
+          hasUserQuestion: !!userQuestion,
+        });
+
         if (userQuestion) {
-          const resp = this.createResponse(output || userQuestion.question, true, tokens, finalDuration, statusUpdates, states);
+          const resp = this.createResponse(cls.output || userQuestion.question, true, tokens, finalDuration, statusUpdates, states);
           resp.userQuestion = userQuestion;
           safeResolve(resp);
-        } else if (code === 0 && output) {
-          const successResp = this.createResponse(output, true, tokens, finalDuration, statusUpdates, states, permissionDenials);
+        } else if (cls.success) {
+          const successResp = this.createResponse(cls.output, true, tokens, finalDuration, statusUpdates, states, permissionDenials);
           successResp.thinking = thinkingText || undefined;
           safeResolve(successResp);
         } else {
           // Clear session on failure to avoid "session already in use" errors
           this.sessionId = undefined;
-          const error = stderr || (code !== 0 ? `Claude Code exited with code ${code}` : 'Claude Code returned empty response');
-          this.debug(`[claude-code] Error: ${error}`);
-          safeResolve(this.createResponse(error, false, undefined, finalDuration, statusUpdates, states));
+          const message = cls.error ?? (code !== 0 ? `Claude Code exited with code ${code}` : 'Claude Code returned empty response');
+          this.debug(`[claude-code] Error: ${message}`);
+          safeResolve(this.createResponse(message, false, undefined, finalDuration, statusUpdates, states));
         }
       });
 

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'src/skill-crystallizer.test.ts',
       'src/playbook-induction.test.ts',
       'src/agents/tool-events.test.ts',
+      'src/agents/claude-code.test.ts',
       'src/context.extract-meta.test.ts',
       'src/aide-automation.test.ts',
       'src/speech-digest.test.ts',


### PR DESCRIPTION
## Problem

Model fallback stopped working. When the primary `claude-code` agent hit an API-level failure (402 Insufficient Balance, session limit, unknown model), the user saw the raw error text instead of the gateway trying the configured fallback agents.

The `claude` CLI reports these failures as a stream-json `result` event with `is_error: true` and the message in `result` — and it **can exit 0** for some of them (e.g. session limits). The claude-code adapter's success check was only `exitCode === 0 && output`; the `is_error` field was declared on the event type but never read. So such runs were classified as `success: true`, and `runWithFallback` returned immediately without engaging the chain.

Reproduced against the real CLI: an API error surfaces as `{"is_error":true,"terminal_reason":"api_error","result":"API Error: …","type":"result"}`.

## Fix

`packages/core/src/agents/claude-code.ts`:
- Track `resultIsError` from the result event's `is_error` flag.
- Extract a pure `classifyClaudeRunResult()` that treats `is_error` as the authoritative failure signal regardless of exit code, and prefers the API error message over stderr (which may hold only an auth-source warning).
- Close handler uses the classifier.

New `claude-code.test.ts` covers: exit-0 API error → failure, clean result → success, streamed-text fallback, stderr noise, non-zero exit without flag, and AskUserQuestion.

## Verification

- `packages/core`: 354 tests pass (6 new)
- `packages/gateway`: 238 tests pass
- `codey-mac`: 372 tests pass
- `tsc --noEmit` clean

Note: a working fallback also depends on the runtime config — the local `gateway.json` fallback entries must point at targets the gateway can authenticate with. That config is local and not part of this PR.