### PR TITLE
Add a thinking-effort control across all three agent CLIs

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3512,6 +3512,13 @@ app.whenReady().then(async () => {
     })
   )
 
+  ipcMain.handle('chats:updateEffort', async (_e, id: string, effort: string | null) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.getChatManager().updateEffort(id, effort as any)
+    })
+  )
+
   ipcMain.handle('chats:updateContextPanelOpen', async (_e, id: string, open: boolean | null) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -160,6 +160,8 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('chats:updateSelection', id, selection),
     updateAgentModel: (id: string, agent: string | null, model: string | null) =>
       ipcRenderer.invoke('chats:updateAgentModel', id, agent, model),
+    updateEffort: (id: string, effort: string | null) =>
+      ipcRenderer.invoke('chats:updateEffort', id, effort),
     link: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>
       ipcRenderer.invoke('chats:link', chatId, channel, channelUserId),
     unlink: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) =>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -291,6 +291,7 @@ declare global {
         delete: (id: string) => Promise<IpcResult<null>>
         updateSelection: (id: string, selection: ChatSelection) => Promise<IpcResult<Chat>>
         updateAgentModel: (id: string, agent: string | null, model: string | null) => Promise<IpcResult<Chat>>
+        updateEffort: (id: string, effort: string | null) => Promise<IpcResult<Chat>>
         send: (payload: { chatId: string; text: string; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) => Promise<IpcResult<{ response: string; chatId: string; tokens?: number; durationSec?: number }>>
         stop: (chatId: string) => Promise<IpcResult<boolean>>
         onEvent: (handler: (ev: ChatStreamEvent) => void) => () => void

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -275,8 +275,8 @@ declare global {
         promote: (name: string) => Promise<IpcResult<{ name: string; dir: string }>>
       }
       agents: {
-        get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; env?: Record<string, string> }>>>
-        set: (updates: Record<string, { enabled?: boolean; defaultModel?: string; env?: Record<string, string> }>) => Promise<IpcResult<void>>
+        get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>>>
+        set: (updates: Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>) => Promise<IpcResult<void>>
         checkInstalled: () => Promise<IpcResult<Record<string, { installed: boolean; path?: string }>>>
         slashCommands: (agent: string) => Promise<IpcResult<Array<{ name: string; description: string; source: 'agent' | 'gateway' | 'skill' }>>>
       }

--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
-import { fieldStyle, pageStyle, pillButton, Section, unwrap } from './settingsAtoms'
+import { fieldStyle, pageStyle, pillButton, Section, selectStyle, unwrap } from './settingsAtoms'
 import {
   AGENT_INSTALL_URL,
   AGENT_NAMES,
@@ -13,7 +13,9 @@ interface Props {
   isGatewayRunning: boolean
 }
 
-type AgentSlot = { enabled?: boolean; defaultModel?: string; env?: Record<string, string> }
+type AgentSlot = { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }
+
+const EFFORT_OPTIONS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
 
 export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
   const [agents, setAgents] = useState<Record<string, AgentSlot>>({})
@@ -73,6 +75,31 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
                 checking={checkingInstalls && !status}
                 onInstall={() => window.codey.openExternal(AGENT_INSTALL_URL[a])}
               />
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, marginTop: 10 }}>
+              <span style={{ color: C.fg3, fontSize: 12 }}>Default effort</span>
+              <select
+                value={agents[a]?.defaultEffort ?? ''}
+                onChange={async e => {
+                  // Empty option clears the key rather than storing ''.
+                  const next = e.target.value || undefined
+                  const updated: Record<string, AgentSlot> = {
+                    ...agents,
+                    [a]: { ...(agents[a] ?? {}), defaultEffort: next },
+                  }
+                  setAgents(updated)
+                  // agents:set merges shallowly, so sending just this agent's
+                  // slot is enough — no need to re-send the others.
+                  await unwrap(await window.codey.agents.set({ [a]: updated[a] }))
+                }}
+                style={{ ...selectStyle, width: 180 }}
+                title="Thinking effort used when neither the chat nor a worker overrides it"
+              >
+                <option value="">Unset (CLI default)</option>
+                {EFFORT_OPTIONS.map(o => (
+                  <option key={o} value={o}>{o}</option>
+                ))}
+              </select>
             </div>
             <EnvEditor
               env={env}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1122,7 +1122,7 @@ export const ChatTab: React.FC<Props> = ({
         try {
           const ag = await window.codey.agents.get()
           if (ag.ok) {
-            const slots = ag.data as Record<string, { defaultEffort?: string } | undefined>
+            const slots = ag.data
             const efforts: Record<string, string | undefined> = {}
             for (const n of AGENT_NAMES) efforts[n] = slots[n]?.defaultEffort
             setAgentDefaultEfforts(efforts)

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -838,7 +838,7 @@ export const ChatTab: React.FC<Props> = ({
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
 }) => {
-  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setWorkingDir: setChatWorkingDir, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setWorkingDir: setChatWorkingDir, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -873,6 +873,9 @@ export const ChatTab: React.FC<Props> = ({
   const [enabledAgents, setEnabledAgents] = useState<string[]>([...AGENT_NAMES])
   const [defaultAgent, setDefaultAgent] = useState<string | null>(null)
   const [agentDefaultModels, setAgentDefaultModels] = useState<Record<string, string | undefined>>({})
+  // Per-agent default effort lives in the agents config, not in fallback.order
+  // (which carries no effort), so it needs its own lookup.
+  const [agentDefaultEfforts, setAgentDefaultEfforts] = useState<Record<string, string | undefined>>({})
   const [advisorConfig, setAdvisorConfig] = useState<{ agent?: string; model?: string }>({})
   const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>(() => getDraft(chatId).attachments)
   const [isDragging, setIsDragging] = useState(false)
@@ -1114,6 +1117,17 @@ export const ChatTab: React.FC<Props> = ({
           }
           setAgentDefaultModels(defaults)
         }
+        // Effort isn't part of fallback.order — read it off the agents config.
+        // Fetched separately so a failure here still leaves models populated.
+        try {
+          const ag = await window.codey.agents.get()
+          if (ag.ok) {
+            const slots = ag.data as Record<string, { defaultEffort?: string } | undefined>
+            const efforts: Record<string, string | undefined> = {}
+            for (const n of AGENT_NAMES) efforts[n] = slots[n]?.defaultEffort
+            setAgentDefaultEfforts(efforts)
+          }
+        } catch { /* leave the effort dropdown on its "CLI default" placeholder */ }
       } catch { /* surface via dropdown placeholders */ }
     })()
   }, [isGatewayRunning])
@@ -1311,6 +1325,8 @@ export const ChatTab: React.FC<Props> = ({
   const workerModel = selectedWorker?.config.model
   const effectiveAgent: string = chat.agent ?? workerAgent ?? defaultAgent ?? 'claude-code'
   const effectiveModel: string | undefined = chat.model ?? workerModel ?? agentDefaultModels[effectiveAgent]
+  const workerEffort = selectedWorker?.config.effort
+  const effectiveEffort: string | undefined = chat.effort ?? workerEffort ?? agentDefaultEfforts[effectiveAgent]
   const effectiveAdvisorAgent = advisorConfig.agent ?? defaultAgent ?? 'claude-code'
   const effectiveAdvisorModel = advisorConfig.model ?? agentDefaultModels[effectiveAdvisorAgent] ?? 'Default model'
   const apiTypeForAgent = AGENT_API_TYPE[effectiveAgent]
@@ -1356,6 +1372,10 @@ export const ChatTab: React.FC<Props> = ({
   }
   const onModelChange = async (v: string) => {
     await setAgentModel(chat.id, chat.agent ?? null, v === '' ? null : v)
+  }
+  const onEffortChange = async (v: string) => {
+    // '' is the Inherit option — clears the chat override.
+    await setEffort(chat.id, v === '' ? null : v)
   }
 
   const uploadFiles = async (files: FileList | File[]) => {
@@ -1881,6 +1901,22 @@ export const ChatTab: React.FC<Props> = ({
                         {modelsForAgent.map(m => (
                           <option key={m.model} value={m.model}>{m.model}</option>
                         ))}
+                      </select>
+                    </label>
+                    <label style={styles.runSettingGroup}>
+                      <span style={styles.runSettingLabel}>Effort</span>
+                      <select
+                        value={chat.effort ?? ''}
+                        onChange={e => void onEffortChange(e.target.value)}
+                        style={styles.runSettingSelect}
+                        title={`Effort: ${effectiveEffort ?? 'CLI default'}${chat.effort ? ' (override)' : workerEffort ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
+                      >
+                        <option value="">Inherit ({effectiveEffort ?? 'CLI default'})</option>
+                        <option value="low">low</option>
+                        <option value="medium">medium</option>
+                        <option value="high">high</option>
+                        <option value="xhigh">xhigh</option>
+                        <option value="max">max</option>
                       </select>
                     </label>
                     <button

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -37,7 +37,7 @@ export default function WorkersTab() {
               style={{ display: 'block', width: '100%', textAlign: 'left', padding: '10px 12px', background: mode.kind === 'select' && mode.name === w.name ? C.surface2 : 'transparent', border: 'none', color: C.fg, cursor: 'pointer' }}>
               <div style={{ fontWeight: 600 }}>{w.name}</div>
               <div style={{ fontSize: 11, color: C.fg3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{w.personality.role}</div>
-              <div style={{ fontSize: 10, color: C.fg3, marginTop: 2 }}>{w.config.codingAgent} · {w.config.model}</div>
+              <div style={{ fontSize: 10, color: C.fg3, marginTop: 2 }}>{w.config.codingAgent} · {w.config.model}{w.config.effort ? ` · ${w.config.effort}` : ''}</div>
             </button>
           ))}
         </div>
@@ -99,6 +99,7 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
   const [instructions, setInstructions] = useState(worker.personality.instructions)
   const [codingAgent, setCodingAgent] = useState(worker.config.codingAgent)
   const [model, setModel] = useState(worker.config.model)
+  const [effort, setEffort] = useState(worker.config.effort ?? '')
   const [toolsText, setToolsText] = useState(worker.config.tools.join(', '))
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -112,6 +113,7 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
   useEffect(() => {
     setRole(worker.personality.role); setSoul(worker.personality.soul); setInstructions(worker.personality.instructions)
     setCodingAgent(worker.config.codingAgent); setModel(worker.config.model); setToolsText(worker.config.tools.join(', '))
+    setEffort(worker.config.effort ?? '')
     setSaved(false); setError(null)
   }, [worker.name])
 
@@ -125,7 +127,12 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
     try {
       await apiService.updateWorker(worker.name, {
         personality: { role, soul, instructions },
-        config: { codingAgent, model, tools: toolsText.split(',').map(s => s.trim()).filter(Boolean) },
+        config: {
+          codingAgent,
+          model,
+          tools: toolsText.split(',').map(s => s.trim()).filter(Boolean),
+          ...(effort ? { effort } : {}),
+        },
       })
       setSaved(true); setTimeout(() => setSaved(false), 1500); onSaved()
     } catch (err: any) {
@@ -183,6 +190,16 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
           <option key={m.model} value={m.model}>{m.model}</option>
         ))}
         {filteredModels.length === 0 && <option value={model}>{model || '(no models available)'}</option>}
+      </select>
+
+      <label style={labelStyle}>Effort</label>
+      <select value={effort} onChange={e => setEffort(e.target.value)} style={fieldStyle}>
+        <option value="">Unset (inherit)</option>
+        <option value="low">low</option>
+        <option value="medium">medium</option>
+        <option value="high">high</option>
+        <option value="xhigh">xhigh</option>
+        <option value="max">max</option>
       </select>
 
       <label style={labelStyle}>Tools (comma-separated)</label>

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -457,6 +457,7 @@ interface ChatsContextValue {
   deleteChat: (chatId: string) => Promise<void>
   setSelection: (chatId: string, selection: ChatSelection) => Promise<void>
   setAgentModel: (chatId: string, agent: string | null, model: string | null) => Promise<void>
+  setEffort: (chatId: string, effort: string | null) => Promise<void>
   setWorkingDir: (chatId: string, dir: string | null) => Promise<void>
   setContextPanelOpen: (chatId: string, open: boolean | null) => Promise<void>
   setSoloAdvisor: (chatId: string, enabled: boolean) => Promise<void>
@@ -733,6 +734,10 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     },
     async setAgentModel(chatId, agent, model) {
       const chat = await apiService.chats.updateAgentModel(chatId, agent, model)
+      dispatch({ type: 'upsert', chat })
+    },
+    async setEffort(chatId, effort) {
+      const chat = await apiService.chats.updateEffort(chatId, effort)
       dispatch({ type: 'upsert', chat })
     },
     async setWorkingDir(chatId, dir) {

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -35,7 +35,7 @@ function unwrap<T>(result: { ok: true; data: T } | { ok: false; error: string })
 
 // Type aliases for the shapes returned by core
 export interface WorkerPersonality { role: string; soul: string; instructions: string }
-export interface WorkerConfig { codingAgent: 'claude-code' | 'opencode' | 'codex'; model: string; tools: string[] }
+export interface WorkerConfig { codingAgent: 'claude-code' | 'opencode' | 'codex'; model: string; tools: string[]; effort?: string; dispatchHint?: string }
 export interface WorkerDto {
   name: string
   personality: WorkerPersonality

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -194,6 +194,8 @@ export const apiService = {
       unwrap(await window.codey.chats.updateSelection(id, selection)),
     updateAgentModel: async (id: string, agent: string | null, model: string | null): Promise<Chat> =>
       unwrap(await window.codey.chats.updateAgentModel(id, agent, model)),
+    updateEffort: async (id: string, effort: string | null): Promise<Chat> =>
+      unwrap(await window.codey.chats.updateEffort(id, effort)),
     updateContextPanelOpen: async (id: string, open: boolean | null): Promise<Chat> =>
       unwrap(await window.codey.chats.updateContextPanelOpen(id, open)),
     setSoloAdvisor: async (id: string, enabled: boolean): Promise<Chat> =>

--- a/docs/superpowers/plans/2026-08-09-thinking-effort-control.md
+++ b/docs/superpowers/plans/2026-08-09-thinking-effort-control.md
@@ -1,0 +1,1320 @@
+# Thinking-Effort Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users set a reasoning-effort level (low/medium/high/xhigh/max) per chat, per worker, and per agent default, forwarded to whichever coding-agent CLI runs the turn.
+
+**Architecture:** One `ThinkingEffort` union type stored at three layers (chat override > worker config > per-agent global default), carried on `AgentRequest.effort`, and turned into agent-specific argv by pure builders in `packages/core/src/agents/effort.ts`. codex validates the level server-side and hard-fails, so the codex adapter retries once without the flag and prepends a note to the output.
+
+**Tech Stack:** TypeScript (ES2020/CommonJS, strict), Vitest, React (codey-mac renderer), Electron IPC.
+
+---
+
+## Environment setup (do this first)
+
+The repo's default `node` is v16, which cannot run `vitest` or `tsc` here. Every
+command in this plan assumes Node 22:
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+node -v   # must print v22.17.1
+```
+
+Single-file test runs use, from the repo root:
+
+```bash
+cd packages/core && npx vitest run src/agents/<file>.test.ts
+```
+
+## Spec
+
+`docs/superpowers/specs/2026-08-09-thinking-effort-control-design.md`
+
+**One refinement over the spec:** the spec named the helper file
+`effort-retry.ts` holding only `isEffortRejection`. This plan uses
+`packages/core/src/agents/effort.ts` and also puts the three argv builders there.
+Reason: the adapters spawn real subprocesses and are not directly unit-testable
+(see `packages/core/src/agents/claude-code.test.ts`, which tests the extracted
+pure function `classifyClaudeRunResult` rather than the adapter). Extracting the
+argv logic as pure functions is the only way to test it in this codebase's style,
+and it keeps all effort knowledge in one file.
+
+**Second refinement:** the spec did not say *where* the global default tier is
+applied. `runWithFallback` (`packages/gateway/src/gateway.ts:5063`) is the single
+choke point through which ~20 agent-run call sites pass. Applying the global
+default there means only the chat and worker tiers need explicit wiring.
+
+## File Structure
+
+**Create:**
+- `packages/core/src/agents/effort.ts` — the `ThinkingEffort` argv builders, the codex rejection detector, and the retry marker type. All pure.
+- `packages/core/src/agents/effort.test.ts` — tests for the above.
+- `packages/gateway/src/effort-resolve.ts` — pure precedence resolver (chat > worker > global).
+- `packages/gateway/src/effort-resolve.test.ts` — tests for the resolver.
+
+**Modify:**
+- `packages/core/src/types/index.ts` — `ThinkingEffort`, `AgentRequest.effort`, `AgentModelConfig.defaultEffort`.
+- `packages/core/src/types/chat.ts` — `Chat.effort`.
+- `packages/core/src/workers.ts` — `WorkerConfig.effort`, `getWorkerEffort()`.
+- `packages/core/src/agents/claude-code.ts` — append `--effort`.
+- `packages/core/src/agents/opencode.ts` — append `--variant`.
+- `packages/core/src/agents/codex.ts` — append `-c model_reasoning_effort`, degrade-retry.
+- `packages/gateway/src/chats.ts` — `updateEffort()`.
+- `packages/gateway/src/gateway.ts` — global-default injection, chat/worker wiring, `/effort` command.
+- `codey-mac/electron/preload.ts`, `codey-mac/electron/main.ts`, `codey-mac/src/codey-api.d.ts` — `chats:updateEffort` IPC.
+- `codey-mac/src/components/ChatTab.tsx` — Effort select in the run-settings row.
+- `codey-mac/src/components/AgentsTab.tsx` — per-agent `Default effort`.
+- `codey-mac/src/components/WorkersTab.tsx` — worker Effort select.
+
+---
+
+### Task 1: The `ThinkingEffort` type and its three storage fields
+
+**Files:**
+- Modify: `packages/core/src/types/index.ts:60` (near `ModelConfig`), `:117` (`AgentRequest`), `:267` (`AgentModelConfig`)
+- Modify: `packages/core/src/types/chat.ts:145` (`Chat`)
+- Modify: `packages/core/src/workers.ts:11` (`WorkerConfig`)
+
+- [ ] **Step 1: Add the union type to `packages/core/src/types/index.ts`**
+
+Insert immediately above `export interface ModelConfig {` (line 60):
+
+```ts
+/**
+ * Reasoning-effort level, forwarded verbatim to every agent CLI.
+ *
+ * These five values are claude-code's `--effort` enum and are a strict subset
+ * of codex's `model_reasoning_effort` enum, so no per-agent translation is
+ * needed — only the flag syntax differs. `undefined` means "pass no flag" and
+ * lets each CLI use its own default; there is deliberately no 'default'
+ * literal, so there is exactly one representation of "unset".
+ */
+export type ThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+/** Runtime guard for values arriving from JSON config or chat commands. */
+export function isThinkingEffort(v: unknown): v is ThinkingEffort {
+  return v === 'low' || v === 'medium' || v === 'high' || v === 'xhigh' || v === 'max';
+}
+```
+
+- [ ] **Step 2: Add `effort` to `AgentRequest`**
+
+In `packages/core/src/types/index.ts`, inside `interface AgentRequest` (starts
+line 117), add after the `model?: ModelConfig;` line:
+
+```ts
+  /**
+   * Reasoning-effort level for this single invocation. Deliberately NOT part of
+   * ModelConfig: effort is per-call intent, not a property of a model
+   * definition, and storing it there would pollute the gateway.json catalog.
+   */
+  effort?: ThinkingEffort;
+```
+
+- [ ] **Step 3: Add `defaultEffort` to `AgentModelConfig`**
+
+In the same file, `interface AgentModelConfig` (line 267) becomes:
+
+```ts
+export interface AgentModelConfig {
+  enabled?: boolean;
+  provider?: 'anthropic' | 'openai' | 'google';
+  defaultModel?: string;
+  models?: string[];  // model names only, provider determined by agent.provider
+  /**
+   * Per-agent default reasoning effort. Per-agent rather than one global value
+   * because codex's valid subset varies by model, and `max` costs a different
+   * order of magnitude across agents — a single value would force everyone onto
+   * the most conservative agent's ceiling.
+   */
+  defaultEffort?: ThinkingEffort;
+}
+```
+
+- [ ] **Step 4: Add `effort` to `Chat`**
+
+In `packages/core/src/types/chat.ts`, after the `model?: string;` line (line 145):
+
+```ts
+  /** Per-chat reasoning-effort override. Falls back to the worker's effort, then the agent's defaultEffort. */
+  effort?: ThinkingEffort;
+```
+
+Add `ThinkingEffort` to the existing import from `./index` at the top of the
+file. If `chat.ts` has no import from `./index` yet, add:
+
+```ts
+import type { ThinkingEffort } from './index';
+```
+
+- [ ] **Step 5: Add `effort` to `WorkerConfig`**
+
+In `packages/core/src/workers.ts`, `interface WorkerConfig` (line 11) becomes:
+
+```ts
+export interface WorkerConfig {
+  codingAgent: 'claude-code' | 'opencode' | 'codex';
+  model: string;
+  tools: string[];
+  /**
+   * Optional one-line summary fed to the auto-dispatcher when this worker
+   * appears in a team with `dispatch: 'auto'`. When unset, the dispatcher
+   * uses the first line of `personality.role` truncated to 120 chars.
+   * `personality.soul` and `.instructions` are never sent to the dispatcher.
+   */
+  dispatchHint?: string;
+  /** Optional per-worker reasoning effort. Overridden by a chat-level effort. */
+  effort?: ThinkingEffort;
+}
+```
+
+Add the import at the top of `workers.ts`:
+
+```ts
+import type { ThinkingEffort } from './types';
+```
+
+Verify the existing import style in that file first — if it already imports from
+`'./types'`, add `ThinkingEffort` to that import instead of adding a new line.
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w @codey/core`
+Expected: exits 0, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/types/index.ts packages/core/src/types/chat.ts packages/core/src/workers.ts
+git commit -m "Add ThinkingEffort type and its three storage fields"
+```
+
+---
+
+### Task 2: Pure effort helpers (argv builders + codex rejection detector)
+
+**Files:**
+- Create: `packages/core/src/agents/effort.ts`
+- Test: `packages/core/src/agents/effort.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/agents/effort.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  claudeEffortArgs,
+  codexEffortArgs,
+  opencodeEffortArgs,
+  isEffortRejection,
+} from './effort';
+
+// The real error text codex emits when the API rejects the level. Captured from
+// `codex exec -c model_reasoning_effort="bogus"` against codex v0.145.0.
+const REAL_REJECTION =
+  `ERROR: {"type":"error","error":{"type":"invalid_request_error","message":` +
+  `"[ReasoningEffortParam] [reasoning.effort] [invalid_enum_value] Invalid value: 'max'. ` +
+  `Supported values are: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', and 'max'."}}`;
+
+describe('argv builders', () => {
+  it('emits nothing when effort is unset', () => {
+    expect(claudeEffortArgs(undefined)).toEqual([]);
+    expect(codexEffortArgs(undefined)).toEqual([]);
+    expect(opencodeEffortArgs(undefined)).toEqual([]);
+  });
+
+  it('emits each agent flag verbatim', () => {
+    expect(claudeEffortArgs('xhigh')).toEqual(['--effort', 'xhigh']);
+    expect(codexEffortArgs('xhigh')).toEqual(['-c', 'model_reasoning_effort="xhigh"']);
+    expect(opencodeEffortArgs('xhigh')).toEqual(['--variant', 'xhigh']);
+  });
+});
+
+describe('isEffortRejection', () => {
+  it('detects the real codex rejection for the effort that was passed', () => {
+    expect(isEffortRejection(REAL_REJECTION, 'max')).toBe(true);
+  });
+
+  it('does not fire when the rejected value is a different effort', () => {
+    // The run passed 'low' but the error quotes 'max' — this is some other
+    // request's error text, not ours.
+    expect(isEffortRejection(REAL_REJECTION, 'low')).toBe(false);
+  });
+
+  it('does not fire on invalid_enum_value alone', () => {
+    expect(isEffortRejection("[invalid_enum_value] Invalid value: 'max'.", 'max')).toBe(false);
+  });
+
+  it('does not fire on reasoning.effort alone', () => {
+    expect(isEffortRejection('adjusting reasoning.effort for max throughput', 'max')).toBe(false);
+  });
+
+  it('does not fire on empty text', () => {
+    expect(isEffortRejection('', 'max')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/agents/effort.test.ts`
+Expected: FAIL — `Failed to resolve import "./effort"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/core/src/agents/effort.ts`:
+
+```ts
+import type { ThinkingEffort } from '../types';
+
+/**
+ * Per-agent argv for a reasoning-effort level.
+ *
+ * All three agents take the same five level strings, so these are verbatim
+ * passthroughs that differ only in flag syntax. Verified against claude-code
+ * 2.1.221, codex v0.145.0 and opencode:
+ *
+ *   claude-code  --effort <L>                      lenient (warns, uses default)
+ *   codex        -c model_reasoning_effort="<L>"   STRICT (API rejects the run)
+ *   opencode     --variant <L>                     lenient (silently ignored)
+ */
+export function claudeEffortArgs(effort?: ThinkingEffort): string[] {
+  return effort ? ['--effort', effort] : [];
+}
+
+export function codexEffortArgs(effort?: ThinkingEffort): string[] {
+  return effort ? ['-c', `model_reasoning_effort="${effort}"`] : [];
+}
+
+export function opencodeEffortArgs(effort?: ThinkingEffort): string[] {
+  return effort ? ['--variant', effort] : [];
+}
+
+/** Marker set on a retried request so a degrade can never loop. */
+export interface EffortRetryable {
+  __effortRetried?: boolean;
+}
+
+/**
+ * True when a codex run failed *because of* the effort flag it was given.
+ *
+ * Requires all three markers: the enum-error code, the parameter path, and the
+ * exact level this run passed out. The three-way AND is what stops a user
+ * prompt that happens to quote this error text from being misread as a degrade
+ * signal — all three appearing together, with our own value quoted, is not
+ * something arbitrary output produces.
+ */
+export function isEffortRejection(text: string, passedEffort: string): boolean {
+  if (!text) return false;
+  return text.includes('invalid_enum_value')
+    && text.includes('reasoning.effort')
+    && text.includes(`'${passedEffort}'`);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/core && npx vitest run src/agents/effort.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/agents/effort.ts packages/core/src/agents/effort.test.ts
+git commit -m "Add pure effort argv builders and codex rejection detector"
+```
+
+---
+
+### Task 3: Forward effort from the claude-code adapter
+
+**Files:**
+- Modify: `packages/core/src/agents/claude-code.ts:66-71`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `packages/core/src/agents/claude-code.ts`, alongside the existing
+imports:
+
+```ts
+import { claudeEffortArgs } from './effort';
+```
+
+- [ ] **Step 2: Append the flag**
+
+The block at line 66 currently reads:
+
+```ts
+      const args = [
+        '--verbose',
+        '--output-format', 'stream-json',
+        '--include-partial-messages',
+      ];
+```
+
+Add immediately after it:
+
+```ts
+      args.push(...claudeEffortArgs(request.effort));
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w @codey/core`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/agents/claude-code.ts
+git commit -m "Forward thinking effort to the claude-code CLI"
+```
+
+---
+
+### Task 4: Forward effort from the opencode adapter
+
+**Files:**
+- Modify: `packages/core/src/agents/opencode.ts:67-82`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `packages/core/src/agents/opencode.ts`:
+
+```ts
+import { opencodeEffortArgs } from './effort';
+```
+
+- [ ] **Step 2: Append the flag**
+
+The adapter currently has, around line 80:
+
+```ts
+      if (request.model) {
+        args.push('--model', request.model.model);
+      }
+```
+
+Add immediately after that `if` block (still before `args.push(request.prompt)`
+at line 91 — the prompt must stay last):
+
+```ts
+      args.push(...opencodeEffortArgs(request.effort));
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w @codey/core`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/agents/opencode.ts
+git commit -m "Forward thinking effort to the opencode CLI"
+```
+
+---
+
+### Task 5: Forward effort from codex, with a one-shot degrade retry
+
+**Files:**
+- Modify: `packages/core/src/agents/codex.ts:128-135` (argv), `:271-305` (retry)
+
+- [ ] **Step 1: Add the import**
+
+At the top of `packages/core/src/agents/codex.ts`:
+
+```ts
+import { codexEffortArgs, isEffortRejection, type EffortRetryable } from './effort';
+```
+
+- [ ] **Step 2: Append the flag**
+
+The block at line 128 currently reads:
+
+```ts
+      args.push(
+        '--json',
+        '--skip-git-repo-check',
+      );
+```
+
+Add immediately after it:
+
+```ts
+      args.push(...codexEffortArgs(request.effort));
+```
+
+- [ ] **Step 3: Add the degrade retry**
+
+In the `childProcess.on('close', ...)` handler, the code at line 290 currently
+reads:
+
+```ts
+        const response: AgentResponse = {
+          success: code === 0 && !errorMessage && !!output,
+```
+
+Insert this block immediately BEFORE that `const response` declaration (it must
+come after `output` is computed at line 288):
+
+```ts
+        // codex validates model_reasoning_effort server-side and fails the whole
+        // run on a level the current model doesn't accept. Retry once without
+        // the flag so a stale effort setting can never wedge the user.
+        const attempted = request.effort;
+        const retryable = request as AgentRequest & EffortRetryable;
+        if (attempted && !retryable.__effortRetried
+            && isEffortRejection(`${errorMessage ?? ''}\n${stderr}\n${output}`, attempted)) {
+          const retryReq: AgentRequest & EffortRetryable = { ...request, effort: undefined };
+          retryReq.__effortRetried = true;
+          // resumeSessionId is carried through unchanged: the first attempt
+          // failed at parameter validation, so the session state is untouched.
+          void this.run(retryReq).then(retried => {
+            safeResolve(retried.success
+              ? {
+                  ...retried,
+                  output: `> Effort \`${attempted}\` isn't accepted by the current codex model — reran with the model's default effort.\n\n${retried.output}`,
+                }
+              : retried);
+          });
+          return;
+        }
+```
+
+Note: `safeResolve` (line 177) unlinks the *outer* run's `outFile` and guards
+double-resolution, so calling it with the retried response is correct — the
+retry created and cleaned up its own tempfile.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w @codey/core`
+Expected: exits 0.
+
+- [ ] **Step 5: Run the whole core suite for regressions**
+
+Run: `cd packages/core && npx vitest run`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/agents/codex.ts
+git commit -m "Forward thinking effort to codex and degrade once on rejection"
+```
+
+---
+
+### Task 6: Pure precedence resolver
+
+**Files:**
+- Create: `packages/gateway/src/effort-resolve.ts`
+- Test: `packages/gateway/src/effort-resolve.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/effort-resolve.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveEffort } from './effort-resolve';
+
+describe('resolveEffort', () => {
+  it('prefers the chat override over everything', () => {
+    expect(resolveEffort({ chat: 'low', worker: 'high', global: 'max' })).toBe('low');
+  });
+
+  it('falls back to the worker effort when the chat has none', () => {
+    expect(resolveEffort({ worker: 'high', global: 'max' })).toBe('high');
+  });
+
+  it('falls back to the global default when neither is set', () => {
+    expect(resolveEffort({ global: 'max' })).toBe('max');
+  });
+
+  it('returns undefined when nothing is set, so no flag is passed', () => {
+    expect(resolveEffort({})).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/gateway && npx vitest run src/effort-resolve.test.ts`
+Expected: FAIL — `Failed to resolve import "./effort-resolve"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/gateway/src/effort-resolve.ts`:
+
+```ts
+import type { ThinkingEffort } from '@codey/core';
+
+/**
+ * Reasoning-effort precedence: chat override > worker config > per-agent
+ * global default. Mirrors the model chain in ChatTab's `effectiveModel`.
+ * `undefined` propagates as "pass no flag".
+ */
+export function resolveEffort(tiers: {
+  chat?: ThinkingEffort;
+  worker?: ThinkingEffort;
+  global?: ThinkingEffort;
+}): ThinkingEffort | undefined {
+  return tiers.chat ?? tiers.worker ?? tiers.global;
+}
+```
+
+No barrel change is needed: `packages/core/src/index.ts:2` is
+`export * from './types'`, so `ThinkingEffort` and `isThinkingEffort` are already
+public once Task 1 lands.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/gateway && npx vitest run src/effort-resolve.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/effort-resolve.ts packages/gateway/src/effort-resolve.test.ts
+git commit -m "Add pure thinking-effort precedence resolver"
+```
+
+---
+
+### Task 7: Persist the per-chat effort override
+
+**Files:**
+- Modify: `packages/gateway/src/chats.ts:303` (next to `updateAgentModel`)
+
+- [ ] **Step 1: Add the setter**
+
+In `packages/gateway/src/chats.ts`, immediately after the closing brace of
+`updateAgentModel` (which ends at line 314), add:
+
+```ts
+  /**
+   * Set or clear the per-chat reasoning-effort override. Pass null/undefined to
+   * clear and fall back to the worker/global tiers.
+   *
+   * Deliberately separate from updateAgentModel: that setter's session-anchor
+   * behavior is tied to agent/model identity, and changing effort must NOT
+   * rotate the session — raising effort and continuing the same thread is the
+   * primary use case, and rotating would drop the conversation context.
+   */
+  updateEffort(chatId: string, effort?: ThinkingEffort | null): Chat {
+    const chat = this.requireChat(chatId);
+    if (effort === null || effort === undefined) delete chat.effort;
+    else chat.effort = effort;
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+```
+
+Add `ThinkingEffort` to the existing `@codey/core` type import at the top of
+`chats.ts`.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w @codey/gateway`
+Expected: exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/gateway/src/chats.ts
+git commit -m "Add per-chat thinking-effort override setter"
+```
+
+---
+
+### Task 8: Apply the global default centrally, and the chat tier on the chat path
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts:5063` (`runWithFallback`), `:5398` (quick question), `:5681` (`sendToChat`)
+
+- [ ] **Step 1: Add the imports**
+
+At the top of `packages/gateway/src/gateway.ts`, add to the existing imports:
+
+```ts
+import { resolveEffort } from './effort-resolve';
+```
+
+and add `ThinkingEffort` to the existing `@codey/core` type import.
+
+- [ ] **Step 2: Inject the global default in `runWithFallback`**
+
+`runWithFallback` (line 5063) is the single choke point every agent run passes
+through. Replace its first line:
+
+```ts
+  private async runWithFallback(agent: CodingAgent, request: AgentRequest): Promise<AgentResponse> {
+    const response = await this.runAgentWithNetworkRetry(agent, request);
+```
+
+with:
+
+```ts
+  private async runWithFallback(agent: CodingAgent, request: AgentRequest): Promise<AgentResponse> {
+    // Global tier: any caller that didn't set an explicit chat/worker effort
+    // inherits the agent's configured default. Applied here rather than at each
+    // of the ~20 call sites.
+    if (request.effort === undefined) {
+      request = { ...request, effort: this.getDefaultEffort(agent) };
+    }
+    const response = await this.runAgentWithNetworkRetry(agent, request);
+```
+
+Note the effort is intentionally NOT re-resolved per fallback agent: the level is
+a verbatim passthrough, and if a fallback lands on codex with an unsupported
+level, Task 5's degrade-retry handles it.
+
+- [ ] **Step 3: Add the `getDefaultEffort` accessor**
+
+Add this method next to `getDefaultModelConfig` (line 419):
+
+```ts
+  /** The per-agent configured default effort, if any. */
+  private getDefaultEffort(agent: CodingAgent): ThinkingEffort | undefined {
+    return this.config.agents?.[agent]?.defaultEffort;
+  }
+```
+
+- [ ] **Step 4: Pass the chat override on the `sendToChat` path**
+
+At line 5678 the chat path reads:
+
+```ts
+    // Per-chat override takes precedence over the gateway default.
+    const agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
+```
+
+Add immediately after that line:
+
+```ts
+    const chatEffort = resolveEffort({ chat: chat.effort });
+```
+
+Then, at each `this.runWithFallback(agent, { ... })` call inside this method
+(lines 5885 and 5912), add `effort: chatEffort,` to the request object literal,
+directly after the existing `model,` property.
+
+- [ ] **Step 5: Pass the chat override on the quick-question path**
+
+At line 5397, inside the `else` branch:
+
+```ts
+        agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
+        model = chat.model
+          ? this.getModelConfig(agent, chat.model)
+          : this.getDefaultModelConfig(agent);
+```
+
+Then at the `this.runWithFallback(agent, { ... })` call at line 5429, add to the
+request object literal, after `model,`:
+
+```ts
+        effort: resolveEffort({ chat: chat.effort }),
+```
+
+- [ ] **Step 6: Verify it compiles and the gateway suite passes**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w @codey/gateway && cd packages/gateway && npx vitest run`
+Expected: build exits 0, all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts
+git commit -m "Resolve global and per-chat thinking effort on the run paths"
+```
+
+---
+
+### Task 9: Worker-tier effort
+
+**Files:**
+- Modify: `packages/core/src/workers.ts:181` (next to `getWorkerModel`)
+- Modify: `packages/gateway/src/gateway.ts` — worker run sites at `:3573`, `:3974`, `:4091`, `:4206`, `:4431`
+
+- [ ] **Step 1: Add the worker accessor**
+
+In `packages/core/src/workers.ts`, `getWorkerModel` at line 181 reads:
+
+```ts
+    return this.getWorker(name)?.config.model || '';
+```
+
+Add this method immediately after that method's closing brace:
+
+```ts
+  /** The worker's configured reasoning effort, or undefined when unset. */
+  getWorkerEffort(name: string): ThinkingEffort | undefined {
+    return this.getWorker(name)?.config.effort;
+  }
+```
+
+- [ ] **Step 2: Preserve `effort` through worker writes**
+
+In `packages/core/src/workers.ts`, the validation at line 111 reads:
+
+```ts
+    if (!config.codingAgent || !config.model) {
+```
+
+Leave that check as-is — `effort` is optional. But confirm the write path
+persists unknown-to-required fields: search the file for where `config` is
+serialized into `workspace.json` and make sure it writes the whole `config`
+object rather than picking named fields. If it picks fields explicitly, add
+`effort` to that pick list.
+
+- [ ] **Step 3: Pass worker effort at each worker run site**
+
+At each of `packages/gateway/src/gateway.ts:3573`, `:3974`, `:4091`, `:4206`,
+`:4431`, the surrounding code resolves a worker's model via
+`wm.getWorkerModel(memberName)` (or a local `workerModelName`) and then builds a
+`runWithFallback` request. In each of those request object literals, add after
+the `model` property:
+
+```ts
+        effort: resolveEffort({
+          chat: chatEffort,
+          worker: wm.getWorkerEffort(memberName),
+        }),
+```
+
+Adjust the two variable names per site: use whatever local holds the worker name
+at that site (`memberName`, `workerName`, or `opts.worker`), and pass
+`chat: undefined` at sites that have no chat in scope. Do not invent a chat
+variable where none exists — the global tier still applies via Task 8 Step 2.
+
+- [ ] **Step 4: Verify it compiles and both suites pass**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build && npm test`
+Expected: build exits 0, all workspace tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/workers.ts packages/gateway/src/gateway.ts
+git commit -m "Apply per-worker thinking effort on team and worker runs"
+```
+
+---
+
+### Task 10: The `/effort` chat command
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts:2378` (dispatch), `:2566` (next to `cmdModel`)
+
+**Context the implementer needs:** channel-side `/model` (line 2566) is an
+informational stub that persists nothing, and `/agent` (line 2584) writes the
+*global* default via `configManager`. Channel chats have no `Chat` record, so
+`/effort` follows `/agent`: it sets the per-agent global default. That is the
+only tier reachable from Telegram/Discord.
+
+- [ ] **Step 1: Add the dispatch case**
+
+In the command `switch` block, immediately after the `case 'model':` block that
+ends at line 2380, add:
+
+```ts
+      case 'effort':
+        await this.cmdEffort(args, chatId, channel);
+        break;
+```
+
+- [ ] **Step 2: Add the command handler**
+
+Add this method immediately after `cmdModel` (which ends at line 2582):
+
+```ts
+  private async cmdEffort(args: string[], chatId: string, channel: ChannelType): Promise<void> {
+    const agent = this.getDefaultAgent() as CodingAgent;
+    const current = this.getDefaultEffort(agent);
+
+    if (args.length === 0) {
+      await this.sendResponse({
+        chatId,
+        channel,
+        text: `Current effort for **${agent}**: ${current ?? 'unset (CLI default)'}\n\n` +
+          `Set with: /effort <low|medium|high|xhigh|max>\nClear with: /effort clear`,
+      });
+      return;
+    }
+
+    const raw = args[0].toLowerCase();
+    if (raw === 'clear') {
+      this.configManager?.setAgentDefaultEffort(agent, undefined);
+      await this.sendResponse({
+        chatId,
+        channel,
+        text: `✅ Cleared effort for **${agent}** — using the CLI default.`,
+      });
+      return;
+    }
+
+    if (!isThinkingEffort(raw)) {
+      await this.sendResponse({
+        chatId,
+        channel,
+        text: `Unknown effort: ${raw}\n\nAvailable: low, medium, high, xhigh, max`,
+      });
+      return;
+    }
+
+    this.configManager?.setAgentDefaultEffort(agent, raw);
+    await this.sendResponse({
+      chatId,
+      channel,
+      text: `✅ Effort for **${agent}** set to **${raw}**.`,
+    });
+  }
+```
+
+Add `isThinkingEffort` to the existing `@codey/core` value import at the top of
+`gateway.ts` (it is a function, so it must be a value import, not `import type`).
+
+- [ ] **Step 3: Add the config setter**
+
+In `packages/gateway/src/config.ts`, next to the existing agent accessors around
+line 334, add:
+
+```ts
+  /** Set or clear an agent's default reasoning effort and persist gateway.json. */
+  setAgentDefaultEffort(agent: CodingAgent, effort?: ThinkingEffort): void {
+    if (!this.config.agents) this.config.agents = {};
+    const slot = this.config.agents[agent] ?? {};
+    if (effort === undefined) delete slot.defaultEffort;
+    else slot.defaultEffort = effort;
+    this.config.agents[agent] = slot;
+    this.save();
+  }
+```
+
+Check the file's existing persistence method name — if it is not `save()`, use
+whatever `setDefaultAgent` calls to write `gateway.json`, and match the same
+import style for `ThinkingEffort` / `CodingAgent`.
+
+- [ ] **Step 4: Register the command in the help text**
+
+Search `packages/gateway/src/gateway.ts` for the `/model` entry in the help
+listing (`cmdHelp` or a `HELP_TEXT` constant) and add a matching line:
+
+```
+/effort <level> — Set reasoning effort (low/medium/high/xhigh/max)
+```
+
+- [ ] **Step 5: Verify it compiles and tests pass**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build && npm test`
+Expected: build exits 0, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts packages/gateway/src/config.ts
+git commit -m "Add /effort chat command"
+```
+
+---
+
+### Task 11: IPC for the per-chat effort override
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts:3508`, `codey-mac/electron/preload.ts:161`, `codey-mac/src/codey-api.d.ts:293`
+
+- [ ] **Step 1: Add the main-process handler**
+
+In `codey-mac/electron/main.ts`, the handler at line 3508 reads:
+
+```ts
+ipcMain.handle('chats:updateAgentModel', async (_e, id: string, agent: string | null, model: string | null) =>
+```
+
+Add a sibling handler immediately after that handler's closing `)`:
+
+```ts
+ipcMain.handle('chats:updateEffort', async (_e, id: string, effort: string | null) =>
+  withGateway(() =>
+    inProcessGateway!.getChatManager().updateEffort(id, effort as any)
+  ))
+```
+
+Match the exact wrapper the neighbouring handler uses (line 3509-3511 shows the
+`withGateway`/guard style in this file) rather than the sketch above — copy that
+handler's structure verbatim and swap the method and arguments.
+
+- [ ] **Step 2: Add the preload binding**
+
+In `codey-mac/electron/preload.ts`, after line 162:
+
+```ts
+    updateEffort: (id: string, effort: string | null) =>
+      ipcRenderer.invoke('chats:updateEffort', id, effort),
+```
+
+- [ ] **Step 3: Add the type declaration**
+
+In `codey-mac/src/codey-api.d.ts`, after line 293:
+
+```ts
+        updateEffort: (id: string, effort: string | null) => Promise<IpcResult<Chat>>
+```
+
+- [ ] **Step 4: Expose it from the chats hook**
+
+Find the `useChats` hook (imported at `codey-mac/src/components/ChatTab.tsx:841`)
+and add a `setEffort` action next to the existing `setAgentModel`, following that
+action's exact shape — it calls `window.codey.chats.updateAgentModel` and merges
+the returned `Chat` into state. The new one calls
+`window.codey.chats.updateEffort(chatId, effort)` and merges the same way.
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w codey-mac`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/electron/main.ts codey-mac/electron/preload.ts codey-mac/src/codey-api.d.ts codey-mac/src/hooks
+git commit -m "Add chats:updateEffort IPC"
+```
+
+---
+
+### Task 12: Effort select in the chat run-settings row
+
+**Files:**
+- Modify: `codey-mac/src/components/ChatTab.tsx:841`, `:1311-1313`, `:1357`, `:1885`
+
+- [ ] **Step 1: Pull `setEffort` out of the hook**
+
+At line 841, add `setEffort` to the destructured actions:
+
+```ts
+  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setWorkingDir: setChatWorkingDir, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+```
+
+- [ ] **Step 2: Derive the effective effort**
+
+`agentDefaultModels` (line 875) is built from `fallback.order`, which carries no
+effort, so the defaults must be fetched from the agents config instead.
+
+Add the state next to line 875:
+
+```ts
+  const [agentDefaultEfforts, setAgentDefaultEfforts] = useState<Record<string, string | undefined>>({})
+```
+
+Populate it inside the same `useEffect` that ends at line 1119, immediately after
+the `setAgentDefaultModels(defaults)` call at line 1115:
+
+```ts
+          try {
+            const ag = await window.codey.agents.get()
+            if (ag.ok) {
+              const slots = (ag.data ?? {}) as Record<string, { defaultEffort?: string }>
+              const efforts: Record<string, string | undefined> = {}
+              for (const n of AGENT_NAMES) efforts[n] = slots[n]?.defaultEffort
+              setAgentDefaultEfforts(efforts)
+            }
+          } catch { /* falls back to "CLI default" in the dropdown */ }
+```
+
+Then, after line 1313 (`const effectiveModel = ...`), add:
+
+```ts
+  const workerEffort = selectedWorker?.config.effort
+  const effectiveEffort: string | undefined = chat.effort ?? workerEffort ?? agentDefaultEfforts[effectiveAgent]
+```
+
+- [ ] **Step 3: Add the change handler**
+
+After `onModelChange` (line 1357-1359), add:
+
+```ts
+  const onEffortChange = async (v: string) => {
+    // '' is the Inherit option — clears the chat override.
+    await setEffort(chat.id, v === '' ? null : v)
+  }
+```
+
+- [ ] **Step 4: Add the select**
+
+After the Model `</label>` at line 1885 and before the Advisor `<button>` at
+line 1886, insert:
+
+```tsx
+                    <label style={styles.runSettingGroup}>
+                      <span style={styles.runSettingLabel}>Effort</span>
+                      <select
+                        value={chat.effort ?? ''}
+                        onChange={e => void onEffortChange(e.target.value)}
+                        style={styles.runSettingSelect}
+                        title={`Effort: ${effectiveEffort ?? 'CLI default'}${chat.effort ? ' (override)' : workerEffort ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
+                      >
+                        <option value="">Inherit ({effectiveEffort ?? 'CLI default'})</option>
+                        <option value="low">low</option>
+                        <option value="medium">medium</option>
+                        <option value="high">high</option>
+                        <option value="xhigh">xhigh</option>
+                        <option value="max">max</option>
+                      </select>
+                    </label>
+```
+
+This sits inside the non-team branch that opens at line 1856, so the team case
+(line 1853, "Teams choose their own agent routing.") already hides it.
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w codey-mac`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/src/components/ChatTab.tsx
+git commit -m "Add Effort select to the chat run-settings row"
+```
+
+---
+
+### Task 13: Per-agent default effort in Settings
+
+**Files:**
+- Modify: `codey-mac/src/components/AgentsTab.tsx:16`, and the agent card near `:85`
+
+- [ ] **Step 1: Extend the slot type**
+
+Line 16 becomes:
+
+```ts
+type AgentSlot = { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }
+```
+
+- [ ] **Step 2: Add the select to each agent card**
+
+Find the `Default model` control inside the per-agent card (the code around line
+85 that calls `window.codey.agents.set({ [a]: updated[a] })`). Add a sibling
+control next to it:
+
+```tsx
+<label style={{ display: 'block', marginTop: 10 }}>
+  <span style={{ fontSize: 11, color: C.fg3 }}>Default effort</span>
+  <select
+    value={agents[a]?.defaultEffort ?? ''}
+    onChange={async e => {
+      const v = e.target.value
+      const updated = { ...agents, [a]: { ...agents[a], defaultEffort: v === '' ? undefined : v } }
+      setAgents(updated)
+      // agents:set merges shallowly, so sending just this agent's slot is enough.
+      await unwrap(await window.codey.agents.set({ [a]: updated[a] }))
+    }}
+  >
+    <option value="">Unset (CLI default)</option>
+    <option value="low">low</option>
+    <option value="medium">medium</option>
+    <option value="high">high</option>
+    <option value="xhigh">xhigh</option>
+    <option value="max">max</option>
+  </select>
+</label>
+```
+
+Match the surrounding control's exact styling props rather than the minimal
+inline styles above — copy them from the adjacent `Default model` control.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build -w codey-mac`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add codey-mac/src/components/AgentsTab.tsx
+git commit -m "Add per-agent default effort to Settings"
+```
+
+---
+
+### Task 14: Worker effort in the worker editor
+
+**Files:**
+- Modify: `codey-mac/src/components/WorkersTab.tsx:40`, `:100`, `:114`, `:128`, and the Model field near `:180`
+
+- [ ] **Step 1: Add editor state**
+
+After line 100 (`const [model, setModel] = useState(worker.config.model)`), add:
+
+```ts
+  const [effort, setEffort] = useState(worker.config.effort ?? '')
+```
+
+- [ ] **Step 2: Reset it when the selected worker changes**
+
+Line 114 currently reads:
+
+```ts
+    setCodingAgent(worker.config.codingAgent); setModel(worker.config.model); setToolsText(worker.config.tools.join(', '))
+```
+
+Append to that line:
+
+```ts
+    setEffort(worker.config.effort ?? '')
+```
+
+- [ ] **Step 3: Persist it on save**
+
+Line 128 currently reads:
+
+```ts
+        config: { codingAgent, model, tools: toolsText.split(',').map(s => s.trim()).filter(Boolean) },
+```
+
+becomes:
+
+```ts
+        config: {
+          codingAgent,
+          model,
+          tools: toolsText.split(',').map(s => s.trim()).filter(Boolean),
+          ...(effort ? { effort } : {}),
+        },
+```
+
+The spread keeps `effort` out of the JSON entirely when unset, so `workspace.json`
+stays clean for workers that never use it.
+
+- [ ] **Step 4: Add the field**
+
+After the Model field (the `<label style={labelStyle}>Model</label>` block that
+starts at line 180) add:
+
+```tsx
+      <label style={labelStyle}>Effort</label>
+      <select value={effort} onChange={e => setEffort(e.target.value)} style={fieldStyle}>
+        <option value="">Unset (inherit)</option>
+        <option value="low">low</option>
+        <option value="medium">medium</option>
+        <option value="high">high</option>
+        <option value="xhigh">xhigh</option>
+        <option value="max">max</option>
+      </select>
+```
+
+- [ ] **Step 5: Show it in the list row**
+
+Line 40 currently reads:
+
+```tsx
+              <div style={{ fontSize: 10, color: C.fg3, marginTop: 2 }}>{w.config.codingAgent} · {w.config.model}</div>
+```
+
+becomes:
+
+```tsx
+              <div style={{ fontSize: 10, color: C.fg3, marginTop: 2 }}>{w.config.codingAgent} · {w.config.model}{w.config.effort ? ` · ${w.config.effort}` : ''}</div>
+```
+
+- [ ] **Step 6: Verify the whole repo builds and every suite passes**
+
+Run: `source ~/.nvm/nvm.sh && nvm use 22.17.1 && npm run build && npm test && npm run lint`
+Expected: build exits 0, all tests pass, lint reports no non-English characters.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add codey-mac/src/components/WorkersTab.tsx
+git commit -m "Add worker-level thinking effort to the worker editor"
+```
+
+---
+
+### Task 15: Real-agent smoke test
+
+Every prior task is verified by unit tests and the type checker, but nothing so
+far has actually spawned a CLI with the flag. This task is manual and required —
+the argv builders being correct does not prove the CLIs accept the result.
+
+- [ ] **Step 1: claude-code accepts the flag**
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+cd /tmp && claude -p "reply with the single word ok" --effort xhigh --output-format stream-json --verbose 2>&1 | tail -3
+```
+
+Expected: a `result` event with `is_error: false`. Specifically, NO line
+containing `Unknown --effort value` — that warning means the level string is
+being mangled somewhere in the argv builder.
+
+- [ ] **Step 2: codex accepts a supported level**
+
+```bash
+cd /tmp && codex exec --skip-git-repo-check -c model_reasoning_effort="high" "reply with the single word ok" 2>&1 | tail -5
+```
+
+Expected: normal completion, and the banner line reads `reasoning effort: high`.
+
+- [ ] **Step 3: codex degrade-retry fires end to end**
+
+Set a chat's effort to `max` in the Mac app, switch that chat's agent to codex
+with a model that rejects `max`, and send "hi".
+
+Expected: the reply arrives successfully and begins with the note
+`> Effort \`max\` isn't accepted by the current codex model — reran with the model's default effort.`
+Expected NOT: a raw `invalid_enum_value` error surfaced to the user.
+
+If no available model rejects `max`, verify the path by temporarily changing the
+`codexEffortArgs` return to `['-c', 'model_reasoning_effort="bogus"']`, running
+one turn, confirming the note appears, then reverting that edit.
+
+- [ ] **Step 4: opencode tolerates the flag**
+
+```bash
+cd /tmp && opencode run --variant high "reply with the single word ok" 2>&1 | tail -3
+```
+
+Expected: normal completion. opencode ignores unknown variants silently, so the
+only failure mode worth catching here is a crash or an argv parse error.
+
+- [ ] **Step 5: Precedence works in the app**
+
+Set a global default of `low` for claude-code in Settings, `high` on a worker,
+and `max` on a chat. Run one turn per configuration and confirm via the
+gateway log that the argv carries `max` (chat), then `high` (chat cleared), then
+`low` (chat and worker cleared).
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "Fix issues found in thinking-effort smoke test"
+```
+
+---
+
+## Self-review notes
+
+Checked against the spec:
+
+- Spec §1 (data model, three tiers, `AgentRequest.effort`, not in `ModelConfig`) → Tasks 1, 7, 9, 13, 14.
+- Spec §2 (three argv insertions, `isEffortRejection` three-way AND, single retry, `__effortRetried`, output-prepended note, session carried through) → Tasks 2, 3, 4, 5.
+- Spec §3a (chat select, Inherit clears) → Tasks 11, 12. §3b → Task 13. §3c → Task 14. §3d (`/effort`) → Task 10.
+- Spec test plan (rejection detector, argv presence/absence, retry-once, precedence, command) → Tasks 2, 6, 10, 15.
+
+**Deviation from the spec worth flagging to the reviewer:** the spec's §3d said
+`/effort clear` clears "the chat override". Task 10 instead sets and clears the
+*per-agent global default*, because channel chats have no `Chat` record —
+channel-side `/model` persists nothing and `/agent` writes the global default
+(`gateway.ts:2584`). Changing the global from a chat command is the only tier
+actually reachable from Telegram/Discord. The command's reply text says which
+agent it changed so this is not silently surprising.

--- a/docs/superpowers/plans/2026-08-09-thinking-effort-control.md
+++ b/docs/superpowers/plans/2026-08-09-thinking-effort-control.md
@@ -309,7 +309,11 @@ export function isEffortRejection(text: string, passedEffort: string): boolean {
   if (!text) return false;
   return text.includes('invalid_enum_value')
     && text.includes('reasoning.effort')
-    && text.includes(`'${passedEffort}'`);
+    // Anchored to "Invalid value: '<L>'", never a bare '<L>' match: the error's
+    // own "Supported values are: 'none', 'minimal', 'low', ..." enumeration
+    // quotes every level, so a bare match fires on 'low' even when the run
+    // passed 'max'.
+    && text.includes(`Invalid value: '${passedEffort}'`);
 }
 ```
 

--- a/docs/superpowers/specs/2026-08-09-thinking-effort-control-design.md
+++ b/docs/superpowers/specs/2026-08-09-thinking-effort-control-design.md
@@ -1,0 +1,157 @@
+# Thinking-effort control
+
+**Date:** 2026-08-09
+**Status:** Approved, ready for planning
+
+## Problem
+
+Each coding agent CLI exposes a reasoning-effort knob, but Codey never forwards it,
+so every prompt runs at the CLI's default effort. There is no way to make a hard
+problem think harder, or cheap chatter think less, from the chat surfaces.
+
+## Verified CLI surface
+
+Probed on this machine (claude-code 2.1.221, codex v0.145.0, opencode latest):
+
+| Agent | Knob | Valid values | Invalid-value behavior |
+|---|---|---|---|
+| claude-code | `--effort <L>` | low, medium, high, xhigh, max | lenient: warns, falls back to default |
+| codex | `-c model_reasoning_effort="<L>"` | none, minimal, low, medium, high, xhigh, max | **strict**: `invalid_enum_value` → whole run fails |
+| opencode | `--variant <L>` | provider-specific | lenient: silently ignored |
+
+The unified vocabulary is **low / medium / high / xhigh / max**, forwarded
+verbatim to every agent — no translation table needed, only the flag syntax
+differs. `undefined` = pass no flag = the CLI's own default; we never invent a
+`'default'` literal.
+
+## Design
+
+### 1. Data model and precedence
+
+`packages/core/src/types/index.ts`:
+
+```ts
+export type ThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+```
+
+Three storage layers, mirroring the existing Model chain exactly:
+
+| Layer | Location | Field |
+|---|---|---|
+| worker | `packages/core/src/workers.ts:11` `WorkerConfig` | `effort?: ThinkingEffort` |
+| chat override | chat record, `packages/gateway/src/chats.ts:303` | `effort?: ThinkingEffort` |
+| global default | `packages/core/src/types/index.ts:267` `AgentModelConfig` | `defaultEffort?: ThinkingEffort` |
+
+Precedence: `chat.effort ?? worker.config.effort ?? agents[agent].defaultEffort`,
+structurally identical to the `effectiveModel` derivation at
+`codey-mac/src/components/ChatTab.tsx:1313`.
+
+The global default is per-agent, not a single cross-agent value: codex's valid
+subset varies by model and claude's `max` vs codex's `max` cost differently, so a
+single value would force the most conservative agent on everyone.
+
+Transport: `AgentRequest` (`types/index.ts:117`) gains `effort?: ThinkingEffort`.
+Deliberately **not** in `ModelConfig` — effort is per-invocation intent, not a
+property of a model definition, and putting it there would pollute the `gateway.json`
+model catalog.
+
+### 2. Adapter wiring and codex degrade-retry
+
+Three argv insertions, all verbatim passthrough when `request.effort` is set:
+
+| File | Insertion point | Append |
+|---|---|---|
+| `packages/core/src/agents/claude-code.ts:69` | after `--output-format` block | `--effort <e>` |
+| `packages/core/src/agents/codex.ts:128` | after `--json --skip-git-repo-check` | `-c model_reasoning_effort="<e>"` |
+| `packages/core/src/agents/opencode.ts:81` | near `--model` | `--variant <e>` |
+
+claude-code and opencode need no fallback — both are lenient on invalid values.
+
+codex gets a degrade-retry. New pure helper
+`packages/core/src/agents/effort-retry.ts` (unit-tested):
+
+```ts
+/** True when a codex run failed *because of* the effort flag it was given. */
+export function isEffortRejection(text: string, passedEffort: string): boolean
+```
+
+It requires **all three** to match: `invalid_enum_value`, `reasoning.effort`, and
+the exact effort value that was passed out (the `passedEffort` argument, quoted as
+`'<value>'` in the probe error). The three-way AND stops a prompt that happens to
+quote this error text from being misread as a degrade signal. (Probed
+error: `[ReasoningEffortParam] [reasoning.effort] [invalid_enum_value] Invalid value: 'bogus'. Supported values are: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', and 'max'.`)
+
+Retry lives inside `CodexAdapter.run`, in the `close` callback just before the
+`AgentResponse` is assembled (`codex.ts:290`). On a hit, the adapter clears
+`request.effort` and recurses `this.run(request)` once, guarded by a private
+`__effortRetried` marker so it can never loop. `resumeSessionId` is carried into
+the retry unchanged — the first attempt failed at parameter validation, so the
+session state is untouched.
+
+On retry success, the user-visible note is prepended to `AgentResponse.output`:
+
+```
+> Effort `max` isn't accepted by the current codex model — reran with the model's default effort.
+```
+
+Not `statusUpdates`: that channel is transient process state and vanishes when the
+run ends, while this is a config correction the user should see afterward.
+
+Deliberately not done: no "this model rejects X" cache (stale-cache risk; a retry
+costs one API rejection that fails before token billing), and the retry does not
+rotate the session.
+
+### 3. UI and command surfaces
+
+Four surfaces, one per existing Model surface.
+
+**3a. Chat run-settings row** (`codey-mac/src/components/ChatTab.tsx:1871-1885`,
+insert after Model). A `<select>` — not a cycling button: the row's other three
+controls are selects, and 5 levels would take 4 clicks to traverse from low to
+max with no visible full set. Options: `Inherit (high)` / low / medium / high /
+xhigh / max. Selecting `Inherit` clears the chat override (same behavior as
+`/effort clear`). `title` reuses the Model row's three-state wording (`(override)` /
+`(worker: X)` / `(default)`). The team branch (`ChatTab.tsx:1853`, "Teams choose
+their own agent routing.") already hides the whole block — team members each
+carry worker-level effort.
+
+**3b. Settings → Agents** (`codey-mac/src/components/AgentsTab.tsx:16`): `AgentSlot`
+gains `defaultEffort?: ThinkingEffort`; each agent card gets a `Default effort`
+select next to `Default model`, defaulting to `Unset`.
+
+**3c. Worker editor** (`codey-mac/src/components/WorkersTab.tsx:100-128`): an
+Effort select next to the model input, written to `WorkerConfig.effort`. The
+list-row summary (`WorkersTab.tsx:40`) appends effort when set:
+`claude-code · opus · max`.
+
+**3d. Channel command** `/effort [level]`, dispatched beside `case 'model'`
+(`packages/gateway/src/gateway.ts:2378`) via a new `cmdEffort`. No arg prints the
+effective value and its source layer; `/effort clear` clears the chat override.
+Required for Telegram/Discord users, who have no Mac UI and would otherwise have
+no way to reach this feature.
+
+Deliberate asymmetry: `updateAgentModel` (`chats.ts:303`) is **not** extended —
+a new `updateEffort(chatId, effort)` is added instead. That function's docstring
+says it keeps every agent/model session anchored; changing effort mid-conversation
+should *not* rotate the session, since raising effort and continuing the same
+thread is the primary use case.
+
+## Test plan
+
+- `effort-retry.ts`: unit tests for `isEffortRejection` (hit on the real probed
+  error text, miss on each single-marker text, miss when the quoted effort doesn't
+  match what was passed).
+- Adapter argv: assert the flag lands in the spawned argv for each agent, and is
+  absent when `request.effort` is undefined.
+- codex retry: assert recursion happens exactly once, `__effortRetried` prevents a
+  second retry, and the output note is prepended on retry success.
+- Precedence: `chat > worker > global` resolution unit test.
+- `/effort` command: set / clear / report, including `clear` behavior.
+
+## Out of scope
+
+- Per-worker-per-agent variant of the global default (worker already carries
+  effort; per-agent is enough).
+- Surfacing effort in the run-log / activity feed.
+- A model→supported-levels whitelist (would rot as OpenAI ships models; the
+  degrade-retry covers the failure).

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -5,6 +5,7 @@ import { AgentSpawnError } from '../errors';
 import { thinkingDeltaFrom } from './thinking-stream';
 import { writeClaudeMcpConfig } from './mcp-config';
 import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
+import { claudeEffortArgs } from './effort';
 
 interface StreamEvent {
   type: string;
@@ -103,6 +104,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         '--output-format', 'stream-json',
         '--include-partial-messages',
       ];
+      args.push(...claudeEffortArgs(request.effort));
 
       if (request.skipPermissions) {
         args.push('--dangerously-skip-permissions');

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -9,6 +9,7 @@ import { AgentSpawnError } from '../errors';
 import { ToolCallCollector } from './tool-events';
 import { ChecklistTracker, checklistFromCodexItem } from './checklist';
 import { codexMcpArgs } from './mcp-config';
+import { codexEffortArgs, isEffortRejection, type EffortRetryable } from './effort';
 
 /**
  * Codex emits JSONL events to stdout when invoked with `--json`.
@@ -129,6 +130,7 @@ export class CodexAdapter extends BaseAgentAdapter {
         '--json',
         '--skip-git-repo-check',
       );
+      args.push(...codexEffortArgs(request.effort));
       if (request.skipPermissions) {
         args.push('--dangerously-bypass-approvals-and-sandbox');
       }
@@ -286,6 +288,28 @@ export class CodexAdapter extends BaseAgentAdapter {
           }
         } catch { /* fall through to streamedText */ }
         if (!output) output = streamedText.trim();
+
+        // codex validates model_reasoning_effort server-side and fails the whole
+        // run on a level the current model doesn't accept. Retry once without
+        // the flag so a stale effort setting can never wedge the user.
+        const attempted = request.effort;
+        const retryable = request as AgentRequest & EffortRetryable;
+        if (attempted && !retryable.__effortRetried
+            && isEffortRejection(`${errorMessage ?? ''}\n${stderr}\n${output}`, attempted)) {
+          const retryReq: AgentRequest & EffortRetryable = { ...request, effort: undefined };
+          retryReq.__effortRetried = true;
+          // resumeSessionId is carried through unchanged: the first attempt
+          // failed at parameter validation, so the session state is untouched.
+          void this.run(retryReq).then(retried => {
+            safeResolve(retried.success
+              ? {
+                  ...retried,
+                  output: `> Effort \`${attempted}\` isn't accepted by the current codex model — reran with the model's default effort.\n\n${retried.output}`,
+                }
+              : retried);
+          });
+          return;
+        }
 
         const response: AgentResponse = {
           success: code === 0 && !errorMessage && !!output,

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -9,7 +9,7 @@ import { AgentSpawnError } from '../errors';
 import { ToolCallCollector } from './tool-events';
 import { ChecklistTracker, checklistFromCodexItem } from './checklist';
 import { codexMcpArgs } from './mcp-config';
-import { codexEffortArgs, isEffortRejection, type EffortRetryable } from './effort';
+import { codexEffortArgs, shouldDegradeEffort, withDegradeNotice, type EffortRetryable } from './effort';
 
 /**
  * Codex emits JSONL events to stdout when invoked with `--json`.
@@ -292,21 +292,15 @@ export class CodexAdapter extends BaseAgentAdapter {
         // codex validates model_reasoning_effort server-side and fails the whole
         // run on a level the current model doesn't accept. Retry once without
         // the flag so a stale effort setting can never wedge the user.
-        const attempted = request.effort;
         const retryable = request as AgentRequest & EffortRetryable;
-        if (attempted && !retryable.__effortRetried
-            && isEffortRejection(`${errorMessage ?? ''}\n${stderr}\n${output}`, attempted)) {
+        if (shouldDegradeEffort(retryable, `${errorMessage ?? ''}\n${stderr}\n${output}`)) {
+          const attempted = retryable.effort;
           const retryReq: AgentRequest & EffortRetryable = { ...request, effort: undefined };
           retryReq.__effortRetried = true;
           // resumeSessionId is carried through unchanged: the first attempt
           // failed at parameter validation, so the session state is untouched.
           void this.run(retryReq).then(retried => {
-            safeResolve(retried.success
-              ? {
-                  ...retried,
-                  output: `> Effort \`${attempted}\` isn't accepted by the current codex model — reran with the model's default effort.\n\n${retried.output}`,
-                }
-              : retried);
+            safeResolve(withDegradeNotice(attempted, retried));
           });
           return;
         }

--- a/packages/core/src/agents/effort.test.ts
+++ b/packages/core/src/agents/effort.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  claudeEffortArgs,
+  codexEffortArgs,
+  opencodeEffortArgs,
+  isEffortRejection,
+} from './effort';
+
+// The real error text codex emits when the API rejects the level. Captured from
+// `codex exec -c model_reasoning_effort="bogus"` against codex v0.145.0.
+const REAL_REJECTION =
+  `ERROR: {"type":"error","error":{"type":"invalid_request_error","message":` +
+  `"[ReasoningEffortParam] [reasoning.effort] [invalid_enum_value] Invalid value: 'max'. ` +
+  `Supported values are: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', and 'max'."}}`;
+
+describe('argv builders', () => {
+  it('emits nothing when effort is unset', () => {
+    expect(claudeEffortArgs(undefined)).toEqual([]);
+    expect(codexEffortArgs(undefined)).toEqual([]);
+    expect(opencodeEffortArgs(undefined)).toEqual([]);
+  });
+
+  it('emits each agent flag verbatim', () => {
+    expect(claudeEffortArgs('xhigh')).toEqual(['--effort', 'xhigh']);
+    expect(codexEffortArgs('xhigh')).toEqual(['-c', 'model_reasoning_effort="xhigh"']);
+    expect(opencodeEffortArgs('xhigh')).toEqual(['--variant', 'xhigh']);
+  });
+});
+
+describe('isEffortRejection', () => {
+  it('detects the real codex rejection for the effort that was passed', () => {
+    expect(isEffortRejection(REAL_REJECTION, 'max')).toBe(true);
+  });
+
+  it('does not fire when the rejected value is a different effort', () => {
+    // The run passed 'low' but the error quotes 'max' — this is some other
+    // request's error text, not ours.
+    expect(isEffortRejection(REAL_REJECTION, 'low')).toBe(false);
+  });
+
+  it('does not fire on invalid_enum_value alone', () => {
+    expect(isEffortRejection("[invalid_enum_value] Invalid value: 'max'.", 'max')).toBe(false);
+  });
+
+  it('does not fire on reasoning.effort alone', () => {
+    expect(isEffortRejection('adjusting reasoning.effort for max throughput', 'max')).toBe(false);
+  });
+
+  it('does not fire on empty text', () => {
+    expect(isEffortRejection('', 'max')).toBe(false);
+  });
+});

--- a/packages/core/src/agents/effort.test.ts
+++ b/packages/core/src/agents/effort.test.ts
@@ -4,7 +4,10 @@ import {
   codexEffortArgs,
   opencodeEffortArgs,
   isEffortRejection,
+  shouldDegradeEffort,
+  withDegradeNotice,
 } from './effort';
+import type { AgentResponse } from '../types';
 
 // The real error text codex emits when the API rejects the level. Captured from
 // `codex exec -c model_reasoning_effort="bogus"` against codex v0.145.0.
@@ -48,5 +51,67 @@ describe('isEffortRejection', () => {
 
   it('does not fire on empty text', () => {
     expect(isEffortRejection('', 'max')).toBe(false);
+  });
+});
+
+describe('shouldDegradeEffort', () => {
+  it('is false when no effort was passed', () => {
+    // Nothing to degrade to — a run that never sent the flag can't have been
+    // rejected for it, whatever the output happens to contain.
+    expect(shouldDegradeEffort({ effort: undefined }, REAL_REJECTION)).toBe(false);
+  });
+
+  it('is false when this is already the retry', () => {
+    // The guard that makes the degrade at most one hop deep.
+    expect(shouldDegradeEffort({ effort: 'max', __effortRetried: true }, REAL_REJECTION)).toBe(false);
+  });
+
+  it('is false when the text is not a rejection', () => {
+    expect(shouldDegradeEffort({ effort: 'max' }, 'All done. Wrote 3 files.')).toBe(false);
+  });
+
+  it('is true on the real rejection text for the effort that was passed', () => {
+    expect(shouldDegradeEffort({ effort: 'max' }, REAL_REJECTION)).toBe(true);
+  });
+});
+
+describe('withDegradeNotice', () => {
+  const failed: AgentResponse = {
+    success: false,
+    output: 'connection reset by peer',
+    error: 'connection reset by peer',
+    duration: 4,
+  };
+
+  it('leaves a FAILED retry completely untouched', () => {
+    // Prepending "reran successfully with the default effort" on top of a
+    // failure would tell the user the opposite of what happened.
+    const result = withDegradeNotice('max', failed);
+    expect(result).toEqual(failed);
+    expect(result.output).toBe('connection reset by peer');
+    expect(result.output).not.toContain('default effort');
+  });
+
+  it('prepends the notice on a successful retry and preserves the other fields', () => {
+    const succeeded: AgentResponse = {
+      success: true,
+      output: 'Refactored the parser.',
+      duration: 12,
+      tokens: { input: 100, output: 50, total: 150 },
+      sessionId: 'thread-abc',
+    };
+
+    const result = withDegradeNotice('max', succeeded);
+
+    expect(result.output).toBe(
+      "> Effort `max` isn't accepted by the current codex model — reran with the model's default effort.\n\n"
+      + 'Refactored the parser.',
+    );
+    expect(result.success).toBe(true);
+    expect(result.duration).toBe(12);
+    expect(result.tokens).toEqual({ input: 100, output: 50, total: 150 });
+    expect(result.sessionId).toBe('thread-abc');
+    // The input response is not mutated in place.
+    expect(succeeded.output).toBe('Refactored the parser.');
   });
 });

--- a/packages/core/src/agents/effort.ts
+++ b/packages/core/src/agents/effort.ts
@@ -41,5 +41,11 @@ export function isEffortRejection(text: string, passedEffort: string): boolean {
   if (!text) return false;
   return text.includes('invalid_enum_value')
     && text.includes('reasoning.effort')
+    // Anchored to "Invalid value: '<L>'" — never a bare `'${passedEffort}'`
+    // match. The same error also lists every valid level in a trailing
+    // "Supported values are: 'none', 'minimal', 'low', ..." enumeration, so a
+    // bare quoted-value check would match on 'low' being *listed as
+    // supported* even when the run actually passed and got rejected for
+    // 'max'. Caught this via TDD — keep the anchor.
     && text.includes(`Invalid value: '${passedEffort}'`);
 }

--- a/packages/core/src/agents/effort.ts
+++ b/packages/core/src/agents/effort.ts
@@ -4,12 +4,24 @@ import type { AgentRequest, AgentResponse, ThinkingEffort } from '../types';
  * Per-agent argv for a reasoning-effort level.
  *
  * All three agents take the same five level strings, so these are verbatim
- * passthroughs that differ only in flag syntax. Verified against claude-code
- * 2.1.221, codex v0.145.0 and opencode 1.14.18:
+ * passthroughs that differ only in flag syntax:
  *
  *   claude-code  --effort <L>                      lenient (warns, uses default)
  *   codex        -c model_reasoning_effort="<L>"   STRICT (API rejects the run)
  *   opencode     --variant <L>                     lenient (silently ignored)
+ *
+ * None of that comes from published docs — it was probed directly. The versions
+ * below are what those observations were made ON, not a minimum requirement:
+ * nothing enforces them, and no lower bound has been tested. They are here only
+ * so a future reader can tell how stale the observations are and re-probe when
+ * something looks wrong.
+ *
+ *   observed on: claude-code 2.1.221, codex v0.145.0, opencode 1.14.18
+ *
+ * The leniency column is the load-bearing part. codex being the only strict one
+ * is why the degrade-retry below exists and why the other two need no fallback.
+ * If a future version makes claude-code or opencode strict, they need the same
+ * treatment.
  *
  * opencode's variants are provider-specific (its help cites `high, max,
  * minimal`), so `low`/`xhigh` may not map on every provider. That is safe

--- a/packages/core/src/agents/effort.ts
+++ b/packages/core/src/agents/effort.ts
@@ -1,0 +1,45 @@
+import type { ThinkingEffort } from '../types';
+
+/**
+ * Per-agent argv for a reasoning-effort level.
+ *
+ * All three agents take the same five level strings, so these are verbatim
+ * passthroughs that differ only in flag syntax. Verified against claude-code
+ * 2.1.221, codex v0.145.0 and opencode:
+ *
+ *   claude-code  --effort <L>                      lenient (warns, uses default)
+ *   codex        -c model_reasoning_effort="<L>"   STRICT (API rejects the run)
+ *   opencode     --variant <L>                     lenient (silently ignored)
+ */
+export function claudeEffortArgs(effort?: ThinkingEffort): string[] {
+  return effort ? ['--effort', effort] : [];
+}
+
+export function codexEffortArgs(effort?: ThinkingEffort): string[] {
+  return effort ? ['-c', `model_reasoning_effort="${effort}"`] : [];
+}
+
+export function opencodeEffortArgs(effort?: ThinkingEffort): string[] {
+  return effort ? ['--variant', effort] : [];
+}
+
+/** Marker set on a retried request so a degrade can never loop. */
+export interface EffortRetryable {
+  __effortRetried?: boolean;
+}
+
+/**
+ * True when a codex run failed *because of* the effort flag it was given.
+ *
+ * Requires all three markers: the enum-error code, the parameter path, and the
+ * exact level this run passed out. The three-way AND is what stops a user
+ * prompt that happens to quote this error text from being misread as a degrade
+ * signal — all three appearing together, with our own value quoted, is not
+ * something arbitrary output produces.
+ */
+export function isEffortRejection(text: string, passedEffort: string): boolean {
+  if (!text) return false;
+  return text.includes('invalid_enum_value')
+    && text.includes('reasoning.effort')
+    && text.includes(`Invalid value: '${passedEffort}'`);
+}

--- a/packages/core/src/agents/effort.ts
+++ b/packages/core/src/agents/effort.ts
@@ -5,11 +5,15 @@ import type { AgentRequest, AgentResponse, ThinkingEffort } from '../types';
  *
  * All three agents take the same five level strings, so these are verbatim
  * passthroughs that differ only in flag syntax. Verified against claude-code
- * 2.1.221, codex v0.145.0 and opencode:
+ * 2.1.221, codex v0.145.0 and opencode 1.14.18:
  *
  *   claude-code  --effort <L>                      lenient (warns, uses default)
  *   codex        -c model_reasoning_effort="<L>"   STRICT (API rejects the run)
  *   opencode     --variant <L>                     lenient (silently ignored)
+ *
+ * opencode's variants are provider-specific (its help cites `high, max,
+ * minimal`), so `low`/`xhigh` may not map on every provider. That is safe
+ * precisely because it is lenient: an unmapped level is a no-op, not a failure.
  */
 export function claudeEffortArgs(effort?: ThinkingEffort): string[] {
   return effort ? ['--effort', effort] : [];

--- a/packages/core/src/agents/effort.ts
+++ b/packages/core/src/agents/effort.ts
@@ -1,4 +1,4 @@
-import type { ThinkingEffort } from '../types';
+import type { AgentRequest, AgentResponse, ThinkingEffort } from '../types';
 
 /**
  * Per-agent argv for a reasoning-effort level.
@@ -48,4 +48,39 @@ export function isEffortRejection(text: string, passedEffort: string): boolean {
     // supported* even when the run actually passed and got rejected for
     // 'max'. Caught this via TDD — keep the anchor.
     && text.includes(`Invalid value: '${passedEffort}'`);
+}
+
+/** The only part of a request the degrade decision actually reads. */
+export type EffortDegradable = Pick<AgentRequest, 'effort'> & EffortRetryable;
+
+/**
+ * Whether a finished codex run should be retried once without the effort flag.
+ *
+ * Three conditions, all required: an effort was actually passed, this isn't
+ * already the retry, and the run output is a rejection of *that* level. The
+ * type predicate narrows `effort` for the caller, so the retry path can read
+ * the attempted level without a non-null assertion.
+ */
+export function shouldDegradeEffort(
+  request: EffortDegradable,
+  text: string,
+): request is EffortDegradable & { effort: ThinkingEffort } {
+  return !!request.effort
+    && !request.__effortRetried
+    && isEffortRejection(text, request.effort);
+}
+
+/**
+ * Prepend the "we degraded your effort" notice to a successful retry.
+ *
+ * A FAILED retry is returned completely untouched: the retry's own error is
+ * what the user needs to see, and claiming we reran successfully on top of a
+ * failure would be actively misleading.
+ */
+export function withDegradeNotice(attempted: ThinkingEffort, retried: AgentResponse): AgentResponse {
+  if (!retried.success) return retried;
+  return {
+    ...retried,
+    output: `> Effort \`${attempted}\` isn't accepted by the current codex model — reran with the model's default effort.\n\n${retried.output}`,
+  };
 }

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -5,6 +5,7 @@ import { AgentSpawnError } from '../errors';
 import { writeOpenCodeMcpConfig } from './mcp-config';
 import { ObservedToolEvent, ToolCallCollector } from './tool-events';
 import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
+import { opencodeEffortArgs } from './effort';
 
 export interface OpenCodeEvent {
   type: string;
@@ -80,6 +81,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       if (request.model?.model) {
         args.push('--model', request.model.model);
       }
+      args.push(...opencodeEffortArgs(request.effort));
 
       let mcpCleanup: (() => void) | undefined;
       let mcpEnv: Record<string, string> = {};

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -1,5 +1,6 @@
 import { ChatRoute } from './route';
 import { PendingTeamState } from './pending-team';
+import type { ThinkingEffort } from './index';
 
 /** The three CLIs report task lists in three shapes; the adapters normalize
  *  onto this one. codex has only a completed boolean, so it never produces
@@ -143,6 +144,8 @@ export interface Chat {
   agent?: 'claude-code' | 'opencode' | 'codex';
   /** Per-chat model override (model id from the global catalog). Falls back to the agent's default model when unset. */
   model?: string;
+  /** Per-chat reasoning-effort override. Falls back to the worker's effort, then the agent's defaultEffort. */
+  effort?: ThinkingEffort;
   /** Per-chat "solo advisor" backup toggle. When true and the chat is NOT a team,
    *  a stuck single agent (one that emits `[ASK_ADVISOR]: <reason>`) is escalated
    *  to the stronger advisor model for guidance, then re-run. Default off. */

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -57,6 +57,22 @@ export interface ApiKeyEntry {
   purpose?: 'general' | 'voice';
 }
 
+/**
+ * Reasoning-effort level, forwarded verbatim to every agent CLI.
+ *
+ * These five values are claude-code's `--effort` enum and are a strict subset
+ * of codex's `model_reasoning_effort` enum, so no per-agent translation is
+ * needed — only the flag syntax differs. `undefined` means "pass no flag" and
+ * lets each CLI use its own default; there is deliberately no 'default'
+ * literal, so there is exactly one representation of "unset".
+ */
+export type ThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+/** Runtime guard for values arriving from JSON config or chat commands. */
+export function isThinkingEffort(v: unknown): v is ThinkingEffort {
+  return v === 'low' || v === 'medium' || v === 'high' || v === 'xhigh' || v === 'max';
+}
+
 export interface ModelConfig {
   provider: string;
   model: string;
@@ -118,6 +134,12 @@ export interface AgentRequest {
   prompt: string;
   agent: CodingAgent;
   model?: ModelConfig;
+  /**
+   * Reasoning-effort level for this single invocation. Deliberately NOT part of
+   * ModelConfig: effort is per-call intent, not a property of a model
+   * definition, and storing it there would pollute the gateway.json catalog.
+   */
+  effort?: ThinkingEffort;
   timeout?: number;
   interactive?: boolean;
   skipPermissions?: boolean;
@@ -269,6 +291,13 @@ export interface AgentModelConfig {
   provider?: 'anthropic' | 'openai' | 'google';
   defaultModel?: string;
   models?: string[];  // model names only, provider determined by agent.provider
+  /**
+   * Per-agent default reasoning effort. Per-agent rather than one global value
+   * because codex's valid subset varies by model, and `max` costs a different
+   * order of magnitude across agents — a single value would force everyone onto
+   * the most conservative agent's ceiling.
+   */
+  defaultEffort?: ThinkingEffort;
 }
 
 // Advisor configuration — routing/orchestration LLM used by /team and

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -184,6 +184,11 @@ export class WorkerManager {
     return this.getWorker(name)?.config.model || '';
   }
 
+  /** The worker's configured reasoning effort, or undefined when unset. */
+  getWorkerEffort(name: string): ThinkingEffort | undefined {
+    return this.getWorker(name)?.config.effort;
+  }
+
   /**
    * Returns the one-line summary the auto-dispatcher should see for this worker.
    * Prefers `config.dispatchHint`; otherwise falls back to the first line of

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { BLACKBOARD_MARKER_INSTRUCTIONS } from './team-blackboard';
+import type { ThinkingEffort } from './types';
 
 export interface WorkerPersonality {
   role: string;
@@ -19,6 +20,8 @@ export interface WorkerConfig {
    * `personality.soul` and `.instructions` are never sent to the dispatcher.
    */
   dispatchHint?: string;
+  /** Optional per-worker reasoning effort. Overridden by a chat-level effort. */
+  effort?: ThinkingEffort;
 }
 
 export interface Worker {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       'src/playbook-induction.test.ts',
       'src/agents/tool-events.test.ts',
       'src/agents/claude-code.test.ts',
+      'src/agents/effort.test.ts',
       'src/context.extract-meta.test.ts',
       'src/aide-automation.test.ts',
       'src/speech-digest.test.ts',

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { Chat, ChatCompaction, ChatMessage, ChatSelection, ChatRoute, ChannelKind, ChecklistItem, TaskBrief } from '@codey/core';
+import { Chat, ChatCompaction, ChatMessage, ChatSelection, ChatRoute, ChannelKind, ChecklistItem, TaskBrief, ThinkingEffort } from '@codey/core';
 import { Logger } from './logger';
 
 const log = Logger.getInstance();
@@ -308,6 +308,24 @@ export class ChatManager {
     else chat.model = model;
     // Keep every agent/model session. The next turn selects the matching
     // anchor and incrementally synchronizes only the messages it has missed.
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
+  /**
+   * Set or clear the per-chat reasoning-effort override. Pass null/undefined to
+   * clear and fall back to the worker/global tiers.
+   *
+   * Deliberately separate from updateAgentModel: that setter's session-anchor
+   * behavior is tied to agent/model identity, and changing effort must NOT
+   * rotate the session — raising effort and continuing the same thread is the
+   * primary use case, and rotating would drop the conversation context.
+   */
+  updateEffort(chatId: string, effort?: ThinkingEffort | null): Chat {
+    const chat = this.requireChat(chatId);
+    if (effort === null || effort === undefined) delete chat.effort;
+    else chat.effort = effort;
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;

--- a/packages/gateway/src/chats.workingDirOverride.test.ts
+++ b/packages/gateway/src/chats.workingDirOverride.test.ts
@@ -89,6 +89,41 @@ describe('ChatManager.updateAgentModel', () => {
   });
 });
 
+describe('ChatManager.updateEffort', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('sets and clears the per-chat effort override, bumping updatedAt', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    const beforeUpdatedAt = chat.updatedAt;
+
+    const set = mgr.updateEffort(chat.id, 'high');
+    expect(set.effort).toBe('high');
+    expect(set.updatedAt).toBeGreaterThanOrEqual(beforeUpdatedAt);
+
+    const cleared = mgr.updateEffort(chat.id, null);
+    expect(cleared.effort).toBeUndefined();
+    expect('effort' in cleared).toBe(false);
+  });
+
+  it('persists the cleared effort so it does not round-trip from disk', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.updateEffort(chat.id, 'max');
+    mgr.updateEffort(chat.id, undefined);
+
+    const reloaded = new ChatManager(root);
+    expect(reloaded.get(chat.id)?.effort).toBeUndefined();
+  });
+});
+
 describe('buildChatCatchupPrompt', () => {
   let root: string;
   let mgr: ChatManager;

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -77,6 +77,40 @@ describe('config normalize', () => {
   });
 });
 
+describe('setAgentDefaultEffort', () => {
+  it('sets an effort and persists it to disk', () => {
+    withTempConfig({}, (cm, p) => {
+      cm.setAgentDefaultEffort('codex', 'high');
+      expect(cm.getAgentConfig('codex')?.defaultEffort).toBe('high');
+      const onDisk = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      expect(onDisk.agents.codex.defaultEffort).toBe('high');
+    });
+  });
+
+  it('deletes the key entirely when cleared', () => {
+    withTempConfig({ agents: { codex: { defaultEffort: 'max', env: { FOO: 'bar' } } } }, (cm, p) => {
+      cm.setAgentDefaultEffort('codex', undefined);
+      expect(cm.getAgentConfig('codex')?.defaultEffort).toBeUndefined();
+      const onDisk = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      expect('defaultEffort' in onDisk.agents.codex).toBe(false);
+      // Unrelated slot fields survive the clear.
+      expect(onDisk.agents.codex.env).toEqual({ FOO: 'bar' });
+    });
+  });
+
+  it('round-trips a set effort through a fresh ConfigManager', () => {
+    withTempConfig({}, (cm, p) => {
+      cm.setAgentDefaultEffort('claude-code', 'xhigh');
+      const reloaded = new ConfigManager(p);
+      try {
+        expect(reloaded.getAgentConfig('claude-code')?.defaultEffort).toBe('xhigh');
+      } finally {
+        reloaded.stop();
+      }
+    });
+  });
+});
+
 describe('api key CRUD', () => {
   it('saveApiKey rejects missing name or key', () => {
     withTempConfig({}, cm => {

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { EventEmitter } from 'events';
-import { ApiKeyEntry, CodingAgent, FallbackConfig, FallbackEntry, McpServerSpec, ModelEntry, TeamConfigRaw } from '@codey/core';
+import { ApiKeyEntry, CodingAgent, FallbackConfig, FallbackEntry, McpServerSpec, ModelEntry, TeamConfigRaw, ThinkingEffort } from '@codey/core';
 
 // ── Configuration types ─────────────────────────────────────────────
 
@@ -147,6 +147,8 @@ export interface GatewayConfigJson {
  */
 export interface AgentSlot {
   env?: Record<string, string>;
+  /** Default reasoning effort for this agent, when the user has set one. */
+  defaultEffort?: ThinkingEffort;
 }
 
 /** Text-to-speech settings for spoken replies. */
@@ -533,6 +535,17 @@ export class ConfigManager extends EventEmitter {
   // ── Agent config ───────────────────────────────────────────────────
   getAgentConfig(agent: string): AgentSlot | undefined {
     return this.config.agents[agent as keyof typeof this.config.agents];
+  }
+
+  /** Set or clear an agent's default reasoning effort and persist gateway.json. */
+  setAgentDefaultEffort(agent: CodingAgent, effort?: ThinkingEffort): void {
+    if (!this.config.agents) this.config.agents = {};
+    const key = agent as keyof typeof this.config.agents;
+    const slot: AgentSlot = this.config.agents[key] ?? {};
+    if (effort === undefined) delete slot.defaultEffort;
+    else slot.defaultEffort = effort;
+    this.config.agents[key] = slot;
+    this.save();
   }
 
   /** True only when the user has explicitly enabled the named plugin. */

--- a/packages/gateway/src/effort-resolve.test.ts
+++ b/packages/gateway/src/effort-resolve.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEffort } from './effort-resolve';
+
+describe('resolveEffort', () => {
+  it('prefers the chat override over everything', () => {
+    expect(resolveEffort({ chat: 'low', worker: 'high', global: 'max' })).toBe('low');
+  });
+
+  it('falls back to the worker effort when the chat has none', () => {
+    expect(resolveEffort({ worker: 'high', global: 'max' })).toBe('high');
+  });
+
+  it('falls back to the global default when neither is set', () => {
+    expect(resolveEffort({ global: 'max' })).toBe('max');
+  });
+
+  it('returns undefined when nothing is set, so no flag is passed', () => {
+    expect(resolveEffort({})).toBeUndefined();
+  });
+});

--- a/packages/gateway/src/effort-resolve.ts
+++ b/packages/gateway/src/effort-resolve.ts
@@ -1,0 +1,14 @@
+import type { ThinkingEffort } from '@codey/core';
+
+/**
+ * Reasoning-effort precedence: chat override > worker config > per-agent
+ * global default. Mirrors the model chain in ChatTab's `effectiveModel`.
+ * `undefined` propagates as "pass no flag".
+ */
+export function resolveEffort(tiers: {
+  chat?: ThinkingEffort;
+  worker?: ThinkingEffort;
+  global?: ThinkingEffort;
+}): ThinkingEffort | undefined {
+  return tiers.chat ?? tiers.worker ?? tiers.global;
+}

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -22,6 +22,7 @@ import { MemoryStore } from '@codey/core';
 import { WorkspaceManager, TeamConfigRaw, TeamConfig, DEFAULT_PARALLEL_SETTINGS } from '@codey/core';
 import { WorkerManager } from '@codey/core';
 import { ChatManager } from './chats';
+import { resolveEffort } from './effort-resolve';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
@@ -420,6 +421,11 @@ export class Codey {
     const modelName = this.getDefaultModelName(agent);
     if (!modelName) return undefined;
     return this.getModelConfig(agent, modelName);
+  }
+
+  /** The per-agent configured default effort, if any. */
+  private getDefaultEffort(agent: CodingAgent): ThinkingEffort | undefined {
+    return this.config.agents?.[agent]?.defaultEffort;
   }
 
   private getAdvisorAgentAndModel(): { agent: CodingAgent; model?: ModelConfig } {
@@ -5061,6 +5067,12 @@ Example: /model gpt-4.1 write a Python script`;
   }
 
   private async runWithFallback(agent: CodingAgent, request: AgentRequest): Promise<AgentResponse> {
+    // Global tier: any caller that didn't set an explicit chat/worker effort
+    // inherits the agent's configured default. Applied here rather than at each
+    // of the ~20 call sites.
+    if (request.effort === undefined) {
+      request = { ...request, effort: this.getDefaultEffort(agent) };
+    }
     const response = await this.runAgentWithNetworkRetry(agent, request);
     if (response.success) return response;
 
@@ -5430,6 +5442,7 @@ Example: /model gpt-4.1 write a Python script`;
         prompt,
         agent,
         model,
+        effort: resolveEffort({ chat: chat.effort }),
         context: { workingDir },
         skipPermissions: true,
         allowedTools: READ_ONLY_TOOLS,
@@ -5676,6 +5689,7 @@ Example: /model gpt-4.1 write a Python script`;
 
     // Per-chat override takes precedence over the gateway default.
     const agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
+    const chatEffort = resolveEffort({ chat: chat.effort });
     let model: ModelConfig | undefined;
     try {
       model = chat.model
@@ -5886,6 +5900,7 @@ Example: /model gpt-4.1 write a Python script`;
           prompt,
           agent,
           model,
+          effort: chatEffort,
           context: { workingDir },
           browserTools: true,
           browserChatId: chatId,
@@ -5913,6 +5928,7 @@ Example: /model gpt-4.1 write a Python script`;
             prompt,
             agent,
             model,
+            effort: chatEffort,
             context: { workingDir },
             browserTools: true,
             browserChatId: chatId,
@@ -5960,6 +5976,7 @@ Example: /model gpt-4.1 write a Python script`;
             prompt: followup,
             agent,
             model,
+            effort: chatEffort,
             context: { workingDir },
             browserTools: true,
             browserChatId: chatId,

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -5402,11 +5402,18 @@ Example: /model gpt-4.1 write a Python script`;
     const aideCfg = this.config.aide;
     let agent: CodingAgent;
     let model: ModelConfig | undefined;
+    let effort: ThinkingEffort | undefined;
     try {
       if (aideCfg?.agent || aideCfg?.model) {
         ({ agent, model } = this.getAideAgentAndModel());
+        // Deliberately no chat effort here: the Aide override replaces agent AND
+        // model wholesale, so the chat's tier would land on a model picked for
+        // speed. Left undefined so runWithFallback applies the Aide agent's own
+        // configured default instead.
+        effort = undefined;
       } else {
         agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
+        effort = resolveEffort({ chat: chat.effort });
         model = chat.model
           ? this.getModelConfig(agent, chat.model)
           : this.getDefaultModelConfig(agent);
@@ -5442,7 +5449,7 @@ Example: /model gpt-4.1 write a Python script`;
         prompt,
         agent,
         model,
-        effort: resolveEffort({ chat: chat.effort }),
+        effort,
         context: { workingDir },
         skipPermissions: true,
         allowedTools: READ_ONLY_TOOLS,

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -4703,6 +4703,13 @@ Example: /model gpt-4.1 write a Python script`;
           prompt: req.prompt,
           agent: chatAgent ?? this.getDefaultAgent() as CodingAgent,
           model: chatModel ?? this.getDefaultModelConfig(chatAgent ?? this.getDefaultAgent() as CodingAgent),
+          // Effort follows agent/model: this path already honours the chat's
+          // agent and model, so it honours the chat's effort too. The worker
+          // tier is deliberately skipped here — parallel mode runs every member
+          // on the chat's agent/model rather than per-worker config, so mixing
+          // in a per-worker effort would contradict that. Global default still
+          // fills in via runWithFallback when the chat has no override.
+          effort: resolveEffort({ chat: chat.effort }),
           context: { workingDir },
           browserTools: true,
           browserChatId: chatId,

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -212,6 +212,9 @@ export class Codey {
     const baseReq = {
       agent: opts.codingAgent,
       model: opts.modelConfig,
+      // Worker tier. No chat is in scope on this path, and the per-agent
+      // global default is filled in by runWithFallback when this is undefined.
+      effort: resolveEffort({ worker: wm.getWorkerEffort(opts.workerName) }),
       context: { workingDir: opts.workingDir ?? this.workingDir },
       browserTools: true,
       browserChatId: opts.browserChatId,

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -15,7 +15,7 @@ import { ConfigManager, ResolvedVoiceTtsSettings } from './config';
 import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, VoiceChannelHandler, ChannelHandler } from './channels';
 import { synthesizeSpeech } from './voice-tts';
 import { runTextCompletion, streamTextCompletion, canRunDirectly } from './text-completion';
-import { AgentFactory } from '@codey/core';
+import { AgentFactory, isThinkingEffort } from '@codey/core';
 import { Logger } from './logger';
 import { ContextManager, ContextWindow } from '@codey/core';
 import { MemoryStore } from '@codey/core';
@@ -2387,6 +2387,9 @@ export class Codey {
       case 'model':
         await this.cmdModel(args, chatId, channel);
         break;
+      case 'effort':
+        await this.cmdEffort(args, chatId, channel);
+        break;
       case 'agent':
         await this.cmdAgent(args, chatId, channel);
         if (this.isPairableChannel(channel) && args.length > 0) {
@@ -2588,6 +2591,53 @@ export class Codey {
         text: `Current default model: ${this.getEffectiveModel()}`,
       });
     }
+  }
+
+  /**
+   * Show, set, or clear the reasoning effort for the current default agent.
+   * Chat platforms have no Chat record, so the per-chat override tier is not
+   * reachable here — like /agent, this writes the global per-agent default.
+   */
+  private async cmdEffort(args: string[], chatId: string, channel: ChannelType): Promise<void> {
+    const agent = this.getDefaultAgent() as CodingAgent;
+    const current = this.getDefaultEffort(agent);
+
+    if (args.length === 0) {
+      await this.sendResponse({
+        chatId,
+        channel,
+        text: `Current effort for **${agent}**: ${current ?? 'unset (CLI default)'}\n\n` +
+          `Set with: /effort <low|medium|high|xhigh|max>\nClear with: /effort clear`,
+      });
+      return;
+    }
+
+    const raw = args[0].toLowerCase();
+    if (raw === 'clear') {
+      this.configManager?.setAgentDefaultEffort(agent, undefined);
+      await this.sendResponse({
+        chatId,
+        channel,
+        text: `✅ Cleared effort for **${agent}** — using the CLI default.`,
+      });
+      return;
+    }
+
+    if (!isThinkingEffort(raw)) {
+      await this.sendResponse({
+        chatId,
+        channel,
+        text: `Unknown effort: ${raw}\n\nAvailable: low, medium, high, xhigh, max`,
+      });
+      return;
+    }
+
+    this.configManager?.setAgentDefaultEffort(agent, raw);
+    await this.sendResponse({
+      chatId,
+      channel,
+      text: `✅ Effort for **${agent}** set to **${raw}**.`,
+    });
   }
 
   private async cmdAgent(args: string[], chatId: string, channel: ChannelType): Promise<void> {
@@ -3278,6 +3328,7 @@ export class Codey {
 /clear - Clear conversation history
 /reset - Start a new conversation
 /model [name] - Show/set model
+/effort <level> - Set reasoning effort (low/medium/high/xhigh/max)
 /config - Show current config
 
 Example: /worker architect design a REST API

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       'src/automations/engine.test.ts',
       'src/automations/chats-hidden.test.ts',
       'src/automations/dry-run.test.ts',
+      'src/effort-resolve.test.ts',
     ],
     exclude: ['dist/**', 'node_modules/**'],
   },


### PR DESCRIPTION
Adds a thinking-effort control: a level (`low | medium | high | xhigh | max`) forwarded to whichever agent CLI runs a turn.

Spec: `docs/superpowers/specs/2026-08-09-thinking-effort-control-design.md`
Plan: `docs/superpowers/plans/2026-08-09-thinking-effort-control.md`

## Why the vocabulary is what it is

Probed all three CLIs on a real machine:

| Agent | Flag | Valid values | Bad value |
|---|---|---|---|
| claude-code 2.1.221 | `--effort <L>` | low, medium, high, xhigh, max | lenient — warns, uses default |
| codex v0.145.0 | `-c model_reasoning_effort="<L>"` | none, minimal, low, medium, high, xhigh, max | **strict — API rejects the whole run** |
| opencode | `--variant <L>` | provider-specific | lenient — silently ignored |

claude-code's five levels are a strict subset of codex's, so the unified vocabulary is those five, forwarded **verbatim** — no translation table, only the flag syntax differs. `undefined` means "pass no flag" and lets each CLI use its own default; there is deliberately no `'default'` literal, so "unset" has exactly one representation.

## Precedence

**chat override > worker config > per-agent default**, mirroring the existing model chain.

The global tier is injected once in `runWithFallback`, the single choke point all ~20 agent-run call sites pass through, so only the chat and worker tiers need explicit wiring.

## codex degrade-retry

codex is the only strict agent, and its valid subset varies by model — so a stale `max` would wedge the user with a raw OpenAI error they'd never connect to a dropdown. `CodexAdapter` detects that specific rejection, retries once without the flag, and prepends a notice.

Detection requires **all three** markers — `invalid_enum_value`, `reasoning.effort`, and `Invalid value: '<level>'` — so a prompt that happens to quote the error text is never misread as a degrade signal. The anchor on the full `Invalid value:` phrase matters: the error's own "Supported values are: 'none', 'minimal', 'low', …" enumeration quotes every level, so a bare quoted match fires on `'low'` even when the run passed `'max'`. That bug was caught by TDD and the reason is documented in the code so nobody simplifies it back.

## Surfaces

- Chat run-settings row: `Effort` select next to Model (`Inherit` clears the override). Hidden for teams, which carry worker-level effort.
- Settings -> Agents: `Default effort` per agent.
- Worker editor: per-worker `Effort`, shown in the list row summary.
- `/effort <level>` chat command for Telegram/Discord, which have no `Chat` record and so can only reach the global tier — it follows `/agent`'s existing behavior and names the agent it changed.

## Two deliberate asymmetries

- **Effort changes never rotate the session.** `updateEffort` is separate from `updateAgentModel` for this reason: raising effort and continuing the same thread is the primary use case, and rotating would drop the conversation.
- **The Aide override does not inherit chat effort.** Aide replaces agent *and* model wholesale, so a chat pinned to `max` would otherwise send `max` to a model picked for speed — the exact cost profile that override exists to avoid.

## Verification

Unit: `effort.test.ts` (13), `effort-resolve.test.ts` + `config.test.ts` additions (23). Full suite green — core 27/364, gateway 27/247, codey-mac 46/383. `tsc --noEmit` clean, lint clean.

Against the real CLIs:
- claude-code `--effort xhigh` -> `is_error:false`, no "Unknown --effort value"
- codex `model_reasoning_effort="high"` -> banner shows `reasoning effort: high`
- opencode `--variant high` -> normal completion
- **degrade-retry end to end**: passing a level codex rejects produced `success: true` with output starting `> Effort ... isn't accepted by the current codex model — reran with the model's default effort.` followed by the real answer; a valid level produced no notice, confirming it doesn't fire spuriously

## Drive-by fix

`codey-mac/src/services/api.ts` declared a **duplicate `WorkerConfig`** shadowing core's, missing `effort` and `dispatchHint` — so the worker tier was unreadable in the renderer. This was invisible because `npm run build -w codey-mac` is `vite build && electron-builder` and never runs `tsc`. Fixed by adding the fields; worth considering deleting the duplicate in favor of importing core's type (that file already type-imports from core one line above).

## Not yet verified

The in-app precedence round-trip (global `low`, worker `high`, chat `max`, confirming each wins in turn) has not been run — every layer below the UI is unit-tested or read-verified, but `select -> IPC -> chat record -> run` has never executed once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
