### PR TITLE
Add a Settings switch for the chat Status panel

### DIFF
--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { C, ThemeMode, PaletteName, PALETTES, useThemeMode, useEffectiveTheme, usePaletteName } from '../theme'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import { Section, pageStyle } from './settingsAtoms'
+import { getStatusPanelEnabled, setStatusPanelEnabled } from './statusPanelPref'
 
 const OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: 'light',  label: 'Light'  },
@@ -41,6 +42,7 @@ export const AppearanceTab: React.FC = () => {
   const [screenshotHotkey, setScreenshotHotkey] = React.useState<string>('Control+Alt+Space')
   const [launchAtLogin, setLaunchAtLogin] = React.useState<boolean>(false)
   const [dockless, setDockless] = React.useState<boolean>(false)
+  const [statusPanel, setStatusPanel] = React.useState<boolean>(getStatusPanelEnabled)
   const [loaded, setLoaded] = React.useState(false)
 
   React.useEffect(() => {
@@ -143,6 +145,19 @@ export const AppearanceTab: React.FC = () => {
             <option key={opt.value} value={opt.value}>{opt.label}</option>
           ))}
         </select>
+      </div>
+
+      <div style={styles.settingRow}>
+        <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
+          <div>Status panel</div>
+          <div style={styles.settingDesc}>
+            Show the Status tab and the floating status card in the chat's right panel. Off also stops Codey from generating the status brief.
+          </div>
+        </div>
+        <Toggle
+          on={statusPanel}
+          onChange={(v) => { setStatusPanel(v); setStatusPanelEnabled(v) }}
+        />
       </div>
       </div>
 

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -48,6 +48,8 @@ interface Props {
   taskBriefLoading: boolean
   /** Called when the task tab becomes visible — triggers brief generation. */
   onTaskTabShown: () => void
+  /** Settings switch. Off drops the Status tab entirely. Defaults to on. */
+  statusPanelEnabled?: boolean
   /** Render inside the shared right-panel shell, which owns resize and close controls. */
   embedded?: boolean
 }
@@ -68,6 +70,7 @@ export const ChatContextPanel: React.FC<Props> = ({
   width, onFollowLatest, onClose, onResize, onRevealFile, onScrollToStep, isTurnStreaming,
   activeTab, onTabChange, qqInputRef,
   onAnswerNextAction, taskBriefLoading, onTaskTabShown,
+  statusPanelEnabled = true,
   embedded = false,
 }) => {
   const turn: ChatMessage | undefined = selectedTurnId
@@ -94,7 +97,10 @@ export const ChatContextPanel: React.FC<Props> = ({
   })()
 
   const [localTab, setLocalTab] = React.useState<ContextPanelTab>('current')
-  const tab: ContextPanelTab = activeTab ?? localTab
+  const requestedTab: ContextPanelTab = activeTab ?? localTab
+  // With the Status panel switched off the tab disappears; a chat left sitting
+  // on it falls back to Tools rather than rendering an empty body.
+  const tab: ContextPanelTab = requestedTab === 'task' && !statusPanelEnabled ? 'current' : requestedTab
   const setTab = (t: ContextPanelTab) => { onTabChange ? onTabChange(t) : setLocalTab(t) }
 
   React.useEffect(() => { if (tab === 'task') onTaskTabShown() }, [tab])
@@ -153,12 +159,14 @@ export const ChatContextPanel: React.FC<Props> = ({
 
       {/* Tabs */}
       <div style={styles.tabs} role="tablist">
-        <button
-          role="tab"
-          aria-selected={tab === 'task'}
-          style={{ ...styles.tab, ...(tab === 'task' ? styles.tabActive : null) }}
-          onClick={() => setTab('task')}
-        >Status</button>
+        {statusPanelEnabled && (
+          <button
+            role="tab"
+            aria-selected={tab === 'task'}
+            style={{ ...styles.tab, ...(tab === 'task' ? styles.tabActive : null) }}
+            onClick={() => setTab('task')}
+          >Status</button>
+        )}
         <button
           role="tab"
           aria-selected={tab === 'current'}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -13,6 +13,7 @@ import { extractPreview, parseTeamMessage } from './teamMessageFormat'
 import { groupMessages } from './teamGroup'
 import type { RenderItem } from './teamGroup'
 import { StatusSidecar } from './StatusSidecar'
+import { useStatusPanelEnabled } from './statusPanelPref'
 import { isTaskBriefStale, extractSidecarBrief } from './taskHudView'
 import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
@@ -924,6 +925,8 @@ export const ChatTab: React.FC<Props> = ({
   const [statusSidecarHidden, setStatusSidecarHidden] = useState(
     () => localStorage.getItem(STATUS_SIDECAR_HIDDEN_KEY) === '1',
   )
+  // Settings switch. Off hides both status surfaces and suppresses brief generation.
+  const statusPanelEnabled = useStatusPanelEnabled()
   const [bottomTerminalOpen, setBottomTerminalOpen] = useState(false)
   const [bottomTerminalHeight, setBottomTerminalHeight] = useState<number>(() => {
     const value = Number(localStorage.getItem('codey.bottomTerminalHeight'))
@@ -1184,7 +1187,7 @@ export const ChatTab: React.FC<Props> = ({
     prevTurnActiveRef.current = turnActive
     if (!toggled) return
     if (!turnActive) void refreshGit()
-    if (!chat || panelTab !== 'task') return
+    if (!chat || panelTab !== 'task' || !statusPanelEnabled) return
     const sharedDigestIsCurrent = !turnActive
       && !!chat.taskBrief?.teamTurnId
       && chat.messages.some(message =>
@@ -1192,7 +1195,7 @@ export const ChatTab: React.FC<Props> = ({
     if (sharedDigestIsCurrent) return
     setTaskBriefLoading(true)
     generateTaskBrief(chat.id).finally(() => setTaskBriefLoading(false))
-  }, [turnActive, panelTab, chatId])
+  }, [turnActive, panelTab, chatId, statusPanelEnabled])
   // Keep the per-chat draft store in sync so the current text/attachments are
   // preserved when ChatTab remounts on a chat switch. setDraft drops the entry
   // once both are empty (e.g. after send), so this also clears sent drafts.
@@ -1302,7 +1305,8 @@ export const ChatTab: React.FC<Props> = ({
   const SIDECAR_W = 264
   const sidecarFits = windowWidth >= 720
   const hasAssistantMsg = (chat?.messages ?? []).some(m => m.role === 'assistant')
-  const sidecarVisible = !panelOpen
+  const sidecarVisible = statusPanelEnabled
+    && !panelOpen
     && (statusSidecarHidden || sidecarFits)
     && !!chat
     && hasAssistantMsg
@@ -2626,8 +2630,9 @@ export const ChatTab: React.FC<Props> = ({
               qqInputRef={qqInputRef}
               onAnswerNextAction={() => taRef.current?.focus()}
               taskBriefLoading={taskBriefLoading}
+              statusPanelEnabled={statusPanelEnabled}
               onTaskTabShown={async () => {
-                if (!isTaskBriefStale(chat)) return
+                if (!statusPanelEnabled || !isTaskBriefStale(chat)) return
                 setTaskBriefLoading(true)
                 try { await generateTaskBrief(chat.id) } finally { setTaskBriefLoading(false) }
               }}

--- a/codey-mac/src/components/statusPanelPref.test.ts
+++ b/codey-mac/src/components/statusPanelPref.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// The renderer globals this module reads — the suite runs in the node env.
+const store = new Map<string, string>()
+const events: string[] = []
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, v) },
+  removeItem: (k: string) => { store.delete(k) },
+}
+;(globalThis as any).window = {
+  dispatchEvent: (e: any) => { events.push(e.type); return true },
+  addEventListener: () => {},
+  removeEventListener: () => {},
+}
+;(globalThis as any).CustomEvent = class { type: string; constructor(type: string) { this.type = type } }
+
+import { getStatusPanelEnabled, setStatusPanelEnabled, STATUS_PANEL_ENABLED_KEY } from './statusPanelPref'
+
+describe('statusPanelPref', () => {
+  beforeEach(() => { store.clear(); events.length = 0 })
+
+  it('defaults to enabled when nothing is stored', () => {
+    expect(getStatusPanelEnabled()).toBe(true)
+  })
+
+  it('round-trips the off state', () => {
+    setStatusPanelEnabled(false)
+    expect(store.get(STATUS_PANEL_ENABLED_KEY)).toBe('0')
+    expect(getStatusPanelEnabled()).toBe(false)
+    setStatusPanelEnabled(true)
+    expect(getStatusPanelEnabled()).toBe(true)
+  })
+
+  it('notifies same-window listeners on change', () => {
+    setStatusPanelEnabled(false)
+    expect(events).toEqual(['codey:statusPanelEnabled'])
+  })
+
+  it('treats unreadable storage as enabled', () => {
+    const original = (globalThis as any).localStorage.getItem
+    ;(globalThis as any).localStorage.getItem = vi.fn(() => { throw new Error('denied') })
+    expect(getStatusPanelEnabled()).toBe(true)
+    ;(globalThis as any).localStorage.getItem = original
+  })
+})

--- a/codey-mac/src/components/statusPanelPref.ts
+++ b/codey-mac/src/components/statusPanelPref.ts
@@ -1,0 +1,37 @@
+// Whether the Status panel (right-panel Status tab + the floating sidecar) is
+// available at all. Off means it is never rendered and its brief is never
+// generated — the setting gates the LLM call, not just the pixels.
+import { useEffect, useState } from 'react'
+
+export const STATUS_PANEL_ENABLED_KEY = 'codey.statusPanelEnabled'
+const CHANGED_EVENT = 'codey:statusPanelEnabled'
+
+export function getStatusPanelEnabled(): boolean {
+  try {
+    return localStorage.getItem(STATUS_PANEL_ENABLED_KEY) !== '0'
+  } catch {
+    return true
+  }
+}
+
+export function setStatusPanelEnabled(enabled: boolean): void {
+  try { localStorage.setItem(STATUS_PANEL_ENABLED_KEY, enabled ? '1' : '0') } catch { /* ignore */ }
+  // Settings and the chat live in the same window, so `storage` never fires
+  // between them — broadcast explicitly so the panel reacts immediately.
+  window.dispatchEvent(new CustomEvent(CHANGED_EVENT))
+}
+
+export function useStatusPanelEnabled(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(getStatusPanelEnabled)
+  useEffect(() => {
+    const sync = () => setEnabled(getStatusPanelEnabled())
+    const onStorage = (e: StorageEvent) => { if (e.key === STATUS_PANEL_ENABLED_KEY) sync() }
+    window.addEventListener(CHANGED_EVENT, sync)
+    window.addEventListener('storage', onStorage)
+    return () => {
+      window.removeEventListener(CHANGED_EVENT, sync)
+      window.removeEventListener('storage', onStorage)
+    }
+  }, [])
+  return enabled
+}


### PR DESCRIPTION
## What

Adds an **Appearance → Status panel** toggle (default on). Turning it off removes both Status surfaces from the chat's right side and stops the status brief from being generated.

- `statusPanelPref.ts` (new) — localStorage-backed preference + `useStatusPanelEnabled()` hook. Settings and the chat share one window, so `storage` never fires between them; the setter broadcasts a `codey:statusPanelEnabled` CustomEvent so the toggle applies immediately, no restart.
- `AppearanceTab.tsx` — the toggle, under Theme.
- `ChatTab.tsx` — `sidecarVisible` is false when off (neither the floating card nor its compact pill renders), and all three `generateTaskBrief` triggers are skipped: turn boundary, sidecar self-population, Status tab open. So the LLM call stops, not just the pixels.
- `ChatContextPanel.tsx` — the Status tab is not rendered when off; a chat parked on it falls back to Tools instead of showing an empty body.

## Testing

- `tsc --noEmit` clean
- `vitest run` — 48 files / 388 tests pass, including 4 new `statusPanelPref` cases
- `npm run lint` clean
- Not exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)