### PR TITLE
Switch chats to existing branch worktrees

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2036,7 +2036,7 @@ app.whenReady().then(async () => {
 
   // ── Git status IPC ────────────────────────────────────────────────
   // Live git branch watching: one fs.watch per workingDir, ref-counted by renderer subscriptions.
-  const gitWatchers = new Map<string, { watcher: import('fs').FSWatcher; count: number; timer: NodeJS.Timeout | null }>()
+  const gitWatchers = new Map<string, { watchers: import('fs').FSWatcher[]; count: number; timer: NodeJS.Timeout | null }>()
 
   ipcMain.handle('git:status', async (_e, workingDir: string) =>
     wrap(async () => {
@@ -2365,6 +2365,7 @@ app.whenReady().then(async () => {
       if (!workingDir) return { ok: false }
       const fsMod = await import('fs')
       const pathMod = await import('path')
+      const { execFile } = await import('child_process')
       const gitDir = pathMod.join(workingDir, '.git')
       const existing = gitWatchers.get(workingDir)
       if (existing) { existing.count++; return { ok: true } }
@@ -2382,8 +2383,22 @@ app.whenReady().then(async () => {
               try { return fsMod.readFileSync(gitDir, 'utf8').match(/gitdir:\s*(.+)/)?.[1]?.trim() } catch { return undefined }
             })()
         if (!resolvedGitDir) return { ok: false }
-        const watcher = fsMod.watch(resolvedGitDir, { persistent: false }, () => emit())
-        gitWatchers.set(workingDir, { watcher, count: 1, timer: null })
+        // A linked worktree's private git dir sees its own HEAD/index changes,
+        // while branch refs and worktree add/remove operations live under the
+        // repository's common git dir. Watch both and keep polling in the
+        // renderer as a fallback for nested ref directories and dropped events.
+        const commonOut = await new Promise<string | undefined>(resolve => {
+          execFile('git', ['rev-parse', '--git-common-dir'], { cwd: workingDir, timeout: 1500 }, (err, stdout) => {
+            resolve(err ? undefined : stdout.trim())
+          })
+        })
+        const commonGitDir = commonOut ? pathMod.resolve(workingDir, commonOut) : undefined
+        const candidates = Array.from(new Set([
+          resolvedGitDir,
+          commonGitDir,
+        ].filter((candidate): candidate is string => Boolean(candidate && fsMod.existsSync(candidate)))))
+        const watchers = candidates.map(candidate => fsMod.watch(candidate, { persistent: false }, () => emit()))
+        gitWatchers.set(workingDir, { watchers, count: 1, timer: null })
         return { ok: true }
       } catch {
         return { ok: false }
@@ -2399,7 +2414,9 @@ app.whenReady().then(async () => {
       entry.count--
       if (entry.count <= 0) {
         if (entry.timer) clearTimeout(entry.timer)
-        try { entry.watcher.close() } catch { /* ignore */ }
+        for (const watcher of entry.watchers) {
+          try { watcher.close() } catch { /* ignore */ }
+        }
         gitWatchers.delete(workingDir)
       }
       return { ok: true }
@@ -3733,6 +3750,13 @@ app.whenReady().then(async () => {
     wrap(async () => {
       if (!inProcessGateway) throw new Error('Gateway not initialized')
       return inProcessGateway.setChatExecutionMode(id, mode)
+    })
+  )
+
+  ipcMain.handle('chats:bindWorktree', async (_e, id: string, worktreePath: string, expectedBranch?: string) =>
+    wrap(async () => {
+      if (!inProcessGateway) throw new Error('Gateway not initialized')
+      return inProcessGateway.bindChatToWorktree(id, worktreePath, expectedBranch)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -174,6 +174,7 @@ contextBridge.exposeInMainWorld('codey', {
     setWorkingDir: (id: string, dir: string | null) =>
       ipcRenderer.invoke('chats:setWorkingDir', id, dir),
     setExecutionMode: (id: string, mode: 'shared-checkout' | 'isolated-worktree') => ipcRenderer.invoke('chats:setExecutionMode', id, mode),
+    bindWorktree: (id: string, worktreePath: string, expectedBranch?: string) => ipcRenderer.invoke('chats:bindWorktree', id, worktreePath, expectedBranch),
     createWorktree: (id: string, name: string) => ipcRenderer.invoke('chats:createWorktree', id, name),
     setPullRequest: (id: string, pullRequest: any) =>
       ipcRenderer.invoke('chats:setPullRequest', id, pullRequest),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -302,6 +302,7 @@ declare global {
         setSoloAdvisor: (id: string, enabled: boolean) => Promise<IpcResult<Chat>>
         setWorkingDir: (id: string, dir: string | null) => Promise<IpcResult<Chat>>
         setExecutionMode: (id: string, mode: 'shared-checkout' | 'isolated-worktree') => Promise<IpcResult<Chat>>
+        bindWorktree: (id: string, worktreePath: string, expectedBranch?: string) => Promise<IpcResult<Chat>>
         createWorktree: (id: string, name: string) => Promise<IpcResult<Chat>>
         setPullRequest: (id: string, pullRequest: NonNullable<Chat['pullRequest']>) => Promise<IpcResult<Chat>>
       }

--- a/codey-mac/src/components/BranchPicker.tsx
+++ b/codey-mac/src/components/BranchPicker.tsx
@@ -1,23 +1,25 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { C } from '../theme'
 import { useGitBranches } from '../hooks/useGitBranches'
-import { BranchNote, compactWorktreePath, currentFirst, describePullResult, filterBranches } from './branchPickerModel'
+import { BranchNote, compactWorktreePath, currentFirst, describePullResult, filterBranches, worktreeForBranch } from './branchPickerModel'
 import { UIIcon } from './UIIcons'
 
 interface Props {
   workingDir: string | undefined
+  repositoryDir?: string
   chatWorktree?: { name?: string; path: string }
   executionMode?: 'shared-checkout' | 'isolated-worktree'
   onCreateWorktree: (name: string) => Promise<void>
   onExecutionModeChange: (mode: 'shared-checkout' | 'isolated-worktree') => Promise<void>
+  onSelectWorktree: (path: string, expectedBranch: string) => Promise<void>
 }
 
 type Mode = { kind: 'list' } | { kind: 'createBranch' } | { kind: 'createWorktree' } | { kind: 'dirty'; target: string }
 
 export const BranchPicker: React.FC<Props> = ({
-  workingDir, chatWorktree, executionMode = 'shared-checkout', onCreateWorktree, onExecutionModeChange,
+  workingDir, repositoryDir, chatWorktree, executionMode = 'shared-checkout', onCreateWorktree, onExecutionModeChange, onSelectWorktree,
 }) => {
-  const git = useGitBranches(workingDir)
+  const git = useGitBranches(workingDir, repositoryDir)
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [mode, setMode] = useState<Mode>({ kind: 'list' })
@@ -52,11 +54,15 @@ export const BranchPicker: React.FC<Props> = ({
   const isolated = executionMode === 'isolated-worktree'
   const worktreeLabel = chatWorktree?.name || chatWorktree?.path.split('/').filter(Boolean).pop() || 'Isolated worktree'
   const branchLabel = state?.branch === 'HEAD' ? '—' : (state?.branch ?? '—')
+  const activeWorktree = state?.branch ? worktreeForBranch(state.worktrees, state.branch) : undefined
+  const externalWorktree = !isolated && activeWorktree && !activeWorktree.isMain ? activeWorktree : undefined
   const pathLabel = compactWorktreePath(path)
   const lastSlash = pathLabel.lastIndexOf('/')
   const pathHead = lastSlash >= 0 ? pathLabel.slice(0, lastSlash + 1) : ''
   const pathTail = lastSlash >= 0 ? pathLabel.slice(lastSlash + 1) : pathLabel
-  const checkoutLabel = isolated ? worktreeLabel : 'Current checkout'
+  const checkoutLabel = isolated
+    ? worktreeLabel
+    : externalWorktree?.path.split('/').filter(Boolean).pop() || 'Current checkout'
   // One status line for the whole picker: an explicit note wins, otherwise the
   // last git failure surfaces in the same place instead of at the bottom.
   const banner: BranchNote | null = note ?? (git.error ? { tone: 'error', text: git.error } : null)
@@ -72,15 +78,44 @@ export const BranchPicker: React.FC<Props> = ({
   }
 
   const switchBranch = async (name: string) => {
+    const holder = worktreeForBranch(state?.worktrees ?? [], name)
+    if (holder) {
+      await switchToWorktree(holder.path, holder.branch)
+      return
+    }
     const result = await git.checkout(name)
     if (result.ok) { setOpen(false); return }
     if (result.reason === 'dirty') setMode({ kind: 'dirty', target: name })
   }
 
   const switchRemoteBranch = async (name: string) => {
+    const holder = worktreeForBranch(state?.worktrees ?? [], name, true)
+    if (holder) {
+      await switchToWorktree(holder.path, holder.branch)
+      return
+    }
+    const localName = name.replace(/^[^/]+\//, '')
+    if (state?.local.includes(localName)) {
+      await switchBranch(localName)
+      return
+    }
     const result = await git.checkout(name, { track: true })
     if (result.ok) { setOpen(false); return }
     if (result.reason === 'dirty') setMode({ kind: 'dirty', target: name.replace(/^[^/]+\//, '') })
+  }
+
+  const switchToWorktree = async (worktreePath: string, expectedBranch: string) => {
+    if (changingMode) return
+    setChangingMode(true); setNote(null); git.setError(null)
+    try {
+      await onSelectWorktree(worktreePath, expectedBranch)
+      setMode({ kind: 'list' })
+      setOpen(false)
+    } catch (error) {
+      setNote({ tone: 'error', text: error instanceof Error ? error.message : 'Could not switch worktree' })
+    } finally {
+      setChangingMode(false)
+    }
   }
 
   const syncWithRemote = async () => {
@@ -203,8 +238,8 @@ export const BranchPicker: React.FC<Props> = ({
           </div>
 
           <div style={styles.checkoutMode}>
-            <span style={isolated ? styles.worktreeBadge : styles.modeLabel} title={chatWorktree?.path}>
-              {isolated ? worktreeLabel : 'Current checkout'}
+            <span style={isolated || externalWorktree ? styles.worktreeBadge : styles.modeLabel} title={externalWorktree?.path || chatWorktree?.path}>
+              {isolated ? worktreeLabel : externalWorktree?.path.split('/').filter(Boolean).pop() || 'Current checkout'}
             </span>
             {!chatWorktree ? (
               <button style={styles.createWorktreeButton} onClick={() => { setNewWorktreeName(''); setMode({ kind: 'createWorktree' }) }}>
@@ -270,16 +305,18 @@ export const BranchPicker: React.FC<Props> = ({
               <div style={styles.scroll}>
                 {localBranches.length > 0 && <div style={styles.divider}>Local</div>}
                 {localBranches.map(branch => (
-                  <button key={branch} style={styles.item} disabled={branch === state?.branch} onClick={() => void switchBranch(branch)}>
+                  <button key={branch} style={styles.item} disabled={branch === state?.branch || changingMode} onClick={() => void switchBranch(branch)}>
                     <span style={styles.checkSlot}>{branch === state?.branch && <UIIcon name="check" size={13} />}</span>
                     <span style={styles.branchName}>{branch}</span>
+                    {worktreeForBranch(state?.worktrees ?? [], branch) && branch !== state?.branch && <span style={styles.branchMeta}>worktree</span>}
                   </button>
                 ))}
                 {remoteBranches.length > 0 && <div style={styles.divider}>Remote</div>}
                 {remoteBranches.map(branch => (
-                  <button key={branch} style={styles.item} onClick={() => void switchRemoteBranch(branch)}>
+                  <button key={branch} style={styles.item} disabled={changingMode} onClick={() => void switchRemoteBranch(branch)}>
                     <span style={styles.checkSlot} />
                     <span style={styles.branchName}>{branch}</span>
+                    {worktreeForBranch(state?.worktrees ?? [], branch, true) && <span style={styles.branchMeta}>worktree</span>}
                   </button>
                 ))}
                 {localBranches.length === 0 && remoteBranches.length === 0 && <div style={styles.empty}>No branches found</div>}
@@ -328,6 +365,7 @@ const styles: Record<string, React.CSSProperties> = {
   scroll: { maxHeight: 260, overflowY: 'auto', display: 'flex', flexDirection: 'column', borderBottom: `1px solid ${C.border}` },
   item: { width: '100%', textAlign: 'left', background: 'transparent', border: 'none', color: C.fg, fontSize: 12, padding: '6px 8px', borderRadius: 6, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 },
   branchName: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  branchMeta: { marginLeft: 'auto', color: C.green, fontSize: 9, flexShrink: 0 },
   checkSlot: { width: 14, flexShrink: 0, display: 'inline-flex', alignItems: 'center' },
   empty: { color: C.fg3, fontSize: 11, padding: '14px 8px', textAlign: 'center' },
   hint: { color: C.fg3, fontSize: 10, lineHeight: 1.4 },

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -824,7 +824,7 @@ export const ChatTab: React.FC<Props> = ({
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
 }) => {
-  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -1806,6 +1806,7 @@ export const ChatTab: React.FC<Props> = ({
         </div>
         <BranchPicker
           workingDir={workingDir}
+          repositoryDir={workspaceDir}
           chatWorktree={chat.chatWorkspace ? {
             name: chat.chatWorkspace.name,
             path: chat.chatWorkspace.worktreePath,
@@ -1813,6 +1814,7 @@ export const ChatTab: React.FC<Props> = ({
           executionMode={chat?.executionMode ?? 'shared-checkout'}
           onCreateWorktree={async name => { await createWorktree(chat.id, name) }}
           onExecutionModeChange={async mode => { await setExecutionMode(chat.id, mode) }}
+          onSelectWorktree={async (path, expectedBranch) => { await bindWorktree(chat.id, path, expectedBranch) }}
         />
         <div style={{ ...styles.openInWrap, marginLeft: 'auto' }}>
           <div style={styles.openInSplit}>

--- a/codey-mac/src/components/branchPickerModel.test.ts
+++ b/codey-mac/src/components/branchPickerModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { compactWorktreePath, currentFirst, describePullResult, filterBranches } from './branchPickerModel';
+import { compactWorktreePath, currentFirst, describePullResult, filterBranches, worktreeForBranch } from './branchPickerModel';
 
 describe('describePullResult', () => {
   it('reports how many commits arrived', () => {
@@ -35,6 +35,21 @@ describe('filterBranches', () => {
   });
   it('is case-insensitive substring match', () => {
     expect(filterBranches(['Main', 'feature/x', 'dev'], 'fe')).toEqual(['feature/x']);
+  });
+});
+
+describe('worktreeForBranch', () => {
+  const worktrees = [
+    { branch: 'main', path: '/repo', isMain: true },
+    { branch: 'feature/auth', path: '/worktrees/auth', isMain: false },
+  ];
+
+  it('finds the checkout holding a local branch', () => {
+    expect(worktreeForBranch(worktrees, 'feature/auth')?.path).toBe('/worktrees/auth');
+  });
+
+  it('maps a remote label to its local tracking branch', () => {
+    expect(worktreeForBranch(worktrees, 'origin/feature/auth', true)?.path).toBe('/worktrees/auth');
   });
 });
 

--- a/codey-mac/src/components/branchPickerModel.ts
+++ b/codey-mac/src/components/branchPickerModel.ts
@@ -3,12 +3,24 @@
 // renderer bundle. The path building below is plain string work (macOS paths).
 
 export interface BranchData { current: string; local: string[]; remote: string[] }
+export interface WorktreeData { branch: string; path: string; isMain: boolean }
 
 /** Case-insensitive substring filter; empty query returns the list unchanged. */
 export function filterBranches(list: string[], query: string): string[] {
   const q = query.trim().toLowerCase();
   if (!q) return list;
   return list.filter(b => b.toLowerCase().includes(q));
+}
+
+/** Return the checkout that already owns a local branch. Remote picker labels
+ * are mapped to their conventional local tracking name before lookup. */
+export function worktreeForBranch(
+  worktrees: WorktreeData[],
+  branch: string,
+  remote = false,
+): WorktreeData | undefined {
+  const localBranch = remote ? branch.replace(/^[^/]+\//, '') : branch;
+  return worktrees.find(worktree => worktree.branch === localBranch);
 }
 
 /** Compact a filesystem path without hiding its identifying final segments. */

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -476,6 +476,7 @@ interface ChatsContextValue {
   setEffort: (chatId: string, effort: string | null) => Promise<void>
   setWorkingDir: (chatId: string, dir: string | null) => Promise<void>
   setExecutionMode: (chatId: string, mode: 'shared-checkout' | 'isolated-worktree') => Promise<Chat>
+  bindWorktree: (chatId: string, worktreePath: string, expectedBranch?: string) => Promise<Chat>
   createWorktree: (chatId: string, name: string) => Promise<Chat>
   setPullRequest: (chatId: string, pullRequest: NonNullable<Chat['pullRequest']>) => Promise<void>
   setContextPanelOpen: (chatId: string, open: boolean | null) => Promise<void>
@@ -781,6 +782,11 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     },
     async setExecutionMode(chatId, mode) {
       const chat = await apiService.chats.setExecutionMode(chatId, mode)
+      dispatch({ type: 'upsert', chat })
+      return chat
+    },
+    async bindWorktree(chatId, worktreePath, expectedBranch) {
+      const chat = await apiService.chats.bindWorktree(chatId, worktreePath, expectedBranch)
       dispatch({ type: 'upsert', chat })
       return chat
     },

--- a/codey-mac/src/hooks/useGitBranches.ts
+++ b/codey-mac/src/hooks/useGitBranches.ts
@@ -5,6 +5,7 @@ export interface BranchState {
   dirty: number
   local: string[]
   remote: string[]
+  worktrees: { branch: string; path: string; isMain: boolean }[]
 }
 
 export interface PullOutcome {
@@ -15,30 +16,42 @@ export interface PullOutcome {
   reason?: 'dirty' | 'diverged' | 'no-upstream'
 }
 
-export function useGitBranches(workingDir: string | undefined) {
+export function useGitBranches(workingDir: string | undefined, repositoryDir?: string) {
   const [state, setState] = useState<BranchState | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
-    if (!workingDir) { setState(null); return }
+    const topologyDir = repositoryDir || workingDir
+    if (!topologyDir) { setState(null); return }
     try {
-      const [s, b] = await Promise.all([
-        window.codey.git.status(workingDir),
-        window.codey.git.branches(workingDir),
+      const [s, b, w] = await Promise.all([
+        workingDir ? window.codey.git.status(workingDir) : Promise.resolve({ ok: true as const, data: null }),
+        window.codey.git.branches(topologyDir),
+        window.codey.git.worktrees(topologyDir),
       ])
-      if (!s.ok || !s.data) { setState(null); return }
-      const br = b.ok ? b.data : { current: s.data.branch, local: [], remote: [] }
-      setState({ branch: s.data.branch, dirty: s.data.dirty, local: br.local, remote: br.remote })
+      const br = b.ok ? b.data : { current: '', local: [], remote: [] }
+      if (!s.ok && !b.ok && !w.ok) { setState(null); return }
+      setState({
+        // A missing selected checkout must not masquerade as the repository's
+        // main branch. Keep topology available so the user can recover by
+        // selecting another worktree, but render the active branch as unknown.
+        branch: s.ok && s.data ? s.data.branch : 'HEAD',
+        dirty: s.ok && s.data ? s.data.dirty : 0,
+        local: br.local,
+        remote: br.remote,
+        worktrees: w.ok ? w.data.list : [],
+      })
     } catch { setState(null) }
-  }, [workingDir])
+  }, [workingDir, repositoryDir])
 
   useEffect(() => { void refresh() }, [refresh])
 
   // Live updates: watch .git and re-pull on change. Polling fallback every 5s.
   useEffect(() => {
-    if (!workingDir) return
-    void window.codey.git.watch(workingDir)
-    const off = window.codey.git.onChanged(ev => { if (ev.workingDir === workingDir) void refresh() })
+    const watchedDirs = Array.from(new Set([workingDir, repositoryDir].filter((dir): dir is string => Boolean(dir))))
+    if (watchedDirs.length === 0) return
+    for (const dir of watchedDirs) void window.codey.git.watch(dir)
+    const off = window.codey.git.onChanged(ev => { if (watchedDirs.includes(ev.workingDir)) void refresh() })
     const onFocus = () => void refresh()
     window.addEventListener('focus', onFocus)
     const poll = setInterval(() => void refresh(), 5000)
@@ -46,9 +59,9 @@ export function useGitBranches(workingDir: string | undefined) {
       off()
       window.removeEventListener('focus', onFocus)
       clearInterval(poll)
-      void window.codey.git.unwatch(workingDir)
+      for (const dir of watchedDirs) void window.codey.git.unwatch(dir)
     }
-  }, [workingDir, refresh])
+  }, [workingDir, repositoryDir, refresh])
 
   const checkout = useCallback(async (name: string, opts?: { create?: boolean; track?: boolean }) => {
     if (!workingDir) return { ok: false, error: 'no dir' }

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -205,6 +205,8 @@ export const apiService = {
       unwrap(await window.codey.chats.setWorkingDir(id, dir)),
     setExecutionMode: async (id: string, mode: 'shared-checkout' | 'isolated-worktree'): Promise<Chat> =>
       unwrap(await window.codey.chats.setExecutionMode(id, mode)),
+    bindWorktree: async (id: string, worktreePath: string, expectedBranch?: string): Promise<Chat> =>
+      unwrap(await window.codey.chats.bindWorktree(id, worktreePath, expectedBranch)),
     createWorktree: async (id: string, name: string): Promise<Chat> =>
       unwrap(await window.codey.chats.createWorktree(id, name)),
     setPullRequest: async (id: string, pullRequest: NonNullable<Chat['pullRequest']>): Promise<Chat> =>

--- a/packages/gateway/src/chat-worktree.test.ts
+++ b/packages/gateway/src/chat-worktree.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { chatWorktreeParent, discoverChatWorktree, normalizeWorktreeName, provisionChatWorktree, removeCleanChatWorktree, workspaceHasUncommittedChanges } from './chat-worktree';
+import { chatWorktreeParent, discoverChatWorktree, normalizeWorktreeName, provisionChatWorktree, removeCleanChatWorktree, resolveRegisteredWorktreeBinding, workspaceHasUncommittedChanges } from './chat-worktree';
 import { ChatManager } from './chats';
 
 const roots: string[] = [];
@@ -147,6 +147,50 @@ describe('discoverChatWorktree', () => {
   });
 });
 
+describe('resolveRegisteredWorktreeBinding', () => {
+  it('maps a registered worktree root to the configured workspace subdirectory', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-bind-worktree-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const workspaceWorkingDir = path.join(repositoryRoot, 'packages', 'app');
+    fs.mkdirSync(workspaceWorkingDir, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+    git(repositoryRoot, ['config', 'user.email', 'test@codey.local']);
+    git(repositoryRoot, ['config', 'user.name', 'Codey Test']);
+    fs.writeFileSync(path.join(repositoryRoot, 'README.md'), 'hello\n');
+    fs.writeFileSync(path.join(workspaceWorkingDir, '.gitkeep'), '');
+    git(repositoryRoot, ['add', '.']);
+    git(repositoryRoot, ['commit', '-m', 'initial']);
+    const linked = path.join(root, 'linked');
+    git(repositoryRoot, ['worktree', 'add', '-b', 'feature-linked', linked, 'HEAD']);
+
+    const result = await resolveRegisteredWorktreeBinding({ workspaceWorkingDir, worktreePath: linked });
+
+    expect(result).toMatchObject({
+      repositoryRoot: fs.realpathSync(repositoryRoot),
+      worktreePath: fs.realpathSync(linked),
+      workingDir: path.join(fs.realpathSync(linked), 'packages', 'app'),
+      branch: 'feature-linked',
+      isMain: false,
+    });
+  });
+
+  it('rejects an arbitrary directory outside the registered worktree list', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-bind-invalid-'));
+    roots.push(root);
+    const repositoryRoot = path.join(root, 'repo');
+    const arbitrary = path.join(root, 'arbitrary');
+    fs.mkdirSync(repositoryRoot, { recursive: true });
+    fs.mkdirSync(arbitrary, { recursive: true });
+    git(repositoryRoot, ['init', '-b', 'main']);
+
+    await expect(resolveRegisteredWorktreeBinding({
+      workspaceWorkingDir: repositoryRoot,
+      worktreePath: arbitrary,
+    })).rejects.toThrow(/not a registered worktree/i);
+  });
+});
+
 describe('normalizeWorktreeName', () => {
   it('turns a user label into a safe semantic directory name', () => {
     expect(normalizeWorktreeName(' Feature / Auth ')).toBe('Feature-Auth');
@@ -266,6 +310,23 @@ describe('ChatManager isolated workspace binding', () => {
     const isolated = manager.setExecutionMode(chat.id, 'isolated-worktree');
     expect(isolated.workingDirOverride).toBe(workspace.workingDir);
     expect(isolated.sessionAnchors).toBeUndefined();
+  });
+
+  it('binds an external checkout without claiming it and clears the old session', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-external-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
+    const manager = new ChatManager(root);
+    const chat = manager.create({ workspaceName: 'demo', executionMode: 'shared-checkout' });
+    manager.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'old-session' });
+
+    const updated = manager.setExternalWorkingDir(chat.id, '/worktrees/user-managed');
+
+    expect(updated.executionMode).toBe('shared-checkout');
+    expect(updated.workingDirOverride).toBe('/worktrees/user-managed');
+    expect(updated.chatWorkspace).toBeUndefined();
+    expect(updated.sessionAnchor).toBeUndefined();
+    expect(updated.sessionAnchors).toBeUndefined();
   });
 
   it('persists pull request state without changing conversation activity time', () => {

--- a/packages/gateway/src/chat-worktree.ts
+++ b/packages/gateway/src/chat-worktree.ts
@@ -51,6 +51,14 @@ interface WorktreeRecord {
   branch?: string;
 }
 
+export interface RegisteredWorktreeBinding {
+  repositoryRoot: string;
+  worktreePath: string;
+  workingDir: string;
+  branch?: string;
+  isMain: boolean;
+}
+
 function parseWorktreeList(output: string): WorktreeRecord[] {
   const records: WorktreeRecord[] = [];
   let current: WorktreeRecord | undefined;
@@ -66,6 +74,49 @@ function parseWorktreeList(output: string): WorktreeRecord[] {
   }
   if (current) records.push(current);
   return records;
+}
+
+/** Resolve a path selected from `git worktree list` back to the workspace's
+ * configured subdirectory. Git is the source of truth: arbitrary directories,
+ * stale registrations, and worktrees from another repository are rejected. */
+export async function resolveRegisteredWorktreeBinding(input: {
+  workspaceWorkingDir: string;
+  worktreePath: string;
+}): Promise<RegisteredWorktreeBinding> {
+  const sourceDir = fs.realpathSync(path.resolve(input.workspaceWorkingDir));
+  let repositoryRoot: string;
+  try {
+    repositoryRoot = fs.realpathSync(path.resolve(await git(sourceDir, ['rev-parse', '--show-toplevel'])));
+  } catch {
+    throw new Error('Worktree switching requires a Git workspace');
+  }
+
+  const relativeWorkingDir = path.relative(repositoryRoot, sourceDir);
+  if (relativeWorkingDir.startsWith('..') || path.isAbsolute(relativeWorkingDir)) {
+    throw new Error(`Workspace directory is outside its Git repository: ${sourceDir}`);
+  }
+  if (!fs.existsSync(input.worktreePath)) {
+    throw new Error(`Worktree is no longer available: ${input.worktreePath}`);
+  }
+
+  const requested = fs.realpathSync(path.resolve(input.worktreePath));
+  const records = parseWorktreeList(await git(repositoryRoot, ['worktree', 'list', '--porcelain']));
+  const record = records.find(candidate =>
+    fs.existsSync(candidate.worktreePath) && fs.realpathSync(candidate.worktreePath) === requested
+  );
+  if (!record) throw new Error(`Directory is not a registered worktree of this workspace: ${requested}`);
+
+  const workingDir = path.join(requested, relativeWorkingDir);
+  if (!fs.existsSync(workingDir) || !fs.statSync(workingDir).isDirectory()) {
+    throw new Error(`Workspace subdirectory is missing from the selected worktree: ${relativeWorkingDir || '.'}`);
+  }
+  return {
+    repositoryRoot,
+    worktreePath: requested,
+    workingDir,
+    branch: record.branch,
+    isMain: requested === repositoryRoot,
+  };
 }
 
 /** Discover a worktree an agent created for this chat. The container is shared

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -358,8 +358,29 @@ export class ChatManager {
    *  Pass null/undefined/'' to clear and fall back to the workspace dir. */
   setWorkingDirOverride(chatId: string, dir: string | null): Chat {
     const chat = this.requireChat(chatId);
+    const previousWorkingDir = chat.workingDirOverride;
     if (dir === null || dir === undefined || dir === '') delete chat.workingDirOverride;
     else chat.workingDirOverride = dir;
+    if (previousWorkingDir !== chat.workingDirOverride) {
+      delete chat.sessionAnchor;
+      delete chat.sessionAnchors;
+    }
+    chat.updatedAt = Date.now();
+    this.persist(chat);
+    return chat;
+  }
+
+  /** Select a registered user-managed worktree without claiming ownership of
+   * it. A chat-owned worktree, if any, remains available to switch back to. */
+  setExternalWorkingDir(chatId: string, dir: string): Chat {
+    const chat = this.requireChat(chatId);
+    const previousWorkingDir = chat.workingDirOverride;
+    chat.executionMode = 'shared-checkout';
+    chat.workingDirOverride = dir;
+    if (previousWorkingDir !== dir) {
+      delete chat.sessionAnchor;
+      delete chat.sessionAnchors;
+    }
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -23,7 +23,7 @@ import { MemoryStore } from '@codey/core';
 import { WorkspaceManager, TeamConfigRaw, TeamConfig, DEFAULT_PARALLEL_SETTINGS } from '@codey/core';
 import { WorkerManager } from '@codey/core';
 import { ChatManager, CreateChatInput } from './chats';
-import { chatWorktreeParent, discoverChatWorktree, ensureWorktreeContainer, provisionChatWorktree, removeCleanChatWorktree, workspaceHasUncommittedChanges } from './chat-worktree';
+import { chatWorktreeParent, discoverChatWorktree, ensureWorktreeContainer, provisionChatWorktree, removeCleanChatWorktree, resolveRegisteredWorktreeBinding, workspaceHasUncommittedChanges } from './chat-worktree';
 import { resolveEffort } from './effort-resolve';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
@@ -822,6 +822,41 @@ export class Codey {
       return this.ensureChatWorkspace(chatId);
     }
     return this.chatManager.setExecutionMode(chatId, mode);
+  }
+
+  /** Bind a chat to a worktree already registered in the workspace repository.
+   * The checkout remains user-managed: binding never transfers ownership and
+   * deleting the chat must therefore never remove it. */
+  public async bindChatToWorktree(chatId: string, worktreePath: string, expectedBranch?: string): Promise<Chat> {
+    const chat = await this.getChat(chatId);
+    if (this.chatAborts.has(chatId)) throw new Error('Wait for the current agent turn to finish before switching worktrees');
+    const binding = await resolveRegisteredWorktreeBinding({
+      workspaceWorkingDir: this.resolveWorkspaceWorkingDir(chat.workspaceName),
+      worktreePath,
+    });
+    if (expectedBranch && binding.branch !== expectedBranch) {
+      throw new Error(`Git changed while switching: this worktree now has branch "${binding.branch ?? '(detached)'}" instead of "${expectedBranch}"`);
+    }
+
+    if (binding.isMain) return this.chatManager.setExecutionMode(chatId, 'shared-checkout');
+    if (chat.chatWorkspace
+      && fs.existsSync(chat.chatWorkspace.worktreePath)
+      && fs.realpathSync(chat.chatWorkspace.worktreePath) === binding.worktreePath) {
+      return this.setChatExecutionMode(chatId, 'isolated-worktree');
+    }
+
+    const occupied = this.chatManager.list(chat.workspaceName, { includeAutomation: true }).find(other => {
+      if (other.id === chat.id) return false;
+      if (other.executionMode === 'isolated-worktree' && other.chatWorkspace) {
+        return fs.existsSync(other.chatWorkspace.worktreePath)
+          && fs.realpathSync(other.chatWorkspace.worktreePath) === binding.worktreePath;
+      }
+      return Boolean(other.workingDirOverride)
+        && path.resolve(other.workingDirOverride!) === path.resolve(binding.workingDir);
+    });
+    if (occupied) throw new Error(`This worktree is already used by chat "${occupied.title}"`);
+
+    return this.chatManager.setExternalWorkingDir(chatId, binding.workingDir);
   }
 
   public setChatEventListener(fn: (ev: any) => void): void {
@@ -1810,7 +1845,7 @@ export class Codey {
     }
     if (chat.workingDirOverride) {
       if (fs.existsSync(chat.workingDirOverride)) return chat.workingDirOverride;
-      this.logger.warn(`Chat ${chat.id} workingDirOverride=${chat.workingDirOverride} is gone; falling back to workspace dir`);
+      throw new Error(`Selected checkout is no longer available: ${chat.workingDirOverride}. Choose another branch or worktree before continuing.`);
     }
     return this.resolveWorkspaceWorkingDir(chat.workspaceName);
   }


### PR DESCRIPTION
## Summary

- detect branches already checked out in registered Git worktrees and bind the chat to that checkout instead of running a conflicting `git checkout`
- keep external worktrees user-managed so deleting a chat cannot remove them
- refresh branch/worktree topology from Git and validate the expected branch again before persisting a binding
- clear stale agent session anchors when the effective checkout changes and block execution when a selected checkout disappears

## Why

Selecting a branch that was already attached to another worktree failed with `is already used by worktree at ...`. The branch picker knew only about refs and always attempted checkout in the current directory, while chat-owned worktree state also could not safely represent an arbitrary user-managed checkout.

## Impact

Users can select an existing local or remote-tracking branch from the normal branch list and Codey will move that chat into the worktree that already holds it. Direct Git changes are reflected through common-dir watching, focus refresh, polling, and a final gateway-side validation.

## Validation

- `npm test -w @codey/gateway -- --run src/chat-worktree.test.ts src/chats.workingDirOverride.test.ts` — 28 passed
- `npm test -- --run src/components/branchPickerModel.test.ts` — 13 passed
- `npm run build -w @codey/gateway`
- `npx tsc --noEmit`
- `npx vite build`
- `npm run lint`
- `git diff --check`

The full gateway suite completed all 301 assertions successfully, but Vitest reported environment-level `EMFILE: too many open files` watcher errors after the assertions.
