### PR TITLE
Show the branch sync outcome at the top of the picker

### DIFF
--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { C } from '../theme'
 import { useGitBranches } from '../hooks/useGitBranches'
-import { compactWorktreePath, currentFirst, describePullResult, filterBranches } from './branchPickerModel'
+import { BranchNote, compactWorktreePath, currentFirst, describePullResult, filterBranches } from './branchPickerModel'
 import { UIIcon } from './UIIcons'
 
 interface Props {
@@ -23,7 +23,7 @@ export const BranchPicker: React.FC<Props> = ({
   const [mode, setMode] = useState<Mode>({ kind: 'list' })
   const [newBranchName, setNewBranchName] = useState('')
   const [newWorktreeName, setNewWorktreeName] = useState('')
-  const [note, setNote] = useState<string | null>(null)
+  const [note, setNote] = useState<BranchNote | null>(null)
   const [changingMode, setChangingMode] = useState(false)
   const [syncing, setSyncing] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -54,14 +54,17 @@ export const BranchPicker: React.FC<Props> = ({
   const branchLabel = state?.branch === 'HEAD' ? '—' : (state?.branch ?? '—')
   const pathLabel = compactWorktreePath(path)
   const checkoutLabel = isolated ? worktreeLabel : 'Current checkout'
+  // One status line for the whole picker: an explicit note wins, otherwise the
+  // last git failure surfaces in the same place instead of at the bottom.
+  const banner: BranchNote | null = note ?? (git.error ? { tone: 'error', text: git.error } : null)
 
   const copyPath = async () => {
     if (!path) return
     try {
       await navigator.clipboard.writeText(path)
-      setNote('Worktree path copied')
+      setNote({ tone: 'ok', text: 'Worktree path copied' })
     } catch {
-      setNote('Could not copy worktree path')
+      setNote({ tone: 'error', text: 'Could not copy worktree path' })
     }
   }
 
@@ -107,7 +110,7 @@ export const BranchPicker: React.FC<Props> = ({
       setMode({ kind: 'list' })
       setOpen(false)
     } catch (error) {
-      setNote(error instanceof Error ? error.message : 'Could not create worktree')
+      setNote({ tone: 'error', text: error instanceof Error ? error.message : 'Could not create worktree' })
     } finally {
       setChangingMode(false)
     }
@@ -118,12 +121,15 @@ export const BranchPicker: React.FC<Props> = ({
     setChangingMode(true); setNote(null)
     try {
       await onExecutionModeChange(nextMode)
-      setNote(nextMode === 'isolated-worktree'
-        ? 'Using this chat’s worktree'
-        : 'Using the current checkout; the isolated worktree is preserved')
+      setNote({
+        tone: 'ok',
+        text: nextMode === 'isolated-worktree'
+          ? 'Using this chat’s worktree'
+          : 'Using the current checkout; the isolated worktree is preserved',
+      })
       setMode({ kind: 'list' })
     } catch (error) {
-      setNote(error instanceof Error ? error.message : 'Could not switch checkout mode')
+      setNote({ tone: 'error', text: error instanceof Error ? error.message : 'Could not switch checkout mode' })
     } finally {
       setChangingMode(false)
     }
@@ -157,25 +163,35 @@ export const BranchPicker: React.FC<Props> = ({
       {open && (
         <div style={styles.menu}>
           <div style={styles.currentCheckout}>
-            <div style={styles.currentIdentity}>
-              <div style={styles.currentBranch}>{branchLabel}</div>
-              <div style={styles.currentPath} title={path}>{pathLabel}</div>
+            <div style={styles.currentRow}>
+              <div style={styles.currentIdentity}>
+                <div style={styles.currentBranch}>{branchLabel}</div>
+                <div style={styles.currentPath} title={path}>{pathLabel}</div>
+              </div>
+              <button style={styles.iconButton} onClick={() => void copyPath()} title="Copy path" aria-label="Copy worktree path">
+                <UIIcon name="copy" size={13} />
+              </button>
+              <button
+                style={styles.iconButton}
+                disabled={!workingDir || syncing}
+                onClick={() => void syncWithRemote()}
+                title={syncing ? 'Syncing…' : 'Sync: fetch and fast-forward this branch to its upstream'}
+                aria-label="Sync with the latest upstream commits"
+              >
+                <style>{'@keyframes codey-branch-sync-spin { to { transform: rotate(360deg) } }'}</style>
+                <span style={syncing ? styles.spinning : undefined}>
+                  <UIIcon name="refresh" size={13} />
+                </span>
+              </button>
             </div>
-            <button style={styles.iconButton} onClick={() => void copyPath()} title="Copy path" aria-label="Copy worktree path">
-              <UIIcon name="copy" size={13} />
-            </button>
-            <button
-              style={styles.iconButton}
-              disabled={!workingDir || syncing}
-              onClick={() => void syncWithRemote()}
-              title={syncing ? 'Syncing…' : 'Sync: fetch and fast-forward this branch to its upstream'}
-              aria-label="Sync with the latest upstream commits"
-            >
-              <style>{'@keyframes codey-branch-sync-spin { to { transform: rotate(360deg) } }'}</style>
-              <span style={syncing ? styles.spinning : undefined}>
-                <UIIcon name="refresh" size={13} />
-              </span>
-            </button>
+            {/* Sync and checkout outcomes belong next to the branch they describe,
+              * not buried under the branch list where they used to sit. */}
+            {banner && (
+              <div style={{ ...styles.banner, color: noteColors[banner.tone] }} role="status" title={banner.text}>
+                <span style={styles.bannerIcon}><UIIcon name={banner.tone === 'ok' ? 'check' : 'alert'} size={12} /></span>
+                <span style={styles.bannerText}>{banner.text}</span>
+              </div>
+            )}
           </div>
 
           <div style={styles.checkoutMode}>
@@ -200,7 +216,7 @@ export const BranchPicker: React.FC<Props> = ({
                 <button style={styles.primary} onClick={async () => {
                   const result = await git.stashAndSwitch(mode.target)
                   if (result.ok) {
-                    setNote('Local changes stashed — restore with `git stash pop`')
+                    setNote({ tone: 'ok', text: 'Local changes stashed — restore with `git stash pop`' })
                     setMode({ kind: 'list' })
                   }
                 }}>Stash & switch</button>
@@ -219,7 +235,6 @@ export const BranchPicker: React.FC<Props> = ({
                 style={styles.input}
               />
               <div style={styles.hint}>Creates a worktree and same-named branch from HEAD. Uncommitted changes stay in the current checkout.</div>
-              {note && <div style={styles.err}>{note}</div>}
               <div style={styles.row}>
                 <button style={styles.primary} disabled={!newWorktreeName.trim() || changingMode} onClick={() => void createWorktree()}>{changingMode ? 'Creating…' : 'Create worktree'}</button>
                 <button style={styles.ghost} disabled={changingMode} onClick={() => setMode({ kind: 'list' })}>Cancel</button>
@@ -261,8 +276,6 @@ export const BranchPicker: React.FC<Props> = ({
                 ))}
                 {localBranches.length === 0 && remoteBranches.length === 0 && <div style={styles.empty}>No branches found</div>}
               </div>
-              {git.error && <div style={styles.err}>{git.error}</div>}
-              {note && <div style={styles.noteBox} role="status">{note}</div>}
               <div style={styles.footer}>
                 <button style={styles.ghost} onClick={() => { setNewBranchName(''); setMode({ kind: 'createBranch' }) }}>+ New branch</button>
                 <button style={styles.ghost} onClick={() => void git.fetchRemote()}>Fetch</button>
@@ -284,7 +297,11 @@ const styles: Record<string, React.CSSProperties> = {
   dirty: { color: C.yellow, opacity: 0.85 },
   caret: { color: C.fg3, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, flexShrink: 0, transformOrigin: 'center', transition: 'transform 0.15s ease' },
   menu: { position: 'absolute', top: 'calc(100% + 7px)', left: 0, zIndex: 20, width: 340, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8, boxShadow: '0 14px 30px rgba(0,0,0,0.26)', padding: 8, display: 'flex', flexDirection: 'column', gap: 7 },
-  currentCheckout: { display: 'flex', alignItems: 'center', gap: 7, padding: '6px 7px 8px', borderBottom: `1px solid ${C.border}` },
+  currentCheckout: { display: 'flex', flexDirection: 'column', gap: 6, padding: '6px 7px 8px', borderBottom: `1px solid ${C.border}` },
+  currentRow: { display: 'flex', alignItems: 'center', gap: 7 },
+  banner: { display: 'flex', alignItems: 'flex-start', gap: 5, fontSize: 10, lineHeight: 1.35 },
+  bannerIcon: { display: 'inline-flex', flexShrink: 0, paddingTop: 1 },
+  bannerText: { minWidth: 0, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' },
   currentIdentity: { minWidth: 0, flex: 1 },
   currentBranch: { color: C.fg, fontSize: 11, fontWeight: 600, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   currentPath: { color: C.fg3, fontSize: 9, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
@@ -309,6 +326,6 @@ const styles: Record<string, React.CSSProperties> = {
   footer: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
   spinning: { display: 'inline-flex', animation: 'codey-branch-sync-spin 0.9s linear infinite' },
   warn: { fontSize: 12, color: C.yellow },
-  err: { fontSize: 11, color: C.red, padding: '2px 4px' },
-  noteBox: { fontSize: 11, color: C.fg3, padding: '2px 4px' },
 }
+
+const noteColors: Record<BranchNote['tone'], string> = { ok: C.green, warn: C.yellow, error: C.red }

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -312,7 +312,10 @@ const styles: Record<string, React.CSSProperties> = {
   createWorktreeButton: { background: C.accentDim, color: C.accent, border: `1px solid ${C.accent}55`, borderRadius: 6, padding: '5px 8px', fontSize: 10, cursor: 'pointer' },
   section: { display: 'flex', flexDirection: 'column', gap: 8 },
   sectionLabel: { color: C.fg3, fontSize: 10 },
-  scroll: { maxHeight: 260, overflowY: 'auto', display: 'flex', flexDirection: 'column' },
+  // The rule sits on the scroll box itself, not on the footer: with the menu's
+  // flex gap between them a footer border floats below the clipped last row and
+  // stops reading as the list's edge.
+  scroll: { maxHeight: 260, overflowY: 'auto', display: 'flex', flexDirection: 'column', borderBottom: `1px solid ${C.border}` },
   item: { width: '100%', textAlign: 'left', background: 'transparent', border: 'none', color: C.fg, fontSize: 12, padding: '6px 8px', borderRadius: 6, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 },
   branchName: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   checkSlot: { width: 14, flexShrink: 0, display: 'inline-flex', alignItems: 'center' },
@@ -323,7 +326,7 @@ const styles: Record<string, React.CSSProperties> = {
   row: { display: 'flex', gap: 6 },
   primary: { background: C.accent, color: C.onAccent, border: 'none', borderRadius: 6, padding: '5px 10px', fontSize: 12, cursor: 'pointer' },
   ghost: { background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, padding: '5px 10px', fontSize: 11, cursor: 'pointer' },
-  footer: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderTop: `1px solid ${C.border}`, paddingTop: 6 },
+  footer: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
   spinning: { display: 'inline-flex', animation: 'codey-branch-sync-spin 0.9s linear infinite' },
   warn: { fontSize: 12, color: C.yellow },
 }

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export type IconName =
-  | 'activity' | 'add' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
+  | 'activity' | 'add' | 'alert' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
   | 'clock' | 'code' | 'copy' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
   | 'waveform' | 'git-merge' | 'pull-request' | 'globe' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
   | 'telegram' | 'discord' | 'imessage'
@@ -21,6 +21,7 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
   const paths: Record<IconName, React.ReactNode> = {
     activity: <><path {...common} d="M3 12h4l3-7 4 14 3-7h4" /></>,
     add: <><circle {...common} cx="12" cy="12" r="9" /><path {...common} d="M12 8v8M8 12h8" /></>,
+    alert: <><path {...common} d="M12 4.5L21 19.5H3L12 4.5z" /><path {...common} d="M12 10v4M12 17h.01" /></>,
     archive: <><path {...common} d="M4 7h16v13H4zM3 4h18v3H3zM9 12h6" /></>,
     bell: <><path {...common} d="M18 9a6 6 0 00-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9" /><path {...common} d="M10 21h4" /></>,
     bot: <><rect {...common} x="4" y="7" width="16" height="13" rx="3" /><path {...common} d="M12 3v4M9 13h.01M15 13h.01M8 17h8" /><circle fill="currentColor" cx="9" cy="13" r="1" /><circle fill="currentColor" cx="15" cy="13" r="1" /></>,

--- a/codey-mac/src/components/branchPickerModel.test.ts
+++ b/codey-mac/src/components/branchPickerModel.test.ts
@@ -4,25 +4,28 @@ import { compactWorktreePath, currentFirst, describePullResult, filterBranches }
 describe('describePullResult', () => {
   it('reports how many commits arrived', () => {
     expect(describePullResult({ ok: true, updated: 3, upstream: 'origin/main' }))
-      .toBe('Pulled 3 commits from origin/main');
+      .toEqual({ tone: 'ok', text: 'Pulled 3 commits from origin/main' });
     expect(describePullResult({ ok: true, updated: 1, upstream: 'origin/main' }))
-      .toBe('Pulled 1 commit from origin/main');
+      .toEqual({ tone: 'ok', text: 'Pulled 1 commit from origin/main' });
   });
 
   it('says up to date when nothing changed', () => {
-    expect(describePullResult({ ok: true, updated: 0 })).toBe('Already up to date');
+    expect(describePullResult({ ok: true, updated: 0 })).toEqual({ tone: 'ok', text: 'Already up to date' });
   });
 
-  it('explains each blocked reason', () => {
-    expect(describePullResult({ ok: false, reason: 'no-upstream' })).toMatch(/no upstream/i);
-    expect(describePullResult({ ok: false, reason: 'dirty' })).toMatch(/commit or stash/i);
-    expect(describePullResult({ ok: false, reason: 'diverged' })).toMatch(/diverged/i);
+  it('explains each blocked reason as a warning', () => {
+    expect(describePullResult({ ok: false, reason: 'no-upstream' }))
+      .toEqual({ tone: 'warn', text: expect.stringMatching(/no upstream/i) });
+    expect(describePullResult({ ok: false, reason: 'dirty' }))
+      .toEqual({ tone: 'warn', text: expect.stringMatching(/commit or stash/i) });
+    expect(describePullResult({ ok: false, reason: 'diverged' }))
+      .toEqual({ tone: 'warn', text: expect.stringMatching(/diverged/i) });
   });
 
   it('falls back to the first line of an unclassified error', () => {
     expect(describePullResult({ ok: false, error: 'fatal: could not read\nmore detail' }))
-      .toBe('fatal: could not read');
-    expect(describePullResult({ ok: false })).toBe('Could not sync');
+      .toEqual({ tone: 'error', text: 'fatal: could not read' });
+    expect(describePullResult({ ok: false })).toEqual({ tone: 'error', text: 'Could not sync' });
   });
 });
 

--- a/codey-mac/src/components/branchPickerModel.ts
+++ b/codey-mac/src/components/branchPickerModel.ts
@@ -26,17 +26,24 @@ export interface PullResult {
   reason?: 'dirty' | 'diverged' | 'no-upstream';
 }
 
-/** Human-readable note for a sync attempt, shown under the branch list. */
-export function describePullResult(result: PullResult): string {
+/** A short status line shown at the top of the picker, next to the branch identity. */
+export interface BranchNote { tone: 'ok' | 'warn' | 'error'; text: string }
+
+/** Human-readable note for a sync attempt. Blocked syncs are warnings rather than
+ * errors: the branch is fine, it just needs the user to decide what to do next. */
+export function describePullResult(result: PullResult): BranchNote {
   if (result.ok) {
     const count = result.updated ?? 0;
-    if (count === 0) return 'Already up to date';
-    return `Pulled ${count} commit${count === 1 ? '' : 's'}${result.upstream ? ` from ${result.upstream}` : ''}`;
+    if (count === 0) return { tone: 'ok', text: 'Already up to date' };
+    return {
+      tone: 'ok',
+      text: `Pulled ${count} commit${count === 1 ? '' : 's'}${result.upstream ? ` from ${result.upstream}` : ''}`,
+    };
   }
-  if (result.reason === 'no-upstream') return 'No upstream branch — push this branch first';
-  if (result.reason === 'dirty') return 'Local changes would be overwritten — commit or stash first';
-  if (result.reason === 'diverged') return 'Branch has diverged from its upstream — rebase or merge manually';
-  return result.error?.split('\n')[0] || 'Could not sync';
+  if (result.reason === 'no-upstream') return { tone: 'warn', text: 'No upstream branch — push this branch first' };
+  if (result.reason === 'dirty') return { tone: 'warn', text: 'Local changes would be overwritten — commit or stash first' };
+  if (result.reason === 'diverged') return { tone: 'warn', text: 'Branch has diverged from its upstream — rebase or merge manually' };
+  return { tone: 'error', text: result.error?.split('\n')[0] || 'Could not sync' };
 }
 
 /** Move the current item to the front while preserving every other item's order. */


### PR DESCRIPTION
Closes #240.

The sync message used to render under the branch list, near the bottom of the picker — far from the branch it describes.

- The status line now sits directly beneath the current branch and worktree path, inside the same top block.
- It carries a tone icon instead of bare words: `check` (green) for a clean pull or "already up to date", `alert` (yellow) for a blocked sync — no upstream, dirty tree, diverged — and `alert` (red) for a failure.
- `describePullResult` now returns `{ tone, text }` so the tone is decided in tested model code, not in JSX.
- Git errors and the copy/worktree/stash notes all share that single status line; the duplicate error rows at the bottom of the menu and inside the create-worktree form are gone.
- New `alert` icon in `UIIcons`.

## Testing

- `npm test -w codey-mac` — 424 passed
- `npx tsc --noEmit` — clean
- No live UI check: the repo has no renderer-render test setup, and the banner only appears after a real sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)