### PR TITLE
Clip the voice HUD with a maskImage, not just cornerRadius

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2092,6 +2092,44 @@ app.whenReady().then(async () => {
     })
   )
 
+  ipcMain.handle('git:pull', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir) return { ok: false, error: 'missing workingDir' }
+      const { execFile } = await import('child_process')
+      const run = (args: string[], timeout = 30000) => new Promise<{ ok: boolean; stdout: string; error?: string }>((resolve) => {
+        execFile('git', args, { cwd: workingDir, timeout }, (err, stdout, stderr) => {
+          if (err) resolve({ ok: false, stdout: stdout || '', error: (stderr || String(err)).trim() })
+          else resolve({ ok: true, stdout: stdout || '' })
+        })
+      })
+
+      const upstream = await run(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], 3000)
+      if (!upstream.ok) return { ok: false, reason: 'no-upstream' as const, error: 'This branch has no upstream branch' }
+      const upstreamRef = upstream.stdout.trim()
+      const remote = upstreamRef.split('/')[0]
+
+      const fetched = await run(['fetch', '--prune', remote, `+refs/heads/*:refs/remotes/${remote}/*`])
+      if (!fetched.ok) return { ok: false, error: fetched.error }
+
+      const behindOut = await run(['rev-list', '--count', `HEAD..${upstreamRef}`], 5000)
+      const behind = behindOut.ok ? parseInt(behindOut.stdout.trim(), 10) || 0 : 0
+      if (behind === 0) return { ok: true, updated: 0, upstream: upstreamRef }
+
+      // --ff-only keeps the pull non-destructive: divergent history stops here
+      // instead of leaving a surprise merge (or conflicts) in the checkout.
+      const pulled = await run(['pull', '--ff-only'], 60000)
+      if (pulled.ok) return { ok: true, updated: behind, upstream: upstreamRef }
+      const stderr = pulled.error || ''
+      const dirty = /would be overwritten|Your local changes|commit your changes or stash/i.test(stderr)
+      const diverged = /Not possible to fast-forward|non-fast-forward|diverged/i.test(stderr)
+      return {
+        ok: false,
+        reason: dirty ? 'dirty' as const : diverged ? 'diverged' as const : undefined,
+        error: stderr.trim(),
+      }
+    })
+  )
+
   ipcMain.handle('git:worktrees', async (_e, workingDir: string) =>
     wrap(async () => {
       if (!workingDir) return { list: [] }

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -214,6 +214,7 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('git:checkout', workingDir, name, opts),
     stash: (workingDir: string, message?: string) => ipcRenderer.invoke('git:stash', workingDir, message),
     fetch: (workingDir: string) => ipcRenderer.invoke('git:fetch', workingDir),
+    pull: (workingDir: string) => ipcRenderer.invoke('git:pull', workingDir),
     worktrees: (workingDir: string) => ipcRenderer.invoke('git:worktrees', workingDir),
     worktreeAdd: (workingDir: string, args: { name: string; path: string }) =>
       ipcRenderer.invoke('git:worktreeAdd', workingDir, args),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -329,6 +329,7 @@ declare global {
         checkout: (workingDir: string, name: string, opts?: { create?: boolean; track?: boolean }) => Promise<IpcResult<{ ok: boolean; error?: string; reason?: 'dirty' }>>
         stash: (workingDir: string, message?: string) => Promise<IpcResult<{ ok: boolean; error?: string }>>
         fetch: (workingDir: string) => Promise<IpcResult<{ ok: boolean; error?: string }>>
+        pull: (workingDir: string) => Promise<IpcResult<{ ok: boolean; updated?: number; upstream?: string; error?: string; reason?: 'dirty' | 'diverged' | 'no-upstream' }>>
         worktrees: (workingDir: string) => Promise<IpcResult<{ list: { branch: string; path: string; isMain: boolean }[] }>>
         worktreeAdd: (workingDir: string, args: { name: string; path: string }) => Promise<IpcResult<{ ok: boolean; path?: string; error?: string }>>
         createPr: (workingDir: string, input: { title: string; body?: string }) => Promise<IpcResult<{ ok: boolean; url?: string; error?: string }>>

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { C } from '../theme'
 import { useGitBranches } from '../hooks/useGitBranches'
-import { compactWorktreePath, currentFirst, filterBranches } from './branchPickerModel'
+import { compactWorktreePath, currentFirst, describePullResult, filterBranches } from './branchPickerModel'
 import { UIIcon } from './UIIcons'
 
 interface Props {
@@ -26,6 +26,7 @@ export const BranchPicker: React.FC<Props> = ({
   const [newWorktreeName, setNewWorktreeName] = useState('')
   const [note, setNote] = useState<string | null>(null)
   const [changingMode, setChangingMode] = useState(false)
+  const [syncing, setSyncing] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -75,6 +76,18 @@ export const BranchPicker: React.FC<Props> = ({
     const result = await git.checkout(name, { track: true })
     if (result.ok) { setOpen(false); return }
     if (result.reason === 'dirty') setMode({ kind: 'dirty', target: name.replace(/^[^/]+\//, '') })
+  }
+
+  const syncWithRemote = async () => {
+    if (syncing) return
+    setSyncing(true); setNote(null); git.setError(null)
+    try {
+      const result = await git.pull()
+      setNote(describePullResult(result))
+      git.setError(null) // the note already carries the failure reason
+    } finally {
+      setSyncing(false)
+    }
   }
 
   const createBranch = async () => {
@@ -244,7 +257,21 @@ export const BranchPicker: React.FC<Props> = ({
               {note && <div style={styles.noteBox} role="status">{note}</div>}
               <div style={styles.footer}>
                 <button style={styles.ghost} onClick={() => { setNewBranchName(''); setMode({ kind: 'createBranch' }) }}>+ New branch</button>
-                <button style={styles.ghost} onClick={() => void git.fetchRemote()}>Fetch</button>
+                <div style={styles.footerActions}>
+                  <button style={styles.ghost} onClick={() => void git.fetchRemote()}>Fetch</button>
+                  <button
+                    style={styles.iconButton}
+                    disabled={!workingDir || syncing}
+                    onClick={() => void syncWithRemote()}
+                    title={syncing ? 'Syncing…' : 'Sync: fetch and fast-forward this branch to its upstream'}
+                    aria-label="Sync with the latest upstream commits"
+                  >
+                    <style>{'@keyframes codey-branch-sync-spin { to { transform: rotate(360deg) } }'}</style>
+                    <span style={syncing ? styles.spinning : undefined}>
+                      <UIIcon name="refresh" size={13} />
+                    </span>
+                  </button>
+                </div>
               </div>
             </>
           )}
@@ -285,7 +312,9 @@ const styles: Record<string, React.CSSProperties> = {
   row: { display: 'flex', gap: 6 },
   primary: { background: C.accent, color: C.onAccent, border: 'none', borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
   ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '5px 10px', fontSize: 11, cursor: 'pointer' },
-  footer: { display: 'flex', justifyContent: 'space-between', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
+  footer: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
+  footerActions: { display: 'flex', alignItems: 'center', gap: 6 },
+  spinning: { display: 'inline-flex', animation: 'codey-branch-sync-spin 0.9s linear infinite' },
   warn: { fontSize: 12, color: C.yellow },
   err: { fontSize: 11, color: C.red, padding: '2px 4px' },
   noteBox: { fontSize: 11, color: C.fg3, padding: '2px 4px' },

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1324,6 +1324,11 @@ export const ChatTab: React.FC<Props> = ({
   const effectiveEffort: string | undefined = chat.effort ?? workerEffort ?? agentDefaultEfforts[effectiveAgent]
   const effectiveAdvisorAgent = advisorConfig.agent ?? defaultAgent ?? 'claude-code'
   const effectiveAdvisorModel = advisorConfig.model ?? agentDefaultModels[effectiveAdvisorAgent] ?? 'Default model'
+  // Seeds the streaming turn's header. A team run has no single identity — its
+  // members each carry their own — so it opts out and waits for the real values.
+  const turnIdentity = chat.selection.type === 'team'
+    ? undefined
+    : { agent: effectiveAgent as ChatMessage['agent'], model: effectiveModel }
   const apiTypeForAgent = AGENT_API_TYPE[effectiveAgent]
   const modelsForAgent = models.filter(m => m.apiType === apiTypeForAgent)
 
@@ -1523,7 +1528,7 @@ export const ChatTab: React.FC<Props> = ({
     setPendingAttachments([])
     if (taRef.current && composerHeight == null) taRef.current.style.height = 'auto'
     setFollowLatest(true)
-    await sendMessage(chat.id, text, atts)
+    await sendMessage(chat.id, text, atts, turnIdentity)
   }
 
   const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -2220,7 +2225,7 @@ export const ChatTab: React.FC<Props> = ({
                           cursor: multiChoice.length === 0 ? 'default' : 'pointer',
                         }}
                         disabled={isSending || !!flight || multiChoice.length === 0}
-                        onClick={() => { void sendMessage(chat.id, multiChoice.join(', ')) }}
+                        onClick={() => { void sendMessage(chat.id, multiChoice.join(', '), undefined, turnIdentity) }}
                       >
                         Submit{multiChoice.length > 0 ? ` (${multiChoice.length})` : ''}
                       </button>
@@ -2232,7 +2237,7 @@ export const ChatTab: React.FC<Props> = ({
                           key={i}
                           style={styles.choiceButton}
                           disabled={isSending || !!flight}
-                          onClick={() => { void sendMessage(chat.id, opt.label) }}
+                          onClick={() => { void sendMessage(chat.id, opt.label, undefined, turnIdentity) }}
                         >
                           <span style={styles.choiceLabel}>{opt.label}</span>
                           {opt.description && <span style={styles.choiceDesc}>{opt.description}</span>}
@@ -2255,7 +2260,7 @@ export const ChatTab: React.FC<Props> = ({
                         key={i}
                         style={styles.choiceButton}
                         disabled={isSending || !!flight}
-                        onClick={() => { void sendMessage(chat.id, label) }}
+                        onClick={() => { void sendMessage(chat.id, label, undefined, turnIdentity) }}
                       >
                         {label}
                       </button>

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -23,6 +23,23 @@ export const TURN_TEXT_INSET = MESSAGE_ROW_INSET + TURN_RAIL_WIDTH + TURN_TEXT_P
  *  its timestamp lines up on the right edge and needs this, not TURN_TEXT_INSET. */
 export const USER_BUBBLE_PADDING_X = 14
 
+/** Seconds since `since`, re-rendering once a second while `active`.
+ *
+ *  The agent only reports its own duration with the final result event, so a
+ *  turn in flight has to count locally. Off while inactive: a finished turn
+ *  must not keep a timer alive per message in the transcript. */
+function useElapsedSeconds(active: boolean, since: number): number | undefined {
+  const [now, setNow] = React.useState(() => Date.now())
+  React.useEffect(() => {
+    if (!active) return
+    setNow(Date.now())
+    const timer = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(timer)
+  }, [active, since])
+  if (!active || !Number.isFinite(since)) return undefined
+  return Math.max(0, Math.floor((now - since) / 1000))
+}
+
 interface Props {
   msg: ChatMessage
   /** Rendered only when the turn has thinking to disclose. */
@@ -48,7 +65,8 @@ interface Props {
  *  something to put in it, so a turn with no metadata is a bare hairline rather
  *  than a blank row. */
 export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete }) => {
-  const meta = turnHeaderMeta(msg)
+  const elapsedSec = useElapsedSeconds(!turnComplete, msg.timestamp)
+  const meta = turnHeaderMeta(msg, { elapsedSec })
   const rule = turnComplete ? <div style={styles.rule} /> : null
   if (meta.isEmpty && !hasThinking) return rule
 

--- a/codey-mac/src/components/branchPickerModel.test.ts
+++ b/codey-mac/src/components/branchPickerModel.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { compactWorktreePath, currentFirst, filterBranches } from './branchPickerModel';
+import { compactWorktreePath, currentFirst, describePullResult, filterBranches } from './branchPickerModel';
+
+describe('describePullResult', () => {
+  it('reports how many commits arrived', () => {
+    expect(describePullResult({ ok: true, updated: 3, upstream: 'origin/main' }))
+      .toBe('Pulled 3 commits from origin/main');
+    expect(describePullResult({ ok: true, updated: 1, upstream: 'origin/main' }))
+      .toBe('Pulled 1 commit from origin/main');
+  });
+
+  it('says up to date when nothing changed', () => {
+    expect(describePullResult({ ok: true, updated: 0 })).toBe('Already up to date');
+  });
+
+  it('explains each blocked reason', () => {
+    expect(describePullResult({ ok: false, reason: 'no-upstream' })).toMatch(/no upstream/i);
+    expect(describePullResult({ ok: false, reason: 'dirty' })).toMatch(/commit or stash/i);
+    expect(describePullResult({ ok: false, reason: 'diverged' })).toMatch(/diverged/i);
+  });
+
+  it('falls back to the first line of an unclassified error', () => {
+    expect(describePullResult({ ok: false, error: 'fatal: could not read\nmore detail' }))
+      .toBe('fatal: could not read');
+    expect(describePullResult({ ok: false })).toBe('Could not sync');
+  });
+});
 
 describe('filterBranches', () => {
   it('returns all when query empty', () => {

--- a/codey-mac/src/components/branchPickerModel.ts
+++ b/codey-mac/src/components/branchPickerModel.ts
@@ -18,6 +18,27 @@ export function compactWorktreePath(path: string, maxSegments = 3): string {
   return `…/${parts.slice(-maxSegments).join('/')}`;
 }
 
+export interface PullResult {
+  ok: boolean;
+  updated?: number;
+  upstream?: string;
+  error?: string;
+  reason?: 'dirty' | 'diverged' | 'no-upstream';
+}
+
+/** Human-readable note for a sync attempt, shown under the branch list. */
+export function describePullResult(result: PullResult): string {
+  if (result.ok) {
+    const count = result.updated ?? 0;
+    if (count === 0) return 'Already up to date';
+    return `Pulled ${count} commit${count === 1 ? '' : 's'}${result.upstream ? ` from ${result.upstream}` : ''}`;
+  }
+  if (result.reason === 'no-upstream') return 'No upstream branch — push this branch first';
+  if (result.reason === 'dirty') return 'Local changes would be overwritten — commit or stash first';
+  if (result.reason === 'diverged') return 'Branch has diverged from its upstream — rebase or merge manually';
+  return result.error?.split('\n')[0] || 'Could not sync';
+}
+
 /** Move the current item to the front while preserving every other item's order. */
 export function currentFirst<T>(list: T[], isCurrent: (item: T) => boolean): T[] {
   const currentIndex = list.findIndex(isCurrent);

--- a/codey-mac/src/components/turnHeaderModel.test.ts
+++ b/codey-mac/src/components/turnHeaderModel.test.ts
@@ -51,6 +51,28 @@ describe('turnHeaderMeta', () => {
     expect(turnHeaderMeta(msg({ tokens: 45_000 })).stats).toEqual(['45k tok'])
   })
 
+  // A streaming turn counts locally; the agent's own duration is authoritative
+  // the moment it arrives, so it must win over the live counter.
+  it('shows the live elapsed count while the turn has no reported duration', () => {
+    expect(turnHeaderMeta(msg(), { elapsedSec: 7 }).stats).toEqual(['7s'])
+    expect(turnHeaderMeta(msg({ tokens: 3400 }), { elapsedSec: 7 }).stats)
+      .toEqual(['7s', '3.4k tok'])
+  })
+
+  it('prefers the reported duration over the live count', () => {
+    expect(turnHeaderMeta(msg({ durationSec: 12 }), { elapsedSec: 7 }).stats).toEqual(['12s'])
+  })
+
+  it('floors and rejects unusable elapsed values', () => {
+    expect(turnHeaderMeta(msg(), { elapsedSec: 7.9 }).stats).toEqual(['7s'])
+    expect(turnHeaderMeta(msg(), { elapsedSec: -1 }).stats).toEqual([])
+    expect(turnHeaderMeta(msg(), { elapsedSec: NaN }).stats).toEqual([])
+  })
+
+  it('is not empty while only the live count is known', () => {
+    expect(turnHeaderMeta(msg(), { elapsedSec: 3 }).isEmpty).toBe(false)
+  })
+
   it('passes the fallback through', () => {
     const f = { from: 'claude-code(opus)', to: 'codex(gpt-5)' }
     expect(turnHeaderMeta(msg({ fallback: f })).fallback).toEqual(f)

--- a/codey-mac/src/components/turnHeaderModel.ts
+++ b/codey-mac/src/components/turnHeaderModel.ts
@@ -20,17 +20,25 @@ export interface TurnHeaderMeta {
   isEmpty: boolean
 }
 
+export interface TurnHeaderInput {
+  /** Seconds this turn has been running, measured in the renderer. Used only
+   *  while the turn streams; the agent's own durationSec wins once it lands. */
+  elapsedSec?: number
+}
+
 /** The metadata identifying one assistant turn, ready to render.
  *
  *  Every field on a ChatMessage that this reads is optional: older messages
- *  predate the model/token bookkeeping, and duration and tokens are only set
- *  once a turn completes, so a streaming turn legitimately has neither. */
-export function turnHeaderMeta(msg: ChatMessage): TurnHeaderMeta {
+ *  predate the model/token bookkeeping, and tokens only arrive with the agent's
+ *  final result event, so a streaming turn legitimately has none. */
+export function turnHeaderMeta(msg: ChatMessage, input: TurnHeaderInput = {}): TurnHeaderMeta {
   const identity = [msg.agent, msg.model].filter(Boolean).join(' · ') || null
 
   const stats: string[] = []
   if (msg.durationSec != null && Number.isFinite(msg.durationSec)) {
     stats.push(`${msg.durationSec}s`)
+  } else if (input.elapsedSec != null && Number.isFinite(input.elapsedSec) && input.elapsedSec >= 0) {
+    stats.push(`${Math.floor(input.elapsedSec)}s`)
   }
   if (msg.tokens != null) {
     const tok = formatTokens(msg.tokens)

--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -142,3 +142,39 @@ describe('reducer: adoptInFlight (externally-initiated turns)', () => {
     )).toBe(true)
   })
 })
+
+describe('startSend seeds the turn header', () => {
+  const userMessage = { id: 'u1', role: 'user' as const, content: 'go', timestamp: 1, isComplete: true }
+  const sendState = (chat: Partial<Chat> = {}): State => ({
+    ...emptyState(),
+    chats: { c1: { id: 'c1', title: 't', workspaceName: 'ws', selection: { type: 'none' }, messages: [], createdAt: 0, updatedAt: 0, ...chat } },
+    order: ['c1'], selectedChatId: 'c1',
+  })
+
+  it('puts the caller-resolved agent/model on the assistant stub', () => {
+    const s = reducer(sendState(), { type: 'startSend', chatId: 'c1', userMessage, assistantMessageId: 'a1', agent: 'claude-code', model: 'claude-opus-5' })
+    expect(s.chats.c1.messages.find(m => m.id === 'a1')).toMatchObject({
+      agent: 'claude-code', model: 'claude-opus-5', isComplete: false,
+    })
+  })
+
+  it("falls back to the chat's own overrides when the caller passes none", () => {
+    const s = reducer(sendState({ agent: 'codex', model: 'gpt-5' }), { type: 'startSend', chatId: 'c1', userMessage, assistantMessageId: 'a1' })
+    expect(s.chats.c1.messages.find(m => m.id === 'a1')).toMatchObject({ agent: 'codex', model: 'gpt-5' })
+  })
+
+  it('leaves the stub unidentified when nothing is known', () => {
+    const s = reducer(sendState(), { type: 'startSend', chatId: 'c1', userMessage, assistantMessageId: 'a1' })
+    const stub = s.chats.c1.messages.find(m => m.id === 'a1')!
+    expect(stub.agent).toBeUndefined()
+    expect(stub.model).toBeUndefined()
+  })
+
+  it('completeSend overwrites the provisional identity with what actually ran', () => {
+    let s = reducer(sendState(), { type: 'startSend', chatId: 'c1', userMessage, assistantMessageId: 'a1', agent: 'claude-code', model: 'claude-opus-5' })
+    s = reducer(s, { type: 'completeSend', chatId: 'c1', assistantMessageId: 'a1', content: 'done', agent: 'codex', model: 'gpt-5', tokens: 2100, durationSec: 60 })
+    expect(s.chats.c1.messages.find(m => m.id === 'a1')).toMatchObject({
+      agent: 'codex', model: 'gpt-5', tokens: 2100, durationSec: 60, isComplete: true,
+    })
+  })
+})

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -38,7 +38,7 @@ type Action =
   | { type: 'remove'; chatId: string }
   | { type: 'select'; chatId: string | null }
   | { type: 'toggleWorkspace'; workspaceName: string }
-  | { type: 'startSend'; chatId: string; userMessage: ChatMessage; assistantMessageId: string }
+  | { type: 'startSend'; chatId: string; userMessage: ChatMessage; assistantMessageId: string; agent?: ChatMessage['agent']; model?: string }
   | { type: 'streamToken'; chatId: string; token: string; messageId?: string }
   | { type: 'thinkingToken'; chatId: string; token: string; step?: number; messageId?: string }
   | { type: 'toolCall'; chatId: string; entry: ToolCallEntry; status: AgentActivity; messageId?: string }
@@ -223,6 +223,13 @@ export function reducer(state: State, action: Action): State {
         timestamp: Date.now(),
         toolCalls: [],
         isComplete: false,
+        // Provisional identity so the header exists while the reply streams
+        // instead of appearing only once `done` lands. The caller passes the
+        // resolved agent/model (per-chat → worker → gateway default); the
+        // chat's own overrides are the fallback for senders without that
+        // context. `completeSend` overwrites both with what actually ran.
+        agent: action.agent ?? chat.agent,
+        model: action.model ?? chat.model,
       }
       const updated: Chat = {
         ...chat,
@@ -476,7 +483,10 @@ interface ChatsContextValue {
   generateTaskBrief: (chatId: string) => Promise<TaskBrief | null>
   linkChannel: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<void>
   unlinkChannel: (chatId: string, channel: 'telegram' | 'discord' | 'imessage', channelUserId: string) => Promise<void>
-  sendMessage: (chatId: string, text: string, attachments?: FileAttachment[]) => Promise<void>
+  /** `identity` is the agent/model the caller resolved for this chat; it seeds
+   *  the turn header while the reply streams. Omit it and the chat's own
+   *  overrides are used instead. */
+  sendMessage: (chatId: string, text: string, attachments?: FileAttachment[], identity?: { agent?: ChatMessage['agent']; model?: string }) => Promise<void>
   stopChat: (chatId: string) => Promise<void>
   resolvePermission: (chatId: string, allow: boolean) => Promise<void>
   clearRestore: (chatId: string) => void
@@ -701,7 +711,12 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     return off
   }, [])
 
-  const sendMessage = useCallback(async (chatId: string, text: string, attachments?: FileAttachment[]) => {
+  const sendMessage = useCallback(async (
+    chatId: string,
+    text: string,
+    attachments?: FileAttachment[],
+    identity?: { agent?: ChatMessage['agent']; model?: string },
+  ) => {
     const assistantMessageId = `asst-${Date.now()}-${Math.random()}`
     const userMessage: ChatMessage = {
       id: `user-${Date.now()}-${Math.random()}`,
@@ -712,7 +727,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       isComplete: true,
     }
     pendingAssistantId.current[chatId] = assistantMessageId
-    dispatch({ type: 'startSend', chatId, userMessage, assistantMessageId })
+    dispatch({ type: 'startSend', chatId, userMessage, assistantMessageId, agent: identity?.agent, model: identity?.model })
     try {
       await apiService.chats.send(chatId, text, attachments)
     } catch (err) {

--- a/codey-mac/src/hooks/useGitBranches.ts
+++ b/codey-mac/src/hooks/useGitBranches.ts
@@ -7,6 +7,14 @@ export interface BranchState {
   remote: string[]
 }
 
+export interface PullOutcome {
+  ok: boolean
+  updated?: number
+  upstream?: string
+  error?: string
+  reason?: 'dirty' | 'diverged' | 'no-upstream'
+}
+
 export function useGitBranches(workingDir: string | undefined) {
   const [state, setState] = useState<BranchState | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -71,5 +79,15 @@ export function useGitBranches(workingDir: string | undefined) {
     else setError((r.ok ? r.data.error : r.error) || 'fetch failed')
   }, [workingDir, refresh])
 
-  return { state, error, setError, refresh, checkout, stashAndSwitch, createBranch, fetchRemote }
+  const pull = useCallback(async (): Promise<PullOutcome> => {
+    if (!workingDir) return { ok: false, error: 'no dir' }
+    setError(null)
+    const r = await window.codey.git.pull(workingDir)
+    if (!r.ok) { setError(r.error || 'pull failed'); return { ok: false, error: r.error } }
+    const d = r.data
+    if (d.ok) { await refresh(); return { ok: true, updated: d.updated ?? 0, upstream: d.upstream } }
+    return { ok: false, error: d.error, reason: d.reason }
+  }, [workingDir, refresh])
+
+  return { state, error, setError, refresh, checkout, stashAndSwitch, createBranch, fetchRemote, pull }
 }

--- a/voice/Sources/CodeyVoice/HudOverlay.swift
+++ b/voice/Sources/CodeyVoice/HudOverlay.swift
@@ -56,6 +56,10 @@ final class HudOverlay {
     /// is a repeated action and rebuilding the gradient each time is waste.
     private var capsuleLayer: RainbowCapsuleLayer?
     private var isCapsuleMode = false
+    /// Size/radius the blur view's `maskImage` was last drawn for, so a resize
+    /// that changes neither skips the redraw.
+    private var maskedSize: CGSize = .zero
+    private var maskedRadius: CGFloat = -1
 
     private let pillHeight: CGFloat = 44
     private let pillSidePadding: CGFloat = 16
@@ -245,6 +249,7 @@ final class HudOverlay {
         blur.layer?.borderWidth = 0.5
         blur.layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.4).cgColor
         p.contentView = blur
+        applyMask(to: blur, size: rect.size, radius: pillHeight / 2)
 
         // Click-to-dismiss for the dictation card. Active even in pill modes,
         // but those have ignoresMouseEvents = true so clicks pass through.
@@ -372,6 +377,37 @@ final class HudOverlay {
         hide()
     }
 
+    // MARK: - Shape
+
+    /// Clip the blur view to the rounded shape with an explicit `maskImage`.
+    ///
+    /// `layer.cornerRadius` is not enough on its own: a `.behindWindow`
+    /// visual-effect view's material is composited by the window server, not
+    /// drawn into that layer, so the corner radius is not a reliable clip. When
+    /// the blur degrades to a flat opaque fill — Accessibility's "Reduce
+    /// transparency"/"Increase contrast", screen sharing, or any session where
+    /// background blur is unavailable — the material paints the full rectangle
+    /// and a box shows up around the pill. `maskImage` is honoured on every one
+    /// of those paths, and it also makes the window shadow follow the rounded
+    /// shape instead of the bounding box.
+    ///
+    /// Redrawn at the exact view size on each shape change (cheap, and it only
+    /// happens when the panel resizes) rather than using a stretched cap-inset
+    /// image, whose center slice would collapse at the pill's height.
+    private func applyMask(to blur: NSVisualEffectView, size: CGSize, radius: CGFloat) {
+        guard size.width > 0, size.height > 0 else { return }
+        if maskedSize == size, maskedRadius == radius, blur.maskImage != nil { return }
+        let r = max(0, min(radius, min(size.width, size.height) / 2))
+        let image = NSImage(size: size, flipped: false) { rect in
+            NSColor.black.setFill()
+            NSBezierPath(roundedRect: rect, xRadius: r, yRadius: r).fill()
+            return true
+        }
+        blur.maskImage = image
+        maskedSize = size
+        maskedRadius = radius
+    }
+
     // MARK: - Layouts
 
     /// Single-line pill: icon (dot or spinner) + status text. Panel width
@@ -412,6 +448,7 @@ final class HudOverlay {
 
         resizePanel(width: panelWidth, height: pillHeight)
         blur.layer?.cornerRadius = pillHeight / 2
+        applyMask(to: blur, size: CGSize(width: panelWidth, height: pillHeight), radius: pillHeight / 2)
 
         let usedContentWidth = iconWidth + gap + finalLabelWidth
         var x = floor((panelWidth - usedContentWidth) / 2)
@@ -453,6 +490,7 @@ final class HudOverlay {
 
         resizePanel(width: dictationMaxWidth, height: totalHeight)
         blur.layer?.cornerRadius = 14
+        applyMask(to: blur, size: CGSize(width: dictationMaxWidth, height: totalHeight), radius: 14)
 
         label.frame = NSRect(x: dictationPadding, y: dictationPadding, width: textWidth, height: labelHeight)
     }


### PR DESCRIPTION
## Problem

On some Macs a rectangular box shows up around the voice HUD — both the dictation card and the conversation capsule.

The HUD panel's content view is an `NSVisualEffectView` with `.behindWindow` blending, rounded via `layer.cornerRadius` + `masksToBounds`. That material is composited by the window server *behind* the window, so the layer's corner radius is not a reliable clip for it. On most machines the system happens to clip it to the layer shape; when that path is bypassed (Reduce transparency, Increase contrast, screen sharing / recording, some displays) the material is drawn as a full rectangle — the box you see. `hasShadow = true` then draws a rectangular shadow too, making it more obvious.

Capsule mode is affected because `RainbowCapsuleLayer`'s opaque fill only covers the inside of the rounded path — the corners stay transparent, so the rectangular material leaks through.

## Fix

Set an explicit `maskImage` on the `NSVisualEffectView`, which is the supported way to shape that material — every render path honors it, and the window shadow follows the mask.

- New `applyMask(to:size:radius:)` draws a rounded-rect `NSImage` at the panel's exact size. Exact redraw rather than a cap-inset stretchable image: the capsule is 44pt tall with a 22pt radius, so a stretchable image's middle slice collapses to nothing.
- Called from `ensurePanel()`, `applyPillLayout()` (radius 22) and `applyDictationLayout()` (radius 14).
- `maskedSize` / `maskedRadius` cache skips the redraw when neither changed.

`layer.cornerRadius` stays — it still shapes the 0.5pt border used in non-capsule mode.

## Testing

`swift build` passes. The visual regression only reproduces with Reduce transparency (or one of the other degraded paths) enabled, which I did not toggle on this machine — needs a manual check on an affected Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)