### PR TITLE
Simplify chat chrome and unify activity status

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -8,7 +8,7 @@ import { ChatsProvider, useChats } from './hooks/useChats'
 import { QuickQuestionProvider } from './hooks/useQuickQuestion'
 import { useGateway } from './hooks/useGateway'
 import { CoreOfflineBanner } from './components/CoreOfflineBanner'
-import { CodeyMark, UIIcon } from './components/UIIcons'
+import { UIIcon } from './components/UIIcons'
 import { AutomationsView } from './components/AutomationsView'
 import { ToolsView } from './components/ToolsView'
 import type { BrowserLoginWaitEvent } from './codey-api'
@@ -281,7 +281,6 @@ const Shell: React.FC = () => {
             </svg>
           </button>
           <div style={styles.titleCenter}>
-            <CodeyMark size={22} />
             {(rightTool || activeChat) && (
               <span style={styles.appName} title={activeChat?.title ?? (rightTool === 'browser' ? 'Browser' : 'Terminal')}>
                 {activeChat?.title ?? (rightTool === 'browser' ? 'Browser' : 'Terminal')}

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -453,7 +453,11 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                       setChatMenu({ chat, x: e.clientX, y: e.clientY })
                     }}
                   >
-                    <span style={{ ...styles.chatIcon, color: active ? C.accent : C.fg3 }}><UIIcon name="chat" size={14} /></span>
+                    {/* Fixed-width leading slot so a chat's name never shifts
+                        sideways the moment its run starts or ends. */}
+                    <span style={styles.activitySlot}>
+                      {flight && <span style={styles.dot} title="Running" aria-label="Running" />}
+                    </span>
                     {isRenaming ? (
                       <input
                         autoFocus
@@ -479,7 +483,6 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                     )}
                     <RouteIcons routes={chat.routes} />
                     {unread && !active && <span style={styles.unreadDot} />}
-                    {flight && <span style={styles.dot} />}
                     {!isRenaming && (
                       <span style={styles.trailingAction}>
                         {hoveredChatId === chat.id ? (
@@ -707,13 +710,13 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '7px 9px', borderRadius: 8, cursor: 'pointer',
     fontSize: 12, color: C.fg2, margin: '2px 2px 2px 20px', border: '1px solid transparent',
   },
-  chatIcon: { display: 'inline-flex', flexShrink: 0 },
+  activitySlot: { width: 8, flexShrink: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' },
   title: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   renameInput: {
     flex: 1, background: C.surface3, border: `1px solid ${C.border2}`,
     borderRadius: 4, padding: '2px 6px', color: C.fg, fontSize: 12, outline: 'none',
   },
-  dot: { width: 6, height: 6, borderRadius: '50%', background: C.accent, animation: 'codey-pulse-dot 1.2s infinite' },
+  dot: { width: 6, height: 6, borderRadius: '50%', background: C.accent, flexShrink: 0, animation: 'codey-pulse-dot 1.2s infinite' },
   unreadDot: { width: 6, height: 6, borderRadius: '50%', background: C.accent, flexShrink: 0 },
   trailingAction: { width: 22, height: 22, flexShrink: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' },
   xBtn: {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -23,6 +23,7 @@ import {
   USER_BUBBLE_PADDING_X,
 } from './TurnHeader'
 import { ACTIVITY_LABEL } from './agentActivity'
+import { ShimmerStatus } from './ShimmerStatus'
 import { statusLine } from './checklistView'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
@@ -79,39 +80,6 @@ const StopIcon: React.FC<{ color: string }> = ({ color }) => (
 
 const fmtTime = (ts: number) =>
   new Date(ts).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
-
-/** The live status word ("Thinking", "Reading", …). The motion is a light
- *  sweeping across the letters — no marching dots beside it, so the word alone
- *  carries "still running" without pulling the eye off the transcript. */
-const ShimmerStatus: React.FC<{ label: string }> = ({ label }) => (
-  <>
-    <style>{`
-      @keyframes codey-status-shimmer {
-        0%   { background-position: 200% 0; }
-        100% { background-position: -200% 0; }
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .codey-status-shimmer { animation: none !important; }
-      }
-    `}</style>
-    <span
-      className="codey-status-shimmer"
-      aria-live="polite"
-      style={{
-        backgroundImage: `linear-gradient(90deg, ${C.fg3} 0%, ${C.fg3} 35%, ${C.fg} 50%, ${C.fg3} 65%, ${C.fg3} 100%)`,
-        backgroundSize: '200% 100%',
-        WebkitBackgroundClip: 'text',
-        backgroundClip: 'text',
-        color: 'transparent',
-        WebkitTextFillColor: 'transparent',
-        animation: 'codey-status-shimmer 2s linear infinite',
-        fontWeight: 600,
-      }}
-    >
-      {label}
-    </span>
-  </>
-)
 
 /** Elapsed recording time. A counter answers "is it still listening?" without
  *  a sentence of prose, and reassures during a long dictation. */

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2089,7 +2089,7 @@ export const ChatTab: React.FC<Props> = ({
               }}
             >
               <div style={isUser ? {
-                minWidth: 0, maxWidth: '72%', padding: `10px ${USER_BUBBLE_PADDING_X}px`,
+                minWidth: 0, maxWidth: 'min(84%, 88ch)', padding: `10px ${USER_BUBBLE_PADDING_X}px`,
                 borderRadius: '16px 16px 4px 16px',
                 background: C.userBg,
                 color: C.onAccent, fontSize: 13, lineHeight: 1.55,
@@ -2099,13 +2099,12 @@ export const ChatTab: React.FC<Props> = ({
                 // reads as a document; the header rule below carries the
                 // boundary the bubble used to provide.
                 //
-                // `ch` resolves against this element's 13px font, so 78ch is
-                // ~562px. box-sizing is border-box, so the rail and the 27px of
-                // horizontal padding come out of that, leaving ~535px of text —
-                // about 68 characters of the 14px roomy body, or ~41 Chinese
-                // characters. Unlike the old 72%, it does not grow with the
-                // window.
-                minWidth: 0, width: '100%', maxWidth: 'min(100%, 78ch)',
+                // `ch` resolves against this element's 13px font, so 96ch is
+                // roughly 700px. This gives prose, code, and tables more room
+                // than the previous 78ch column while retaining a readable
+                // line-length ceiling on wide windows. Small windows still use
+                // all available space via the 100% cap.
+                minWidth: 0, width: '100%', maxWidth: 'min(100%, 96ch)',
                 // Padding on all four sides so the selected highlight reads as a
                 // card rather than a rectangle cut through the text. It is
                 // unconditional — applying it only when selected would shift the

--- a/codey-mac/src/components/QuickQuestionView.tsx
+++ b/codey-mac/src/components/QuickQuestionView.tsx
@@ -4,6 +4,8 @@ import { Markdown } from './Markdown'
 import { useQuickQuestion } from '../hooks/useQuickQuestion'
 import { apiService } from '../services/api'
 import type { FileAttachment } from '../types'
+import { ACTIVITY_LABEL } from './agentActivity'
+import { ShimmerStatus } from './ShimmerStatus'
 
 interface Props {
   chatId: string
@@ -127,6 +129,13 @@ export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
 
   const canSend = (!!draft.trim() || pending.length > 0) && !thread.inFlight
 
+  // Same activity vocabulary as the main chat. The tool's own message is kept
+  // as the detail half when the agent sent one; the verb alone otherwise.
+  const status = thread.status && thread.status !== 'idle' ? thread.status : 'thinking'
+  const activityLabel = thread.activity
+    ? `${ACTIVITY_LABEL[status]} · ${thread.activity}`
+    : `${ACTIVITY_LABEL[status]}…`
+
   const submit = () => {
     if (!canSend) return
     const q = draft
@@ -184,8 +193,10 @@ export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
             )}
           </div>
         ))}
-        {thread.inFlight && thread.activity && (
-          <div style={qqStyles.activity}>{thread.activity}</div>
+        {thread.inFlight && (
+          <div style={qqStyles.activity}>
+            <ShimmerStatus label={activityLabel} fontSize={11} />
+          </div>
         )}
       </div>
 
@@ -274,7 +285,7 @@ const qqStyles: Record<string, React.CSSProperties> = {
   userText: { color: C.fg, fontSize: 12, whiteSpace: 'pre-wrap' },
   asstMsg: { alignSelf: 'flex-start', maxWidth: '100%', fontSize: 12, color: C.fg2, minWidth: 0 },
   errText: { color: C.dangerFg ?? '#e66', fontSize: 12, whiteSpace: 'pre-wrap' },
-  activity: { color: C.fg3, fontSize: 10, fontStyle: 'italic' },
+  activity: { fontSize: 11, padding: '2px 0' },
 
   msgAttRow: { display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 },
   msgAttImg: { width: 64, height: 64, objectFit: 'cover', borderRadius: 6, border: `1px solid ${C.border2}`, cursor: 'pointer' },

--- a/codey-mac/src/components/ShimmerStatus.tsx
+++ b/codey-mac/src/components/ShimmerStatus.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { C } from '../theme'
+
+/** The live status word ("Thinking", "Reading", …). The motion is a light
+ *  sweeping across the letters — no marching dots beside it, so the word alone
+ *  carries "still running" without pulling the eye off the transcript.
+ *  Shared by the main chat transcript and the Quick Question side-thread so
+ *  both surfaces report activity the same way. */
+export const ShimmerStatus: React.FC<{ label: string; fontSize?: number }> = ({ label, fontSize }) => (
+  <>
+    <style>{`
+      @keyframes codey-status-shimmer {
+        0%   { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .codey-status-shimmer { animation: none !important; }
+      }
+    `}</style>
+    <span
+      className="codey-status-shimmer"
+      aria-live="polite"
+      style={{
+        backgroundImage: `linear-gradient(90deg, ${C.fg3} 0%, ${C.fg3} 35%, ${C.fg} 50%, ${C.fg3} 65%, ${C.fg3} 100%)`,
+        backgroundSize: '200% 100%',
+        WebkitBackgroundClip: 'text',
+        backgroundClip: 'text',
+        color: 'transparent',
+        WebkitTextFillColor: 'transparent',
+        animation: 'codey-status-shimmer 2s linear infinite',
+        fontWeight: 600,
+        ...(fontSize ? { fontSize } : null),
+      }}
+    >
+      {label}
+    </span>
+  </>
+)

--- a/codey-mac/src/hooks/useQuickQuestion.tsx
+++ b/codey-mac/src/hooks/useQuickQuestion.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useMemo, useReducer } from
 import { apiService } from '../services/api'
 import type { QQStreamEvent } from '../services/api'
 import type { FileAttachment } from '../types'
+import { activityForTool, type AgentActivity } from '../components/agentActivity'
 
 export interface QQMessage {
   id: string
@@ -16,6 +17,9 @@ export interface QQThread {
   messages: QQMessage[]
   inFlight: boolean
   activity?: string // latest tool/status line while running
+  /** Same vocabulary as the main chat ("thinking", "reading", …) so both
+   *  surfaces name what the agent is doing the same way. */
+  status?: AgentActivity
 }
 
 interface State {
@@ -25,7 +29,7 @@ interface State {
 type Action =
   | { type: 'startAsk'; chatId: string; userMsg: QQMessage; assistantId: string }
   | { type: 'token'; chatId: string; token: string }
-  | { type: 'activity'; chatId: string; message: string }
+  | { type: 'activity'; chatId: string; message: string; status: AgentActivity }
   | { type: 'done'; chatId: string; content: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'stopped'; chatId: string }
@@ -47,6 +51,9 @@ function reducer(state: State, action: Action): State {
             ],
             inFlight: true,
             activity: undefined,
+            // Nothing has run yet, so the honest first word is "Thinking" —
+            // same opening state as a main-chat turn.
+            status: 'thinking',
           },
         },
       }
@@ -57,7 +64,7 @@ function reducer(state: State, action: Action): State {
       return { threads: { ...state.threads, [action.chatId]: { ...t, messages: msgs } } }
     }
     case 'activity':
-      return { threads: { ...state.threads, [action.chatId]: { ...t, activity: action.message } } }
+      return { threads: { ...state.threads, [action.chatId]: { ...t, activity: action.message, status: action.status } } }
     case 'done': {
       const msgs = t.messages.map(m =>
         m.streaming ? { ...m, content: action.content || m.content, streaming: false } : m,
@@ -97,7 +104,7 @@ export const QuickQuestionProvider: React.FC<{ children: React.ReactNode }> = ({
           dispatch({ type: 'token', chatId: ev.chatId, token: ev.token })
           break
         case 'tool':
-          dispatch({ type: 'activity', chatId: ev.chatId, message: ev.message })
+          dispatch({ type: 'activity', chatId: ev.chatId, message: ev.message, status: activityForTool(ev.tool) })
           break
         case 'done':
           dispatch({ type: 'done', chatId: ev.chatId, content: ev.response })

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -24,7 +24,7 @@ export type ChatStreamEvent =
 
 export type QQStreamEvent =
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'tool'; chatId: string; message: string }
+  | { type: 'tool'; chatId: string; message: string; tool?: string }
   | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number }
   | { type: 'stopped'; chatId: string }
   | { type: 'error'; chatId: string; message: string };

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -248,7 +248,7 @@ export interface QQHistoryEntry {
 /** Stream events for a Quick Question run. `chatId` is the parent chat it belongs to. */
 export type QQStreamEvent =
   | { type: 'stream'; chatId: string; token: string }
-  | { type: 'tool'; chatId: string; message: string }
+  | { type: 'tool'; chatId: string; message: string; tool?: string }
   | { type: 'done'; chatId: string; response: string; tokens?: number; durationSec?: number }
   | { type: 'stopped'; chatId: string }
   | { type: 'error'; chatId: string; message: string };

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -5647,7 +5647,16 @@ Example: /model gpt-4.1 write a Python script`;
     const onStatus = (update: any) => {
       try {
         const parsed = typeof update === 'string' ? JSON.parse(update) : update;
-        if (parsed?.message) sink({ type: 'tool', chatId, message: String(parsed.message) });
+        // The tool name drives the UI's activity word ("Reading", "Searching");
+        // some adapters send it with no human-readable message at all.
+        if (parsed?.message || parsed?.tool) {
+          sink({
+            type: 'tool',
+            chatId,
+            message: parsed.message ? String(parsed.message) : '',
+            tool: parsed.tool ? String(parsed.tool) : undefined,
+          });
+        }
       } catch { /* non-JSON status */ }
     };
 


### PR DESCRIPTION
## What

Three UI cleanups in the Mac app, plus the plumbing one of them needed.

1. **Chat list rows** — removed the per-chat bubble icon. The pulsing activity dot moves from the trailing edge to a fixed-width leading slot before the chat name, so names don't shift sideways when a run starts or ends. Unread dot and PR badge stay trailing.
2. **Window header** — dropped the Codey mark beside the chat title.
3. **Quick Question** — now reports activity with the same vocabulary as the main chat ("Thinking", "Reading", "Searching"…) via the shimmering status word, instead of a raw italic status line. The tool's own message is kept as the detail half when there is one.

Also includes the earlier "Widen chat message layout" commit already on this branch.

## Supporting changes

- `ShimmerStatus` extracted out of `ChatTab.tsx` into its own component so both surfaces share one implementation.
- The QQ stream event now carries the tool name (`chat-runner.ts`, `gateway.ts`). It previously emitted only a free-text message, so the renderer had nothing to map to an activity. `useQuickQuestion` runs it through the existing `activityForTool` and seeds `thinking` at turn start.

## Testing

- `tsc --noEmit` clean for `codey-mac`, `packages/core`, `packages/gateway`
- `codey-mac`: 384 tests pass (47 files)
- `packages/gateway`: 263 tests pass (28 files)

Not smoke-tested in the running app — verification was typecheck + unit suites only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)