### PR TITLE
Show fallback as a warning icon with a reason popup

### DIFF
--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -92,14 +92,7 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
           ) : meta.identity ? (
             <span style={styles.identity} title={meta.identity}>{meta.identity}</span>
           ) : null}
-          {meta.fallback && (
-            <span
-              style={styles.fallback}
-              title={`Primary ${meta.fallback.from} failed — answered by fallback ${meta.fallback.to}`}
-            >
-              ⤷ {meta.fallback.to}
-            </span>
-          )}
+          {meta.fallback && <FallbackWarning fallback={meta.fallback} />}
         </div>
         <div style={styles.right}>
           {meta.stats.length > 0 && (
@@ -109,6 +102,59 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
       </div>
       {rule}
     </div>
+  )
+}
+
+/** Marks a turn that a fallback agent answered.
+ *
+ *  The identity to its left already names the agent/model that actually
+ *  replied — the header used to spell that same pair out again in a badge. All
+ *  this has to add is that the turn took a detour, and a way to ask why; the
+ *  reason itself is long and rare, so it belongs in a popup rather than in the
+ *  metadata row. */
+const FallbackWarning: React.FC<{ fallback: { from: string; to: string; reason?: string } }> = ({ fallback }) => {
+  const [open, setOpen] = React.useState(false)
+  const wrapRef = React.useRef<HTMLSpanElement>(null)
+
+  // Dismiss like a menu: a click anywhere else, or Escape. Without this the
+  // popup would survive scrolling away and opening another turn's popup.
+  React.useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <span ref={wrapRef} style={styles.fallbackWrap}>
+      <button
+        type="button"
+        style={styles.fallbackButton}
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        aria-label={`Answered by a fallback after ${fallback.from} failed`}
+        title="Answered by a fallback — click for details"
+      >
+        <UIIcon name="alert" size={13} strokeWidth={1.8} />
+      </button>
+      {open && (
+        <div role="dialog" style={styles.fallbackPopover}>
+          <div style={styles.fallbackTitle}>Fallback used</div>
+          <div style={styles.fallbackLine}>
+            <span style={styles.fallbackLabel}>{fallback.from}</span> failed, so{' '}
+            <span style={styles.fallbackLabel}>{fallback.to}</span> answered instead.
+          </div>
+          {fallback.reason && <div style={styles.fallbackReason}>{fallback.reason}</div>}
+        </div>
+      )}
+    </span>
   )
 }
 
@@ -134,10 +180,26 @@ const styles: Record<string, React.CSSProperties> = {
     flexShrink: 0, userSelect: 'none', transition: 'transform 0.15s ease',
   },
   stats: { fontVariantNumeric: 'tabular-nums', opacity: 0.55 },
-  fallback: {
-    color: C.warningFg, background: C.warningBg,
-    borderRadius: 6, padding: '1px 6px', fontSize: 10,
-    minWidth: 0, maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+  fallbackWrap: { position: 'relative', display: 'inline-flex', flexShrink: 0 },
+  fallbackButton: {
+    appearance: 'none', border: 0, background: 'transparent', color: C.warningFg,
+    padding: '2px', margin: '-2px', display: 'inline-flex', alignItems: 'center',
+    cursor: 'pointer', lineHeight: 0,
+  },
+  fallbackPopover: {
+    position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 40,
+    width: 300, maxWidth: '70vw',
+    background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 8,
+    padding: '8px 10px', boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+    fontSize: 11, color: C.fg2, whiteSpace: 'normal', textAlign: 'left', cursor: 'default',
+  },
+  fallbackTitle: { color: C.warningFg, fontSize: 10, letterSpacing: 0.3, textTransform: 'uppercase', marginBottom: 4 },
+  fallbackLine: { lineHeight: 1.45 },
+  fallbackLabel: { fontFamily: 'SF Mono, Menlo, monospace' },
+  fallbackReason: {
+    marginTop: 6, paddingTop: 6, borderTop: `1px solid ${C.border2}`,
+    fontFamily: 'SF Mono, Menlo, monospace', fontSize: 10, lineHeight: 1.45,
+    color: C.fg3, maxHeight: 160, overflowY: 'auto', overflowWrap: 'anywhere',
   },
   rule: { borderTop: `1px solid ${C.border2}`, marginBottom: 8 },
 }

--- a/codey-mac/src/components/turnHeaderModel.ts
+++ b/codey-mac/src/components/turnHeaderModel.ts
@@ -15,7 +15,7 @@ export interface TurnHeaderMeta {
   /** Right-side items, already ordered. Returned as items rather than a joined
    *  string so an absent field cannot leave an orphaned separator. */
   stats: string[]
-  fallback?: { from: string; to: string }
+  fallback?: { from: string; to: string; reason?: string }
   /** Nothing to show — the caller renders the rule without a metadata row. */
   isEmpty: boolean
 }

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -17,7 +17,7 @@ export type ChatStreamEvent =
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
   | { type: 'workspace_ready'; chatId: string }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string; reason?: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -65,10 +65,11 @@ export interface ChatMessage {
   model?: string;
   /**
    * Present when this turn was produced by a fallback agent after the primary
-   * failed. Rendered as a small badge in the message footer. `from`/`to` are
-   * display labels like "claude-code(opus)".
+   * failed. Rendered as a warning affordance next to the turn's identity.
+   * `from`/`to` are display labels like "claude-code(opus)"; `reason` is the
+   * primary's failure text, shown on demand.
    */
-  fallback?: { from: string; to: string };
+  fallback?: { from: string; to: string; reason?: string };
   /** Extended-thinking for a single-agent assistant message (collapsed in UI). */
   thinking?: string;
   /** Per-team-step extended-thinking, keyed by step number. */

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -262,7 +262,13 @@ export interface AgentResponse {
    * a badge. Kept as structured metadata — never injected into `output` — so
    * machine-consumed Aide calls (titles, summaries, JSON) stay clean.
    */
-  fallback?: { from: string; to: string };
+  fallback?: {
+    from: string;
+    to: string;
+    /** Why the primary failed, taken from its error/output. Truncated for
+     *  display; the full text stays in the gateway log. */
+    reason?: string;
+  };
   /** Structured question extracted from an AskUserQuestion tool call. */
   userQuestion?: {
     question: string;

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -29,7 +29,7 @@ export type ChatStreamEvent =
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
   | { type: 'workspace_ready'; chatId: string }
-  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string }; teamTurnId?: string }
+  | { type: 'done'; chatId: string; response: string; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string; reason?: string }; teamTurnId?: string }
   | { type: 'stopped'; chatId: string; userMessageId: string; text: string }
   | { type: 'error'; chatId: string; message: string }
   | { type: 'permission_denials'; chatId: string; denials: Array<{ toolName: string; toolInput?: Record<string, unknown> }> };

