### PR TITLE
Move the unread dot into the chat row's leading slot

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -456,7 +456,11 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                     {/* Fixed-width leading slot so a chat's name never shifts
                         sideways the moment its run starts or ends. */}
                     <span style={styles.activitySlot}>
-                      {flight && <span style={styles.dot} title="Running" aria-label="Running" />}
+                      {flight
+                        ? <span style={styles.dot} title="Running" aria-label="Running" />
+                        : unread && !active
+                          ? <span style={styles.unreadDot} title="Unread" aria-label="Unread" />
+                          : null}
                     </span>
                     {isRenaming ? (
                       <input
@@ -482,7 +486,6 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                       <span style={styles.title}>{chat.title?.trim() || 'New Chat'}</span>
                     )}
                     <RouteIcons routes={chat.routes} />
-                    {unread && !active && <span style={styles.unreadDot} />}
                     {!isRenaming && (
                       <span style={styles.trailingAction}>
                         {hoveredChatId === chat.id ? (


### PR DESCRIPTION
The unread marker sat after the route icons, on the opposite side of the chat row from the running-pulse dot, so "this chat has something new" and "this chat is working" read as two unrelated signals in two unrelated places. They are the same kind of signal.

Both now render in the fixed-width leading slot before the title, with the running pulse taking priority when a chat is both in flight and unread. The slot already had a fixed width to keep titles from shifting when a run starts, so nothing moves when the dot swaps.

`npx tsc --noEmit` in `codey-mac` passes. Visual-only change; not smoke-tested in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)