### PR TITLE
Drop the duplicate Terminal button from the branch picker

### DIFF
--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -10,13 +10,12 @@ interface Props {
   executionMode?: 'shared-checkout' | 'isolated-worktree'
   onCreateWorktree: (name: string) => Promise<void>
   onExecutionModeChange: (mode: 'shared-checkout' | 'isolated-worktree') => Promise<void>
-  onOpenTerminal?: () => void
 }
 
 type Mode = { kind: 'list' } | { kind: 'createBranch' } | { kind: 'createWorktree' } | { kind: 'dirty'; target: string }
 
 export const BranchPicker: React.FC<Props> = ({
-  workingDir, chatWorktree, executionMode = 'shared-checkout', onCreateWorktree, onExecutionModeChange, onOpenTerminal,
+  workingDir, chatWorktree, executionMode = 'shared-checkout', onCreateWorktree, onExecutionModeChange,
 }) => {
   const git = useGitBranches(workingDir)
   const [open, setOpen] = useState(false)
@@ -177,11 +176,6 @@ export const BranchPicker: React.FC<Props> = ({
                 <UIIcon name="refresh" size={13} />
               </span>
             </button>
-            {onOpenTerminal && (
-              <button style={styles.iconButton} onClick={() => { onOpenTerminal(); setOpen(false) }} disabled={!workingDir} title="Open Terminal here" aria-label="Open Terminal in this checkout">
-                <UIIcon name="terminal" size={14} />
-              </button>
-            )}
           </div>
 
           <div style={styles.checkoutMode}>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1791,7 +1791,6 @@ export const ChatTab: React.FC<Props> = ({
           executionMode={chat?.executionMode ?? 'shared-checkout'}
           onCreateWorktree={async name => { await createWorktree(chat.id, name) }}
           onExecutionModeChange={async mode => { await setExecutionMode(chat.id, mode) }}
-          onOpenTerminal={openChatTerminal}
         />
         <div style={{ ...styles.openInWrap, marginLeft: 'auto' }}>
           <div style={styles.openInSplit}>


### PR DESCRIPTION
The chat header already has a Terminal button (⌘J) that toggles the bottom terminal panel. The branch picker dropdown had a second Terminal button doing roughly the same thing, so this removes it along with the now-unused `onOpenTerminal` prop threading from `ChatTab` into `BranchPicker`.

`openChatTerminal` is unchanged and still backs the header button.

## Testing
- `tsc --noEmit` on `codey-mac` — clean
- `vitest run` — 385/385 tests pass (one suite, `electron/browser-controller.test.ts`, fails to load in this worktree because deps were installed with `--ignore-scripts` so the Electron binary is missing; unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)