### PR TITLE
Let "@" mentions see gitignored files

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -24,7 +24,7 @@ import { BrowserControlPermissionGate } from './browser-control-permission'
 import { BrowserSitePermissionManager } from './browser-site-permissions'
 import { canConfigureBrowserWebAuthn, configureBrowserWebAuthn, passkeyAccountLabel, type BrowserPasskeyPickerRequest } from './browser-webauthn'
 import { BrowserExtensionManager } from './browser-extensions'
-import { deriveEntries, parseGitFileList, walkDirectory, type FileEntry } from './workspace-files'
+import { deriveEntries, parseGitFileList, walkDirectory, MAX_ENTRIES, type FileEntry } from './workspace-files'
 import * as pty from 'node-pty'
 
 protocol.registerSchemesAsPrivileged([
@@ -2008,11 +2008,12 @@ app.whenReady().then(async () => {
       const fsMod = await import('fs')
       let paths: string[]
       try {
-        // -z keeps paths with spaces/unicode intact (git quotes them otherwise);
-        // --exclude-standard applies .gitignore to the untracked half.
+        // -z keeps paths with spaces/unicode intact (git quotes them otherwise).
+        // No --exclude-standard: .gitignore'd files (.env, build output) should
+        // still be mentionable; parseGitFileList drops the heavy dirs instead.
         const stdout = await new Promise<string>((resolve, reject) => {
           execFile(
-            'git', ['ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+            'git', ['ls-files', '-z', '--cached', '--others'],
             { cwd: workingDir, timeout: 4000, maxBuffer: 32 * 1024 * 1024 },
             (err, out) => (err ? reject(err) : resolve(out)),
           )
@@ -2023,6 +2024,11 @@ app.whenReady().then(async () => {
         paths = walkDirectory(workingDir, fsMod as never)
       }
       const entries = deriveEntries(paths)
+      // Truncation is invisible in the menu — a missing file just looks like a
+      // typo — so say so at least once per index build.
+      if (entries.length >= MAX_ENTRIES) {
+        console.warn(`[workspace:files] ${workingDir}: index hit the ${MAX_ENTRIES}-entry cap; deepest paths were dropped`)
+      }
       fileIndexCache.set(workingDir, { at: Date.now(), entries })
       return entries
     })

--- a/codey-mac/electron/workspace-files.test.ts
+++ b/codey-mac/electron/workspace-files.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveEntries, parseGitFileList, walkDirectory } from './workspace-files'
+import { deriveEntries, parseGitFileList, walkDirectory, MAX_ENTRIES } from './workspace-files'
 
 describe('parseGitFileList', () => {
   it('splits NUL-delimited output and drops empties', () => {
@@ -8,6 +8,11 @@ describe('parseGitFileList', () => {
 
   it('returns nothing for empty output', () => {
     expect(parseGitFileList('')).toEqual([])
+  })
+
+  it('keeps gitignored paths but drops heavy directories', () => {
+    expect(parseGitFileList('.env\0node_modules/foo/index.js\0dist/app.js\0src/a.ts\0'))
+      .toEqual(['.env', 'src/a.ts'])
   })
 })
 
@@ -30,6 +35,20 @@ describe('deriveEntries', () => {
   it('sets name to the last path segment', () => {
     const entry = deriveEntries(['src/components/ChatTab.tsx']).find(e => !e.isDir)
     expect(entry?.name).toBe('ChatTab.tsx')
+  })
+
+  it('drops the deepest paths when over the cap, not the alphabetical tail', () => {
+    // One shallow file per top-level dir, plus enough deep junk to blow the cap.
+    const shallow = ['a.ts', 'zzz.ts']
+    const deep: string[] = []
+    for (let i = 0; i < MAX_ENTRIES + 10; i++) deep.push(`deep/l1/l2/l3/f${i}.ts`)
+    const entries = deriveEntries([...shallow, ...deep])
+
+    expect(entries).toHaveLength(MAX_ENTRIES)
+    // Both shallow files survive — including "zzz.ts", which an alphabetical
+    // slice would have been the first to discard.
+    expect(entries.map(e => e.path)).toEqual(expect.arrayContaining(['a.ts', 'zzz.ts']))
+    expect(entries.map(e => e.path)).toEqual([...entries.map(e => e.path)].sort((x, y) => x.localeCompare(y)))
   })
 })
 
@@ -59,12 +78,13 @@ describe('walkDirectory', () => {
     expect(walkDirectory('/root', fs as never)).toEqual(['a.ts'])
   })
 
-  it('skips dotfiles but keeps .github', () => {
+  it('keeps dotfiles but still skips .git', () => {
     const fs = fakeFs({
-      '/root': [{ name: '.env', dir: false }, { name: '.github', dir: true }],
+      '/root': [{ name: '.env', dir: false }, { name: '.github', dir: true }, { name: '.git', dir: true }],
       '/root/.github': [{ name: 'ci.yml', dir: false }],
+      '/root/.git': [{ name: 'HEAD', dir: false }],
     })
-    expect(walkDirectory('/root', fs as never)).toEqual(['.github/ci.yml'])
+    expect(walkDirectory('/root', fs as never).sort()).toEqual(['.env', '.github/ci.yml'])
   })
 
   it('stops at the limit', () => {

--- a/codey-mac/electron/workspace-files.ts
+++ b/codey-mac/electron/workspace-files.ts
@@ -1,9 +1,11 @@
 // Workspace file index behind the composer's "@" mention menu.
 //
-// The listing comes from `git ls-files` when the working dir is a repo — that
-// gives us .gitignore filtering for free, which a naive fs walk would have to
-// reimplement badly. Non-repo directories fall back to a bounded manual walk
-// that skips the usual heavyweight directories.
+// The listing comes from `git ls-files` when the working dir is a repo, purely
+// because it is a fast single fork. It deliberately does NOT pass
+// --exclude-standard: .gitignore'd paths (.env, build output, local scratch
+// files) are exactly the things people want to point an agent at. Instead both
+// the git path and the non-repo fs walk drop the handful of heavyweight
+// directories below, which would otherwise drown the menu.
 
 export type FileEntry = {
   /** Path relative to the working dir, POSIX separators, no leading "./". */
@@ -17,17 +19,26 @@ export type FileEntry = {
 export const MAX_ENTRIES = 20000
 
 const SKIP_DIRS = new Set([
-  '.git', 'node_modules', 'dist', 'build', 'out', 'target', 'vendor',
+  '.git', 'node_modules', 'dist', 'build', '.build', 'out', 'target', 'vendor',
   '.next', '.nuxt', '.cache', '.venv', 'venv', '__pycache__', '.pytest_cache',
   'coverage', '.turbo', '.gradle', '.idea', 'DerivedData',
 ])
 
-/** Split `git ls-files -z` output into clean relative paths. */
+/** True when any segment of `path` is a directory we never index. */
+export function isSkippedPath(path: string): boolean {
+  return path.split('/').some(segment => SKIP_DIRS.has(segment))
+}
+
+/**
+ * Split `git ls-files -z` output into clean relative paths, minus anything
+ * under a skipped directory — without --exclude-standard the raw listing
+ * includes every ignored build artifact and dependency tree.
+ */
 export function parseGitFileList(stdout: string): string[] {
   return stdout
     .split('\0')
     .map(l => l.trim())
-    .filter(l => l.length > 0)
+    .filter(l => l.length > 0 && !isSkippedPath(l))
 }
 
 /**
@@ -51,8 +62,25 @@ export function deriveEntries(paths: string[]): FileEntry[] {
     return { path, name: segments[segments.length - 1], isDir: true }
   })
   const all = [...dirs, ...files]
-  all.sort((a, b) => a.path.localeCompare(b.path))
-  return all.slice(0, MAX_ENTRIES)
+  all.sort(byPath)
+  if (all.length <= MAX_ENTRIES) return all
+
+  // Over the cap. Slicing the alphabetical list would delete whole top-level
+  // directories from the tail — "src/" simply vanishing is far worse than
+  // losing scattered deep files. Keep the shallowest paths instead, so
+  // truncation thins the deep tails of a huge tree and every top-level entry
+  // survives. Re-sort by path afterwards so callers still get a stable order.
+  const kept = [...all].sort((a, b) => depthOf(a.path) - depthOf(b.path) || byPath(a, b))
+  kept.length = MAX_ENTRIES
+  kept.sort(byPath)
+  return kept
+}
+
+const byPath = (a: FileEntry, b: FileEntry) => a.path.localeCompare(b.path)
+const depthOf = (path: string) => {
+  let depth = 1
+  for (let i = 0; i < path.length; i++) if (path[i] === '/') depth++
+  return depth
 }
 
 /** Bounded fs walk for working dirs that are not git repos. */
@@ -69,7 +97,8 @@ export function walkDirectory(
     let dirEntries
     try { dirEntries = fs.readdirSync(abs, { withFileTypes: true }) } catch { continue }
     for (const dirent of dirEntries) {
-      if (dirent.name.startsWith('.') && dirent.name !== '.github') continue
+      // Dotfiles are included on purpose — .env and friends are worth mentioning.
+      // .git itself is excluded via SKIP_DIRS below.
       const childRel = rel ? `${rel}/${dirent.name}` : dirent.name
       if (dirent.isDirectory()) {
         if (SKIP_DIRS.has(dirent.name)) continue

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1401,7 +1401,12 @@ export const ChatTab: React.FC<Props> = ({
   // repo's paths must not linger in the menu.
   useEffect(() => { setFileIndex([]) }, [workingDir])
 
-  const mentionMatches = mention ? filterEntries(fileIndex, mention.query) : []
+  // Scoring touches every indexed entry, so keep it tied to the query rather
+  // than to render count — this component re-renders on every streamed token.
+  const mentionMatches = React.useMemo(
+    () => (mention ? filterEntries(fileIndex, mention.query) : []),
+    [mention?.query, fileIndex], // eslint-disable-line react-hooks/exhaustive-deps
+  )
   const showMentionMenu = mentionMatches.length > 0
   useEffect(() => { setMentionIdx(0) }, [mention?.query, mention?.start])
   useEffect(() => {


### PR DESCRIPTION
The composer's file index passed `--exclude-standard` to `git ls-files`, so `.env`, build output, and local scratch files were invisible to `@` — often exactly the files worth pointing an agent at. This drops the flag and filters the heavy directories explicitly instead, since `.gitignore` was the only thing keeping `node_modules` out of the listing.

The fs-walk fallback stops skipping dotfiles for the same reason. `.git` stays out via `SKIP_DIRS`, which also picks up `.build` (SwiftPM output — same class as `dist`/`target`).

### Why the cap changed too

Without gitignore filtering this repo indexes **6884** entries instead of **23636**, so it no longer trips `MAX_ENTRIES`. But the cap's failure mode was bad enough to fix while here: it sorted by path and sliced, so an over-cap repo lost whole top-level directories off the alphabetical tail — `src/` simply vanishing, with no indication why. Truncation now keeps the shallowest paths, so deep tails thin out and every top-level entry survives, and the main process logs when it happens instead of dropping files silently.

### Unrelated win found along the way

`filterEntries` was called bare in `ChatTab`'s render body, scoring every indexed entry on every render — and the component re-renders per streamed token, so with the menu open each token of an agent reply rescored the whole index. Now memoized on the query.

### Testing

- `npx tsc --noEmit` clean for both `tsconfig.electron.json` and `tsconfig.json`
- `npx vitest run` — 52 files / 474 tests pass
- New cases cover gitignored-paths-kept/heavy-dirs-dropped, dotfiles-kept-but-`.git`-skipped, and depth-based truncation (asserts `zzz.ts` — the first casualty of the old alphabetical slice — survives)

Not smoke-tested in the packaged app; the changed code is all pure functions plus one IPC handler, and both are covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)