### PR TITLE
Quiet the inline tool-call row and auto-close the branch picker

### DIFF
--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -90,8 +90,10 @@ export const BranchPicker: React.FC<Props> = ({
     setChangingMode(true); setNote(null)
     try {
       await onCreateWorktree(name)
-      setNote('Worktree and same-named branch created')
+      // Creation succeeded — dismiss the picker instead of dropping back to the
+      // branch list; the pill itself now shows the new worktree and branch.
       setMode({ kind: 'list' })
+      setOpen(false)
     } catch (error) {
       setNote(error instanceof Error ? error.message : 'Could not create worktree')
     } finally {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -237,8 +237,16 @@ const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }>
         style={{ ...styles.liveActivity, cursor: canExpand ? 'pointer' : 'default' }}
         onClick={canExpand ? () => setExpanded(v => !v) : undefined}
       >
-        <span style={styles.liveActivityDot}>{active ? (expanded ? '▾' : '●') : canExpand ? (expanded ? '▾' : '▸') : '○'}</span>
-        <span>{headline}</span>
+        <span style={active ? styles.liveActivityMarkerActive : styles.liveActivityMarker}>
+          {canExpand ? (
+            <span style={{ ...styles.liveActivityChevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+              <UIIcon name="disclosure" size={12} />
+            </span>
+          ) : (
+            <span style={styles.liveActivityDot} />
+          )}
+        </span>
+        <span style={styles.liveActivityText}>{headline}</span>
       </div>
       {expanded && canExpand && detailTarget && (
         <div style={styles.liveActivityDetail}>
@@ -3322,18 +3330,35 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.fg2, fontSize: 12, lineHeight: 1.55,
     whiteSpace: 'pre-wrap' as const, overflowWrap: 'anywhere' as const,
   },
+  // Reads as one quiet line of the transcript rather than a boxed callout: same
+  // typography as the tool rows in `ToolCallList` (minimal), no fill, no border.
   liveActivity: {
-    display: 'flex', alignItems: 'center', gap: 6,
-    fontSize: 11, color: C.fg3, fontStyle: 'italic',
-    padding: '2px 6px', marginBottom: 6,
-    background: 'rgba(43,230,155,0.08)',
-    borderRadius: 4, border: `1px solid ${C.border2}`,
+    display: 'flex', alignItems: 'flex-start', gap: 6,
+    padding: '2px 0', marginBottom: 6,
   },
-  liveActivityDot: { color: C.accent, fontSize: 9 },
+  liveActivityMarker: {
+    color: C.fg3, width: 12, height: 16, flexShrink: 0,
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  },
+  liveActivityMarkerActive: {
+    color: C.accent, width: 12, height: 16, flexShrink: 0,
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    animation: 'codey-pulse 1.4s ease-in-out infinite',
+  },
+  liveActivityChevron: {
+    width: 12, height: 12, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    transformOrigin: 'center', transition: 'transform 0.15s ease',
+  },
+  liveActivityDot: { width: 5, height: 5, borderRadius: '50%', background: 'currentColor' },
+  liveActivityText: {
+    color: C.fg2, fontSize: 12, fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  },
   liveActivityDetail: {
-    marginTop: 4, marginBottom: 6,
-    padding: 8, background: 'rgba(0,0,0,0.25)', borderRadius: 4,
-    border: `1px solid ${C.border}`,
+    marginLeft: 18, marginTop: 4, marginBottom: 6,
+    padding: 9, background: C.surface3,
+    border: `1px solid ${C.border2}`, borderRadius: 7,
+    maxHeight: 280, overflowY: 'auto',
   },
   slashMenu: {
     position: 'absolute' as const, bottom: '100%', left: 0, right: 0,


### PR DESCRIPTION
## What

Two small chat-UI fixes.

**1. Inline tool-call row (`ChatTab.tsx` `LiveActivity`)** — it rendered as a full-width green-tinted bordered card with 11px italic text, which read as a callout bolted onto the message rather than a line of the transcript. It now matches the minimal `ToolCallList` row exactly:

- no fill, no border
- 12px Menlo monospace in `C.fg2`, not italic
- 12px marker slot: a rotating disclosure chevron when there is detail to expand, a small dot otherwise; while a tool is running the marker is accent-colored and uses the global `codey-pulse` animation
- expanded detail panel restyled to `C.surface3` / `C.border2` / radius 7 / `marginLeft: 18`, matching the tool-list detail panel

**2. Branch picker (`BranchPicker.tsx`)** — creating a worktree left the popover open on the branch list. It now dismisses on success; the pill itself already shows the new worktree and branch, so the confirmation note was redundant. Failure paths are unchanged: the error stays in the create panel with the popover open.

## Testing

- `npm test -w codey-mac` — 48 files, 388 tests passing
- `tsc --noEmit -p codey-mac/tsconfig.json` — clean

Visual change only; not yet exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)