### PR TITLE
Refresh app themes and palette picker

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -23,11 +23,7 @@ import {
   getStoredThemeMode,
   getStoredPalette,
   resolveEffectiveTheme,
-  paletteToCssVars,
-  classicLight,
-  classicDark,
-  terminalLight,
-  terminalDark,
+  paletteThemeCss,
 } from './theme'
 
 const clampLeftPanelWidth = (width: number) => {
@@ -366,30 +362,8 @@ const Shell: React.FC = () => {
         {!activeChat && <VoiceHotkeyFallback />}
       </div>
       <style>{`
-  /* Fallback (classic) until data-theme / data-palette are set. */
-  :root {
-${paletteToCssVars(classicDark)}
-  }
-  :root[data-theme="light"] {
-${paletteToCssVars(classicLight)}
-  }
-  :root[data-theme="dark"] {
-${paletteToCssVars(classicDark)}
-  }
-  /* Classic theme */
-  :root[data-palette="classic"][data-theme="light"] {
-${paletteToCssVars(classicLight)}
-  }
-  :root[data-palette="classic"][data-theme="dark"] {
-${paletteToCssVars(classicDark)}
-  }
-  /* Terminal theme */
-  :root[data-palette="terminal"][data-theme="light"] {
-${paletteToCssVars(terminalLight)}
-  }
-  :root[data-palette="terminal"][data-theme="dark"] {
-${paletteToCssVars(terminalDark)}
-  }
+  /* Fallback plus every palette's light/dark variant. */
+  ${paletteThemeCss()}
   html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
   /* Roomy headings open a section with a large top margin. The first block in a
      turn has nothing above it to separate from, so that margin is dead space. */

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -1,6 +1,6 @@
 // codey-mac/src/components/AppearanceTab.tsx
 import React from 'react'
-import { C, ThemeMode, PaletteName, PALETTES, useThemeMode, useEffectiveTheme, usePaletteName } from '../theme'
+import { C, ThemeMode, PaletteName, PaletteDefinition, PALETTES, useThemeMode, useEffectiveTheme, usePaletteName } from '../theme'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import { Section, pageStyle } from './settingsAtoms'
 import { getStatusPanelEnabled, setStatusPanelEnabled } from './statusPanelPref'
@@ -11,10 +11,7 @@ const OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: 'system', label: 'System' },
 ]
 
-const PALETTE_OPTIONS: { value: PaletteName; label: string }[] = [
-  { value: 'classic',  label: PALETTES.classic.label  },
-  { value: 'terminal', label: PALETTES.terminal.label },
-]
+const PALETTE_OPTIONS = Object.entries(PALETTES) as [PaletteName, PaletteDefinition][]
 
 const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
   <div onClick={() => onChange(!on)} style={{
@@ -35,6 +32,7 @@ export const AppearanceTab: React.FC = () => {
   const [mode, setMode] = useThemeMode()
   const [palette, setPalette] = usePaletteName()
   const effective = useEffectiveTheme()
+  const previewMode = mode === 'system' ? effective : mode
   const [version, setVersion] = React.useState<string>('')
   const [skipPerms, setSkipPerms] = React.useState<boolean>(true)
   const [notifyEnabled, setNotifyEnabled] = React.useState<boolean>(true)
@@ -126,25 +124,42 @@ export const AppearanceTab: React.FC = () => {
         </div>
       </div>
 
-      <div style={styles.settingRow}>
-        <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
-          <div>Theme</div>
-          <div style={styles.settingDesc}>
-            {palette === 'terminal'
-              ? 'Warm paper and terminal green.'
-              : 'The original macOS-style colors.'}
-          </div>
+      <div style={{ ...styles.settingRow, ...styles.themeRow }}>
+        <div style={{ ...styles.label, width: 'auto' }}>
+          <div>Color theme</div>
+          <div style={styles.settingDesc}>Choose a palette. Each one adapts to Light and Dark mode.</div>
         </div>
-        <select
-          aria-label="Color theme"
-          value={palette}
-          onChange={(e) => setPalette(e.target.value as PaletteName)}
-          style={styles.select}
-        >
-          {PALETTE_OPTIONS.map(opt => (
-            <option key={opt.value} value={opt.value}>{opt.label}</option>
-          ))}
-        </select>
+        <div role="radiogroup" aria-label="Color theme" style={styles.paletteGrid}>
+          {PALETTE_OPTIONS.map(([name, definition]) => {
+            const active = palette === name
+            const preview = definition[previewMode]
+            return (
+              <button
+                key={name}
+                role="radio"
+                aria-checked={active}
+                onClick={() => setPalette(name)}
+                style={{
+                  ...styles.paletteCard,
+                  background: active ? C.accentDim : C.surface2,
+                  borderColor: active ? C.accent : C.border,
+                  boxShadow: active ? `0 0 0 1px ${C.accentDim}` : 'none',
+                }}
+              >
+                <span style={{ ...styles.palettePreview, background: preview.bg, borderColor: preview.border2 }}>
+                  <span style={{ ...styles.previewSidebar, background: preview.surface }} />
+                  <span style={{ ...styles.previewLine, background: preview.fg3 }} />
+                  <span style={{ ...styles.previewAccent, background: preview.accent }} />
+                </span>
+                <span style={styles.paletteCopy}>
+                  <span style={{ ...styles.paletteName, color: active ? C.accent : C.fg }}>{definition.label}</span>
+                  <span style={styles.paletteDescription}>{definition.description}</span>
+                </span>
+                <span aria-hidden="true" style={{ ...styles.check, opacity: active ? 1 : 0 }}>✓</span>
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       <div style={styles.settingRow}>
@@ -274,16 +289,22 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     cursor: 'pointer',
   },
-  select: {
-    background: C.surface2,
-    color: C.fg,
-    border: `1px solid ${C.border}`,
-    borderRadius: 8,
-    padding: '8px 10px',
-    fontSize: 12,
-    fontWeight: 500,
-    cursor: 'pointer',
-    minWidth: 140,
+  themeRow: { flexDirection: 'column', alignItems: 'stretch', gap: 12 },
+  paletteGrid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 8 },
+  paletteCard: {
+    minWidth: 0, display: 'flex', alignItems: 'center', gap: 10, position: 'relative',
+    padding: 10, border: '1px solid', borderRadius: 10, cursor: 'pointer', textAlign: 'left',
   },
+  palettePreview: {
+    width: 48, height: 36, flexShrink: 0, position: 'relative', overflow: 'hidden',
+    border: '1px solid', borderRadius: 7,
+  },
+  previewSidebar: { position: 'absolute', inset: '0 auto 0 0', width: 14 },
+  previewLine: { position: 'absolute', left: 20, top: 10, width: 18, height: 3, borderRadius: 2, opacity: 0.72 },
+  previewAccent: { position: 'absolute', left: 20, top: 19, width: 21, height: 8, borderRadius: 4 },
+  paletteCopy: { minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 },
+  paletteName: { fontSize: 12, fontWeight: 650 },
+  paletteDescription: { color: C.fg3, fontSize: 10, lineHeight: 1.35 },
+  check: { marginLeft: 'auto', color: C.accent, fontSize: 12, fontWeight: 800 },
   value: { fontSize: 13, color: C.fg2, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' },
 }

--- a/codey-mac/src/components/CaptureWindow.tsx
+++ b/codey-mac/src/components/CaptureWindow.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   C, applyTheme, applyPalette, getStoredThemeMode, getStoredPalette,
-  paletteToCssVars, classicLight, classicDark, terminalLight, terminalDark,
+  paletteThemeCss,
 } from '../theme'
 
 // Spotlight-style capture UI rendered in its own frameless BrowserWindow
@@ -232,13 +232,7 @@ export const CaptureWindow: React.FC = () => {
       {error && <div style={styles.error}>{error}</div>}
       <style>{`
   /* Same theme matrix as App.tsx so applyTheme/applyPalette take effect. */
-  :root { ${paletteToCssVars(classicDark)} }
-  :root[data-theme="light"] { ${paletteToCssVars(classicLight)} }
-  :root[data-theme="dark"] { ${paletteToCssVars(classicDark)} }
-  :root[data-palette="classic"][data-theme="light"] { ${paletteToCssVars(classicLight)} }
-  :root[data-palette="classic"][data-theme="dark"] { ${paletteToCssVars(classicDark)} }
-  :root[data-palette="terminal"][data-theme="light"] { ${paletteToCssVars(terminalLight)} }
-  :root[data-palette="terminal"][data-theme="dark"] { ${paletteToCssVars(terminalDark)} }
+  ${paletteThemeCss()}
   html, body, #root { margin: 0; background: transparent; }
   body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; }
   * { box-sizing: border-box; }

--- a/codey-mac/src/theme.ts
+++ b/codey-mac/src/theme.ts
@@ -6,7 +6,7 @@ export type EffectiveTheme = 'light' | 'dark'
 
 const STORAGE_KEY = 'codey.theme'
 
-interface Palette {
+export interface Palette {
   bg: string
   surface: string
   surface2: string
@@ -52,73 +52,73 @@ interface Palette {
 
 // ---- Classic: the original macOS-style look (Apple blue + neutral grays) ----
 export const classicDark: Palette = {
-  bg:        '#10131b',
-  surface:   '#171b26',
-  surface2:  '#1d2230',
-  surface3:  '#262d3d',
-  border:    '#293144',
-  border2:   '#374159',
-  fg:        '#f2f5fb',
-  fg2:       '#aeb8cc',
-  fg3:       '#71809b',
-  accent:    '#6d7cff',
-  accentDim: '#6d7cff22',
-  green:     '#32D74B',
-  purple:    '#A371F7',
-  red:       '#FF453A',
-  yellow:    '#FFD60A',
-  userBg:    '#6475f5',
-  onAccent:  '#ffffff',
-  aiBg:      '#1b2030',
-  scrollbar: '#3b465e',
-  dangerBg:      '#3a1a1a',
-  dangerBorder:  '#6a2a2a',
-  dangerFg:      '#ff8080',
-  codeBg:        '#141414',
-  codeFg:        '#e6e6e6',
-  inlineCodeBg:  '#1a1a1a',
-  inlineCodeFg:  '#e6e6e6',
-  logBg:         '#0d0d0d',
-  logFg:         '#6a9955',
-  warningBg:     '#ff950033',
-  warningFg:     '#ffb84d',
-  sidebarBg:     'rgba(23, 27, 38, 0.76)',
-  sidebarBorder: 'rgba(84, 100, 132, 0.44)',
+  bg:        '#0e1116',
+  surface:   '#151920',
+  surface2:  '#1b2029',
+  surface3:  '#242b36',
+  border:    '#252c37',
+  border2:   '#343e4d',
+  fg:        '#edf1f7',
+  fg2:       '#aab4c2',
+  fg3:       '#737f90',
+  accent:    '#74a7ff',
+  accentDim: '#74a7ff20',
+  green:     '#48c78e',
+  purple:    '#b18cff',
+  red:       '#ff7168',
+  yellow:    '#e8bd61',
+  userBg:    '#74a7ff',
+  onAccent:  '#0a1626',
+  aiBg:      '#171c24',
+  scrollbar: '#374250',
+  dangerBg:      '#351b1d',
+  dangerBorder:  '#653035',
+  dangerFg:      '#ff928b',
+  codeBg:        '#0b0e12',
+  codeFg:        '#dce4ee',
+  inlineCodeBg:  '#202731',
+  inlineCodeFg:  '#9dc0ff',
+  logBg:         '#090c10',
+  logFg:         '#66d6a3',
+  warningBg:     '#382d19',
+  warningFg:     '#edc573',
+  sidebarBg:     'rgba(21, 25, 32, 0.82)',
+  sidebarBorder: 'rgba(64, 76, 94, 0.58)',
 }
 
 export const classicLight: Palette = {
-  bg:        '#f6f7fb',
+  bg:        '#f4f6f9',
   surface:   '#ffffff',
-  surface2:  '#f9faff',
-  surface3:  '#edf0f7',
-  border:    '#e0e5f0',
-  border2:   '#d3dae9',
-  fg:        '#172033',
-  fg2:       '#536078',
-  fg3:       '#7f8aa1',
-  accent:    '#5265e8',
-  accentDim: '#5265e81c',
-  green:     '#34C759',
-  purple:    '#8250DF',
-  red:       '#FF3B30',
-  yellow:    '#FFCC00',
-  userBg:    '#5265e8',
+  surface2:  '#f8f9fb',
+  surface3:  '#e9edf2',
+  border:    '#dde2e8',
+  border2:   '#cdd4dd',
+  fg:        '#18202b',
+  fg2:       '#546171',
+  fg3:       '#7d8997',
+  accent:    '#3377d5',
+  accentDim: '#3377d51a',
+  green:     '#17865b',
+  purple:    '#7557b7',
+  red:       '#d84942',
+  yellow:    '#a66f08',
+  userBg:    '#3377d5',
   onAccent:  '#ffffff',
   aiBg:      '#ffffff',
-  scrollbar: '#cbd3e1',
-  dangerBg:      '#FFE5E5',
-  dangerBorder:  '#FFB3B3',
-  dangerFg:      '#C92A2A',
-  codeBg:        '#f5f5f7',
-  codeFg:        '#1d1d1f',
-  inlineCodeBg:  '#ebebef',
-  inlineCodeFg:  '#1d1d1f',
-  logBg:         '#fafafa',
-  logFg:         '#28792B',
-  warningBg:     '#FFE9C4',
-  warningFg:     '#A85D00',
-  sidebarBg:     'rgba(255, 255, 255, 0.76)',
-  sidebarBorder: 'rgba(211, 218, 233, 0.76)',
+  scrollbar: '#c5ccd5',
+  dangerBg:      '#fbe9e8',
+  dangerBorder:  '#efc2bf',
+  dangerFg:      '#ad332d',
+  codeBg:        '#eef1f5',
+  codeFg:        '#202833',
+  inlineCodeBg:  '#e8edf4',
+  inlineCodeFg:  '#285f9f',
+  logBg:         '#f1f4f6',
+  logFg:         '#176b4b',
+  warningBg:     '#f8eed7',
+  warningFg:     '#855b0e',
+  sidebarBg:     'rgba(255, 255, 255, 0.82)',
+  sidebarBorder: 'rgba(205, 212, 221, 0.78)',
 }
 
 // ---- Terminal: warm paper + terminal green; matches the Codey landing page ----
@@ -192,11 +192,84 @@ export const terminalLight: Palette = {
   sidebarBorder: 'rgba(216, 207, 188, 0.72)',
 }
 
-export type PaletteName = 'classic' | 'terminal'
+// ---- Ocean: deep navy surfaces with a crisp cyan signal color ----
+export const oceanDark: Palette = {
+  bg: '#071219', surface: '#0c1a23', surface2: '#10232e', surface3: '#18303d',
+  border: '#19303c', border2: '#274756', fg: '#e8f4f7', fg2: '#9db9c2', fg3: '#668894',
+  accent: '#4bc7e5', accentDim: '#4bc7e520', green: '#54d6a0', purple: '#a99af2', red: '#ff716f', yellow: '#e8c66a',
+  userBg: '#4bc7e5', onAccent: '#041b22', aiBg: '#0e202a', scrollbar: '#28505e',
+  dangerBg: '#351c20', dangerBorder: '#71333b', dangerFg: '#ff9692',
+  codeBg: '#050d12', codeFg: '#d7e8ec', inlineCodeBg: '#142b36', inlineCodeFg: '#74d9ef', logBg: '#040b0f', logFg: '#57d9aa',
+  warningBg: '#342c19', warningFg: '#ebcb79', sidebarBg: 'rgba(9, 25, 34, 0.84)', sidebarBorder: 'rgba(39, 71, 86, 0.64)',
+}
 
-export const PALETTES: Record<PaletteName, { label: string; light: Palette; dark: Palette }> = {
-  classic:  { label: 'Classic',  light: classicLight,  dark: classicDark  },
-  terminal: { label: 'Terminal', light: terminalLight, dark: terminalDark },
+export const oceanLight: Palette = {
+  bg: '#f1f8fa', surface: '#ffffff', surface2: '#f4fafb', surface3: '#e3f0f3',
+  border: '#d7e8ec', border2: '#bfd8de', fg: '#10272f', fg2: '#486873', fg3: '#78949d',
+  accent: '#087f9f', accentDim: '#087f9f18', green: '#16805a', purple: '#6658b1', red: '#cb4545', yellow: '#9a6b0d',
+  userBg: '#087f9f', onAccent: '#ffffff', aiBg: '#ffffff', scrollbar: '#b9d2d8',
+  dangerBg: '#fbe8e8', dangerBorder: '#efc0c0', dangerFg: '#a93434',
+  codeBg: '#e8f2f4', codeFg: '#17323a', inlineCodeBg: '#deedf1', inlineCodeFg: '#076d88', logBg: '#eaf3f1', logFg: '#126b4d',
+  warningBg: '#f7efd9', warningFg: '#7c5912', sidebarBg: 'rgba(247, 252, 253, 0.84)', sidebarBorder: 'rgba(191, 216, 222, 0.78)',
+}
+
+// ---- Dusk: muted plum neutrals with a soft violet accent ----
+export const duskDark: Palette = {
+  bg: '#15121b', surface: '#1c1824', surface2: '#241e2d', surface3: '#30273b',
+  border: '#30283a', border2: '#453951', fg: '#f1ebf5', fg2: '#b8a9c0', fg3: '#85748f',
+  accent: '#c29af4', accentDim: '#c29af420', green: '#68ce9b', purple: '#c29af4', red: '#f27683', yellow: '#ddb96b',
+  userBg: '#c29af4', onAccent: '#21132c', aiBg: '#211b2a', scrollbar: '#493b55',
+  dangerBg: '#391d26', dangerBorder: '#6e3344', dangerFg: '#fa98a3',
+  codeBg: '#100d14', codeFg: '#e8dfee', inlineCodeBg: '#2b2334', inlineCodeFg: '#d5b5fa', logBg: '#0d0a11', logFg: '#79d8a9',
+  warningBg: '#382d1e', warningFg: '#e6c47b', sidebarBg: 'rgba(28, 24, 36, 0.84)', sidebarBorder: 'rgba(69, 57, 81, 0.64)',
+}
+
+export const duskLight: Palette = {
+  bg: '#f8f4fa', surface: '#ffffff', surface2: '#fbf8fc', surface3: '#eee6f2',
+  border: '#e8dfec', border2: '#d7c9dd', fg: '#2b2031', fg2: '#67566f', fg3: '#94839c',
+  accent: '#7651aa', accentDim: '#7651aa18', green: '#287d58', purple: '#7651aa', red: '#bf4655', yellow: '#966711',
+  userBg: '#7651aa', onAccent: '#ffffff', aiBg: '#ffffff', scrollbar: '#d1c3d7',
+  dangerBg: '#fae9ed', dangerBorder: '#edc2cb', dangerFg: '#9f3544',
+  codeBg: '#f0eaf3', codeFg: '#33253a', inlineCodeBg: '#ece3f0', inlineCodeFg: '#684396', logBg: '#f1ecf2', logFg: '#236d4e',
+  warningBg: '#f8efd9', warningFg: '#7b5613', sidebarBg: 'rgba(255, 252, 255, 0.84)', sidebarBorder: 'rgba(215, 201, 221, 0.8)',
+}
+
+// ---- Ember: charcoal and clay with a restrained copper accent ----
+export const emberDark: Palette = {
+  bg: '#171311', surface: '#201a17', surface2: '#29211d', surface3: '#342923',
+  border: '#352a24', border2: '#4a3a31', fg: '#f4ece6', fg2: '#c0ada1', fg3: '#8b766a',
+  accent: '#f08a5d', accentDim: '#f08a5d20', green: '#79c88d', purple: '#b99ae8', red: '#f06f68', yellow: '#e6b85d',
+  userBg: '#f08a5d', onAccent: '#2a1007', aiBg: '#251e1a', scrollbar: '#4d3c33',
+  dangerBg: '#3b1d1c', dangerBorder: '#743530', dangerFg: '#fa958d',
+  codeBg: '#100d0b', codeFg: '#eadfd8', inlineCodeBg: '#30251f', inlineCodeFg: '#f4a47e', logBg: '#0d0a09', logFg: '#82d296',
+  warningBg: '#3a2b18', warningFg: '#e9bd6c', sidebarBg: 'rgba(32, 26, 23, 0.84)', sidebarBorder: 'rgba(74, 58, 49, 0.66)',
+}
+
+export const emberLight: Palette = {
+  bg: '#faf5f1', surface: '#ffffff', surface2: '#fcf8f5', surface3: '#f0e5de',
+  border: '#eadfd8', border2: '#dac9bf', fg: '#30221c', fg2: '#6e594e', fg3: '#9a8478',
+  accent: '#b94f29', accentDim: '#b94f2918', green: '#2c7d4d', purple: '#7559a5', red: '#bd443e', yellow: '#936510',
+  userBg: '#b94f29', onAccent: '#ffffff', aiBg: '#ffffff', scrollbar: '#d5c3b9',
+  dangerBg: '#fbe8e6', dangerBorder: '#efc1bc', dangerFg: '#a13731',
+  codeBg: '#f1e9e4', codeFg: '#362720', inlineCodeBg: '#eee2db', inlineCodeFg: '#9b3f20', logBg: '#f1ece8', logFg: '#276b43',
+  warningBg: '#f8edd8', warningFg: '#7d5711', sidebarBg: 'rgba(255, 252, 249, 0.84)', sidebarBorder: 'rgba(218, 201, 191, 0.8)',
+}
+
+export type PaletteName = 'classic' | 'terminal' | 'ocean' | 'dusk' | 'ember'
+
+export interface PaletteDefinition {
+  label: string
+  description: string
+  light: Palette
+  dark: Palette
+}
+
+export const PALETTES: Record<PaletteName, PaletteDefinition> = {
+  classic:  { label: 'Classic',  description: 'Clean graphite with a calm blue accent.', light: classicLight, dark: classicDark },
+  terminal: { label: 'Terminal', description: 'Warm paper and focused terminal green.', light: terminalLight, dark: terminalDark },
+  ocean:    { label: 'Ocean',    description: 'Deep navy and crisp cyan.', light: oceanLight, dark: oceanDark },
+  dusk:     { label: 'Dusk',     description: 'Muted plum with soft violet.', light: duskLight, dark: duskDark },
+  ember:    { label: 'Ember',    description: 'Charcoal and clay with copper warmth.', light: emberLight, dark: emberDark },
 }
 
 export const DEFAULT_PALETTE: PaletteName = 'classic'
@@ -212,6 +285,19 @@ export function paletteToCssVars(p: Palette): string {
   return (Object.keys(p) as (keyof Palette)[])
     .map(k => `  --${k}: ${p[k]};`)
     .join('\n')
+}
+
+/** Complete theme matrix shared by the main and Quick Capture windows. */
+export function paletteThemeCss(): string {
+  const defaults = `:root {\n${paletteToCssVars(classicDark)}\n}\n` +
+    `:root[data-theme="light"] {\n${paletteToCssVars(classicLight)}\n}\n` +
+    `:root[data-theme="dark"] {\n${paletteToCssVars(classicDark)}\n}`
+  const themes = (Object.entries(PALETTES) as [PaletteName, PaletteDefinition][])
+    .flatMap(([name, definition]) => (['light', 'dark'] as const).map(mode =>
+      `:root[data-palette="${name}"][data-theme="${mode}"] {\n${paletteToCssVars(definition[mode])}\n}`,
+    ))
+    .join('\n')
+  return `${defaults}\n${themes}`
 }
 
 export function getStoredThemeMode(): ThemeMode {
@@ -266,7 +352,7 @@ export function useEffectiveTheme(): EffectiveTheme {
 export function getStoredPalette(): PaletteName {
   try {
     const v = localStorage.getItem(PALETTE_KEY)
-    if (v === 'classic' || v === 'terminal') return v
+    if (v && Object.prototype.hasOwnProperty.call(PALETTES, v)) return v as PaletteName
   } catch {}
   return DEFAULT_PALETTE
 }


### PR DESCRIPTION
## Summary

- refine the Classic light and dark palettes with a more cohesive graphite and blue color system
- add Ocean, Dusk, and Ember palettes, each with coordinated light and dark variants
- replace the theme dropdown with visual palette cards that preview each palette in the active appearance mode
- centralize palette CSS generation so the main app and Quick Capture window stay in sync

## Why

Terminal Dark had a clear visual identity, while the other available appearance options felt less cohesive and were difficult to compare from a plain dropdown. This gives every palette a deliberate surface hierarchy, readable accent pairing, and an immediate visual preview.

## Impact

Users can choose from five distinct color themes, all compatible with Light, Dark, and System appearance modes. Existing stored Classic and Terminal preferences continue to work.

## Validation

- `npx tsc --noEmit`
- `npx vite build`
- `npx vitest run src/components src/hooks --reporter=verbose` — 29 files, 269 tests passed
- `git diff --check`

The full Electron packaging command was also attempted, but the Swift helper build could not access the sandboxed user module cache. The independent renderer and Electron Vite production builds completed successfully.
