### PR TITLE
Keep chat worktrees inside the workspace

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -23,11 +23,7 @@ import {
   getStoredThemeMode,
   getStoredPalette,
   resolveEffectiveTheme,
-  paletteToCssVars,
-  classicLight,
-  classicDark,
-  terminalLight,
-  terminalDark,
+  paletteThemeCss,
 } from './theme'
 
 const clampLeftPanelWidth = (width: number) => {
@@ -366,30 +362,8 @@ const Shell: React.FC = () => {
         {!activeChat && <VoiceHotkeyFallback />}
       </div>
       <style>{`
-  /* Fallback (classic) until data-theme / data-palette are set. */
-  :root {
-${paletteToCssVars(classicDark)}
-  }
-  :root[data-theme="light"] {
-${paletteToCssVars(classicLight)}
-  }
-  :root[data-theme="dark"] {
-${paletteToCssVars(classicDark)}
-  }
-  /* Classic theme */
-  :root[data-palette="classic"][data-theme="light"] {
-${paletteToCssVars(classicLight)}
-  }
-  :root[data-palette="classic"][data-theme="dark"] {
-${paletteToCssVars(classicDark)}
-  }
-  /* Terminal theme */
-  :root[data-palette="terminal"][data-theme="light"] {
-${paletteToCssVars(terminalLight)}
-  }
-  :root[data-palette="terminal"][data-theme="dark"] {
-${paletteToCssVars(terminalDark)}
-  }
+  /* Fallback plus every palette's light/dark variant. */
+  ${paletteThemeCss()}
   html, body, #root { height: 100%; margin: 0; background: ${C.bg}; }
   /* Roomy headings open a section with a large top margin. The first block in a
      turn has nothing above it to separate from, so that margin is dead space. */

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -1,6 +1,6 @@
 // codey-mac/src/components/AppearanceTab.tsx
 import React from 'react'
-import { C, ThemeMode, PaletteName, PALETTES, useThemeMode, useEffectiveTheme, usePaletteName } from '../theme'
+import { C, ThemeMode, PaletteName, PaletteDefinition, PALETTES, useThemeMode, useEffectiveTheme, usePaletteName } from '../theme'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import { Section, pageStyle } from './settingsAtoms'
 import { getStatusPanelEnabled, setStatusPanelEnabled } from './statusPanelPref'
@@ -11,10 +11,7 @@ const OPTIONS: { value: ThemeMode; label: string }[] = [
   { value: 'system', label: 'System' },
 ]
 
-const PALETTE_OPTIONS: { value: PaletteName; label: string }[] = [
-  { value: 'classic',  label: PALETTES.classic.label  },
-  { value: 'terminal', label: PALETTES.terminal.label },
-]
+const PALETTE_OPTIONS = Object.entries(PALETTES) as [PaletteName, PaletteDefinition][]
 
 const Toggle: React.FC<{ on: boolean; onChange: (v: boolean) => void }> = ({ on, onChange }) => (
   <div onClick={() => onChange(!on)} style={{
@@ -35,6 +32,7 @@ export const AppearanceTab: React.FC = () => {
   const [mode, setMode] = useThemeMode()
   const [palette, setPalette] = usePaletteName()
   const effective = useEffectiveTheme()
+  const previewMode = mode === 'system' ? effective : mode
   const [version, setVersion] = React.useState<string>('')
   const [skipPerms, setSkipPerms] = React.useState<boolean>(true)
   const [notifyEnabled, setNotifyEnabled] = React.useState<boolean>(true)
@@ -126,25 +124,42 @@ export const AppearanceTab: React.FC = () => {
         </div>
       </div>
 
-      <div style={styles.settingRow}>
-        <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
-          <div>Theme</div>
-          <div style={styles.settingDesc}>
-            {palette === 'terminal'
-              ? 'Warm paper and terminal green.'
-              : 'The original macOS-style colors.'}
-          </div>
+      <div style={{ ...styles.settingRow, ...styles.themeRow }}>
+        <div style={{ ...styles.label, width: 'auto' }}>
+          <div>Color theme</div>
+          <div style={styles.settingDesc}>Choose a palette. Each one adapts to Light and Dark mode.</div>
         </div>
-        <select
-          aria-label="Color theme"
-          value={palette}
-          onChange={(e) => setPalette(e.target.value as PaletteName)}
-          style={styles.select}
-        >
-          {PALETTE_OPTIONS.map(opt => (
-            <option key={opt.value} value={opt.value}>{opt.label}</option>
-          ))}
-        </select>
+        <div role="radiogroup" aria-label="Color theme" style={styles.paletteGrid}>
+          {PALETTE_OPTIONS.map(([name, definition]) => {
+            const active = palette === name
+            const preview = definition[previewMode]
+            return (
+              <button
+                key={name}
+                role="radio"
+                aria-checked={active}
+                onClick={() => setPalette(name)}
+                style={{
+                  ...styles.paletteCard,
+                  background: active ? C.accentDim : C.surface2,
+                  borderColor: active ? C.accent : C.border,
+                  boxShadow: active ? `0 0 0 1px ${C.accentDim}` : 'none',
+                }}
+              >
+                <span style={{ ...styles.palettePreview, background: preview.bg, borderColor: preview.border2 }}>
+                  <span style={{ ...styles.previewSidebar, background: preview.surface }} />
+                  <span style={{ ...styles.previewLine, background: preview.fg3 }} />
+                  <span style={{ ...styles.previewAccent, background: preview.accent }} />
+                </span>
+                <span style={styles.paletteCopy}>
+                  <span style={{ ...styles.paletteName, color: active ? C.accent : C.fg }}>{definition.label}</span>
+                  <span style={styles.paletteDescription}>{definition.description}</span>
+                </span>
+                <span aria-hidden="true" style={{ ...styles.check, opacity: active ? 1 : 0 }}>✓</span>
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       <div style={styles.settingRow}>
@@ -274,16 +289,22 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     cursor: 'pointer',
   },
-  select: {
-    background: C.surface2,
-    color: C.fg,
-    border: `1px solid ${C.border}`,
-    borderRadius: 8,
-    padding: '8px 10px',
-    fontSize: 12,
-    fontWeight: 500,
-    cursor: 'pointer',
-    minWidth: 140,
+  themeRow: { flexDirection: 'column', alignItems: 'stretch', gap: 12 },
+  paletteGrid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 8 },
+  paletteCard: {
+    minWidth: 0, display: 'flex', alignItems: 'center', gap: 10, position: 'relative',
+    padding: 10, border: '1px solid', borderRadius: 10, cursor: 'pointer', textAlign: 'left',
   },
+  palettePreview: {
+    width: 48, height: 36, flexShrink: 0, position: 'relative', overflow: 'hidden',
+    border: '1px solid', borderRadius: 7,
+  },
+  previewSidebar: { position: 'absolute', inset: '0 auto 0 0', width: 14 },
+  previewLine: { position: 'absolute', left: 20, top: 10, width: 18, height: 3, borderRadius: 2, opacity: 0.72 },
+  previewAccent: { position: 'absolute', left: 20, top: 19, width: 21, height: 8, borderRadius: 4 },
+  paletteCopy: { minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 },
+  paletteName: { fontSize: 12, fontWeight: 650 },
+  paletteDescription: { color: C.fg3, fontSize: 10, lineHeight: 1.35 },
+  check: { marginLeft: 'auto', color: C.accent, fontSize: 12, fontWeight: 800 },
   value: { fontSize: 13, color: C.fg2, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' },
 }

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -53,6 +53,9 @@ export const BranchPicker: React.FC<Props> = ({
   const worktreeLabel = chatWorktree?.name || chatWorktree?.path.split('/').filter(Boolean).pop() || 'Isolated worktree'
   const branchLabel = state?.branch === 'HEAD' ? '—' : (state?.branch ?? '—')
   const pathLabel = compactWorktreePath(path)
+  const lastSlash = pathLabel.lastIndexOf('/')
+  const pathHead = lastSlash >= 0 ? pathLabel.slice(0, lastSlash + 1) : ''
+  const pathTail = lastSlash >= 0 ? pathLabel.slice(lastSlash + 1) : pathLabel
   const checkoutLabel = isolated ? worktreeLabel : 'Current checkout'
   // One status line for the whole picker: an explicit note wins, otherwise the
   // last git failure surfaces in the same place instead of at the bottom.
@@ -166,7 +169,12 @@ export const BranchPicker: React.FC<Props> = ({
             <div style={styles.currentRow}>
               <div style={styles.currentIdentity}>
                 <div style={styles.currentBranch}>{branchLabel}</div>
-                <div style={styles.currentPath} title={path}>{pathLabel}</div>
+                {/* The last segment names the worktree, so it must never be the
+                  * part that gets clipped: only the leading directories shrink. */}
+                <div style={styles.currentPath} title={path}>
+                  <span style={styles.currentPathHead}>{pathHead}</span>
+                  <span style={styles.currentPathTail}>{pathTail}</span>
+                </div>
               </div>
               <button style={styles.iconButton} onClick={() => void copyPath()} title="Copy path" aria-label="Copy worktree path">
                 <UIIcon name="copy" size={13} />
@@ -304,7 +312,9 @@ const styles: Record<string, React.CSSProperties> = {
   bannerText: { minWidth: 0, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' },
   currentIdentity: { minWidth: 0, flex: 1 },
   currentBranch: { color: C.fg, fontSize: 11, fontWeight: 600, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
-  currentPath: { color: C.fg3, fontSize: 9, fontFamily: 'SF Mono, Menlo, monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  currentPath: { color: C.fg3, fontSize: 9, fontFamily: 'SF Mono, Menlo, monospace', display: 'flex', minWidth: 0, whiteSpace: 'nowrap' },
+  currentPathHead: { overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 },
+  currentPathTail: { flexShrink: 0 },
   iconButton: { width: 27, height: 27, padding: 0, border: `1px solid ${C.border2}`, borderRadius: 6, background: C.surface3, color: C.fg2, cursor: 'pointer', display: 'grid', placeItems: 'center', flexShrink: 0 },
   checkoutMode: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: '1px 3px 2px' },
   modeLabel: { display: 'inline-flex', alignItems: 'center', gap: 5, color: C.fg3, fontSize: 10, paddingLeft: 3 },

--- a/codey-mac/src/components/CaptureWindow.tsx
+++ b/codey-mac/src/components/CaptureWindow.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   C, applyTheme, applyPalette, getStoredThemeMode, getStoredPalette,
-  paletteToCssVars, classicLight, classicDark, terminalLight, terminalDark,
+  paletteThemeCss,
 } from '../theme'
 
 // Spotlight-style capture UI rendered in its own frameless BrowserWindow
@@ -232,13 +232,7 @@ export const CaptureWindow: React.FC = () => {
       {error && <div style={styles.error}>{error}</div>}
       <style>{`
   /* Same theme matrix as App.tsx so applyTheme/applyPalette take effect. */
-  :root { ${paletteToCssVars(classicDark)} }
-  :root[data-theme="light"] { ${paletteToCssVars(classicLight)} }
-  :root[data-theme="dark"] { ${paletteToCssVars(classicDark)} }
-  :root[data-palette="classic"][data-theme="light"] { ${paletteToCssVars(classicLight)} }
-  :root[data-palette="classic"][data-theme="dark"] { ${paletteToCssVars(classicDark)} }
-  :root[data-palette="terminal"][data-theme="light"] { ${paletteToCssVars(terminalLight)} }
-  :root[data-palette="terminal"][data-theme="dark"] { ${paletteToCssVars(terminalDark)} }
+  ${paletteThemeCss()}
   html, body, #root { margin: 0; background: transparent; }
   body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; }
   * { box-sizing: border-box; }

--- a/codey-mac/src/components/branchPickerModel.test.ts
+++ b/codey-mac/src/components/branchPickerModel.test.ts
@@ -44,6 +44,11 @@ describe('workspace identity labels', () => {
       .toBe('…/.codey/worktrees/chat-1842');
   });
 
+  it('drops the opaque chat-<uuid> directory of a legacy worktree path', () => {
+    expect(compactWorktreePath('/Users/jack/.codey/chat-worktrees/codey/chat-4be57559-ae33-4863-aab3-c19527e869af/improve-agent-management'))
+      .toBe('…/chat-worktrees/codey/improve-agent-management');
+  });
+
   it('leaves short paths intact and handles an empty path', () => {
     expect(compactWorktreePath('/repo/worktree')).toBe('/repo/worktree');
     expect(compactWorktreePath('')).toBe('—');

--- a/codey-mac/src/components/branchPickerModel.ts
+++ b/codey-mac/src/components/branchPickerModel.ts
@@ -11,11 +11,17 @@ export function filterBranches(list: string[], query: string): string[] {
   return list.filter(b => b.toLowerCase().includes(q));
 }
 
+/** A chat worktree nests under `chat-<uuid>/<worktree name>`. The uuid segment
+ *  carries no meaning for a reader and, being long, it is what pushes the
+ *  worktree name out of the visible label — so drop it before compacting. */
+const OPAQUE_SEGMENT = /^chat-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /** Compact a filesystem path without hiding its identifying final segments. */
 export function compactWorktreePath(path: string, maxSegments = 3): string {
   const parts = path.split('/').filter(Boolean);
-  if (parts.length <= maxSegments) return path || '—';
-  return `…/${parts.slice(-maxSegments).join('/')}`;
+  const kept = parts.filter(part => !OPAQUE_SEGMENT.test(part));
+  if (kept.length === parts.length && parts.length <= maxSegments) return path || '—';
+  return `…/${kept.slice(-maxSegments).join('/')}`;
 }
 
 export interface PullResult {

--- a/codey-mac/src/theme.ts
+++ b/codey-mac/src/theme.ts
@@ -6,7 +6,7 @@ export type EffectiveTheme = 'light' | 'dark'
 
 const STORAGE_KEY = 'codey.theme'
 
-interface Palette {
+export interface Palette {
   bg: string
   surface: string
   surface2: string
@@ -52,73 +52,73 @@ interface Palette {
 
 // ---- Classic: the original macOS-style look (Apple blue + neutral grays) ----
 export const classicDark: Palette = {
-  bg:        '#10131b',
-  surface:   '#171b26',
-  surface2:  '#1d2230',
-  surface3:  '#262d3d',
-  border:    '#293144',
-  border2:   '#374159',
-  fg:        '#f2f5fb',
-  fg2:       '#aeb8cc',
-  fg3:       '#71809b',
-  accent:    '#6d7cff',
-  accentDim: '#6d7cff22',
-  green:     '#32D74B',
-  purple:    '#A371F7',
-  red:       '#FF453A',
-  yellow:    '#FFD60A',
-  userBg:    '#6475f5',
-  onAccent:  '#ffffff',
-  aiBg:      '#1b2030',
-  scrollbar: '#3b465e',
-  dangerBg:      '#3a1a1a',
-  dangerBorder:  '#6a2a2a',
-  dangerFg:      '#ff8080',
-  codeBg:        '#141414',
-  codeFg:        '#e6e6e6',
-  inlineCodeBg:  '#1a1a1a',
-  inlineCodeFg:  '#e6e6e6',
-  logBg:         '#0d0d0d',
-  logFg:         '#6a9955',
-  warningBg:     '#ff950033',
-  warningFg:     '#ffb84d',
-  sidebarBg:     'rgba(23, 27, 38, 0.76)',
-  sidebarBorder: 'rgba(84, 100, 132, 0.44)',
+  bg:        '#0e1116',
+  surface:   '#151920',
+  surface2:  '#1b2029',
+  surface3:  '#242b36',
+  border:    '#252c37',
+  border2:   '#343e4d',
+  fg:        '#edf1f7',
+  fg2:       '#aab4c2',
+  fg3:       '#737f90',
+  accent:    '#74a7ff',
+  accentDim: '#74a7ff20',
+  green:     '#48c78e',
+  purple:    '#b18cff',
+  red:       '#ff7168',
+  yellow:    '#e8bd61',
+  userBg:    '#74a7ff',
+  onAccent:  '#0a1626',
+  aiBg:      '#171c24',
+  scrollbar: '#374250',
+  dangerBg:      '#351b1d',
+  dangerBorder:  '#653035',
+  dangerFg:      '#ff928b',
+  codeBg:        '#0b0e12',
+  codeFg:        '#dce4ee',
+  inlineCodeBg:  '#202731',
+  inlineCodeFg:  '#9dc0ff',
+  logBg:         '#090c10',
+  logFg:         '#66d6a3',
+  warningBg:     '#382d19',
+  warningFg:     '#edc573',
+  sidebarBg:     'rgba(21, 25, 32, 0.82)',
+  sidebarBorder: 'rgba(64, 76, 94, 0.58)',
 }
 
 export const classicLight: Palette = {
-  bg:        '#f6f7fb',
+  bg:        '#f4f6f9',
   surface:   '#ffffff',
-  surface2:  '#f9faff',
-  surface3:  '#edf0f7',
-  border:    '#e0e5f0',
-  border2:   '#d3dae9',
-  fg:        '#172033',
-  fg2:       '#536078',
-  fg3:       '#7f8aa1',
-  accent:    '#5265e8',
-  accentDim: '#5265e81c',
-  green:     '#34C759',
-  purple:    '#8250DF',
-  red:       '#FF3B30',
-  yellow:    '#FFCC00',
-  userBg:    '#5265e8',
+  surface2:  '#f8f9fb',
+  surface3:  '#e9edf2',
+  border:    '#dde2e8',
+  border2:   '#cdd4dd',
+  fg:        '#18202b',
+  fg2:       '#546171',
+  fg3:       '#7d8997',
+  accent:    '#3377d5',
+  accentDim: '#3377d51a',
+  green:     '#17865b',
+  purple:    '#7557b7',
+  red:       '#d84942',
+  yellow:    '#a66f08',
+  userBg:    '#3377d5',
   onAccent:  '#ffffff',
   aiBg:      '#ffffff',
-  scrollbar: '#cbd3e1',
-  dangerBg:      '#FFE5E5',
-  dangerBorder:  '#FFB3B3',
-  dangerFg:      '#C92A2A',
-  codeBg:        '#f5f5f7',
-  codeFg:        '#1d1d1f',
-  inlineCodeBg:  '#ebebef',
-  inlineCodeFg:  '#1d1d1f',
-  logBg:         '#fafafa',
-  logFg:         '#28792B',
-  warningBg:     '#FFE9C4',
-  warningFg:     '#A85D00',
-  sidebarBg:     'rgba(255, 255, 255, 0.76)',
-  sidebarBorder: 'rgba(211, 218, 233, 0.76)',
+  scrollbar: '#c5ccd5',
+  dangerBg:      '#fbe9e8',
+  dangerBorder:  '#efc2bf',
+  dangerFg:      '#ad332d',
+  codeBg:        '#eef1f5',
+  codeFg:        '#202833',
+  inlineCodeBg:  '#e8edf4',
+  inlineCodeFg:  '#285f9f',
+  logBg:         '#f1f4f6',
+  logFg:         '#176b4b',
+  warningBg:     '#f8eed7',
+  warningFg:     '#855b0e',
+  sidebarBg:     'rgba(255, 255, 255, 0.82)',
+  sidebarBorder: 'rgba(205, 212, 221, 0.78)',
 }
 
 // ---- Terminal: warm paper + terminal green; matches the Codey landing page ----
@@ -192,11 +192,84 @@ export const terminalLight: Palette = {
   sidebarBorder: 'rgba(216, 207, 188, 0.72)',
 }
 
-export type PaletteName = 'classic' | 'terminal'
+// ---- Ocean: deep navy surfaces with a crisp cyan signal color ----
+export const oceanDark: Palette = {
+  bg: '#071219', surface: '#0c1a23', surface2: '#10232e', surface3: '#18303d',
+  border: '#19303c', border2: '#274756', fg: '#e8f4f7', fg2: '#9db9c2', fg3: '#668894',
+  accent: '#4bc7e5', accentDim: '#4bc7e520', green: '#54d6a0', purple: '#a99af2', red: '#ff716f', yellow: '#e8c66a',
+  userBg: '#4bc7e5', onAccent: '#041b22', aiBg: '#0e202a', scrollbar: '#28505e',
+  dangerBg: '#351c20', dangerBorder: '#71333b', dangerFg: '#ff9692',
+  codeBg: '#050d12', codeFg: '#d7e8ec', inlineCodeBg: '#142b36', inlineCodeFg: '#74d9ef', logBg: '#040b0f', logFg: '#57d9aa',
+  warningBg: '#342c19', warningFg: '#ebcb79', sidebarBg: 'rgba(9, 25, 34, 0.84)', sidebarBorder: 'rgba(39, 71, 86, 0.64)',
+}
 
-export const PALETTES: Record<PaletteName, { label: string; light: Palette; dark: Palette }> = {
-  classic:  { label: 'Classic',  light: classicLight,  dark: classicDark  },
-  terminal: { label: 'Terminal', light: terminalLight, dark: terminalDark },
+export const oceanLight: Palette = {
+  bg: '#f1f8fa', surface: '#ffffff', surface2: '#f4fafb', surface3: '#e3f0f3',
+  border: '#d7e8ec', border2: '#bfd8de', fg: '#10272f', fg2: '#486873', fg3: '#78949d',
+  accent: '#087f9f', accentDim: '#087f9f18', green: '#16805a', purple: '#6658b1', red: '#cb4545', yellow: '#9a6b0d',
+  userBg: '#087f9f', onAccent: '#ffffff', aiBg: '#ffffff', scrollbar: '#b9d2d8',
+  dangerBg: '#fbe8e8', dangerBorder: '#efc0c0', dangerFg: '#a93434',
+  codeBg: '#e8f2f4', codeFg: '#17323a', inlineCodeBg: '#deedf1', inlineCodeFg: '#076d88', logBg: '#eaf3f1', logFg: '#126b4d',
+  warningBg: '#f7efd9', warningFg: '#7c5912', sidebarBg: 'rgba(247, 252, 253, 0.84)', sidebarBorder: 'rgba(191, 216, 222, 0.78)',
+}
+
+// ---- Dusk: muted plum neutrals with a soft violet accent ----
+export const duskDark: Palette = {
+  bg: '#15121b', surface: '#1c1824', surface2: '#241e2d', surface3: '#30273b',
+  border: '#30283a', border2: '#453951', fg: '#f1ebf5', fg2: '#b8a9c0', fg3: '#85748f',
+  accent: '#c29af4', accentDim: '#c29af420', green: '#68ce9b', purple: '#c29af4', red: '#f27683', yellow: '#ddb96b',
+  userBg: '#c29af4', onAccent: '#21132c', aiBg: '#211b2a', scrollbar: '#493b55',
+  dangerBg: '#391d26', dangerBorder: '#6e3344', dangerFg: '#fa98a3',
+  codeBg: '#100d14', codeFg: '#e8dfee', inlineCodeBg: '#2b2334', inlineCodeFg: '#d5b5fa', logBg: '#0d0a11', logFg: '#79d8a9',
+  warningBg: '#382d1e', warningFg: '#e6c47b', sidebarBg: 'rgba(28, 24, 36, 0.84)', sidebarBorder: 'rgba(69, 57, 81, 0.64)',
+}
+
+export const duskLight: Palette = {
+  bg: '#f8f4fa', surface: '#ffffff', surface2: '#fbf8fc', surface3: '#eee6f2',
+  border: '#e8dfec', border2: '#d7c9dd', fg: '#2b2031', fg2: '#67566f', fg3: '#94839c',
+  accent: '#7651aa', accentDim: '#7651aa18', green: '#287d58', purple: '#7651aa', red: '#bf4655', yellow: '#966711',
+  userBg: '#7651aa', onAccent: '#ffffff', aiBg: '#ffffff', scrollbar: '#d1c3d7',
+  dangerBg: '#fae9ed', dangerBorder: '#edc2cb', dangerFg: '#9f3544',
+  codeBg: '#f0eaf3', codeFg: '#33253a', inlineCodeBg: '#ece3f0', inlineCodeFg: '#684396', logBg: '#f1ecf2', logFg: '#236d4e',
+  warningBg: '#f8efd9', warningFg: '#7b5613', sidebarBg: 'rgba(255, 252, 255, 0.84)', sidebarBorder: 'rgba(215, 201, 221, 0.8)',
+}
+
+// ---- Ember: charcoal and clay with a restrained copper accent ----
+export const emberDark: Palette = {
+  bg: '#171311', surface: '#201a17', surface2: '#29211d', surface3: '#342923',
+  border: '#352a24', border2: '#4a3a31', fg: '#f4ece6', fg2: '#c0ada1', fg3: '#8b766a',
+  accent: '#f08a5d', accentDim: '#f08a5d20', green: '#79c88d', purple: '#b99ae8', red: '#f06f68', yellow: '#e6b85d',
+  userBg: '#f08a5d', onAccent: '#2a1007', aiBg: '#251e1a', scrollbar: '#4d3c33',
+  dangerBg: '#3b1d1c', dangerBorder: '#743530', dangerFg: '#fa958d',
+  codeBg: '#100d0b', codeFg: '#eadfd8', inlineCodeBg: '#30251f', inlineCodeFg: '#f4a47e', logBg: '#0d0a09', logFg: '#82d296',
+  warningBg: '#3a2b18', warningFg: '#e9bd6c', sidebarBg: 'rgba(32, 26, 23, 0.84)', sidebarBorder: 'rgba(74, 58, 49, 0.66)',
+}
+
+export const emberLight: Palette = {
+  bg: '#faf5f1', surface: '#ffffff', surface2: '#fcf8f5', surface3: '#f0e5de',
+  border: '#eadfd8', border2: '#dac9bf', fg: '#30221c', fg2: '#6e594e', fg3: '#9a8478',
+  accent: '#b94f29', accentDim: '#b94f2918', green: '#2c7d4d', purple: '#7559a5', red: '#bd443e', yellow: '#936510',
+  userBg: '#b94f29', onAccent: '#ffffff', aiBg: '#ffffff', scrollbar: '#d5c3b9',
+  dangerBg: '#fbe8e6', dangerBorder: '#efc1bc', dangerFg: '#a13731',
+  codeBg: '#f1e9e4', codeFg: '#362720', inlineCodeBg: '#eee2db', inlineCodeFg: '#9b3f20', logBg: '#f1ece8', logFg: '#276b43',
+  warningBg: '#f8edd8', warningFg: '#7d5711', sidebarBg: 'rgba(255, 252, 249, 0.84)', sidebarBorder: 'rgba(218, 201, 191, 0.8)',
+}
+
+export type PaletteName = 'classic' | 'terminal' | 'ocean' | 'dusk' | 'ember'
+
+export interface PaletteDefinition {
+  label: string
+  description: string
+  light: Palette
+  dark: Palette
+}
+
+export const PALETTES: Record<PaletteName, PaletteDefinition> = {
+  classic:  { label: 'Classic',  description: 'Clean graphite with a calm blue accent.', light: classicLight, dark: classicDark },
+  terminal: { label: 'Terminal', description: 'Warm paper and focused terminal green.', light: terminalLight, dark: terminalDark },
+  ocean:    { label: 'Ocean',    description: 'Deep navy and crisp cyan.', light: oceanLight, dark: oceanDark },
+  dusk:     { label: 'Dusk',     description: 'Muted plum with soft violet.', light: duskLight, dark: duskDark },
+  ember:    { label: 'Ember',    description: 'Charcoal and clay with copper warmth.', light: emberLight, dark: emberDark },
 }
 
 export const DEFAULT_PALETTE: PaletteName = 'classic'
@@ -212,6 +285,19 @@ export function paletteToCssVars(p: Palette): string {
   return (Object.keys(p) as (keyof Palette)[])
     .map(k => `  --${k}: ${p[k]};`)
     .join('\n')
+}
+
+/** Complete theme matrix shared by the main and Quick Capture windows. */
+export function paletteThemeCss(): string {
+  const defaults = `:root {\n${paletteToCssVars(classicDark)}\n}\n` +
+    `:root[data-theme="light"] {\n${paletteToCssVars(classicLight)}\n}\n` +
+    `:root[data-theme="dark"] {\n${paletteToCssVars(classicDark)}\n}`
+  const themes = (Object.entries(PALETTES) as [PaletteName, PaletteDefinition][])
+    .flatMap(([name, definition]) => (['light', 'dark'] as const).map(mode =>
+      `:root[data-palette="${name}"][data-theme="${mode}"] {\n${paletteToCssVars(definition[mode])}\n}`,
+    ))
+    .join('\n')
+  return `${defaults}\n${themes}`
 }
 
 export function getStoredThemeMode(): ThemeMode {
@@ -266,7 +352,7 @@ export function useEffectiveTheme(): EffectiveTheme {
 export function getStoredPalette(): PaletteName {
   try {
     const v = localStorage.getItem(PALETTE_KEY)
-    if (v === 'classic' || v === 'terminal') return v
+    if (v && Object.prototype.hasOwnProperty.call(PALETTES, v)) return v as PaletteName
   } catch {}
   return DEFAULT_PALETTE
 }

--- a/packages/gateway/src/chat-worktree.test.ts
+++ b/packages/gateway/src/chat-worktree.test.ts
@@ -29,16 +29,14 @@ describe('provisionChatWorktree', () => {
 
     const result = await provisionChatWorktree({
       workspaceWorkingDir,
-      workspacesRoot: path.join(root, 'data', 'workspaces'),
-      workspaceName: 'demo',
-      chatId: 'chat-123',
       worktreeName: 'feature-auth',
     });
 
     expect(result.workingDir).toBe(path.join(result.worktreePath, 'packages', 'app'));
     expect(result.name).toBe('feature-auth');
     expect(path.basename(result.worktreePath)).toBe('feature-auth');
-    expect(result.worktreePath).toContain(`${path.sep}chat-worktrees${path.sep}demo${path.sep}chat-chat-123${path.sep}`);
+    expect(result.worktreePath).toBe(path.join(fs.realpathSync(workspaceWorkingDir), '.worktrees', 'feature-auth'));
+    expect(fs.readFileSync(path.join(fs.realpathSync(workspaceWorkingDir), '.worktrees', '.gitignore'), 'utf8')).toBe('*\n');
     expect(result.baseCommit).toBe(git(repositoryRoot, ['rev-parse', 'HEAD']));
     expect(git(result.worktreePath, ['branch', '--show-current'])).toBe('feature-auth');
     expect(fs.statSync(result.workingDir).isDirectory()).toBe(true);
@@ -49,21 +47,17 @@ describe('provisionChatWorktree', () => {
     roots.push(root);
     await expect(provisionChatWorktree({
       workspaceWorkingDir: root,
-      workspacesRoot: path.join(root, 'workspaces'),
-      workspaceName: 'plain',
-      chatId: 'chat-plain',
       worktreeName: 'plain-work',
     })).rejects.toThrow(/Git workspace/);
   });
 });
 
 describe('discoverChatWorktree', () => {
-  it('adopts the one direct-child worktree owned by a chat and keeps its semantic name', async () => {
+  it('adopts the one new direct-child worktree and keeps its semantic name', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-agent-worktree-'));
     roots.push(root);
     const repositoryRoot = path.join(root, 'repo');
     const workspaceWorkingDir = path.join(repositoryRoot, 'packages', 'app');
-    const workspacesRoot = path.join(root, 'data', 'workspaces');
     fs.mkdirSync(workspaceWorkingDir, { recursive: true });
     git(repositoryRoot, ['init', '-b', 'main']);
     git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
@@ -72,14 +66,14 @@ describe('discoverChatWorktree', () => {
     git(repositoryRoot, ['add', 'README.md']);
     git(repositoryRoot, ['commit', '-m', 'initial']);
 
-    const parent = chatWorktreeParent(workspacesRoot, 'demo', 'abc-123');
+    const parent = chatWorktreeParent(workspaceWorkingDir);
     const worktreePath = path.join(parent, 'feature-search');
     fs.mkdirSync(parent, { recursive: true });
     git(repositoryRoot, ['worktree', 'add', '-b', 'feature-search', worktreePath, 'HEAD']);
     fs.mkdirSync(path.join(worktreePath, 'packages', 'app'), { recursive: true });
 
     const workspace = await discoverChatWorktree({
-      workspaceWorkingDir, workspacesRoot, workspaceName: 'demo', chatId: 'abc-123', createdAt: 42,
+      workspaceWorkingDir, notBefore: 0, createdAt: 42,
     });
 
     expect(workspace).toMatchObject({
@@ -90,11 +84,10 @@ describe('discoverChatWorktree', () => {
     });
   });
 
-  it('does not adopt a worktree belonging to another chat', async () => {
+  it('does not adopt a worktree already bound to another chat', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-agent-owner-'));
     roots.push(root);
     const repositoryRoot = path.join(root, 'repo');
-    const workspacesRoot = path.join(root, 'data', 'workspaces');
     fs.mkdirSync(repositoryRoot, { recursive: true });
     git(repositoryRoot, ['init', '-b', 'main']);
     git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
@@ -102,12 +95,54 @@ describe('discoverChatWorktree', () => {
     fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
     git(repositoryRoot, ['add', 'README.md']);
     git(repositoryRoot, ['commit', '-m', 'initial']);
-    const otherPath = path.join(chatWorktreeParent(workspacesRoot, 'demo', 'other-chat'), 'feature-other');
+    const otherPath = path.join(chatWorktreeParent(repositoryRoot), 'feature-other');
     fs.mkdirSync(path.dirname(otherPath), { recursive: true });
     git(repositoryRoot, ['worktree', 'add', '-b', 'feature-other', otherPath, 'HEAD']);
 
     await expect(discoverChatWorktree({
-      workspaceWorkingDir: repositoryRoot, workspacesRoot, workspaceName: 'demo', chatId: 'this-chat',
+      workspaceWorkingDir: repositoryRoot, notBefore: 0, claimedPaths: [otherPath],
+    })).resolves.toBeUndefined();
+  });
+
+  it('does not adopt a worktree that predates the chat', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-agent-age-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    fs.mkdirSync(repositoryRoot, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+    const preexisting = path.join(chatWorktreeParent(repositoryRoot), 'hand-made');
+    fs.mkdirSync(path.dirname(preexisting), { recursive: true });
+    git(repositoryRoot, ['worktree', 'add', '-b', 'hand-made', preexisting, 'HEAD']);
+
+    await expect(discoverChatWorktree({
+      workspaceWorkingDir: repositoryRoot, notBefore: Date.now() + 60_000,
+    })).resolves.toBeUndefined();
+  });
+
+  it('adopts nothing when two candidates qualify', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-agent-tie-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    fs.mkdirSync(repositoryRoot, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
+    git(repositoryRoot, ['add', 'README.md']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+    for (const name of ['first', 'second']) {
+      const target = path.join(chatWorktreeParent(repositoryRoot), name);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      git(repositoryRoot, ['worktree', 'add', '-b', name, target, 'HEAD']);
+    }
+
+    await expect(discoverChatWorktree({
+      workspaceWorkingDir: repositoryRoot, notBefore: 0,
     })).resolves.toBeUndefined();
   });
 });

--- a/packages/gateway/src/chat-worktree.ts
+++ b/packages/gateway/src/chat-worktree.ts
@@ -20,20 +20,29 @@ export function normalizeWorktreeName(name: string): string {
   return normalized;
 }
 
-export function chatWorktreeParent(workspacesRoot: string, workspaceName: string, chatId: string): string {
-  const safeWorkspace = workspaceName.replace(/[^a-zA-Z0-9._-]/g, '-');
-  const safeChatId = chatId.replace(/[^a-zA-Z0-9._-]/g, '-');
-  // The UUID is intentionally confined to this hidden ownership boundary. It
-  // never becomes the user-facing worktree/branch name, but prevents two
-  // concurrently running chats from adopting each other's new checkout.
-  return path.join(path.dirname(workspacesRoot), 'chat-worktrees', safeWorkspace, `chat-${safeChatId}`);
+/** Chat checkouts live beside the code they branch from, inside the workspace
+ *  directory, so everything belonging to a project stays under that project. */
+export const WORKTREE_CONTAINER = '.worktrees';
+
+export function chatWorktreeParent(workspaceWorkingDir: string): string {
+  return path.join(path.resolve(workspaceWorkingDir), WORKTREE_CONTAINER);
 }
 
-export function chatWorktreeDirectory(workspacesRoot: string, workspaceName: string, chatId: string, worktreeName: string): string {
+export function chatWorktreeDirectory(workspaceWorkingDir: string, worktreeName: string): string {
   const safeName = normalizeWorktreeName(worktreeName);
-  // Keep code checkouts outside the workspace metadata directory. Deleting or
-  // renaming a Workspace must not silently erase a chat's uncommitted files.
-  return path.join(chatWorktreeParent(workspacesRoot, workspaceName, chatId), safeName);
+  return path.join(chatWorktreeParent(workspaceWorkingDir), safeName);
+}
+
+/** The container sits inside a checkout, so it must exclude itself from Git:
+ *  without this, every chat worktree would surface as untracked noise in the
+ *  workspace's own `git status`. Repos that already ignore `.worktrees/` are
+ *  unaffected — a second, narrower ignore rule is harmless. */
+export function ensureWorktreeContainer(workspaceWorkingDir: string): string {
+  const container = path.join(path.resolve(workspaceWorkingDir), WORKTREE_CONTAINER);
+  fs.mkdirSync(container, { recursive: true });
+  const ignoreFile = path.join(container, '.gitignore');
+  if (!fs.existsSync(ignoreFile)) fs.writeFileSync(ignoreFile, '*\n');
+  return container;
 }
 
 interface WorktreeRecord {
@@ -59,13 +68,18 @@ function parseWorktreeList(output: string): WorktreeRecord[] {
   return records;
 }
 
-/** Discover a worktree created by an agent inside this chat's private
- *  ownership directory. A direct-child rule keeps adoption deterministic. */
+/** Discover a worktree an agent created for this chat. The container is shared
+ *  by every chat in the workspace and by the user's own worktrees, so ownership
+ *  is established without a path marker: a candidate must be a direct child of
+ *  the container, unclaimed by another chat, and newer than this chat. When two
+ *  candidates qualify, none is adopted — leaving a chat in the shared checkout
+ *  is recoverable, binding it to someone else's worktree is not. */
 export async function discoverChatWorktree(input: {
   workspaceWorkingDir: string;
-  workspacesRoot: string;
-  workspaceName: string;
-  chatId: string;
+  /** Only worktrees created after this moment can belong to the chat. */
+  notBefore: number;
+  /** Worktree paths already bound to a chat. */
+  claimedPaths?: string[];
   createdAt?: number;
 }): Promise<ChatWorkspace | undefined> {
   const sourceDir = fs.realpathSync(path.resolve(input.workspaceWorkingDir));
@@ -78,13 +92,19 @@ export async function discoverChatWorktree(input: {
   const relativeWorkingDir = path.relative(repositoryRoot, sourceDir);
   if (relativeWorkingDir.startsWith('..') || path.isAbsolute(relativeWorkingDir)) return undefined;
 
-  const parent = chatWorktreeParent(input.workspacesRoot, input.workspaceName, input.chatId);
+  const parent = chatWorktreeParent(input.workspaceWorkingDir);
   if (!fs.existsSync(parent)) return undefined;
   const realParent = fs.realpathSync(parent);
+  const claimed = new Set((input.claimedPaths ?? [])
+    .filter(claimedPath => fs.existsSync(claimedPath))
+    .map(claimedPath => fs.realpathSync(claimedPath)));
   const records = parseWorktreeList(await git(repositoryRoot, ['worktree', 'list', '--porcelain']));
   const owned = records.filter(record => {
     if (!fs.existsSync(record.worktreePath)) return false;
-    return path.dirname(fs.realpathSync(record.worktreePath)) === realParent;
+    const realPath = fs.realpathSync(record.worktreePath);
+    if (path.dirname(realPath) !== realParent) return false;
+    if (claimed.has(realPath)) return false;
+    return fs.statSync(realPath).birthtimeMs >= input.notBefore;
   });
   if (owned.length !== 1) return undefined;
 
@@ -163,9 +183,6 @@ export async function removeCleanChatWorktree(workspace: ChatWorkspace): Promise
 /** Create a chat-owned worktree and a same-named branch from the source HEAD. */
 export async function provisionChatWorktree(input: {
   workspaceWorkingDir: string;
-  workspacesRoot: string;
-  workspaceName: string;
-  chatId: string;
   worktreeName: string;
 }): Promise<ChatWorkspace> {
   const sourceDir = fs.realpathSync(path.resolve(input.workspaceWorkingDir));
@@ -183,7 +200,8 @@ export async function provisionChatWorktree(input: {
 
   const baseCommit = await git(sourceDir, ['rev-parse', 'HEAD']);
   const name = normalizeWorktreeName(input.worktreeName);
-  const requestedPath = chatWorktreeDirectory(input.workspacesRoot, input.workspaceName, input.chatId, name);
+  const requestedPath = chatWorktreeDirectory(sourceDir, name);
+  ensureWorktreeContainer(sourceDir);
   fs.mkdirSync(path.dirname(requestedPath), { recursive: true });
   const worktreePath = path.join(fs.realpathSync(path.dirname(requestedPath)), path.basename(requestedPath));
   const workingDir = path.join(worktreePath, relativeWorkingDir);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -22,7 +22,7 @@ import { MemoryStore } from '@codey/core';
 import { WorkspaceManager, TeamConfigRaw, TeamConfig, DEFAULT_PARALLEL_SETTINGS } from '@codey/core';
 import { WorkerManager } from '@codey/core';
 import { ChatManager, CreateChatInput } from './chats';
-import { chatWorktreeParent, describeLegacyChatWorktree, discoverChatWorktree, provisionChatWorktree, removeCleanChatWorktree, workspaceHasUncommittedChanges } from './chat-worktree';
+import { chatWorktreeParent, describeLegacyChatWorktree, discoverChatWorktree, ensureWorktreeContainer, provisionChatWorktree, removeCleanChatWorktree, workspaceHasUncommittedChanges } from './chat-worktree';
 import { resolveEffort } from './effort-resolve';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
@@ -773,9 +773,6 @@ export class Codey {
     if (pending) return pending;
     const provision = provisionChatWorktree({
       workspaceWorkingDir: this.resolveWorkspaceWorkingDir(chat.workspaceName),
-      workspacesRoot: this.workspaceManager.getWorkspacesRoot(),
-      workspaceName: chat.workspaceName,
-      chatId: chat.id,
       worktreeName,
     }).then(workspace => {
       const updated = this.chatManager.setChatWorkspace(chat.id, workspace);
@@ -786,19 +783,24 @@ export class Codey {
     return provision;
   }
 
-  /** Adopt a worktree that an agent created in this chat's private directory.
-   *  No model call is involved: ownership is determined from local Git state. */
+  /** Adopt a worktree that an agent created for this chat. No model call is
+   *  involved: ownership is determined from local Git state. */
   private async adoptAgentCreatedWorktree(chatId: string): Promise<Chat | undefined> {
     const chat = this.chatManager.get(chatId);
     if (!chat || chat.chatWorkspace) return undefined;
     try {
       const workspace = await discoverChatWorktree({
         workspaceWorkingDir: this.resolveWorkspaceWorkingDir(chat.workspaceName),
-        workspacesRoot: this.workspaceManager.getWorkspacesRoot(),
-        workspaceName: chat.workspaceName,
-        chatId: chat.id,
+        // The container is shared, so anything older than the chat, or already
+        // bound to another chat, belongs to someone else.
+        notBefore: chat.createdAt,
+        claimedPaths: this.chatManager.list(chat.workspaceName, { includeAutomation: true })
+          .flatMap(other => other.chatWorkspace ? [other.chatWorkspace.worktreePath] : []),
       });
       if (!workspace) return undefined;
+      // The agent created the checkout with plain Git, so the container may not
+      // be excluded from the workspace's own status yet.
+      ensureWorktreeContainer(this.resolveWorkspaceWorkingDir(chat.workspaceName));
       const updated = this.chatManager.setChatWorkspace(chat.id, workspace);
       this.logger.info(`[chat ${chat.id}] adopted agent-created worktree ${workspace.name ?? workspace.worktreePath}`);
       return updated;
@@ -814,6 +816,9 @@ export class Codey {
     if (chat.chatWorkspace) throw new Error(`This chat already owns the worktree "${chat.chatWorkspace.name ?? path.basename(chat.chatWorkspace.worktreePath)}"`);
     if (this.chatAborts.has(chatId)) throw new Error('Wait for the current agent turn to finish before creating a worktree');
     const previousMode = chat.executionMode ?? 'shared-checkout';
+    // Logged so a chat that turns out to be bound to a worktree can be traced
+    // back to this explicit UI action rather than to agent-side adoption.
+    this.logger.info(`[chat ${chatId}] Branch Selector requested worktree "${worktreeName}"`);
     this.chatManager.setExecutionMode(chatId, 'isolated-worktree');
     try {
       return await this.ensureChatWorkspace(chatId, worktreeName);
@@ -5920,14 +5925,15 @@ Example: /model gpt-4.1 write a Python script`;
     let prompt: string;
     let resumeSessionId: string | undefined;
     let newSessionId: string | undefined;
+    // Named, not created: `git worktree add` makes the leading directories, and
+    // pre-creating them would leave empty folders inside the user's project.
     const agentWorktreeParent = chat.executionMode !== 'isolated-worktree' && !chat.chatWorkspace
-      ? chatWorktreeParent(workspacesRoot, chat.workspaceName, chat.id)
+      ? chatWorktreeParent(this.resolveWorkspaceWorkingDir(chat.workspaceName))
       : undefined;
-    if (agentWorktreeParent) fs.mkdirSync(agentWorktreeParent, { recursive: true });
     const chatWorkspaceInstruction = chat.executionMode === 'isolated-worktree'
       ? '\n\n[Codey chat workspace]\nThis chat owns the current worktree and starts on its own same-named branch. You may rename or switch branches as the task evolves; do not operate in another chat’s worktree.'
       : agentWorktreeParent
-        ? `\n\n[Codey chat workspace]\nThis chat currently uses the shared checkout. If the task benefits from isolation, you may create one worktree for this chat without asking first. Choose a short semantic lower-kebab name with no slash, then run \`git worktree add -b <name> ${JSON.stringify(path.join(agentWorktreeParent, '<name>'))} HEAD\` and perform all subsequent work in that new directory. Create it only as a direct child of ${JSON.stringify(agentWorktreeParent)} so Codey can bind and display it. Do not create a worktree when the task does not need one.`
+        ? `\n\n[Codey chat workspace]\nThis chat uses the shared checkout. Work there; do not create a worktree on your own initiative. Only when the user explicitly asks for one, choose a short semantic lower-kebab name with no slash, then run \`git worktree add -b <name> ${JSON.stringify(path.join(agentWorktreeParent, '<name>'))} HEAD\` and perform all subsequent work in that new directory. Create it only as a direct child of ${JSON.stringify(agentWorktreeParent)} so Codey can bind and display it.`
         : '\n\n[Codey chat workspace]\nThis chat already has a user-managed worktree. Continue using the selected checkout; do not create another worktree.';
     if (warmAnchor) {
       // Resume the agent's own session. If other agents produced messages

--- a/scripts/migrate-chat-worktrees.ts
+++ b/scripts/migrate-chat-worktrees.ts
@@ -1,0 +1,140 @@
+/**
+ * Move chat worktrees from the old data-root layout into the workspace.
+ *
+ *   ~/.codey/chat-worktrees/<workspace>/chat-<id>/<name>   (old)
+ *   <workspace workingDir>/.worktrees/<name>               (new)
+ *
+ * Git owns the checkout, so `git worktree move` does the relocation and updates
+ * the repository's own registry; this script only adds the two things Git does
+ * not know about: the chat records that point at the old absolute path, and the
+ * self-ignoring container.
+ *
+ * Dry run (default):  npx ts-node scripts/migrate-chat-worktrees.ts
+ * Apply:              npx ts-node scripts/migrate-chat-worktrees.ts --apply
+ * One chat:           ... --apply --chat <chatId>
+ * Skip one chat:      ... --apply --skip <chatId>
+ */
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const WORKTREE_CONTAINER = '.worktrees';
+const dataRoot = process.env.CODEY_HOME ?? path.join(os.homedir(), '.codey');
+const workspacesRoot = path.join(dataRoot, 'workspaces');
+
+const args = process.argv.slice(2);
+const apply = args.includes('--apply');
+const only = args[args.indexOf('--chat') + 1];
+const onlyChat = args.includes('--chat') ? only : undefined;
+const skipChat = args.includes('--skip') ? args[args.indexOf('--skip') + 1] : undefined;
+
+interface ChatFile {
+  file: string;
+  id: string;
+  title?: string;
+  workspaceName: string;
+  chatWorkspace?: { worktreePath: string; workingDir: string; repositoryRoot: string; name?: string };
+  workingDirOverride?: string;
+}
+
+function readChats(): ChatFile[] {
+  const chats: ChatFile[] = [];
+  for (const workspace of fs.readdirSync(workspacesRoot, { withFileTypes: true })) {
+    if (!workspace.isDirectory()) continue;
+    const chatsDir = path.join(workspacesRoot, workspace.name, 'chats');
+    if (!fs.existsSync(chatsDir)) continue;
+    for (const entry of fs.readdirSync(chatsDir)) {
+      if (!entry.endsWith('.json')) continue;
+      const file = path.join(chatsDir, entry);
+      try {
+        chats.push({ ...JSON.parse(fs.readFileSync(file, 'utf8')), file });
+      } catch { /* unreadable chat file — leave it alone */ }
+    }
+  }
+  return chats;
+}
+
+function workspaceWorkingDir(workspaceName: string): string | undefined {
+  const config = path.join(workspacesRoot, workspaceName, 'workspace.json');
+  if (!fs.existsSync(config)) return undefined;
+  try {
+    return JSON.parse(fs.readFileSync(config, 'utf8')).workingDir || undefined;
+  } catch { return undefined; }
+}
+
+const git = (cwd: string, gitArgs: string[]) =>
+  execFileSync('git', gitArgs, { cwd, encoding: 'utf8' }).trim();
+
+let moved = 0;
+let skipped = 0;
+
+for (const chat of readChats()) {
+  const workspace = chat.chatWorkspace;
+  if (!workspace?.worktreePath) continue;
+  const container = path.join(path.resolve(workspaceWorkingDir(chat.workspaceName) ?? ''), WORKTREE_CONTAINER);
+  if (path.dirname(workspace.worktreePath) === container) continue; // already migrated
+
+  const label = `${chat.title || 'Untitled'} (${chat.id})`;
+  const name = workspace.name || path.basename(workspace.worktreePath);
+  const target = path.join(container, name);
+  const reasons: string[] = [];
+  if (onlyChat && chat.id !== onlyChat) reasons.push('not the requested --chat');
+  if (skipChat && chat.id === skipChat) reasons.push('excluded by --skip');
+  if (!workspaceWorkingDir(chat.workspaceName)) reasons.push(`workspace "${chat.workspaceName}" has no workingDir`);
+  if (!fs.existsSync(workspace.worktreePath)) reasons.push('worktree directory is gone');
+  if (fs.existsSync(target)) reasons.push(`target already exists: ${target}`);
+  if (workspace.worktreePath === process.cwd() || process.cwd().startsWith(workspace.worktreePath + path.sep)) {
+    reasons.push('this script is running inside that worktree');
+  }
+  if (reasons.length) {
+    console.log(`SKIP  ${label}\n      ${reasons.join('; ')}`);
+    skipped++;
+    continue;
+  }
+
+  console.log(`${apply ? 'MOVE' : 'PLAN'}  ${label}\n      ${workspace.worktreePath}\n   -> ${target}`);
+  if (!apply) { moved++; continue; }
+
+  // Uncommitted work is fine (the checkout moves intact), but a running agent
+  // is not: Git rewrites the admin files while the process holds the old path.
+  const dirty = git(workspace.worktreePath, ['status', '--porcelain']);
+  if (dirty) console.log('      note: worktree has uncommitted changes; they move with it');
+
+  fs.mkdirSync(container, { recursive: true });
+  const ignoreFile = path.join(container, '.gitignore');
+  if (!fs.existsSync(ignoreFile)) fs.writeFileSync(ignoreFile, '*\n');
+
+  git(workspace.repositoryRoot, ['worktree', 'move', workspace.worktreePath, target]);
+
+  const record = JSON.parse(fs.readFileSync(chat.file, 'utf8'));
+  const relativeWorkingDir = path.relative(workspace.worktreePath, workspace.workingDir);
+  record.chatWorkspace.worktreePath = target;
+  record.chatWorkspace.workingDir = path.join(target, relativeWorkingDir);
+  if (record.workingDirOverride) record.workingDirOverride = record.chatWorkspace.workingDir;
+  const temp = `${chat.file}.migrating`;
+  fs.writeFileSync(temp, JSON.stringify(record, null, 2));
+  fs.renameSync(temp, chat.file); // atomic, mirrors ChatManager.persist
+  moved++;
+}
+
+const oldRoot = path.join(dataRoot, 'chat-worktrees');
+if (apply && fs.existsSync(oldRoot)) {
+  // Prune whatever is left empty; anything still holding a checkout stays put.
+  // Finder litter (.DS_Store) would otherwise keep a drained directory alive —
+  // and, being a file rather than a directory, break the walk.
+  const prune = (dir: string, depth: number): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (depth > 0) prune(path.join(dir, entry.name), depth - 1);
+      } else if (entry.name === '.DS_Store') {
+        fs.rmSync(path.join(dir, entry.name));
+      }
+    }
+    try { fs.rmdirSync(dir); } catch { /* still holds a checkout */ }
+  };
+  prune(oldRoot, 2);
+}
+
+console.log(`\n${apply ? 'Migrated' : 'Would migrate'} ${moved}; skipped ${skipped}.`);
+if (!apply) console.log('Re-run with --apply to perform the moves.');


### PR DESCRIPTION
Every new chat was ending up in its own worktree under `~/.codey/chat-worktrees/`, far from the project it belonged to, and the branch picker labelled the same worktree two different ways depending on whether it was expanded.

## Where worktrees live

`<workspace workingDir>/.worktrees/<name>` instead of `~/.codey/chat-worktrees/<ws>/chat-<uuid>/<name>`. The container gets a self-ignoring `.gitignore` so the checkouts never show up as untracked files in the workspace's own `git status`.

Dropping the `chat-<uuid>` level removed the path marker that made adoption unambiguous, so ownership is now derived from state instead: a candidate must be a direct child of the container, unclaimed by any other chat, and newer than the chat itself. Two qualifying candidates adopt nothing — leaving a chat in the shared checkout is recoverable, binding it to another chat's worktree is not.

## No more agent-initiated worktrees

The injected instruction used to tell the agent it could create a worktree "without asking first", which is why every chat became isolated. It now says to work in the shared checkout unless the user asks for isolation; the path and naming rules are kept for when they do. The Branch Selector path logs its request so a bound chat can be traced back to the action that bound it.

## Branch picker label

Expanded, the picker showed three path segments — one of them a 36-character `chat-<uuid>` — and the CSS ellipsis then ate the tail, so it read `…/codey/chat-4be57559-ae33-…` while the collapsed pill read `improve-agent-management`. The uuid segment is now elided when compacting, and the label splits into a head that truncates and a tail that never does.

## Migration

`scripts/migrate-chat-worktrees.ts` moves existing chats over (`git worktree move` plus a rewrite of the stored absolute paths). Dry run by default; refuses to move the worktree it is running inside. Restart the app after running it — `ChatManager` caches chat records in memory.

## Testing

- `packages/gateway`: 299 tests pass, including new cases for the ownership rules (predates the chat, already claimed, two candidates)
- `codey-mac`: `branchPickerModel` 11 tests pass
- `tsc --noEmit -p packages/gateway/tsconfig.json` and `npm run lint` clean

Ran the migration locally: two chats moved into `.worktrees/`, `~/.codey` went from 3.9G to 450M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)