### PR TITLE
Improve chat worktree isolation and controls

### DIFF
--- a/codey-mac/electron/delivery-status.test.ts
+++ b/codey-mac/electron/delivery-status.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { deriveDeliveryState } from './delivery-status'
+
+describe('deriveDeliveryState', () => {
+  it('maps open and closed pull requests', () => {
+    expect(deriveDeliveryState({ providerState: 'OPEN', sameBranch: true, commitsAfterMerge: false, dirty: false })).toBe('pr-open')
+    expect(deriveDeliveryState({ providerState: 'CLOSED', sameBranch: true, commitsAfterMerge: false, dirty: false })).toBe('closed-unmerged')
+  })
+
+  it('marks a clean merged checkout as merged', () => {
+    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: false, dirty: false })).toBe('merged')
+  })
+
+  it('detects dirty files or commits added after merge', () => {
+    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: false, dirty: true })).toBe('merged-with-changes')
+    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: true, dirty: false })).toBe('merged-with-changes')
+  })
+
+  it('does not treat a different checkout branch as post-merge work', () => {
+    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: false, commitsAfterMerge: true, dirty: true })).toBe('merged')
+  })
+})

--- a/codey-mac/electron/delivery-status.ts
+++ b/codey-mac/electron/delivery-status.ts
@@ -1,0 +1,14 @@
+export type DeliveryState = 'pr-open' | 'merged' | 'merged-with-changes' | 'closed-unmerged'
+
+export function deriveDeliveryState(input: {
+  providerState: string
+  sameBranch: boolean
+  commitsAfterMerge: boolean
+  dirty: boolean
+}): DeliveryState {
+  const state = input.providerState.toUpperCase()
+  if (state === 'OPEN') return 'pr-open'
+  if (state !== 'MERGED') return 'closed-unmerged'
+  if (!input.sameBranch) return 'merged'
+  return input.dirty || input.commitsAfterMerge ? 'merged-with-changes' : 'merged'
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -14,6 +14,7 @@ import { applyEvent, clearAttention, summarize } from './tray-state'
 import { SKILL_FILE, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
+import { deriveDeliveryState } from './delivery-status'
 import type { ScannedSkill } from './skills'
 import { scanSkillUsage } from './skill-usage'
 import type { SkillUsageMap, UsageCacheEntry } from './skill-usage'
@@ -1837,7 +1838,7 @@ app.whenReady().then(async () => {
       const known = workspaceManager.listWorkspaces()
       const resolved = resolveCaptureSubmit(payload?.text ?? '', payload?.workspaceName, known)
       if (!resolved.ok) throw new Error(resolved.error)
-      const chat = inProcessGateway.getChatManager().create({ workspaceName: resolved.workspaceName })
+      const chat = await inProcessGateway.createChat({ workspaceName: resolved.workspaceName })
 
       // Copy any picked files into the target workspace's .codey/uploads/ and
       // build FileAttachments — mirrors the chats:upload handler so the agent
@@ -2179,6 +2180,63 @@ app.whenReady().then(async () => {
     })
   )
 
+  ipcMain.handle('git:prStatus', async (_e, workingDir: string, url?: string) =>
+    wrap(async () => {
+      if (!workingDir) throw new Error('A working directory is required')
+      const { execFile } = await import('child_process')
+      const fsMod = await import('fs')
+      const run = (cmd: string, args: string[], timeout: number) => new Promise<string>((resolve, reject) => {
+        execFile(cmd, args, { cwd: workingDir, timeout }, (error, stdout, stderr) => {
+          if (error) reject(new Error((stderr || String(error)).trim()))
+          else resolve(stdout.trim())
+        })
+      })
+      const gh = ['/opt/homebrew/bin/gh', '/usr/local/bin/gh', '/usr/bin/gh']
+        .find(candidate => fsMod.existsSync(candidate)) || 'gh'
+      const raw = await run(gh, [
+        'pr', 'view', ...(url ? [url] : []),
+        '--json', 'url,number,state,mergedAt,headRefName,headRefOid,baseRefName',
+      ], 15_000)
+      const view = JSON.parse(raw) as {
+        url: string
+        number?: number
+        state: string
+        mergedAt?: string | null
+        headRefName?: string
+        headRefOid?: string
+        baseRefName?: string
+      }
+      const [localHead, currentBranch, porcelain] = await Promise.all([
+        run('git', ['rev-parse', 'HEAD'], 3_000),
+        run('git', ['branch', '--show-current'], 3_000),
+        run('git', ['status', '--porcelain'], 3_000),
+      ])
+      const sameBranch = !!view.headRefName && currentBranch === view.headRefName
+      let commitsAfterMerge = false
+      if (sameBranch && view.state.toUpperCase() === 'MERGED' && view.headRefOid && localHead !== view.headRefOid) {
+        try {
+          const count = await run('git', ['rev-list', '--count', `${view.headRefOid}..HEAD`], 3_000)
+          commitsAfterMerge = Number.parseInt(count, 10) > 0
+        } catch { /* a missing remote object is not evidence of new work */ }
+      }
+      return {
+        url: view.url || url || '',
+        number: view.number,
+        state: deriveDeliveryState({
+          providerState: view.state,
+          sameBranch,
+          commitsAfterMerge,
+          dirty: sameBranch && porcelain.length > 0,
+        }),
+        headBranch: view.headRefName,
+        baseBranch: view.baseRefName,
+        headCommit: view.headRefOid,
+        mergedAt: view.mergedAt ? Date.parse(view.mergedAt) : undefined,
+        lastCheckedAt: Date.now(),
+      }
+    })
+  )
+
   ipcMain.handle('git:watch', async (_e, workingDir: string) =>
     wrap(async () => {
       if (!workingDir) return { ok: false }
@@ -2341,6 +2399,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('workspaces:delete', async (_e, name: string) =>
     wrap(async () => {
       if (!workspaceManager) throw new Error('Workspace manager not ready')
+      await inProcessGateway?.prepareWorkspaceDeletion(name)
       await workspaceManager.deleteWorkspace(name)
       inProcessGateway?.getChatManager().cascadeDeleteWorkspace(name)
     })
@@ -3456,23 +3515,21 @@ app.whenReady().then(async () => {
   ipcMain.handle('chats:list', async (_e, workspaceName?: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      return inProcessGateway.getChatManager().list(workspaceName)
+      return inProcessGateway.listChats(workspaceName)
     })
   )
 
   ipcMain.handle('chats:get', async (_e, id: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      const c = inProcessGateway.getChatManager().get(id)
-      if (!c) throw new Error(`Chat not found: ${id}`)
-      return c
+      return inProcessGateway.getChat(id)
     })
   )
 
   ipcMain.handle('chats:create', async (_e, input: { workspaceName: string; selection?: any; title?: string }) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      return inProcessGateway.getChatManager().create(input)
+      return inProcessGateway.createChat(input)
     })
   )
 
@@ -3493,7 +3550,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('chats:delete', async (_e, id: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
-      inProcessGateway.getChatManager().delete(id)
+      await inProcessGateway.deleteChat(id)
       return null
     })
   )
@@ -3530,6 +3587,27 @@ app.whenReady().then(async () => {
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
       return inProcessGateway.getChatManager().setWorkingDirOverride(id, dir)
+    })
+  )
+
+  ipcMain.handle('chats:setExecutionMode', async (_e, id: string, mode: 'shared-checkout' | 'isolated-worktree') =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.setChatExecutionMode(id, mode)
+    })
+  )
+
+  ipcMain.handle('chats:createWorktree', async (_e, id: string, name: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.createChatWorktree(id, name)
+    })
+  )
+
+  ipcMain.handle('chats:setPullRequest', async (_e, id: string, pullRequest: NonNullable<import('@codey/core').Chat['pullRequest']>) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.getChatManager().setPullRequest(id, pullRequest)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -170,6 +170,10 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('chats:setSoloAdvisor', id, enabled),
     setWorkingDir: (id: string, dir: string | null) =>
       ipcRenderer.invoke('chats:setWorkingDir', id, dir),
+    setExecutionMode: (id: string, mode: 'shared-checkout' | 'isolated-worktree') => ipcRenderer.invoke('chats:setExecutionMode', id, mode),
+    createWorktree: (id: string, name: string) => ipcRenderer.invoke('chats:createWorktree', id, name),
+    setPullRequest: (id: string, pullRequest: any) =>
+      ipcRenderer.invoke('chats:setPullRequest', id, pullRequest),
     send: (payload: { chatId: string; text: string; attachments?: any[] }) =>
       ipcRenderer.invoke('chats:send', payload),
     stop: (chatId: string) => ipcRenderer.invoke('chats:stop', chatId),
@@ -213,6 +217,7 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('git:worktreeAdd', workingDir, args),
     createPr: (workingDir: string, input: { title: string; body?: string }) =>
       ipcRenderer.invoke('git:createPr', workingDir, input),
+    prStatus: (workingDir: string, url?: string) => ipcRenderer.invoke('git:prStatus', workingDir, url),
     watch: (workingDir: string) => ipcRenderer.invoke('git:watch', workingDir),
     unwatch: (workingDir: string) => ipcRenderer.invoke('git:unwatch', workingDir),
     onChanged: (handler: (ev: { workingDir: string }) => void) => {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -299,6 +299,9 @@ declare global {
         updateContextPanelOpen: (id: string, open: boolean | null) => Promise<IpcResult<Chat>>
         setSoloAdvisor: (id: string, enabled: boolean) => Promise<IpcResult<Chat>>
         setWorkingDir: (id: string, dir: string | null) => Promise<IpcResult<Chat>>
+        setExecutionMode: (id: string, mode: 'shared-checkout' | 'isolated-worktree') => Promise<IpcResult<Chat>>
+        createWorktree: (id: string, name: string) => Promise<IpcResult<Chat>>
+        setPullRequest: (id: string, pullRequest: NonNullable<Chat['pullRequest']>) => Promise<IpcResult<Chat>>
       }
       qq: {
         ask: (payload: { chatId: string; question: string; history: Array<{ role: 'user' | 'assistant'; content: string }>; attachments?: Array<{ id: string; name: string; path: string; mimeType: string; size: number }> }) => Promise<IpcResult<{ response: string; tokens?: number; durationSec?: number }>>
@@ -328,6 +331,7 @@ declare global {
         worktrees: (workingDir: string) => Promise<IpcResult<{ list: { branch: string; path: string; isMain: boolean }[] }>>
         worktreeAdd: (workingDir: string, args: { name: string; path: string }) => Promise<IpcResult<{ ok: boolean; path?: string; error?: string }>>
         createPr: (workingDir: string, input: { title: string; body?: string }) => Promise<IpcResult<{ ok: boolean; url?: string; error?: string }>>
+        prStatus: (workingDir: string, url?: string) => Promise<IpcResult<NonNullable<Chat['pullRequest']>>>
         watch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
         unwatch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
         onChanged: (handler: (ev: { workingDir: string }) => void) => () => void

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -1,117 +1,139 @@
-import React, { useMemo, useRef, useState, useEffect } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { C } from '../theme'
 import { useGitBranches } from '../hooks/useGitBranches'
-import { compactWorktreePath, currentFirst, defaultWorktreePath, filterBranches, partitionWorktrees } from './branchPickerModel'
+import { compactWorktreePath, currentFirst, filterBranches } from './branchPickerModel'
 import { UIIcon } from './UIIcons'
 
 interface Props {
   workingDir: string | undefined
-  repoRoot: string | undefined           // for default worktree path; falls back to workingDir
-  boundWorktreePath?: string             // chat.workingDirOverride
-  onBindWorktree: (path: string | null) => void
+  chatWorktree?: { name?: string; path: string }
+  executionMode?: 'shared-checkout' | 'isolated-worktree'
+  onCreateWorktree: (name: string) => Promise<void>
+  onExecutionModeChange: (mode: 'shared-checkout' | 'isolated-worktree') => Promise<void>
   onOpenTerminal?: () => void
 }
 
-type Mode = { kind: 'list' } | { kind: 'create' } | { kind: 'dirty'; target: string }
-type PickerView = 'branches' | 'worktrees'
+type Mode = { kind: 'list' } | { kind: 'createBranch' } | { kind: 'createWorktree' } | { kind: 'dirty'; target: string }
 
-export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorktreePath, onBindWorktree, onOpenTerminal }) => {
+export const BranchPicker: React.FC<Props> = ({
+  workingDir, chatWorktree, executionMode = 'shared-checkout', onCreateWorktree, onExecutionModeChange, onOpenTerminal,
+}) => {
   const git = useGitBranches(workingDir)
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
-  const [view, setView] = useState<PickerView>('branches')
   const [mode, setMode] = useState<Mode>({ kind: 'list' })
-  const [newName, setNewName] = useState('')
-  const [useWorktree, setUseWorktree] = useState(true)   // worktree is the DEFAULT
+  const [newBranchName, setNewBranchName] = useState('')
+  const [newWorktreeName, setNewWorktreeName] = useState('')
   const [note, setNote] = useState<string | null>(null)
+  const [changingMode, setChangingMode] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!open) return
-    const onDown = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false) }
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    const onDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false)
+    }
+    const onKey = (event: KeyboardEvent) => { if (event.key === 'Escape') setOpen(false) }
     document.addEventListener('mousedown', onDown)
     document.addEventListener('keydown', onKey)
