### PR TITLE
Tidy the Effort selector and keep PR badges fresh in the ChatList

### DIFF
--- a/codey-mac/electron/delivery-status.test.ts
+++ b/codey-mac/electron/delivery-status.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest'
-import { deriveDeliveryState } from './delivery-status'
+import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
+
+describe('shouldRediscoverPr', () => {
+  it('re-resolves when the checkout moved to another branch', () => {
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'old-work', currentBranch: 'new-work' })).toBe(true)
+  })
+
+  it('keeps the pinned PR on its own branch', () => {
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: 'work' })).toBe(false)
+  })
+
+  it('keeps the pinned PR when the branch is unknown or detached', () => {
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: '' })).toBe(false)
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: 'HEAD' })).toBe(false)
+    expect(shouldRediscoverPr({ currentBranch: 'work' })).toBe(false)
+  })
+})
 
 describe('deriveDeliveryState', () => {
   it('maps open and closed pull requests', () => {

--- a/codey-mac/electron/delivery-status.ts
+++ b/codey-mac/electron/delivery-status.ts
@@ -1,5 +1,19 @@
 export type DeliveryState = 'pr-open' | 'merged' | 'merged-with-changes' | 'closed-unmerged'
 
+/** A pinned PR url describes one branch. Once the checkout has moved to a
+ *  different branch, that PR no longer describes the chat's work and its state
+ *  (typically `merged`) would stick forever — re-resolve from the branch we're
+ *  actually on. `HEAD` (detached) and an unknown head branch are not evidence
+ *  of drift, so they keep the pinned PR. */
+export function shouldRediscoverPr(input: {
+  pinnedHeadBranch?: string
+  currentBranch?: string
+}): boolean {
+  const { pinnedHeadBranch, currentBranch } = input
+  if (!pinnedHeadBranch || !currentBranch || currentBranch === 'HEAD') return false
+  return pinnedHeadBranch !== currentBranch
+}
+
 export function deriveDeliveryState(input: {
   providerState: string
   sameBranch: boolean

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -14,7 +14,7 @@ import { applyEvent, clearAttention, summarize } from './tray-state'
 import { SKILL_FILE, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
-import { deriveDeliveryState } from './delivery-status'
+import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
 import type { ScannedSkill } from './skills'
 import { scanSkillUsage } from './skill-usage'
 import type { SkillUsageMap, UsageCacheEntry } from './skill-usage'
@@ -2231,11 +2231,8 @@ app.whenReady().then(async () => {
       })
       const gh = ['/opt/homebrew/bin/gh', '/usr/local/bin/gh', '/usr/bin/gh']
         .find(candidate => fsMod.existsSync(candidate)) || 'gh'
-      const raw = await run(gh, [
-        'pr', 'view', ...(url ? [url] : []),
-        '--json', 'url,number,state,mergedAt,headRefName,headRefOid,baseRefName',
-      ], 15_000)
-      const view = JSON.parse(raw) as {
+      const PR_FIELDS = 'url,number,state,mergedAt,headRefName,headRefOid,baseRefName'
+      type PrView = {
         url: string
         number?: number
         state: string
@@ -2244,11 +2241,23 @@ app.whenReady().then(async () => {
         headRefOid?: string
         baseRefName?: string
       }
+      // No url means "whatever PR the current branch has" — gh resolves it.
+      const view$ = async (prUrl?: string): Promise<PrView> =>
+        JSON.parse(await run(gh, ['pr', 'view', ...(prUrl ? [prUrl] : []), '--json', PR_FIELDS], 15_000))
+
+      let view = await view$(url)
       const [localHead, currentBranch, porcelain] = await Promise.all([
         run('git', ['rev-parse', 'HEAD'], 3_000),
         run('git', ['branch', '--show-current'], 3_000),
         run('git', ['status', '--porcelain'], 3_000),
       ])
+      // The caller's stored url can outlive the branch it belongs to: finish a
+      // chat's PR, start the next branch in the same checkout, and the old
+      // (merged) PR would keep answering forever. When the pinned PR's head is
+      // not the branch we're on, ask again for this branch's own PR.
+      if (shouldRediscoverPr({ pinnedHeadBranch: view.headRefName, currentBranch })) {
+        try { view = await view$() } catch { /* no PR for this branch; keep the pinned one */ }
+      }
       const sameBranch = !!view.headRefName && currentBranch === view.headRefName
       let commitsAfterMerge = false
       if (sameBranch && view.state.toUpperCase() === 'MERGED' && view.headRefOid && localHead !== view.headRefOid) {

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -5,6 +5,7 @@ import { SettingsOverlay } from './components/SettingsOverlay'
 import { VoiceRecorder } from './components/VoiceRecorder'
 import { NotificationCenter } from './components/NotificationCenter'
 import { ChatsProvider, useChats } from './hooks/useChats'
+import { usePullRequestWatcher } from './hooks/usePullRequestWatcher'
 import { QuickQuestionProvider } from './hooks/useQuickQuestion'
 import { useGateway } from './hooks/useGateway'
 import { CoreOfflineBanner } from './components/CoreOfflineBanner'
@@ -36,6 +37,8 @@ const clampLeftPanelWidth = (width: number) => {
 const Shell: React.FC = () => {
   const { isRunning, coreState, relaunchApp } = useGateway()
   const { state, createChat, selectChat, openChatById, refreshWorkspaces, sendMessage } = useChats()
+  // Keeps the ChatList PR badges current for chats the user isn't looking at.
+  usePullRequestWatcher()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<string | undefined>(undefined)
   const [automationsOpen, setAutomationsOpen] = useState(false)

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1382,7 +1382,7 @@ export const ChatTab: React.FC<Props> = ({
     await setAgentModel(chat.id, chat.agent ?? null, v === '' ? null : v)
   }
   const onEffortChange = async (v: string) => {
-    // '' is the Inherit option — clears the chat override.
+    // '' is the inherited-effort option — clears the chat override.
     await setEffort(chat.id, v === '' ? null : v)
   }
 
@@ -1919,7 +1919,7 @@ export const ChatTab: React.FC<Props> = ({
                         style={styles.runSettingSelect}
                         title={`Effort: ${effectiveEffort ?? 'CLI default'}${chat.effort ? ' (override)' : workerEffort ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
                       >
-                        <option value="">Inherit ({effectiveEffort ?? 'CLI default'})</option>
+                        <option value="">{effectiveEffort ?? 'CLI default'}</option>
                         <option value="low">low</option>
                         <option value="medium">medium</option>
                         <option value="high">high</option>

--- a/codey-mac/src/hooks/usePullRequestWatcher.test.ts
+++ b/codey-mac/src/hooks/usePullRequestWatcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { chatsNeedingPrRefresh, prStatusChanged, prWorkingDir } from './usePullRequestWatcher'
+import { chatsWithTrackedPr, needsPrRefresh, prStatusChanged, prWorkingDir } from './usePullRequestWatcher'
 import type { Chat } from '../types'
 
 const makeChat = (overrides: Partial<Chat> = {}): Chat => ({
@@ -12,21 +12,37 @@ const pr = (overrides: Partial<NonNullable<Chat['pullRequest']>> = {}): NonNulla
   url: 'https://github.com/o/r/pull/1', number: 1, state: 'pr-open', lastCheckedAt: 100, ...overrides,
 })
 
-describe('chatsNeedingPrRefresh', () => {
-  it('picks chats with an open PR', () => {
+describe('chatsWithTrackedPr', () => {
+  it('picks chats carrying a PR url', () => {
     const open = makeChat({ id: 'open', pullRequest: pr() })
-    const chats = [
-      open,
-      makeChat({ id: 'none' }),
-      makeChat({ id: 'merged', pullRequest: pr({ state: 'merged' }) }),
-      makeChat({ id: 'closed', pullRequest: pr({ state: 'closed-unmerged' }) }),
-      makeChat({ id: 'changes', pullRequest: pr({ state: 'merged-with-changes' }) }),
-    ]
-    expect(chatsNeedingPrRefresh(chats)).toEqual([open])
+    const merged = makeChat({ id: 'merged', pullRequest: pr({ state: 'merged' }) })
+    const chats = [open, makeChat({ id: 'none' }), merged, makeChat({ id: 'urlless', pullRequest: pr({ url: '' }) })]
+    expect(chatsWithTrackedPr(chats)).toEqual([open, merged])
+  })
+})
+
+describe('needsPrRefresh', () => {
+  it('always checks an open PR', () => {
+    expect(needsPrRefresh(pr(), 'feature')).toBe(true)
   })
 
-  it('skips an open PR with no url to check', () => {
-    expect(chatsNeedingPrRefresh([makeChat({ pullRequest: pr({ url: '' }) })])).toEqual([])
+  it('skips a merged PR while the checkout is still on its branch', () => {
+    expect(needsPrRefresh(pr({ state: 'merged', headBranch: 'feature' }), 'feature')).toBe(false)
+  })
+
+  it('re-checks a merged PR once the checkout moved to another branch', () => {
+    expect(needsPrRefresh(pr({ state: 'merged', headBranch: 'shipped' }), 'next-thing')).toBe(true)
+  })
+
+  it('leaves a terminal PR alone when the branch is unknown or detached', () => {
+    const merged = pr({ state: 'merged', headBranch: 'shipped' })
+    expect(needsPrRefresh(merged, undefined)).toBe(false)
+    expect(needsPrRefresh(merged, 'HEAD')).toBe(false)
+    expect(needsPrRefresh(pr({ state: 'merged' }), 'next-thing')).toBe(false)
+  })
+
+  it('ignores chats with no PR', () => {
+    expect(needsPrRefresh(undefined, 'feature')).toBe(false)
   })
 })
 

--- a/codey-mac/src/hooks/usePullRequestWatcher.test.ts
+++ b/codey-mac/src/hooks/usePullRequestWatcher.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { chatsNeedingPrRefresh, prStatusChanged, prWorkingDir } from './usePullRequestWatcher'
+import type { Chat } from '../types'
+
+const makeChat = (overrides: Partial<Chat> = {}): Chat => ({
+  id: 'c1', title: 'Ship it', workspaceName: 'codey',
+  selection: { type: 'none' }, createdAt: 1, updatedAt: 1, messages: [],
+  ...overrides,
+})
+
+const pr = (overrides: Partial<NonNullable<Chat['pullRequest']>> = {}): NonNullable<Chat['pullRequest']> => ({
+  url: 'https://github.com/o/r/pull/1', number: 1, state: 'pr-open', lastCheckedAt: 100, ...overrides,
+})
+
+describe('chatsNeedingPrRefresh', () => {
+  it('picks chats with an open PR', () => {
+    const open = makeChat({ id: 'open', pullRequest: pr() })
+    const chats = [
+      open,
+      makeChat({ id: 'none' }),
+      makeChat({ id: 'merged', pullRequest: pr({ state: 'merged' }) }),
+      makeChat({ id: 'closed', pullRequest: pr({ state: 'closed-unmerged' }) }),
+      makeChat({ id: 'changes', pullRequest: pr({ state: 'merged-with-changes' }) }),
+    ]
+    expect(chatsNeedingPrRefresh(chats)).toEqual([open])
+  })
+
+  it('skips an open PR with no url to check', () => {
+    expect(chatsNeedingPrRefresh([makeChat({ pullRequest: pr({ url: '' }) })])).toEqual([])
+  })
+})
+
+describe('prStatusChanged', () => {
+  it('ignores a poll that only moved lastCheckedAt', () => {
+    expect(prStatusChanged(pr(), pr({ lastCheckedAt: 999 }))).toBe(false)
+  })
+
+  it('reports a merge', () => {
+    expect(prStatusChanged(pr(), pr({ state: 'merged', mergedAt: 500 }))).toBe(true)
+  })
+
+  it('reports a new head commit on the same state', () => {
+    expect(prStatusChanged(pr({ headCommit: 'aaa' }), pr({ headCommit: 'bbb' }))).toBe(true)
+  })
+})
+
+describe('prWorkingDir', () => {
+  const dirs = { codey: '/repo/codey' }
+
+  it('uses the worktree dir for isolated chats', () => {
+    const chat = makeChat({
+      executionMode: 'isolated-worktree',
+      chatWorkspace: {
+        repositoryRoot: '/repo/codey', worktreePath: '/wt/x', workingDir: '/wt/x',
+        baseCommit: 'abc', createdAt: 1,
+      },
+    })
+    expect(prWorkingDir(chat, dirs)).toBe('/wt/x')
+  })
+
+  it('prefers a per-chat override over the workspace dir', () => {
+    expect(prWorkingDir(makeChat({ workingDirOverride: '/other' }), dirs)).toBe('/other')
+  })
+
+  it('falls back to the workspace dir', () => {
+    expect(prWorkingDir(makeChat(), dirs)).toBe('/repo/codey')
+  })
+
+  it('returns undefined when the workspace dir is unknown', () => {
+    expect(prWorkingDir(makeChat({ workspaceName: 'ghost' }), dirs)).toBeUndefined()
+  })
+})

--- a/codey-mac/src/hooks/usePullRequestWatcher.ts
+++ b/codey-mac/src/hooks/usePullRequestWatcher.ts
@@ -10,11 +10,19 @@ export const PR_POLL_INTERVAL_MS = 2 * 60_000
 
 type PullRequest = NonNullable<Chat['pullRequest']>
 
-/** Chats worth polling: those whose PR is still open. Merged/closed chats are
- *  terminal for the watcher — ChatTab still refreshes the active chat, which is
- *  what turns `merged` into `merged-with-changes` once new commits land. */
-export function chatsNeedingPrRefresh(chats: Chat[]): Chat[] {
-  return chats.filter(chat => chat.pullRequest?.state === 'pr-open' && !!chat.pullRequest.url)
+/** Chats that carry a PR the watcher could check. */
+export function chatsWithTrackedPr(chats: Chat[]): Chat[] {
+  return chats.filter(chat => !!chat.pullRequest?.url)
+}
+
+/** Whether this chat's PR is worth a `gh` call right now. An open PR always is
+ *  — that's the merge we're watching for. A terminal one only is when the
+ *  checkout has moved off the branch that PR belongs to, which means the badge
+ *  is describing finished work and needs to be re-resolved for the new branch. */
+export function needsPrRefresh(pullRequest: PullRequest | undefined, branch: string | undefined): boolean {
+  if (!pullRequest?.url) return false
+  if (pullRequest.state === 'pr-open') return true
+  return !!branch && branch !== 'HEAD' && !!pullRequest.headBranch && branch !== pullRequest.headBranch
 }
 
 /** True when a fetched status differs in a way the ChatList badge cares about.
@@ -59,6 +67,13 @@ export function usePullRequestWatcher(): void {
     return prWorkingDir(chat, workspaceDirs.current)
   }, [])
 
+  const currentBranch = useCallback(async (workingDir: string): Promise<string | undefined> => {
+    try {
+      const result = await window.codey.git.status(workingDir)
+      return result.ok ? result.data?.branch : undefined
+    } catch { return undefined }
+  }, [])
+
   const sweep = useCallback(async () => {
     // Skip while the window is hidden: nobody is looking at the badges, and
     // the focus listener below catches up as soon as they are.
@@ -66,9 +81,13 @@ export function usePullRequestWatcher(): void {
     running.current = true
     try {
       // Sequential on purpose — each check spawns a `gh` process.
-      for (const chat of chatsNeedingPrRefresh(Object.values(chatsRef.current))) {
+      for (const chat of chatsWithTrackedPr(Object.values(chatsRef.current))) {
         const workingDir = await resolveWorkingDir(chat)
         if (!workingDir) continue
+        // Local git first: it's cheap, and it tells us whether a terminal-state
+        // PR still describes this chat's branch before we pay for a gh call.
+        const branch = await currentBranch(workingDir)
+        if (!needsPrRefresh(chat.pullRequest, branch)) continue
         try {
           const result = await window.codey.git.prStatus(workingDir, chat.pullRequest!.url)
           const current = chatsRef.current[chat.id]?.pullRequest
@@ -80,7 +99,7 @@ export function usePullRequestWatcher(): void {
     } finally {
       running.current = false
     }
-  }, [resolveWorkingDir, setPullRequest])
+  }, [currentBranch, resolveWorkingDir, setPullRequest])
 
   useEffect(() => {
     void sweep()

--- a/codey-mac/src/hooks/usePullRequestWatcher.ts
+++ b/codey-mac/src/hooks/usePullRequestWatcher.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { apiService } from '../services/api'
+import { useChats } from './useChats'
+import type { Chat } from '../types'
+
+/** How often the watcher re-checks open PRs. Each check shells out to `gh`,
+ *  so this is deliberately slower than the per-chat refresh ChatTab already
+ *  does on mount and on window focus. */
+export const PR_POLL_INTERVAL_MS = 2 * 60_000
+
+type PullRequest = NonNullable<Chat['pullRequest']>
+
+/** Chats worth polling: those whose PR is still open. Merged/closed chats are
+ *  terminal for the watcher — ChatTab still refreshes the active chat, which is
+ *  what turns `merged` into `merged-with-changes` once new commits land. */
+export function chatsNeedingPrRefresh(chats: Chat[]): Chat[] {
+  return chats.filter(chat => chat.pullRequest?.state === 'pr-open' && !!chat.pullRequest.url)
+}
+
+/** True when a fetched status differs in a way the ChatList badge cares about.
+ *  `lastCheckedAt` alone changes on every poll and is not worth a disk write. */
+export function prStatusChanged(prev: PullRequest, next: PullRequest): boolean {
+  return prev.state !== next.state
+    || prev.url !== next.url
+    || prev.number !== next.number
+    || prev.mergedAt !== next.mergedAt
+    || prev.headCommit !== next.headCommit
+}
+
+/** The directory `gh`/`git` should run in for a chat — the same resolution
+ *  ChatTab uses, with the workspace root looked up from `workspaceDirs`. */
+export function prWorkingDir(chat: Chat, workspaceDirs: Record<string, string>): string | undefined {
+  if (chat.executionMode === 'isolated-worktree') return chat.chatWorkspace?.workingDir
+  return chat.workingDirOverride || workspaceDirs[chat.workspaceName]
+}
+
+/** Periodically re-checks every chat with an open PR and updates the chat when
+ *  the PR has been merged or closed, so the ChatList badge stays honest without
+ *  the user having to open each chat. Mount once, app-wide. */
+export function usePullRequestWatcher(): void {
+  const { state, setPullRequest } = useChats()
+
+  // Read chats through a ref so the polling effect doesn't restart (and reset
+  // its timer) on every message that lands in any chat.
+  const chatsRef = useRef(state.chats)
+  chatsRef.current = state.chats
+  const workspaceDirs = useRef<Record<string, string>>({})
+  const running = useRef(false)
+
+  const resolveWorkingDir = useCallback(async (chat: Chat): Promise<string | undefined> => {
+    if (chat.executionMode !== 'isolated-worktree'
+      && !chat.workingDirOverride
+      && !(chat.workspaceName in workspaceDirs.current)) {
+      try {
+        const info = await apiService.getWorkspaceInfo(chat.workspaceName)
+        workspaceDirs.current[chat.workspaceName] = info.workingDir
+      } catch { /* an unreachable workspace just means we skip this chat */ }
+    }
+    return prWorkingDir(chat, workspaceDirs.current)
+  }, [])
+
+  const sweep = useCallback(async () => {
+    // Skip while the window is hidden: nobody is looking at the badges, and
+    // the focus listener below catches up as soon as they are.
+    if (running.current || document.hidden) return
+    running.current = true
+    try {
+      // Sequential on purpose — each check spawns a `gh` process.
+      for (const chat of chatsNeedingPrRefresh(Object.values(chatsRef.current))) {
+        const workingDir = await resolveWorkingDir(chat)
+        if (!workingDir) continue
+        try {
+          const result = await window.codey.git.prStatus(workingDir, chat.pullRequest!.url)
+          const current = chatsRef.current[chat.id]?.pullRequest
+          if (result.ok && current && prStatusChanged(current, result.data)) {
+            await setPullRequest(chat.id, result.data)
+          }
+        } catch { /* PR status is best effort */ }
+      }
+    } finally {
+      running.current = false
+    }
+  }, [resolveWorkingDir, setPullRequest])
+
+  useEffect(() => {
+    void sweep()
+    const timer = setInterval(() => void sweep(), PR_POLL_INTERVAL_MS)
+    const onFocus = () => void sweep()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      clearInterval(timer)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [sweep])
+}


### PR DESCRIPTION
Three chat-surface fixes.

**Effort selector.** The dropdown's placeholder option read `Inherit (medium)`. It now shows just the inherited value — `medium`, or `CLI default` when nothing is set — the same way the Model selector renders its default option. Selecting it still clears the per-chat override, and the hover tooltip still says whether the effective effort comes from an override, the worker, or the default.

**PR badges go stale.** The delivery badge in the ChatList only refreshed for whichever chat was open (ChatTab refreshes on mount and on window focus), so a chat whose PR got merged elsewhere kept showing "open" until you clicked into it.

`usePullRequestWatcher` now sweeps app-wide, every two minutes and on window focus:

- runs `gh pr view` in that chat's effective working dir (worktree → per-chat override → workspace root, cached per workspace)
- persists only when a badge-visible field changed, so a poll that just moves `lastCheckedAt` doesn't cause a disk write
- sequential, and paused while the window is hidden, to avoid a burst of `gh` processes

**PR badges point at the wrong PR.** A chat pins the url of the PR it opened, and every later check asked `gh` about that same url. In a shared checkout the url outlives its branch: finish one PR, start the next branch in the same chat, and the badge stays on the old merged PR forever — polling harder doesn't help. (Caught live: this very chat showed "merged" while its actual PR was open.)

`git:prStatus` now compares the pinned PR's head branch against the branch the checkout is on, and asks `gh` for *this* branch's PR when they differ, keeping the pinned one if the new branch has no PR yet. The watcher does a cheap local `git status` first so terminal-state chats are re-checked on branch drift instead of never.

Known gap: if the new branch has no PR at all, the old badge stays until one exists — clearing a chat's PR isn't expressible in the current `Chat['pullRequest']` shape.

Unit tests cover the pure helpers on both sides (which chats to poll, what counts as a change, working-dir resolution, the re-resolve decision). Full `codey-mac` suite passes (416 tests); `tsc --noEmit` and `npm run lint` clean. Not yet watched live in a rebuilt app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)