### PR TITLE
Preserve context across warm session resumes

### DIFF
--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -129,14 +129,43 @@ export function buildChatBootstrapPrompt(
   return buildChatPrompt(chat, userText, attachments, windowSize);
 }
 
-/** Resume-turn prompt: just the new user text, optionally prefixed by attachments. */
+const RESUME_CONTEXT_MAX_CHARS = 8_000;
+const RESUME_CONTEXT_HEAD_CHARS = 2_000;
+
+/** Keep a bounded head + tail checkpoint for warm-session turns. */
+export function resumeContextExcerpt(text: string): string {
+  if (text.length <= RESUME_CONTEXT_MAX_CHARS) return text;
+  const tailChars = RESUME_CONTEXT_MAX_CHARS - RESUME_CONTEXT_HEAD_CHARS;
+  return text.slice(0, RESUME_CONTEXT_HEAD_CHARS)
+    + '\n\n[… middle of prior assistant message omitted …]\n\n'
+    + text.slice(-tailChars);
+}
+
+/**
+ * Resume-turn prompt. Always pin the most recent persisted assistant message
+ * so Codey's durable transcript remains the semantic checkpoint even when the
+ * CLI inserts permission/interruption events or automatically replays a prompt.
+ * The checkpoint is bounded to avoid repeatedly injecting an unbounded reply.
+ */
 export function buildChatResumePrompt(
+  chat: Chat,
   userText: string,
   attachments?: FileAttachment[],
 ): string {
   const parts: string[] = [];
   if (attachments && attachments.length > 0) {
     parts.push(formatAttachmentList(attachments));
+  }
+  const latestAssistant = [...chat.messages].reverse()
+    .find(message => message.role === 'assistant' && message.content.trim());
+  if (latestAssistant) {
+    parts.push(
+      '[Most recent persisted assistant message — conversation checkpoint. ' +
+      'CLI-internal permission or interruption events may have occurred afterward; use this ' +
+      'checkpoint together with the new user message below.]\n' + resumeContextExcerpt(latestAssistant.content),
+      `[Respond to this new user message]\n${userText}`,
+    );
+    return parts.join('\n\n');
   }
   parts.push(userText);
   return parts.join('\n\n');
@@ -156,7 +185,7 @@ export function buildChatCatchupPrompt(
 ): string {
   const cursor = chat.messages.findIndex(message => message.id === syncedThroughMessageId);
   if (cursor < 0 || cursor === chat.messages.length - 1) {
-    return buildChatResumePrompt(userText, attachments);
+    return buildChatResumePrompt(chat, userText, attachments);
   }
 
   const parts: string[] = [];

--- a/packages/gateway/src/chats.workingDirOverride.test.ts
+++ b/packages/gateway/src/chats.workingDirOverride.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { ChatManager } from './chats';
-import { buildChatCatchupPrompt } from './chat-runner';
+import { buildChatCatchupPrompt, buildChatResumePrompt, resumeContextExcerpt } from './chat-runner';
 
 describe('ChatManager.setWorkingDirOverride', () => {
   let root: string;
@@ -150,5 +150,53 @@ describe('buildChatCatchupPrompt', () => {
     expect(prompt).toContain('new question');
     expect(prompt).not.toContain('already known user turn');
     expect(prompt).not.toContain('already known answer');
+  });
+});
+
+describe('buildChatResumePrompt', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('pins the latest persisted assistant message for a digit reply', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'How should we execute?', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, {
+      id: 'a1', role: 'assistant', content: '1. Subagent-driven\n2. Inline execution\n\nWhich one?', timestamp: 2, isComplete: true,
+    });
+
+    const prompt = buildChatResumePrompt(mgr.get(chat.id)!, '1');
+
+    expect(prompt).toContain('Most recent persisted assistant message');
+    expect(prompt).toContain('1. Subagent-driven');
+    expect(prompt).toContain('Respond to this new user message]\n1');
+  });
+
+  it('pins the checkpoint for a substantive new request too', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'a1', role: 'assistant', content: 'old answer', timestamp: 1, isComplete: true });
+
+    const prompt = buildChatResumePrompt(mgr.get(chat.id)!, 'Implement the authentication middleware');
+
+    expect(prompt).toContain('old answer');
+    expect(prompt).toContain('Implement the authentication middleware');
+  });
+
+  it('bounds a large checkpoint while preserving its head and tail', () => {
+    const prior = `HEAD:${'a'.repeat(5_000)}:TAIL:${'z'.repeat(5_000)}`;
+
+    const excerpt = resumeContextExcerpt(prior);
+
+    expect(excerpt.length).toBeLessThan(prior.length);
+    expect(excerpt).toContain('HEAD:');
+    expect(excerpt).toContain(':TAIL:');
+    expect(excerpt).toContain('middle of prior assistant message omitted');
   });
 });

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -5582,9 +5582,10 @@ Example: /model gpt-4.1 write a Python script`;
     // message and handed to the resume path.
     let userText = userTextParam;
 
-    // Detect a paused team and decide how this turn relates to it. A slash turn
-    // cancels the paused run and proceeds normally; otherwise this turn is an
-    // answer to the team's question, so map any digit reply to the option text.
+    // Detect a paused team or a structured choice from the last normal-chat
+    // response. A digit reply must be resolved here as well as in the channel
+    // handler: Mac-origin turns call sendToChat directly and bypass
+    // handleMessage's choice mapping.
     const pendingTeam = chat.pendingTeam;
     // A channel-origin explicit `/skill` invoke arrives with userText already
     // rewritten to the raw task (handleMessage stripped the slash), so count
@@ -5598,6 +5599,15 @@ Example: /model gpt-4.1 write a Python script`;
         const resolved = resolveChoiceDigit(userText, pendingTeam.options);
         if (resolved !== null) userText = resolved;
       }
