### PR TITLE
Support pi as a fourth coding agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 ## Project
 
-Codey — a TypeScript gateway that routes prompts from chat platforms (Telegram, Discord, iMessage) to coding agents (Codex, OpenCode, Codex). Supports multi-workspace worker teams, conversation context, and parallel agent execution.
+Codey — a TypeScript gateway that routes prompts from chat platforms (Telegram, Discord, iMessage) to coding agents (Codex, OpenCode, Codex, pi). Supports multi-workspace worker teams, conversation context, and parallel agent execution.
 
 ## Commands
 
@@ -29,7 +29,7 @@ No test runner is configured.
 
 - **Gateway** (`src/gateway.ts`) — Central orchestrator. Handles message routing, command parsing, rate limiting (10s cooldown), response chunking (2000 char max), workspace switching, and worker/team execution.
 - **Channel handlers** (`src/channels/`) — Abstract base + platform implementations (Telegram, Discord, iMessage). Each emits UserMessage to gateway via callback.
-- **Agent adapters** (`src/agents/`) — Abstract base + implementations for Codex, opencode, codex. Each spawns a CLI process with 5-minute timeout. AgentFactory creates instances.
+- **Agent adapters** (`src/agents/`) — Abstract base + implementations for Codex, opencode, codex, pi. Each spawns a CLI process with 5-minute timeout. AgentFactory creates instances.
 - **Workspace manager** (`src/workspace.ts`) — Manages workspace lifecycle. Each workspace has a `workspace.json` (workingDir + worker configs), `memory.md`, and `workers/` directory. Switching workspaces sets the agent's working directory.
 - **Worker system** (`src/workers.ts`) — Workers have personality defined in markdown files and execution config in `workspace.json`. Workers run individually (`/worker <name> <task>`) or as teams (`/team <task>`). Teams dispatch in one of three modes: `all` (every member runs in order, carrying output forward), `auto` (the Advisor picks the relevant subset), or `parallel` (all members run concurrently in an Advisor-moderated roundtable).
 - **Advisor** (`src/advisor.ts`, `src/discussion/parallel-advisor.ts`) — The routing/orchestration LLM behind teams. It is a coordination role only (it never writes code): in `auto`/sequential mode it iteratively picks the next worker and can loop back for revisions; in `parallel` mode an Advisor loop evaluates progress, maintains the shared summary, and decides when to ask the user, continue, or terminate. Configured via `gateway.json` `advisor.{agent, model}` (falls back to the gateway default). Workers escalate to it with an `[ASK_ADVISOR]` line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Codey — a TypeScript gateway that routes prompts from chat platforms (Telegram, Discord, iMessage) to coding agents (Claude Code, OpenCode, Codex). Supports multi-workspace worker teams, conversation context, and parallel agent execution.
+Codey — a TypeScript gateway that routes prompts from chat platforms (Telegram, Discord, iMessage) to coding agents (Claude Code, OpenCode, Codex, pi). Supports multi-workspace worker teams, conversation context, and parallel agent execution.
 
 ## Commands
 
@@ -32,7 +32,7 @@ Tests run on Vitest. `npm test` runs every workspace's suite (`packages/core`,
 
 - **Gateway** (`src/gateway.ts`) — Central orchestrator. Handles message routing, command parsing, rate limiting (10s cooldown), response chunking (2000 char max), workspace switching, and worker/team execution.
 - **Channel handlers** (`src/channels/`) — Abstract base + platform implementations (Telegram, Discord, iMessage). Each emits UserMessage to gateway via callback.
