### PR TITLE
Show chat details on hover in the sidebar

### DIFF
--- a/codey-mac/src/components/ChatHoverCard.tsx
+++ b/codey-mac/src/components/ChatHoverCard.tsx
@@ -1,0 +1,118 @@
+import React, { useLayoutEffect, useRef, useState } from 'react'
+import { C } from '../theme'
+import {
+  HOVER_CARD_WIDTH,
+  hoverCardPosition,
+  type HoverCard,
+  type HoverCardAnchor,
+  type HoverTone,
+} from './chatHoverCardView'
+
+interface Props {
+  card: HoverCard
+  anchor: HoverCardAnchor
+}
+
+const TONE_COLOR: Record<HoverTone, string> = {
+  accent: C.accent,
+  green: C.green,
+  yellow: C.yellow,
+  red: C.red,
+  muted: C.fg3,
+}
+
+/** Read-only detail popover for a sidebar row. Deliberately pointer-events:none
+ *  — it overlaps neighbouring rows, and a card that swallowed the click that
+ *  was meant for the chat under it would be worse than no card at all. */
+export const ChatHoverCard: React.FC<Props> = ({ card, anchor }) => {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [height, setHeight] = useState(0)
+
+  // Height depends on how many rows this particular chat has, so it is measured
+  // after the first paint and the card is only placed once it is known.
+  useLayoutEffect(() => {
+    if (ref.current) setHeight(ref.current.offsetHeight)
+  }, [card, anchor])
+
+  const placed = height > 0
+  const pos = hoverCardPosition(
+    anchor,
+    { width: window.innerWidth, height: window.innerHeight },
+    height,
+  )
+  const tone = TONE_COLOR[card.status.tone]
+
+  return (
+    <div
+      ref={ref}
+      role="tooltip"
+      style={{ ...styles.card, left: pos.left, top: pos.top, opacity: placed ? 1 : 0 }}
+    >
+      <div style={styles.title}>{card.title}</div>
+      <div style={styles.statusRow}>
+        <span style={{ ...styles.pill, color: tone, background: `${tone}22` }}>{card.status.label}</span>
+        {card.progress && (
+          <span style={styles.progressText}>{card.progress.label ?? `${card.progress.percent}%`}</span>
+        )}
+      </div>
+      {card.progress && (
+        <div style={styles.progressTrack}>
+          <div style={{ ...styles.progressFill, width: `${card.progress.percent}%`, background: tone }} />
+        </div>
+      )}
+      {card.detail && <div style={styles.detail}>{card.detail}</div>}
+      <div style={styles.rows}>
+        {card.rows.map(row => (
+          <div key={row.label} style={styles.row}>
+            <span style={styles.rowLabel}>{row.label}</span>
+            <span style={styles.rowValue}>{row.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  card: {
+    position: 'fixed',
+    zIndex: 900,
+    width: HOVER_CARD_WIDTH,
+    padding: '9px 11px',
+    background: C.surface2 ?? C.surface,
+    border: `1px solid ${C.border2 ?? C.border}`,
+    borderRadius: 8,
+    boxShadow: '0 14px 30px rgba(0,0,0,0.26)',
+    pointerEvents: 'none',
+    transition: 'opacity 90ms ease-out',
+  },
+  title: {
+    fontSize: 12,
+    fontWeight: 600,
+    color: C.fg,
+    marginBottom: 6,
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+  },
+  statusRow: { display: 'flex', alignItems: 'center', gap: 6 },
+  pill: { fontSize: 10, fontWeight: 600, padding: '2px 6px', borderRadius: 5, whiteSpace: 'nowrap' },
+  progressText: { fontSize: 10, color: C.fg3, marginLeft: 'auto' },
+  progressTrack: { height: 3, borderRadius: 2, background: C.border, marginTop: 6, overflow: 'hidden' },
+  progressFill: { height: '100%', borderRadius: 2 },
+  detail: {
+    fontSize: 11,
+    color: C.fg2,
+    marginTop: 6,
+    lineHeight: 1.35,
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+  },
+  rows: { marginTop: 8, paddingTop: 7, borderTop: `1px solid ${C.border}`, display: 'grid', gap: 3 },
+  row: { display: 'flex', alignItems: 'baseline', gap: 8, fontSize: 11 },
+  rowLabel: { color: C.fg3, flex: '0 0 66px' },
+  rowValue: { color: C.fg2, flex: 1, textAlign: 'right', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+}

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useChats } from '../hooks/useChats'
 import { apiService } from '../services/api'
 import type { Chat } from '../types'
@@ -9,6 +9,8 @@ import { setPendingPairing } from './pendingPairing'
 import { onWorkspacesChanged } from './workspacesChanged'
 import { UIIcon } from './UIIcons'
 import { moveWorkspace, reconcileWorkspaceOrder } from './workspaceOrder'
+import { ChatHoverCard } from './ChatHoverCard'
+import { buildChatHoverCard, HOVER_CARD_DELAY_MS, type HoverCardAnchor } from './chatHoverCardView'
 
 interface Props {
   onOpenSettings: (tab?: string) => void
@@ -59,6 +61,9 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
   const [hoveredChatId, setHoveredChatId] = useState<string | null>(null)
+  const [hoverCard, setHoverCard] = useState<{ chatId: string; anchor: HoverCardAnchor } | null>(null)
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [defaultAgent, setDefaultAgent] = useState<string>('')
   const [wsOrder, setWsOrder] = useState<string[]>(() => {
     try {
       const saved = JSON.parse(localStorage.getItem('codey.workspaceOrder') || '[]')
@@ -228,6 +233,54 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
     }
   }, [wsMenu, chatMenu])
 
+  // Only for the "(default)" note on chats with no agent override; a failure
+  // here just falls back to the generic label.
+  useEffect(() => {
+    apiService.getConfig()
+      .then(cfg => setDefaultAgent(typeof cfg?.defaultAgent === 'string' ? cfg.defaultAgent : ''))
+      .catch(() => {})
+  }, [])
+
+  const closeHoverCard = useCallback(() => {
+    if (hoverTimer.current) {
+      clearTimeout(hoverTimer.current)
+      hoverTimer.current = null
+    }
+    setHoverCard(null)
+  }, [])
+
+  /** The card is worth showing only if the pointer stays put, so the anchor is
+   *  captured now — by the time the timer fires the event object is gone. */
+  const scheduleHoverCard = useCallback((chatId: string, element: HTMLElement) => {
+    if (hoverTimer.current) clearTimeout(hoverTimer.current)
+    const { top, bottom, left, right } = element.getBoundingClientRect()
+    hoverTimer.current = setTimeout(() => {
+      hoverTimer.current = null
+      setHoverCard({ chatId, anchor: { top, bottom, left, right } })
+    }, HOVER_CARD_DELAY_MS)
+  }, [])
+
+  useEffect(() => () => { if (hoverTimer.current) clearTimeout(hoverTimer.current) }, [])
+
+  // Escape is the expected way out for a keyboard user who focused the row, and
+  // a resize invalidates the anchor the card was placed against.
+  useEffect(() => {
+    if (!hoverCard) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') closeHoverCard() }
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('resize', closeHoverCard)
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('resize', closeHoverCard)
+    }
+  }, [hoverCard, closeHoverCard])
+
+  // A fixed-position card can't follow its row, and a menu or rename box means
+  // the user is acting on the chat rather than reading about it.
+  useEffect(() => {
+    if (wsMenu || chatMenu || renamingId) closeHoverCard()
+  }, [wsMenu, chatMenu, renamingId, closeHoverCard])
+
   const handleAddWorkspace = async () => {
     if (addingWorkspace) return
     setAddingWorkspace(true)
@@ -304,7 +357,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
       </div>
       <div style={styles.chatSection}>
         <div style={styles.chatSectionHeader}><span>Chats</span><span>{state.order.length}</span></div>
-        <div style={styles.scroll}>
+        <div style={styles.scroll} onScroll={closeHoverCard}>
         {groupNames.length === 0 && (
           <div style={styles.empty}>No chats yet. Click "New Chat".</div>
         )}
@@ -424,15 +477,26 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                     style={{ ...styles.item, background: active ? C.accentDim : 'transparent', borderColor: active ? C.accent : 'transparent', opacity: orphaned ? 0.5 : 1 }}
                     onClick={() => {
                       if (isRenaming) return
+                      closeHoverCard()
                       onSelectChat()
                       selectChat(chat.id)
                     }}
-                    onMouseEnter={() => setHoveredChatId(chat.id)}
-                    onMouseLeave={() => setHoveredChatId(current => current === chat.id ? null : current)}
-                    onFocus={() => setHoveredChatId(chat.id)}
+                    onMouseEnter={event => {
+                      setHoveredChatId(chat.id)
+                      scheduleHoverCard(chat.id, event.currentTarget)
+                    }}
+                    onMouseLeave={() => {
+                      setHoveredChatId(current => current === chat.id ? null : current)
+                      closeHoverCard()
+                    }}
+                    onFocus={event => {
+                      setHoveredChatId(chat.id)
+                      scheduleHoverCard(chat.id, event.currentTarget)
+                    }}
                     onBlur={event => {
                       if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
                         setHoveredChatId(current => current === chat.id ? null : current)
+                        closeHoverCard()
                       }
                     }}
                     onKeyDown={event => {
@@ -522,6 +586,19 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
         <button style={styles.footerButton} onClick={() => onOpenSettings()}><UIIcon name="settings" size={15} />Settings</button>
         </div>
       </div>
+      {hoverCard && state.chats[hoverCard.chatId] && (
+        <ChatHoverCard
+          key={hoverCard.chatId}
+          anchor={hoverCard.anchor}
+          card={buildChatHoverCard({
+            chat: state.chats[hoverCard.chatId],
+            flight: state.inFlight[hoverCard.chatId],
+            unread: !!state.unreadChats[hoverCard.chatId],
+            pendingPermissions: state.pendingPermissions[hoverCard.chatId],
+            defaultAgent: defaultAgent || undefined,
+          })}
+        />
+      )}
       {wsMenu && (
         <div
           style={{ ...styles.menu, top: wsMenu.y, left: wsMenu.x }}

--- a/codey-mac/src/components/chatHoverCardView.test.ts
+++ b/codey-mac/src/components/chatHoverCardView.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest'
+import { buildChatHoverCard, hoverCardPosition, HOVER_CARD_WIDTH } from './chatHoverCardView'
+import type { Chat } from '../types'
+
+const NOW = 1_700_000_000_000
+
+function makeChat(overrides: Partial<Chat> = {}): Chat {
+  return {
+    id: 'c1',
+    title: 'Fix the reducer',
+    workspaceName: 'codey',
+    selection: { type: 'none' },
+    messages: [],
+    createdAt: NOW - 3_600_000,
+    updatedAt: NOW - 60_000,
+    ...overrides,
+  } as Chat
+}
+
+function rowValue(card: ReturnType<typeof buildChatHoverCard>, label: string) {
+  return card.rows.find(r => r.label === label)?.value
+}
+
+describe('buildChatHoverCard — status', () => {
+  it('reports the live activity while a turn is in flight', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat(),
+      flight: { agentStatus: 'editing' },
+      unread: false,
+      now: NOW,
+    })
+    expect(card.status).toEqual({ label: 'Editing', tone: 'accent' })
+  })
+
+  it('says where in the queue a waiting turn sits', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat(),
+      flight: { agentStatus: 'thinking', queuedPosition: 2 },
+      unread: false,
+      now: NOW,
+    })
+    expect(card.status.label).toBe('Queued · 2nd in line')
+  })
+
+  it('puts a permission prompt ahead of the running state — it is the thing blocking', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat(),
+      flight: { agentStatus: 'running' },
+      unread: false,
+      pendingPermissions: ['Bash'],
+      now: NOW,
+    })
+    expect(card.status).toEqual({ label: 'Needs permission', tone: 'yellow' })
+    expect(card.detail).toBe('Bash')
+  })
+
+  it('names all the tools waiting on a permission decision', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat(),
+      unread: false,
+      pendingPermissions: ['Bash', 'Write'],
+      now: NOW,
+    })
+    expect(card.detail).toBe('Bash, Write')
+  })
+
+  it('surfaces a paused team run as waiting on the user', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({ pendingTeam: { askingWorker: 'aide', question: 'Which database?' } as unknown as Chat['pendingTeam'] }),
+      unread: false,
+      now: NOW,
+    })
+    expect(card.status).toEqual({ label: 'Waiting on you', tone: 'yellow' })
+    expect(card.detail).toBe('Which database?')
+  })
+
+  it('falls back to the task brief when the chat is idle', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({
+        messages: [{ id: 'm1', role: 'assistant', content: 'hi', timestamp: NOW - 120_000 }] as Chat['messages'],
+        taskBrief: {
+          goal: 'Ship the hover card',
+          state: { progress: 40, status: 'blocked' },
+          nextAction: { text: 'Waiting on API access' },
+          timeline: [],
+          generatedAt: NOW - 60_000,
+        },
+      }),
+      unread: false,
+      now: NOW,
+    })
+    expect(card.status).toEqual({ label: 'Blocked', tone: 'red' })
+    expect(card.detail).toBe('Waiting on API access')
+    expect(card.progress).toMatchObject({ percent: 40 })
+  })
+
+  it('ignores a task brief that predates the newest message rather than showing a stale claim', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({
+        messages: [{ id: 'm1', role: 'assistant', content: 'hi', timestamp: NOW - 10_000 }] as Chat['messages'],
+        taskBrief: {
+          goal: 'Ship the hover card',
+          state: { progress: 40, status: 'done' },
+          timeline: [],
+          generatedAt: NOW - 600_000,
+        },
+      }),
+      unread: false,
+      now: NOW,
+    })
+    expect(card.status.label).not.toBe('Done')
+    expect(card.progress).toBeUndefined()
+  })
+
+  it('marks an unread finished chat as having a new reply', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({ messages: [{ id: 'm1', role: 'assistant', content: 'done', timestamp: NOW }] as Chat['messages'] }),
+      unread: true,
+      now: NOW,
+    })
+    expect(card.status).toEqual({ label: 'New reply', tone: 'green' })
+  })
+
+  it('calls an empty chat empty instead of idle', () => {
+    const card = buildChatHoverCard({ chat: makeChat(), unread: false, now: NOW })
+    expect(card.status).toEqual({ label: 'No messages yet', tone: 'muted' })
+  })
+
+  it('prefers the agent-reported checklist item over the activity word', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({
+        checklist: [
+          { text: 'Write the model', status: 'completed' },
+          { text: 'Wire the card', activeForm: 'Wiring the card', status: 'in_progress' },
+          { text: 'Test it', status: 'pending' },
+        ] as Chat['checklist'],
+      }),
+      flight: { agentStatus: 'editing' },
+      unread: false,
+      now: NOW,
+    })
+    expect(card.detail).toBe('Wiring the card')
+    expect(card.progress).toEqual({ percent: 33, label: '1/3' })
+  })
+})
+
+describe('buildChatHoverCard — rows', () => {
+  it('names the agent, model and effort on one line', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({ agent: 'claude-code', model: 'claude-opus-5', effort: 'high' }),
+      unread: false,
+      now: NOW,
+    })
+    expect(rowValue(card, 'Agent')).toBe('claude-code · claude-opus-5 · high effort')
+  })
+
+  it('marks an unset agent as following the gateway default', () => {
+    const card = buildChatHoverCard({ chat: makeChat(), unread: false, defaultAgent: 'codex', now: NOW })
+    expect(rowValue(card, 'Agent')).toBe('codex (default)')
+  })
+
+  it('says gateway default when even the default is unknown', () => {
+    const card = buildChatHoverCard({ chat: makeChat(), unread: false, now: NOW })
+    expect(rowValue(card, 'Agent')).toBe('Gateway default')
+  })
+
+  it('reports the worktree a chat is isolated in', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({
+        executionMode: 'isolated-worktree',
+        chatWorkspace: {
+          name: 'hover-card',
+          repositoryRoot: '/repo',
+          worktreePath: '/repo/.worktrees/hover-card',
+          workingDir: '/repo/.worktrees/hover-card',
+          baseCommit: 'abc',
+          createdAt: NOW,
+        },
+      }),
+      unread: false,
+      now: NOW,
+    })
+    expect(rowValue(card, 'Checkout')).toBe('Isolated worktree · hover-card')
+  })
+
+  it('says shared checkout when the chat is not isolated', () => {
+    const card = buildChatHoverCard({ chat: makeChat(), unread: false, now: NOW })
+    expect(rowValue(card, 'Checkout')).toBe('Shared checkout')
+  })
+
+  it('shows the team or worker a chat is bound to', () => {
+    const team = buildChatHoverCard({ chat: makeChat({ selection: { type: 'team', name: 'builders' } }), unread: false, now: NOW })
+    expect(rowValue(team, 'Team')).toBe('builders')
+    const worker = buildChatHoverCard({ chat: makeChat({ selection: { type: 'worker', name: 'aide' } }), unread: false, now: NOW })
+    expect(rowValue(worker, 'Worker')).toBe('aide')
+  })
+
+  it('omits the team row for a plain chat', () => {
+    const card = buildChatHoverCard({ chat: makeChat(), unread: false, now: NOW })
+    expect(rowValue(card, 'Team')).toBeUndefined()
+    expect(rowValue(card, 'Worker')).toBeUndefined()
+  })
+
+  it('reports the pull request state in words', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({ pullRequest: { url: 'u', number: 42, state: 'merged-with-changes', lastCheckedAt: NOW } }),
+      unread: false,
+      now: NOW,
+    })
+    expect(rowValue(card, 'Delivery')).toBe('PR #42 · merged, new changes since')
+  })
+
+  it('counts messages and dates the last activity', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({
+        messages: [
+          { id: 'm1', role: 'user', content: 'a', timestamp: NOW - 200_000 },
+          { id: 'm2', role: 'assistant', content: 'b', timestamp: NOW - 100_000 },
+        ] as Chat['messages'],
+        updatedAt: NOW - 7_200_000,
+      }),
+      unread: false,
+      now: NOW,
+    })
+    expect(rowValue(card, 'Messages')).toBe('2')
+    expect(rowValue(card, 'Last active')).toBe('2h ago')
+  })
+
+  it('singularizes a lone message', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({ messages: [{ id: 'm1', role: 'user', content: 'a', timestamp: NOW }] as Chat['messages'] }),
+      unread: false,
+      now: NOW,
+    })
+    expect(rowValue(card, 'Messages')).toBe('1')
+  })
+
+  it('lists the channels a chat is routed to', () => {
+    const card = buildChatHoverCard({
+      chat: makeChat({
+        routes: [
+          { channel: 'telegram', channelUserId: 'u1', channelChatId: '1', attachedAt: NOW },
+          { channel: 'discord', channelUserId: 'u2', channelChatId: '2', attachedAt: NOW },
+        ],
+      }),
+      unread: false,
+      now: NOW,
+    })
+    expect(rowValue(card, 'Channels')).toBe('telegram, discord')
+  })
+
+  it('falls back to a placeholder title for an unnamed chat', () => {
+    const card = buildChatHoverCard({ chat: makeChat({ title: '   ' }), unread: false, now: NOW })
+    expect(card.title).toBe('New Chat')
+  })
+})
+
+describe('hoverCardPosition', () => {
+  const viewport = { width: 1400, height: 900 }
+  const rect = { top: 100, bottom: 128, left: 20, right: 240 }
+
+  it('anchors to the right of the row, level with its top', () => {
+    const pos = hoverCardPosition(rect, viewport, 200)
+    expect(pos.left).toBe(rect.right + 8)
+    expect(pos.top).toBe(rect.top)
+  })
+
+  it('flips to the left of the row when the card would overflow the viewport', () => {
+    const pos = hoverCardPosition({ ...rect, left: 1150, right: 1380 }, viewport, 200)
+    expect(pos.left).toBe(1150 - 8 - HOVER_CARD_WIDTH)
+  })
+
+  it('lifts the card so a tall one stays on screen', () => {
+    const pos = hoverCardPosition({ ...rect, top: 820, bottom: 848 }, viewport, 200)
+    expect(pos.top).toBe(900 - 200 - 8)
+  })
+
+  it('never pushes the card off the top edge', () => {
+    const pos = hoverCardPosition({ ...rect, top: 10, bottom: 38 }, { width: 1400, height: 180 }, 200)
+    expect(pos.top).toBe(8)
+  })
+
+  it('keeps the card on screen when neither side has room', () => {
+    const pos = hoverCardPosition({ top: 10, bottom: 38, left: 4, right: 100 }, { width: 320, height: 900 }, 200)
+    expect(pos.left).toBeGreaterThanOrEqual(8)
+    expect(pos.left + HOVER_CARD_WIDTH).toBeLessThanOrEqual(320 - 8)
+  })
+})