+    } else if (!isSlashTurn && chat.lastAskedOptions?.options.length) {
+      const resolved = resolveChoiceDigit(userText, chat.lastAskedOptions.options);
+      if (resolved !== null) userText = resolved;
+    }
+
+    // A structured choice applies to exactly one subsequent user message,
+    // whether it came from a channel or the Mac app.
+    if (chat.lastAskedOptions) {
+      this.chatManager.clearLastAskedOptions(chatId);
     }
 
     // Persisted alongside the assistant message at completion. Declared here
@@ -5791,7 +5801,7 @@ Example: /model gpt-4.1 write a Python script`;
       // while it was inactive, replay only that unseen gap before the new turn.
       prompt = selPrefix + (warmAnchor.syncedThroughMessageId
         ? buildChatCatchupPrompt(chat, warmAnchor.syncedThroughMessageId, userText, attachments)
-        : buildChatResumePrompt(userText, attachments));
+        : buildChatResumePrompt(chat, userText, attachments));
       resumeSessionId = warmAnchor.sessionId;
     } else {
       // Bootstrap turn: include prior history once. For claude-code, pre-allocate


### PR DESCRIPTION
## What changed

- Include the most recent persisted assistant message as a bounded context checkpoint on every warm-session resume.
- Retain the beginning and end of large assistant replies while capping the checkpoint at 8,000 characters.
- Resolve persisted numeric choices for Mac-origin chat turns as well as channel-origin turns.
- Add regression coverage for digit replies, substantive follow-ups, and bounded context excerpts.

## Why

Claude CLI can insert permission/interruption events and automatically replay the current prompt. Codey previously sent only the new text when resuming a warm CLI session, so those CLI-internal events could become the apparent previous turn and change the meaning of replies such as `1`.

Codey's persisted transcript is now included as the semantic checkpoint for every warm-session continuation, preventing the CLI's internal event ordering from displacing the conversation context.

## Impact

Warm-session follow-ups retain their intended conversation context across permission denials and automatic prompt replay. Large replies are bounded to avoid unbounded prompt growth.

## Validation

- `npm test -w @codey/gateway -- --run src/chats.workingDirOverride.test.ts src/digit-mapping.test.ts` — 16 tests passed
- `npm run build -w @codey/core`
- `npm run build -w @codey/gateway`
- `git diff --check`