-- **Agent adapters** (`src/agents/`) — Abstract base + implementations for claude-code, opencode, codex. Each spawns a CLI process with 5-minute timeout. AgentFactory creates instances.
+- **Agent adapters** (`src/agents/`) — Abstract base + implementations for claude-code, opencode, codex, pi. Each spawns a CLI process with 5-minute timeout. AgentFactory creates instances.
 - **Workspace manager** (`src/workspace.ts`) — Manages workspace lifecycle. Each workspace has a `workspace.json` (workingDir + worker configs), `memory.md`, and `workers/` directory. Switching workspaces sets the agent's working directory.
 - **Worker system** (`src/workers.ts`) — Workers have personality defined in markdown files and execution config in `workspace.json`. Workers run individually (`/worker <name> <task>`) or as teams (`/team <task>`). Teams dispatch in one of three modes: `all` (every member runs in order, carrying output forward), `auto` (the Advisor picks the relevant subset), or `parallel` (all members run concurrently in an Advisor-moderated roundtable).
 - **Flow graphs (Sequential)** (`src/team-graph.ts`, `src/judge.ts`) — An `all`/Sequential team may optionally define a `graph` (`{ entry, maxHops, nodes, edges }`) in its config. Nodes are workers (plus `start`/`end`); edges carry natural-language conditions. After each worker runs, a judge LLM (reuses the Advisor's `gateway.json` `advisor.{agent, model}`) picks the next edge by its condition, so flows can branch and loop back to an earlier worker for revision. Reaching an `end` node or the `maxHops` cap stops the run; `validateGraph` drops an invalid graph back to plain linear Sequential. Workers can pause mid-flow with `[ASK_USER]`; pause state is persisted and resumed on both the channel (`handleMessage`) and chat/Mac (`sendToChat`) surfaces via the shared `TeamEmitter` continuation path (`src/team-emitter.ts`) — the same path also powers `sequential` and `auto` resume on chat. Authored on a drag-and-drop canvas in the Mac app (`codey-mac` `FlowEditor.tsx`). `auto` and `parallel` are unaffected.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/its-ahoh/codey/stargazers"><img src="https://img.shields.io/github/stars/its-ahoh/codey?style=social" alt="GitHub stars" /></a>
 </p>
 
-**A multi-agent workbench for coding agents.** Codey is one place to organize, switch between, and orchestrate Claude Code, OpenCode, Codex (and more) across your projects — give each project its own workspace, build worker teams with different agents/models per role, run several agents in parallel on the same task to compare, and reach all of it from a native macOS app, chat platforms (Telegram / Discord / iMessage), or system-wide push-to-talk voice.
+**A multi-agent workbench for coding agents.** Codey is one place to organize, switch between, and orchestrate Claude Code, OpenCode, Codex, pi (and more) across your projects — give each project its own workspace, build worker teams with different agents/models per role, run several agents in parallel on the same task to compare, and reach all of it from a native macOS app, chat platforms (Telegram / Discord / iMessage), or system-wide push-to-talk voice.
 
 Think of it less as a chat bridge and more as **the control plane for the coding agents you already use**.
 
@@ -42,7 +42,7 @@ Builds are currently unsigned — on first launch, right-click the app → **Ope
 ## Features
 
 **Agent management**
-- **Multiple coding agents**: Claude Code, OpenCode, Codex (with session resume)
+- **Multiple coding agents**: Claude Code, OpenCode, Codex, [pi](https://pi.dev) (with session resume)
 - **Parallel execution**: Run multiple agents on the same prompt simultaneously to compare
 - **Per-workspace defaults**: Each project picks its own default agent + model
 - **Auto-dispatcher**: Optional built-in dispatcher routes a task to the right subset of a team
@@ -111,6 +111,7 @@ Edit `gateway.json`:
   "agents": {
     "claude-code": { "enabled": true, "provider": "anthropic", "defaultModel": "claude-sonnet-4-20250514" },
     "opencode": { "enabled": true, "provider": "openai", "defaultModel": "gpt-4.1" },
+    "pi": { "enabled": true, "provider": "anthropic", "defaultModel": "claude-sonnet-4-5" },
     "codex": { "enabled": true, "provider": "openai", "defaultModel": "gpt-5-codex" }
   },
   "profiles": [
@@ -314,7 +315,7 @@ packages/
 │   └── src/
 └── gateway/             # Gateway server, channels, agents
     └── src/
-        ├── agents/      # Coding agent adapters (claude-code, opencode, codex)
+        ├── agents/      # Coding agent adapters (claude-code, opencode, codex, pi)
         ├── channels/    # Chat platform handlers (telegram, discord, imessage)
         ├── config.ts
         ├── conversation.ts

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -111,6 +111,7 @@ npm run build:mac -w codey-mac  # 在 codey-mac/release/ 生成 DMG
   "agents": {
     "claude-code": { "enabled": true, "provider": "anthropic", "defaultModel": "claude-sonnet-4-20250514" },
     "opencode": { "enabled": true, "provider": "openai", "defaultModel": "gpt-4.1" },
+    "pi": { "enabled": true, "provider": "anthropic", "defaultModel": "claude-sonnet-4-5" },
     "codex": { "enabled": true, "provider": "openai", "defaultModel": "gpt-5-codex" }
   },
   "profiles": [
@@ -306,7 +307,7 @@ packages/
 │   └── src/
 └── gateway/             # 网关服务、渠道、代理
     └── src/
-        ├── agents/      # 编码代理适配器（claude-code、opencode、codex）
+        ├── agents/      # 编码代理适配器（claude-code、opencode、codex、pi）
         ├── channels/    # 聊天平台处理器（telegram、discord、imessage）
         ├── config.ts
         ├── conversation.ts

--- a/codey-mac/electron/automation-validate.ts
+++ b/codey-mac/electron/automation-validate.ts
@@ -80,7 +80,7 @@ function validateReport(report: unknown): void {
 const CREATE_FIELDS = new Set(['name', 'icon', 'enabled', 'target', 'brief', 'params', 'schedule', 'report'])
 const UPDATE_FIELDS = new Set(['name', 'icon', 'target', 'brief', 'params', 'schedule', 'report'])
 const CHAT_FIELDS = new Set(['name', 'target', 'brief', 'params', 'schedule', 'notify'])
-const AGENTS = new Set(['claude-code', 'opencode', 'codex'])
+const AGENTS = new Set(['claude-code', 'opencode', 'codex', 'pi'])
 
 function validateObject(value: unknown, label: string): asserts value is Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -702,6 +702,7 @@ async function detectInstalledAgents(): Promise<Record<string, { installed: bool
     'claude-code': 'claude',
     'opencode': 'opencode',
     'codex': 'codex',
+    'pi': 'pi',
   }
   const shell = process.env.SHELL || '/bin/zsh'
   const probe = (bin: string) => new Promise<string | null>(resolve => {
@@ -770,6 +771,20 @@ const BUILTIN_SLASH: Record<string, SlashCommand[]> = {
     { name: 'upgrade', description: 'Upgrade opencode to the latest version', source: 'agent' },
     { name: 'debug', description: 'Debugging and troubleshooting tools', source: 'agent' },
   ],
+  'pi': [
+    { name: 'model', description: 'Switch models', source: 'agent' },
+    { name: 'resume', description: 'Pick from previous sessions', source: 'agent' },
+    { name: 'new', description: 'Start a new session', source: 'agent' },
+    { name: 'session', description: 'Show session file, id, tokens, and cost', source: 'agent' },
+    { name: 'tree', description: 'Jump to any point in the session', source: 'agent' },
+    { name: 'fork', description: 'Create a new session from an earlier message', source: 'agent' },
+    { name: 'compact', description: 'Compact context, optionally with instructions', source: 'agent' },
+    { name: 'export', description: 'Export session to HTML or JSONL', source: 'agent' },
+    { name: 'share', description: 'Upload as a private gist with a shareable link', source: 'agent' },
+    { name: 'settings', description: 'Thinking level, theme, message delivery', source: 'agent' },
+    { name: 'trust', description: 'Save the project trust decision', source: 'agent' },
+    { name: 'login', description: 'Manage OAuth or API-key credentials', source: 'agent' },
+  ],
   'codex': [
     { name: 'exec', description: 'Run Codex non-interactively', source: 'agent' },
     { name: 'review', description: 'Run a code review non-interactively', source: 'agent' },
@@ -823,6 +838,7 @@ async function fetchSlashCommands(agent: string): Promise<SlashCommand[]> {
     'claude-code': 'claude',
     'opencode': 'opencode',
     'codex': 'codex',
+    'pi': 'pi',
   }
   const bin = binaries[agent]
   if (!bin) return []
@@ -3306,6 +3322,7 @@ app.whenReady().then(async () => {
     // Codex and OpenCode also discover the cross-agent .agents convention.
     'codex':       { userDirs: ['.codex/skills', '.agents/skills'], projectSubdirs: ['.codex/skills', '.agents/skills'] },
     'opencode':    { userDirs: ['.config/opencode/skills', '.opencode/skills', '.agents/skills'], projectSubdirs: ['.opencode/skills', '.agents/skills'] },
+    'pi':          { userDirs: ['.pi/agent/skills', '.agents/skills'], projectSubdirs: ['.pi/skills', '.agents/skills'] },
   }
 
   function configuredUserSkillDirs(agentKey: string, home: string, pathMod: typeof import('path')): string[] {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -206,11 +206,12 @@ const userFoldStyles: Record<string, React.CSSProperties> = {
 
 // Agents that the gateway supports. Mirror of AGENT_NAMES in SettingsTab — kept
 // local so the chat header doesn't depend on the settings module.
-const AGENT_NAMES = ['claude-code', 'opencode', 'codex'] as const
+const AGENT_NAMES = ['claude-code', 'opencode', 'codex', 'pi'] as const
 const AGENT_API_TYPE: Record<string, 'anthropic' | 'openai'> = {
   'claude-code': 'anthropic',
   'opencode': 'openai',
   'codex': 'openai',
+  'pi': 'anthropic',
 }
 type ModelEntry = { apiType: 'anthropic' | 'openai'; model: string }
 

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -25,8 +25,9 @@ export const AGENT_API_TYPE: Record<string, ApiType> = {
   'claude-code': 'anthropic',
   'opencode': 'openai',
   'codex': 'openai',
+  'pi': 'anthropic',
 }
-export const AGENT_NAMES = ['claude-code', 'opencode', 'codex'] as const
+export const AGENT_NAMES = ['claude-code', 'opencode', 'codex', 'pi'] as const
 
 // Where the user goes to install each agent's CLI when it isn't on PATH.
 // Picked to land on the official quickstart / install page rather than a
@@ -35,6 +36,7 @@ export const AGENT_INSTALL_URL: Record<string, string> = {
   'claude-code': 'https://docs.claude.com/en/docs/claude-code/quickstart',
   'opencode':    'https://opencode.ai',
   'codex':       'https://github.com/openai/codex',
+  'pi':          'https://pi.dev',
 }
 
 // ── Small helpers ────────────────────────────────────────────────────

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -7,17 +7,19 @@ import { SKILL_SORT_MODES, sortSkills, usageFor, usageLabel } from './skillsSort
 import type { SkillSortMode } from './skillsSort'
 import type { SkillEntry, SkillUsageMap, SkillsListResult } from '../codey-api'
 
-type AgentFilter = 'claude-code' | 'opencode' | 'codex'
+type AgentFilter = 'claude-code' | 'opencode' | 'codex' | 'pi'
 const AGENTS: { key: AgentFilter; label: string }[] = [
   { key: 'claude-code', label: 'Claude Code' },
   { key: 'opencode',    label: 'OpenCode' },
   { key: 'codex',       label: 'Codex' },
+  { key: 'pi',          label: 'Pi' },
 ]
 
 const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
   'claude-code': '~/.claude/skills/',
   'codex': '~/.codex/skills/',
   'opencode': '~/.config/opencode/skills/',
+  'pi': '~/.pi/agent/skills/',
 }
 
 // Matches the toggle idiom already used by PluginsTab / AppearanceTab.

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -7,6 +7,7 @@ const AGENT_API_TYPE: Record<string, 'anthropic' | 'openai'> = {
   'claude-code': 'anthropic',
   'opencode': 'openai',
   'codex': 'openai',
+  'pi': 'anthropic',
 }
 
 type Mode = { kind: 'idle' } | { kind: 'select'; name: string } | { kind: 'create' }
@@ -182,6 +183,7 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
         <option value="claude-code">claude-code</option>
         <option value="opencode">opencode</option>
         <option value="codex">codex</option>
+        <option value="pi">pi</option>
       </select>
 
       <label style={labelStyle}>Model</label>

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -12,12 +12,12 @@ export type ChatStreamEvent =
   | { type: 'checklist'; chatId: string; message: string; items: ChecklistItem[] }
   | { type: 'stream'; chatId: string; token: string; messageId?: string; step?: number }
   | { type: 'thinking'; chatId: string; token: string; step?: number; messageId?: string }
-  | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string }> }
-  | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; reason?: string }
+  | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string }> }
+  | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; reason?: string }
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
   | { type: 'workspace_ready'; chatId: string }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };
@@ -36,7 +36,7 @@ function unwrap<T>(result: { ok: true; data: T } | { ok: false; error: string })
 
 // Type aliases for the shapes returned by core
 export interface WorkerPersonality { role: string; soul: string; instructions: string }
-export interface WorkerConfig { codingAgent: 'claude-code' | 'opencode' | 'codex'; model: string; tools: string[]; effort?: string; dispatchHint?: string }
+export interface WorkerConfig { codingAgent: 'claude-code' | 'opencode' | 'codex' | 'pi'; model: string; tools: string[]; effort?: string; dispatchHint?: string }
 export interface WorkerDto {
   name: string
   personality: WorkerPersonality

--- a/packages/core/src/agents/effort.ts
+++ b/packages/core/src/agents/effort.ts
@@ -39,6 +39,21 @@ export function opencodeEffortArgs(effort?: ThinkingEffort): string[] {
   return effort ? ['--variant', effort] : [];
 }
 
+/**
+ * pi takes `--thinking <level>` with off, minimal, low, medium, high, xhigh,
+ * max — a superset of ThinkingEffort, so every level we can pass is a level pi
+ * documents. That is why this needs no degrade-retry: unlike codex's
+ * server-side enum, there is no level we can send that pi has to reject.
+ *
+ *   pi           --thinking <L>                    documented enum, superset
+ *
+ * Read from pi's published CLI reference rather than probed, unlike the three
+ * above; re-probe if a run ever fails on the flag itself.
+ */
+export function piEffortArgs(effort?: ThinkingEffort): string[] {
+  return effort ? ['--thinking', effort] : [];
+}
+
 /** Marker set on a retried request so a degrade can never loop. */
 export interface EffortRetryable {
   __effortRetried?: boolean;

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -3,11 +3,13 @@ import { CodingAgentAdapter } from './base';
 import { ClaudeCodeAdapter } from './claude-code';
 import { OpenCodeAdapter } from './opencode';
 import { CodexAdapter } from './codex';
+import { PiAdapter } from './pi';
 
 export type { CodingAgentAdapter } from './base';
 export { ClaudeCodeAdapter } from './claude-code';
 export { OpenCodeAdapter } from './opencode';
 export { CodexAdapter } from './codex';
+export { PiAdapter } from './pi';
 export { applyModelEnv } from './env';
 
 /**
@@ -81,6 +83,7 @@ export class AgentFactory {
     this.register('claude-code', new ClaudeCodeAdapter());
     this.register('opencode', new OpenCodeAdapter());
     this.register('codex', new CodexAdapter());
+    this.register('pi', new PiAdapter());
   }
 
   register(agent: CodingAgent, adapter: CodingAgentAdapter): void {

--- a/packages/core/src/agents/pi.test.ts
+++ b/packages/core/src/agents/pi.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  piArgs,
+  piToolEvent,
+  piTextFromMessage,
+  piTokensFrom,
+  classifyPiRunResult,
+  type PiEvent,
+} from './pi';
+import { piEffortArgs } from './effort';
+
+// The shapes asserted here come from pi's documented JSON mode
+// (packages/coding-agent/docs/json.md in earendil-works/pi-mono): a `session`
+// header line, then AgentEvent records. Everything the adapter reads is
+// pinned here so a wire change shows up as a test failure rather than a
+// silently empty answer.
+
+describe('piArgs', () => {
+  const base = { prompt: 'hello', agent: 'pi' as const };
+
+  it('always asks for the JSON event stream and puts the prompt last', () => {
+    const args = piArgs(base);
+    expect(args.slice(0, 2)).toEqual(['--mode', 'json']);
+    expect(args[args.length - 1]).toBe('hello');
+  });
+
+  it('resumes a session by id', () => {
+    expect(piArgs({ ...base, resumeSessionId: 'abc-123' })).toContain('--session');
+    expect(piArgs({ ...base, resumeSessionId: 'abc-123' })).toContain('abc-123');
+  });
+
+  it('passes the model through', () => {
+    const args = piArgs({ ...base, model: { model: 'anthropic/claude-opus-4', provider: 'anthropic' } });
+    expect(args).toContain('--model');
+    expect(args).toContain('anthropic/claude-opus-4');
+  });
+
+  it('maps effort onto --thinking', () => {
+    expect(piArgs({ ...base, effort: 'high' })).toContain('--thinking');
+    expect(piArgs({ ...base, effort: 'high' })).toContain('high');
+    expect(piEffortArgs('max')).toEqual(['--thinking', 'max']);
+    expect(piEffortArgs(undefined)).toEqual([]);
+  });
+
+  it('only overrides project trust when permissions are skipped', () => {
+    expect(piArgs({ ...base, skipPermissions: true })).toContain('-a');
+    expect(piArgs(base)).not.toContain('-a');
+  });
+});
+
+describe('piToolEvent', () => {
+  it('opens a tool on tool_execution_start', () => {
+    const observed = piToolEvent({
+      type: 'tool_execution_start',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      args: { command: 'ls' },
+    });
+    expect(observed).toEqual({
+      tool: 'bash',
+      key: 'call_1',
+      phase: 'start',
+      input: { command: 'ls' },
+    });
+  });
+
+  it('closes a tool on tool_execution_end and reports failure', () => {
+    const ok = piToolEvent({ type: 'tool_execution_end', toolCallId: 'c', toolName: 'read', result: 'x', isError: false });
+    expect(ok).toMatchObject({ phase: 'end', status: 'completed', output: 'x' });
+
+    const bad = piToolEvent({ type: 'tool_execution_end', toolCallId: 'c', toolName: 'read', result: 'boom', isError: true });
+    expect(bad).toMatchObject({ phase: 'end', status: 'failed' });
+  });
+
+  it('ignores events that are not tool execution', () => {
+    expect(piToolEvent({ type: 'turn_start' })).toBeNull();
+    // A tool event without a name carries nothing worth showing.
+    expect(piToolEvent({ type: 'tool_execution_start', toolCallId: 'c' })).toBeNull();
+  });
+});
+
+describe('piTextFromMessage', () => {
+  it('keeps only the assistant text blocks', () => {
+    const text = piTextFromMessage({
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'hmm' },
+        { type: 'text', text: 'Hello ' },
+        { type: 'toolCall', id: 't', name: 'bash', arguments: {} },
+        { type: 'text', text: 'world' },
+      ],
+    });
+    expect(text).toBe('Hello world');
+  });
+
+  it('ignores non-assistant messages', () => {
+    expect(piTextFromMessage({ role: 'user', content: [{ type: 'text', text: 'hi' }] })).toBe('');
+    expect(piTextFromMessage(undefined)).toBe('');
+  });
+});
+
+describe('piTokensFrom', () => {
+  it('sums usage across assistant messages and derives the total', () => {
+    let tokens = piTokensFrom(undefined, {
+      input: 10, output: 5, cacheRead: 2, cacheWrite: 1, totalTokens: 15,
+    });
+    tokens = piTokensFrom(tokens, {
+      input: 20, output: 7, cacheRead: 3, cacheWrite: 0, reasoning: 4, totalTokens: 27,
+    });
+    expect(tokens).toEqual({
+      input: 30,
+      output: 12,
+      total: 42,
+      reasoning: 4,
+      cache: { read: 5, write: 1 },
+    });
+  });
+
+  it('leaves tokens unset when pi reports no usage', () => {
+    expect(piTokensFrom(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('classifyPiRunResult', () => {
+  it('prefers the final message over streamed deltas', () => {
+    const cls = classifyPiRunResult({ code: 0, finalText: 'final', streamedText: 'partial', stderr: '' });
+    expect(cls.success).toBe(true);
+    expect(cls.output).toBe('final');
+  });
+
+  it('falls back to streamed text when no message_end arrived', () => {
+    const cls = classifyPiRunResult({ code: 0, finalText: '', streamedText: 'partial', stderr: '' });
+    expect(cls.success).toBe(true);
+    expect(cls.output).toBe('partial');
+  });
+
+  it('fails on a provider error even when pi exits 0', () => {
+    const cls = classifyPiRunResult({
+      code: 0,
+      finalText: '',
+      streamedText: 'some text',
+      stderr: '',
+      errorMessage: 'API Error: 401 Unauthorized',
+    });
+    expect(cls.success).toBe(false);
+    expect(cls.error).toContain('401');
+  });
+
+  it('reports a non-zero exit with stderr', () => {
+    const cls = classifyPiRunResult({ code: 1, finalText: '', streamedText: '', stderr: 'pi: no such model' });
+    expect(cls.success).toBe(false);
+    expect(cls.error).toContain('no such model');
+  });
+
+  it('never claims success on an empty run', () => {
+    const cls = classifyPiRunResult({ code: 0, finalText: '', streamedText: '', stderr: '' });
+    expect(cls.success).toBe(false);
+    expect(cls.error).toBeTruthy();
+  });
+});
+
+describe('the session header', () => {
+  it('is the line the adapter reads the resumable session id from', () => {
+    const header: PiEvent = JSON.parse('{"type":"session","version":3,"id":"uuid-1","timestamp":"t","cwd":"/tmp"}');
+    expect(header.type).toBe('session');
+    expect(header.id).toBe('uuid-1');
+  });
+});

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,0 +1,374 @@
+import { spawn, ChildProcess } from 'child_process';
+import { AgentRequest, AgentResponse } from '../types';
+import { BaseAgentAdapter } from './base';
+import { AgentSpawnError } from '../errors';
+import { ObservedToolEvent, ToolCallCollector } from './tool-events';
+import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
+import { piEffortArgs } from './effort';
+
+/**
+ * pi (https://pi.dev) adapter.
+ *
+ * `pi --mode json "<prompt>"` runs non-interactively and writes newline-
+ * delimited events to stdout. The first line is a session header; the rest are
+ * `AgentEvent` records. Shapes below follow pi's `docs/json.md`; unknown fields
+ * are tolerated.
+ *
+ * Two pi behaviours shape this adapter:
+ *
+ *   - Non-interactive modes (`-p`, `--mode json`, `--mode rpc`) never show a
+ *     trust prompt, so there is nothing to "skip" for permissions. What project
+ *     trust decides is whether pi loads project-local settings/extensions, and
+ *     `--approve`/`-a` forces that on for one run — which is what
+ *     `skipPermissions` means here. pi ships no sandbox to bypass.
+ *   - pi has no MCP surface, so `request.mcpServers` is deliberately ignored;
+ *     the browser plugin and external MCP servers stay claude-code/opencode/
+ *     codex only.
+ */
+
+export interface PiUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  reasoning?: number;
+  totalTokens?: number;
+}
+
+/** An assistant content block. pi mixes text, thinking and tool calls in one
+ *  array, and only the text blocks are the answer. */
+export interface PiContentBlock {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+}
+
+export interface PiMessage {
+  role?: string;
+  content?: PiContentBlock[] | string;
+  usage?: PiUsage;
+  stopReason?: string;
+  errorMessage?: string;
+}
+
+export interface PiEvent {
+  type: string;
+  // `session` header
+  id?: string;
+  cwd?: string;
+  version?: number;
+  // `message_update` — delta-only; `usage` is the latest cumulative usage.
+  usage?: PiUsage;
+  assistantMessageEvent?: {
+    type?: string;
+    contentIndex?: number;
+    delta?: string;
+    content?: string;
+  };
+  // `message_start` / `message_end` / `turn_end`
+  message?: PiMessage;
+  // `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
+  toolCallId?: string;
+  toolName?: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  isError?: boolean;
+}
+
+/** The argv for one pi run, minus the binary. Split out so the flag mapping is
+ *  testable without spawning anything. */
+export function piArgs(
+  request: Pick<AgentRequest, 'prompt' | 'model' | 'effort' | 'skipPermissions' | 'resumeSessionId'>,
+): string[] {
+  const args = ['--mode', 'json'];
+
+  // pi generates the session id itself; we capture it from the header line and
+  // hand it back on the next turn.
+  if (request.resumeSessionId) {
+    args.push('--session', request.resumeSessionId);
+  }
+  if (request.model?.model) {
+    args.push('--model', request.model.model);
+  }
+  args.push(...piEffortArgs(request.effort));
+  if (request.skipPermissions) {
+    args.push('-a');
+  }
+  args.push(request.prompt);
+  return args;
+}
+
+/** Map a pi tool execution event onto an observed tool event, or null when the
+ *  event is anything else. pi reports both ends of a call and pairs them by
+ *  `toolCallId`, so no start has to be synthesized. */
+export function piToolEvent(event: PiEvent): ObservedToolEvent | null {
+  if (event.type !== 'tool_execution_start' && event.type !== 'tool_execution_end') return null;
+  if (!event.toolName) return null;
+  const key = event.toolCallId ?? event.toolName;
+  if (event.type === 'tool_execution_start') {
+    return {
+      tool: event.toolName,
+      key,
+      phase: 'start',
+      ...(event.args ? { input: event.args } : {}),
+    };
+  }
+  return {
+    tool: event.toolName,
+    key,
+    phase: 'end',
+    status: event.isError ? 'failed' : 'completed',
+    ...(event.result !== undefined ? { output: event.result } : {}),
+  };
+}
+
+/** The answer text of an assistant message: text blocks only, in order. */
+export function piTextFromMessage(message?: PiMessage): string {
+  if (!message || message.role !== 'assistant') return '';
+  if (typeof message.content === 'string') return message.content;
+  if (!Array.isArray(message.content)) return '';
+  return message.content
+    .filter(block => block?.type === 'text' && typeof block.text === 'string')
+    .map(block => block.text)
+    .join('');
+}
+
+/** Add one message's usage to the run total. pi reports usage per assistant
+ *  message, so a multi-turn run has to sum rather than overwrite. `total` is
+ *  derived: pi's own `totalTokens` counts cache reads/writes too, and the rest
+ *  of the gateway treats `total` as input+output. */
+export function piTokensFrom(
+  current: AgentResponse['tokens'],
+  usage?: PiUsage,
+): AgentResponse['tokens'] {
+  if (!usage) return current;
+  const input = (current?.input ?? 0) + (usage.input ?? 0);
+  const output = (current?.output ?? 0) + (usage.output ?? 0);
+  const read = (current?.cache?.read ?? 0) + (usage.cacheRead ?? 0);
+  const write = (current?.cache?.write ?? 0) + (usage.cacheWrite ?? 0);
+  const reasoning = usage.reasoning !== undefined
+    ? (current?.reasoning ?? 0) + usage.reasoning
+    : current?.reasoning;
+  return {
+    input,
+    output,
+    total: input + output,
+    ...(reasoning !== undefined ? { reasoning } : {}),
+    ...(read || write ? { cache: { read, write } } : {}),
+  };
+}
+
+export interface PiRunResult {
+  code: number | null;
+  /** Text of the last assistant `message_end` — authoritative when present. */
+  finalText: string;
+  /** Text assembled from `text_delta` updates, used when no message_end came. */
+  streamedText: string;
+  stderr: string;
+  /** Set when pi reported an errored assistant message. */
+  errorMessage?: string;
+}
+
+/** Decide whether a finished pi run succeeded, and what to show for it.
+ *  A reported error wins over any partial text: pi can stream a sentence and
+ *  then fail the turn, and calling that a success would hide the failure from
+ *  the gateway's fallback chain. */
+export function classifyPiRunResult(run: PiRunResult): { success: boolean; output: string; error?: string } {
+  const output = run.finalText.trim() || run.streamedText.trim();
+  const success = run.code === 0 && !run.errorMessage && !!output;
+  let error = run.errorMessage
+    ?? (run.code !== 0 ? (run.stderr.trim() || `pi exited with code ${run.code}`) : undefined);
+  if (!success && !error) error = 'pi returned empty response';
+  return { success, output, error };
+}
+
+export class PiAdapter extends BaseAgentAdapter {
+  name = 'pi';
+  private debug: (msg: string) => void;
+  private activeProcess?: ChildProcess;
+
+  constructor(debug?: (msg: string) => void) {
+    super();
+    this.debug = debug ?? (() => {});
+  }
+
+  async run(request: AgentRequest): Promise<AgentResponse> {
+    return new Promise((resolve) => {
+      const args = piArgs(request);
+      this.debug(`[pi] Spawning: pi ${args.slice(0, -1).join(' ')} "<prompt>"`);
+
+      const { applyModelEnv } = require('./env') as typeof import('./env');
+      // pi is provider-agnostic and picks the provider from the model pattern;
+      // anthropic is the closest thing to a house default.
+      const env = applyModelEnv({ ...process.env }, request.model, 'anthropic');
+      if (request.extraEnv) Object.assign(env, request.extraEnv);
+
+      const childProcess: ChildProcess = spawn('pi', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: request.context?.workingDir || undefined,
+        env,
+      });
+      this.activeProcess = childProcess;
+      childProcess.on('close', () => { this.activeProcess = undefined; });
+
+      const startTime = Date.now();
+      let resolved = false;
+      let buffer = '';
+      let stderr = '';
+      let streamedText = '';
+      let thinkingText = '';
+      let finalText = '';
+      let errorMessage: string | undefined;
+      let capturedSessionId: string | undefined;
+      let tokens: AgentResponse['tokens'];
+      const tools = new ToolCallCollector(request.onStatus);
+      const statusUpdates = tools.statusUpdates;
+      const states = tools.states;
+      const checklist = new ChecklistTracker(request.onStatus);
+
+      const safeResolve = (response: AgentResponse) => {
+        if (resolved) return;
+        resolved = true;
+        resolve(response);
+      };
+
+      const handleEvent = (event: PiEvent) => {
+        switch (event.type) {
+          case 'session':
+            if (event.id) capturedSessionId = event.id;
+            break;
+          case 'message_update': {
+            const update = event.assistantMessageEvent;
+            if (!update?.delta) break;
+            if (update.type === 'text_delta') {
+              streamedText += update.delta;
+              request.onStream?.(update.delta);
+            } else if (update.type === 'thinking_delta') {
+              thinkingText += update.delta;
+              request.onThinking?.(update.delta);
+            }
+            break;
+          }
+          case 'message_end':
+            // The final authoritative message. A later assistant message
+            // replaces an earlier one — the last turn is the answer.
+            if (event.message?.role === 'assistant') {
+              const text = piTextFromMessage(event.message);
+              if (text) finalText = text;
+              tokens = piTokensFrom(tokens, event.message.usage);
+              if (event.message.stopReason === 'error' || event.message.stopReason === 'aborted') {
+                errorMessage = event.message.errorMessage || `pi turn ${event.message.stopReason}`;
+              }
+            }
+            break;
+          case 'tool_execution_start':
+          case 'tool_execution_end': {
+            const observed = piToolEvent(event);
+            if (observed) tools.record(observed);
+            // pi's task-list tool, if the model uses one, arrives as an
+            // ordinary tool call with a `todos` argument.
+            if (event.type === 'tool_execution_start' && isChecklistTool(event.toolName)) {
+              checklist.record(checklistFromTodos(event.args));
+            }
+            break;
+          }
+        }
+      };
+
+      childProcess.stdout?.on('data', (data: Buffer) => {
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('{')) continue;
+          try {
+            handleEvent(JSON.parse(trimmed) as PiEvent);
+          } catch {
+            // Not JSON, or a partial line — skip.
+          }
+        }
+      });
+
+      childProcess.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      childProcess.on('close', (code: number | null) => {
+        tools.finish();
+        if (buffer.trim().startsWith('{')) {
+          try { handleEvent(JSON.parse(buffer.trim()) as PiEvent); } catch { /* ignore */ }
+        }
+
+        const duration = Math.round((Date.now() - startTime) / 1000);
+        const cls = classifyPiRunResult({ code, finalText, streamedText, stderr, errorMessage });
+        this.debug(`[pi] Exit ${code}, ${cls.output.length} chars, tokens: ${tokens?.total ?? 'none'}`);
+
+        safeResolve({
+          success: cls.success,
+          output: cls.output,
+          error: cls.error,
+          duration,
+          tokens,
+          statusUpdates,
+          states,
+          sessionId: capturedSessionId,
+          thinking: thinkingText || undefined,
+        });
+      });
+
+      childProcess.on('error', (err: Error) => {
+        const duration = Math.round((Date.now() - startTime) / 1000);
+        this.debug(`[pi] Spawn error: ${err.message}`);
+        const spawnError = new AgentSpawnError(this.name, err.message);
+        safeResolve({
+          success: false,
+          output: spawnError.message,
+          error: spawnError.message,
+          duration,
+        });
+      });
+
+      const timeout = request.timeout || 900000;
+      setTimeout(() => {
+        if (resolved) return;
+        childProcess.kill();
+        const duration = Math.round((Date.now() - startTime) / 1000);
+        safeResolve({
+          success: false,
+          output: `Timeout after ${Math.round(timeout / 60000)} minutes`,
+          error: 'timeout',
+          duration,
+        });
+      }, timeout);
+
+      if (request.signal) {
+        const onAbort = () => {
+          if (resolved) return;
+          try { childProcess.kill('SIGTERM'); } catch { /* already dead */ }
+          const duration = Math.round((Date.now() - startTime) / 1000);
+          safeResolve({
+            success: false,
+            output: 'Stopped',
+            error: 'aborted',
+            duration,
+            statusUpdates,
+            states,
+          });
+        };
+        if (request.signal.aborted) onAbort();
+        else request.signal.addEventListener('abort', onAbort, { once: true });
+      }
+    });
+  }
+
+  dispose(): void {
+    if (this.activeProcess) {
+      this.activeProcess.kill('SIGTERM');
+      this.activeProcess = undefined;
+    }
+  }
+}

--- a/packages/core/src/aide-automation.ts
+++ b/packages/core/src/aide-automation.ts
@@ -62,7 +62,7 @@ function isValidTargetPatch(v: unknown): v is AutomationTarget {
   if (!v || typeof v !== 'object' || Array.isArray(v)) return false;
   const t = v as Record<string, unknown>;
   if (t.kind === 'prompt') {
-    const agentOk = t.agent === undefined || t.agent === 'claude-code' || t.agent === 'opencode' || t.agent === 'codex';
+    const agentOk = t.agent === undefined || t.agent === 'claude-code' || t.agent === 'opencode' || t.agent === 'codex' || t.agent === 'pi';
     const modelOk = t.model === undefined || (typeof t.model === 'string' && !!t.model.trim());
     return typeof t.workspaceName === 'string' && !!t.workspaceName && agentOk && modelOk;
   }

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -61,7 +61,7 @@ export interface ChatMessage {
   durationSec?: number;
   /** Agent/model that produced this assistant message. Stored per turn so
    * historical labels remain accurate after the chat configuration changes. */
-  agent?: 'claude-code' | 'opencode' | 'codex';
+  agent?: 'claude-code' | 'opencode' | 'codex' | 'pi';
   model?: string;
   /**
    * Present when this turn was produced by a fallback agent after the primary
@@ -141,7 +141,7 @@ export interface Chat {
   createdAt: number;
   updatedAt: number;
   /** Per-chat coding agent override. Falls back to gateway default when unset. */
-  agent?: 'claude-code' | 'opencode' | 'codex';
+  agent?: 'claude-code' | 'opencode' | 'codex' | 'pi';
   /** Per-chat model override (model id from the global catalog). Falls back to the agent's default model when unset. */
   model?: string;
   /** Per-chat reasoning-effort override. Falls back to the worker's effort, then the agent's defaultEffort. */
@@ -210,7 +210,7 @@ export interface Chat {
   };
   /** Warm CLI sessions retained independently for each agent/model identity. */
   sessionAnchors?: Array<{
-    agent: 'claude-code' | 'opencode' | 'codex';
+    agent: 'claude-code' | 'opencode' | 'codex' | 'pi';
     model?: string;
     sessionId: string;
     /** Last Codey transcript message already visible inside this CLI session. */
@@ -218,7 +218,7 @@ export interface Chat {
   }>;
   /** Legacy single-anchor field. Read for migration, never written by new code. */
   sessionAnchor?: {
-    agent: 'claude-code' | 'opencode' | 'codex';
+    agent: 'claude-code' | 'opencode' | 'codex' | 'pi';
     model?: string;
     sessionId: string;
     syncedThroughMessageId?: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -32,7 +32,7 @@ export interface GatewayResponse {
 }
 
 // Coding agent types
-export type CodingAgent = 'claude-code' | 'opencode' | 'codex';
+export type CodingAgent = 'claude-code' | 'opencode' | 'codex' | 'pi';
 
 // Model configuration for agents
 export type ApiType = 'anthropic' | 'openai';
@@ -248,7 +248,8 @@ export interface AgentResponse {
   states?: AgentStateEntry[];
   /**
    * Session id captured from the CLI on this run when the CLI generates
-   * its own id (codex `thread_id`, opencode `sessionID`). Adapters that
+   * its own id (codex `thread_id`, opencode `sessionID`, pi `session.id`).
+   * Adapters that
    * accept a pre-allocated `newSessionId` (claude-code) leave this unset —
    * the gateway already knows the id it sent.
    */
@@ -343,6 +344,7 @@ export interface GatewayConfig {
     'claude-code'?: AgentModelConfig;
     'opencode'?: AgentModelConfig;
     'codex'?: AgentModelConfig;
+    'pi'?: AgentModelConfig;
   };
   /** Global model catalog — mirrors GatewayConfigJson.models. */
   models?: ModelEntry[];

--- a/packages/core/src/worker-generator.ts
+++ b/packages/core/src/worker-generator.ts
@@ -18,7 +18,7 @@ interface GeneratedWorker {
   role: string;
   soul: string;
   instructions: string;
-  codingAgent: 'claude-code' | 'opencode' | 'codex';
+  codingAgent: 'claude-code' | 'opencode' | 'codex' | 'pi';
   model: string;
   tools: string[];
 }
@@ -30,7 +30,7 @@ const SCHEMA_INSTRUCTION = `You are generating a Codey worker definition. Given 
   "role": "one or two sentences describing what this worker does",
   "soul": "two to four sentences describing the worker's personality and working style",
   "instructions": "numbered or bulleted steps the worker follows when given a task",
-  "codingAgent": "claude-code" | "opencode" | "codex",
+  "codingAgent": "claude-code" | "opencode" | "codex" | "pi",
   "model": "a model id like claude-opus-4-6 or claude-sonnet-4-6",
   "tools": ["array", "of", "tool-tokens"]
 }
@@ -52,7 +52,7 @@ function tryParse(raw: string): GeneratedWorker | null {
 function validate(g: GeneratedWorker | null): string | null {
   if (!g) return 'Response was not valid JSON';
   if (!/^[a-z][a-z0-9-]*$/.test(g.name || '')) return `name "${g.name}" is not a valid lowercase-kebab-case identifier`;
-  if (!['claude-code', 'opencode', 'codex'].includes(g.codingAgent)) return `codingAgent "${g.codingAgent}" is invalid`;
+  if (!['claude-code', 'opencode', 'codex', 'pi'].includes(g.codingAgent)) return `codingAgent "${g.codingAgent}" is invalid`;
   if (!g.model || typeof g.model !== 'string') return 'model must be a non-empty string';
   if (!Array.isArray(g.tools)) return 'tools must be an array';
   if (!g.role || !g.soul || !g.instructions) return 'role, soul, and instructions are all required';

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -10,7 +10,7 @@ export interface WorkerPersonality {
 }
 
 export interface WorkerConfig {
-  codingAgent: 'claude-code' | 'opencode' | 'codex';
+  codingAgent: 'claude-code' | 'opencode' | 'codex' | 'pi';
   model: string;
   tools: string[];
   /**
@@ -38,7 +38,7 @@ export interface ParallelPromptInputs {
   peerOpinions: Array<{ name: string; path: string }>;
 }
 
-const VALID_CODING_AGENTS: readonly WorkerConfig['codingAgent'][] = ['claude-code', 'opencode', 'codex'];
+const VALID_CODING_AGENTS: readonly WorkerConfig['codingAgent'][] = ['claude-code', 'opencode', 'codex', 'pi'];
 
 export class WorkerManager {
   private workersDir: string;

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -29,7 +29,7 @@ export type ChatStreamEvent =
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
   | { type: 'workspace_ready'; chatId: string }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -78,9 +78,10 @@ export class CLI {
     this.logger.info('1. claude-code');
     this.logger.info('2. opencode');
     this.logger.info('3. codex');
+    this.logger.info('4. pi');
 
-    const choice = await this.prompt('\nSelect agent (1-3): ');
-    const agents = ['claude-code', 'opencode', 'codex'];
+    const choice = await this.prompt('\nSelect agent (1-4): ');
+    const agents = ['claude-code', 'opencode', 'codex', 'pi'];
     const agent = agents[parseInt(choice) - 1];
 
     if (agent) {

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -35,6 +35,7 @@ export interface GatewayConfigJson {
     'claude-code'?: AgentSlot;
     'opencode'?: AgentSlot;
     'codex'?: AgentSlot;
+    'pi'?: AgentSlot;
   };
   /** Global, reusable model catalog. Each agent references an entry by name. */
   models: ModelEntry[];
@@ -653,7 +654,7 @@ export class ConfigManager extends EventEmitter {
     }
     console.log(`\nAgents:`);
     const inOrder = new Set(this.config.fallback.order.map(e => e.agent));
-    for (const a of ['claude-code', 'opencode', 'codex'] as const) {
+    for (const a of ['claude-code', 'opencode', 'codex', 'pi'] as const) {
       console.log(`  ${inOrder.has(a) ? '✅' : '❌'} ${a}`);
     }
     console.log(`\nPriority: ${this.config.fallback.enabled ? '✅' : '❌'} order=${formatFallbackOrder(this.config.fallback.order)}`);
@@ -664,7 +665,7 @@ export class ConfigManager extends EventEmitter {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-const KNOWN_AGENTS: ReadonlySet<CodingAgent> = new Set(['claude-code', 'opencode', 'codex']);
+const KNOWN_AGENTS: ReadonlySet<CodingAgent> = new Set(['claude-code', 'opencode', 'codex', 'pi']);
 
 /**
  * Coerce a raw fallback blob (legacy `string[]` order or new `FallbackEntry[]`)
@@ -710,6 +711,7 @@ function getDefaultConfig(): GatewayConfigJson {
       'claude-code': {},
       'opencode':    {},
       'codex':       {},
+      'pi':          {},
     },
     models: [
       { apiType: 'anthropic', model: 'claude-sonnet-4-5', provider: 'anthropic' },

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -134,8 +134,8 @@ export class Codey {
   private static readonly REGEX_COMMAND = /^\/(\w+)(?:\s+(.*))?$/;
   private static readonly REGEX_WORKER = /\/worker\s+(\w+)\s+(.+)/i;
   private static readonly REGEX_TEAM = /\/team\s+(\w+)(?:\s+(--all))?\s+(?!--all\s*$)(.+)/i;
-  private static readonly REGEX_AGENT_PROMPT = /\/agent\s+(claude-code|opencode|codex)\s+(.+)/i;
-  private static readonly REGEX_AGENT = /\/agent\s+(claude-code|opencode|codex)/i;
+  private static readonly REGEX_AGENT_PROMPT = /\/agent\s+(claude-code|opencode|codex|pi)\s+(.+)/i;
+  private static readonly REGEX_AGENT = /\/agent\s+(claude-code|opencode|codex|pi)/i;
   private static readonly REGEX_MODEL_PROMPT = /\/model\s+(\S+)(?:\s+(.+))?/i;
   private static readonly REGEX_MODEL = /\/model\s+(\S+)/i;
   private static readonly REGEX_HELP_COMMAND = /^\/(help|status|clear|reset|model|agents|config)\s*/i;
@@ -1506,7 +1506,7 @@ export class Codey {
       context: () => ({
         workspaces: this.getWorkspaceList(),
         teams: Object.keys(this.configManager?.getTeams() ?? {}),
-        agents: ['claude-code', 'opencode', 'codex'] as CodingAgent[],
+        agents: ['claude-code', 'opencode', 'codex', 'pi'] as CodingAgent[],
         models: (this.configManager?.listModels() ?? this.config.models ?? []).map(m => m.model),
         tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
         nowIso: new Date().toString(),
@@ -2493,8 +2493,8 @@ export class Codey {
         await this.cmdAgent(args, chatId, channel);
         if (this.isPairableChannel(channel) && args.length > 0) {
           const a = args[0].toLowerCase();
-          if (['claude-code', 'opencode', 'codex'].includes(a)) {
-            this.pairingStore.updatePrefs(channel, message.userId, { agent: a as 'claude-code' | 'opencode' | 'codex' });
+          if (['claude-code', 'opencode', 'codex', 'pi'].includes(a)) {
+            this.pairingStore.updatePrefs(channel, message.userId, { agent: a as 'claude-code' | 'opencode' | 'codex' | 'pi' });
           }
         }
         break;
@@ -2742,7 +2742,7 @@ export class Codey {
   private async cmdAgent(args: string[], chatId: string, channel: ChannelType): Promise<void> {
     if (args.length > 0) {
       const agentName = args[0].toLowerCase();
-      const validAgents: CodingAgent[] = ['claude-code', 'opencode', 'codex'];
+      const validAgents: CodingAgent[] = ['claude-code', 'opencode', 'codex', 'pi'];
       if (validAgents.includes(agentName as CodingAgent)) {
         // Persist via the canonical setter so fallback.order[0] stays in sync;
         // the runtime config gets refreshed on the next applyConfig() event.
@@ -2758,7 +2758,7 @@ export class Codey {
         await this.sendResponse({
           chatId,
           channel,
-          text: `Unknown agent: ${agentName}\n\nAvailable: claude-code, opencode, codex`,
+          text: `Unknown agent: ${agentName}\n\nAvailable: claude-code, opencode, codex, pi`,
         });
       }
     } else {
@@ -3456,7 +3456,7 @@ Example: /model gpt-4.1 write a Python script`;
     });
 
     // Get enabled agents
-    const enabledAgents: CodingAgent[] = ['claude-code', 'opencode', 'codex'];
+    const enabledAgents: CodingAgent[] = ['claude-code', 'opencode', 'codex', 'pi'];
 
     // Run all agents in parallel (with per-agent fallback)
     const results = await Promise.allSettled(
@@ -5141,7 +5141,7 @@ Example: /model gpt-4.1 write a Python script`;
       let prompt = '';
 
       // Check if combined with prompt
-      const promptMatch = text.match(/\/agent\s+(claude-code|opencode|codex)\s+(.+)/i);
+      const promptMatch = text.match(/\/agent\s+(claude-code|opencode|codex|pi)\s+(.+)/i);
       if (promptMatch) {
         agent = promptMatch[1] as CodingAgent;
         prompt = promptMatch[2];
@@ -5159,7 +5159,7 @@ Example: /model gpt-4.1 write a Python script`;
     }
 
     // Not a command - parse agent/model from anywhere in text
-    const agentMatch = text.match(/\/agent\s+(claude-code|opencode|codex)/i);
+    const agentMatch = text.match(/\/agent\s+(claude-code|opencode|codex|pi)/i);
     const agent = (agentMatch ? agentMatch[1] : this.getDefaultAgent()) as CodingAgent;
 
     const modelMatch = text.match(/\/model\s+(\S+)/i);
@@ -5170,7 +5170,7 @@ Example: /model gpt-4.1 write a Python script`;
 
     // Remove inline commands from prompt, but preserve the rest
     let prompt = text
-      .replace(/\/agent\s+(claude-code|opencode|codex)\s*/i, '')
+      .replace(/\/agent\s+(claude-code|opencode|codex|pi)\s*/i, '')
       .replace(/\/model\s+\S+\s*/i, '')
       .replace(/^\/(help|status|clear|reset|model|agents|config)\s*/i, '')
       .trim();
@@ -5178,7 +5178,7 @@ Example: /model gpt-4.1 write a Python script`;
     return { command: '', args: [], agent, model, prompt };
   }
 
-  private static readonly ALL_AGENTS: CodingAgent[] = ['claude-code', 'opencode', 'codex'];
+  private static readonly ALL_AGENTS: CodingAgent[] = ['claude-code', 'opencode', 'codex', 'pi'];
 
   private getEnabledAgents(): CodingAgent[] {
     // Enablement is membership in fallback.order. Order matters: the priority

--- a/packages/gateway/src/pairings.ts
+++ b/packages/gateway/src/pairings.ts
@@ -4,7 +4,7 @@ import { ChannelKind } from '@codey/core';
 
 export interface PairingPrefs {
   workspace?: string;
-  agent?: 'claude-code' | 'opencode' | 'codex';
+  agent?: 'claude-code' | 'opencode' | 'codex' | 'pi';
   model?: string;
 }
 


### PR DESCRIPTION
Closes #241.

The issue had no body, so the CLI surface here was read off [pi's own docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/docs) (`usage.md`, `json.md`, `security.md`, `skills.md`) rather than guessed.

## The adapter

`pi --mode json "<prompt>"` runs non-interactively and emits a `session` header line followed by newline-delimited `AgentEvent` records. `packages/core/src/agents/pi.ts` reads that stream the way the other three adapters read theirs:

| pi event | used for |
|---|---|
| `session.id` | `AgentResponse.sessionId`, replayed next turn as `--session <id>` |
| `message_update` → `text_delta` / `thinking_delta` | streamed answer / streamed reasoning |
| `message_end` | authoritative answer text + per-message usage (summed across the run) |
| `tool_execution_start` / `_end` | the tool timeline, paired by `toolCallId` |

pi reports both ends of a tool call, so unlike opencode and codex it needs no synthesized `tool_start`.

## Two places pi differs, handled rather than papered over

- **Permissions.** Non-interactive modes (`-p`, `--mode json`, `--mode rpc`) never show a prompt, so there is no approval to bypass and pi ships no sandbox. What project trust actually gates is whether pi loads project-local settings and extensions; `--approve`/`-a` forces that on for one run, which is what `skipPermissions` maps to.
- **MCP.** pi has no MCP surface, so `request.mcpServers` is deliberately ignored — the browser plugin and external MCP servers stay claude-code/opencode/codex only.

Effort maps onto `--thinking <level>`. pi's documented enum (`off, minimal, low, medium, high, xhigh, max`) is a superset of `ThinkingEffort`, so unlike codex's server-side enum there is no level we can send that pi has to reject, and no degrade-retry is needed.

## Registration

The `CodingAgent` union plus every site that spelled the three agents out longhand: config defaults and `KNOWN_AGENTS`, `/agent` parsing, worker configs and the worker generator's prompt schema, automation task validation, the Mac app's agent pickers (Settings / Chat / Workers / Skills), binary detection (`pi`), the slash-command list, and skill discovery at `~/.pi/agent/skills` and `.pi/skills`.

pi is intentionally **not** added to the default fallback chain — a chain entry for a CLI the user may not have installed would turn a first-choice failure into a second failure.

## Verification

- `npm run build` — clean (all workspaces, including the packaged Mac app)
- `npm test` — 1225 passed, of which 18 are new in `packages/core/src/agents/pi.test.ts` covering argv mapping, tool-event mapping, assistant-text extraction, usage accumulation, and run classification
- `npm run lint` — clean

Not verified: no live `pi` run. The binary is not installed on this machine, so the event handling is pinned to the documented wire format by tests rather than observed on a real stream — worth one smoke run before relying on it.