--- a/packages/gateway/src/gateway.fallback-reason.test.ts
+++ b/packages/gateway/src/gateway.fallback-reason.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentResponse } from '@codey/core';
+import { summarizeFailure } from './gateway';
+
+describe('fallback reason summary', () => {
+  it('prefers the adapter error over the raw output', () => {
+    const response: AgentResponse = { success: false, output: 'noisy stdout', error: 'model overloaded' };
+    expect(summarizeFailure(response)).toBe('model overloaded');
+  });
+
+  it('falls back to the output when there is no error field', () => {
+    expect(summarizeFailure({ success: false, output: '  exited with code 1  ' })).toBe('exited with code 1');
+  });
+
+  it('has nothing to report when the failure carried no text', () => {
+    expect(summarizeFailure({ success: false, output: '' })).toBeUndefined();
+  });
+
+  it('truncates a long failure so the popup stays readable', () => {
+    const reason = summarizeFailure({ success: false, output: 'x'.repeat(900) })!;
+    expect(reason.length).toBeLessThanOrEqual(401);
+    expect(reason.endsWith('…')).toBe(true);
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -64,6 +64,18 @@ export function isRetryableNetworkFailure(response: AgentResponse): boolean {
   return /(?:\btimeout\b|timed out|deadline exceeded|etimedout|econnreset|econnrefused|enotfound|eai_again|socket hang up|fetch failed|network (?:error|unavailable)|connection (?:closed|lost|reset|refused|error)|temporarily unavailable|service unavailable|gateway timeout|\b(?:408|429|500|502|503|504)\b)/i.test(text);
 }
 
+/** Longest primary-failure text carried into fallback metadata. The full text
+ *  stays in the gateway log; this only has to explain the fallback in a popup. */
+const FALLBACK_REASON_MAX = 400;
+
+/** One-line-ish explanation of why a run failed, for the fallback badge.
+ *  Prefers `error` (the adapter's own diagnosis) over raw `output`. */
+export function summarizeFailure(response: AgentResponse): string | undefined {
+  const raw = (response.error ?? response.output ?? '').trim();
+  if (!raw) return undefined;
+  return raw.length > FALLBACK_REASON_MAX ? `${raw.slice(0, FALLBACK_REASON_MAX).trimEnd()}…` : raw;
+}
+
 /** Explicit `/skill <name> <task>` invocation. Threaded per-turn: handleMessage
  *  attaches it to the queued turn's payload, runOneTurn reads it from the
  *  payload, and (for channel-linked chats) it rides into sendToChat on the
@@ -5309,7 +5321,7 @@ Example: /model gpt-4.1 write a Python script`;
         // banner to the output text. The Aide reuses this same fallback-routed
         // runner for housekeeping (title/summary/JSON), and a text banner would
         // leak into those — e.g. a chat title becoming "[Fallback: …]".
-        fallbackResponse.fallback = { from: fromLabel, to: label };
+        fallbackResponse.fallback = { from: fromLabel, to: label, reason: summarizeFailure(response) };
         return fallbackResponse;
       }
       this.logger.error(`Fallback ${label} also failed: ${fallbackResponse.error || fallbackResponse.output}`);


### PR DESCRIPTION
## Problem

When a turn was answered by a fallback agent, the turn header read:

`claude-code · claude-opus-5   ⤷ claude-code(claude-opus-5)`

The identity on the left is already the agent/model that *actually answered* (the gateway persists the fallback's identity, not the failed primary's), so the badge repeated it verbatim. And it never said the one thing worth knowing: why the fallback happened.

## Change

- **`TurnHeader.tsx`** — the text badge becomes a small amber alert icon next to the identity. Clicking it opens a popover: "Fallback used — `<primary>` failed, so `<fallback>` answered instead," plus the primary's failure text in a scrollable mono block. Dismisses on outside click or Escape.
- **`gateway.ts`** — fallback metadata carried only `{from, to}`, so there was no reason to show. Added `summarizeFailure()` (prefers the adapter's `error` over raw `output`, trims, truncates at 400 chars) and attaches it as `fallback.reason` when a fallback succeeds. The full text still goes to the gateway log.
- Types threaded through `AgentResponse.fallback.reason`, `ChatMessage.fallback.reason`, the `done` sink event in `chat-runner.ts` / `api.ts`, and `turnHeaderModel.ts`.

## Testing

`npm run build` (core + gateway), `tsc --noEmit` in codey-mac, `npm test` (773 tests passing), `npm run lint` clean. New `gateway.fallback-reason.test.ts` covers the reason summary.

The popover has no render test — this repo has no component-render harness for codey-mac (all model-level `.test.ts`), and adding one felt out of scope for this change. **It has not been seen in the running app yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)