--- a/codey-mac/src/components/chatHoverCardView.ts
+++ b/codey-mac/src/components/chatHoverCardView.ts
@@ -1,0 +1,198 @@
+// codey-mac/src/components/chatHoverCard.ts
+//
+// What the sidebar says about a chat when you hover its title. The row itself
+// has space for a name and one dot, so everything else a user needs to answer
+// "what is this chat doing right now?" has to live here.
+//
+// Pure by convention (see checklistView.ts): no React, core types only, so the
+// precedence rules below can be tested directly rather than through the DOM.
+
+import type { Chat } from '../types'
+import { ACTIVITY_LABEL, type AgentActivity } from './agentActivity'
+import { checklistProgress, currentChecklistItem, currentItemLabel } from './checklistView'
+import { formatAgo, isTaskBriefStale, statusMeta, type StatusTone } from './taskHudView'
+
+/** taskHudView's tones plus the one a HUD never needs: nothing has happened. */
+export type HoverTone = StatusTone | 'muted'
+
+export interface HoverCardRow {
+  label: string
+  value: string
+}
+
+export interface HoverCardProgress {
+  percent: number
+  /** "3/7" when counted from the agent's own list; absent for an LLM estimate. */
+  label?: string
+}
+
+export interface HoverCard {
+  title: string
+  status: { label: string; tone: HoverTone }
+  /** One line under the status: the current step, question, or blocker. */
+  detail?: string
+  progress?: HoverCardProgress
+  rows: HoverCardRow[]
+}
+
+export interface HoverCardInput {
+  chat: Chat
+  /** state.inFlight[chat.id] — present only while a turn is running. */
+  flight?: { agentStatus: AgentActivity; queuedPosition?: number }
+  unread: boolean
+  /** state.pendingPermissions[chat.id] — tools awaiting a decision. */
+  pendingPermissions?: string[]
+  /** Gateway default, shown when the chat has no per-chat agent override. */
+  defaultAgent?: string
+  now?: number
+}
+
+const PR_STATE_LABEL: Record<NonNullable<Chat['pullRequest']>['state'], string> = {
+  'pr-open': 'open',
+  merged: 'merged',
+  'merged-with-changes': 'merged, new changes since',
+  'closed-unmerged': 'closed without merging',
+}
+
+function ordinal(n: number): string {
+  const rem100 = n % 100
+  if (rem100 >= 11 && rem100 <= 13) return `${n}th`
+  switch (n % 10) {
+    case 1: return `${n}st`
+    case 2: return `${n}nd`
+    case 3: return `${n}rd`
+    default: return `${n}th`
+  }
+}
+
+/** The status line, most-blocking cause first. A permission prompt outranks the
+ *  running state because the run has already stopped for it; an unread reply
+ *  outranks "idle" because it is the reason to open the chat. */
+function deriveStatus(
+  input: HoverCardInput,
+  brief: Chat['taskBrief'] | undefined,
+): { status: { label: string; tone: HoverTone }; detail?: string } {
+  const { chat, flight, unread, pendingPermissions } = input
+
+  if (pendingPermissions?.length) {
+    return { status: { label: 'Needs permission', tone: 'yellow' }, detail: pendingPermissions.join(', ') }
+  }
+
+  if (chat.pendingTeam) {
+    return { status: { label: 'Waiting on you', tone: 'yellow' }, detail: chat.pendingTeam.question }
+  }
+
+  if (flight) {
+    const current = chat.checklist?.length ? currentChecklistItem(chat.checklist) : null
+    const label = flight.queuedPosition
+      ? `Queued · ${ordinal(flight.queuedPosition)} in line`
+      : ACTIVITY_LABEL[flight.agentStatus]
+    return {
+      status: { label, tone: 'accent' },
+      // The agent's own words for the step beat our verb for the tool it ran.
+      detail: current ? currentItemLabel(current.item) : undefined,
+    }
+  }
+
+  if (brief) {
+    const meta = statusMeta(brief.state.status)
+    return { status: meta, detail: brief.nextAction?.text }
+  }
+
+  if (unread) return { status: { label: 'New reply', tone: 'green' } }
+  if (!chat.messages.length) return { status: { label: 'No messages yet', tone: 'muted' } }
+  return { status: { label: 'Idle', tone: 'muted' } }
+}
+
+function deriveProgress(chat: Chat, brief: Chat['taskBrief'] | undefined): HoverCardProgress | undefined {
+  // Counted beats estimated: the checklist is what the agent said it would do.
+  if (chat.checklist?.length) {
+    const p = checklistProgress(chat.checklist)
+    return { percent: p.percent, label: p.label }
+  }
+  if (brief) return { percent: brief.state.progress }
+  return undefined
+}
+
+function deriveRows(input: HoverCardInput): HoverCardRow[] {
+  const { chat, defaultAgent, now } = input
+  const rows: HoverCardRow[] = []
+
+  const agent = chat.agent
+    ? [chat.agent, chat.model, chat.effort ? `${chat.effort} effort` : undefined].filter(Boolean).join(' · ')
+    : defaultAgent ? `${defaultAgent} (default)` : 'Gateway default'
+  rows.push({ label: 'Agent', value: agent })
+
+  if (chat.selection.type === 'team' && chat.selection.name) rows.push({ label: 'Team', value: chat.selection.name })
+  if (chat.selection.type === 'worker' && chat.selection.name) rows.push({ label: 'Worker', value: chat.selection.name })
+
+  rows.push({
+    label: 'Checkout',
+    value: chat.executionMode === 'isolated-worktree'
+      ? ['Isolated worktree', chat.chatWorkspace?.name].filter(Boolean).join(' · ')
+      : 'Shared checkout',
+  })
+
+  if (chat.pullRequest) {
+    const pr = chat.pullRequest.number ? `PR #${chat.pullRequest.number}` : 'Pull request'
+    rows.push({ label: 'Delivery', value: `${pr} · ${PR_STATE_LABEL[chat.pullRequest.state]}` })
+  }
+
+  if (chat.routes?.length) {
+    rows.push({ label: 'Channels', value: chat.routes.map(r => r.channel).join(', ') })
+  }
+
+  rows.push({ label: 'Messages', value: String(chat.messages.length) })
+  rows.push({ label: 'Last active', value: formatAgo(chat.updatedAt, now) })
+
+  return rows
+}
+
+export function buildChatHoverCard(input: HoverCardInput): HoverCard {
+  const { chat } = input
+  // A brief generated before the newest message describes a turn that has since
+  // moved on, so it is dropped rather than shown as the current state.
+  const brief = chat.taskBrief && !isTaskBriefStale(chat) ? chat.taskBrief : undefined
+  const { status, detail } = deriveStatus(input, brief)
+
+  return {
+    title: chat.title?.trim() || 'New Chat',
+    status,
+    detail,
+    progress: deriveProgress(chat, brief),
+    rows: deriveRows(input),
+  }
+}
+
+export const HOVER_CARD_WIDTH = 260
+/** Long enough that skimming the list doesn't strobe cards open. */
+export const HOVER_CARD_DELAY_MS = 450
+
+const GAP = 8
+
+export interface HoverCardAnchor {
+  top: number
+  bottom: number
+  left: number
+  right: number
+}
+
+/** Fixed-position placement beside the hovered row. The sidebar scrolls and the
+ *  window resizes, so the card is clamped into the viewport instead of trusting
+ *  the row's position. */
+export function hoverCardPosition(
+  anchor: HoverCardAnchor,
+  viewport: { width: number; height: number },
+  cardHeight: number,
+): { left: number; top: number } {
+  const right = anchor.right + GAP
+  const fitsRight = right + HOVER_CARD_WIDTH <= viewport.width - GAP
+  const left = fitsRight ? right : anchor.left - GAP - HOVER_CARD_WIDTH
+  const maxLeft = Math.max(GAP, viewport.width - GAP - HOVER_CARD_WIDTH)
+
+  const maxTop = viewport.height - cardHeight - GAP
+  return {
+    left: Math.min(Math.max(GAP, left), maxLeft),
+    top: Math.min(Math.max(GAP, anchor.top), Math.max(GAP, maxTop)),
+  }
+}


