### PR TITLE
Isolate each chat in its own branch and worktree

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1910,7 +1910,7 @@ app.whenReady().then(async () => {
       const known = workspaceManager.listWorkspaces()
       const resolved = resolveCaptureSubmit(payload?.text ?? '', payload?.workspaceName, known)
       if (!resolved.ok) throw new Error(resolved.error)
-      const chat = inProcessGateway.getChatManager().create({ workspaceName: resolved.workspaceName })
+      const chat = await inProcessGateway.createChat({ workspaceName: resolved.workspaceName })
 
       // Copy any picked files into the target workspace's .codey/uploads/ and
       // build FileAttachments — mirrors the chats:upload handler so the agent
@@ -3547,7 +3547,14 @@ app.whenReady().then(async () => {
   ipcMain.handle('chats:create', async (_e, input: { workspaceName: string; selection?: any; title?: string }) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      return inProcessGateway.getChatManager().create(input)
+      return inProcessGateway.createChat(input)
+    })
+  )
+
+  ipcMain.handle('chats:ensureWorktree', async (_e, id: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.ensureChatWorktree(id)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -153,6 +153,7 @@ contextBridge.exposeInMainWorld('codey', {
     get: (id: string) => ipcRenderer.invoke('chats:get', id),
     create: (input: { workspaceName: string; selection?: any; title?: string }) =>
       ipcRenderer.invoke('chats:create', input),
+    ensureWorktree: (id: string) => ipcRenderer.invoke('chats:ensureWorktree', id),
     rename: (id: string, title: string) => ipcRenderer.invoke('chats:rename', id, title),
     taskBrief: (id: string) => ipcRenderer.invoke('chats:taskBrief', id),
     delete: (id: string) => ipcRenderer.invoke('chats:delete', id),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -286,6 +286,7 @@ declare global {
         list: (workspaceName?: string) => Promise<IpcResult<Chat[]>>
         get: (id: string) => Promise<IpcResult<Chat>>
         create: (input: { workspaceName: string; selection?: ChatSelection; title?: string }) => Promise<IpcResult<Chat>>
+        ensureWorktree: (id: string) => Promise<IpcResult<Chat>>
         rename: (id: string, title: string) => Promise<IpcResult<Chat>>
         taskBrief: (id: string) => Promise<IpcResult<TaskBrief | null>>
         delete: (id: string) => Promise<IpcResult<null>>

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -8,6 +8,7 @@ interface Props {
   workingDir: string | undefined
   repoRoot: string | undefined           // for default worktree path; falls back to workingDir
   boundWorktreePath?: string             // chat.workingDirOverride
+  gitContext?: { branch: string; worktreePath: string }
   onBindWorktree: (path: string | null) => void
   onOpenTerminal?: () => void
 }
@@ -15,7 +16,7 @@ interface Props {
 type Mode = { kind: 'list' } | { kind: 'create' } | { kind: 'dirty'; target: string }
 type PickerView = 'branches' | 'worktrees'
 
-export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorktreePath, onBindWorktree, onOpenTerminal }) => {
+export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorktreePath, gitContext, onBindWorktree, onOpenTerminal }) => {
   const git = useGitBranches(workingDir)
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -43,7 +44,9 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
   )
   const remoteFiltered = useMemo(() => filterBranches(s?.remote ?? [], query), [s, query])
   const repo = repoRoot || workingDir || ''
-  const worktreePath = boundWorktreePath || workingDir || ''
+  const worktreePath = gitContext?.worktreePath || boundWorktreePath || workingDir || ''
+  const branchLabel = s?.branch || gitContext?.branch || '—'
+  const branchDrift = !!gitContext && !!s?.branch && s.branch !== gitContext.branch
   const orderedWorktrees = useMemo(
     () => currentFirst(
       [...(main ? [main] : []), ...others],
@@ -101,14 +104,14 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
         }
         return !o
       })}
-        title={worktreePath ? `${s?.branch ?? 'Unknown branch'}\n${worktreePath}` : 'Chat workspace unavailable'}
-        aria-label={`Chat workspace: ${s?.branch ?? 'unknown branch'}, ${worktreePath || 'unavailable'}`}
+        title={worktreePath ? `${branchLabel}\n${worktreePath}` : 'Chat workspace unavailable'}
+        aria-label={`Chat workspace: ${branchLabel}, ${worktreePath || 'unavailable'}`}
         aria-expanded={open}
       >
         <UIIcon name="code" size={15} />
         <span style={styles.pillIdentity}>
           <span style={styles.pillBranch}>
-            <span style={styles.ellipsis}>{s?.branch ?? '—'}</span>
+            <span style={styles.ellipsis}>{branchLabel}</span>
             {s && s.dirty > 0 && <span style={styles.dirty}>+{s.dirty}</span>}
           </span>
           <span style={styles.pillPath}>{compactWorktreePath(worktreePath)}</span>
@@ -123,7 +126,7 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
           <div style={styles.currentWorkspace}>
             <UIIcon name="workspace" size={15} />
             <div style={styles.currentIdentity}>
-              <div style={styles.currentBranch}>{s?.branch ?? '—'}</div>
+              <div style={styles.currentBranch}>{branchLabel}</div>
               <div style={styles.currentPath} title={worktreePath}>{compactWorktreePath(worktreePath)}</div>
             </div>
             <button style={styles.iconButton} onClick={() => void copyWorktreePath()} title="Copy worktree path" aria-label="Copy worktree path">
@@ -135,7 +138,15 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
               </button>
             )}
           </div>
-          {mode.kind === 'dirty' ? (
+          {gitContext ? (
+            <div style={branchDrift ? styles.driftNote : styles.dedicatedNote}>
+              <UIIcon name={branchDrift ? 'activity' : 'check'} size={13} />
+              {branchDrift ? `Expected ${gitContext.branch}` : 'Dedicated to this chat'}
+            </div>
+          ) : (
+            <>
+              <div style={styles.sharedNote}>Shared workspace</div>
+              {mode.kind === 'dirty' ? (
             <div style={styles.section}>
               <div style={styles.warn}>Switching would overwrite local changes.</div>
               <div style={styles.row}>
@@ -147,7 +158,7 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
                 <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
               </div>
             </div>
-          ) : mode.kind === 'create' ? (
+              ) : mode.kind === 'create' ? (
             <div style={styles.section}>
               <input autoFocus placeholder="new-branch-name" value={newName}
                 onChange={e => setNewName(e.target.value)} style={styles.input} />
@@ -161,7 +172,7 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
                 <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
               </div>
             </div>
-          ) : (
+              ) : (
             <>
               <div style={styles.viewTabs} role="tablist" aria-label="Workspace choices">
                 <button role="tab" aria-selected={view === 'branches'} style={view === 'branches' ? styles.viewTabActive : styles.viewTab} onClick={() => setView('branches')}>Branches</button>
@@ -212,6 +223,8 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
                 {view === 'branches' && <button style={styles.ghost} onClick={() => git.fetchRemote()}>Fetch</button>}
               </div>
             </>
+              )}
+            </>
           )}
         </div>
       )}
@@ -248,6 +261,9 @@ const styles: Record<string, React.CSSProperties> = {
   currentBranch: { color: C.fg, fontSize: 11, fontWeight: 600, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   currentPath: { color: C.fg3, fontSize: 9, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   iconButton: { width: 27, height: 27, padding: 0, border: `1px solid ${C.border2}`, borderRadius: 6, background: C.surface3, color: C.fg2, cursor: 'pointer', display: 'grid', placeItems: 'center', flexShrink: 0 },
+  dedicatedNote: { display: 'flex', alignItems: 'center', gap: 6, color: C.green, fontSize: 10, padding: '5px 7px 2px' },
+  driftNote: { display: 'flex', alignItems: 'center', gap: 6, color: C.red, fontSize: 10, padding: '5px 7px 2px', fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden' },
+  sharedNote: { color: C.yellow, fontSize: 9, fontWeight: 600, padding: '3px 7px 0' },
   viewTabs: { display: 'flex', padding: 2, borderRadius: 6, background: C.surface3 },
   viewTab: { flex: 1, border: 'none', borderRadius: 5, padding: '5px 8px', background: 'transparent', color: C.fg3, cursor: 'pointer', fontSize: 11 },
   viewTabActive: { flex: 1, border: `1px solid ${C.border2}`, borderRadius: 5, padding: '4px 8px', background: C.surface2, color: C.fg, cursor: 'pointer', fontSize: 11, fontWeight: 600 },

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -838,9 +838,19 @@ export const ChatTab: React.FC<Props> = ({
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
 }) => {
-  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setWorkingDir: setChatWorkingDir, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, sendMessage, stopChat, clearRestore, ensureWorktree, setSelection, setAgentModel, setWorkingDir: setChatWorkingDir, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
+  const worktreeEnsureAttemptedRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!chat || chat.kind === 'automation' || !isGatewayRunning || chat.gitContext) return
+    if (worktreeEnsureAttemptedRef.current === chat.id) return
+    worktreeEnsureAttemptedRef.current = chat.id
+    void ensureWorktree(chat.id).catch(error => {
+      console.error(`Failed to isolate chat ${chat.id}:`, error)
+    })
+  }, [chat?.id, chat?.kind, chat?.gitContext, isGatewayRunning, ensureWorktree])
 
   // Voice for this chat: the transcript is sent through the normal chat path
   // below, and only the reply is read aloud.
@@ -1758,7 +1768,8 @@ export const ChatTab: React.FC<Props> = ({
         <BranchPicker
           workingDir={workingDir}
           repoRoot={workspaceDir}
-          boundWorktreePath={chat?.workingDirOverride}
+          boundWorktreePath={chat?.gitContext?.worktreePath ?? chat?.workingDirOverride}
+          gitContext={chat?.gitContext}
           onBindWorktree={async (path) => {
             if (!chat) return
             await setChatWorkingDir(chat.id, path)

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -450,6 +450,7 @@ export function reducer(state: State, action: Action): State {
 interface ChatsContextValue {
   state: State
   createChat: (workspaceName: string) => Promise<Chat>
+  ensureWorktree: (chatId: string) => Promise<Chat>
   selectChat: (chatId: string | null) => void
   /** Fetch a chat by id (works for hidden automation chats) and select it. */
   openChatById: (chatId: string) => Promise<void>
@@ -709,6 +710,11 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       const chat = await apiService.chats.create({ workspaceName })
       dispatch({ type: 'upsert', chat })
       dispatch({ type: 'select', chatId: chat.id })
+      return chat
+    },
+    async ensureWorktree(chatId) {
+      const chat = await apiService.chats.ensureWorktree(chatId)
+      dispatch({ type: 'upsert', chat })
       return chat
     },
     selectChat(chatId) { dispatch({ type: 'select', chatId }) },

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -183,6 +183,8 @@ export const apiService = {
       unwrap(await window.codey.chats.get(id)),
     create: async (input: { workspaceName: string; selection?: ChatSelection; title?: string }): Promise<Chat> =>
       unwrap(await window.codey.chats.create(input)),
+    ensureWorktree: async (id: string): Promise<Chat> =>
+      unwrap(await window.codey.chats.ensureWorktree(id)),
     rename: async (id: string, title: string): Promise<Chat> =>
       unwrap(await window.codey.chats.rename(id, title)),
     taskBrief: async (id: string): Promise<TaskBrief | null> =>

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -159,6 +159,15 @@ export interface Chat {
    *  runs here instead of the workspace's workingDir — used to bind a chat to a
    *  git worktree. Cleared (deleted) to fall back to the workspace dir. */
   workingDirOverride?: string;
+  /** Git environment owned by this chat. Normal chats in Git workspaces are
+   *  provisioned with one dedicated branch and worktree; all execution
+   *  surfaces use `workingDir` as their cwd. */
+  gitContext?: {
+    repositoryRoot: string;
+    branch: string;
+    worktreePath: string;
+    workingDir: string;
+  };
   /** Last unanswered choice question in a non-team chat. Cleared on next user message. */
   lastAskedOptions?: { messageId: string; options: string[] };
   /** Set when the skill distiller has proposed a new skill and is waiting for

--- a/packages/gateway/src/chat-worktree.test.ts
+++ b/packages/gateway/src/chat-worktree.test.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { chatWorktreeBranch, inspectChatWorktree, provisionChatWorktree } from './chat-worktree';
+
+const roots: string[] = [];
+
+const git = (cwd: string, args: string[]) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('provisionChatWorktree', () => {
+  it('creates a dedicated branch/worktree and preserves a workspace subdirectory', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-worktree-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const workspaceWorkingDir = path.join(repositoryRoot, 'packages', 'app');
+    const workspacesRoot = path.join(root, 'data', 'workspaces');
+    fs.mkdirSync(workspaceWorkingDir, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+
+    const result = await provisionChatWorktree({
+      workspaceWorkingDir,
+      workspacesRoot,
+      workspaceName: 'demo',
+      chatId: 'abc-123',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.branch).toBe(chatWorktreeBranch('abc-123'));
+    expect(result?.workingDir).toBe(path.join(result!.worktreePath, 'packages', 'app'));
+    expect(fs.statSync(result!.workingDir).isDirectory()).toBe(true);
+    expect(git(result!.worktreePath, ['branch', '--show-current'])).toBe(result?.branch);
+    await expect(inspectChatWorktree(result!.workingDir)).resolves.toEqual(result);
+
+    // Provisioning is idempotent and recovers the same environment.
+    await expect(provisionChatWorktree({ workspaceWorkingDir, workspacesRoot, workspaceName: 'demo', chatId: 'abc-123' }))
+      .resolves.toEqual(result);
+
+    fs.writeFileSync(path.join(repositoryRoot, 'local-change.txt'), 'dirty\n');
+    await expect(provisionChatWorktree({
+      workspaceWorkingDir,
+      workspacesRoot,
+      workspaceName: 'demo',
+      chatId: 'legacy-chat',
+      requireCleanSource: true,
+    })).rejects.toThrow(/local changes/i);
+  });
+
+  it('returns null outside a Git repository', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-worktree-'));
+    roots.push(root);
+    await expect(provisionChatWorktree({
+      workspaceWorkingDir: root,
+      workspacesRoot: path.join(root, 'workspaces'),
+      workspaceName: 'plain',
+      chatId: 'abc',
+    })).resolves.toBeNull();
+  });
+});

--- a/packages/gateway/src/chat-worktree.ts
+++ b/packages/gateway/src/chat-worktree.ts
@@ -1,0 +1,115 @@
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface ProvisionedChatWorktree {
+  repositoryRoot: string;
+  branch: string;
+  worktreePath: string;
+  workingDir: string;
+}
+
+export function chatWorktreeBranch(chatId: string): string {
+  return `codey/chat-${chatId}`;
+}
+
+export function chatWorktreeDirectory(workspacesRoot: string, workspaceName: string, chatId: string): string {
+  return path.join(workspacesRoot, workspaceName, 'worktrees', `chat-${chatId}`);
+}
+
+/** Describe an existing worktree binding without changing its branch. */
+export async function inspectChatWorktree(workingDirInput: string): Promise<ProvisionedChatWorktree | null> {
+  const workingDir = fs.realpathSync(path.resolve(workingDirInput));
+  try {
+    const worktreePath = fs.realpathSync(path.resolve(await git(workingDir, ['rev-parse', '--show-toplevel'])));
+    const branch = await git(workingDir, ['branch', '--show-current']);
+    if (!branch) return null;
+    const porcelain = await git(workingDir, ['worktree', 'list', '--porcelain']);
+    const firstWorktree = porcelain.split('\n').find(line => line.startsWith('worktree '));
+    const repositoryRoot = firstWorktree
+      ? fs.realpathSync(path.resolve(firstWorktree.slice('worktree '.length).trim()))
+      : worktreePath;
+    return { repositoryRoot, branch, worktreePath, workingDir };
+  } catch {
+    return null;
+  }
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync('git', args, { cwd, timeout: 30_000 });
+  return result.stdout.trim();
+}
+
+async function gitSucceeds(cwd: string, args: string[]): Promise<boolean> {
+  try {
+    await git(cwd, args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create (or recover) the branch/worktree owned by one chat.
+ * Returns null for a non-Git workspace; all other failures are actionable and
+ * are allowed to reach the caller so it never silently falls back to sharing.
+ */
+export async function provisionChatWorktree(input: {
+  workspaceWorkingDir: string;
+  workspacesRoot: string;
+  workspaceName: string;
+  chatId: string;
+  requireCleanSource?: boolean;
+}): Promise<ProvisionedChatWorktree | null> {
+  // macOS exposes /var as a symlink to /private/var. Normalize both sides so
+  // path.relative does not misclassify a real repository subdirectory.
+  const sourceDir = fs.realpathSync(path.resolve(input.workspaceWorkingDir));
+  let repositoryRoot: string;
+  try {
+    repositoryRoot = fs.realpathSync(path.resolve(await git(sourceDir, ['rev-parse', '--show-toplevel'])));
+  } catch {
+    return null;
+  }
+
+  const relativeWorkingDir = path.relative(repositoryRoot, sourceDir);
+  if (relativeWorkingDir.startsWith('..') || path.isAbsolute(relativeWorkingDir)) {
+    throw new Error(`Workspace directory is outside its Git repository: ${sourceDir}`);
+  }
+  if (input.requireCleanSource) {
+    const dirty = await git(sourceDir, ['status', '--porcelain']);
+    if (dirty) {
+      throw new Error('Cannot automatically isolate this existing chat while the shared workspace has local changes');
+    }
+  }
+
+  const branch = chatWorktreeBranch(input.chatId);
+  const requestedWorktreePath = chatWorktreeDirectory(input.workspacesRoot, input.workspaceName, input.chatId);
+  fs.mkdirSync(path.dirname(requestedWorktreePath), { recursive: true });
+  const worktreePath = path.join(fs.realpathSync(path.dirname(requestedWorktreePath)), path.basename(requestedWorktreePath));
+  const workingDir = path.join(worktreePath, relativeWorkingDir);
+
+  if (fs.existsSync(worktreePath)) {
+    const existingRoot = await git(worktreePath, ['rev-parse', '--show-toplevel']).catch(() => '');
+    const existingBranch = await git(worktreePath, ['branch', '--show-current']).catch(() => '');
+    if (path.resolve(existingRoot) !== path.resolve(worktreePath) || existingBranch !== branch) {
+      throw new Error(`Chat worktree path already exists but does not belong to ${branch}: ${worktreePath}`);
+    }
+    fs.mkdirSync(workingDir, { recursive: true });
+    return { repositoryRoot, branch, worktreePath, workingDir };
+  }
+
+  // Remove stale registrations left behind if a worktree directory was
+  // deleted outside Codey, then recover the existing branch when present.
+  await git(repositoryRoot, ['worktree', 'prune']);
+  const branchExists = await gitSucceeds(repositoryRoot, ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`]);
+  const args = branchExists
+    ? ['worktree', 'add', worktreePath, branch]
+    : ['worktree', 'add', worktreePath, '-b', branch, 'HEAD'];
+  await git(repositoryRoot, args);
+  fs.mkdirSync(workingDir, { recursive: true });
+
+  return { repositoryRoot, branch, worktreePath, workingDir };
+}

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -340,6 +340,19 @@ export class ChatManager {
     const chat = this.requireChat(chatId);
     if (dir === null || dir === undefined || dir === '') delete chat.workingDirOverride;
     else chat.workingDirOverride = dir;
+    // A manual override predates the owned git-context model. Never retain a
+    // stale branch/worktree identity when the cwd is changed independently.
+    delete chat.gitContext;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
+  /** Persist the dedicated Git environment provisioned for a chat. */
+  setGitContext(chatId: string, context: NonNullable<Chat['gitContext']>): Chat {
+    const chat = this.requireChat(chatId);
+    chat.gitContext = context;
+    chat.workingDirOverride = context.workingDir;
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;

--- a/packages/gateway/src/chats.workingDirOverride.test.ts
+++ b/packages/gateway/src/chats.workingDirOverride.test.ts
@@ -22,6 +22,22 @@ describe('ChatManager.setWorkingDirOverride', () => {
     const cleared = mgr.setWorkingDirOverride(chat.id, null);
     expect(cleared.workingDirOverride).toBeUndefined();
   });
+
+  it('persists an owned git context and clears stale identity on manual override', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    const context = {
+      repositoryRoot: '/repo',
+      branch: 'codey/chat-123',
+      worktreePath: '/worktrees/chat-123',
+      workingDir: '/worktrees/chat-123/packages/app',
+    };
+    const isolated = mgr.setGitContext(chat.id, context);
+    expect(isolated.gitContext).toEqual(context);
+    expect(isolated.workingDirOverride).toBe(context.workingDir);
+
+    const rebound = mgr.setWorkingDirOverride(chat.id, '/tmp/other');
+    expect(rebound.gitContext).toBeUndefined();
+  });
 });
 
 describe('ChatManager.updateAgentModel', () => {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -21,7 +21,8 @@ import { ContextManager, ContextWindow } from '@codey/core';
 import { MemoryStore } from '@codey/core';
 import { WorkspaceManager, TeamConfigRaw, TeamConfig, DEFAULT_PARALLEL_SETTINGS } from '@codey/core';
 import { WorkerManager } from '@codey/core';
-import { ChatManager } from './chats';
+import { ChatManager, CreateChatInput } from './chats';
+import { inspectChatWorktree, provisionChatWorktree } from './chat-worktree';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
@@ -119,6 +120,7 @@ export class Codey {
    *  so a later workspace switch can't save it into the wrong skills store.
    *  (Chat-surface suggestions are persisted on the Chat via ChatManager instead.) */
   private pendingSkillSuggestions = new Map<string, { suggestion: DistillResult; workspaceName: string }>();
+  private pendingChatWorktrees = new Map<string, Promise<Chat>>();
   private skillRunCounter = 0;
   private lastSkillDistillTime = 0;
   private static SKILL_DISTILL_COOLDOWN_MS = 300_000; // 5 min
@@ -691,6 +693,63 @@ export class Codey {
 
   getWorkspaceManager(): WorkspaceManager { return this.workspaceManager; }
   getChatManager(): ChatManager { return this.chatManager; }
+
+  /** Create a user chat and provision its owned Git environment before the
+   *  caller can select or run it. Non-Git workspaces continue to work without
+   *  a gitContext; Git provisioning failures remove the half-created chat. */
+  public async createChat(input: CreateChatInput): Promise<Chat> {
+    const chat = this.chatManager.create(input);
+    if (input.kind === 'automation') return chat;
+    try {
+      return await this.ensureChatWorktree(chat.id);
+    } catch (error) {
+      this.chatManager.delete(chat.id);
+      throw error;
+    }
+  }
+
+  /** Lazily migrate an existing normal chat onto its own branch/worktree. */
+  public async ensureChatWorktree(chatId: string): Promise<Chat> {
+    const chat = this.chatManager.get(chatId);
+    if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    if (chat.kind === 'automation') return chat;
+    if (chat.gitContext && fs.existsSync(chat.gitContext.workingDir)) {
+      const actual = await inspectChatWorktree(chat.gitContext.workingDir);
+      if (actual?.branch === chat.gitContext.branch && actual.worktreePath === chat.gitContext.worktreePath) return chat;
+      throw new Error(`Chat worktree branch changed outside Codey; expected ${chat.gitContext.branch}, found ${actual?.branch || 'unknown'}`);
+    }
+
+    const pending = this.pendingChatWorktrees.get(chatId);
+    if (pending) return pending;
+    const provision = (async () => {
+      // Chats explicitly bound to a legacy worktree already have isolation;
+      // adopt that identity instead of manufacturing a replacement checkout.
+      if (chat.workingDirOverride && fs.existsSync(chat.workingDirOverride)) {
+        const existing = await inspectChatWorktree(chat.workingDirOverride);
+        if (existing && existing.worktreePath !== existing.repositoryRoot) {
+          return this.chatManager.setGitContext(chat.id, existing);
+        }
+        // An override pointing at the repository's main worktree is still
+        // shared, so continue below and create a genuinely dedicated one.
+        if (!existing) return chat;
+      }
+      const context = await provisionChatWorktree({
+        workspaceWorkingDir: this.resolveWorkspaceWorkingDir(chat.workspaceName),
+        workspacesRoot: this.workspaceManager.getWorkspacesRoot(),
+        workspaceName: chat.workspaceName,
+        chatId: chat.id,
+        requireCleanSource: chat.messages.length > 0,
+      });
+      if (!context) {
+        this.logger.info(`Chat ${chat.id} workspace is not a Git repository; using workspace directory`);
+        return chat;
+      }
+      this.logger.info(`Chat ${chat.id} isolated on ${context.branch} at ${context.worktreePath}`);
+      return this.chatManager.setGitContext(chat.id, context);
+    })().finally(() => this.pendingChatWorktrees.delete(chatId));
+    this.pendingChatWorktrees.set(chatId, provision);
+    return provision;
+  }
 
   public setChatEventListener(fn: (ev: any) => void): void {
     this.chatEventListener = fn;
@@ -3171,7 +3230,7 @@ export class Codey {
     }
     const workspace = binding.prefs?.workspace ?? this.workspaceManager.getCurrentWorkspace();
     const title = args.join(' ').trim() || undefined;
-    const chat = this.chatManager.create({ workspaceName: workspace, title });
+    const chat = await this.createChat({ workspaceName: workspace, title });
     if (binding.prefs?.agent || binding.prefs?.model) {
       this.chatManager.updateAgentModel(chat.id, binding.prefs.agent, binding.prefs.model);
     }
@@ -5368,8 +5427,9 @@ Example: /model gpt-4.1 write a Python script`;
     sink: (e: QQStreamEvent) => void,
     attachments?: import('@codey/core').FileAttachment[],
   ): Promise<{ response: string; tokens?: number; durationSec?: number }> {
-    const chat = this.chatManager.get(chatId);
+    let chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    if (chat.kind !== 'automation') chat = await this.ensureChatWorktree(chatId);
 
     // Resolve workingDir from the chat's workspace.json (mirrors sendToChat).
     const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
@@ -5493,8 +5553,9 @@ Example: /model gpt-4.1 write a Python script`;
     // skill pre-run pass, taking precedence over the auto-apply matcher).
     origin?: { channel: ChannelType; channelUserId: string; skillInvoke?: SkillInvoke },
   ): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> {
-    const chat = this.chatManager.get(chatId);
+    let chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    if (chat.kind !== 'automation') chat = await this.ensureChatWorktree(chatId);
 
     // Resolvable copy of the incoming text. A digit reply to a paused team is
     // rewritten to the chosen option's text BEFORE it is persisted as the user

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       'src/team-emitter.test.ts',
       'src/worker-message-emitter.test.ts',
       'src/chats.workingDirOverride.test.ts',
+      'src/chat-worktree.test.ts',
       'src/chats.pendingSkillSuggestion.test.ts',
       'src/automations/chat.test.ts',
       'src/automations/schedule.test.ts',


### PR DESCRIPTION
## What changed

- Provision a dedicated `codey/chat-<chat-id>` branch and Git worktree for every new normal chat.
- Persist the repository root, branch, worktree root, and effective working directory as the chat's Git context.
- Route Mac chats, Quick Capture, paired-channel `/new`, Quick Questions, agents, editors, and terminals through the chat-owned working directory.
- Lazily migrate existing chats when safe and adopt already-bound linked worktrees.
- Turn the branch/worktree selector into a locked environment indicator for isolated chats.
- Detect branch drift caused outside Codey and block agent execution with an actionable error.

## Why

Chats without an explicit worktree previously fell back to the workspace's shared checkout. Switching branches in one chat therefore changed the Git context shown and used by other chats. The selector reflected the shared repository state correctly, but the underlying execution model did not provide per-chat isolation.

## Safety and compatibility

- Existing chats are auto-migrated only when the shared checkout is clean, so uncommitted work is not left behind silently.
- Existing linked-worktree bindings are adopted instead of replaced.
- Non-Git workspaces continue using their normal workspace directory.
- Automation chats remain on their existing lifecycle.

## Validation

- Core: 348 tests passed
- Gateway: 241 tests passed
- Mac: 372 tests passed
- Core and Gateway TypeScript builds
- Mac production build
- Repository lint
- `git diff --check`