-    return () => { document.removeEventListener('mousedown', onDown); document.removeEventListener('keydown', onKey) }
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
   }, [open])
 
-  const s = git.state
-  const { main, others } = useMemo(() => partitionWorktrees(s?.worktrees ?? []), [s])
-  const localFiltered = useMemo(
-    () => currentFirst(filterBranches(s?.local ?? [], query), branch => branch === s?.branch),
-    [s, query],
+  const state = git.state
+  const localBranches = useMemo(
+    () => currentFirst(filterBranches(state?.local ?? [], query), branch => branch === state?.branch),
+    [state, query],
   )
-  const remoteFiltered = useMemo(() => filterBranches(s?.remote ?? [], query), [s, query])
-  const repo = repoRoot || workingDir || ''
-  const worktreePath = boundWorktreePath || workingDir || ''
-  const orderedWorktrees = useMemo(
-    () => currentFirst(
-      [...(main ? [main] : []), ...others],
-      worktree => boundWorktreePath ? worktree.path === boundWorktreePath : worktree.isMain,
-    ),
-    [main, others, boundWorktreePath],
-  )
-  const previewPath = useWorktree && newName ? defaultWorktreePath(repo, newName) : ''
+  const remoteBranches = useMemo(() => filterBranches(state?.remote ?? [], query), [state, query])
+  const path = workingDir || ''
+  const isolated = executionMode === 'isolated-worktree'
+  const worktreeLabel = chatWorktree?.name || chatWorktree?.path.split('/').filter(Boolean).pop() || 'Isolated worktree'
+  const branchLabel = state?.branch === 'HEAD' ? '—' : (state?.branch ?? '—')
+  const pathLabel = compactWorktreePath(path)
+  const checkoutLabel = isolated ? worktreeLabel : 'Current checkout'
 
-  const copyWorktreePath = async () => {
-    const value = worktreePath
-    if (!value) return
+  const copyPath = async () => {
+    if (!path) return
     try {
-      await navigator.clipboard.writeText(value)
+      await navigator.clipboard.writeText(path)
       setNote('Worktree path copied')
     } catch {
       setNote('Could not copy worktree path')
     }
   }
 
-  const doSwitch = async (name: string) => {
-    const r = await git.checkout(name)
-    if (r.ok) { setOpen(false); return }
-    if (r.reason === 'dirty') setMode({ kind: 'dirty', target: name })
+  const switchBranch = async (name: string) => {
+    const result = await git.checkout(name)
+    if (result.ok) { setOpen(false); return }
+    if (result.reason === 'dirty') setMode({ kind: 'dirty', target: name })
   }
 
-  const doSwitchRemote = async (b: string) => {
-    // `git checkout --track` needs the remote-tracking ref (origin/foo), not the local name.
-    const r = await git.checkout(b, { track: true })
-    if (r.ok) { setOpen(false); return }
-    // On retry after stash, plain `git checkout foo` DWIMs to a tracking branch.
-    if (r.reason === 'dirty') setMode({ kind: 'dirty', target: b.replace(/^[^/]+\//, '') })
+  const switchRemoteBranch = async (name: string) => {
+    const result = await git.checkout(name, { track: true })
+    if (result.ok) { setOpen(false); return }
+    if (result.reason === 'dirty') setMode({ kind: 'dirty', target: name.replace(/^[^/]+\//, '') })
   }
 
-  const doCreate = async () => {
-    if (!newName.trim()) return
-    if (useWorktree) {
-      const r = await git.addWorktree(newName.trim(), defaultWorktreePath(repo, newName.trim()))
-      if (r.ok && r.path) { onBindWorktree(r.path); setOpen(false) }
-    } else {
-      const r = await git.createBranch(newName.trim())
-      if (r.ok) { setOpen(false) }
+  const createBranch = async () => {
+    const name = newBranchName.trim()
+    if (!name) return
+    const result = await git.createBranch(name)
+    if (result.ok) setOpen(false)
+  }
+
+  const createWorktree = async () => {
+    const name = newWorktreeName.trim()
+    if (!name || changingMode) return
+    setChangingMode(true); setNote(null)
+    try {
+      await onCreateWorktree(name)
+      setNote('Worktree and same-named branch created')
+      setMode({ kind: 'list' })
+    } catch (error) {
+      setNote(error instanceof Error ? error.message : 'Could not create worktree')
+    } finally {
+      setChangingMode(false)
+    }
+  }
+
+  const changeExecutionMode = async (nextMode: 'shared-checkout' | 'isolated-worktree') => {
+    if (changingMode || nextMode === executionMode) return
+    setChangingMode(true); setNote(null)
+    try {
+      await onExecutionModeChange(nextMode)
+      setNote(nextMode === 'isolated-worktree'
+        ? 'Using this chat’s worktree'
+        : 'Using the current checkout; the isolated worktree is preserved')
+      setMode({ kind: 'list' })
+    } catch (error) {
+      setNote(error instanceof Error ? error.message : 'Could not switch checkout mode')
+    } finally {
+      setChangingMode(false)
     }
   }
 
   return (
     <div ref={ref} style={{ position: 'relative' }}>
-      <button style={styles.pill} onClick={() => setOpen(o => {
-        if (!o) {
-          setNote(null)
-          // A branch may have been created by Codex/Terminal while the app was
-          // in the background. Refresh at the moment the user opens the menu
-          // instead of relying only on the .git watcher or 5s polling fallback.
-          void git.refresh()
-        }
-        return !o
-      })}
-        title={worktreePath ? `${s?.branch ?? 'Unknown branch'}\n${worktreePath}` : 'Chat workspace unavailable'}
-        aria-label={`Chat workspace: ${s?.branch ?? 'unknown branch'}, ${worktreePath || 'unavailable'}`}
+      <button
+        style={styles.pill}
+        onClick={() => setOpen(value => {
+          if (!value) { setNote(null); void git.refresh() }
+          return !value
+        })}
+        title={path ? `${branchLabel}\n${path}` : 'Chat checkout unavailable'}
+        aria-label={`Chat branch: ${branchLabel}, ${path || 'unavailable'}`}
         aria-expanded={open}
       >
         <UIIcon name="code" size={15} />
         <span style={styles.pillIdentity}>
           <span style={styles.pillBranch}>
-            <span style={styles.ellipsis}>{s?.branch ?? '—'}</span>
-            {s && s.dirty > 0 && <span style={styles.dirty}>+{s.dirty}</span>}
+            <span style={styles.ellipsis}>{branchLabel}</span>
+            {state && state.dirty > 0 && <span style={styles.dirty}>+{state.dirty}</span>}
           </span>
-          <span style={styles.pillPath}>{compactWorktreePath(worktreePath)}</span>
+          <span style={styles.pillPath} title={path}>{checkoutLabel}</span>
         </span>
         <span style={{ ...styles.caret, transform: open ? 'rotate(-90deg)' : 'rotate(90deg)' }}>
           <UIIcon name="chevron" size={12} />
@@ -120,96 +142,109 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
 
       {open && (
         <div style={styles.menu}>
-          <div style={styles.currentWorkspace}>
-            <UIIcon name="workspace" size={15} />
+          <div style={styles.currentCheckout}>
             <div style={styles.currentIdentity}>
-              <div style={styles.currentBranch}>{s?.branch ?? '—'}</div>
-              <div style={styles.currentPath} title={worktreePath}>{compactWorktreePath(worktreePath)}</div>
+              <div style={styles.currentBranch}>{branchLabel}</div>
+              <div style={styles.currentPath} title={path}>{pathLabel}</div>
             </div>
-            <button style={styles.iconButton} onClick={() => void copyWorktreePath()} title="Copy worktree path" aria-label="Copy worktree path">
+            <button style={styles.iconButton} onClick={() => void copyPath()} title="Copy path" aria-label="Copy worktree path">
               <UIIcon name="copy" size={13} />
             </button>
             {onOpenTerminal && (
-              <button style={styles.iconButton} onClick={() => { onOpenTerminal(); setOpen(false) }} disabled={!worktreePath} title="Open Terminal here" aria-label="Open Terminal in this worktree">
+              <button style={styles.iconButton} onClick={() => { onOpenTerminal(); setOpen(false) }} disabled={!workingDir} title="Open Terminal here" aria-label="Open Terminal in this checkout">
                 <UIIcon name="terminal" size={14} />
               </button>
             )}
           </div>
+
+          <div style={styles.checkoutMode}>
+            <span style={isolated ? styles.worktreeBadge : styles.modeLabel} title={chatWorktree?.path}>
+              {isolated ? worktreeLabel : 'Current checkout'}
+            </span>
+            {!chatWorktree ? (
+              <button style={styles.createWorktreeButton} onClick={() => { setNewWorktreeName(''); setMode({ kind: 'createWorktree' }) }}>
+                + Create worktree
+              </button>
+            ) : (
+              <button style={styles.ghost} disabled={changingMode} onClick={() => void changeExecutionMode(isolated ? 'shared-checkout' : 'isolated-worktree')}>
+                {isolated ? 'Use current' : 'Use worktree'}
+              </button>
+            )}
+          </div>
+
           {mode.kind === 'dirty' ? (
             <div style={styles.section}>
               <div style={styles.warn}>Switching would overwrite local changes.</div>
               <div style={styles.row}>
                 <button style={styles.primary} onClick={async () => {
-                  const r = await git.stashAndSwitch(mode.target)
-                  // Keep the menu open so the stash note is actually visible.
-                  if (r.ok) { setNote('Local changes stashed — restore with `git stash pop`'); setMode({ kind: 'list' }) }
+                  const result = await git.stashAndSwitch(mode.target)
+                  if (result.ok) {
+                    setNote('Local changes stashed — restore with `git stash pop`')
+                    setMode({ kind: 'list' })
+                  }
                 }}>Stash & switch</button>
                 <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
               </div>
             </div>
-          ) : mode.kind === 'create' ? (
+          ) : mode.kind === 'createWorktree' ? (
             <div style={styles.section}>
-              <input autoFocus placeholder="new-branch-name" value={newName}
-                onChange={e => setNewName(e.target.value)} style={styles.input} />
-              <div style={styles.toggle}>
-                <button style={useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(true)}>Worktree</button>
-                <button style={!useWorktree ? styles.segOn : styles.seg} onClick={() => setUseWorktree(false)}>Branch</button>
-              </div>
-              {previewPath && <div style={styles.preview}>{previewPath}</div>}
+              <div style={styles.sectionLabel}>Worktree name</div>
+              <input
+                autoFocus
+                placeholder="feature-auth"
+                value={newWorktreeName}
+                onChange={event => setNewWorktreeName(event.target.value)}
+                onKeyDown={event => { if (event.key === 'Enter') void createWorktree() }}
+                style={styles.input}
+              />
+              <div style={styles.hint}>Creates a worktree and same-named branch from HEAD. Uncommitted changes stay in the current checkout.</div>
+              {note && <div style={styles.err}>{note}</div>}
               <div style={styles.row}>
-                <button style={styles.primary} onClick={doCreate}>Create</button>
+                <button style={styles.primary} disabled={!newWorktreeName.trim() || changingMode} onClick={() => void createWorktree()}>{changingMode ? 'Creating…' : 'Create worktree'}</button>
+                <button style={styles.ghost} disabled={changingMode} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
+              </div>
+            </div>
+          ) : mode.kind === 'createBranch' ? (
+            <div style={styles.section}>
+              <div style={styles.sectionLabel}>Create branch in this checkout</div>
+              <input
+                autoFocus
+                placeholder="new-branch-name"
+                value={newBranchName}
+                onChange={event => setNewBranchName(event.target.value)}
+                onKeyDown={event => { if (event.key === 'Enter') void createBranch() }}
+                style={styles.input}
+              />
+              <div style={styles.row}>
+                <button style={styles.primary} onClick={() => void createBranch()}>Create</button>
                 <button style={styles.ghost} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
               </div>
             </div>
           ) : (
             <>
-              <div style={styles.viewTabs} role="tablist" aria-label="Workspace choices">
-                <button role="tab" aria-selected={view === 'branches'} style={view === 'branches' ? styles.viewTabActive : styles.viewTab} onClick={() => setView('branches')}>Branches</button>
-                <button role="tab" aria-selected={view === 'worktrees'} style={view === 'worktrees' ? styles.viewTabActive : styles.viewTab} onClick={() => setView('worktrees')}>Worktrees</button>
-              </div>
-              {view === 'branches' && (
-                <input placeholder="Filter branches…" value={query}
-                  onChange={e => setQuery(e.target.value)} style={styles.input} />
-              )}
+              <input placeholder="Filter branches…" value={query} onChange={event => setQuery(event.target.value)} style={styles.input} />
               <div style={styles.scroll}>
-                {view === 'branches' ? (
-                  <>
-                    {localFiltered.length > 0 && <div style={styles.divider}>Local</div>}
-                    {localFiltered.map(b => (
-                      <button key={b} style={styles.item} disabled={b === s?.branch} onClick={() => doSwitch(b)}>
-                        <span style={styles.checkSlot}>{b === s?.branch && <UIIcon name="check" size={13} />}</span>{b}
-                      </button>
-                    ))}
-                    {remoteFiltered.length > 0 && <div style={styles.divider}>Remote</div>}
-                    {remoteFiltered.map(b => (
-                      <button key={b} style={styles.item} onClick={() => doSwitchRemote(b)}>
-                        <span style={styles.checkSlot} />{b}
-                      </button>
-                    ))}
-                  </>
-                ) : (
-                  <>
-                    {orderedWorktrees.map(w => {
-                      const isCurrent = boundWorktreePath ? w.path === boundWorktreePath : w.isMain
-                      return (
-                        <button key={w.path} style={styles.worktreeItem} onClick={() => { onBindWorktree(w.isMain ? null : w.path); setOpen(false) }}>
-                          <span style={styles.checkSlot}>{isCurrent && <UIIcon name="check" size={13} />}</span>
-                          <span style={styles.worktreeIdentity}>
-                            <span>{w.branch} {w.isMain && <span style={styles.mainLabel}>main</span>}</span>
-                            <span style={styles.worktreePath} title={w.path}>{compactWorktreePath(w.path)}</span>
-                          </span>
-                        </button>
-                      )
-                    })}
-                    {orderedWorktrees.length === 0 && <div style={styles.empty}>No worktrees found</div>}
-                  </>
-                )}
+                {localBranches.length > 0 && <div style={styles.divider}>Local</div>}
+                {localBranches.map(branch => (
+                  <button key={branch} style={styles.item} disabled={branch === state?.branch} onClick={() => void switchBranch(branch)}>
+                    <span style={styles.checkSlot}>{branch === state?.branch && <UIIcon name="check" size={13} />}</span>
+                    <span style={styles.branchName}>{branch}</span>
+                  </button>
+                ))}
+                {remoteBranches.length > 0 && <div style={styles.divider}>Remote</div>}
+                {remoteBranches.map(branch => (
+                  <button key={branch} style={styles.item} onClick={() => void switchRemoteBranch(branch)}>
+                    <span style={styles.checkSlot} />
+                    <span style={styles.branchName}>{branch}</span>
+                  </button>
+                ))}
+                {localBranches.length === 0 && remoteBranches.length === 0 && <div style={styles.empty}>No branches found</div>}
               </div>
               {git.error && <div style={styles.err}>{git.error}</div>}
               {note && <div style={styles.noteBox} role="status">{note}</div>}
               <div style={styles.footer}>
-                <button style={styles.ghost} onClick={() => { setNewName(''); setUseWorktree(view === 'worktrees'); setMode({ kind: 'create' }) }}>+ New…</button>
-                {view === 'branches' && <button style={styles.ghost} onClick={() => git.fetchRemote()}>Fetch</button>}
+                <button style={styles.ghost} onClick={() => { setNewBranchName(''); setMode({ kind: 'createBranch' }) }}>+ New branch</button>
+                <button style={styles.ghost} onClick={() => void git.fetchRemote()}>Fetch</button>
               </div>
             </>
           )}
@@ -220,59 +255,36 @@ export const BranchPicker: React.FC<Props> = ({ workingDir, repoRoot, boundWorkt
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  pill: { display: 'inline-flex', alignItems: 'center', gap: 7, color: C.fg2, fontSize: 11,
-    background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 7, padding: '5px 8px',
-    cursor: 'pointer', flexShrink: 1, minWidth: 150, maxWidth: 310,
-    overflow: 'hidden', textAlign: 'left' },
+  pill: { display: 'inline-flex', alignItems: 'center', gap: 7, color: C.fg2, fontSize: 11, background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 7, padding: '5px 8px', cursor: 'pointer', flexShrink: 1, minWidth: 150, maxWidth: 310, overflow: 'hidden', textAlign: 'left' },
   pillIdentity: { display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0, flex: 1 },
   pillBranch: { display: 'flex', alignItems: 'center', gap: 5, minWidth: 0, fontFamily: 'SF Mono, Menlo, monospace' },
   pillPath: { color: C.fg3, fontSize: 9, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   ellipsis: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   dirty: { color: C.yellow, opacity: 0.85 },
-  caret: {
-    color: C.fg3,
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 14,
-    height: 14,
-    flexShrink: 0,
-    transformOrigin: 'center',
-    transition: 'transform 0.15s ease',
-  },
-  menu: { position: 'absolute', top: 'calc(100% + 7px)', left: 0, zIndex: 20, width: 340,
-    background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
-    boxShadow: '0 14px 30px rgba(0,0,0,0.26)', padding: 8, display: 'flex', flexDirection: 'column', gap: 6 },
-  currentWorkspace: { display: 'flex', alignItems: 'center', gap: 7, padding: '6px 7px 8px', borderBottom: `1px solid ${C.border}` },
+  caret: { color: C.fg3, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, flexShrink: 0, transformOrigin: 'center', transition: 'transform 0.15s ease' },
+  menu: { position: 'absolute', top: 'calc(100% + 7px)', left: 0, zIndex: 20, width: 340, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8, boxShadow: '0 14px 30px rgba(0,0,0,0.26)', padding: 8, display: 'flex', flexDirection: 'column', gap: 7 },
+  currentCheckout: { display: 'flex', alignItems: 'center', gap: 7, padding: '6px 7px 8px', borderBottom: `1px solid ${C.border}` },
   currentIdentity: { minWidth: 0, flex: 1 },
   currentBranch: { color: C.fg, fontSize: 11, fontWeight: 600, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   currentPath: { color: C.fg3, fontSize: 9, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   iconButton: { width: 27, height: 27, padding: 0, border: `1px solid ${C.border2}`, borderRadius: 6, background: C.surface3, color: C.fg2, cursor: 'pointer', display: 'grid', placeItems: 'center', flexShrink: 0 },
-  viewTabs: { display: 'flex', padding: 2, borderRadius: 6, background: C.surface3 },
-  viewTab: { flex: 1, border: 'none', borderRadius: 5, padding: '5px 8px', background: 'transparent', color: C.fg3, cursor: 'pointer', fontSize: 11 },
-  viewTabActive: { flex: 1, border: `1px solid ${C.border2}`, borderRadius: 5, padding: '4px 8px', background: C.surface2, color: C.fg, cursor: 'pointer', fontSize: 11, fontWeight: 600 },
+  checkoutMode: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: '1px 3px 2px' },
+  modeLabel: { display: 'inline-flex', alignItems: 'center', gap: 5, color: C.fg3, fontSize: 10, paddingLeft: 3 },
+  worktreeBadge: { display: 'inline-flex', alignItems: 'center', gap: 5, color: C.green, fontSize: 10, paddingLeft: 3, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  createWorktreeButton: { background: C.accentDim, color: C.accent, border: `1px solid ${C.accent}55`, borderRadius: 6, padding: '5px 8px', fontSize: 10, cursor: 'pointer' },
   section: { display: 'flex', flexDirection: 'column', gap: 8 },
+  sectionLabel: { color: C.fg3, fontSize: 10 },
   scroll: { maxHeight: 260, overflowY: 'auto', display: 'flex', flexDirection: 'column' },
-  item: { textAlign: 'left', background: 'transparent', border: 'none', color: C.fg, fontSize: 12,
-    padding: '6px 8px', borderRadius: 6, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5 },
+  item: { width: '100%', textAlign: 'left', background: 'transparent', border: 'none', color: C.fg, fontSize: 12, padding: '6px 8px', borderRadius: 6, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 },
+  branchName: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   checkSlot: { width: 14, flexShrink: 0, display: 'inline-flex', alignItems: 'center' },
-  worktreeItem: { width: '100%', textAlign: 'left', background: 'transparent', border: 'none', color: C.fg, padding: '6px 8px', borderRadius: 6, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5 },
-  worktreeIdentity: { minWidth: 0, display: 'flex', flexDirection: 'column', gap: 1, fontSize: 12 },
-  worktreePath: { color: C.fg3, fontSize: 9, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
-  mainLabel: { color: C.fg3, fontSize: 9, fontWeight: 500 },
   empty: { color: C.fg3, fontSize: 11, padding: '14px 8px', textAlign: 'center' },
+  hint: { color: C.fg3, fontSize: 10, lineHeight: 1.4 },
   divider: { fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, color: C.fg3, padding: '8px 8px 2px' },
-  input: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg,
-    fontSize: 12, padding: '5px 8px', outline: 'none' },
-  toggle: { display: 'flex', gap: 4 },
-  seg: { flex: 1, background: C.surface3, border: `1px solid ${C.border2}`, color: C.fg2, fontSize: 11,
-    padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
-  segOn: { flex: 1, background: C.accent, border: `1px solid ${C.accent}`, color: C.onAccent, fontSize: 11,
-    padding: '5px 6px', borderRadius: 6, cursor: 'pointer' },
-  preview: { fontSize: 10, color: C.fg3, fontFamily: 'SF Mono, Menlo, monospace', wordBreak: 'break-all' },
+  input: { background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6, color: C.fg, fontSize: 12, padding: '5px 8px', outline: 'none' },
   row: { display: 'flex', gap: 6 },
   primary: { background: C.accent, color: C.onAccent, border: 'none', borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
-  ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
+  ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '5px 10px', fontSize: 11, cursor: 'pointer' },
   footer: { display: 'flex', justifyContent: 'space-between', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
   warn: { fontSize: 12, color: C.yellow },
   err: { fontSize: 11, color: C.red, padding: '2px 4px' },

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -26,6 +26,25 @@ interface WsMenuState {
   y: number
 }
 
+const DeliveryBadge: React.FC<{ pullRequest?: Chat['pullRequest'] }> = ({ pullRequest }) => {
+  if (!pullRequest) return null
+  const pr = pullRequest.number ? `PR #${pullRequest.number}` : 'Pull request'
+  if (pullRequest.state === 'pr-open') {
+    return <span style={{ ...styles.deliveryBadge, color: C.accent }} title={`${pr} is open`}><UIIcon name="link" size={10} /></span>
+  }
+  if (pullRequest.state === 'merged') {
+    return <span style={{ ...styles.deliveryBadge, color: C.green }} title={`${pr} merged${pullRequest.baseBranch ? ` into ${pullRequest.baseBranch}` : ''}`}><UIIcon name="check" size={11} /></span>
+  }
+  if (pullRequest.state === 'merged-with-changes') {
+    return (
+      <span style={{ ...styles.deliveryBadge, color: C.yellow }} title={`${pr} merged · new changes`}>
+        <UIIcon name="check" size={11} /><span style={styles.deliveryDot} />
+      </span>
+    )
+  }
+  return <span style={{ ...styles.deliveryBadge, color: C.fg3 }} title={`${pr} closed without merge`}>×</span>
+}
+
 export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomations, onOpenBrowser, onOpenTools, onSelectChat, automationsUnseenCount, activeChatId }) => {
   const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace, refreshWorkspaces, refreshChats, linkChannel, unlinkChannel } = useChats()
   const [addingWorkspace, setAddingWorkspace] = useState(false)
@@ -39,6 +58,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   const [wsRenameValue, setWsRenameValue] = useState('')
   const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
+  const [hoveredChatId, setHoveredChatId] = useState<string | null>(null)
   const [wsOrder, setWsOrder] = useState<string[]>(() => {
     try {
       const saved = JSON.parse(localStorage.getItem('codey.workspaceOrder') || '[]')
@@ -90,8 +110,25 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   const handleNewChat = async (workspaceName?: string) => {
     const target = workspaceName || selectedWorkspace || lastWorkspace
     if (!target) return
-    const chat = await createChat(target)
-    setLastWorkspace(chat.workspaceName)
+    try {
+      const chat = await createChat(target)
+      setLastWorkspace(chat.workspaceName)
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to create chat')
+    }
+  }
+
+  const confirmDeleteChat = async (chat: Chat) => {
+    const title = chat.title?.trim() || 'New Chat'
+    const detail = chat.chatWorkspace
+      ? '\n\nIts clean worktree will be removed. The Git branch will be kept.'
+      : ''
+    if (!confirm(`Delete chat "${title}"?${detail}`)) return
+    try {
+      await deleteChat(chat.id)
+    } catch (error) {
+      alert(error instanceof Error ? error.message : 'Failed to delete chat')
+    }
   }
 
   const closeWsMenu = () => setWsMenu(null)
@@ -382,10 +419,25 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                 return (
                   <div
                     key={chat.id}
+                    tabIndex={0}
                     title={orphaned ? 'Workspace deleted' : undefined}
                     style={{ ...styles.item, background: active ? C.accentDim : 'transparent', borderColor: active ? C.accent : 'transparent', opacity: orphaned ? 0.5 : 1 }}
                     onClick={() => {
                       if (isRenaming) return
+                      onSelectChat()
+                      selectChat(chat.id)
+                    }}
+                    onMouseEnter={() => setHoveredChatId(chat.id)}
+                    onMouseLeave={() => setHoveredChatId(current => current === chat.id ? null : current)}
+                    onFocus={() => setHoveredChatId(chat.id)}
+                    onBlur={event => {
+                      if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                        setHoveredChatId(current => current === chat.id ? null : current)
+                      }
+                    }}
+                    onKeyDown={event => {
+                      if (event.target !== event.currentTarget || isRenaming || (event.key !== 'Enter' && event.key !== ' ')) return
+                      event.preventDefault()
                       onSelectChat()
                       selectChat(chat.id)
                     }}
@@ -429,16 +481,20 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                     {unread && !active && <span style={styles.unreadDot} />}
                     {flight && <span style={styles.dot} />}
                     {!isRenaming && (
-                      <button
-                        style={styles.xBtn}
-                        onClick={async (e) => {
-                          e.stopPropagation()
-                          if (confirm(`Delete chat "${chat.title?.trim() || 'New Chat'}"?`)) {
-                            await deleteChat(chat.id)
-                          }
-                        }}
-                        title="Delete chat"
-                      ><UIIcon name="trash" size={13} /></button>
+                      <span style={styles.trailingAction}>
+                        {hoveredChatId === chat.id ? (
+                          <button
+                            style={styles.xBtn}
+                            onClick={async (e) => {
+                              e.stopPropagation()
+                              await confirmDeleteChat(chat)
+                            }}
+                            title="Delete chat"
+                          ><UIIcon name="trash" size={13} /></button>
+                        ) : (
+                          <DeliveryBadge pullRequest={chat.pullRequest} />
+                        )}
+                      </span>
                     )}
                   </div>
                 )
@@ -523,9 +579,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                 onClick={async () => {
                   const c = chatMenu.chat
                   setChatMenu(null)
-                  if (confirm(`Delete chat "${c.title?.trim() || 'New Chat'}"?`)) {
-                    await deleteChat(c.id)
-                  }
+                  await confirmDeleteChat(c)
                 }}
               ><UIIcon name="trash" size={14} />Delete chat</button>
             </>
@@ -587,13 +641,15 @@ const styles: Record<string, React.CSSProperties> = {
     backdropFilter: 'blur(22px) saturate(1.2)',
     WebkitBackdropFilter: 'blur(22px) saturate(1.2)',
   },
-  brandArea: { padding: '4px' },
+  brandArea: { padding: '4px', position: 'relative' },
   newChatBtn: {
-    width: '100%', border: 'none', borderRadius: 9, padding: '9px 10px',
+    minWidth: 0, width: '100%', border: 'none', borderRadius: 9, padding: '9px 10px',
     background: C.accent, color: C.onAccent, cursor: 'pointer', fontSize: 12, fontWeight: 700,
     display: 'flex', alignItems: 'center', gap: 7, boxShadow: `0 6px 16px ${C.accentDim}`,
   },
   newChatWorkspace: { marginLeft: 'auto', minWidth: 0, maxWidth: 92, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.72, fontWeight: 550, fontSize: 10 },
+  deliveryBadge: { position: 'relative', width: 16, height: 16, flexShrink: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', borderRadius: 5, background: C.surface3, border: `1px solid ${C.border2}`, fontSize: 14, lineHeight: 1, fontWeight: 700 },
+  deliveryDot: { position: 'absolute', right: 1, bottom: 1, width: 4, height: 4, borderRadius: '50%', background: C.yellow, boxShadow: `0 0 0 1px ${C.surface3}` },
   header: { padding: '10px 12px', borderBottom: `1px solid ${C.border}` },
   newBtn: {
     width: '100%',
@@ -659,9 +715,10 @@ const styles: Record<string, React.CSSProperties> = {
   },
   dot: { width: 6, height: 6, borderRadius: '50%', background: C.accent, animation: 'codey-pulse-dot 1.2s infinite' },
   unreadDot: { width: 6, height: 6, borderRadius: '50%', background: C.accent, flexShrink: 0 },
+  trailingAction: { width: 22, height: 22, flexShrink: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' },
   xBtn: {
     background: 'transparent', border: 'none', color: C.fg3,
-    cursor: 'pointer', padding: 3, display: 'inline-flex', borderRadius: 4,
+    cursor: 'pointer', padding: 3, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', borderRadius: 4,
   },
   manageSection: { padding: 8, borderRadius: 12, background: C.surface2, border: `1px solid ${C.sidebarBorder}` },
   footer: { display: 'flex', flexDirection: 'column', gap: 2 },

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -838,7 +838,7 @@ export const ChatTab: React.FC<Props> = ({
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
 }) => {
-  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setWorkingDir: setChatWorkingDir, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setExecutionMode, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -1022,7 +1022,9 @@ export const ChatTab: React.FC<Props> = ({
   // The effective working dir is the chat's per-chat override (a bound
   // worktree) when set, otherwise the workspace's repo root. Git status and the
   // header BranchPicker both operate on this effective dir.
-  const workingDir = chat?.workingDirOverride || workspaceDir
+  const workingDir = chat?.executionMode === 'isolated-worktree'
+    ? chat.chatWorkspace?.workingDir
+    : chat?.workingDirOverride || workspaceDir
 
   const changeRightPanelMode = useCallback((mode: WorkspaceDockTool | null) => {
     onRightPanelModeChange(mode)
@@ -1084,6 +1086,27 @@ export const ChatTab: React.FC<Props> = ({
 
   const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)
   const [showPrModal, setShowPrModal] = useState(false)
+  const refreshPullRequestStatus = useCallback(async (urlOverride?: string) => {
+    const url = urlOverride || chat?.pullRequest?.url
+    if (!workingDir) return
+    const branch = gitStatus?.branch
+    const canDiscover = !!branch && branch !== 'HEAD' && branch !== (gitStatus?.defaultBranch ?? 'main')
+    if (!url && !canDiscover) return
+    try {
+      const result = await window.codey.git.prStatus(workingDir, url)
+      if (result.ok) await setPullRequest(chatId, result.data)
+    } catch { /* PR status is best effort */ }
+  }, [workingDir, chatId, chat?.pullRequest?.url, gitStatus?.branch, gitStatus?.defaultBranch])
+
+  useEffect(() => {
+    void refreshPullRequestStatus()
+  }, [chat?.id, chat?.pullRequest?.url, workingDir, gitStatus?.branch])
+
+  useEffect(() => {
+    const onFocus = () => void refreshPullRequestStatus()
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [refreshPullRequestStatus])
   // Derived from the gitStatus useGitStatus already fetches — no extra IPC round-trip.
   // PR-able: on a non-default branch with commits the default branch doesn't have
   // (ahead is null when there's no remote default ref — fall back to branch check only).
@@ -1723,7 +1746,6 @@ export const ChatTab: React.FC<Props> = ({
         chat.selection.type === 'worker' ? chat.selection.name : null,
         effectiveAgent,
         effectiveModel ?? 'default model',
-        chat.soloAdvisor ? 'Advisor on' : null,
       ].filter(Boolean).join(' · ')
   const [panelTeamGraph, setPanelTeamGraph] = useState<import('../../../packages/core/src/team-graph').TeamGraph | undefined>(undefined)
   useEffect(() => {
@@ -1757,12 +1779,13 @@ export const ChatTab: React.FC<Props> = ({
         </div>
         <BranchPicker
           workingDir={workingDir}
-          repoRoot={workspaceDir}
-          boundWorktreePath={chat?.workingDirOverride}
-          onBindWorktree={async (path) => {
-            if (!chat) return
-            await setChatWorkingDir(chat.id, path)
-          }}
+          chatWorktree={chat.chatWorkspace ? {
+            name: chat.chatWorkspace.name,
+            path: chat.chatWorkspace.worktreePath,
+          } : undefined}
+          executionMode={chat?.executionMode ?? 'shared-checkout'}
+          onCreateWorktree={async name => { await createWorktree(chat.id, name) }}
+          onExecutionModeChange={async mode => { await setExecutionMode(chat.id, mode) }}
           onOpenTerminal={openChatTerminal}
         />
         <div style={{ ...styles.openInWrap, marginLeft: 'auto' }}>
@@ -1895,9 +1918,8 @@ export const ChatTab: React.FC<Props> = ({
                       <span style={styles.advisorSettingIdentity}>
                         <UIIcon name="sparkle" size={14} />
                         <span>Advisor</span>
-                        <span style={styles.advisorModelName}>{effectiveAdvisorModel}</span>
                       </span>
-                      <span>{chat.soloAdvisor ? 'On' : 'Off'}</span>
+                      <span style={styles.advisorModelName}>{effectiveAdvisorModel}</span>
                     </button>
                   </>
                 )}
@@ -2502,6 +2524,7 @@ export const ChatTab: React.FC<Props> = ({
           onCreate={async (input) => {
             if (!workingDir) return { ok: false, error: 'No working dir' }
             const r = await window.codey.git.createPr(workingDir, input)
+            if (r.ok && r.data.ok && r.data.url) await refreshPullRequestStatus(r.data.url)
             return r.ok ? r.data : { ok: false, error: r.error || 'Failed' }
           }}
         />

--- a/codey-mac/src/components/branchPickerModel.test.ts
+++ b/codey-mac/src/components/branchPickerModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { compactWorktreePath, currentFirst, defaultWorktreePath, filterBranches, partitionWorktrees } from './branchPickerModel';
+import { compactWorktreePath, currentFirst, filterBranches } from './branchPickerModel';
 
 describe('filterBranches', () => {
   it('returns all when query empty', () => {
@@ -7,28 +7,6 @@ describe('filterBranches', () => {
   });
   it('is case-insensitive substring match', () => {
     expect(filterBranches(['Main', 'feature/x', 'dev'], 'fe')).toEqual(['feature/x']);
-  });
-});
-
-describe('defaultWorktreePath', () => {
-  it('builds an in-repo .codey/worktrees path with sanitized branch', () => {
-    expect(defaultWorktreePath('/home/u/repo', 'feat/cool thing'))
-      .toBe('/home/u/repo/.codey/worktrees/feat-cool-thing');
-  });
-  it('strips a trailing slash from the repo path', () => {
-    expect(defaultWorktreePath('/home/u/repo/', 'x'))
-      .toBe('/home/u/repo/.codey/worktrees/x');
-  });
-});
-
-describe('partitionWorktrees', () => {
-  it('splits main from the rest', () => {
-    const { main, others } = partitionWorktrees([
-      { branch: 'main', path: '/r', isMain: true },
-      { branch: 'feat', path: '/r2', isMain: false },
-    ]);
-    expect(main?.branch).toBe('main');
-    expect(others.map(w => w.branch)).toEqual(['feat']);
   });
 });
 

--- a/codey-mac/src/components/branchPickerModel.ts
+++ b/codey-mac/src/components/branchPickerModel.ts
@@ -2,7 +2,6 @@
 // not import Node's 'path' — that externalizes to require() and crashes the
 // renderer bundle. The path building below is plain string work (macOS paths).
 
-export interface Worktree { branch: string; path: string; isMain: boolean }
 export interface BranchData { current: string; local: string[]; remote: string[] }
 
 /** Case-insensitive substring filter; empty query returns the list unchanged. */
@@ -10,20 +9,6 @@ export function filterBranches(list: string[], query: string): string[] {
   const q = query.trim().toLowerCase();
   if (!q) return list;
   return list.filter(b => b.toLowerCase().includes(q));
-}
-
-/** Default worktree location: `<repo>/.codey/worktrees/<branch>` (in-repo, gitignored). */
-export function defaultWorktreePath(repoPath: string, branchName: string): string {
-  const root = repoPath.replace(/\/+$/, '');
-  const safe = branchName.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-  return `${root}/.codey/worktrees/${safe}`;
-}
-
-/** Separate the main worktree from the rest for display. */
-export function partitionWorktrees(list: Worktree[]): { main?: Worktree; others: Worktree[] } {
-  const main = list.find(w => w.isMain);
-  const others = list.filter(w => !w.isMain);
-  return { main, others };
 }
 
 /** Compact a filesystem path without hiding its identifying final segments. */

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -51,6 +51,7 @@ type Action =
   | { type: 'patchContextPanelOpen'; chatId: string; open: boolean | null }
   | { type: 'patchSoloAdvisor'; chatId: string; enabled: boolean }
   | { type: 'patchTaskBrief'; chatId: string; brief: TaskBrief }
+  | { type: 'patchPullRequest'; chatId: string; pullRequest: NonNullable<Chat['pullRequest']> }
   | { type: 'permissionRequest'; chatId: string; toolNames: string[] }
   | { type: 'dismissPermission'; chatId: string }
   | { type: 'teamStart'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string }> }
@@ -153,6 +154,14 @@ export function reducer(state: State, action: Action): State {
       if (!chat) return state
       const updated: Chat = { ...chat, contextPanelOpen: action.open ?? undefined }
       return { ...state, chats: { ...state.chats, [chat.id]: updated } }
+    }
+    case 'patchPullRequest': {
+      const chat = state.chats[action.chatId]
+      if (!chat) return state
+      return {
+        ...state,
+        chats: { ...state.chats, [chat.id]: { ...chat, pullRequest: action.pullRequest } },
+      }
     }
     case 'patchSoloAdvisor': {
       const chat = state.chats[action.chatId]
@@ -458,6 +467,9 @@ interface ChatsContextValue {
   setSelection: (chatId: string, selection: ChatSelection) => Promise<void>
   setAgentModel: (chatId: string, agent: string | null, model: string | null) => Promise<void>
   setWorkingDir: (chatId: string, dir: string | null) => Promise<void>
+  setExecutionMode: (chatId: string, mode: 'shared-checkout' | 'isolated-worktree') => Promise<Chat>
+  createWorktree: (chatId: string, name: string) => Promise<Chat>
+  setPullRequest: (chatId: string, pullRequest: NonNullable<Chat['pullRequest']>) => Promise<void>
   setContextPanelOpen: (chatId: string, open: boolean | null) => Promise<void>
   setSoloAdvisor: (chatId: string, enabled: boolean) => Promise<void>
   generateTaskBrief: (chatId: string) => Promise<TaskBrief | null>
@@ -612,6 +624,11 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         case 'team_end':
           dispatch({ type: 'teamEnd', chatId: ev.chatId, teamTurnId: ev.teamTurnId, summary: ev.summary, taskBrief: ev.taskBrief })
           break
+        case 'workspace_ready':
+          apiService.chats.get(ev.chatId)
+            .then(chat => dispatch({ type: 'upsert', chat }))
+            .catch(() => {})
+          break
         case 'done': {
           adopting.current.delete(ev.chatId)
           const asstId = pendingAssistantId.current[ev.chatId]
@@ -741,6 +758,20 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       // bound chip reflects the binding immediately.
       const chat = await apiService.chats.setWorkingDir(chatId, dir)
       dispatch({ type: 'upsert', chat })
+    },
+    async setExecutionMode(chatId, mode) {
+      const chat = await apiService.chats.setExecutionMode(chatId, mode)
+      dispatch({ type: 'upsert', chat })
+      return chat
+    },
+    async createWorktree(chatId, name) {
+      const chat = await apiService.chats.createWorktree(chatId, name)
+      dispatch({ type: 'upsert', chat })
+      return chat
+    },
+    async setPullRequest(chatId, pullRequest) {
+      dispatch({ type: 'patchPullRequest', chatId, pullRequest })
+      try { await apiService.chats.setPullRequest(chatId, pullRequest) } catch { /* refresh is best effort */ }
     },
     async setContextPanelOpen(chatId, open) {
       // Optimistically patch the local state so we don't replace the chat

--- a/codey-mac/src/hooks/useGitBranches.ts
+++ b/codey-mac/src/hooks/useGitBranches.ts
@@ -1,12 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
-import type { Worktree } from '../components/branchPickerModel'
 
 export interface BranchState {
   branch: string
   dirty: number
   local: string[]
   remote: string[]
-  worktrees: Worktree[]
 }
 
 export function useGitBranches(workingDir: string | undefined) {
@@ -16,15 +14,13 @@ export function useGitBranches(workingDir: string | undefined) {
   const refresh = useCallback(async () => {
     if (!workingDir) { setState(null); return }
     try {
-      const [s, b, w] = await Promise.all([
+      const [s, b] = await Promise.all([
         window.codey.git.status(workingDir),
         window.codey.git.branches(workingDir),
-        window.codey.git.worktrees(workingDir),
       ])
       if (!s.ok || !s.data) { setState(null); return }
       const br = b.ok ? b.data : { current: s.data.branch, local: [], remote: [] }
-      const wl = w.ok ? w.data.list : []
-      setState({ branch: s.data.branch, dirty: s.data.dirty, local: br.local, remote: br.remote, worktrees: wl })
+      setState({ branch: s.data.branch, dirty: s.data.dirty, local: br.local, remote: br.remote })
     } catch { setState(null) }
   }, [workingDir])
 
@@ -75,12 +71,5 @@ export function useGitBranches(workingDir: string | undefined) {
     else setError((r.ok ? r.data.error : r.error) || 'fetch failed')
   }, [workingDir, refresh])
 
-  const addWorktree = useCallback(async (name: string, path: string) => {
-    if (!workingDir) return { ok: false }
-    const r = await window.codey.git.worktreeAdd(workingDir, { name, path })
-    if (r.ok && r.data.ok) { await refresh(); return { ok: true, path: r.data.path } }
-    setError((r.ok ? r.data.error : r.error) || 'worktree add failed'); return { ok: false }
-  }, [workingDir, refresh])
-
-  return { state, error, setError, refresh, checkout, stashAndSwitch, createBranch, fetchRemote, addWorktree }
+  return { state, error, setError, refresh, checkout, stashAndSwitch, createBranch, fetchRemote }
 }

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -16,6 +16,7 @@ export type ChatStreamEvent =
   | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; reason?: string }
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
+  | { type: 'workspace_ready'; chatId: string }
   | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
@@ -200,6 +201,12 @@ export const apiService = {
       unwrap(await window.codey.chats.setSoloAdvisor(id, enabled)),
     setWorkingDir: async (id: string, dir: string | null): Promise<Chat> =>
       unwrap(await window.codey.chats.setWorkingDir(id, dir)),
+    setExecutionMode: async (id: string, mode: 'shared-checkout' | 'isolated-worktree'): Promise<Chat> =>
+      unwrap(await window.codey.chats.setExecutionMode(id, mode)),
+    createWorktree: async (id: string, name: string): Promise<Chat> =>
+      unwrap(await window.codey.chats.createWorktree(id, name)),
+    setPullRequest: async (id: string, pullRequest: NonNullable<Chat['pullRequest']>): Promise<Chat> =>
+      unwrap(await window.codey.chats.setPullRequest(id, pullRequest)),
     upload: async (chatId: string, fileName: string, mimeType: string, data: ArrayBuffer): Promise<{ id: string; name: string; path: string; mimeType: string; size: number }> =>
       unwrap(await window.codey.chats.upload(chatId, fileName, mimeType, data)),
     send: async (chatId: string, text: string, attachments?: { id: string; name: string; path: string; mimeType: string; size: number }[]): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> =>

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -159,6 +159,31 @@ export interface Chat {
    *  runs here instead of the workspace's workingDir — used to bind a chat to a
    *  git worktree. Cleared (deleted) to fall back to the workspace dir. */
   workingDirOverride?: string;
+  /** Checkout currently used by this chat. Missing on legacy chats means the
+   *  shared project checkout. */
+  executionMode?: 'shared-checkout' | 'isolated-worktree';
+  /** Stable filesystem environment owned by an isolated chat. The branch is
+   *  deliberately not persisted: it is live Git state managed by the agent. */
+  chatWorkspace?: {
+    /** User-chosen, filesystem-safe name for this chat's worktree. */
+    name?: string;
+    repositoryRoot: string;
+    worktreePath: string;
+    workingDir: string;
+    baseCommit: string;
+    createdAt: number;
+  };
+  /** Pull request delivery state associated with this chat's current branch. */
+  pullRequest?: {
+    url: string;
+    number?: number;
+    state: 'pr-open' | 'merged' | 'merged-with-changes' | 'closed-unmerged';
+    headBranch?: string;
+    baseBranch?: string;
+    headCommit?: string;
+    mergedAt?: number;
+    lastCheckedAt: number;
+  };
   /** Last unanswered choice question in a non-team chat. Cleared on next user message. */
   lastAskedOptions?: { messageId: string; options: string[] };
   /** Set when the skill distiller has proposed a new skill and is waiting for

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -28,6 +28,7 @@ export type ChatStreamEvent =
   | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: CodingAgent; model?: string; reason?: string }
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
+  | { type: 'workspace_ready'; chatId: string }
   | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }

--- a/packages/gateway/src/chat-worktree.test.ts
+++ b/packages/gateway/src/chat-worktree.test.ts
@@ -1,0 +1,280 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { chatWorktreeParent, describeLegacyChatWorktree, discoverChatWorktree, normalizeWorktreeName, provisionChatWorktree, removeCleanChatWorktree, workspaceHasUncommittedChanges } from './chat-worktree';
+import { ChatManager } from './chats';
+
+const roots: string[] = [];
+const git = (cwd: string, args: string[]) => execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('provisionChatWorktree', () => {
+  it('creates a same-named branch and preserves a workspace subdirectory', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-worktree-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const workspaceWorkingDir = path.join(repositoryRoot, 'packages', 'app');
+    fs.mkdirSync(workspaceWorkingDir, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+
+    const result = await provisionChatWorktree({
+      workspaceWorkingDir,
+      workspacesRoot: path.join(root, 'data', 'workspaces'),
+      workspaceName: 'demo',
+      chatId: 'chat-123',
+      worktreeName: 'feature-auth',
+    });
+
+    expect(result.workingDir).toBe(path.join(result.worktreePath, 'packages', 'app'));
+    expect(result.name).toBe('feature-auth');
+    expect(path.basename(result.worktreePath)).toBe('feature-auth');
+    expect(result.worktreePath).toContain(`${path.sep}chat-worktrees${path.sep}demo${path.sep}chat-chat-123${path.sep}`);
+    expect(result.baseCommit).toBe(git(repositoryRoot, ['rev-parse', 'HEAD']));
+    expect(git(result.worktreePath, ['branch', '--show-current'])).toBe('feature-auth');
+    expect(fs.statSync(result.workingDir).isDirectory()).toBe(true);
+  });
+
+  it('rejects isolated mode for a non-Git workspace', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-worktree-'));
+    roots.push(root);
+    await expect(provisionChatWorktree({
+      workspaceWorkingDir: root,
+      workspacesRoot: path.join(root, 'workspaces'),
+      workspaceName: 'plain',
+      chatId: 'chat-plain',
+      worktreeName: 'plain-work',
+    })).rejects.toThrow(/Git workspace/);
+  });
+});
+
+describe('discoverChatWorktree', () => {
+  it('adopts the one direct-child worktree owned by a chat and keeps its semantic name', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-agent-worktree-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const workspaceWorkingDir = path.join(repositoryRoot, 'packages', 'app');
+    const workspacesRoot = path.join(root, 'data', 'workspaces');
+    fs.mkdirSync(workspaceWorkingDir, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+
+    const parent = chatWorktreeParent(workspacesRoot, 'demo', 'abc-123');
+    const worktreePath = path.join(parent, 'feature-search');
+    fs.mkdirSync(parent, { recursive: true });
+    git(repositoryRoot, ['worktree', 'add', '-b', 'feature-search', worktreePath, 'HEAD']);
+    fs.mkdirSync(path.join(worktreePath, 'packages', 'app'), { recursive: true });
+
+    const workspace = await discoverChatWorktree({
+      workspaceWorkingDir, workspacesRoot, workspaceName: 'demo', chatId: 'abc-123', createdAt: 42,
+    });
+
+    expect(workspace).toMatchObject({
+      name: 'feature-search',
+      worktreePath: fs.realpathSync(worktreePath),
+      workingDir: path.join(fs.realpathSync(worktreePath), 'packages', 'app'),
+      createdAt: 42,
+    });
+  });
+
+  it('does not adopt a worktree belonging to another chat', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-agent-owner-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const workspacesRoot = path.join(root, 'data', 'workspaces');
+    fs.mkdirSync(repositoryRoot, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+    const otherPath = path.join(chatWorktreeParent(workspacesRoot, 'demo', 'other-chat'), 'feature-other');
+    fs.mkdirSync(path.dirname(otherPath), { recursive: true });
+    git(repositoryRoot, ['worktree', 'add', '-b', 'feature-other', otherPath, 'HEAD']);
+
+    await expect(discoverChatWorktree({
+      workspaceWorkingDir: repositoryRoot, workspacesRoot, workspaceName: 'demo', chatId: 'this-chat',
+    })).resolves.toBeUndefined();
+  });
+});
+
+describe('normalizeWorktreeName', () => {
+  it('turns a user label into a safe semantic directory name', () => {
+    expect(normalizeWorktreeName(' Feature / Auth ')).toBe('Feature-Auth');
+  });
+
+  it('rejects a name without usable characters', () => {
+    expect(() => normalizeWorktreeName('///')).toThrow(/worktree name/i);
+  });
+});
+
+describe('workspaceHasUncommittedChanges', () => {
+  it('detects tracked and untracked changes that would not reach a new worktree', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-dirty-'));
+    roots.push(root);
+    git(root, ['init', '-b', 'main']);
+    git(root, ['config', 'user.email', 'test@codey.local']);
+    git(root, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(root, 'README.md'), 'clean\n');
+    git(root, ['add', 'README.md']);
+    git(root, ['commit', '-m', 'initial']);
+
+    await expect(workspaceHasUncommittedChanges(root)).resolves.toBe(false);
+    fs.writeFileSync(path.join(root, 'new-file.txt'), 'not committed\n');
+    await expect(workspaceHasUncommittedChanges(root)).resolves.toBe(true);
+  });
+});
+
+describe('legacy worktree migration and cleanup', () => {
+  it('recognizes an existing legacy worktree and removes it only when clean', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-legacy-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const legacyPath = path.join(root, 'legacy-feature');
+    fs.mkdirSync(repositoryRoot, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'clean\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+    git(repositoryRoot, ['worktree', 'add', '-b', 'legacy-feature', legacyPath, 'HEAD']);
+
+    const workspace = await describeLegacyChatWorktree({
+      workspaceWorkingDir: repositoryRoot,
+      workingDirOverride: legacyPath,
+      createdAt: 123,
+    });
+    const realRepositoryRoot = fs.realpathSync(repositoryRoot);
+    const realLegacyPath = fs.realpathSync(legacyPath);
+
+    expect(workspace).toMatchObject({
+      name: 'legacy-feature', repositoryRoot: realRepositoryRoot, worktreePath: realLegacyPath,
+      workingDir: realLegacyPath, createdAt: 123,
+    });
+    await removeCleanChatWorktree(workspace!);
+    expect(fs.existsSync(legacyPath)).toBe(false);
+    expect(git(repositoryRoot, ['show-ref', '--verify', 'refs/heads/legacy-feature'])).toBeTruthy();
+  });
+
+  it('refuses to remove a worktree with uncommitted changes', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-cleanup-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const worktreePath = path.join(root, 'feature');
+    fs.mkdirSync(repositoryRoot, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'clean\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+    git(repositoryRoot, ['worktree', 'add', '-b', 'feature', worktreePath, 'HEAD']);
+    fs.writeFileSync(path.join(worktreePath, 'dirty.txt'), 'keep me\n');
+
+    await expect(removeCleanChatWorktree({
+      name: 'feature', repositoryRoot, worktreePath, workingDir: worktreePath,
+      baseCommit: git(worktreePath, ['rev-parse', 'HEAD']), createdAt: 1,
+    })).rejects.toThrow(/uncommitted changes/i);
+    expect(fs.existsSync(worktreePath)).toBe(true);
+  });
+});
+
+describe('ChatManager isolated workspace binding', () => {
+  it('persists the execution mode and effective working directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-workspace-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
+    const manager = new ChatManager(root);
+    const chat = manager.create({ workspaceName: 'demo', executionMode: 'isolated-worktree' });
+    manager.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'old-session' });
+    const workspace = {
+      repositoryRoot: '/repo', worktreePath: '/worktrees/chat-1', workingDir: '/worktrees/chat-1/packages/app',
+      baseCommit: 'abc123', createdAt: 1,
+    };
+
+    const updated = manager.setChatWorkspace(chat.id, workspace);
+
+    expect(updated.executionMode).toBe('isolated-worktree');
+    expect(updated.chatWorkspace).toEqual(workspace);
+    expect(updated.workingDirOverride).toBe(workspace.workingDir);
+    expect(updated.sessionAnchor).toBeUndefined();
+    expect(updated.sessionAnchors).toBeUndefined();
+  });
+
+  it('switches checkout mode without deleting the chat worktree binding', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-mode-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
+    const manager = new ChatManager(root);
+    const chat = manager.create({ workspaceName: 'demo', executionMode: 'isolated-worktree' });
+    const workspace = {
+      repositoryRoot: '/repo', worktreePath: '/worktrees/chat-1', workingDir: '/worktrees/chat-1',
+      baseCommit: 'abc123', createdAt: 1,
+    };
+    manager.setChatWorkspace(chat.id, workspace);
+    manager.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'isolated-session' });
+
+    const shared = manager.setExecutionMode(chat.id, 'shared-checkout');
+    expect(shared.workingDirOverride).toBeUndefined();
+    expect(shared.chatWorkspace).toEqual(workspace);
+    expect(shared.sessionAnchors).toBeUndefined();
+
+    manager.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'shared-session' });
+    const isolated = manager.setExecutionMode(chat.id, 'isolated-worktree');
+    expect(isolated.workingDirOverride).toBe(workspace.workingDir);
+    expect(isolated.sessionAnchors).toBeUndefined();
+  });
+
+  it('migrates a legacy binding without changing conversation order', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-migration-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
+    const manager = new ChatManager(root);
+    const chat = manager.create({ workspaceName: 'demo' });
+    manager.setWorkingDirOverride(chat.id, '/worktrees/legacy');
+    const beforeMigration = manager.get(chat.id)!.updatedAt;
+    const workspace = {
+      name: 'legacy', repositoryRoot: '/repo', worktreePath: '/worktrees/legacy', workingDir: '/worktrees/legacy',
+      baseCommit: 'abc123', createdAt: 1,
+    };
+
+    const migrated = manager.migrateChatWorkspace(chat.id, workspace);
+
+    expect(migrated.chatWorkspace).toEqual(workspace);
+    expect(migrated.executionMode).toBe('isolated-worktree');
+    expect(migrated.updatedAt).toBe(beforeMigration);
+  });
+
+  it('persists pull request state without changing conversation activity time', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-delivery-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
+    const manager = new ChatManager(root);
+    const chat = manager.create({ workspaceName: 'demo' });
+    const updatedAt = chat.updatedAt;
+    const pullRequest = {
+      url: 'https://github.com/example/repo/pull/12', number: 12,
+      state: 'merged' as const, baseBranch: 'main', lastCheckedAt: 2,
+    };
+
+    const updated = manager.setPullRequest(chat.id, pullRequest);
+
+    expect(updated.pullRequest).toEqual(pullRequest);
+    expect(updated.updatedAt).toBe(updatedAt);
+  });
+});

--- a/packages/gateway/src/chat-worktree.ts
+++ b/packages/gateway/src/chat-worktree.ts
@@ -1,0 +1,209 @@
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import type { Chat } from '@codey/core';
+
+const execFileAsync = promisify(execFile);
+export type ChatWorkspace = NonNullable<Chat['chatWorkspace']>;
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync('git', args, { cwd, timeout: 30_000 });
+  return result.stdout.trim();
+}
+
+export function normalizeWorktreeName(name: string): string {
+  const normalized = name.trim().replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80);
+  if (!normalized || normalized === '.' || normalized === '..') {
+    throw new Error('Enter a worktree name using letters, numbers, dots, dashes, or underscores');
+  }
+  return normalized;
+}
+
+export function chatWorktreeParent(workspacesRoot: string, workspaceName: string, chatId: string): string {
+  const safeWorkspace = workspaceName.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const safeChatId = chatId.replace(/[^a-zA-Z0-9._-]/g, '-');
+  // The UUID is intentionally confined to this hidden ownership boundary. It
+  // never becomes the user-facing worktree/branch name, but prevents two
+  // concurrently running chats from adopting each other's new checkout.
+  return path.join(path.dirname(workspacesRoot), 'chat-worktrees', safeWorkspace, `chat-${safeChatId}`);
+}
+
+export function chatWorktreeDirectory(workspacesRoot: string, workspaceName: string, chatId: string, worktreeName: string): string {
+  const safeName = normalizeWorktreeName(worktreeName);
+  // Keep code checkouts outside the workspace metadata directory. Deleting or
+  // renaming a Workspace must not silently erase a chat's uncommitted files.
+  return path.join(chatWorktreeParent(workspacesRoot, workspaceName, chatId), safeName);
+}
+
+interface WorktreeRecord {
+  worktreePath: string;
+  head?: string;
+  branch?: string;
+}
+
+function parseWorktreeList(output: string): WorktreeRecord[] {
+  const records: WorktreeRecord[] = [];
+  let current: WorktreeRecord | undefined;
+  for (const line of output.split(/\r?\n/)) {
+    if (line.startsWith('worktree ')) {
+      if (current) records.push(current);
+      current = { worktreePath: line.slice('worktree '.length) };
+    } else if (current && line.startsWith('HEAD ')) {
+      current.head = line.slice('HEAD '.length);
+    } else if (current && line.startsWith('branch ')) {
+      current.branch = line.slice('branch '.length).replace(/^refs\/heads\//, '');
+    }
+  }
+  if (current) records.push(current);
+  return records;
+}
+
+/** Discover a worktree created by an agent inside this chat's private
+ *  ownership directory. A direct-child rule keeps adoption deterministic. */
+export async function discoverChatWorktree(input: {
+  workspaceWorkingDir: string;
+  workspacesRoot: string;
+  workspaceName: string;
+  chatId: string;
+  createdAt?: number;
+}): Promise<ChatWorkspace | undefined> {
+  const sourceDir = fs.realpathSync(path.resolve(input.workspaceWorkingDir));
+  let repositoryRoot: string;
+  try {
+    repositoryRoot = fs.realpathSync(path.resolve(await git(sourceDir, ['rev-parse', '--show-toplevel'])));
+  } catch {
+    return undefined;
+  }
+  const relativeWorkingDir = path.relative(repositoryRoot, sourceDir);
+  if (relativeWorkingDir.startsWith('..') || path.isAbsolute(relativeWorkingDir)) return undefined;
+
+  const parent = chatWorktreeParent(input.workspacesRoot, input.workspaceName, input.chatId);
+  if (!fs.existsSync(parent)) return undefined;
+  const realParent = fs.realpathSync(parent);
+  const records = parseWorktreeList(await git(repositoryRoot, ['worktree', 'list', '--porcelain']));
+  const owned = records.filter(record => {
+    if (!fs.existsSync(record.worktreePath)) return false;
+    return path.dirname(fs.realpathSync(record.worktreePath)) === realParent;
+  });
+  if (owned.length !== 1) return undefined;
+
+  const record = owned[0];
+  const worktreePath = fs.realpathSync(record.worktreePath);
+  const workingDir = path.join(worktreePath, relativeWorkingDir);
+  if (!fs.existsSync(workingDir) || !fs.statSync(workingDir).isDirectory()) return undefined;
+  return {
+    name: path.basename(worktreePath),
+    repositoryRoot,
+    worktreePath,
+    workingDir,
+    baseCommit: record.head ?? await git(worktreePath, ['rev-parse', 'HEAD']),
+    createdAt: input.createdAt ?? Date.now(),
+  };
+}
+
+/** A shared checkout cannot be promoted safely while it contains changes that
+ *  are not represented by HEAD: a new worktree starts from a commit. */
+export async function workspaceHasUncommittedChanges(workingDir: string): Promise<boolean> {
+  return (await git(workingDir, ['status', '--porcelain'])).length > 0;
+}
+
+/** Describe a worktree selected by the legacy workingDirOverride model. */
+export async function describeLegacyChatWorktree(input: {
+  workspaceWorkingDir: string;
+  workingDirOverride: string;
+  createdAt: number;
+}): Promise<ChatWorkspace | undefined> {
+  if (!fs.existsSync(input.workingDirOverride)) return undefined;
+  const [workspaceDir, overrideDir] = [input.workspaceWorkingDir, input.workingDirOverride]
+    .map(value => fs.realpathSync(path.resolve(value)));
+  const [workspaceRoot, worktreeRoot] = await Promise.all([
+    git(workspaceDir, ['rev-parse', '--show-toplevel']),
+    git(overrideDir, ['rev-parse', '--show-toplevel']),
+  ]).then(values => values.map(value => fs.realpathSync(path.resolve(value))));
+  if (workspaceRoot === worktreeRoot) return undefined;
+
+  const resolveCommonDir = async (cwd: string): Promise<string> => {
+    const raw = await git(cwd, ['rev-parse', '--git-common-dir']);
+    return fs.realpathSync(path.resolve(cwd, raw));
+  };
+  const [workspaceCommonDir, worktreeCommonDir] = await Promise.all([
+    resolveCommonDir(workspaceDir), resolveCommonDir(overrideDir),
+  ]);
+  if (workspaceCommonDir !== worktreeCommonDir) return undefined;
+
+  const relativeWorkingDir = path.relative(worktreeRoot, overrideDir);
+  const [baseCommit, branch] = await Promise.all([
+    git(overrideDir, ['rev-parse', 'HEAD']),
+    git(overrideDir, ['branch', '--show-current']),
+  ]);
+  return {
+    name: branch || path.basename(worktreeRoot),
+    repositoryRoot: workspaceRoot,
+    worktreePath: worktreeRoot,
+    workingDir: path.join(worktreeRoot, relativeWorkingDir),
+    baseCommit,
+    createdAt: input.createdAt,
+  };
+}
+
+/** Remove a chat's checkout only when Git confirms it has no local changes.
+ *  The branch is intentionally retained so committed work remains recoverable. */
+export async function removeCleanChatWorktree(workspace: ChatWorkspace): Promise<void> {
+  if (!fs.existsSync(workspace.worktreePath)) {
+    if (fs.existsSync(workspace.repositoryRoot)) await git(workspace.repositoryRoot, ['worktree', 'prune']);
+    return;
+  }
+  if (await workspaceHasUncommittedChanges(workspace.worktreePath)) {
+    throw new Error(`Worktree "${workspace.name ?? path.basename(workspace.worktreePath)}" has uncommitted changes. Commit or stash them before deleting this chat.`);
+  }
+  await git(workspace.repositoryRoot, ['worktree', 'remove', workspace.worktreePath]);
+}
+
+/** Create a chat-owned worktree and a same-named branch from the source HEAD. */
+export async function provisionChatWorktree(input: {
+  workspaceWorkingDir: string;
+  workspacesRoot: string;
+  workspaceName: string;
+  chatId: string;
+  worktreeName: string;
+}): Promise<ChatWorkspace> {
+  const sourceDir = fs.realpathSync(path.resolve(input.workspaceWorkingDir));
+  let repositoryRoot: string;
+  try {
+    repositoryRoot = fs.realpathSync(path.resolve(await git(sourceDir, ['rev-parse', '--show-toplevel'])));
+  } catch {
+    throw new Error('Isolated worktrees require a Git workspace');
+  }
+
+  const relativeWorkingDir = path.relative(repositoryRoot, sourceDir);
+  if (relativeWorkingDir.startsWith('..') || path.isAbsolute(relativeWorkingDir)) {
+    throw new Error(`Workspace directory is outside its Git repository: ${sourceDir}`);
+  }
+
+  const baseCommit = await git(sourceDir, ['rev-parse', 'HEAD']);
+  const name = normalizeWorktreeName(input.worktreeName);
+  const requestedPath = chatWorktreeDirectory(input.workspacesRoot, input.workspaceName, input.chatId, name);
+  fs.mkdirSync(path.dirname(requestedPath), { recursive: true });
+  const worktreePath = path.join(fs.realpathSync(path.dirname(requestedPath)), path.basename(requestedPath));
+  const workingDir = path.join(worktreePath, relativeWorkingDir);
+
+  if (fs.existsSync(worktreePath)) {
+    throw new Error(`A worktree named "${name}" already exists in this workspace`);
+  } else {
+    await git(repositoryRoot, ['worktree', 'prune']);
+    const branchExists = await git(repositoryRoot, ['show-ref', '--verify', `refs/heads/${name}`])
+      .then(() => true)
+      .catch(() => false);
+    if (branchExists) throw new Error(`A branch named "${name}" already exists`);
+    await git(repositoryRoot, ['worktree', 'add', '-b', name, worktreePath, baseCommit]);
+  }
+
+  // Git does not track empty directories. Recreate the configured workspace
+  // subdirectory when the source path exists but the checkout omitted it.
+  if (!fs.existsSync(workingDir)) fs.mkdirSync(workingDir, { recursive: true });
+  if (!fs.statSync(workingDir).isDirectory()) {
+    throw new Error(`Workspace subdirectory is not a directory in the isolated checkout: ${relativeWorkingDir}`);
+  }
+  return { name, repositoryRoot, worktreePath, workingDir, baseCommit, createdAt: Date.now() };
+}

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -15,6 +15,7 @@ export interface CreateChatInput {
   /** Per-chat agent/model overrides, set at creation (used by automations). */
   agent?: Chat['agent'];
   model?: string;
+  executionMode?: Chat['executionMode'];
 }
 
 /**
@@ -195,6 +196,7 @@ export class ChatManager {
       ...(input.kind ? { kind: input.kind } : {}),
       ...(input.agent ? { agent: input.agent } : {}),
       ...(input.model ? { model: input.model } : {}),
+      ...(input.executionMode ? { executionMode: input.executionMode } : {}),
     };
     this.cache.set(chat.id, chat);
     this.persist(chat);
@@ -341,6 +343,57 @@ export class ChatManager {
     if (dir === null || dir === undefined || dir === '') delete chat.workingDirOverride;
     else chat.workingDirOverride = dir;
     chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
+  setChatWorkspace(chatId: string, workspace: NonNullable<Chat['chatWorkspace']>): Chat {
+    const chat = this.requireChat(chatId);
+    const workingDirChanged = chat.workingDirOverride !== workspace.workingDir;
+    chat.executionMode = 'isolated-worktree';
+    chat.chatWorkspace = workspace;
+    // Keep the legacy override populated while execution surfaces migrate to
+    // the explicit chatWorkspace model.
+    chat.workingDirOverride = workspace.workingDir;
+    if (workingDirChanged) {
+      delete chat.sessionAnchor;
+      delete chat.sessionAnchors;
+    }
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
+  /** One-time compatibility migration for chats bound through the legacy
+   *  workingDirOverride field. Preserve updatedAt so migration does not reorder chats. */
+  migrateChatWorkspace(chatId: string, workspace: NonNullable<Chat['chatWorkspace']>): Chat {
+    const chat = this.requireChat(chatId);
+    if (chat.chatWorkspace) return chat;
+    chat.executionMode = 'isolated-worktree';
+    chat.chatWorkspace = workspace;
+    chat.workingDirOverride = workspace.workingDir;
+    this.persist(chat);
+    return chat;
+  }
+
+  setExecutionMode(chatId: string, mode: NonNullable<Chat['executionMode']>): Chat {
+    const chat = this.requireChat(chatId);
+    const previousWorkingDir = chat.workingDirOverride;
+    chat.executionMode = mode;
+    if (mode === 'shared-checkout') delete chat.workingDirOverride;
+    else if (chat.chatWorkspace) chat.workingDirOverride = chat.chatWorkspace.workingDir;
+    if (previousWorkingDir !== chat.workingDirOverride) {
+      delete chat.sessionAnchor;
+      delete chat.sessionAnchors;
+    }
+    this.persist(chat);
+    return chat;
+  }
+
+  /** Persist PR delivery metadata without reordering the conversation. */
+  setPullRequest(chatId: string, pullRequest: NonNullable<Chat['pullRequest']>): Chat {
+    const chat = this.requireChat(chatId);
+    chat.pullRequest = pullRequest;
     this.persist(chat);
     return chat;
   }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -21,7 +21,8 @@ import { ContextManager, ContextWindow } from '@codey/core';
 import { MemoryStore } from '@codey/core';
 import { WorkspaceManager, TeamConfigRaw, TeamConfig, DEFAULT_PARALLEL_SETTINGS } from '@codey/core';
 import { WorkerManager } from '@codey/core';
-import { ChatManager } from './chats';
+import { ChatManager, CreateChatInput } from './chats';
+import { chatWorktreeParent, describeLegacyChatWorktree, discoverChatWorktree, provisionChatWorktree, removeCleanChatWorktree, workspaceHasUncommittedChanges } from './chat-worktree';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
@@ -119,6 +120,7 @@ export class Codey {
    *  so a later workspace switch can't save it into the wrong skills store.
    *  (Chat-surface suggestions are persisted on the Chat via ChatManager instead.) */
   private pendingSkillSuggestions = new Map<string, { suggestion: DistillResult; workspaceName: string }>();
+  private pendingChatWorkspaces = new Map<string, Promise<Chat>>();
   private skillRunCounter = 0;
   private lastSkillDistillTime = 0;
   private static SKILL_DISTILL_COOLDOWN_MS = 300_000; // 5 min
@@ -691,6 +693,137 @@ export class Codey {
 
   getWorkspaceManager(): WorkspaceManager { return this.workspaceManager; }
   getChatManager(): ChatManager { return this.chatManager; }
+
+  /** New chats begin in the shared checkout. A worktree is created either by
+   *  the explicit Branch Selector action or when the running agent opts in. */
+  public async createChat(input: CreateChatInput): Promise<Chat> {
+    return this.chatManager.create({ ...input, executionMode: 'shared-checkout' });
+  }
+
+  private async migrateLegacyChatWorkspace(chat: Chat): Promise<Chat> {
+    if (chat.chatWorkspace || !chat.workingDirOverride) return chat;
+    try {
+      const workspace = await describeLegacyChatWorktree({
+        workspaceWorkingDir: this.resolveWorkspaceWorkingDir(chat.workspaceName),
+        workingDirOverride: chat.workingDirOverride,
+        createdAt: chat.createdAt,
+      });
+      return workspace ? this.chatManager.migrateChatWorkspace(chat.id, workspace) : chat;
+    } catch (error) {
+      this.logger.warn(`Could not migrate legacy worktree for chat ${chat.id}: ${error}`);
+      return chat;
+    }
+  }
+
+  public async listChats(workspaceName?: string): Promise<Chat[]> {
+    return Promise.all(this.chatManager.list(workspaceName).map(chat => this.migrateLegacyChatWorkspace(chat)));
+  }
+
+  public async getChat(chatId: string): Promise<Chat> {
+    const chat = this.chatManager.get(chatId);
+    if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    return this.migrateLegacyChatWorkspace(chat);
+  }
+
+  public async deleteChat(chatId: string): Promise<void> {
+    const chat = await this.getChat(chatId);
+    if (this.chatAborts.has(chatId)) throw new Error('Wait for the current agent turn to finish before deleting this chat');
+    if (chat.chatWorkspace) await removeCleanChatWorktree(chat.chatWorkspace);
+    this.chatManager.delete(chatId);
+  }
+
+  /** Preflight every chat worktree before deleting a Workspace, then remove
+   *  only their clean checkouts. Branches remain available in the repository. */
+  public async prepareWorkspaceDeletion(workspaceName: string): Promise<void> {
+    const chats = await Promise.all(
+      this.chatManager.list(workspaceName, { includeAutomation: true })
+        .map(chat => this.migrateLegacyChatWorkspace(chat)),
+    );
+    const worktrees = chats.flatMap(chat => chat.chatWorkspace ? [chat.chatWorkspace] : []);
+    for (const workspace of worktrees) {
+      if (fs.existsSync(workspace.worktreePath) && await workspaceHasUncommittedChanges(workspace.worktreePath)) {
+        throw new Error(`Worktree "${workspace.name ?? path.basename(workspace.worktreePath)}" has uncommitted changes. Commit or stash them before deleting this workspace.`);
+      }
+    }
+    for (const workspace of worktrees) await removeCleanChatWorktree(workspace);
+  }
+
+  /** Idempotently provision the explicitly named filesystem environment owned by a chat. */
+  public async ensureChatWorkspace(chatId: string, worktreeName?: string): Promise<Chat> {
+    const chat = this.chatManager.get(chatId);
+    if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    if (chat.executionMode !== 'isolated-worktree') return chat;
+    if (chat.chatWorkspace) {
+      if (fs.existsSync(chat.chatWorkspace.workingDir)) return chat;
+      throw new Error(`Chat workspace is missing: ${chat.chatWorkspace.workingDir}`);
+    }
+    if (!worktreeName) throw new Error('Create and name a worktree from the Branch Selector first');
+    const pending = this.pendingChatWorkspaces.get(chatId);
+    if (pending) return pending;
+    const provision = provisionChatWorktree({
+      workspaceWorkingDir: this.resolveWorkspaceWorkingDir(chat.workspaceName),
+      workspacesRoot: this.workspaceManager.getWorkspacesRoot(),
+      workspaceName: chat.workspaceName,
+      chatId: chat.id,
+      worktreeName,
+    }).then(workspace => {
+      const updated = this.chatManager.setChatWorkspace(chat.id, workspace);
+      return updated;
+    })
+      .finally(() => this.pendingChatWorkspaces.delete(chatId));
+    this.pendingChatWorkspaces.set(chatId, provision);
+    return provision;
+  }
+
+  /** Adopt a worktree that an agent created in this chat's private directory.
+   *  No model call is involved: ownership is determined from local Git state. */
+  private async adoptAgentCreatedWorktree(chatId: string): Promise<Chat | undefined> {
+    const chat = this.chatManager.get(chatId);
+    if (!chat || chat.chatWorkspace) return undefined;
+    try {
+      const workspace = await discoverChatWorktree({
+        workspaceWorkingDir: this.resolveWorkspaceWorkingDir(chat.workspaceName),
+        workspacesRoot: this.workspaceManager.getWorkspacesRoot(),
+        workspaceName: chat.workspaceName,
+        chatId: chat.id,
+      });
+      if (!workspace) return undefined;
+      const updated = this.chatManager.setChatWorkspace(chat.id, workspace);
+      this.logger.info(`[chat ${chat.id}] adopted agent-created worktree ${workspace.name ?? workspace.worktreePath}`);
+      return updated;
+    } catch (error) {
+      this.logger.warn(`[chat ${chat.id}] could not adopt agent-created worktree: ${(error as Error).message}`);
+      return undefined;
+    }
+  }
+
+  /** Explicitly create and bind a user-named worktree to one chat. */
+  public async createChatWorktree(chatId: string, worktreeName: string): Promise<Chat> {
+    const chat = await this.getChat(chatId);
+    if (chat.chatWorkspace) throw new Error(`This chat already owns the worktree "${chat.chatWorkspace.name ?? path.basename(chat.chatWorkspace.worktreePath)}"`);
+    if (this.chatAborts.has(chatId)) throw new Error('Wait for the current agent turn to finish before creating a worktree');
+    const previousMode = chat.executionMode ?? 'shared-checkout';
+    this.chatManager.setExecutionMode(chatId, 'isolated-worktree');
+    try {
+      return await this.ensureChatWorkspace(chatId, worktreeName);
+    } catch (error) {
+      this.chatManager.setExecutionMode(chatId, previousMode);
+      throw error;
+    }
+  }
+
+  /** Switch the checkout used by one chat. Worktrees are retained when a chat
+   *  switches back to the shared checkout so the operation is reversible. */
+  public async setChatExecutionMode(chatId: string, mode: NonNullable<Chat['executionMode']>): Promise<Chat> {
+    const chat = await this.getChat(chatId);
+    if (this.chatAborts.has(chatId)) throw new Error('Wait for the current agent turn to finish before switching checkout mode');
+    if (mode === 'isolated-worktree') {
+      if (!chat.chatWorkspace) throw new Error('Create and name a worktree first');
+      this.chatManager.setExecutionMode(chatId, mode);
+      return this.ensureChatWorkspace(chatId);
+    }
+    return this.chatManager.setExecutionMode(chatId, mode);
+  }
 
   public setChatEventListener(fn: (ev: any) => void): void {
     this.chatEventListener = fn;
@@ -1688,6 +1821,13 @@ export class Codey {
   }
 
   private resolveChatWorkingDir(chat: Chat): string {
+    if (chat.executionMode === 'isolated-worktree') {
+      const isolatedDir = chat.chatWorkspace?.workingDir;
+      if (isolatedDir && fs.existsSync(isolatedDir)) return isolatedDir;
+      throw new Error(isolatedDir
+        ? `Chat workspace is missing: ${isolatedDir}`
+        : `Chat workspace has not been provisioned: ${chat.id}`);
+    }
     if (chat.workingDirOverride) {
       if (fs.existsSync(chat.workingDirOverride)) return chat.workingDirOverride;
       this.logger.warn(`Chat ${chat.id} workingDirOverride=${chat.workingDirOverride} is gone; falling back to workspace dir`);
@@ -3171,7 +3311,7 @@ export class Codey {
     }
     const workspace = binding.prefs?.workspace ?? this.workspaceManager.getCurrentWorkspace();
     const title = args.join(' ').trim() || undefined;
-    const chat = this.chatManager.create({ workspaceName: workspace, title });
+    const chat = await this.createChat({ workspaceName: workspace, title });
     if (binding.prefs?.agent || binding.prefs?.model) {
       this.chatManager.updateAgentModel(chat.id, binding.prefs.agent, binding.prefs.model);
     }
@@ -5368,8 +5508,13 @@ Example: /model gpt-4.1 write a Python script`;
     sink: (e: QQStreamEvent) => void,
     attachments?: import('@codey/core').FileAttachment[],
   ): Promise<{ response: string; tokens?: number; durationSec?: number }> {
-    const chat = this.chatManager.get(chatId);
+    let chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    if (chat.executionMode === 'isolated-worktree') {
+      chat = chat.chatWorkspace
+        ? await this.ensureChatWorkspace(chatId)
+        : this.chatManager.setExecutionMode(chatId, 'shared-checkout');
+    }
 
     // Resolve workingDir from the chat's workspace.json (mirrors sendToChat).
     const workspacesRoot = this.workspaceManager.getWorkspacesRoot();
@@ -5385,6 +5530,7 @@ Example: /model gpt-4.1 write a Python script`;
       sink({ type: 'error', chatId, message: msg });
       throw new Error(msg);
     }
+    workingDir = this.resolveChatWorkingDir(chat);
 
     // Aide agent/model if configured, else the chat's effective agent/model.
     const aideCfg = this.config.aide;
@@ -5493,8 +5639,23 @@ Example: /model gpt-4.1 write a Python script`;
     // skill pre-run pass, taking precedence over the auto-apply matcher).
     origin?: { channel: ChannelType; channelUserId: string; skillInvoke?: SkillInvoke },
   ): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> {
-    const chat = this.chatManager.get(chatId);
+    let chat = this.chatManager.get(chatId);
     if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    let workspaceAdoptedBeforeTurn = false;
+    // Recover a checkout created during a previous interrupted turn before
+    // selecting this turn's cwd.
+    if (!chat.chatWorkspace) {
+      const adopted = await this.adoptAgentCreatedWorktree(chatId);
+      if (adopted) {
+        chat = adopted;
+        workspaceAdoptedBeforeTurn = true;
+      }
+    }
+    if (chat.executionMode === 'isolated-worktree') {
+      chat = chat.chatWorkspace
+        ? await this.ensureChatWorkspace(chatId)
+        : this.chatManager.setExecutionMode(chatId, 'shared-checkout');
+    }
 
     // Resolvable copy of the incoming text. A digit reply to a paused team is
     // rewritten to the chosen option's text BEFORE it is persisted as the user
@@ -5538,6 +5699,7 @@ Example: /model gpt-4.1 write a Python script`;
         try { this.chatEventListener(ev); } catch { /* swallow */ }
       }
     };
+    if (workspaceAdoptedBeforeTurn) sink({ type: 'workspace_ready', chatId });
 
     // Short-circuit helper for skill-related conversational replies that never
     // reach an agent: persist both sides of the exchange, announce completion,
@@ -5666,13 +5828,7 @@ Example: /model gpt-4.1 write a Python script`;
       throw new Error(msg);
     }
 
-    // Per-chat worktree binding: an explicit workingDirOverride wins over the
-    // workspace's workingDir so the agent actually runs in the bound worktree
-    // (mirrors resolveChatWorkingDir's precedence).
-    if (chat.workingDirOverride) {
-      if (fs.existsSync(chat.workingDirOverride)) workingDir = chat.workingDirOverride;
-      else this.logger.warn(`Chat ${chat.id} workingDirOverride=${chat.workingDirOverride} is gone; falling back to workspace dir`);
-    }
+    workingDir = this.resolveChatWorkingDir(chat);
 
     // Per-chat override takes precedence over the gateway default.
     const agent = (chat.agent ?? this.getDefaultAgent()) as CodingAgent;
@@ -5704,6 +5860,15 @@ Example: /model gpt-4.1 write a Python script`;
     let prompt: string;
     let resumeSessionId: string | undefined;
     let newSessionId: string | undefined;
+    const agentWorktreeParent = chat.executionMode !== 'isolated-worktree' && !chat.chatWorkspace
+      ? chatWorktreeParent(workspacesRoot, chat.workspaceName, chat.id)
+      : undefined;
+    if (agentWorktreeParent) fs.mkdirSync(agentWorktreeParent, { recursive: true });
+    const chatWorkspaceInstruction = chat.executionMode === 'isolated-worktree'
+      ? '\n\n[Codey chat workspace]\nThis chat owns the current worktree and starts on its own same-named branch. You may rename or switch branches as the task evolves; do not operate in another chat’s worktree.'
+      : agentWorktreeParent
+        ? `\n\n[Codey chat workspace]\nThis chat currently uses the shared checkout. If the task benefits from isolation, you may create one worktree for this chat without asking first. Choose a short semantic lower-kebab name with no slash, then run \`git worktree add -b <name> ${JSON.stringify(path.join(agentWorktreeParent, '<name>'))} HEAD\` and perform all subsequent work in that new directory. Create it only as a direct child of ${JSON.stringify(agentWorktreeParent)} so Codey can bind and display it. Do not create a worktree when the task does not need one.`
+        : '\n\n[Codey chat workspace]\nThis chat already has a user-managed worktree. Continue using the selected checkout; do not create another worktree.';
     if (warmAnchor) {
       // Resume the agent's own session. If other agents produced messages
       // while it was inactive, replay only that unseen gap before the new turn.
@@ -5719,6 +5884,7 @@ Example: /model gpt-4.1 write a Python script`;
         newSessionId = randomUUID();
       }
     }
+    prompt += chatWorkspaceInstruction;
 
     // Solo advisor: when enabled (and not a team), tell the agent how to escalate.
     if (chat.soloAdvisor && chat.selection.type !== 'team') {
@@ -5905,7 +6071,7 @@ Example: /model gpt-4.1 write a Python script`;
           streamedText = '';
           resumeSessionId = undefined;
           newSessionId = canResume && agent === 'claude-code' ? randomUUID() : undefined;
-          prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments);
+          prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments) + chatWorkspaceInstruction;
           // Re-apply the skill banner: the rebuilt bootstrap prompt replaced
           // the one that carried it (still exactly once per prompt build).
           if (appliedChatSkill) prompt = applySkill(prompt, appliedChatSkill);
@@ -5990,6 +6156,8 @@ Example: /model gpt-4.1 write a Python script`;
         // it into the input box. Don't append a "Stopped" assistant message
         // and don't fan out to other routes.
         this.chatManager.removeMessage(chatId, userMessage.id);
+        const adoptedWorkspace = await this.adoptAgentCreatedWorktree(chatId);
+        if (adoptedWorkspace) sink({ type: 'workspace_ready', chatId });
         sink({ type: 'stopped', chatId, userMessageId: userMessage.id, text: userText });
         return { response: '', chatId };
       }
@@ -6126,6 +6294,8 @@ Example: /model gpt-4.1 write a Python script`;
         }
       }
 
+      const adoptedWorkspace = await this.adoptAgentCreatedWorktree(chatId);
+      if (adoptedWorkspace) sink({ type: 'workspace_ready', chatId });
       sink({ type: 'done', chatId, response: output, thinking: singleAgentResponse?.thinking, tokens, durationSec, agent: responseAgent, ...(responseModel ? { model: responseModel } : {}), title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion, fallback: singleAgentResponse?.fallback, ...(teamTurnId ? { teamTurnId } : {}) });
 
       // ── Skills: post-run pass (fire-and-forget, response already delivered) ──
@@ -6209,6 +6379,8 @@ Example: /model gpt-4.1 write a Python script`;
         // Same rollback as the abort branch above — agent runners surface
         // aborts as thrown errors, but we still want to restore the prompt.
         this.chatManager.removeMessage(chatId, userMessage.id);
+        const adoptedWorkspace = await this.adoptAgentCreatedWorktree(chatId);
+        if (adoptedWorkspace) sink({ type: 'workspace_ready', chatId });
         sink({ type: 'stopped', chatId, userMessageId: userMessage.id, text: userText });
         return { response: '', chatId };
       }
@@ -6224,6 +6396,8 @@ Example: /model gpt-4.1 write a Python script`;
         ...(model?.model ? { model: model.model } : {}),
       };
       this.chatManager.appendMessage(chatId, assistantMessage);
+      const adoptedWorkspace = await this.adoptAgentCreatedWorktree(chatId);
+      if (adoptedWorkspace) sink({ type: 'workspace_ready', chatId });
       sink({ type: 'error', chatId, message });
       throw err;
     } finally {

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       'src/team-emitter.test.ts',
       'src/worker-message-emitter.test.ts',
       'src/chats.workingDirOverride.test.ts',
+      'src/chat-worktree.test.ts',
       'src/chats.pendingSkillSuggestion.test.ts',
       'src/automations/chat.test.ts',
       'src/automations/schedule.test.ts',


### PR DESCRIPTION
## What changed

- Redesign the Branch Selector around the current branch and worktree, while removing direct worktree switching from the branch list.
- Let users create a semantic branch and worktree explicitly from the selector.
- Bind each managed worktree to its chat and open terminals/editors in that checkout.
- Allow an agent running from Current checkout to create a chat-owned worktree, then automatically adopt it and refresh the UI.
- Clear stale agent session anchors whenever the effective checkout changes.
- Add chat-list delivery state icons for active, pull-request, merged, and completed states.
- Safely clean up only clean chat worktrees while retaining their branches.

## Why

Multiple chats can work in the same repository concurrently. Showing only the process-wide checkout made it unclear where a chat was operating and allowed chat execution context to drift. This change makes branch/worktree ownership explicit and keeps each isolated chat attached to the checkout it actually uses.

Agent-created worktrees use a hidden chat-specific ownership directory to avoid cross-chat adoption, while the UI continues to display semantic worktree and branch names rather than UUIDs.

## Validation

- Gateway: 254 tests passed
- Mac UI: 384 tests passed
- Core and Gateway TypeScript builds passed
- Mac renderer, Node, and Electron TypeScript checks passed
- Mac Vite production build passed
- Repository lint passed
- `git diff --check` passed