### PR DESCRIPTION
Closes #242.

## What

Hovering a chat title in the sidebar (after a ~450ms dwell) opens a small read-only card with the state that the one-line row has no space for.

- **Status pill** — the live activity while a turn runs (`Thinking` / `Editing` / `Queued · 2nd in line`), or the resting state (`Needs permission`, `Waiting on you`, `Blocked`, `New reply`, `Idle`, `No messages yet`).
- **Detail line** — the agent's current checklist item, the question a paused team asked, the tools awaiting a permission decision, or the brief's next action.
- **Progress bar** — counted from the agent's own checklist (`3/7`) when it reported one, otherwise the task brief's estimate.
- **Rows** — agent · model · effort, team/worker, shared checkout vs. isolated worktree, PR delivery state, attached channels, message count, last active.

## How

Derivation lives in `chatHoverCardView.ts` — pure, no React, core types only — following the `taskHudView.ts` / `checklistView.ts` convention, and reusing `ACTIVITY_LABEL`, `checklistProgress`, `currentChecklistItem`, `statusMeta`, `isTaskBriefStale` and `formatAgo` rather than introducing a second source of truth for chat status. `ChatHoverCard.tsx` is presentation only; the panel already tracked `hoveredChatId`, so this adds the dwell timer and anchor capture on top of it.

