### PR TITLE
Offer workspace files when the composer sees an "@"

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -24,6 +24,7 @@ import { BrowserControlPermissionGate } from './browser-control-permission'
 import { BrowserSitePermissionManager } from './browser-site-permissions'
 import { canConfigureBrowserWebAuthn, configureBrowserWebAuthn, passkeyAccountLabel, type BrowserPasskeyPickerRequest } from './browser-webauthn'
 import { BrowserExtensionManager } from './browser-extensions'
+import { deriveEntries, parseGitFileList, walkDirectory, type FileEntry } from './workspace-files'
 import * as pty from 'node-pty'
 
 protocol.registerSchemesAsPrivileged([
@@ -1972,6 +1973,43 @@ app.whenReady().then(async () => {
   // boot would be lost. Expose the ring buffer so the renderer can backfill.
   ipcMain.handle('gateway:recentLogs', async () =>
     wrap(async () => recentGatewayLogs.slice())
+  )
+
+  // ── Workspace file index IPC (composer "@" mentions) ──────────────
+  // Indexing a large repo costs a fork + a walk, and the composer asks on every
+  // "@". Cache per working dir for a few seconds so a burst of keystrokes only
+  // pays once, while still picking up new files during a normal session.
+  const fileIndexCache = new Map<string, { at: number; entries: FileEntry[] }>()
+  const FILE_INDEX_TTL_MS = 5000
+
+  ipcMain.handle('workspace:files', async (_e, workingDir: string) =>
+    wrap(async () => {
+      if (!workingDir || typeof workingDir !== 'string') return []
+      const cached = fileIndexCache.get(workingDir)
+      if (cached && Date.now() - cached.at < FILE_INDEX_TTL_MS) return cached.entries
+
+      const { execFile } = await import('child_process')
+      const fsMod = await import('fs')
+      let paths: string[]
+      try {
+        // -z keeps paths with spaces/unicode intact (git quotes them otherwise);
+        // --exclude-standard applies .gitignore to the untracked half.
+        const stdout = await new Promise<string>((resolve, reject) => {
+          execFile(
+            'git', ['ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+            { cwd: workingDir, timeout: 4000, maxBuffer: 32 * 1024 * 1024 },
+            (err, out) => (err ? reject(err) : resolve(out)),
+          )
+        })
+        paths = parseGitFileList(stdout)
+      } catch {
+        // Not a repo (or git unavailable) — fall back to a bounded walk.
+        paths = walkDirectory(workingDir, fsMod as never)
+      }
+      const entries = deriveEntries(paths)
+      fileIndexCache.set(workingDir, { at: Date.now(), entries })
+      return entries
+    })
   )
 
   // ── Git status IPC ────────────────────────────────────────────────

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -207,6 +207,9 @@ contextBridge.exposeInMainWorld('codey', {
       return () => ipcRenderer.removeListener('pairing:event', listener)
     },
   },
+  workspaceFiles: {
+    list: (workingDir: string) => ipcRenderer.invoke('workspace:files', workingDir),
+  },
   git: {
     status: (workingDir: string) => ipcRenderer.invoke('git:status', workingDir),
     branches: (workingDir: string) => ipcRenderer.invoke('git:branches', workingDir),

--- a/codey-mac/electron/workspace-files.test.ts
+++ b/codey-mac/electron/workspace-files.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { deriveEntries, parseGitFileList, walkDirectory } from './workspace-files'
+
+describe('parseGitFileList', () => {
+  it('splits NUL-delimited output and drops empties', () => {
+    expect(parseGitFileList('src/a.ts\0src/b.ts\0')).toEqual(['src/a.ts', 'src/b.ts'])
+  })
+
+  it('returns nothing for empty output', () => {
+    expect(parseGitFileList('')).toEqual([])
+  })
+})
+
+describe('deriveEntries', () => {
+  it('adds a directory entry for every ancestor of a file', () => {
+    const entries = deriveEntries(['src/components/ChatTab.tsx', 'README.md'])
+    expect(entries.filter(e => e.isDir).map(e => e.path)).toEqual(['src', 'src/components'])
+    expect(entries.filter(e => !e.isDir).map(e => e.path)).toEqual(['README.md', 'src/components/ChatTab.tsx'])
+  })
+
+  it('deduplicates shared ancestors', () => {
+    const dirs = deriveEntries(['src/a.ts', 'src/b.ts']).filter(e => e.isDir)
+    expect(dirs).toHaveLength(1)
+  })
+
+  it('strips a leading ./ from paths', () => {
+    expect(deriveEntries(['./a.ts'])[0].path).toBe('a.ts')
+  })
+
+  it('sets name to the last path segment', () => {
+    const entry = deriveEntries(['src/components/ChatTab.tsx']).find(e => !e.isDir)
+    expect(entry?.name).toBe('ChatTab.tsx')
+  })
+})
+
+describe('walkDirectory', () => {
+  const dirent = (name: string, dir: boolean) => ({ name, isDirectory: () => dir, isFile: () => !dir })
+  const fakeFs = (tree: Record<string, Array<{ name: string; dir: boolean }>>) => ({
+    readdirSync: (p: string) => {
+      const children = tree[p]
+      if (!children) throw new Error(`ENOENT ${p}`)
+      return children.map(c => dirent(c.name, c.dir))
+    },
+  })
+
+  it('collects files recursively', () => {
+    const fs = fakeFs({
+      '/root': [{ name: 'src', dir: true }, { name: 'README.md', dir: false }],
+      '/root/src': [{ name: 'a.ts', dir: false }],
+    })
+    expect(walkDirectory('/root', fs as never).sort()).toEqual(['README.md', 'src/a.ts'])
+  })
+
+  it('skips node_modules and other heavy directories', () => {
+    const fs = fakeFs({
+      '/root': [{ name: 'node_modules', dir: true }, { name: 'a.ts', dir: false }],
+      '/root/node_modules': [{ name: 'junk.ts', dir: false }],
+    })
+    expect(walkDirectory('/root', fs as never)).toEqual(['a.ts'])
+  })
+
+  it('skips dotfiles but keeps .github', () => {
+    const fs = fakeFs({
+      '/root': [{ name: '.env', dir: false }, { name: '.github', dir: true }],
+      '/root/.github': [{ name: 'ci.yml', dir: false }],
+    })
+    expect(walkDirectory('/root', fs as never)).toEqual(['.github/ci.yml'])
+  })
+
+  it('stops at the limit', () => {
+    const fs = fakeFs({ '/root': [{ name: 'a', dir: false }, { name: 'b', dir: false }, { name: 'c', dir: false }] })
+    expect(walkDirectory('/root', fs as never, 2)).toHaveLength(2)
+  })
+
+  it('ignores directories it cannot read', () => {
+    const fs = fakeFs({ '/root': [{ name: 'locked', dir: true }, { name: 'a.ts', dir: false }] })
+    expect(walkDirectory('/root', fs as never)).toEqual(['a.ts'])
+  })
+})

--- a/codey-mac/electron/workspace-files.ts
+++ b/codey-mac/electron/workspace-files.ts
@@ -1,0 +1,84 @@
+// Workspace file index behind the composer's "@" mention menu.
+//
+// The listing comes from `git ls-files` when the working dir is a repo — that
+// gives us .gitignore filtering for free, which a naive fs walk would have to
+// reimplement badly. Non-repo directories fall back to a bounded manual walk
+// that skips the usual heavyweight directories.
+
+export type FileEntry = {
+  /** Path relative to the working dir, POSIX separators, no leading "./". */
+  path: string
+  /** Last segment of `path`. */
+  name: string
+  isDir: boolean
+}
+
+/** Hard cap on indexed entries — big monorepos should not blow up memory. */
+export const MAX_ENTRIES = 20000
+
+const SKIP_DIRS = new Set([
+  '.git', 'node_modules', 'dist', 'build', 'out', 'target', 'vendor',
+  '.next', '.nuxt', '.cache', '.venv', 'venv', '__pycache__', '.pytest_cache',
+  'coverage', '.turbo', '.gradle', '.idea', 'DerivedData',
+])
+
+/** Split `git ls-files -z` output into clean relative paths. */
+export function parseGitFileList(stdout: string): string[] {
+  return stdout
+    .split('\0')
+    .map(l => l.trim())
+    .filter(l => l.length > 0)
+}
+
+/**
+ * Expand a file path list into the menu's entry list: every file plus each
+ * directory that contains one, so "@src/comp" can offer the folder too.
+ */
+export function deriveEntries(paths: string[]): FileEntry[] {
+  const seenDirs = new Set<string>()
+  const files: FileEntry[] = []
+  for (const raw of paths) {
+    const path = raw.replace(/^\.\//, '')
+    if (!path) continue
+    const segments = path.split('/')
+    files.push({ path, name: segments[segments.length - 1], isDir: false })
+    for (let i = 1; i < segments.length; i++) {
+      seenDirs.add(segments.slice(0, i).join('/'))
+    }
+  }
+  const dirs: FileEntry[] = [...seenDirs].map(path => {
+    const segments = path.split('/')
+    return { path, name: segments[segments.length - 1], isDir: true }
+  })
+  const all = [...dirs, ...files]
+  all.sort((a, b) => a.path.localeCompare(b.path))
+  return all.slice(0, MAX_ENTRIES)
+}
+
+/** Bounded fs walk for working dirs that are not git repos. */
+export function walkDirectory(
+  root: string,
+  fs: { readdirSync: (p: string, o: { withFileTypes: true }) => Array<{ name: string; isDirectory(): boolean; isFile(): boolean }> },
+  limit = MAX_ENTRIES,
+): string[] {
+  const out: string[] = []
+  const queue: string[] = ['']
+  while (queue.length > 0 && out.length < limit) {
+    const rel = queue.shift() as string
+    const abs = rel ? `${root}/${rel}` : root
+    let dirEntries
+    try { dirEntries = fs.readdirSync(abs, { withFileTypes: true }) } catch { continue }
+    for (const dirent of dirEntries) {
+      if (dirent.name.startsWith('.') && dirent.name !== '.github') continue
+      const childRel = rel ? `${rel}/${dirent.name}` : dirent.name
+      if (dirent.isDirectory()) {
+        if (SKIP_DIRS.has(dirent.name)) continue
+        queue.push(childRel)
+      } else if (dirent.isFile()) {
+        out.push(childRel)
+        if (out.length >= limit) break
+      }
+    }
+  }
+  return out
+}

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -312,6 +312,9 @@ declare global {
       permissions: {
         addAllowed: (toolNames: string[], chatId?: string) => Promise<IpcResult<{ added: number }>>
       }
+      workspaceFiles: {
+        list: (workingDir: string) => Promise<IpcResult<Array<{ path: string; name: string; isDir: boolean }>>>
+      }
       pairing: {
         start: (channel: 'telegram' | 'discord' | 'imessage') => Promise<IpcResult<{ code: string; deepLink?: string }>>
         list: () => Promise<IpcResult<Array<{

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -28,6 +28,8 @@ import { ShimmerStatus } from './ShimmerStatus'
 import { statusLine } from './checklistView'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
+import { applyMention, filterEntries, findActiveMention, splitMentionSegments } from './mentions'
+import type { ActiveMention, MentionFile } from './mentions'
 import { useGitStatus } from '../hooks/useGitStatus'
 import { BranchPicker } from './BranchPicker'
 import { CreatePrModal } from './CreatePrModal'
@@ -116,6 +118,12 @@ const FileIcon: React.FC<{ color: string; size?: number }> = ({ color, size = 14
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
     <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
     <path d="M14 2v6h6" />
+  </svg>
+)
+
+const FolderIcon: React.FC<{ color: string; size?: number }> = ({ color, size = 14 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
   </svg>
 )
 
@@ -841,6 +849,11 @@ export const ChatTab: React.FC<Props> = ({
   // remount that happens when switching chats (App.tsx keys ChatTab by chat id).
   const [input, setInput] = useState(() => getDraft(chatId).text)
   const [inputHistoryIndex, setInputHistoryIndex] = useState<number | null>(null)
+  // "@" file mentions: the workspace index, the token the caret is inside, and
+  // the highlighted row in the menu.
+  const [fileIndex, setFileIndex] = useState<MentionFile[]>([])
+  const [mention, setMention] = useState<ActiveMention | null>(null)
+  const [mentionIdx, setMentionIdx] = useState(0)
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   const [teamNames, setTeamNames] = useState<string[]>([])
   const [models, setModels] = useState<ModelEntry[]>([])
@@ -856,6 +869,8 @@ export const ChatTab: React.FC<Props> = ({
   const [slashCommands, setSlashCommands] = useState<Array<{ name: string; description: string; source: 'agent' | 'gateway' | 'skill' }>>([])
   const [slashIdx, setSlashIdx] = useState(0)
   const slashMenuRef = useRef<HTMLDivElement>(null)
+  const mentionMenuRef = useRef<HTMLDivElement>(null)
+  const highlightRef = useRef<HTMLDivElement>(null)
   const [panelTab, setPanelTab] = useState<ContextPanelTab>('current')
   const qqInputRef = useRef<HTMLTextAreaElement>(null)
   const { ask: askQuickQuestion } = useQuickQuestion()
@@ -1369,6 +1384,62 @@ export const ChatTab: React.FC<Props> = ({
     : []
   const showSlashMenu = filteredSlash.length > 0
 
+  // ── "@" file mentions ─────────────────────────────────────────────
+  // The index is fetched lazily: only once the user actually opens a mention,
+  // and never while the composer has no working dir to index.
+  useEffect(() => {
+    if (!mention || !workingDir) return
+    let stale = false
+    window.codey.workspaceFiles.list(workingDir).then(r => {
+      if (!stale && r.ok) setFileIndex(r.data)
+    })
+    return () => { stale = true }
+  }, [mention !== null, workingDir]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // A chat can be rebound to a different worktree while mounted; the old
+  // repo's paths must not linger in the menu.
+  useEffect(() => { setFileIndex([]) }, [workingDir])
+
+  const mentionMatches = mention ? filterEntries(fileIndex, mention.query) : []
+  const showMentionMenu = mentionMatches.length > 0
+  useEffect(() => { setMentionIdx(0) }, [mention?.query, mention?.start])
+  useEffect(() => {
+    const el = mentionMenuRef.current?.children[mentionIdx] as HTMLElement | undefined
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [mentionIdx])
+
+  /** Re-read the caret after any edit/selection change and refresh the token. */
+  const syncMention = useCallback((text?: string) => {
+    const ta = taRef.current
+    if (!ta) return
+    setMention(findActiveMention(text ?? ta.value, ta.selectionStart ?? 0))
+  }, [])
+
+  // Sending, clearing, or restoring a draft all go through setInput without a
+  // caret event, so close the menu whenever the composer empties out.
+  useEffect(() => { if (!input) setMention(null) }, [input])
+
+  const knownPaths = React.useMemo(() => new Set(fileIndex.map(e => e.path)), [fileIndex])
+  const inputSegments = React.useMemo(
+    () => splitMentionSegments(input, p => knownPaths.has(p)),
+    [input, knownPaths],
+  )
+
+  const chooseMention = (entry: MentionFile) => {
+    if (!mention) return
+    const next = applyMention(input, mention, entry.path, entry.isDir)
+    setInputHistoryIndex(null)
+    setInput(next.text)
+    requestAnimationFrame(() => {
+      const ta = taRef.current
+      if (!ta) return
+      ta.focus()
+      try { ta.setSelectionRange(next.caret, next.caret) } catch { /* unsupported */ }
+      // A directory keeps the menu open so the next segment can be picked.
+      setMention(findActiveMention(next.text, next.caret))
+    })
+  }
+
   const onAgentChange = async (v: string) => {
     const nextAgent = v === '' ? null : v
     // Clear the model override when switching agents — the previous model id
@@ -1537,6 +1608,32 @@ export const ChatTab: React.FC<Props> = ({
   }
 
   const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // The mention menu claims the arrow/Enter keys first — it is only open when
+    // the caret is inside an "@" token, so it never shadows history navigation.
+    if (showMentionMenu) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setMentionIdx(i => Math.min(i + 1, mentionMatches.length - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setMentionIdx(i => Math.max(i - 1, 0))
+        return
+      }
+      if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+        e.preventDefault()
+        const entry = mentionMatches[mentionIdx]
+        if (entry) chooseMention(entry)
+        return
+      }
+      if (e.key === 'Escape') {
+        // Dismiss the menu only — the typed text stays put.
+        e.preventDefault()
+        setMention(null)
+        return
+      }
+    }
     if (showSlashMenu) {
       if (e.key === 'ArrowDown') {
         e.preventDefault()
@@ -2264,6 +2361,24 @@ export const ChatTab: React.FC<Props> = ({
             ))}
           </div>
         )}
+        {showMentionMenu && (
+          <div ref={mentionMenuRef} style={styles.slashMenu}>
+            {mentionMatches.map((entry, i) => (
+              <div
+                key={entry.path}
+                style={{ ...styles.slashMenuItem, ...(i === mentionIdx ? styles.slashMenuItemActive : {}) }}
+                onMouseDown={e => { e.preventDefault(); chooseMention(entry) }}
+                onMouseEnter={() => setMentionIdx(i)}
+              >
+                <span style={styles.mentionIcon}>
+                  {entry.isDir ? <FolderIcon color={C.fg3} size={13} /> : <FileIcon color={C.fg3} size={13} />}
+                </span>
+                <span style={styles.slashCmdName}>{entry.name}{entry.isDir ? '/' : ''}</span>
+                <span style={styles.slashCmdDesc}>{entry.path}</span>
+              </div>
+            ))}
+          </div>
+        )}
         {uploadError && (
           <div style={styles.uploadError}>{uploadError}</div>
         )}
@@ -2307,24 +2422,46 @@ export const ChatTab: React.FC<Props> = ({
             </div>
           )}
           <div style={styles.composerInputRow}>
-            <textarea
-              ref={taRef}
-              value={input}
-              onChange={e => { setInputHistoryIndex(null); setInput(e.target.value) }}
-              onKeyDown={handleKey}
-              onInput={e => {
-                if (composerHeight != null) return // manual height pinned
-                const el = e.currentTarget
-                el.style.height = 'auto'
-                el.style.height = Math.min(el.scrollHeight, 120) + 'px'
-              }}
-              placeholder={composerPlaceholder({ coreFailed: !!coreFailed, isGatewayRunning, isSending })}
-              disabled={!isGatewayRunning || !!coreFailed}
-              rows={1}
-              style={composerHeight != null
-                ? { ...styles.input, height: composerHeight, maxHeight: 'none' }
-                : styles.input}
-            />
+            {/* The textarea sits on a mirror layer that paints a pill behind
+                every resolved "@" mention. The mirror renders the same text in
+                the same metrics but fully transparent, so only the pills show
+                through and the real text/caret/selection stay in the textarea. */}
+            <div style={styles.composerInputStack}>
+              <div
+                ref={highlightRef}
+                aria-hidden
+                style={composerHeight != null
+                  ? { ...styles.inputHighlight, height: composerHeight, maxHeight: 'none' }
+                  : styles.inputHighlight}
+              >
+                {inputSegments.map((seg, i) => (
+                  <span key={i} style={seg.isMention ? styles.inputHighlightMention : undefined}>{seg.text}</span>
+                ))}
+              </div>
+              <textarea
+                ref={taRef}
+                value={input}
+                onChange={e => { setInputHistoryIndex(null); setInput(e.target.value); syncMention(e.target.value) }}
+                onKeyDown={handleKey}
+                onKeyUp={() => syncMention()}
+                onClick={() => syncMention()}
+                onBlur={() => setMention(null)}
+                onScroll={e => { if (highlightRef.current) highlightRef.current.scrollTop = e.currentTarget.scrollTop }}
+                onInput={e => {
+                  if (composerHeight != null) return // manual height pinned
+                  const el = e.currentTarget
+                  el.style.height = 'auto'
+                  el.style.height = Math.min(el.scrollHeight, 120) + 'px'
+                  if (highlightRef.current) highlightRef.current.style.height = el.style.height
+                }}
+                placeholder={composerPlaceholder({ coreFailed: !!coreFailed, isGatewayRunning, isSending })}
+                disabled={!isGatewayRunning || !!coreFailed}
+                rows={1}
+                style={composerHeight != null
+                  ? { ...styles.input, height: composerHeight, maxHeight: 'none' }
+                  : styles.input}
+              />
+            </div>
           </div>
           <div style={styles.composerToolbar}>
             <input
@@ -2728,7 +2865,23 @@ const styles: Record<string, React.CSSProperties> = {
     width: '100%', background: 'transparent', border: 'none', borderRadius: 8,
     color: C.fg, fontSize: 13, padding: '4px 2px', outline: 'none', resize: 'none',
     lineHeight: 1.5, maxHeight: 120, overflowY: 'auto',
+    position: 'relative' as const, zIndex: 1,
   },
+  composerInputStack: { position: 'relative' as const, flex: 1, minWidth: 0 },
+  // Must mirror `input`'s box and text metrics exactly, or the mention pills
+  // drift away from the characters they sit behind.
+  inputHighlight: {
+    position: 'absolute' as const, inset: 0, pointerEvents: 'none' as const,
+    fontSize: 13, padding: '4px 2px', lineHeight: 1.5,
+    maxHeight: 120, overflow: 'hidden' as const,
+    whiteSpace: 'pre-wrap' as const, overflowWrap: 'break-word' as const,
+    color: 'transparent',
+  },
+  inputHighlightMention: {
+    background: 'rgba(43,230,155,0.18)', borderRadius: 4,
+    boxShadow: '0 0 0 1px rgba(43,230,155,0.35)',
+  },
+  mentionIcon: { display: 'flex', alignItems: 'center', flexShrink: 0 },
   sendButton: {
     width: 38, height: 38, borderRadius: 11, border: 'none',
     display: 'flex', alignItems: 'center', justifyContent: 'center',

--- a/codey-mac/src/components/mentions.test.ts
+++ b/codey-mac/src/components/mentions.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import { applyMention, filterEntries, findActiveMention, scoreEntry, splitMentionSegments } from './mentions'
+
+/** Mirror of the main-process index shape: files plus their ancestor dirs. */
+const toEntries = (paths: string[]) => {
+  const dirs = new Set<string>()
+  for (const p of paths) {
+    const segs = p.split('/')
+    for (let i = 1; i < segs.length; i++) dirs.add(segs.slice(0, i).join('/'))
+  }
+  return [
+    ...[...dirs].map(path => ({ path, name: path.split('/').pop() as string, isDir: true })),
+    ...paths.map(path => ({ path, name: path.split('/').pop() as string, isDir: false })),
+  ]
+}
+
+describe('findActiveMention', () => {
+  it('finds a mention being typed at the start of the input', () => {
+    expect(findActiveMention('@src', 4)).toEqual({ start: 0, end: 4, query: 'src' })
+  })
+
+  it('finds a mention after a space', () => {
+    expect(findActiveMention('look at @src/app', 16)).toEqual({ start: 8, end: 16, query: 'src/app' })
+  })
+
+  it('finds a mention at the start of a later line', () => {
+    expect(findActiveMention('one\n@two', 8)).toEqual({ start: 4, end: 8, query: 'two' })
+  })
+
+  it('matches a bare @ with an empty query', () => {
+    expect(findActiveMention('@', 1)).toEqual({ start: 0, end: 1, query: '' })
+  })
+
+  it('ignores an @ glued to preceding text, like an email', () => {
+    expect(findActiveMention('me@example.com', 14)).toBeNull()
+  })
+
+  it('returns null once the token contains whitespace', () => {
+    expect(findActiveMention('@src file', 9)).toBeNull()
+  })
+
+  it('returns null when the caret sits before the @', () => {
+    expect(findActiveMention('@src', 0)).toBeNull()
+  })
+
+  it('stops the token at the caret so trailing text is untouched', () => {
+    expect(findActiveMention('@srcXY', 4)).toEqual({ start: 0, end: 4, query: 'src' })
+  })
+
+  it('returns null when there is no @ at all', () => {
+    expect(findActiveMention('plain text', 10)).toBeNull()
+  })
+})
+
+describe('applyMention', () => {
+  it('replaces the active token and appends a trailing space', () => {
+    const mention = { start: 0, end: 4, query: 'src' }
+    expect(applyMention('@src', mention, 'src/app.ts')).toEqual({ text: '@src/app.ts ', caret: 12 })
+  })
+
+  it('appends a trailing slash instead of a space for a directory', () => {
+    const mention = { start: 0, end: 4, query: 'src' }
+    expect(applyMention('@src', mention, 'src/components', true)).toEqual({ text: '@src/components/', caret: 16 })
+  })
+
+  it('keeps text on both sides of the token intact', () => {
+    const mention = { start: 5, end: 9, query: 'app' }
+    const result = applyMention('read @app now', mention, 'src/app.ts')
+    expect(result.text).toBe('read @src/app.ts  now')
+    expect(result.caret).toBe(17)
+  })
+
+  it('quotes a path containing a space so the token stays one unit', () => {
+    const mention = { start: 0, end: 3, query: 'my' }
+    expect(applyMention('@my', mention, 'my docs/a.ts').text).toBe('@"my docs/a.ts" ')
+  })
+})
+
+describe('splitMentionSegments', () => {
+  const known = (p: string) => ['src/app.ts', 'src/components'].includes(p)
+
+  it('marks a known path as a mention', () => {
+    expect(splitMentionSegments('see @src/app.ts here', known)).toEqual([
+      { text: 'see ', isMention: false },
+      { text: '@src/app.ts', isMention: true },
+      { text: ' here', isMention: false },
+    ])
+  })
+
+  it('leaves an unknown path as plain text', () => {
+    expect(splitMentionSegments('see @nope.ts', known)).toEqual([{ text: 'see @nope.ts', isMention: false }])
+  })
+
+  it('recognises a directory mention with a trailing slash', () => {
+    expect(splitMentionSegments('@src/components/', known)).toEqual([
+      { text: '@src/components/', isMention: true },
+    ])
+  })
+
+  it('recognises a quoted path with a space', () => {
+    const withSpace = (p: string) => p === 'my docs/a.ts'
+    expect(splitMentionSegments('@"my docs/a.ts" ok', withSpace)).toEqual([
+      { text: '@"my docs/a.ts"', isMention: true },
+      { text: ' ok', isMention: false },
+    ])
+  })
+
+  it('does not treat an email address as a mention', () => {
+    const anything = () => true
+    expect(splitMentionSegments('me@example.com', anything)).toEqual([
+      { text: 'me@example.com', isMention: false },
+    ])
+  })
+
+  it('marks several mentions in one line', () => {
+    const segments = splitMentionSegments('@src/app.ts and @src/components', known)
+    expect(segments.filter(s => s.isMention).map(s => s.text)).toEqual(['@src/app.ts', '@src/components'])
+  })
+
+  it('returns a single plain segment for text without mentions', () => {
+    expect(splitMentionSegments('hello', known)).toEqual([{ text: 'hello', isMention: false }])
+  })
+
+  it('returns nothing for empty text', () => {
+    expect(splitMentionSegments('', known)).toEqual([])
+  })
+})
+
+describe('scoreEntry', () => {
+  const entry = (path: string, isDir = false) => ({ path, name: path.split('/').pop() as string, isDir })
+
+  it('returns null when the query does not match at all', () => {
+    expect(scoreEntry(entry('src/a.ts'), 'zzz')).toBeNull()
+  })
+
+  it('ranks an exact filename above a weaker match on the same query', () => {
+    const exact = scoreEntry(entry('src/tab.ts'), 'tab.ts') as number
+    const scattered = scoreEntry(entry('src/tab-extra.ts'), 'tab.ts') as number
+    expect(exact).toBeGreaterThan(scattered)
+  })
+
+  it('ranks a name prefix above a name substring', () => {
+    const prefix = scoreEntry(entry('src/chatty.ts'), 'chat') as number
+    const substring = scoreEntry(entry('src/mychat.ts'), 'chat') as number
+    expect(prefix).toBeGreaterThan(substring)
+  })
+
+  it('ranks a name match above a directory-only path match', () => {
+    const nameHit = scoreEntry(entry('lib/chat.ts'), 'chat') as number
+    const pathHit = scoreEntry(entry('chat/index.ts'), 'chat') as number
+    expect(nameHit).toBeGreaterThan(pathHit)
+  })
+
+  it('prefers shallower paths at the same match quality', () => {
+    const shallow = scoreEntry(entry('a.ts'), 'a.ts') as number
+    const deep = scoreEntry(entry('x/y/z/a.ts'), 'a.ts') as number
+    expect(shallow).toBeGreaterThan(deep)
+  })
+
+  it('matches a scattered subsequence as a last resort', () => {
+    expect(scoreEntry(entry('src/components/ChatTab.tsx'), 'sccht')).not.toBeNull()
+  })
+
+  it('is case-insensitive', () => {
+    expect(scoreEntry(entry('src/ChatTab.tsx'), 'chattab')).not.toBeNull()
+  })
+
+  it('scores every entry as equal for an empty query', () => {
+    expect(scoreEntry(entry('anything.ts'), '')).toBe(0)
+  })
+})
+
+describe('filterEntries', () => {
+  const entries = toEntries([
+    'src/components/ChatTab.tsx',
+    'src/components/ChatListPanel.tsx',
+    'src/gateway.ts',
+    'README.md',
+  ])
+
+  it('puts the closest filename match first', () => {
+    expect(filterEntries(entries, 'chattab')[0].path).toBe('src/components/ChatTab.tsx')
+  })
+
+  it('honours the result limit', () => {
+    expect(filterEntries(entries, '', 2)).toHaveLength(2)
+  })
+
+  it('matches directories as well as files', () => {
+    expect(filterEntries(entries, 'components').some(e => e.isDir && e.path === 'src/components')).toBe(true)
+  })
+
+  it('returns nothing when no entry matches', () => {
+    expect(filterEntries(entries, 'nonexistentthing')).toEqual([])
+  })
+
+  it('supports a path fragment containing a slash', () => {
+    expect(filterEntries(entries, 'components/chatl')[0].path).toBe('src/components/ChatListPanel.tsx')
+  })
+})

--- a/codey-mac/src/components/mentions.ts
+++ b/codey-mac/src/components/mentions.ts
@@ -1,0 +1,142 @@
+// Parsing for "@path" file mentions in the composer.
+//
+// Two jobs, both pure so they can be unit-tested away from React:
+//   - findActiveMention/applyMention drive the autocomplete menu
+//   - splitMentionSegments drives the highlight overlay behind the textarea
+
+/** One indexed workspace path, as returned by the `workspace:files` IPC. */
+export type MentionFile = { path: string; name: string; isDir: boolean }
+
+export type ActiveMention = {
+  /** Index of the "@" in the input. */
+  start: number
+  /** Exclusive end of the token — always the caret position. */
+  end: number
+  /** Text between the "@" and the caret. */
+  query: string
+}
+
+export type MentionSegment = { text: string; isMention: boolean }
+
+/** True for the characters that may sit directly before a mention's "@". */
+const isBoundary = (ch: string | undefined) => ch === undefined || /\s/.test(ch)
+
+/**
+ * The mention the caret is currently inside, or null. A mention only starts at
+ * the beginning of the input or after whitespace, so email addresses and
+ * decorators never open the menu.
+ */
+export function findActiveMention(text: string, caret: number): ActiveMention | null {
+  for (let i = caret - 1; i >= 0; i--) {
+    const ch = text[i]
+    if (/\s/.test(ch)) return null
+    if (ch === '@') {
+      if (!isBoundary(text[i - 1])) return null
+      return { start: i, end: caret, query: text.slice(i + 1, caret) }
+    }
+  }
+  return null
+}
+
+/** Wrap in quotes only when the path would otherwise break at a space. */
+const formatPath = (path: string) => (/\s/.test(path) ? `"${path}"` : path)
+
+/**
+ * Replace the active token with the chosen path. Directories keep the caret
+ * glued to a trailing slash so the next keystroke drills further in; files get
+ * a trailing space so typing continues normally.
+ */
+export function applyMention(
+  text: string,
+  mention: ActiveMention,
+  path: string,
+  isDir = false,
+): { text: string; caret: number } {
+  const inserted = `@${formatPath(path)}${isDir ? '/' : ' '}`
+  return {
+    text: text.slice(0, mention.start) + inserted + text.slice(mention.end),
+    caret: mention.start + inserted.length,
+  }
+}
+
+/** Depth-first subsequence match — every query char appears in order. */
+function subsequenceIndex(haystack: string, needle: string): number {
+  let hi = 0
+  let first = -1
+  for (let ni = 0; ni < needle.length; ni++) {
+    const ch = needle[ni]
+    let found = -1
+    while (hi < haystack.length) {
+      if (haystack[hi] === ch) { found = hi; hi++; break }
+      hi++
+    }
+    if (found === -1) return -1
+    if (first === -1) first = found
+  }
+  return first
+}
+
+/**
+ * Rank one entry against the query. Higher is better; `null` means no match.
+ * Ordering intent: exact name > name prefix > name substring > path substring >
+ * scattered subsequence, with shallower and shorter paths breaking ties.
+ */
+export function scoreEntry(entry: MentionFile, query: string): number | null {
+  if (!query) return 0
+  const q = query.toLowerCase()
+  const name = entry.name.toLowerCase()
+  const path = entry.path.toLowerCase()
+
+  let base: number
+  if (name === q) base = 6000
+  else if (name.startsWith(q)) base = 5000
+  else if (name.includes(q)) base = 4000
+  else if (path.startsWith(q)) base = 3000
+  else if (path.includes(q)) base = 2000
+  else if (subsequenceIndex(path, q) !== -1) base = 1000
+  else return null
+
+  const depth = entry.path.split('/').length
+  return base - depth * 10 - Math.min(entry.path.length, 200) / 10
+}
+
+/** Best `limit` entries for `query`, already ordered for display. */
+export function filterEntries(entries: MentionFile[], query: string, limit = 12): MentionFile[] {
+  const scored: Array<{ entry: MentionFile; score: number }> = []
+  for (const entry of entries) {
+    const score = scoreEntry(entry, query)
+    if (score === null) continue
+    scored.push({ entry, score })
+  }
+  scored.sort((a, b) => (b.score - a.score) || a.entry.path.localeCompare(b.entry.path))
+  return scored.slice(0, limit).map(s => s.entry)
+}
+
+const MENTION_RE = /(^|\s)@("[^"\n]*"|\S+)/g
+
+/**
+ * Split `text` into alternating plain and mention segments. Only tokens that
+ * `isKnownPath` recognises are highlighted, so a half-typed path stays plain
+ * until it actually resolves to something in the workspace.
+ */
+export function splitMentionSegments(text: string, isKnownPath: (path: string) => boolean): MentionSegment[] {
+  if (!text) return []
+  const segments: MentionSegment[] = []
+  let plainFrom = 0
+
+  MENTION_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = MENTION_RE.exec(text)) !== null) {
+    const tokenStart = match.index + match[1].length
+    const token = `@${match[2]}`
+    const raw = match[2].startsWith('"') ? match[2].slice(1, -1) : match[2]
+    const path = raw.endsWith('/') ? raw.slice(0, -1) : raw
+    if (!path || !isKnownPath(path)) continue
+    if (tokenStart > plainFrom) segments.push({ text: text.slice(plainFrom, tokenStart), isMention: false })
+    segments.push({ text: token, isMention: true })
+    plainFrom = tokenStart + token.length
+  }
+
+  if (plainFrom < text.length) segments.push({ text: text.slice(plainFrom), isMention: false })
+  return segments
+}


### PR DESCRIPTION
Closes #239.

Typing `@` in the chat composer opens a file/folder picker scoped to the chat's working dir, and a chosen path gets highlighted in the input.

### How it works

**Index (`electron/workspace-files.ts` + `workspace:files` IPC)** — `git ls-files -z --cached --others --exclude-standard`, so `.gitignore` filtering comes for free. Non-repo working dirs fall back to a bounded walk that skips `node_modules`, `dist`, `.venv`, etc. Cached 5s per working dir, and fetched lazily — nothing is indexed until an `@` is actually typed. Capped at 20k entries.

**Menu (`ChatTab.tsx`)** — reuses the slash-menu shell and keybindings: ↑/↓ to move, Tab/Enter to pick, Esc to dismiss, mouse hover/click. Picking a directory appends `/` and keeps the menu open so you can drill in; picking a file appends a space. Paths containing spaces are quoted.

**Highlight** — a transparent mirror layer behind the textarea paints a pill behind each resolved mention. The real text, caret, and selection stay in the textarea, so nothing about typing or selection behaviour changes. Only tokens that resolve to a real indexed path light up, so a half-typed path stays plain.

**Ranking (`src/components/mentions.ts`)** — exact name > name prefix > name substring > path substring > scattered subsequence, with shallower/shorter paths breaking ties. Runs in the renderer, so filtering is instant with no IPC per keystroke.

### Notes

- Mentions only open at the start of the input or after whitespace, so email addresses and decorators never trigger the menu.
- The index is cleared when a chat is rebound to a different worktree.

### Testing

45 new unit tests across the two pure modules (parsing, ranking, segment splitting, the git/fs listing). Full suite green: 297 core+gateway, 469 codey-mac, `npm run lint` clean, `tsc --noEmit` clean.

Not yet exercised in the running app — the menu and the highlight overlay alignment want a quick live look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)