### PR TITLE
Unblock automation authoring from its dry-run gate

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2717,17 +2717,24 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('automations:chat:retryCheck', async (_e, sessionId: string) =>
+  ipcMain.handle('automations:chat:save', async (_e, sessionId: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not ready')
-      return inProcessGateway.retryAutomationChatCheck(sessionId)
+      return inProcessGateway.saveAutomationChat(sessionId)
     })
   )
 
-  ipcMain.handle('automations:chat:save', async (_e, sessionId: string, allowUnchecked?: boolean) =>
+  ipcMain.handle('automations:recheck', async (_e, id: string) =>
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not ready')
-      return inProcessGateway.saveAutomationChat(sessionId, allowUnchecked === true)
+      inProcessGateway.recheckAutomation(id)
+    })
+  )
+
+  ipcMain.handle('automations:dismissCheck', async (_e, id: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      inProcessGateway.dismissAutomationCheck(id)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -49,8 +49,9 @@ contextBridge.exposeInMainWorld('codey', {
     chatStart: (mode: 'create' | 'edit', automationId?: string) => ipcRenderer.invoke('automations:chat:start', mode, automationId),
     chatSend: (sessionId: string, text: string) => ipcRenderer.invoke('automations:chat:send', sessionId, text),
     chatPatch: (sessionId: string, patch: any) => ipcRenderer.invoke('automations:chat:patch', sessionId, patch),
-    chatRetryCheck: (sessionId: string) => ipcRenderer.invoke('automations:chat:retryCheck', sessionId),
-    chatSave: (sessionId: string, allowUnchecked?: boolean) => ipcRenderer.invoke('automations:chat:save', sessionId, allowUnchecked),
+    chatSave: (sessionId: string) => ipcRenderer.invoke('automations:chat:save', sessionId),
+    recheck: (id: string) => ipcRenderer.invoke('automations:recheck', id),
+    dismissCheck: (id: string) => ipcRenderer.invoke('automations:dismissCheck', id),
     chatCancel: (sessionId: string) => ipcRenderer.invoke('automations:chat:cancel', sessionId),
     onEvent: (handler: (ev: any) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, ev: any) => handler(ev)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -193,8 +193,9 @@ declare global {
         chatStart: (mode: 'create' | 'edit', automationId?: string) => Promise<IpcResult<ChatStep>>
         chatSend: (sessionId: string, text: string) => Promise<IpcResult<ChatStep>>
         chatPatch: (sessionId: string, patch: Partial<AutomationDraft>) => Promise<IpcResult<ChatStep>>
-        chatRetryCheck: (sessionId: string) => Promise<IpcResult<ChatStep>>
-        chatSave: (sessionId: string, allowUnchecked?: boolean) => Promise<IpcResult<Automation>>
+        chatSave: (sessionId: string) => Promise<IpcResult<Automation>>
+        recheck: (id: string) => Promise<IpcResult<void>>
+        dismissCheck: (id: string) => Promise<IpcResult<void>>
         chatCancel: (sessionId: string) => Promise<IpcResult<void>>
         onEvent: (handler: (ev: AutomationEvent) => void) => () => void
         onUnseen: (handler: (msg: { automationId: string; runIds: string[] }) => void) => () => void

--- a/codey-mac/src/components/AutomationChatCreate.tsx
+++ b/codey-mac/src/components/AutomationChatCreate.tsx
@@ -5,7 +5,7 @@ import { C } from '../theme'
 import { pillButton, unwrap, inputStyle, selectStyle } from './settingsAtoms'
 import { Markdown } from './Markdown'
 import {
-  checkLabel, draftComplete, formatHHMM, NOTIFY_OPTIONS, scheduleSummary,
+  draftComplete, formatHHMM, NOTIFY_OPTIONS, scheduleSummary,
   slotsToSchedule, type NotifyMode, type ScheduleSlotInput,
 } from './automationsModel'
 import type { AutomationDraft } from '../../../packages/core/src/aide-automation'
@@ -37,31 +37,20 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
   const [draft, setDraft] = useState<AutomationDraft>({})
   const [context, setContext] = useState<ComposerContext>({ workspaces: [], teams: [], agents: [], models: [], tz: Intl.DateTimeFormat().resolvedOptions().timeZone })
   const [suggestions, setSuggestions] = useState<string[]>([])
-  const [ready, setReady] = useState(false)
-  const [check, setCheck] = useState<ChatStep['check']>(undefined)
-  const [checkDetail, setCheckDetail] = useState<string | undefined>()
   const [chatBusy, setChatBusy] = useState(false)
   const [formBusy, setFormBusy] = useState(false)
   const [saving, setSaving] = useState(false)
   const [failedText, setFailedText] = useState<string | null>(null)
+  const [failedError, setFailedError] = useState<string | null>(null)
   const [sessionLost, setSessionLost] = useState(false)
   const [input, setInput] = useState('')
   const [newParam, setNewParam] = useState('')
   const scrollRef = useRef<HTMLDivElement | null>(null)
-  const saveAfterCheckRef = useRef(false)
-
-  // A check event can beat the request response that triggered it. A resolved
-  // verdict wins over a stale pending response; callers clear first when they
-  // intentionally re-arm a check.
-  const applyCheck = (incoming: ChatStep['check']) =>
-    setCheck(prev => incoming === 'pending' && prev !== undefined && prev !== 'pending' ? prev : incoming)
 
   const applyStep = (step: ChatStep, appendReply = false) => {
     setDraft(step.draft)
     setContext(step.context)
     setSuggestions(step.suggestions)
-    setReady(step.ready)
-    applyCheck(step.check)
     if (appendReply && step.reply) setMessages(prev => [...prev, { role: 'assistant', text: step.reply }])
   }
 
@@ -81,7 +70,6 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
     setSessionId(step.sessionId)
     setMessages([{ role: 'assistant', text: step.reply }])
     setSessionLost(false)
-    setCheckDetail(undefined)
     applyStep(step)
   }, [mode, automationId])
 
@@ -90,16 +78,6 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
     void begin().catch((e: any) => { if (!cancelled) setError(e?.message ?? String(e)) })
     return () => { cancelled = true }
   }, [begin, setError])
-
-  useEffect(() => {
-    if (!sessionId) return
-    return window.codey.automations.onEvent(ev => {
-      if (ev.type !== 'chat-check' || ev.sessionId !== sessionId) return
-      applyCheck(ev.check)
-      setCheckDetail(ev.detail)
-      if (ev.message) setMessages(ms => [...ms, { role: 'assistant', text: ev.message! }])
-    })
-  }, [sessionId])
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
@@ -111,18 +89,20 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
     if (!sid || !trimmed || chatBusy || formBusy) return
     setChatBusy(true)
     setFailedText(null)
+    setFailedError(null)
     setSuggestions([])
-    setCheck(undefined)
     if (!retry) setMessages(prev => [...prev, { role: 'user', text: trimmed }])
     try {
       const step: ChatStep = unwrap(await window.codey.automations.chatSend(sid, trimmed))
       applyStep(step, true)
     } catch (e: any) {
-      if (/Unknown automation chat session/.test(e?.message ?? '')) {
+      const message = e?.message ?? String(e)
+      if (/Unknown automation chat session/.test(message)) {
         setSessionLost(true)
         setInput(trimmed)
       } else {
         setFailedText(trimmed)
+        setFailedError(message)
       }
     } finally {
       setChatBusy(false)
@@ -133,7 +113,6 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
     const sid = sessionIdRef.current
     if (!sid || formBusy || chatBusy) return
     setFormBusy(true)
-    setCheck(undefined)
     try {
       const step: ChatStep = unwrap(await window.codey.automations.chatPatch(sid, patch as any))
       applyStep(step)
@@ -151,22 +130,7 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
     void send(text)
   }
 
-  const finishSave = async (sid: string, allowUnchecked = false) => {
-    if (allowUnchecked && !confirm('The unattended check failed. Save this automation anyway?')) {
-      setSaving(false)
-      return
-    }
-    try {
-      unwrap(await window.codey.automations.chatSave(sid, allowUnchecked))
-      sessionIdRef.current = null
-      onDone()
-    } catch (e: any) {
-      setError(e?.message ?? String(e))
-      setSaving(false)
-    }
-  }
-
-  const save = async (allowUnchecked = false) => {
+  const save = async () => {
     const sid = sessionIdRef.current
     if (!sid || saving) return
     setSaving(true)
@@ -174,7 +138,7 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
       // Flush the visible form before finalizing. Text fields intentionally
       // keep local state while typing, so relying only on blur can otherwise
       // race a click on Save and persist the previous value.
-      const synced: ChatStep = unwrap(await window.codey.automations.chatPatch(sid, {
+      unwrap(await window.codey.automations.chatPatch(sid, {
         name: (draft.name?.trim() || null) as any,
         target: (draft.target ?? null) as any,
         schedule: (draft.schedule ?? null) as any,
@@ -182,47 +146,14 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
         brief: (draft.brief?.trim() || null) as any,
         params: draft.params ?? {},
       }))
-      applyStep(synced)
-      if (synced.check === 'clean' || (allowUnchecked && synced.check === 'error')) {
-        await finishSave(sid, allowUnchecked)
-        return
-      }
-      // Saving doubles as the verification fallback. Keep the save intent
-      // armed so a clean result persists automatically without a second click.
-      saveAfterCheckRef.current = true
-      const checking: ChatStep = unwrap(await window.codey.automations.chatRetryCheck(sid))
-      applyStep(checking)
+      unwrap(await window.codey.automations.chatSave(sid))
+      sessionIdRef.current = null
+      onDone()
     } catch (e: any) {
-      saveAfterCheckRef.current = false
       setError(e?.message ?? String(e))
       setSaving(false)
     }
   }
-
-  const retryCheck = async () => {
-    const sid = sessionIdRef.current
-    if (!sid || check === 'pending') return
-    setCheck('pending')
-    try {
-      const step: ChatStep = unwrap(await window.codey.automations.chatRetryCheck(sid))
-      applyStep(step)
-    } catch (e: any) {
-      setCheck(undefined)
-      setError(e?.message ?? String(e))
-    }
-  }
-
-  useEffect(() => {
-    if (!saveAfterCheckRef.current) return
-    if (check === 'clean') {
-      saveAfterCheckRef.current = false
-      const sid = sessionIdRef.current
-      if (sid) void finishSave(sid)
-    } else if (check === 'gaps' || check === 'error') {
-      saveAfterCheckRef.current = false
-      setSaving(false)
-    }
-  }, [check])
 
   const setTargetKind = (kind: 'prompt' | 'team') => {
     const workspaceName = draft.target?.workspaceName || context.workspaces[0] || ''
@@ -264,7 +195,6 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
     draft.target?.kind === 'team' && !draft.target.teamName?.trim() && 'team',
     !draft.brief?.trim() && 'instructions',
   ].filter(Boolean) as string[]
-  const checkInfo = checkLabel(check)
   const locked = chatBusy || formBusy || saving || sessionLost
 
   return (
@@ -284,7 +214,9 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
           {chatBusy && <div style={{ ...bubbleAssistant, color: C.fg3, fontStyle: 'italic' }}>Refining the automation…</div>}
           {failedText && (
             <div style={{ ...bubbleAssistant, borderColor: C.red, color: C.red }}>
-              That message did not go through. <button style={inlineButton} onClick={() => void send(failedText, true)}>Retry</button>
+              {failedError ?? 'That message did not go through.'}
+              {' '}<button style={inlineButton} onClick={() => void send(failedText, true)}>Retry</button>
+              <div style={{ color: C.fg3, marginTop: 6 }}>You can also fill in the form on the right and save directly.</div>
             </div>
           )}
           {sessionLost && (
@@ -464,33 +396,17 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
 
         <footer style={footerStyle}>
           <div style={{ flex: 1, minWidth: 0 }}>
-            {missing.length > 0 ? (
-              <div style={statusMuted}>Complete: {missing.join(', ')}</div>
-            ) : checkInfo ? (
-              <div style={{ color: checkInfo.tone === 'good' ? C.green : checkInfo.tone === 'warn' ? C.yellow : C.fg3, fontSize: 12 }}>
-                {checkInfo.text}
-                {check === 'gaps' && ' — answer the assistant’s questions'}
-                {check === 'error' && checkDetail && <span title={checkDetail}> — verification unavailable</span>}
-              </div>
-            ) : (
-              <div style={statusMuted}>Not verified yet</div>
-            )}
+            {missing.length > 0
+              ? <div style={statusMuted}>Complete: {missing.join(', ')}</div>
+              : <div style={statusMuted}>Ready to save</div>}
           </div>
-          {ready && draftComplete(draft) && check !== 'pending' && check !== 'clean' && (
-            <button style={pillButton('ghost')} disabled={saving} onClick={() => void retryCheck()}>
-              {check === 'error' ? 'Retry verification' : 'Verify setup'}
-            </button>
-          )}
-          {ready && draftComplete(draft) && check === 'clean' && (
-            <button style={pillButton('primary')} disabled={saving} onClick={() => void save()}>{saving ? 'Saving…' : mode === 'edit' ? 'Save changes' : 'Create automation'}</button>
-          )}
-          {ready && draftComplete(draft) && check === undefined && (
-            <button style={pillButton('primary')} disabled={saving} onClick={() => void save()}>{saving ? 'Verifying…' : mode === 'edit' ? 'Save changes' : 'Create automation'}</button>
-          )}
-          {ready && draftComplete(draft) && check === 'pending' && <button style={pillButton('primary')} disabled>Checking…</button>}
-          {ready && draftComplete(draft) && check === 'error' && (
-            <button style={pillButton('ghost')} disabled={saving} onClick={() => void save(true)}>Save anyway…</button>
-          )}
+          <button
+            style={pillButton('primary')}
+            disabled={!draftComplete(draft) || saving || locked}
+            onClick={() => void save()}
+          >
+            {saving ? 'Saving…' : mode === 'edit' ? 'Save changes' : 'Create automation'}
+          </button>
         </footer>
       </section>
     </div>

--- a/codey-mac/src/components/AutomationOnePager.tsx
+++ b/codey-mac/src/components/AutomationOnePager.tsx
@@ -6,7 +6,7 @@ import { C } from '../theme'
 import { pillButton, unwrap, inputStyle, selectStyle } from './settingsAtoms'
 import {
   scheduleSummary, slotsToSchedule, nextRunAt, humanizeDelta,
-  knobsFrom, knobsEqual, NOTIFY_OPTIONS, type Knobs, type NotifyMode,
+  knobsFrom, knobsEqual, NOTIFY_OPTIONS, checkBanner, type Knobs, type NotifyMode,
 } from './automationsModel'
 import { isScheduled } from '../../../packages/core/src/types/automation'
 import type { Automation, AutomationRun } from '../../../packages/core/src/types/automation'
@@ -208,6 +208,24 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
     }
   }
 
+  const recheck = async () => {
+    try {
+      unwrap(await window.codey.automations.recheck(id))
+      void refresh()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
+  }
+
+  const dismissCheck = async () => {
+    try {
+      unwrap(await window.codey.automations.dismissCheck(id))
+      void refresh()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
+  }
+
   if (!a) return <div style={{ color: C.fg3, fontSize: 13, textAlign: 'center', paddingTop: 24 }}>Loading…</div>
 
   const scheduled = isScheduled(a)
@@ -241,6 +259,29 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
           </button>
         </div>
       </header>
+
+      {(() => {
+        const banner = checkBanner(a.check)
+        if (!banner) return null
+        return (
+          <div style={checkBannerStyle(banner.tone)}>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ color: C.fg, fontSize: 12, fontWeight: 700 }}>{banner.title}</div>
+              {banner.questions && banner.questions.length > 0 && (
+                <ul style={checkQuestionList}>
+                  {banner.questions.map((q, i) => <li key={i}>{q}</li>)}
+                </ul>
+              )}
+            </div>
+            {banner.actions && (
+              <div style={{ display: 'flex', gap: 7, flexShrink: 0 }}>
+                <button style={pillButton('ghost')} onClick={() => void recheck()}>Re-run</button>
+                <button style={pillButton('ghost')} onClick={() => void dismissCheck()}>Dismiss</button>
+              </div>
+            )}
+          </div>
+        )
+      })()}
 
       {latest?.status === 'parked' && latest.question && (
         <div style={parkedBanner}>
@@ -507,6 +548,19 @@ const parkedBanner: React.CSSProperties = {
   border: `1px solid ${C.yellow}`, background: C.warningBg,
 }
 const attentionIcon: React.CSSProperties = { width: 24, height: 24, flexShrink: 0, display: 'grid', placeItems: 'center', borderRadius: 8, background: C.yellow, color: C.bg, fontWeight: 900, fontSize: 12 }
+
+/** The error tone is deliberately quiet: a failed dry run almost always means
+ *  an environment problem, not a misconfigured automation. */
+const checkBannerStyle = (tone: 'neutral' | 'warn' | 'muted'): React.CSSProperties => ({
+  display: 'flex', alignItems: 'center', gap: 12, margin: '0 0 12px',
+  padding: '10px 12px', borderRadius: 10,
+  border: `1px solid ${tone === 'warn' ? C.yellow : C.border}`,
+  background: tone === 'warn' ? C.surface2 : C.surface,
+  opacity: tone === 'muted' ? 0.8 : 1,
+})
+const checkQuestionList: React.CSSProperties = {
+  margin: '4px 0 0', paddingLeft: 18, color: C.fg2, fontSize: 12, lineHeight: 1.5,
+}
 
 const summaryGrid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 9, marginTop: 15 }
 const summaryCard: React.CSSProperties = { display: 'flex', gap: 10, minWidth: 0, padding: '11px 12px', border: `1px solid ${C.border}`, borderRadius: 11, background: C.surface }

--- a/codey-mac/src/components/AutomationsView.tsx
+++ b/codey-mac/src/components/AutomationsView.tsx
@@ -243,6 +243,9 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
                     <span style={nameRow}>
                       <strong style={automationName}>{a.name}</strong>
                       <span style={statusPill(health.color)}><span style={{ ...statusDot, background: health.color }} />{health.label}</span>
+                      {a.check?.status === 'gaps' && (
+                        <span style={gapsMarker} title="Dry run found things to pin down">!</span>
+                      )}
                     </span>
                     <span style={metaRow}>
                       {scheduled ? (
@@ -318,6 +321,11 @@ const cardCopy: React.CSSProperties = { display: 'flex', flexDirection: 'column'
 const nameRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }
 const automationName: React.CSSProperties = { color: C.fg, fontSize: 13, fontWeight: 720, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
 const statusPill = (color: string): React.CSSProperties => ({ display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0, padding: '2px 6px', borderRadius: 999, color, background: C.surface3, fontSize: 9, fontWeight: 700 })
+const gapsMarker: React.CSSProperties = {
+  width: 15, height: 15, borderRadius: 999, flexShrink: 0,
+  display: 'grid', placeItems: 'center',
+  background: C.yellow, color: C.bg, fontSize: 10, fontWeight: 800,
+}
 const statusDot: React.CSSProperties = { width: 5, height: 5, borderRadius: 999 }
 const targetLine: React.CSSProperties = { color: C.fg3, fontSize: 10, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
 const metaRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }

--- a/codey-mac/src/components/automationsModel.test.ts
+++ b/codey-mac/src/components/automationsModel.test.ts
@@ -1,6 +1,6 @@
 // codey-mac/src/components/automationsModel.test.ts
 import { describe, it, expect } from 'vitest'
-import { scheduleSummary, scheduleChipLabel, slotsToSchedule, nextRunAt, humanizeDelta, draftComplete, formatHHMM, knobsFrom, knobsEqual, checkLabel } from './automationsModel'
+import { scheduleSummary, scheduleChipLabel, slotsToSchedule, nextRunAt, humanizeDelta, draftComplete, formatHHMM, knobsFrom, knobsEqual, checkBanner } from './automationsModel'
 
 const t = (hour: number, minute: number, daysOfWeek?: number[]) => ({ hour, minute, ...(daysOfWeek ? { daysOfWeek } : {}) })
 
@@ -220,12 +220,27 @@ describe('draftComplete', () => {
   })
 })
 
-describe('checkLabel', () => {
-  it('maps each check state to its status-row label', () => {
-    expect(checkLabel('pending')).toEqual({ text: 'Checking setup…', tone: 'dim' })
-    expect(checkLabel('clean')).toEqual({ text: 'Ready to run unattended', tone: 'good' })
-    expect(checkLabel('gaps')).toEqual({ text: 'Needs clarification', tone: 'warn' })
-    expect(checkLabel('error')).toEqual({ text: 'Check couldn’t run', tone: 'dim' })
-    expect(checkLabel(undefined)).toEqual({ text: 'Not verified yet', tone: 'dim' })
+describe('checkBanner', () => {
+  it('shows nothing for a clean or absent check', () => {
+    expect(checkBanner(undefined)).toBeNull()
+    expect(checkBanner({ status: 'clean', at: 1 })).toBeNull()
+  })
+
+  it('announces a run in progress without offering actions', () => {
+    expect(checkBanner({ status: 'pending', at: 1 }))
+      .toEqual({ tone: 'neutral', title: 'Dry run in progress…', actions: false })
+  })
+
+  it('lists the questions for gaps', () => {
+    expect(checkBanner({ status: 'gaps', questions: ['Which account?'], at: 1 })).toEqual({
+      tone: 'warn', title: 'Dry run found things to pin down',
+      questions: ['Which account?'], actions: true,
+    })
+  })
+
+  it('keeps an errored run low-key — it is usually the environment, not the setup', () => {
+    expect(checkBanner({ status: 'error', detail: 'agent died', at: 1 })).toEqual({
+      tone: 'muted', title: 'Last dry run didn’t complete', actions: true,
+    })
   })
 })

--- a/codey-mac/src/components/automationsModel.ts
+++ b/codey-mac/src/components/automationsModel.ts
@@ -2,6 +2,7 @@
 // Pure helpers for the Automations view — kept separate for unit tests.
 
 import { isScheduled } from '../../../packages/core/src/types/automation'
+import type { AutomationCheck } from '../../../packages/core/src/types/automation'
 
 export interface ScheduleSlotLike { hour: number; minute: number; daysOfWeek?: number[] }
 export interface ScheduleLike { slots: ScheduleSlotLike[]; tz: string }
@@ -218,17 +219,28 @@ export function draftComplete(d: DraftLike): boolean {
   )
 }
 
-export type CheckTone = 'dim' | 'good' | 'warn'
+export type CheckTone = 'neutral' | 'warn' | 'muted'
 
-/** Status-row label for the authoring dry-run check. */
-export function checkLabel(
-  check: 'pending' | 'clean' | 'gaps' | 'error' | undefined,
-): { text: string; tone: CheckTone } {
-  switch (check) {
-    case 'pending': return { text: 'Checking setup…', tone: 'dim' }
-    case 'clean': return { text: 'Ready to run unattended', tone: 'good' }
-    case 'gaps': return { text: 'Needs clarification', tone: 'warn' }
-    case 'error': return { text: 'Check couldn’t run', tone: 'dim' }
-    default: return { text: 'Not verified yet', tone: 'dim' }
+export interface CheckBanner {
+  tone: CheckTone
+  title: string
+  /** Present for 'gaps'. */
+  questions?: string[]
+  /** Re-run / Dismiss only make sense once a run has finished. */
+  actions: boolean
+}
+
+/** One-pager banner for the advisory dry run. A clean or absent check renders
+ *  nothing — the banner exists to raise problems, not to congratulate. */
+export function checkBanner(check: AutomationCheck | undefined): CheckBanner | null {
+  switch (check?.status) {
+    case 'pending':
+      return { tone: 'neutral', title: 'Dry run in progress…', actions: false }
+    case 'gaps':
+      return { tone: 'warn', title: 'Dry run found things to pin down', questions: check.questions ?? [], actions: true }
+    case 'error':
+      return { tone: 'muted', title: 'Last dry run didn’t complete', actions: true }
+    default:
+      return null
   }
 }

--- a/docs/superpowers/plans/2026-08-13-automation-authoring-friction.md
+++ b/docs/superpowers/plans/2026-08-13-automation-authoring-friction.md
@@ -1,0 +1,1634 @@
+# Automation authoring friction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make saving an automation instant by demoting the dry run from a save gate to a persisted, advisory result, and make authoring-chat turns survive a slow model.
+
+**Architecture:** The dry run moves out of the authoring chat session entirely. It is keyed by automation id, runs after the automation is already persisted, and writes an advisory `check` field onto the automation record which the one-pager renders as a banner. The authoring chat keeps only `draftComplete` as its save precondition. Separately, `runAide` grows a bounded retry for transient failures and the chat prompt caps its transcript so long conversations stop growing without limit.
+
+**Tech Stack:** TypeScript (CommonJS, strict), Vitest, Electron + React (codey-mac), npm workspaces (`packages/core`, `packages/gateway`, `codey-mac`).
+
+**Source spec:** `docs/superpowers/specs/2026-08-13-automation-authoring-friction-design.md`
+
+---
+
+## Before you start
+
+This is a fresh git worktree. Node and dependencies must be set up once:
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 22.17.1
+npm install
+npm run build -w @codey/core && npm run build -w @codey/gateway
+```
+
+`node -v` must print `v22.17.1` before running anything else. Every `npm test` command in this plan assumes that shell.
+
+**Expect the TypeScript build to be red in the middle of this plan.** This is one cross-cutting refactor: Task 1 deletes the `chat-check` event that the Mac renderer still uses until Task 13. Vitest does not typecheck, so each task's own unit tests pass in isolation. Task 15 is where `npm run build` must come back green — do not skip it.
+
+## File structure
+
+**Modified — `packages/core`**
+- `src/types/automation.ts` — add `AutomationCheck`, `Automation.check`; replace the `chat-check` event variant with `automation-check`.
+- `src/aide.ts` — `AideOptions.retries` / `.retryDelayMs`, transient-vs-configuration error classification, retry loop.
+- `src/aide-automation.ts` — capped transcript rendering, per-turn time budget, exported `executionFingerprint`, prompt rule 5 edit.
+
+**Modified — `packages/gateway`**
+- `src/automations/chat.ts` — all check machinery removed; `finalize()` gated only by `draftComplete`.
+- `src/automations/dry-run.ts` — keyed by automation id (documentation and parameter names; mechanics unchanged).
+- `src/automations/store.ts` — `setCheck()`, which writes the advisory verdict without bumping `updatedAt`.
+- `src/gateway.ts` — post-save check scheduling, verdict persistence + event, `recheckAutomation`, `dismissAutomationCheck`, cancel-on-delete.
+
+**Created — `packages/gateway`**
+- `src/automations/check.ts` — two pure helpers: `needsRecheck()` and `verdictToCheck()`. Separate file so the save-time decision is unit-testable without constructing a Gateway.
+- `src/automations/check.test.ts`
+
+**Modified — `codey-mac`**
+- `electron/main.ts`, `electron/preload.ts`, `src/codey-api.d.ts` — drop `chat:retryCheck` and the `allowUnchecked` argument; add `automations:recheck` and `automations:dismissCheck`.
+- `src/components/automationsModel.ts` — `checkLabel` → `checkBanner`.
+- `src/components/AutomationChatCreate.tsx` — one save button, no verification concept, honest failure text.
+- `src/components/AutomationOnePager.tsx` — check banner.
+- `src/components/AutomationsView.tsx` — `gaps` marker on list rows.
+
+## Deviations from the spec (both deliberate, both small)
+
+1. `AutomationEvent`'s `automation-check` variant carries `check?: AutomationCheck` rather than a required `check`. An absent `check` means "cleared", which is what Dismiss needs in order to reach other open windows.
+2. `AutomationCheck.status` reuses the existing exported `AutomationCheckStatus` union instead of re-spelling the same four literals inline.
+3. The spec asks for a Mac test that "the create footer enables on `draftComplete` alone". `codey-mac` has no jsdom or React Testing Library — its suite is pure-model only — so that assertion lives in the manual smoke test (Task 15, step 6.1) rather than a component test. The banner half of that bullet is covered by a real unit test, because Task 12 moves the branching into a pure helper.
+
+---
+
+### Task 1: Persisted check type and event
+
+**Files:**
+- Modify: `packages/core/src/types/automation.ts:164-186`
+
+- [ ] **Step 1: Replace the session-scoped event with the persisted one**
+
+In `packages/core/src/types/automation.ts`, replace everything from the `AutomationCheckStatus` comment (line 164) to the end of the file with:
+
+```ts
+/** Status of an automation's advisory dry-run check. */
+export type AutomationCheckStatus = 'pending' | 'clean' | 'gaps' | 'error';
+
+/** Advisory result of the last unattended dry run. Never blocks saving:
+ *  the automation is already persisted by the time a verdict arrives. */
+export interface AutomationCheck {
+  status: AutomationCheckStatus;
+  /** Present when status === 'gaps'. */
+  questions?: string[];
+  /** Present when status === 'error'. */
+  detail?: string;
+  at: number;
+}
+
+export type AutomationEvent =
+  | {
+      type: 'run-started' | 'run-finished' | 'run-parked';
+      automationId: string;
+      runId: string;
+      run?: AutomationRun;
+    }
+  | {
+      /** The automation's advisory check changed. An absent `check` means it
+       *  was dismissed and the banner should disappear. */
+      type: 'automation-check';
+      automationId: string;
+      check?: AutomationCheck;
+    };
+```
+
+- [ ] **Step 2: Add the field to `Automation`**
+
+In the same file, inside `export interface Automation` (after the `chatId` field at line 113), add:
+
+```ts
+  /** Advisory verdict from the last background dry run. Absent on records
+   *  written before this existed, and after the user dismisses it. */
+  check?: AutomationCheck;
+```
+
+- [ ] **Step 3: Verify the package still compiles**
+
+Run: `npm run build -w @codey/core`
+Expected: exit 0. (`chat-check` had no consumer inside `packages/core`, so this stays green; the gateway and renderer break until Tasks 6 and 13.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/types/automation.ts
+git commit -m "feat(core): persist an advisory dry-run check on the automation"
+```
+
+---
+
+### Task 2: Bounded retry in runAide
+
+**Files:**
+- Modify: `packages/core/src/aide.ts`
+- Test: `packages/core/src/aide.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/aide.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { runAide, runAideJson, isConfigError } from './aide';
+import type { AideOptions } from './aide';
+import type { AgentRequest, AgentResponse } from './types';
+
+/** Aide options whose runner is a caller-supplied mock. Retries are instant
+ *  so tests never wait on the real 1s backoff. */
+const opts = (runner: AideOptions['runner'], over: Partial<AideOptions> = {}): AideOptions => ({
+  agent: 'claude-code', runner, retryDelayMs: 0, ...over,
+});
+
+const ok = (output: string): AgentResponse => ({ success: true, output } as AgentResponse);
+
+describe('isConfigError', () => {
+  it('flags configuration failures a retry cannot fix', () => {
+    expect(isConfigError('Request failed with status 402')).toBe(true);
+    expect(isConfigError('unknown model: deepseek-v4-pro')).toBe(true);
+    expect(isConfigError('Invalid API key provided')).toBe(true);
+  });
+  it('does not flag transient failures', () => {
+    expect(isConfigError('The operation was aborted')).toBe(false);
+    expect(isConfigError('socket hang up')).toBe(false);
+  });
+});
+
+describe('runAide retries', () => {
+  it('does not retry by default', async () => {
+    const runner = vi.fn(async (_r: AgentRequest) => { throw new Error('socket hang up'); });
+    await expect(runAide('p', opts(runner))).rejects.toThrow('socket hang up');
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient failure and returns the second attempt', async () => {
+    const runner = vi.fn()
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValueOnce(ok('  second  '));
+    const out = await runAide('p', opts(runner as any, { retries: 1 }));
+    expect(out).toBe('second');
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a configuration failure', async () => {
+    const runner = vi.fn(async (_r: AgentRequest) => { throw new Error('HTTP 402 payment required'); });
+    await expect(runAide('p', opts(runner, { retries: 3 }))).rejects.toThrow('402');
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying once the caller aborts', async () => {
+    const ac = new AbortController();
+    const runner = vi.fn(async (_r: AgentRequest): Promise<AgentResponse> => {
+      ac.abort();
+      throw new Error('socket hang up');
+    });
+    await expect(runAide('p', opts(runner, { retries: 2, signal: ac.signal }))).rejects.toThrow();
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runAideJson', () => {
+  it('retries unparseable output, then returns the parsed object', async () => {
+    const runner = vi.fn()
+      .mockResolvedValueOnce(ok('sorry, no JSON here'))
+      .mockResolvedValueOnce(ok('{"reply":"hi"}'));
+    const res = await runAideJson('p', opts(runner as any, { retries: 1 }));
+    expect(res).toEqual({ reply: 'hi' });
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('still returns null when every attempt is unparseable', async () => {
+    const runner = vi.fn(async (_r: AgentRequest) => ok('nope'));
+    expect(await runAideJson('p', opts(runner, { retries: 1 }))).toBeNull();
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @codey/core -- aide.test.ts`
+Expected: FAIL — `isConfigError` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Replace the body of `packages/core/src/aide.ts` from the `AideOptions` interface (line 16) to the end of the file with:
+
+```ts
+export interface AideOptions {
+  agent: CodingAgent;
+  model?: ModelConfig;
+  runner: AideRunner;
+  /** Hard timeout per attempt in ms. Default 30_000. */
+  timeoutMs?: number;
+  /** Extra attempts after the first, for transient failures only. Default 0,
+   *  so existing callers are unaffected. */
+  retries?: number;
+  /** Delay between attempts in ms. Default 1_000. */
+  retryDelayMs?: number;
+  signal?: AbortSignal;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+
+/** Configuration failures: a second attempt fails identically, so retrying
+ *  only doubles the wait before the user sees the real problem. */
+const CONFIG_ERROR = /\b40[123]\b|payment required|unknown model|invalid model|model not found|invalid api key|unauthorized/i;
+
+export function isConfigError(message: string): boolean {
+  return CONFIG_ERROR.test(message);
+}
+
+/** Marks output that reached us but wasn't JSON — transient in practice, so
+ *  runAideJson retries it instead of giving up on the first bad completion. */
+class UnparseableAideJson extends Error {
+  constructor() { super('Aide returned unparseable JSON'); }
+}
+
+const delay = (ms: number) => new Promise<void>(res => setTimeout(res, ms));
+
+async function withRetries<T>(opts: AideOptions, attempt: () => Promise<T>): Promise<T> {
+  const total = Math.max(0, opts.retries ?? 0) + 1;
+  let lastErr: unknown;
+  for (let i = 0; i < total; i++) {
+    try {
+      return await attempt();
+    } catch (err) {
+      lastErr = err;
+      if (i === total - 1) break;
+      if (opts.signal?.aborted) break;
+      if (isConfigError((err as Error)?.message ?? '')) break;
+      await delay(opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
+    }
+  }
+  throw lastErr;
+}
+
+/** One attempt: the timeout is per-attempt, so a retry gets a full budget. */
+async function runOnce(prompt: string, opts: AideOptions): Promise<string> {
+  const ac = new AbortController();
+  const onUserAbort = () => ac.abort();
+  if (opts.signal) {
+    if (opts.signal.aborted) ac.abort();
+    else opts.signal.addEventListener('abort', onUserAbort, { once: true });
+  }
+  const timer = setTimeout(() => ac.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  try {
+    const res = await opts.runner({
+      prompt,
+      agent: opts.agent,
+      model: opts.model,
+      signal: ac.signal,
+    });
+    if (!res.success) throw new Error(res.error ?? 'aide runner returned non-success');
+    return (res.output ?? '').trim();
+  } finally {
+    clearTimeout(timer);
+    if (opts.signal) opts.signal.removeEventListener('abort', onUserAbort);
+  }
+}
+
+/** Run a one-shot prompt through the configured Aide. Returns trimmed output, or throws. */
+export async function runAide(prompt: string, opts: AideOptions): Promise<string> {
+  return withRetries(opts, () => runOnce(prompt, opts));
+}
+
+/** JSON variant — runs the prompt, then extracts and parses the first balanced
+ *  object. Unparseable output is retried like any other transient failure;
+ *  null is returned only after the last attempt. */
+export async function runAideJson<T = unknown>(prompt: string, opts: AideOptions): Promise<T | null> {
+  try {
+    return await withRetries(opts, async () => {
+      const txt = await runOnce(prompt, opts);
+      const parsed = extractJsonObject(txt) as T | null;
+      if (parsed === null) throw new UnparseableAideJson();
+      return parsed;
+    });
+  } catch (err) {
+    if (err instanceof UnparseableAideJson) return null;
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @codey/core -- aide.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Confirm no other Aide caller regressed**
+
+Run: `npm test -w @codey/core -- aide-tasks.test.ts aide-automation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/aide.ts packages/core/src/aide.test.ts
+git commit -m "feat(core): bounded retry for transient Aide failures"
+```
+
+---
+
+### Task 3: Cap the authoring transcript
+
+**Files:**
+- Modify: `packages/core/src/aide-automation.ts:73-99`
+- Test: `packages/core/src/aide-automation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/aide-automation.test.ts`:
+
+```ts
+describe('formatTranscript', () => {
+  const msgs = (n: number) => Array.from({ length: n }, (_, i) => ({
+    role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+    text: `m${i}`,
+  }));
+
+  it('renders every message when under the cap', () => {
+    expect(formatTranscript(msgs(2))).toBe('User: m0\nYou: m1');
+  });
+
+  it('keeps the newest MAX_CHAT_HISTORY and marks the elision', () => {
+    const out = formatTranscript(msgs(30));
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('[earlier turns omitted]');
+    expect(lines).toHaveLength(MAX_CHAT_HISTORY + 1);
+    expect(lines[1]).toBe('User: m6');
+    expect(lines[lines.length - 1]).toBe('You: m29');
+    expect(out).not.toContain('m5');
+  });
+});
+```
+
+Add `formatTranscript` and `MAX_CHAT_HISTORY` to the existing import at the top of that file:
+
+```ts
+import {
+  renderBrief, automationChatTurn, buildDryRunPrompt, classifyDryRun,
+  formatTranscript, MAX_CHAT_HISTORY,
+} from './aide-automation';
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @codey/core -- aide-automation.test.ts`
+Expected: FAIL — `formatTranscript is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `packages/core/src/aide-automation.ts`, immediately above `const CHAT_TURN_PROMPT` (line 73), add:
+
+```ts
+/** Newest turns kept verbatim in the prompt. The draft is a complete state
+ *  snapshot, so older turns carry tone and nothing else — dropping them keeps
+ *  a long conversation from growing the prompt until it times out. */
+export const MAX_CHAT_HISTORY = 24;
+
+export function formatTranscript(
+  messages: AutomationChatMessage[], max = MAX_CHAT_HISTORY,
+): string {
+  const recent = messages.slice(-max);
+  const lines = recent.map(m => `${m.role === 'user' ? 'User' : 'You'}: ${m.text}`);
+  if (recent.length < messages.length) lines.unshift('[earlier turns omitted]');
+  return lines.join('\n');
+}
+```
+
+Then in `CHAT_TURN_PROMPT`, replace line 89:
+
+```ts
+${messages.map(m => `${m.role === 'user' ? 'User' : 'You'}: ${m.text}`).join('\n')}
+```
+
+with:
+
+```ts
+${formatTranscript(messages)}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @codey/core -- aide-automation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/aide-automation.ts packages/core/src/aide-automation.test.ts
+git commit -m "feat(core): cap the authoring transcript sent to Aide"
+```
+
+---
+
+### Task 4: Chat-turn time budget and prompt cleanup
+
+**Files:**
+- Modify: `packages/core/src/aide-automation.ts:96` (prompt rule 5), `:101-107` (`automationChatTurn`)
+- Test: `packages/core/src/aide-automation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/aide-automation.test.ts`:
+
+```ts
+describe('automationChatTurn budget', () => {
+  const ctx2 = {
+    workspaces: ['default'], teams: [], tz: 'Asia/Shanghai',
+    nowIso: 'Fri Jul 11 2026 10:00:00 GMT+0800', mode: 'create' as const,
+  };
+
+  it('asks for a 90s budget and one retry, and survives one transient failure', async () => {
+    const seen: Array<AbortSignal | undefined> = [];
+    let calls = 0;
+    const runner = async (req: AgentRequest): Promise<AgentResponse> => {
+      seen.push(req.signal);
+      if (++calls === 1) throw new Error('socket hang up');
+      return { success: true, output: '{"reply":"ok"}' } as AgentResponse;
+    };
+    const t = await automationChatTurn([{ role: 'user', text: 'hi' }], {}, ctx2, {
+      agent: 'claude-code', runner, retryDelayMs: 0,
+    });
+    expect(t.reply).toBe('ok');
+    expect(calls).toBe(2);
+  });
+
+  it('lets an explicit caller budget win', async () => {
+    let calls = 0;
+    const runner = async (_req: AgentRequest): Promise<AgentResponse> => {
+      calls++;
+      throw new Error('socket hang up');
+    };
+    await expect(automationChatTurn([{ role: 'user', text: 'hi' }], {}, ctx2, {
+      agent: 'claude-code', runner, retries: 0,
+    })).rejects.toThrow('socket hang up');
+    expect(calls).toBe(1);
+  });
+});
+```
+
+Add `AgentRequest`/`AgentResponse` to the existing type import if they are not already there — they are, at the top of the file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @codey/core -- aide-automation.test.ts`
+Expected: FAIL — the first test's runner is called once and the turn rejects (no retry configured yet).
+
+- [ ] **Step 3: Implement the budget**
+
+In `packages/core/src/aide-automation.ts`, replace line 107 inside `automationChatTurn`:
+
+```ts
+  const res = await runAideJson<Record<string, unknown>>(CHAT_TURN_PROMPT(messages, draft, context), opts);
+```
+
+with:
+
+```ts
+  // Authoring turns are interactive but not latency-critical, and the failure
+  // mode users hit is a slow model, not a wrong one: give each attempt a wide
+  // budget and one automatic retry. An explicit caller value still wins.
+  const res = await runAideJson<Record<string, unknown>>(CHAT_TURN_PROMPT(messages, draft, context), {
+    ...opts,
+    timeoutMs: opts.timeoutMs ?? 90_000,
+    retries: opts.retries ?? 1,
+  });
+```
+
+- [ ] **Step 4: Drop the dead prompt clause**
+
+In `CHAT_TURN_PROMPT` rule 5 (line 96), delete the final sentence. The rule ends after `...do not repeat the full plan or manual-schedule reminder.` — remove:
+
+```
+ If the conversation contains dry-run findings ("Dry run found things to pin down") that the user has not yet fully addressed, treat them as open questions: keep ready=false until each is resolved.
+```
+
+Dry-run findings no longer appear in the authoring transcript at all, so the clause referenced a mechanism that no longer exists.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test -w @codey/core -- aide-automation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/aide-automation.ts packages/core/src/aide-automation.test.ts
+git commit -m "feat(core): widen the authoring chat turn budget and retry once"
+```
+
+---
+
+### Task 5: Shared execution fingerprint
+
+**Files:**
+- Modify: `packages/core/src/aide-automation.ts`
+- Test: `packages/core/src/aide-automation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/aide-automation.test.ts`:
+
+```ts
+describe('executionFingerprint', () => {
+  const base = {
+    target: { kind: 'prompt' as const, workspaceName: 'default' },
+    brief: 'Post five items.',
+    params: { a: '1', b: '2' },
+  };
+
+  it('ignores everything that does not change what runs', () => {
+    expect(executionFingerprint({ ...base, brief: '  Post five items.  ' }))
+      .toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, params: { b: '2', a: '1' } }))
+      .toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, target: { kind: 'prompt', workspaceName: 'default', agent: undefined } }))
+      .toBe(executionFingerprint(base));
+  });
+
+  it('changes when the target, brief or params change', () => {
+    expect(executionFingerprint({ ...base, brief: 'Post six items.' })).not.toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, params: { a: '9', b: '2' } })).not.toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, target: { kind: 'prompt', workspaceName: 'blog' } }))
+      .not.toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, target: { kind: 'prompt', workspaceName: 'default', model: 'opus' } }))
+      .not.toBe(executionFingerprint(base));
+  });
+
+  it('treats an empty draft as its own fingerprint', () => {
+    expect(executionFingerprint({})).toBe(executionFingerprint({ params: {} }));
+  });
+});
+```
+
+Add `executionFingerprint` to the import list at the top of the file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @codey/core -- aide-automation.test.ts`
+Expected: FAIL — `executionFingerprint is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `packages/core/src/aide-automation.ts`, below `renderBrief` (after line 20), add:
+
+```ts
+/** What actually executes, canonicalized. Renaming, rescheduling or changing
+ *  the notify mode leaves this unchanged, so those edits never cost the user a
+ *  fresh dry run. Key order and surrounding whitespace are normalized because
+ *  a spurious difference here spawns a real agent process. */
+export function executionFingerprint(a: {
+  target?: AutomationTarget;
+  brief?: string;
+  params?: Record<string, string>;
+}): string {
+  const t = a.target;
+  const target = !t ? null
+    : t.kind === 'team'
+      ? { kind: 'team', workspaceName: t.workspaceName, teamName: t.teamName }
+      : { kind: 'prompt', workspaceName: t.workspaceName, agent: t.agent ?? null, model: t.model ?? null };
+  const params = Object.entries(a.params ?? {}).sort(([x], [y]) => x.localeCompare(y));
+  return JSON.stringify({ target, brief: a.brief?.trim() ?? '', params });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @codey/core -- aide-automation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole core suite**
+
+Run: `npm test -w @codey/core`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/aide-automation.ts packages/core/src/aide-automation.test.ts
+git commit -m "feat(core): export a canonical execution fingerprint"
+```
+
+---
+
+### Task 6: Strip verification from the authoring session
+
+**Files:**
+- Modify: `packages/gateway/src/automations/chat.ts`
+- Test: `packages/gateway/src/automations/chat.test.ts:110-255`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/gateway/src/automations/chat.test.ts`, delete the entire block of check-related tests (everything from the `it('...')` at line 121 through the end of the `describe` that contains `resolveCheck` and `retryCheck` — i.e. every test referencing `onReadyTransition`, `retryCheck` or `resolveCheck`, lines ~118-255). Replace that block with:
+
+```ts
+describe('finalize', () => {
+  it('returns the draft for any complete draft, with no verification step', () => {
+    const { mgr } = manager();
+    const { sessionId } = mgr.start('edit', COMPLETE, 'a1');
+    expect(mgr.finalize(sessionId)).toEqual({
+      mode: 'edit', sourceAutomationId: 'a1', draft: COMPLETE,
+    });
+  });
+
+  it('finalizes a create session as soon as the draft is complete', () => {
+    const { mgr } = manager();
+    const { sessionId } = mgr.start('create');
+    expect(() => mgr.finalize(sessionId)).toThrow(/incomplete/);
+    mgr.patch(sessionId, COMPLETE);
+    expect(mgr.finalize(sessionId).draft).toEqual(COMPLETE);
+  });
+
+  it('rejects an unknown session', () => {
+    const { mgr } = manager();
+    expect(() => mgr.finalize('nope')).toThrow(/Unknown automation chat session/);
+  });
+});
+```
+
+Also update the `start` test at line 36: `expect(step.check).toBe('clean')` must be deleted (`ChatStep.check` no longer exists).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @codey/gateway -- automations/chat.test.ts`
+Expected: FAIL — `mgr.finalize(sessionId)` throws "Automation must pass its unattended check".
+
+- [ ] **Step 3: Implement**
+
+In `packages/gateway/src/automations/chat.ts`:
+
+Replace the import on line 2 with:
+
+```ts
+import type { AutomationChatContext, AutomationChatTurn, AutomationDraft, AutomationChatMessage } from '@codey/core';
+```
+
+Replace `ChatManagerDeps` (lines 4-16) with:
+
+```ts
+export interface ChatManagerDeps {
+  /** Bound automationChatTurn with AideOptions pre-applied. */
+  turn: (
+    messages: AutomationChatMessage[],
+    draft: AutomationDraft,
+    context: AutomationChatContext,
+  ) => Promise<AutomationChatTurn>;
+  /** Live grounding lists - re-read per turn so new workspaces/teams appear. */
+  context: () => Omit<AutomationChatContext, 'mode'>;
+  now?: () => number;
+}
+```
+
+Replace `ChatStep` (lines 18-29) with:
+
+```ts
+export interface ChatStep {
+  sessionId: string;
+  reply: string;
+  /** Full draft after the patch - drives the live summary panel. */
+  draft: AutomationDraft;
+  suggestions: string[];
+  /** The assistant has no open questions. Drives copy only - saving is gated
+   *  by draftComplete alone. */
+  ready: boolean;
+  /** Live choices used by the structured editor. */
+  context: Omit<AutomationChatContext, 'mode' | 'nowIso'>;
+}
+```
+
+Replace `Session` (lines 31-41) with:
+
+```ts
+interface Session {
+  mode: 'create' | 'edit';
+  messages: AutomationChatMessage[];
+  draft: AutomationDraft;
+  inFlight: boolean;
+  touchedAt: number;
+  sourceAutomationId?: string;
+}
+```
+
+In `start()`, replace lines 82-93 (the `ready` comment block through `return this.step(...)`) with:
+
+```ts
+    this.sessions.set(sessionId, s);
+    // A persisted automation is already a complete, reviewed baseline, so an
+    // edit session opens ready without forcing an otherwise empty turn.
+    return this.step(sessionId, s, reply, [], mode === 'edit' && draftComplete(s.draft));
+```
+
+In `send()`, delete line 115 (`this.reconcileCheck(sessionId, s, ready);`).
+
+In `patch()`, delete line 135 (`this.reconcileCheck(sessionId, s, ready);`).
+
+Delete `retryCheck()` (lines 139-149), `resolveCheck()` (lines 165-178) and `reconcileCheck()` (lines 180-195) entirely.
+
+Replace `finalize()` (lines 151-163) with:
+
+```ts
+  /** Return a server-owned draft. A complete draft is always saveable: the
+   *  dry run is advisory and runs after the automation is persisted. */
+  finalize(sessionId: string): {
+    mode: 'create' | 'edit'; sourceAutomationId?: string; draft: AutomationDraft;
+  } {
+    this.sweep();
+    const s = this.sessions.get(sessionId);
+    if (!s) throw new Error(`Unknown automation chat session: ${sessionId}`);
+    if (!draftComplete(s.draft)) throw new Error('Automation draft is incomplete');
+    return { mode: s.mode, sourceAutomationId: s.sourceAutomationId, draft: { ...s.draft } };
+  }
+```
+
+Replace `step()` (lines 197-203) with:
+
+```ts
+  private step(sessionId: string, s: Session, reply: string, suggestions: string[], ready: boolean): ChatStep {
+    const { workspaces, teams, agents, models, tz } = this.deps.context();
+    return {
+      sessionId, reply, draft: { ...s.draft }, suggestions, ready,
+      context: { workspaces, teams, agents, models, tz },
+    };
+  }
+```
+
+Delete the local `executionFingerprint` function (lines 211-213) — Task 5 moved it to core.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @codey/gateway -- automations/chat.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/automations/chat.ts packages/gateway/src/automations/chat.test.ts
+git commit -m "refactor(gateway): the authoring session no longer verifies anything"
+```
+
+---
+
+### Task 7: Key dry runs by automation id
+
+**Files:**
+- Modify: `packages/gateway/src/automations/dry-run.ts`
+- Test: `packages/gateway/src/automations/dry-run.test.ts`
+
+The generation mechanics are unchanged; this is the rename that makes the new ownership readable.
+
+- [ ] **Step 1: Update the test to the new key**
+
+In `packages/gateway/src/automations/dry-run.test.ts`, replace every `'s1'` / `'s2'` literal with `'a1'` / `'a2'`, and in the first test change the `onResult` assertion to:
+
+```ts
+    expect(onResult).toHaveBeenCalledWith('a1', { status: 'clean' });
+```
+
+- [ ] **Step 2: Run the test to verify it still passes**
+
+Run: `npm test -w @codey/gateway -- automations/dry-run.test.ts`
+Expected: PASS (the manager is key-agnostic; this step just confirms the rename is behavior-neutral).
+
+- [ ] **Step 3: Rename the parameters and correct the docs**
+
+In `packages/gateway/src/automations/dry-run.ts`:
+
+Replace the `onResult` doc + signature (line 12-13) with:
+
+```ts
+  /** Delivered once per surviving run; superseded/cancelled runs are silent. */
+  onResult: (automationId: string, verdict: DryRunVerdict) => void;
+```
+
+Replace the class doc (lines 17-22) with:
+
+```ts
+/**
+ * Fire-and-forget dry-runs keyed by automation id. At most one verdict is
+ * delivered per automation generation: a newer start() or a cancel() makes any
+ * in-flight run's result be dropped on arrival (the underlying agent process is
+ * not killed - the adapter's own timeout bounds it). Runs are advisory and
+ * start only after the automation is already persisted.
+ */
+```
+
+Rename the `sessionId` parameter to `automationId` in `start()`, `cancel()` and `run()`, and update the `cancel()` doc to:
+
+```ts
+  /** Drop any in-flight run's result (superseded edit, or deleted automation). */
+```
+
+and the log line inside `run()` to:
+
+```ts
+      this.deps.log?.(`dry-run for ${automationId} superseded; verdict dropped`);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @codey/gateway -- automations/dry-run.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/automations/dry-run.ts packages/gateway/src/automations/dry-run.test.ts
+git commit -m "refactor(gateway): key dry runs by automation id"
+```
+
+---
+
+### Task 8: Save-time check decision
+
+**Files:**
+- Create: `packages/gateway/src/automations/check.ts`
+- Test: `packages/gateway/src/automations/check.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/automations/check.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { needsRecheck, verdictToCheck } from './check';
+
+const base = {
+  target: { kind: 'prompt' as const, workspaceName: 'default' },
+  brief: 'Post five items.',
+  params: { count: '5' },
+};
+
+describe('needsRecheck', () => {
+  it('always checks a newly created automation', () => {
+    expect(needsRecheck(undefined, base)).toBe(true);
+  });
+
+  it('skips a rename / reschedule / notify-only edit', () => {
+    expect(needsRecheck(base, { ...base })).toBe(false);
+  });
+
+  it('checks when the brief, params or target change', () => {
+    expect(needsRecheck(base, { ...base, brief: 'Post six items.' })).toBe(true);
+    expect(needsRecheck(base, { ...base, params: { count: '6' } })).toBe(true);
+    expect(needsRecheck(base, { ...base, target: { kind: 'prompt', workspaceName: 'blog' } })).toBe(true);
+  });
+});
+
+describe('verdictToCheck', () => {
+  it('maps each verdict onto the persisted shape', () => {
+    expect(verdictToCheck({ status: 'clean' }, 7)).toEqual({ status: 'clean', at: 7 });
+    expect(verdictToCheck({ status: 'gaps', questions: ['Which account?'] }, 7))
+      .toEqual({ status: 'gaps', questions: ['Which account?'], at: 7 });
+    expect(verdictToCheck({ status: 'error', message: 'agent died' }, 7))
+      .toEqual({ status: 'error', detail: 'agent died', at: 7 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @codey/gateway -- automations/check.test.ts`
+Expected: FAIL — cannot resolve `./check`.
+
+- [ ] **Step 3: Implement**
+
+Create `packages/gateway/src/automations/check.ts`:
+
+```ts
+// packages/gateway/src/automations/check.ts
+import { executionFingerprint } from '@codey/core';
+import type { AutomationCheck, AutomationTarget, DryRunVerdict } from '@codey/core';
+
+/** Just enough of an automation (or draft) to know what would execute. */
+export interface Executable {
+  target?: AutomationTarget;
+  brief?: string;
+  params?: Record<string, string>;
+}
+
+/** A background dry run costs a real agent process, so it is warranted only
+ *  when what executes actually changed. `prev` absent = freshly created. */
+export function needsRecheck(prev: Executable | undefined, next: Executable): boolean {
+  if (!prev) return true;
+  return executionFingerprint(prev) !== executionFingerprint(next);
+}
+
+/** Map a dry-run verdict onto the automation's persisted advisory field. */
+export function verdictToCheck(verdict: DryRunVerdict, at: number): AutomationCheck {
+  if (verdict.status === 'clean') return { status: 'clean', at };
+  if (verdict.status === 'gaps') return { status: 'gaps', questions: verdict.questions, at };
+  return { status: 'error', detail: verdict.message, at };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @codey/gateway -- automations/check.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/automations/check.ts packages/gateway/src/automations/check.test.ts
+git commit -m "feat(gateway): decide at save time whether a dry run is warranted"
+```
+
+---
+
+### Task 9: Persist the check without faking an edit
+
+**Files:**
+- Modify: `packages/gateway/src/automations/store.ts:125-136`
+- Test: `packages/gateway/src/automations/store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/gateway/src/automations/store.test.ts`, inside the `describe('definitions', ...)` block:
+
+```ts
+  it('writes and clears the advisory check without touching updatedAt', () => {
+    const a = store.create(draft(), 111);
+    store.setCheck(a.id, { status: 'pending', at: 222 });
+    expect(store.get(a.id)!.check).toEqual({ status: 'pending', at: 222 });
+    expect(store.get(a.id)!.updatedAt).toBe(111);
+
+    store.setCheck(a.id, { status: 'gaps', questions: ['Which account?'], at: 333 });
+    expect(store.get(a.id)!.check).toEqual({ status: 'gaps', questions: ['Which account?'], at: 333 });
+
+    store.setCheck(a.id, undefined);
+    expect(store.get(a.id)!.check).toBeUndefined();
+    expect(JSON.stringify(store.get(a.id))).not.toContain('check');
+  });
+
+  it('setCheck on an unknown id is a no-op', () => {
+    expect(() => store.setCheck('nope', { status: 'clean', at: 1 })).not.toThrow();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @codey/gateway -- automations/store.test.ts`
+Expected: FAIL — `store.setCheck is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `packages/gateway/src/automations/store.ts`, add `AutomationCheck` to the type import on line 4:
+
+```ts
+import type { Automation, AutomationCheck, AutomationRun } from '@codey/core';
+```
+
+and add this method immediately after `recordLastFired` (line 136):
+
+```ts
+  /** Advisory dry-run verdict. Not a user edit, so updatedAt is untouched —
+   *  a background verdict must not make the one-pager claim the automation
+   *  was just modified. `undefined` removes the field (user dismissed it). */
+  setCheck(id: string, check: AutomationCheck | undefined): void {
+    const raw = this.loadRaw();
+    const cur = raw.automations.find(a => a.id === id);
+    if (!cur) return; // unknown id — don't rewrite the file for a no-op
+    if (check) cur.check = check;
+    else delete cur.check;
+    this.writeRaw(raw);
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @codey/gateway -- automations/store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/automations/store.ts packages/gateway/src/automations/store.test.ts
+git commit -m "feat(gateway): persist the advisory check on the automation record"
+```
+
+---
+
+### Task 10: Gateway wiring
+
+**Files:**
+- Modify: `packages/gateway/src/gateway.ts:1485-1516`, `:1633-1652`, `:1685-1693`, `:1739-1764`
+
+No new unit test: this file has no Gateway-construction test harness, and the two decisions it makes (`needsRecheck`, `verdictToCheck`) are already covered by Task 8. Verification is the type build in Task 15 plus the manual smoke test.
+
+- [ ] **Step 1: Update imports**
+
+In `packages/gateway/src/gateway.ts`, add to the existing `@codey/core` type import the names `AutomationCheck`, and import the new helpers next to the `DryRunManager` import (line 10):
+
+```ts
+import { DryRunManager } from './automations/dry-run';
+import { needsRecheck, verdictToCheck } from './automations/check';
+```
+
+- [ ] **Step 2: Rewire the managers**
+
+Replace lines 1501 and 1514 in `initAutomations()`:
+
+```ts
+      onResult: (sessionId, verdict) => this.onDryRunResult(sessionId, verdict),
+```
+becomes
+```ts
+      onResult: (automationId, verdict) => this.onDryRunResult(automationId, verdict),
+```
+
+and delete the `onReadyTransition` line entirely, so the `AutomationChatManager` construction ends with the `context: () => ({...})` property.
+
+- [ ] **Step 3: Replace the verdict delivery path**
+
+Replace `onDryRunResult` (lines 1633-1652) with:
+
+```ts
+  /** Emit an automation event without letting a listener failure escape. */
+  private emitAutomationEvent(ev: AutomationEvent): void {
+    try { this.automationEventListener?.(ev); }
+    catch { /* swallow - listener failures must not break automations */ }
+  }
+
+  /** Start an advisory background dry run for an already-persisted automation. */
+  private startAutomationCheck(a: Automation): void {
+    const check: AutomationCheck = { status: 'pending', at: Date.now() };
+    this.automationStore?.setCheck(a.id, check);
+    this.emitAutomationEvent({ type: 'automation-check', automationId: a.id, check });
+    this.automationDryRuns?.start(a.id, {
+      name: a.name, target: a.target, brief: a.brief, params: a.params,
+    });
+  }
+
+  /** Persist a dry-run verdict and tell the renderer. Purely advisory - the
+   *  automation has been saved and runnable since before this started. */
+  private onDryRunResult(automationId: string, verdict: DryRunVerdict): void {
+    // Deleted while the run was in flight: nothing left to annotate.
+    if (!this.automationStore?.get(automationId)) return;
+    const check = verdictToCheck(verdict, Date.now());
+    this.automationStore.setCheck(automationId, check);
+    this.emitAutomationEvent({ type: 'automation-check', automationId, check });
+  }
+```
+
+- [ ] **Step 4: Cancel in-flight runs on delete**
+
+In `deleteAutomation` (line 1685), add as the first statement of the method body, after the `if (!a) throw` guard:
+
+```ts
+    this.automationDryRuns?.cancel(id);
+```
+
+- [ ] **Step 5: Replace the save path and the retry method**
+
+Delete `retryAutomationChatCheck` (lines 1745-1747) and replace `saveAutomationChat` (lines 1748-1760) with:
+
+```ts
+  saveAutomationChat(sessionId: string): Automation {
+    const { mode, sourceAutomationId, draft } = this.requireAutomationChats().finalize(sessionId);
+    const payload = {
+      name: draft.name!.trim(), target: draft.target!, brief: draft.brief!.trim(),
+      params: draft.params ?? {}, schedule: draft.schedule,
+      report: { notify: draft.notify ?? 'none' },
+    };
+    // Read the pre-edit record first: the fingerprint comparison is what keeps
+    // a rename or reschedule from costing the user a fresh agent run.
+    const prev = mode === 'edit' ? this.automationStore?.get(sourceAutomationId!) : undefined;
+    const saved = mode === 'edit'
+      ? this.updateAutomation(sourceAutomationId!, payload)
+      : this.createAutomation({ ...payload, enabled: true });
+    this.cancelAutomationChat(sessionId);
+    if (needsRecheck(prev, saved)) this.startAutomationCheck(saved);
+    return saved;
+  }
+
+  /** Re-arm the advisory dry run for a saved automation (banner "Re-run"). */
+  recheckAutomation(id: string): void {
+    const a = this.requireAutomationStore().get(id);
+    if (!a) throw new Error(`Automation not found: ${id}`);
+    this.startAutomationCheck(a);
+  }
+
+  /** Clear the advisory check and drop any in-flight verdict (banner "Dismiss"). */
+  dismissAutomationCheck(id: string): void {
+    this.automationDryRuns?.cancel(id);
+    this.requireAutomationStore().setCheck(id, undefined);
+    this.emitAutomationEvent({ type: 'automation-check', automationId: id });
+  }
+```
+
+- [ ] **Step 6: Stop cancelling dry runs by session id**
+
+Replace `cancelAutomationChat` (lines 1761-1764) with:
+
+```ts
+  cancelAutomationChat(sessionId: string): void {
+    this.automationChats?.cancel(sessionId);
+  }
+```
+
+Closing the authoring panel must no longer kill the dry run — that is the whole point of persisting the verdict.
+
+- [ ] **Step 7: Typecheck the gateway package**
+
+Run: `npm run build -w @codey/gateway`
+Expected: compiles (this requires `npm run build -w @codey/core` to have been run after Task 5).
+
+- [ ] **Step 8: Run the gateway suite**
+
+Run: `npm test -w @codey/gateway`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/gateway/src/gateway.ts
+git commit -m "feat(gateway): run the dry run after save, advisory and persisted"
+```
+
+---
+
+### Task 11: IPC surface
+
+**Files:**
+- Modify: `codey-mac/electron/main.ts:2720-2732`
+- Modify: `codey-mac/electron/preload.ts:52-53`
+- Modify: `codey-mac/src/codey-api.d.ts:196-199`
+
+- [ ] **Step 1: Replace the main-process handlers**
+
+In `codey-mac/electron/main.ts`, replace the `automations:chat:retryCheck` and `automations:chat:save` handlers (lines 2720-2732) with:
+
+```ts
+  ipcMain.handle('automations:chat:save', async (_e, sessionId: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      return inProcessGateway.saveAutomationChat(sessionId)
+    })
+  )
+
+  ipcMain.handle('automations:recheck', async (_e, id: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      inProcessGateway.recheckAutomation(id)
+    })
+  )
+
+  ipcMain.handle('automations:dismissCheck', async (_e, id: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not ready')
+      inProcessGateway.dismissAutomationCheck(id)
+    })
+  )
+```
+
+- [ ] **Step 2: Update the preload bridge**
+
+In `codey-mac/electron/preload.ts`, replace lines 52-53 with:
+
+```ts
+    chatSave: (sessionId: string) => ipcRenderer.invoke('automations:chat:save', sessionId),
+    recheck: (id: string) => ipcRenderer.invoke('automations:recheck', id),
+    dismissCheck: (id: string) => ipcRenderer.invoke('automations:dismissCheck', id),
+```
+
+- [ ] **Step 3: Update the renderer typings**
+
+In `codey-mac/src/codey-api.d.ts`, replace lines 196-197 (`chatRetryCheck` and `chatSave`) with:
+
+```ts
+        chatSave: (sessionId: string) => Promise<IpcResult<Automation>>
+        recheck: (id: string) => Promise<IpcResult<void>>
+        dismissCheck: (id: string) => Promise<IpcResult<void>>
+```
+
+- [ ] **Step 4: Confirm nothing else references the removed channel**
+
+Run: `grep -rn "retryCheck\|allowUnchecked" codey-mac/electron codey-mac/src packages --include='*.ts' --include='*.tsx'`
+Expected: only `codey-mac/src/components/AutomationChatCreate.tsx` (fixed in Task 13).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/electron/main.ts codey-mac/electron/preload.ts codey-mac/src/codey-api.d.ts
+git commit -m "feat(mac): recheck/dismiss IPC, ungated chat save"
+```
+
+---
+
+### Task 12: Banner model helper
+
+**Files:**
+- Modify: `codey-mac/src/components/automationsModel.ts:221-234`
+- Test: `codey-mac/src/components/automationsModel.test.ts:3`, `:223-230`
+
+- [ ] **Step 1: Write the failing test**
+
+In `codey-mac/src/components/automationsModel.test.ts`, replace the `checkLabel` import name with `checkBanner` on line 3, and replace the whole `describe('checkLabel', ...)` block (lines 223-230) with:
+
+```ts
+describe('checkBanner', () => {
+  it('shows nothing for a clean or absent check', () => {
+    expect(checkBanner(undefined)).toBeNull()
+    expect(checkBanner({ status: 'clean', at: 1 })).toBeNull()
+  })
+
+  it('announces a run in progress without offering actions', () => {
+    expect(checkBanner({ status: 'pending', at: 1 }))
+      .toEqual({ tone: 'neutral', title: 'Dry run in progress…', actions: false })
+  })
+
+  it('lists the questions for gaps', () => {
+    expect(checkBanner({ status: 'gaps', questions: ['Which account?'], at: 1 })).toEqual({
+      tone: 'warn', title: 'Dry run found things to pin down',
+      questions: ['Which account?'], actions: true,
+    })
+  })
+
+  it('keeps an errored run low-key — it is usually the environment, not the setup', () => {
+    expect(checkBanner({ status: 'error', detail: 'agent died', at: 1 })).toEqual({
+      tone: 'muted', title: 'Last dry run didn’t complete', actions: true,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w codey-mac -- automationsModel.test.ts`
+Expected: FAIL — `checkBanner is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `codey-mac/src/components/automationsModel.ts`, replace lines 221-234 (`CheckTone` and `checkLabel`) with:
+
+```ts
+export type CheckTone = 'neutral' | 'warn' | 'muted'
+
+export interface CheckBanner {
+  tone: CheckTone
+  title: string
+  /** Present for 'gaps'. */
+  questions?: string[]
+  /** Re-run / Dismiss only make sense once a run has finished. */
+  actions: boolean
+}
+
+/** One-pager banner for the advisory dry run. A clean or absent check renders
+ *  nothing — the banner exists to raise problems, not to congratulate. */
+export function checkBanner(check: AutomationCheck | undefined): CheckBanner | null {
+  switch (check?.status) {
+    case 'pending':
+      return { tone: 'neutral', title: 'Dry run in progress…', actions: false }
+    case 'gaps':
+      return { tone: 'warn', title: 'Dry run found things to pin down', questions: check.questions ?? [], actions: true }
+    case 'error':
+      return { tone: 'muted', title: 'Last dry run didn’t complete', actions: true }
+    default:
+      return null
+  }
+}
+```
+
+and add the type import at the top of the file, next to the existing `isScheduled` import (line 4):
+
+```ts
+import type { AutomationCheck } from '../../../packages/core/src/types/automation'
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w codey-mac -- automationsModel.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add codey-mac/src/components/automationsModel.ts codey-mac/src/components/automationsModel.test.ts
+git commit -m "feat(mac): model the advisory check banner"
+```
+
+---
+
+### Task 13: One-button authoring panel
+
+**Files:**
+- Modify: `codey-mac/src/components/AutomationChatCreate.tsx`
+
+- [ ] **Step 1: Drop the check state**
+
+In `codey-mac/src/components/AutomationChatCreate.tsx`:
+
+Replace the model import (lines 7-10) with:
+
+```ts
+import {
+  draftComplete, formatHHMM, NOTIFY_OPTIONS, scheduleSummary,
+  slotsToSchedule, type NotifyMode, type ScheduleSlotInput,
+} from './automationsModel'
+```
+
+Delete the `check`, `checkDetail` and `saveAfterCheckRef` declarations (lines 41-42 and 51), and delete `applyCheck` (lines 54-57).
+
+Replace `applyStep` (lines 59-66) with:
+
+```ts
+  const applyStep = (step: ChatStep, appendReply = false) => {
+    setDraft(step.draft)
+    setContext(step.context)
+    setSuggestions(step.suggestions)
+    setReady(step.ready)
+    if (appendReply && step.reply) setMessages(prev => [...prev, { role: 'assistant', text: step.reply }])
+  }
+```
+
+In `begin()` delete `setCheckDetail(undefined)` (line 84).
+
+Delete the whole `chat-check` subscription effect (lines 94-102) and the `saveAfterCheckRef` effect (lines 215-225).
+
+In `send()` delete `setCheck(undefined)` (line 115); in `patchDraft()` delete `setCheck(undefined)` (line 136).
+
+- [ ] **Step 2: Replace the save path**
+
+Replace `finishSave`, `save` and `retryCheck` (lines 154-213) with a single function:
+
+```ts
+  const save = async () => {
+    const sid = sessionIdRef.current
+    if (!sid || saving) return
+    setSaving(true)
+    try {
+      // Flush the visible form before finalizing. Text fields intentionally
+      // keep local state while typing, so relying only on blur can otherwise
+      // race a click on Save and persist the previous value.
+      unwrap(await window.codey.automations.chatPatch(sid, {
+        name: (draft.name?.trim() || null) as any,
+        target: (draft.target ?? null) as any,
+        schedule: (draft.schedule ?? null) as any,
+        notify: draft.notify ?? 'none',
+        brief: (draft.brief?.trim() || null) as any,
+        params: draft.params ?? {},
+      }))
+      unwrap(await window.codey.automations.chatSave(sid))
+      sessionIdRef.current = null
+      onDone()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+      setSaving(false)
+    }
+  }
+```
+
+- [ ] **Step 3: Show the real failure and the way around it**
+
+Replace the `failedText` bubble (lines 285-289) with:
+
+```ts
+          {failedText && (
+            <div style={{ ...bubbleAssistant, borderColor: C.red, color: C.red }}>
+              {failedError ?? 'That message did not go through.'}
+              {' '}<button style={inlineButton} onClick={() => void send(failedText, true)}>Retry</button>
+              <div style={{ color: C.fg3, marginTop: 6 }}>You can also fill in the form on the right and save directly.</div>
+            </div>
+          )}
+```
+
+Add the state next to `failedText` (line 46):
+
+```ts
+  const [failedError, setFailedError] = useState<string | null>(null)
+```
+
+and set it in `send()`: replace the `catch` block (lines 120-126) with:
+
+```ts
+    } catch (e: any) {
+      const message = e?.message ?? String(e)
+      if (/Unknown automation chat session/.test(message)) {
+        setSessionLost(true)
+        setInput(trimmed)
+      } else {
+        setFailedText(trimmed)
+        setFailedError(message)
+      }
+    }
+```
+
+and clear it where `setFailedText(null)` is called at the start of `send()` (line 114):
+
+```ts
+    setFailedText(null)
+    setFailedError(null)
+```
+
+- [ ] **Step 4: Collapse the footer to one button**
+
+Replace the whole `<footer>` block (lines 465-494) with:
+
+```tsx
+        <footer style={footerStyle}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {missing.length > 0
+              ? <div style={statusMuted}>Complete: {missing.join(', ')}</div>
+              : <div style={statusMuted}>Ready to save</div>}
+          </div>
+          <button
+            style={pillButton('primary')}
+            disabled={!draftComplete(draft) || saving || locked}
+            onClick={() => void save()}
+          >
+            {saving ? 'Saving…' : mode === 'edit' ? 'Save changes' : 'Create automation'}
+          </button>
+        </footer>
+```
+
+Delete the now-unused `checkInfo` line (line 267). `ready` stays in state — it still drives nothing beyond assistant copy, and the panel keeps reading it from each step.
+
+- [ ] **Step 5: Confirm nothing check-shaped survives in this file**
+
+Run: `grep -n "check\|Check" codey-mac/src/components/AutomationChatCreate.tsx`
+Expected: no matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codey-mac/src/components/AutomationChatCreate.tsx
+git commit -m "feat(mac): a complete draft saves immediately"
+```
+
+---
+
+### Task 14: Advisory banner on the one-pager
+
+**Files:**
+- Modify: `codey-mac/src/components/AutomationOnePager.tsx`
+- Modify: `codey-mac/src/components/AutomationsView.tsx:238-246`
+
+- [ ] **Step 1: Import the helper**
+
+In `codey-mac/src/components/AutomationOnePager.tsx`, add `checkBanner` to the model import (lines 7-10):
+
+```ts
+import {
+  scheduleSummary, slotsToSchedule, nextRunAt, humanizeDelta,
+  knobsFrom, knobsEqual, NOTIFY_OPTIONS, checkBanner, type Knobs, type NotifyMode,
+} from './automationsModel'
+```
+
+- [ ] **Step 2: Add the actions**
+
+Add next to `saveIcon` (after line 209):
+
+```tsx
+  const recheck = async () => {
+    try {
+      unwrap(await window.codey.automations.recheck(id))
+      void refresh()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
+  }
+
+  const dismissCheck = async () => {
+    try {
+      unwrap(await window.codey.automations.dismissCheck(id))
+      void refresh()
+    } catch (e: any) {
+      setError(e?.message ?? String(e))
+    }
+  }
+```
+
+- [ ] **Step 3: Render the banner**
+
+Add just below the closing `</header>` (line 243), above the parked banner:
+
+```tsx
+      {(() => {
+        const banner = checkBanner(a.check)
+        if (!banner) return null
+        return (
+          <div style={checkBannerStyle(banner.tone)}>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ color: C.fg, fontSize: 12, fontWeight: 700 }}>{banner.title}</div>
+              {banner.questions && banner.questions.length > 0 && (
+                <ul style={checkQuestionList}>
+                  {banner.questions.map((q, i) => <li key={i}>{q}</li>)}
+                </ul>
+              )}
+            </div>
+            {banner.actions && (
+              <div style={{ display: 'flex', gap: 7, flexShrink: 0 }}>
+                <button style={pillButton('ghost')} onClick={() => void recheck()}>Re-run</button>
+                <button style={pillButton('ghost')} onClick={() => void dismissCheck()}>Dismiss</button>
+              </div>
+            )}
+          </div>
+        )
+      })()}
+```
+
+- [ ] **Step 4: Add the styles**
+
+Next to `parkedBanner`'s definition in the style block at the bottom of the file, add:
+
+```ts
+/** The error tone is deliberately quiet: a failed dry run almost always means
+ *  an environment problem, not a misconfigured automation. */
+const checkBannerStyle = (tone: 'neutral' | 'warn' | 'muted'): React.CSSProperties => ({
+  display: 'flex', alignItems: 'center', gap: 12, margin: '0 0 12px',
+  padding: '10px 12px', borderRadius: 10,
+  border: `1px solid ${tone === 'warn' ? C.yellow : C.border}`,
+  background: tone === 'warn' ? C.surface2 : C.surface,
+  opacity: tone === 'muted' ? 0.8 : 1,
+})
+const checkQuestionList: React.CSSProperties = {
+  margin: '4px 0 0', paddingLeft: 18, color: C.fg2, fontSize: 12, lineHeight: 1.5,
+}
+```
+
+- [ ] **Step 5: Mark `gaps` rows in the list**
+
+In `codey-mac/src/components/AutomationsView.tsx`, inside `nameRow` (after the health pill on line 245), add:
+
+```tsx
+                      {a.check?.status === 'gaps' && (
+                        <span style={gapsMarker} title="Dry run found things to pin down">!</span>
+                      )}
+```
+
+and add the style next to `statusPill` in that file's style block:
+
+```ts
+const gapsMarker: React.CSSProperties = {
+  width: 15, height: 15, borderRadius: 999, flexShrink: 0,
+  display: 'grid', placeItems: 'center',
+  background: C.yellow, color: C.bg, fontSize: 10, fontWeight: 800,
+}
+```
+
+- [ ] **Step 6: Run the Mac suite**
+
+Run: `npm test -w codey-mac`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add codey-mac/src/components/AutomationOnePager.tsx codey-mac/src/components/AutomationsView.tsx
+git commit -m "feat(mac): surface the advisory dry-run verdict on the automation"
+```
+
+---
+
+### Task 15: Full verification
+
+**Files:** none modified unless a failure demands it.
+
+- [ ] **Step 1: Build every package**
+
+Run: `npm run build`
+Expected: exit 0, no TypeScript errors. Any error here is a leftover reference to `chat-check`, `ChatStep.check`, `allowUnchecked` or `retryCheck` — fix it in the file that owns it and re-run.
+
+- [ ] **Step 2: Run every suite**
+
+Run: `npm test`
+Expected: all three workspaces pass.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: no non-English characters flagged in source.
+
+- [ ] **Step 4: Confirm the removed vocabulary is gone**
+
+Run: `grep -rn "chat-check\|allowUnchecked\|retryCheck\|resolveCheck\|onReadyTransition\|checkLabel\|reconcileCheck" packages/core/src packages/gateway/src codey-mac/src codey-mac/electron`
+Expected: no matches.
+
+- [ ] **Step 5: Commit anything the verification changed**
+
+```bash
+git status --short
+# only if there are changes:
+git add -A && git commit -m "chore: fix up cross-package references after the check refactor"
+```
+
+- [ ] **Step 6: Manual smoke test (requires the Mac app)**
+
+This is the part unit tests cannot cover. Run the app, then:
+
+1. Open Automations → New. Fill in name, workspace and instructions **entirely by hand**, without sending a chat message. The button reads "Create automation" and is enabled; clicking it returns to the list **immediately** — no "Checking…" state.
+2. The new automation's one-pager shows "Dry run in progress…" and, minutes later, either no banner (clean) or a warning banner listing questions.
+3. Open Edit setup, change only the name, save. No new banner appears and "Updated" is the only thing that changed.
+4. Open Edit setup, change the instructions, save. A fresh "Dry run in progress…" banner appears.
+5. On a `gaps` banner, `Dismiss` removes it and the list marker; `Re-run` puts it back into pending.
+6. Send a chat message and let it fail (e.g. stop the model backend): the red bubble names the real error and offers the form as a way through.
+
+Record the outcome in the PR description — per `docs/superpowers/specs/2026-08-13-automation-authoring-friction-design.md`, the dry-run path has historically been the one place where unit tests looked green and the real app did not.

--- a/docs/superpowers/specs/2026-08-13-automation-authoring-friction-design.md
+++ b/docs/superpowers/specs/2026-08-13-automation-authoring-friction-design.md
@@ -1,0 +1,168 @@
+# Automation authoring friction — design
+
+Date: 2026-08-13
+Status: approved, ready for implementation plan
+
+## Problem
+
+Creating an automation through the Mac app's authoring panel is unreliable and
+slow, in two independent ways.
+
+**Chat turns fail often.** Every message is one Aide call (`packages/core/src/aide.ts`)
+with a hard 30s timeout and no retry. The prompt carries the full draft plus the
+entire transcript (`packages/core/src/aide-automation.ts`), so it grows with the
+conversation and gets more likely to hit the timeout the longer you talk. On
+failure the UI shows only "That message did not go through." — the real cause
+(timeout, HTTP 402, unparseable JSON) is never surfaced.
+
+**Verification is slow and gates saving.** The "check" is not form validation: it
+spawns a real agent process that walks the brief inside the workspace
+(`Gateway.runDryRunPrompt`), then makes a *second* Aide call to classify the
+report. It therefore takes minutes even when the user filled in every field by
+hand. Worse, it is a hard gate: `AutomationChatManager.finalize()` throws unless
+the check is `clean`, so any failure in that chain — agent crash, classifier
+call failing, timeout — becomes `error` and blocks the save behind a "Save
+anyway…" button and a `confirm()` dialog. The failure is almost never about the
+data being wrong.
+
+Actual data validation (`codey-mac/electron/automation-validate.ts`) is already
+pure and instantaneous. It is not the source of the delay and is not changed here.
+
+## Decisions
+
+1. The dry run becomes **advisory, never a gate**. A complete draft saves immediately.
+2. The dry run runs **after save, in the background**, and its verdict is
+   **persisted on the automation** so it survives closing the panel.
+3. Chat turns get a **larger time budget, one bounded retry, a capped transcript,
+   and honest error text**.
+
+## Part 1 — Dry run as persisted advice
+
+### Data
+
+`packages/core/src/types/automation.ts`:
+
+```ts
+/** Advisory result of the last unattended dry run. Never blocks saving. */
+export interface AutomationCheck {
+  status: 'pending' | 'clean' | 'gaps' | 'error'
+  /** Present when status === 'gaps'. */
+  questions?: string[]
+  /** Present when status === 'error'. */
+  detail?: string
+  at: number
+}
+```
+
+`Automation` gains `check?: AutomationCheck`. Optional, so existing records load
+unchanged and simply show no banner.
+
+`AutomationEvent` gains a variant:
+
+```ts
+| { type: 'automation-check'; automationId: string; check: AutomationCheck }
+```
+
+The existing `chat-check` event variant is removed along with the session-scoped
+check.
+
+### Backend
+
+- `packages/gateway/src/automations/chat.ts`
+  - `finalize()` drops the check condition; the only remaining precondition is
+    `draftComplete`. The `allowUnchecked` parameter is removed.
+  - `Session.check` / `Session.checkFingerprint`, `reconcileCheck()`,
+    `retryCheck()`, `resolveCheck()` and `ChatManagerDeps.onReadyTransition` are
+    removed. `ChatStep.check` is removed. The authoring panel no longer has a
+    notion of verification.
+  - `ready` keeps its current meaning (the assistant has no open questions) and
+    still drives nothing more than copy in the panel.
+- `executionFingerprint` moves to `packages/core/src/aide-automation.ts` and is
+  exported, so gateway can compute it for both a draft and a persisted automation.
+- `Gateway.saveAutomationChat(sessionId)`
+  - persists first, exactly as today;
+  - then decides whether to check: **always** on create; on edit, only when the
+    execution fingerprint (`target` + trimmed `brief` + `params`) differs from
+    the pre-edit automation. Renaming, rescheduling or changing notify does not
+    trigger a run.
+  - when it decides to check, writes `check = { status: 'pending', at: now }`
+    through the store, emits `automation-check`, and starts the dry run.
+- `packages/gateway/src/automations/dry-run.ts`
+  - `DryRunManager` is keyed by **automation id** instead of chat session id.
+    The generation-counter semantics are unchanged: a newer `start()` or a
+    `cancel()` makes an in-flight verdict be dropped on arrival.
+  - `onResult` writes the verdict into the store (`check` with `at` stamped at
+    delivery) and emits `automation-check`.
+- Deleting an automation cancels its in-flight dry run.
+- A `Re-run` action from the UI is a new gateway method
+  (`recheckAutomation(id)`) that re-arms `pending` and starts a run from the
+  persisted automation. `Dismiss` clears `check`.
+- `aide-automation.ts` prompt rule 5 loses its trailing clause about keeping
+  `ready=false` while unaddressed "Dry run found things to pin down" findings are
+  in the transcript — that mechanism no longer exists inside the chat.
+
+### IPC
+
+- `automations:chat:save` loses its `allowUnchecked` argument.
+- `automations:chat:retryCheck` is removed.
+- New: `automations:recheck(id)` and `automations:dismissCheck(id)`.
+
+### Frontend
+
+- `codey-mac/src/components/AutomationChatCreate.tsx`
+  - Remove `check`, `checkDetail`, `applyCheck`, `saveAfterCheckRef`,
+    `retryCheck`, the `chat-check` event subscription, and the `confirm()`
+    dialog.
+  - The footer has exactly one action button, enabled when `draftComplete(draft)`.
+    The status line lists missing fields, or reads "Ready to save".
+  - `save()` keeps its pre-save form flush (the `chatPatch` that prevents a
+    click racing an unblurred text field), then saves directly.
+- `AutomationOnePager` gets a check banner at the top:
+  - `pending` → neutral, "Dry run in progress…"
+  - `gaps` → warning tone, the questions as a list, with `Re-run` and `Dismiss`
+  - `error` → muted single line, "Last dry run didn't complete · Re-run".
+    Deliberately low-key: this almost always means an environment problem, not a
+    configuration problem.
+  - `clean` → no banner.
+- `AutomationsView` list rows show a small marker only for `gaps`.
+
+## Part 2 — Chat turn reliability
+
+- `AideOptions` gains `retries?: number`, default `0`, so no other Aide caller
+  changes behaviour. The retry loop lives in `runAide`.
+- Retries are only for transient failures. An error whose message matches a
+  configuration problem — HTTP 402, unknown/invalid model, invalid API key — is
+  rethrown immediately rather than burning a retry.
+- `automationChatTurn` runs with `timeoutMs: 90_000`, `retries: 1`, and a 1s
+  backoff between attempts.
+- The prompt caps transcript history at the most recent 24 messages; anything
+  earlier collapses to a single `[earlier turns omitted]` line. The draft is a
+  complete state snapshot, so truncation loses no settled information. The
+  session keeps the full transcript for display.
+- The failure bubble in `AutomationChatCreate` shows the real error message plus
+  one line: "You can also fill in the form on the right and save directly."
+
+## Part 3 — Explicitly unchanged
+
+`codey-mac/electron/automation-validate.ts` keeps its current IPC-boundary
+validation. Its `validateAutomationChatPatch` still guards the structured form.
+
+## Testing
+
+- **core**: transcript truncation keeps the newest 24 and marks the elision;
+  `retries: 1` retries a transient failure and returns the second attempt's
+  result; a 402/unknown-model error is not retried; `renderBrief` unchanged.
+- **gateway**: `finalize()` succeeds for a complete draft regardless of any
+  prior check state; `saveAutomationChat` starts a dry run on create and on a
+  fingerprint change but not on a rename/reschedule-only edit; a delivered
+  verdict is written to the store and emitted as `automation-check`; deleting an
+  automation cancels its in-flight run and drops the verdict.
+- **mac**: banner renders the right branch per status; the create footer enables
+  on `draftComplete` alone.
+
+## Migration
+
+`check` is optional and absent on existing records, which renders as no banner.
+No data migration. The removed `allowUnchecked` IPC argument and the
+`chat:retryCheck` channel are internal to this repo, so they are deleted rather
+than deprecated.

--- a/packages/core/src/aide-automation.test.ts
+++ b/packages/core/src/aide-automation.test.ts
@@ -131,7 +131,7 @@ describe('CHAT_TURN_PROMPT readiness gate', () => {
     expect(captured).not.toMatch(/scheduling has been explicitly discussed/i);
     expect(captured).toMatch(/scheduling is NOT required for ready/i);
     expect(captured).not.toMatch(/and eventually scheduling/i);
-    expect(captured).toMatch(/dry-run findings/i);
+    expect(captured).not.toMatch(/dry-run findings/i);
     expect(captured).toMatch(/clearly scoped change/i);
     expect(captured).toMatch(/DO NOT restart the setup interview/i);
     expect(captured).toMatch(/Ask a follow-up only when the requested edit itself is ambiguous/i);
@@ -194,5 +194,39 @@ describe('formatTranscript', () => {
     expect(lines[1]).toBe('User: m6');
     expect(lines[lines.length - 1]).toBe('You: m29');
     expect(out).not.toContain('m5');
+  });
+});
+
+describe('automationChatTurn budget', () => {
+  const ctx2 = {
+    workspaces: ['default'], teams: [], tz: 'Asia/Shanghai',
+    nowIso: 'Fri Jul 11 2026 10:00:00 GMT+0800', mode: 'create' as const,
+  };
+
+  it('asks for a 90s budget and one retry, and survives one transient failure', async () => {
+    const seen: Array<AbortSignal | undefined> = [];
+    let calls = 0;
+    const runner = async (req: AgentRequest): Promise<AgentResponse> => {
+      seen.push(req.signal);
+      if (++calls === 1) throw new Error('socket hang up');
+      return { success: true, output: '{"reply":"ok"}' } as AgentResponse;
+    };
+    const t = await automationChatTurn([{ role: 'user', text: 'hi' }], {}, ctx2, {
+      agent: 'claude-code', runner, retryDelayMs: 0,
+    });
+    expect(t.reply).toBe('ok');
+    expect(calls).toBe(2);
+  });
+
+  it('lets an explicit caller budget win', async () => {
+    let calls = 0;
+    const runner = async (_req: AgentRequest): Promise<AgentResponse> => {
+      calls++;
+      throw new Error('socket hang up');
+    };
+    await expect(automationChatTurn([{ role: 'user', text: 'hi' }], {}, ctx2, {
+      agent: 'claude-code', runner, retries: 0,
+    })).rejects.toThrow('socket hang up');
+    expect(calls).toBe(1);
   });
 });

--- a/packages/core/src/aide-automation.test.ts
+++ b/packages/core/src/aide-automation.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   renderBrief, automationChatTurn, buildDryRunPrompt, classifyDryRun,
-  formatTranscript, MAX_CHAT_HISTORY,
+  formatTranscript, MAX_CHAT_HISTORY, executionFingerprint,
 } from './aide-automation';
 import type { AideOptions } from './aide';
 import type { AgentRequest, AgentResponse } from './types';
@@ -228,5 +228,35 @@ describe('automationChatTurn budget', () => {
       agent: 'claude-code', runner, retries: 0,
     })).rejects.toThrow('socket hang up');
     expect(calls).toBe(1);
+  });
+});
+
+describe('executionFingerprint', () => {
+  const base = {
+    target: { kind: 'prompt' as const, workspaceName: 'default' },
+    brief: 'Post five items.',
+    params: { a: '1', b: '2' },
+  };
+
+  it('ignores everything that does not change what runs', () => {
+    expect(executionFingerprint({ ...base, brief: '  Post five items.  ' }))
+      .toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, params: { b: '2', a: '1' } }))
+      .toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, target: { kind: 'prompt', workspaceName: 'default', agent: undefined } }))
+      .toBe(executionFingerprint(base));
+  });
+
+  it('changes when the target, brief or params change', () => {
+    expect(executionFingerprint({ ...base, brief: 'Post six items.' })).not.toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, params: { a: '9', b: '2' } })).not.toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, target: { kind: 'prompt', workspaceName: 'blog' } }))
+      .not.toBe(executionFingerprint(base));
+    expect(executionFingerprint({ ...base, target: { kind: 'prompt', workspaceName: 'default', model: 'opus' } }))
+      .not.toBe(executionFingerprint(base));
+  });
+
+  it('treats an empty draft as its own fingerprint', () => {
+    expect(executionFingerprint({})).toBe(executionFingerprint({ params: {} }));
   });
 });

--- a/packages/core/src/aide-automation.test.ts
+++ b/packages/core/src/aide-automation.test.ts
@@ -1,6 +1,9 @@
 // packages/core/src/aide-automation.test.ts
 import { describe, it, expect } from 'vitest';
-import { renderBrief, automationChatTurn, buildDryRunPrompt, classifyDryRun } from './aide-automation';
+import {
+  renderBrief, automationChatTurn, buildDryRunPrompt, classifyDryRun,
+  formatTranscript, MAX_CHAT_HISTORY,
+} from './aide-automation';
 import type { AideOptions } from './aide';
 import type { AgentRequest, AgentResponse } from './types';
 
@@ -170,5 +173,26 @@ describe('classifyDryRun', () => {
     await expect(classifyDryRun('out', aide('{"verdict":"gaps","questions":[]}'))).rejects.toThrow();
     await expect(classifyDryRun('out', aide('{"verdict":"maybe"}'))).rejects.toThrow();
     await expect(classifyDryRun('out', aide('not json'))).rejects.toThrow();
+  });
+});
+
+describe('formatTranscript', () => {
+  const msgs = (n: number) => Array.from({ length: n }, (_, i) => ({
+    role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+    text: `m${i}`,
+  }));
+
+  it('renders every message when under the cap', () => {
+    expect(formatTranscript(msgs(2))).toBe('User: m0\nYou: m1');
+  });
+
+  it('keeps the newest MAX_CHAT_HISTORY and marks the elision', () => {
+    const out = formatTranscript(msgs(30));
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('[earlier turns omitted]');
+    expect(lines).toHaveLength(MAX_CHAT_HISTORY + 1);
+    expect(lines[1]).toBe('User: m6');
+    expect(lines[lines.length - 1]).toBe('You: m29');
+    expect(out).not.toContain('m5');
   });
 });

--- a/packages/core/src/aide-automation.ts
+++ b/packages/core/src/aide-automation.ts
@@ -107,7 +107,7 @@ Your job this turn:
 2. Reply conversationally. During creation, ask about at most ONE thing at a time when a required or execution-blocking detail is genuinely missing: specifics, choices, accounts/handles, formats, limits, or edge cases (e.g. "what if there is nothing to report?"). During editing, if the latest message requests a specific field or clearly scoped change, apply it immediately, briefly confirm it, preserve every unrelated field, and DO NOT restart the setup interview or ask the next generic setup question. Ask a follow-up only when the requested edit itself is ambiguous, invalid, or cannot be applied safely. Never ask about something the user already answered, even in passing. Patch schedule whenever the user's message settles timing, but do not steer the conversation toward scheduling.
 3. When the answer space is enumerable (workspace names, team names, times, yes/no), offer 2-5 short suggestions the user can tap. Only ever suggest workspace/team names that appear in the environment above.
 4. Maintain the brief as you learn: a frozen, fully self-contained instruction block for an unattended agent - no "the user said", concrete values, edge-case handling, expected output. Surface tweakable knobs as {{placeholder}} in the brief with current values in params.
-5. Set ready=true ONLY when name, target and brief are complete and you have no open questions about the task itself. Scheduling is NOT required for ready: on the initial creation-ready turn, reply with a short summary of the full plan, and if no schedule is set, mention once that it will run manually unless they set a schedule now or later from the automation's page. For a clearly scoped edit to an already-complete draft, keep ready=true after applying it and simply confirm the change; do not repeat the full plan or manual-schedule reminder. If the conversation contains dry-run findings ("Dry run found things to pin down") that the user has not yet fully addressed, treat them as open questions: keep ready=false until each is resolved.
+5. Set ready=true ONLY when name, target and brief are complete and you have no open questions about the task itself. Scheduling is NOT required for ready: on the initial creation-ready turn, reply with a short summary of the full plan, and if no schedule is set, mention once that it will run manually unless they set a schedule now or later from the automation's page. For a clearly scoped edit to an already-complete draft, keep ready=true after applying it and simply confirm the change; do not repeat the full plan or manual-schedule reminder.
 
 Respond with ONLY this JSON:
 {"reply":"...","draftPatch":{},"suggestions":[],"ready":false}`;
@@ -118,7 +118,14 @@ export async function automationChatTurn(
   context: AutomationChatContext,
   opts: AideOptions,
 ): Promise<AutomationChatTurn> {
-  const res = await runAideJson<Record<string, unknown>>(CHAT_TURN_PROMPT(messages, draft, context), opts);
+  // Authoring turns are interactive but not latency-critical, and the failure
+  // mode users hit is a slow model, not a wrong one: give each attempt a wide
+  // budget and one automatic retry. An explicit caller value still wins.
+  const res = await runAideJson<Record<string, unknown>>(CHAT_TURN_PROMPT(messages, draft, context), {
+    ...opts,
+    timeoutMs: opts.timeoutMs ?? 90_000,
+    retries: opts.retries ?? 1,
+  });
   const reply = res && typeof res.reply === 'string' ? res.reply.trim() : '';
   if (!reply) throw new Error('Aide returned no reply');
   const draftPatch: Partial<AutomationDraft> = {};

--- a/packages/core/src/aide-automation.ts
+++ b/packages/core/src/aide-automation.ts
@@ -70,6 +70,20 @@ function isValidTargetPatch(v: unknown): v is AutomationTarget {
   return false;
 }
 
+/** Newest turns kept verbatim in the prompt. The draft is a complete state
+ *  snapshot, so older turns carry tone and nothing else — dropping them keeps
+ *  a long conversation from growing the prompt until it times out. */
+export const MAX_CHAT_HISTORY = 24;
+
+export function formatTranscript(
+  messages: AutomationChatMessage[], max = MAX_CHAT_HISTORY,
+): string {
+  const recent = messages.slice(-max);
+  const lines = recent.map(m => `${m.role === 'user' ? 'User' : 'You'}: ${m.text}`);
+  if (recent.length < messages.length) lines.unshift('[earlier turns omitted]');
+  return lines.join('\n');
+}
+
 const CHAT_TURN_PROMPT = (
   messages: AutomationChatMessage[], draft: AutomationDraft, ctx: AutomationChatContext,
 ) => `You are Codey's automation-setup assistant, configuring an UNATTENDED automation through a short chat. It will run on a schedule with nobody available to answer questions, so every ambiguity that would block a run must be resolved during this conversation.
@@ -86,7 +100,7 @@ Current draft (gathered so far):
 ${JSON.stringify(draft, null, 2)}
 
 Conversation so far:
-${messages.map(m => `${m.role === 'user' ? 'User' : 'You'}: ${m.text}`).join('\n')}
+${formatTranscript(messages)}
 
 Your job this turn:
 1. Update the draft with anything the user's latest message settles. draftPatch contains ONLY fields that changed; set a top-level field to null to clear it. Nested target updates may contain only the properties being changed; they are merged with the current target. Params updates are also merged with the current params; set one param value to null to remove only that variable. Draft fields: name (short title), target ({"kind":"prompt","workspaceName":"...","agent":"optional","model":"optional"} or {"kind":"team","teamName":"...","workspaceName":"..."}), schedule ({"slots":[{"hour":0-23,"minute":0-59,"daysOfWeek":[0-6] optional},...],"tz":"${ctx.tz}"} or null for manual-only). Each slot owns its weekdays; absent daysOfWeek means every day. Example: Mon-Wed at 9pm plus Thu-Fri at noon is {"slots":[{"hour":21,"minute":0,"daysOfWeek":[1,2,3]},{"hour":12,"minute":0,"daysOfWeek":[4,5]}],"tz":"${ctx.tz}"}. notify ("all" | "failure" | "success" | "none" - which run outcomes fire an OS notification; default "none"), brief (string), params (object of string values or null for a removed variable).

--- a/packages/core/src/aide-automation.ts
+++ b/packages/core/src/aide-automation.ts
@@ -19,6 +19,24 @@ export function renderBrief(brief: string, params: Record<string, string>): stri
   return `${out}\n\nParameters:\n${leftovers.map(([k, v]) => `- ${k}: ${v}`).join('\n')}`;
 }
 
+/** What actually executes, canonicalized. Renaming, rescheduling or changing
+ *  the notify mode leaves this unchanged, so those edits never cost the user a
+ *  fresh dry run. Key order and surrounding whitespace are normalized because
+ *  a spurious difference here spawns a real agent process. */
+export function executionFingerprint(a: {
+  target?: AutomationTarget;
+  brief?: string;
+  params?: Record<string, string>;
+}): string {
+  const t = a.target;
+  const target = !t ? null
+    : t.kind === 'team'
+      ? { kind: 'team', workspaceName: t.workspaceName, teamName: t.teamName }
+      : { kind: 'prompt', workspaceName: t.workspaceName, agent: t.agent ?? null, model: t.model ?? null };
+  const params = Object.entries(a.params ?? {}).sort(([x], [y]) => x.localeCompare(y));
+  return JSON.stringify({ target, brief: a.brief?.trim() ?? '', params });
+}
+
 // ---- Conversational authoring (chat-driven creation/edit) ----
 
 /** Partial automation assembled turn-by-turn during the authoring chat. */

--- a/packages/core/src/aide.test.ts
+++ b/packages/core/src/aide.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runAide, runAideJson, isConfigError } from './aide';
+import type { AideOptions } from './aide';
+import type { AgentRequest, AgentResponse } from './types';
+
+/** Aide options whose runner is a caller-supplied mock. Retries are instant
+ *  so tests never wait on the real 1s backoff. */
+const opts = (runner: AideOptions['runner'], over: Partial<AideOptions> = {}): AideOptions => ({
+  agent: 'claude-code', runner, retryDelayMs: 0, ...over,
+});
+
+const ok = (output: string): AgentResponse => ({ success: true, output } as AgentResponse);
+
+describe('isConfigError', () => {
+  it('flags configuration failures a retry cannot fix', () => {
+    expect(isConfigError('Request failed with status 402')).toBe(true);
+    expect(isConfigError('unknown model: deepseek-v4-pro')).toBe(true);
+    expect(isConfigError('Invalid API key provided')).toBe(true);
+  });
+  it('does not flag transient failures', () => {
+    expect(isConfigError('The operation was aborted')).toBe(false);
+    expect(isConfigError('socket hang up')).toBe(false);
+  });
+});
+
+describe('runAide retries', () => {
+  it('does not retry by default', async () => {
+    const runner = vi.fn(async (_r: AgentRequest) => { throw new Error('socket hang up'); });
+    await expect(runAide('p', opts(runner))).rejects.toThrow('socket hang up');
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient failure and returns the second attempt', async () => {
+    const runner = vi.fn()
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValueOnce(ok('  second  '));
+    const out = await runAide('p', opts(runner as any, { retries: 1 }));
+    expect(out).toBe('second');
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a configuration failure', async () => {
+    const runner = vi.fn(async (_r: AgentRequest) => { throw new Error('HTTP 402 payment required'); });
+    await expect(runAide('p', opts(runner, { retries: 3 }))).rejects.toThrow('402');
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying once the caller aborts', async () => {
+    const ac = new AbortController();
+    const runner = vi.fn(async (_r: AgentRequest): Promise<AgentResponse> => {
+      ac.abort();
+      throw new Error('socket hang up');
+    });
+    await expect(runAide('p', opts(runner, { retries: 2, signal: ac.signal }))).rejects.toThrow();
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not wait out the backoff when the caller aborts mid-gap', async () => {
+    const ac = new AbortController();
+    const runner = vi.fn(async (_r: AgentRequest): Promise<AgentResponse> => {
+      throw new Error('socket hang up');
+    });
+    const BACKOFF_MS = 500;
+    setTimeout(() => ac.abort(), 20);
+    const started = Date.now();
+    await expect(
+      runAide('p', opts(runner, { retries: 1, retryDelayMs: BACKOFF_MS, signal: ac.signal }))
+    ).rejects.toThrow();
+    const elapsed = Date.now() - started;
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(elapsed).toBeLessThan(BACKOFF_MS - 100);
+  });
+});
+
+describe('runAideJson', () => {
+  it('retries unparseable output, then returns the parsed object', async () => {
+    const runner = vi.fn()
+      .mockResolvedValueOnce(ok('sorry, no JSON here'))
+      .mockResolvedValueOnce(ok('{"reply":"hi"}'));
+    const res = await runAideJson('p', opts(runner as any, { retries: 1 }));
+    expect(res).toEqual({ reply: 'hi' });
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('still returns null when every attempt is unparseable', async () => {
+    const runner = vi.fn(async (_r: AgentRequest) => ok('nope'));
+    expect(await runAideJson('p', opts(runner, { retries: 1 }))).toBeNull();
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/aide.ts
+++ b/packages/core/src/aide.ts
@@ -17,15 +17,65 @@ export interface AideOptions {
   agent: CodingAgent;
   model?: ModelConfig;
   runner: AideRunner;
-  /** Hard timeout in ms. Default 30_000. */
+  /** Hard timeout per attempt in ms. Default 30_000. */
   timeoutMs?: number;
+  /** Extra attempts after the first, for transient failures only. Default 0,
+   *  so existing callers are unaffected. */
+  retries?: number;
+  /** Delay between attempts in ms. Default 1_000. */
+  retryDelayMs?: number;
   signal?: AbortSignal;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_DELAY_MS = 1_000;
 
-/** Run a one-shot prompt through the configured Aide. Returns trimmed output, or throws. */
-export async function runAide(prompt: string, opts: AideOptions): Promise<string> {
+/** Configuration failures: a second attempt fails identically, so retrying
+ *  only doubles the wait before the user sees the real problem. Rate limiting
+ *  (429) is deliberately excluded — it IS transient and should retry. */
+const CONFIG_ERROR = /\b40[123]\b|payment required|unknown model|invalid model|model not found|invalid api key|unauthorized/i;
+
+export function isConfigError(message: string): boolean {
+  return CONFIG_ERROR.test(message);
+}
+
+/** Marks output that reached us but wasn't JSON — transient in practice, so
+ *  runAideJson retries it instead of giving up on the first bad completion. */
+class UnparseableAideJson extends Error {
+  constructor() { super('Aide returned unparseable JSON'); this.name = 'UnparseableAideJson'; }
+}
+
+/** Abort-aware backoff: a caller who cancels mid-gap should not have to wait
+ *  out the timer before their rejection surfaces. */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise<void>(res => {
+    const done = () => { clearTimeout(timer); signal?.removeEventListener('abort', done); res(); };
+    const timer = setTimeout(done, ms);
+    signal?.addEventListener('abort', done, { once: true });
+  });
+}
+
+async function withRetries<T>(opts: AideOptions, attempt: () => Promise<T>): Promise<T> {
+  const total = Math.max(0, opts.retries ?? 0) + 1;
+  let lastErr: unknown;
+  for (let i = 0; i < total; i++) {
+    try {
+      return await attempt();
+    } catch (err) {
+      lastErr = err;
+      if (i === total - 1) break;
+      if (opts.signal?.aborted) break;
+      if (isConfigError((err as Error)?.message ?? '')) break;
+      await delay(opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS, opts.signal);
+      if (opts.signal?.aborted) break;
+    }
+  }
+  throw lastErr;
+}
+
+/** One attempt: the timeout is per-attempt, so a retry gets a full budget. */
+async function runOnce(prompt: string, opts: AideOptions): Promise<string> {
   const ac = new AbortController();
   const onUserAbort = () => ac.abort();
   if (opts.signal) {
@@ -49,8 +99,24 @@ export async function runAide(prompt: string, opts: AideOptions): Promise<string
   }
 }
 
-/** JSON variant — runs the prompt, then extracts and parses the first balanced object. */
+/** Run a one-shot prompt through the configured Aide. Returns trimmed output, or throws. */
+export async function runAide(prompt: string, opts: AideOptions): Promise<string> {
+  return withRetries(opts, () => runOnce(prompt, opts));
+}
+
+/** JSON variant — runs the prompt, then extracts and parses the first balanced
+ *  object. Unparseable output is retried like any other transient failure;
+ *  null is returned only after the last attempt. */
 export async function runAideJson<T = unknown>(prompt: string, opts: AideOptions): Promise<T | null> {
-  const txt = await runAide(prompt, opts);
-  return extractJsonObject(txt) as T | null;
+  try {
+    return await withRetries(opts, async () => {
+      const txt = await runOnce(prompt, opts);
+      const parsed = extractJsonObject(txt) as T | null;
+      if (parsed === null) throw new UnparseableAideJson();
+      return parsed;
+    });
+  } catch (err) {
+    if (err instanceof UnparseableAideJson) return null;
+    throw err;
+  }
 }

--- a/packages/core/src/types/automation.ts
+++ b/packages/core/src/types/automation.ts
@@ -111,6 +111,9 @@ export interface Automation {
   report: AutomationReport;
   /** Hidden system chat this automation executes in (created lazily). */
   chatId?: string;
+  /** Advisory verdict from the last background dry run. Absent on records
+   *  written before this existed, and after the user dismisses it. */
+  check?: AutomationCheck;
   /** Last slot fired, for double-fire protection. Never used to back-fire. */
   lastFiredAt?: number;
   createdAt: number;
@@ -161,8 +164,19 @@ export interface AutomationRun {
   notifiedAt?: number;
 }
 
-/** Status of the authoring-time dry-run check for a chat session. */
+/** Status of an automation's advisory dry-run check. */
 export type AutomationCheckStatus = 'pending' | 'clean' | 'gaps' | 'error';
+
+/** Advisory result of the last unattended dry run. Never blocks saving:
+ *  the automation is already persisted by the time a verdict arrives. */
+export interface AutomationCheck {
+  status: AutomationCheckStatus;
+  /** Present when status === 'gaps'. */
+  questions?: string[];
+  /** Present when status === 'error'. */
+  detail?: string;
+  at: number;
+}
 
 export type AutomationEvent =
   | {
@@ -172,15 +186,9 @@ export type AutomationEvent =
       run?: AutomationRun;
     }
   | {
-      /** Dry-run verdict for an authoring chat session (never 'pending' -
-       *  pending is signaled by the ChatStep that triggered the check). */
-      type: 'chat-check';
-      sessionId: string;
-      check: Exclude<AutomationCheckStatus, 'pending'>;
-      questions?: string[];
-      /** Assistant message the gateway appended to the session, so the
-       *  renderer can show it without waiting for the next turn. */
-      message?: string;
-      /** Failure detail when check === 'error' (tooltip only, not a chat message). */
-      detail?: string;
+      /** The automation's advisory check changed. An absent `check` means it
+       *  was dismissed and the banner should disappear. */
+      type: 'automation-check';
+      automationId: string;
+      check?: AutomationCheck;
     };

--- a/packages/gateway/src/automations/chat.test.ts
+++ b/packages/gateway/src/automations/chat.test.ts
@@ -32,7 +32,6 @@ describe('start', () => {
     expect(step.reply).toMatch(/What should change/);
     expect(step.draft).toEqual(COMPLETE);
     expect(step.ready).toBe(true);
-    expect(step.check).toBe('clean');
   });
 });
 
@@ -116,137 +115,25 @@ describe('send', () => {
   });
 });
 
-describe('dry-run check state', () => {
-  it('waits for an explicit request before starting a check', async () => {
-    const onReadyTransition = vi.fn();
-    const turn = vi.fn()
-      .mockResolvedValueOnce(turnResult({ ready: true }))
-      .mockResolvedValueOnce(turnResult({ ready: true }));
-    const mgr = new AutomationChatManager({ turn, context: () => CTX, onReadyTransition });
-    const { sessionId } = mgr.start('create', COMPLETE);
-
-    const first = await mgr.send(sessionId, 'go');
-    expect(first.check).toBeUndefined();
-    expect(onReadyTransition).not.toHaveBeenCalled();
-
-    const checking = mgr.retryCheck(sessionId);
-    expect(checking.check).toBe('pending');
-    expect(onReadyTransition).toHaveBeenCalledWith(sessionId, COMPLETE);
-
-    const second = await mgr.send(sessionId, 'still ready');
-    expect(onReadyTransition).toHaveBeenCalledTimes(1); // no re-trigger while ready stays true
-    expect(second.check).toBe('pending');               // state carries over
-  });
-
-  it('clears check when ready drops back to false without automatically restarting it', async () => {
-    const onReadyTransition = vi.fn();
-    const turn = vi.fn()
-      .mockResolvedValueOnce(turnResult({ ready: true }))
-      .mockResolvedValueOnce(turnResult({ ready: false }))
-      .mockResolvedValueOnce(turnResult({ ready: true }));
-    const mgr = new AutomationChatManager({ turn, context: () => CTX, onReadyTransition });
-    const { sessionId } = mgr.start('create', COMPLETE);
-    await mgr.send(sessionId, 'a');
-    mgr.retryCheck(sessionId);
-    const dropped = await mgr.send(sessionId, 'b');
-    expect(dropped.check).toBeUndefined();
-    const readyAgain = await mgr.send(sessionId, 'c');
-    expect(readyAgain.check).toBeUndefined();
-    expect(onReadyTransition).toHaveBeenCalledTimes(1);
-  });
-
-  it('resolveCheck records the verdict and appends the message to the transcript', async () => {
-    const turn = vi.fn().mockResolvedValue(turnResult({ ready: true }));
-    const mgr = new AutomationChatManager({ turn, context: () => CTX });
-    const { sessionId } = mgr.start('create', COMPLETE);
-    await mgr.send(sessionId, 'go');
-    mgr.retryCheck(sessionId);
-
-    expect(mgr.resolveCheck(sessionId, 'clean', 'Dry run passed.')).toBe(true);
-    const next = await mgr.send(sessionId, 'next');
-    expect(next.check).toBe('clean');
-    const transcript = turn.mock.calls[1][0];
-    expect(transcript.some((m: any) => m.role === 'assistant' && m.text === 'Dry run passed.')).toBe(true);
-  });
-
-  it('resolveCheck is rejected when the check is not pending or the session is gone', async () => {
-    const turn = vi.fn().mockResolvedValue(turnResult({ ready: true }));
-    const mgr = new AutomationChatManager({ turn, context: () => CTX });
-    const { sessionId } = mgr.start('create', COMPLETE);
-    expect(mgr.resolveCheck(sessionId, 'clean')).toBe(false); // never went pending
-    await mgr.send(sessionId, 'go');
-    mgr.retryCheck(sessionId);
-    expect(mgr.resolveCheck(sessionId, 'gaps', 'q')).toBe(true);
-    expect(mgr.resolveCheck(sessionId, 'clean')).toBe(false); // already resolved
-    expect(mgr.resolveCheck('nope', 'clean')).toBe(false);    // unknown session
-  });
-
-  it('a late verdict is rejected after ready dropped and cleared the pending check', async () => {
-    const turn = vi.fn()
-      .mockResolvedValueOnce(turnResult({ ready: true }))
-      .mockResolvedValueOnce(turnResult({ ready: false }));
-    const mgr = new AutomationChatManager({ turn, context: () => CTX });
-    const { sessionId } = mgr.start('create', COMPLETE);
-    await mgr.send(sessionId, 'go');
-    mgr.retryCheck(sessionId);             // check -> pending
-    await mgr.send(sessionId, 'actually'); // ready drops, check cleared
-    expect(mgr.resolveCheck(sessionId, 'clean')).toBe(false);
-  });
-
-  it('direct form patches invalidate only execution-relevant checks without starting one', () => {
-    const onReadyTransition = vi.fn();
-    const mgr = new AutomationChatManager({ turn: vi.fn(), context: () => CTX, onReadyTransition });
-    const { sessionId } = mgr.start('create');
-    const complete = mgr.patch(sessionId, COMPLETE);
-    expect(complete.ready).toBe(true);
-    expect(complete.check).toBeUndefined();
-    expect(onReadyTransition).not.toHaveBeenCalled();
-    mgr.retryCheck(sessionId);
-    expect(mgr.resolveCheck(sessionId, 'clean')).toBe(true);
-
-    const renamed = mgr.patch(sessionId, { name: 'Renamed' });
-    expect(renamed.check).toBe('clean');
-    expect(onReadyTransition).toHaveBeenCalledTimes(1);
-
-    const changed = mgr.patch(sessionId, { brief: 'Post ten items.' });
-    expect(changed.check).toBeUndefined();
-    expect(onReadyTransition).toHaveBeenCalledTimes(1);
-  });
-
-  it('finalizes only checked drafts and retains edit source identity', () => {
-    const mgr = new AutomationChatManager({ turn: vi.fn(), context: () => CTX });
-    const { sessionId } = mgr.start('edit', COMPLETE, 'automation-1');
-    mgr.patch(sessionId, { name: 'Renamed' });
+describe('finalize', () => {
+  it('returns the draft for any complete draft, with no verification step', () => {
+    const { mgr } = manager();
+    const { sessionId } = mgr.start('edit', COMPLETE, 'a1');
     expect(mgr.finalize(sessionId)).toEqual({
-      mode: 'edit', sourceAutomationId: 'automation-1', draft: { ...COMPLETE, name: 'Renamed' },
+      mode: 'edit', sourceAutomationId: 'a1', draft: COMPLETE,
     });
   });
 
-  it('requires verification after execution-changing form edits to an existing automation', () => {
-    const onReadyTransition = vi.fn();
-    const mgr = new AutomationChatManager({ turn: vi.fn(), context: () => CTX, onReadyTransition });
-    const { sessionId } = mgr.start('edit', COMPLETE, 'automation-1');
-    const step = mgr.patch(sessionId, { brief: 'Post ten items.' });
-    expect(step.ready).toBe(true);
-    expect(step.check).toBeUndefined();
-    expect(onReadyTransition).not.toHaveBeenCalled();
-    expect(() => mgr.finalize(sessionId)).toThrow(/pass/i);
-    mgr.retryCheck(sessionId);
-    expect(onReadyTransition).toHaveBeenCalledWith(sessionId, { ...COMPLETE, brief: 'Post ten items.' });
+  it('finalizes a create session as soon as the draft is complete', () => {
+    const { mgr } = manager();
+    const { sessionId } = mgr.start('create');
+    expect(() => mgr.finalize(sessionId)).toThrow(/incomplete/);
+    mgr.patch(sessionId, COMPLETE);
+    expect(mgr.finalize(sessionId).draft).toEqual(COMPLETE);
   });
 
-  it('allows an explicit override only for a failed check, never gaps', () => {
-    const mgr = new AutomationChatManager({ turn: vi.fn(), context: () => CTX });
-    const gaps = mgr.start('create', COMPLETE).sessionId;
-    mgr.patch(gaps, { name: 'Ready' });
-    mgr.retryCheck(gaps);
-    mgr.resolveCheck(gaps, 'gaps');
-    expect(() => mgr.finalize(gaps, true)).toThrow(/pass/i);
-
-    const failed = mgr.start('create', COMPLETE).sessionId;
-    mgr.patch(failed, { name: 'Ready' });
-    mgr.retryCheck(failed);
-    mgr.resolveCheck(failed, 'error');
-    expect(mgr.finalize(failed, true).draft.name).toBe('Ready');
+  it('rejects an unknown session', () => {
+    const { mgr } = manager();
+    expect(() => mgr.finalize('nope')).toThrow(/Unknown automation chat session/);
   });
 });

--- a/packages/gateway/src/automations/chat.ts
+++ b/packages/gateway/src/automations/chat.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { AutomationChatContext, AutomationChatTurn, AutomationDraft, AutomationChatMessage, AutomationCheckStatus } from '@codey/core';
+import type { AutomationChatContext, AutomationChatTurn, AutomationDraft, AutomationChatMessage } from '@codey/core';
 
 export interface ChatManagerDeps {
   /** Bound automationChatTurn with AideOptions pre-applied. */
@@ -10,8 +10,6 @@ export interface ChatManagerDeps {
   ) => Promise<AutomationChatTurn>;
   /** Live grounding lists - re-read per turn so new workspaces/teams appear. */
   context: () => Omit<AutomationChatContext, 'mode'>;
-  /** Fired when the user explicitly requests an unattended dry-run check. */
-  onReadyTransition?: (sessionId: string, draft: AutomationDraft) => void;
   now?: () => number;
 }
 
@@ -21,9 +19,9 @@ export interface ChatStep {
   /** Full draft after the patch - drives the live summary panel. */
   draft: AutomationDraft;
   suggestions: string[];
+  /** The assistant has no open questions. Drives copy only - saving is gated
+   *  by draftComplete alone. */
   ready: boolean;
-  /** Dry-run check state; undefined until the first ready transition. */
-  check?: AutomationCheckStatus;
   /** Live choices used by the structured editor. */
   context: Omit<AutomationChatContext, 'mode' | 'nowIso'>;
 }
@@ -35,9 +33,6 @@ interface Session {
   inFlight: boolean;
   touchedAt: number;
   sourceAutomationId?: string;
-  check?: AutomationCheckStatus;
-  /** Execution configuration covered by the current check. */
-  checkFingerprint?: string;
 }
 
 export const SESSION_TTL_MS = 30 * 60_000;
@@ -79,18 +74,10 @@ export class AutomationChatManager {
       touchedAt: this.now(),
       sourceAutomationId,
     };
-    // A persisted automation is already a valid, reviewed baseline. Treat it
-    // as ready so the structured form can save metadata/schedule/notification
-    // edits without forcing an otherwise empty assistant turn. Changes to the
-    // execution fingerprint (target, brief, or params) still trigger a fresh
-    // unattended check through patch().
-    const ready = mode === 'edit' && draftComplete(s.draft);
-    if (ready) {
-      s.check = 'clean';
-      s.checkFingerprint = executionFingerprint(s.draft);
-    }
     this.sessions.set(sessionId, s);
-    return this.step(sessionId, s, reply, [], ready);
+    // A persisted automation is already a complete, reviewed baseline, so an
+    // edit session opens ready without forcing an otherwise empty turn.
+    return this.step(sessionId, s, reply, [], mode === 'edit' && draftComplete(s.draft));
   }
 
   async send(sessionId: string, text: string): Promise<ChatStep> {
@@ -112,7 +99,6 @@ export class AutomationChatManager {
       s.messages.push({ role: 'user', text }, { role: 'assistant', text: turn.reply });
       applyDraftPatch(s.draft, turn.draftPatch);
       const ready = turn.ready && draftComplete(s.draft);
-      this.reconcileCheck(sessionId, s, ready);
       return this.step(sessionId, s, turn.reply, turn.suggestions, ready);
     } finally {
       s.inFlight = false;
@@ -132,72 +118,25 @@ export class AutomationChatManager {
     s.touchedAt = this.now();
     applyDraftPatch(s.draft, patch);
     const ready = draftComplete(s.draft);
-    this.reconcileCheck(sessionId, s, ready);
     return this.step(sessionId, s, '', [], ready);
   }
 
-  retryCheck(sessionId: string): ChatStep {
-    this.sweep();
-    const s = this.sessions.get(sessionId);
-    if (!s) throw new Error(`Unknown automation chat session: ${sessionId}`);
-    const ready = draftComplete(s.draft);
-    if (!ready) throw new Error('Automation draft is incomplete');
-    s.check = undefined;
-    s.checkFingerprint = undefined;
-    this.reconcileCheck(sessionId, s, true, true);
-    return this.step(sessionId, s, '', [], true);
-  }
-
-  /** Return a server-owned draft only when it is safe to persist. */
-  finalize(sessionId: string, allowUnchecked = false): {
+  /** Return a server-owned draft. A complete draft is always saveable: the
+   *  dry run is advisory and runs after the automation is persisted. */
+  finalize(sessionId: string): {
     mode: 'create' | 'edit'; sourceAutomationId?: string; draft: AutomationDraft;
   } {
     this.sweep();
     const s = this.sessions.get(sessionId);
     if (!s) throw new Error(`Unknown automation chat session: ${sessionId}`);
     if (!draftComplete(s.draft)) throw new Error('Automation draft is incomplete');
-    if (s.check !== 'clean' && !(allowUnchecked && s.check === 'error')) {
-      throw new Error(s.check === 'pending' ? 'Unattended check is still running' : 'Automation must pass its unattended check');
-    }
     return { mode: s.mode, sourceAutomationId: s.sourceAutomationId, draft: { ...s.draft } };
-  }
-
-  /**
-   * Record a dry-run verdict. Accepted only while the session's check is
-   * still pending - rejected (returns false) when the session is gone,
-   * ready dropped back to false, or the check was already resolved; the
-   * caller must discard such a stale verdict.
-   * `message` is appended to the transcript so later turns see it.
-   */
-  resolveCheck(sessionId: string, check: Exclude<AutomationCheckStatus, 'pending'>, message?: string): boolean {
-    const s = this.sessions.get(sessionId);
-    if (!s || s.check !== 'pending') return false;
-    s.check = check;
-    if (message) s.messages.push({ role: 'assistant', text: message });
-    return true;
-  }
-
-  private reconcileCheck(sessionId: string, s: Session, ready: boolean, startCheck = false): void {
-    if (!ready) {
-      s.check = undefined;
-      s.checkFingerprint = undefined;
-      return;
-    }
-    const fingerprint = executionFingerprint(s.draft);
-    if (s.checkFingerprint === fingerprint && s.check) return;
-    s.check = undefined;
-    s.checkFingerprint = undefined;
-    if (!startCheck) return;
-    s.check = 'pending';
-    s.checkFingerprint = fingerprint;
-    try { this.deps.onReadyTransition?.(sessionId, { ...s.draft }); }
-    catch { /* dry-run trigger must not fail the edit */ }
   }
 
   private step(sessionId: string, s: Session, reply: string, suggestions: string[], ready: boolean): ChatStep {
     const { workspaces, teams, agents, models, tz } = this.deps.context();
     return {
-      sessionId, reply, draft: { ...s.draft }, suggestions, ready, check: s.check,
+      sessionId, reply, draft: { ...s.draft }, suggestions, ready,
       context: { workspaces, teams, agents, models, tz },
     };
   }
@@ -206,10 +145,6 @@ export class AutomationChatManager {
 export function draftComplete(draft: AutomationDraft): boolean {
   if (!draft.name?.trim() || !draft.brief?.trim() || !draft.target?.workspaceName?.trim()) return false;
   return draft.target.kind !== 'team' || !!draft.target.teamName?.trim();
-}
-
-function executionFingerprint(draft: AutomationDraft): string {
-  return JSON.stringify({ target: draft.target, brief: draft.brief?.trim(), params: draft.params ?? {} });
 }
 
 /** Shallow merge; an explicit null clears the field. */

--- a/packages/gateway/src/automations/check.test.ts
+++ b/packages/gateway/src/automations/check.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { needsRecheck, verdictToCheck } from './check';
+
+const base = {
+  target: { kind: 'prompt' as const, workspaceName: 'default' },
+  brief: 'Post five items.',
+  params: { count: '5' },
+};
+
+describe('needsRecheck', () => {
+  it('always checks a newly created automation', () => {
+    expect(needsRecheck(undefined, base)).toBe(true);
+  });
+
+  it('skips a rename / reschedule / notify-only edit', () => {
+    expect(needsRecheck(base, { ...base })).toBe(false);
+  });
+
+  it('checks when the brief, params or target change', () => {
+    expect(needsRecheck(base, { ...base, brief: 'Post six items.' })).toBe(true);
+    expect(needsRecheck(base, { ...base, params: { count: '6' } })).toBe(true);
+    expect(needsRecheck(base, { ...base, target: { kind: 'prompt', workspaceName: 'blog' } })).toBe(true);
+  });
+});
+
+describe('verdictToCheck', () => {
+  it('maps each verdict onto the persisted shape', () => {
+    expect(verdictToCheck({ status: 'clean' }, 7)).toEqual({ status: 'clean', at: 7 });
+    expect(verdictToCheck({ status: 'gaps', questions: ['Which account?'] }, 7))
+      .toEqual({ status: 'gaps', questions: ['Which account?'], at: 7 });
+    expect(verdictToCheck({ status: 'error', message: 'agent died' }, 7))
+      .toEqual({ status: 'error', detail: 'agent died', at: 7 });
+  });
+});

--- a/packages/gateway/src/automations/check.ts
+++ b/packages/gateway/src/automations/check.ts
@@ -1,0 +1,24 @@
+// packages/gateway/src/automations/check.ts
+import { executionFingerprint } from '@codey/core';
+import type { AutomationCheck, AutomationTarget, DryRunVerdict } from '@codey/core';
+
+/** Just enough of an automation (or draft) to know what would execute. */
+export interface Executable {
+  target?: AutomationTarget;
+  brief?: string;
+  params?: Record<string, string>;
+}
+
+/** A background dry run costs a real agent process, so it is warranted only
+ *  when what executes actually changed. `prev` absent = freshly created. */
+export function needsRecheck(prev: Executable | undefined, next: Executable): boolean {
+  if (!prev) return true;
+  return executionFingerprint(prev) !== executionFingerprint(next);
+}
+
+/** Map a dry-run verdict onto the automation's persisted advisory field. */
+export function verdictToCheck(verdict: DryRunVerdict, at: number): AutomationCheck {
+  if (verdict.status === 'clean') return { status: 'clean', at };
+  if (verdict.status === 'gaps') return { status: 'gaps', questions: verdict.questions, at };
+  return { status: 'error', detail: verdict.message, at };
+}

--- a/packages/gateway/src/automations/dry-run.test.ts
+++ b/packages/gateway/src/automations/dry-run.test.ts
@@ -19,7 +19,7 @@ describe('DryRunManager', () => {
     const onResult = vi.fn();
     const mgr = new DryRunManager({ execute, classify, teamContext: () => undefined, onResult });
 
-    mgr.start('s1', draft());
+    mgr.start('a1', draft());
     await flush();
 
     expect(execute).toHaveBeenCalledTimes(1);
@@ -28,7 +28,7 @@ describe('DryRunManager', () => {
     expect(prompt).toMatch(/DRY RUN/);
     expect(prompt).toContain('Post 5 items.');
     expect(classify).toHaveBeenCalledWith('agent output');
-    expect(onResult).toHaveBeenCalledWith('s1', { status: 'clean' });
+    expect(onResult).toHaveBeenCalledWith('a1', { status: 'clean' });
   });
 
   it('inlines team context for team targets and never team-dispatches', async () => {
@@ -39,7 +39,7 @@ describe('DryRunManager', () => {
       execute, classify: vi.fn().mockResolvedValue({ status: 'clean' as const }), teamContext, onResult,
     });
 
-    mgr.start('s1', draft({ target: { kind: 'team', teamName: 'news', workspaceName: 'blog' } }));
+    mgr.start('a1', draft({ target: { kind: 'team', teamName: 'news', workspaceName: 'blog' } }));
     await flush();
 
     expect(teamContext).toHaveBeenCalledWith('blog', 'news');
@@ -54,7 +54,7 @@ describe('DryRunManager', () => {
       teamContext: () => undefined, onResult: vi.fn(),
     });
     const target = { kind: 'prompt' as const, workspaceName: 'default', agent: 'codex' as const, model: 'gpt-x' };
-    mgr.start('s1', draft({ target }));
+    mgr.start('a1', draft({ target }));
     await flush();
     expect(execute.mock.calls[0][0]).toEqual(target);
   });
@@ -67,9 +67,9 @@ describe('DryRunManager', () => {
       teamContext: () => undefined,
       onResult,
     });
-    mgr.start('s1', draft());
+    mgr.start('a1', draft());
     await flush();
-    expect(onResult).toHaveBeenCalledWith('s1', { status: 'error', message: 'agent timed out' });
+    expect(onResult).toHaveBeenCalledWith('a1', { status: 'error', message: 'agent timed out' });
   });
 
   it('an incomplete draft yields an error verdict', async () => {
@@ -80,9 +80,9 @@ describe('DryRunManager', () => {
       teamContext: () => undefined,
       onResult,
     });
-    mgr.start('s1', { name: 'N' }); // no target/brief
+    mgr.start('a1', { name: 'N' }); // no target/brief
     await flush();
-    expect(onResult).toHaveBeenCalledWith('s1', expect.objectContaining({ status: 'error' }));
+    expect(onResult).toHaveBeenCalledWith('a1', expect.objectContaining({ status: 'error' }));
   });
 
   it('a newer start supersedes an in-flight run - the stale verdict is dropped', async () => {
@@ -97,14 +97,14 @@ describe('DryRunManager', () => {
       teamContext: () => undefined, onResult,
     });
 
-    mgr.start('s1', draft());
-    mgr.start('s1', draft({ brief: 'v2' }));
+    mgr.start('a1', draft());
+    mgr.start('a1', draft({ brief: 'v2' }));
     await flush();
     releaseFirst('first output');
     await flush();
 
     expect(onResult).toHaveBeenCalledTimes(1);
-    expect(onResult).toHaveBeenCalledWith('s1', { status: 'gaps', questions: ['second output'] });
+    expect(onResult).toHaveBeenCalledWith('a1', { status: 'gaps', questions: ['second output'] });
   });
 
   it('a run surviving a cancel-then-restart cannot deliver a stale verdict', async () => {
@@ -119,15 +119,15 @@ describe('DryRunManager', () => {
       classify: vi.fn().mockImplementation(async (o: string) => ({ status: 'gaps' as const, questions: [o] })),
       teamContext: () => undefined, onResult,
     });
-    mgr.start('s1', draft());
-    mgr.cancel('s1');
-    mgr.start('s1', draft({ brief: 'v2' }));
+    mgr.start('a1', draft());
+    mgr.cancel('a1');
+    mgr.start('a1', draft({ brief: 'v2' }));
     releaseFirst('first output'); // stale run resolves while the new run is in flight
     await flush();
     releaseSecond('second output');
     await flush();
     expect(onResult).toHaveBeenCalledTimes(1);
-    expect(onResult).toHaveBeenCalledWith('s1', { status: 'gaps', questions: ['second output'] });
+    expect(onResult).toHaveBeenCalledWith('a1', { status: 'gaps', questions: ['second output'] });
   });
 
   it('cancel drops an in-flight result', async () => {
@@ -138,8 +138,8 @@ describe('DryRunManager', () => {
       classify: vi.fn().mockResolvedValue({ status: 'clean' as const }),
       teamContext: () => undefined, onResult,
     });
-    mgr.start('s1', draft());
-    mgr.cancel('s1');
+    mgr.start('a1', draft());
+    mgr.cancel('a1');
     release('out');
     await flush();
     expect(onResult).not.toHaveBeenCalled();
@@ -152,8 +152,8 @@ describe('DryRunManager', () => {
       classify: vi.fn().mockResolvedValue({ status: 'clean' as const }),
       teamContext: () => undefined, onResult,
     });
-    mgr.start('s1', draft());
-    mgr.start('s2', draft());
+    mgr.start('a1', draft());
+    mgr.start('a2', draft());
     await flush();
     expect(onResult).toHaveBeenCalledTimes(2);
   });

--- a/packages/gateway/src/automations/dry-run.ts
+++ b/packages/gateway/src/automations/dry-run.ts
@@ -10,15 +10,16 @@ export interface DryRunDeps {
   /** Team definitions to inline for team targets (undefined = none found). */
   teamContext: (workspaceName: string, teamName: string) => string | undefined;
   /** Delivered once per surviving run; superseded/cancelled runs are silent. */
-  onResult: (sessionId: string, verdict: DryRunVerdict) => void;
+  onResult: (automationId: string, verdict: DryRunVerdict) => void;
   log?: (msg: string) => void;
 }
 
 /**
- * Fire-and-forget dry-runs keyed by authoring-chat session. At most one
- * verdict is delivered per session generation: a newer start() or a cancel()
- * makes any in-flight run's result be dropped on arrival (the underlying
- * agent process is not killed - the adapter's own timeout bounds it).
+ * Fire-and-forget dry-runs keyed by automation id. At most one verdict is
+ * delivered per automation generation: a newer start() or a cancel() makes any
+ * in-flight run's result be dropped on arrival (the underlying agent process is
+ * not killed - the adapter's own timeout bounds it). Runs are advisory and
+ * start only after the automation is already persisted.
  */
 export class DryRunManager {
   private generations = new Map<string, number>();
@@ -28,18 +29,18 @@ export class DryRunManager {
 
   constructor(private deps: DryRunDeps) {}
 
-  start(sessionId: string, draft: AutomationDraft): void {
+  start(automationId: string, draft: AutomationDraft): void {
     const gen = this.nextGen++;
-    this.generations.set(sessionId, gen);
-    void this.run(sessionId, gen, draft);
+    this.generations.set(automationId, gen);
+    void this.run(automationId, gen, draft);
   }
 
-  /** Drop any in-flight run's result (authoring UI closed / session over). */
-  cancel(sessionId: string): void {
-    this.generations.delete(sessionId);
+  /** Drop any in-flight run's result (superseded edit, or deleted automation). */
+  cancel(automationId: string): void {
+    this.generations.delete(automationId);
   }
 
-  private async run(sessionId: string, gen: number, draft: AutomationDraft): Promise<void> {
+  private async run(automationId: string, gen: number, draft: AutomationDraft): Promise<void> {
     let verdict: DryRunVerdict;
     try {
       if (!draft.target || !draft.brief) throw new Error('Draft is missing target or brief');
@@ -52,12 +53,12 @@ export class DryRunManager {
     } catch (err) {
       verdict = { status: 'error', message: (err as Error).message };
     }
-    if (this.generations.get(sessionId) !== gen) {
-      this.deps.log?.(`dry-run for ${sessionId} superseded; verdict dropped`);
+    if (this.generations.get(automationId) !== gen) {
+      this.deps.log?.(`dry-run for ${automationId} superseded; verdict dropped`);
       return;
     }
-    this.generations.delete(sessionId);
-    try { this.deps.onResult(sessionId, verdict); }
+    this.generations.delete(automationId);
+    try { this.deps.onResult(automationId, verdict); }
     catch (err) { this.deps.log?.(`dry-run onResult failed: ${(err as Error).message}`); }
   }
 }

--- a/packages/gateway/src/automations/store.test.ts
+++ b/packages/gateway/src/automations/store.test.ts
@@ -114,6 +114,24 @@ describe('definitions', () => {
     expect(back.enabled).toBe(false);
     expect(back.lastFiredAt).toBe(333);
   });
+
+  it('writes and clears the advisory check without touching updatedAt', () => {
+    const a = store.create(draft(), 111);
+    store.setCheck(a.id, { status: 'pending', at: 222 });
+    expect(store.get(a.id)!.check).toEqual({ status: 'pending', at: 222 });
+    expect(store.get(a.id)!.updatedAt).toBe(111);
+
+    store.setCheck(a.id, { status: 'gaps', questions: ['Which account?'], at: 333 });
+    expect(store.get(a.id)!.check).toEqual({ status: 'gaps', questions: ['Which account?'], at: 333 });
+
+    store.setCheck(a.id, undefined);
+    expect(store.get(a.id)!.check).toBeUndefined();
+    expect(JSON.stringify(store.get(a.id))).not.toContain('check');
+  });
+
+  it('setCheck on an unknown id is a no-op', () => {
+    expect(() => store.setCheck('nope', { status: 'clean', at: 1 })).not.toThrow();
+  });
 });
 
 describe('run history', () => {

--- a/packages/gateway/src/automations/store.ts
+++ b/packages/gateway/src/automations/store.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import type { Automation, AutomationRun } from '@codey/core';
+import type { Automation, AutomationCheck, AutomationRun } from '@codey/core';
 import { normalizeNotifyMode, normalizeSchedule } from '@codey/core';
 
 /** Fields callers supply on create; id/timestamps are generated. */
@@ -132,6 +132,18 @@ export class AutomationStore {
     const cur = raw.automations.find(a => a.id === id);
     if (!cur) return; // unknown id — don't rewrite the file for a no-op
     cur.lastFiredAt = ts;
+    this.writeRaw(raw);
+  }
+
+  /** Advisory dry-run verdict. Not a user edit, so updatedAt is untouched —
+   *  a background verdict must not make the one-pager claim the automation
+   *  was just modified. `undefined` removes the field (user dismissed it). */
+  setCheck(id: string, check: AutomationCheck | undefined): void {
+    const raw = this.loadRaw();
+    const cur = raw.automations.find(a => a.id === id);
+    if (!cur) return; // unknown id — don't rewrite the file for a no-op
+    if (check) cur.check = check;
+    else delete cur.check;
     this.writeRaw(raw);
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,13 +1,14 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
 import { SchedulerLease } from './automations/lease';
 import { AutomationChatManager, ChatStep } from './automations/chat';
 import { DryRunManager } from './automations/dry-run';
+import { needsRecheck, verdictToCheck } from './automations/check';
 import { detectParked } from './automations/parked';
 import { formatRunSummary } from './automations/report';
 import { formatRunLogEvent } from './automations/run-log';
@@ -1498,7 +1499,7 @@ export class Codey {
         }).join('\n\n');
         return `Team config:\n${JSON.stringify(team, null, 2)}\n\nWorker roles:\n${personas}`;
       },
-      onResult: (sessionId, verdict) => this.onDryRunResult(sessionId, verdict),
+      onResult: (automationId, verdict) => this.onDryRunResult(automationId, verdict),
       log: (msg) => this.logger.info(`[automations] ${msg}`),
     });
     this.automationChats = new AutomationChatManager({
@@ -1511,7 +1512,6 @@ export class Codey {
         tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
         nowIso: new Date().toString(),
       }),
-      onReadyTransition: (sessionId, draft) => this.automationDryRuns!.start(sessionId, draft),
     });
   }
 
@@ -1630,25 +1630,30 @@ export class Codey {
     return response.output;
   }
 
-  /** Deliver a dry-run verdict into the chat session and to the renderer. */
-  private onDryRunResult(sessionId: string, verdict: DryRunVerdict): void {
-    const message = verdict.status === 'clean'
-      ? 'Dry run passed - this can run unattended. Save when ready.'
-      : verdict.status === 'gaps'
-        ? `Dry run found things to pin down:\n${verdict.questions.map(q => `- ${q}`).join('\n')}`
-        : undefined; // errors surface only in the summary-panel status
-    const accepted = this.automationChats?.resolveCheck(sessionId, verdict.status, message) ?? false;
-    if (!accepted) return; // session gone or check superseded
-    try {
-      this.automationEventListener?.({
-        type: 'chat-check',
-        sessionId,
-        check: verdict.status,
-        questions: verdict.status === 'gaps' ? verdict.questions : undefined,
-        message,
-        detail: verdict.status === 'error' ? verdict.message : undefined,
-      });
-    } catch { /* swallow - listener failures must not break the chat */ }
+  /** Emit an automation event without letting a listener failure escape. */
+  private emitAutomationEvent(ev: AutomationEvent): void {
+    try { this.automationEventListener?.(ev); }
+    catch { /* swallow - listener failures must not break automations */ }
+  }
+
+  /** Start an advisory background dry run for an already-persisted automation. */
+  private startAutomationCheck(a: Automation): void {
+    const check: AutomationCheck = { status: 'pending', at: Date.now() };
+    this.automationStore?.setCheck(a.id, check);
+    this.emitAutomationEvent({ type: 'automation-check', automationId: a.id, check });
+    this.automationDryRuns?.start(a.id, {
+      name: a.name, target: a.target, brief: a.brief, params: a.params,
+    });
+  }
+
+  /** Persist a dry-run verdict and tell the renderer. Purely advisory - the
+   *  automation has been saved and runnable since before this started. */
+  private onDryRunResult(automationId: string, verdict: DryRunVerdict): void {
+    // Deleted while the run was in flight: nothing left to annotate.
+    if (!this.automationStore?.get(automationId)) return;
+    const check = verdictToCheck(verdict, Date.now());
+    this.automationStore.setCheck(automationId, check);
+    this.emitAutomationEvent({ type: 'automation-check', automationId, check });
   }
 
   // ---- Automations public API ----
@@ -1685,6 +1690,7 @@ export class Codey {
   deleteAutomation(id: string): void {
     const a = this.requireAutomationStore().get(id);
     if (!a) throw new Error(`Automation not found: ${id}`);
+    this.automationDryRuns?.cancel(id);
     if (a.chatId) {
       this.chatManager.reload(a.chatId);
       try { this.chatManager.delete(a.chatId); } catch { /* already gone */ }
@@ -1742,25 +1748,44 @@ export class Codey {
   patchAutomationChat(sessionId: string, patch: Parameters<AutomationChatManager['patch']>[1]): ChatStep {
     return this.requireAutomationChats().patch(sessionId, patch);
   }
-  retryAutomationChatCheck(sessionId: string): ChatStep {
-    return this.requireAutomationChats().retryCheck(sessionId);
-  }
-  saveAutomationChat(sessionId: string, allowUnchecked = false): Automation {
-    const { mode, sourceAutomationId, draft } = this.requireAutomationChats().finalize(sessionId, allowUnchecked);
+  saveAutomationChat(sessionId: string): Automation {
+    const { mode, sourceAutomationId, draft } = this.requireAutomationChats().finalize(sessionId);
     const payload = {
       name: draft.name!.trim(), target: draft.target!, brief: draft.brief!.trim(),
       params: draft.params ?? {}, schedule: draft.schedule,
       report: { notify: draft.notify ?? 'none' },
     };
+    // Read the pre-edit record first: the fingerprint comparison is what keeps
+    // a rename or reschedule from costing the user a fresh agent run.
+    const prev = mode === 'edit' ? this.automationStore?.get(sourceAutomationId!) : undefined;
     const saved = mode === 'edit'
       ? this.updateAutomation(sourceAutomationId!, payload)
       : this.createAutomation({ ...payload, enabled: true });
     this.cancelAutomationChat(sessionId);
+    // Advisory only: the automation is already persisted, so a failure to
+    // record or start the check must never surface as a failed save.
+    if (needsRecheck(prev, saved)) {
+      try { this.startAutomationCheck(saved); }
+      catch (err) { this.logger.info(`[automations] could not start check for ${saved.id}: ${(err as Error).message}`); }
+    }
     return saved;
+  }
+
+  /** Re-arm the advisory dry run for a saved automation (banner "Re-run"). */
+  recheckAutomation(id: string): void {
+    const a = this.requireAutomationStore().get(id);
+    if (!a) throw new Error(`Automation not found: ${id}`);
+    this.startAutomationCheck(a);
+  }
+
+  /** Clear the advisory check and drop any in-flight verdict (banner "Dismiss"). */
+  dismissAutomationCheck(id: string): void {
+    this.automationDryRuns?.cancel(id);
+    this.requireAutomationStore().setCheck(id, undefined);
+    this.emitAutomationEvent({ type: 'automation-check', automationId: id });
   }
   cancelAutomationChat(sessionId: string): void {
     this.automationChats?.cancel(sessionId);
-    this.automationDryRuns?.cancel(sessionId);
   }
   setAutomationEventListener(fn: (ev: AutomationEvent) => void): void {
     this.automationEventListener = fn;


### PR DESCRIPTION
## Problem

Creating an automation through the Mac app's authoring panel was unreliable and slow, in two independent ways.

**Chat turns failed often.** Every message was one Aide call with a hard 30s timeout and no retry. The prompt carried the full draft *plus the entire transcript*, so it grew with the conversation and got more likely to time out the longer you talked. On failure the UI showed only "That message did not go through." — the real cause (timeout, HTTP 402, unparseable JSON) was never surfaced.

**Verification was slow and gated saving.** The "check" was not form validation: it spawned a real agent process that walked the brief inside the workspace, then made a *second* Aide call to classify the report. It took minutes even when the user filled in every field by hand. Worse, it was a hard gate — `finalize()` threw unless the check was `clean`, so any failure in that chain (agent crash, classifier failure, timeout) became `error` and blocked the save behind a "Save anyway…" button and a `confirm()` dialog. The failure was almost never about the data being wrong.

## What changed

**The dry run is now advisory and never blocks saving.**

- A complete draft saves immediately. `finalize()`'s only precondition is `draftComplete`.
- The dry run runs **after** save, in the background, keyed by automation id. Its verdict is **persisted** on the automation (`Automation.check`), so it survives closing the panel.
- The verdict surfaces as a banner on the automation's one-pager — `pending` neutral, `gaps` warning with the questions listed and Re-run / Dismiss, `error` deliberately muted (it almost always means an environment problem, not a misconfiguration). `clean` renders nothing; the banner exists to raise problems, not to congratulate.
- List rows get a small marker for `gaps` only.
- A re-check only fires when the **execution fingerprint** (target + brief + params) changes. Renaming, rescheduling or changing notify costs nothing.

**Chat turns got a real time budget.**

- `AideOptions` gains `retries` (default 0, so no other caller changes) and a per-attempt `timeoutMs`. The authoring turn runs with 90s and one retry.
- Configuration failures (402, unknown model, invalid API key) are rethrown immediately rather than burning a retry. Rate limits are deliberately *not* in that list — they are transient and should retry.
- The prompt caps transcript history at the newest 24 messages. The draft is a complete state snapshot, so truncation loses no settled information; the session keeps the full transcript for display.
- The failure bubble now shows the real error, plus one line: "You can also fill in the form on the right and save directly."

**Explicitly unchanged:** `automation-validate.ts`'s IPC-boundary validation. It is pure and instantaneous and was never the source of the delay.

## Notable fixes found in review

- **An unguarded write in the advisory path could fail a successful save.** `startAutomationCheck` does a filesystem write (`setCheck`) *after* the automation is already persisted; an exception there propagated out of `saveAutomationChat`, so the caller would report "save failed" for a save that succeeded — and on the create path a retry would double-create. Exactly the bug class this PR exists to remove. Now wrapped: it logs and swallows.
- **The retry backoff ignored the abort signal.** A caller cancelling between attempts waited out the full backoff before the rejection surfaced. `delay()` now races the timer against the signal, and the loop short-circuits after the gap rather than merely waking early.
- **`executionFingerprint` was order-sensitive.** The original bare `JSON.stringify` treated `{workspaceName, kind}` and `{kind, workspaceName}` as different targets. Since a spurious difference spawns a real agent process, the moved-to-core version canonicalizes field order, normalizes absent optionals, sorts params by key, and trims the brief.

## Testing

`npm test` — 1226 passing (core 457, gateway 297, codey-mac 472). `npm run build` exit 0 across all packages. `npm run lint` clean.

New coverage: transcript truncation; retry semantics including config-error short-circuit and abort-during-backoff; fingerprint canonicalization and sensitivity; `needsRecheck` / `verdictToCheck`; `store.setCheck` leaving `updatedAt` alone and removing the key on dismiss; `finalize` succeeding regardless of any prior check state; the banner's branch-per-status.

`gateway.ts` has no harness that can construct a Gateway, so its wiring is covered by the type build plus the two decisions it delegates (`needsRecheck`, `verdictToCheck`), which are unit-tested.

## Not yet verified — manual smoke test pending

`codey-mac` has no jsdom or React Testing Library; its suite is pure-model only, so **the React components have never run in a real render**. Needs a pass on a real machine:

1. Fill the form entirely by hand, send no chat message — the button enables and clicking it returns to the list *immediately*, with no "Checking…" state.
2. The new automation's one-pager shows "Dry run in progress…", then either no banner (clean) or a warning banner listing questions.
3. Edit only the name and save — no new banner appears.
4. Edit the instructions and save — a fresh pending banner appears.
5. On a `gaps` banner, Dismiss clears it and the list marker; Re-run returns it to pending.
6. Stop the model backend and send a message — the red bubble names the real error and offers the form as a way through.

(1) is this PR's core promise and (6) is where the original complaint started.

## Migration

`check` is optional and absent on existing records, which renders as no banner. No data migration. The removed `allowUnchecked` IPC argument and the `automations:chat:retryCheck` channel are internal to this repo, so they are deleted rather than deprecated.

---

Spec: `docs/superpowers/specs/2026-08-13-automation-authoring-friction-design.md`
Plan: `docs/superpowers/plans/2026-08-13-automation-authoring-friction.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