Three judgement calls worth reviewing:

- **Status precedence.** A pending permission outranks "running" — the run has already stopped for it, so reporting `Editing` would be a lie. An unread reply outranks "idle" because it is the reason to open the chat.
- **Stale briefs are dropped, not shown.** A `taskBrief` generated before the newest message describes a turn that has moved on, so the card falls back to the plain state instead of presenting it as current.
- **`pointer-events: none`.** The card overlaps neighbouring rows; one that swallowed a click meant for the chat underneath it would be worse than no card. It is dismissed on click, scroll, resize, Escape, context menu and rename.

Placement is clamped into the viewport (flips to the left of the row when the window is narrow, lifts when the row is near the bottom) rather than trusting the row's position, since the sidebar scrolls.

## Verification

- `npm test -w codey-mac` — 477 passed, including 27 new tests in `chatHoverCardView.test.ts` covering status precedence, stale-brief handling, every row, and the placement clamps.
- `npx tsc --noEmit -p codey-mac/tsconfig.json` — clean for the renderer.
- `npx vite build` — renderer and preload bundles build.
- `npm run lint` — clean.

**Not verified:** no visual check in a running app. This worktree has no `electron` installed (which is also why `electron/browser-controller.test.ts` fails to import here — it fails identically on unmodified `main`), so the card's spacing, contrast and dwell feel have not been seen on screen. That is the one thing left to confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)