### PR TITLE
Fix agent spawn PATH; add Copy / Ask Agent to fallback popover

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -824,7 +824,7 @@ export const ChatTab: React.FC<Props> = ({
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
 }) => {
-  const { state, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, createChat, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
 
@@ -1613,6 +1613,30 @@ export const ChatTab: React.FC<Props> = ({
     await sendMessage(chat.id, text, atts, turnIdentity)
   }
 
+  // "Ask Agent" on a fallback warning: the error is already in hand, so the
+  // useful move is a fresh chat in the same workspace that starts from it,
+  // rather than making the user copy the text into a chat they open themselves.
+  // createChat selects the new chat, so this component unmounts mid-await; the
+  // send still lands because sendMessage lives in the provider, not here.
+  const askAgentAboutFallback = async (detail: string, fallback: { from: string; to: string }) => {
+    if (!chat) return
+    try {
+      const fresh = await createChat(chat.workspaceName)
+      const prompt = [
+        `The \`${fallback.from}\` agent failed to run, so Codey fell back to \`${fallback.to}\`.`,
+        'Diagnose why it failed and tell me how to fix it.',
+        '',
+        'Failure reported by the gateway:',
+        '```',
+        detail,
+        '```',
+      ].join('\n')
+      await sendMessage(fresh.id, prompt)
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to open a chat for this error')
+    }
+  }
+
   const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // The mention menu claims the arrow/Enter keys first — it is only open when
     // the caret is inside an "@" token, so it never shadows history navigation.
@@ -2155,6 +2179,7 @@ export const ChatTab: React.FC<Props> = ({
                         turnComplete={!streaming}
                         expanded={expanded}
                         onToggle={() => setThinkingToggles(p => ({ ...p, [msg.id]: !expanded }))}
+                        onAskAgentAboutFallback={(detail, fb) => { void askAgentAboutFallback(detail, fb) }}
                       />
                       {!!thinking && expanded && (
                         <div style={styles.thinkingBody}>{thinking}</div>

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -47,6 +47,10 @@ interface Props {
   expanded: boolean
   onToggle: () => void
   turnComplete: boolean
+  /** Hands the fallback failure text to a fresh chat. Omitted where no such
+   *  surface exists, which hides the "Ask Agent" action rather than offering a
+   *  button that does nothing. */
+  onAskAgentAboutFallback?: (detail: string, fallback: { from: string; to: string }) => void
 }
 
 /** Identifies an assistant turn and bounds it.
@@ -63,7 +67,7 @@ interface Props {
  *  gaining a line when the turn lands. The metadata row renders only when there
  *  is something to put in it, so a turn with no metadata is a bare hairline
  *  rather than a blank row. */
-export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete }) => {
+export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback }) => {
   const elapsedSec = useElapsedSeconds(!turnComplete, msg.timestamp)
   const meta = turnHeaderMeta(msg, { elapsedSec })
   const rule = <div style={styles.rule} />
@@ -92,7 +96,9 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
           ) : meta.identity ? (
             <span style={styles.identity} title={meta.identity}>{meta.identity}</span>
           ) : null}
-          {meta.fallback && <FallbackWarning fallback={meta.fallback} />}
+          {meta.fallback && (
+            <FallbackWarning fallback={meta.fallback} onAskAgent={onAskAgentAboutFallback} />
+          )}
         </div>
         <div style={styles.right}>
           {meta.stats.length > 0 && (
@@ -109,34 +115,87 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
  *
  *  The identity to its left already names the agent/model that actually
  *  replied, so the only thing worth surfacing here is *why* the first agent
- *  dropped out — the failure itself, verbatim. It rides in a hover tooltip: the
+ *  dropped out — the failure itself, verbatim. It rides in a hover popover: the
  *  reason is long and rare, and asking for a click to read an error the user
- *  never chose to trigger is a toll on the common case. */
-const FallbackWarning: React.FC<{ fallback: { from: string; to: string; reason?: string } }> = ({ fallback }) => {
+ *  never chose to trigger is a toll on the common case.
+ *
+ *  Reading the error is rarely the end of it, so the popover carries the two
+ *  things a user does next — take the text elsewhere, or hand it straight to an
+ *  agent. That makes the layer interactive, so it can no longer opt out of the
+ *  pointer: it stays open while the pointer is anywhere inside the wrapper
+ *  (popover included), and the 6px gap under the icon is padding *inside* the
+ *  layer rather than empty space that would close it mid-travel. */
+const FallbackWarning: React.FC<{
+  fallback: { from: string; to: string; reason?: string }
+  onAskAgent?: (detail: string, fallback: { from: string; to: string }) => void
+}> = ({ fallback, onAskAgent }) => {
   const [open, setOpen] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
   const detail = fallback.reason?.trim() || `${fallback.from} failed, so ${fallback.to} answered instead.`
+
+  // Reset so a re-open never shows a stale "Copied" from the last visit.
+  React.useEffect(() => {
+    if (open) return
+    setCopied(false)
+  }, [open])
+
+  React.useEffect(() => {
+    if (!copied) return
+    const timer = window.setTimeout(() => setCopied(false), 1400)
+    return () => window.clearTimeout(timer)
+  }, [copied])
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(detail)
+      setCopied(true)
+    } catch { /* clipboard denied — leave the label alone */ }
+  }
 
   return (
     <span
       style={styles.fallbackWrap}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
+      // Focus/blur mirror the hover pair so the popover and its actions are
+      // reachable without a pointer. Blur bubbles in React, so the containment
+      // check keeps it open while focus moves between the icon and the buttons.
+      onFocus={() => setOpen(true)}
+      onBlur={e => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false)
+      }}
+      onKeyDown={e => { if (e.key === 'Escape') setOpen(false) }}
     >
       <span
-        // Focusable so the tooltip is reachable without a pointer; it opens on
-        // focus and closes on blur, mirroring the hover pair.
         tabIndex={0}
         role="button"
         style={styles.fallbackButton}
         aria-label={`Answered by a fallback after ${fallback.from} failed: ${detail}`}
-        onFocus={() => setOpen(true)}
-        onBlur={() => setOpen(false)}
-        onKeyDown={e => { if (e.key === 'Escape') setOpen(false) }}
       >
         <UIIcon name="alert" size={13} strokeWidth={1.8} />
       </span>
       {open && (
-        <div role="tooltip" style={styles.fallbackPopover}>{detail}</div>
+        <div style={styles.fallbackLayer}>
+          <div role="tooltip" style={styles.fallbackPopover}>
+            <div style={styles.fallbackReason}>{detail}</div>
+            <div style={styles.fallbackActions}>
+              <button type="button" style={styles.fallbackAction} onClick={copy}>
+                <UIIcon name="copy" size={11} strokeWidth={1.8} />
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+              {onAskAgent && (
+                <button
+                  type="button"
+                  style={styles.fallbackAction}
+                  onClick={() => { setOpen(false); onAskAgent(detail, fallback) }}
+                >
+                  <UIIcon name="chat" size={11} strokeWidth={1.8} />
+                  Ask Agent
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
       )}
     </span>
   )
@@ -169,16 +228,33 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.warningFg, padding: '2px', margin: '-2px',
     display: 'inline-flex', alignItems: 'center', lineHeight: 0,
   },
+  // The layer starts flush against the icon and pays the 6px offset as its own
+  // padding, so travelling from the icon to the buttons never crosses a dead
+  // strip that would close the popover.
+  fallbackLayer: {
+    position: 'absolute', top: '100%', left: 0, zIndex: 40, paddingTop: 6,
+  },
   fallbackPopover: {
-    position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 40,
     width: 300, maxWidth: '70vw',
     background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 8,
     padding: '8px 10px', boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+    textAlign: 'left',
+  },
+  fallbackReason: {
     fontFamily: 'SF Mono, Menlo, monospace', fontSize: 10.5, lineHeight: 1.45,
-    color: C.fg2, whiteSpace: 'normal', textAlign: 'left',
+    color: C.fg2, whiteSpace: 'pre-wrap',
     maxHeight: 200, overflowY: 'auto', overflowWrap: 'anywhere',
-    // Informational only — never intercept the pointer on its way back out.
-    pointerEvents: 'none',
+    userSelect: 'text', cursor: 'text',
+  },
+  fallbackActions: {
+    display: 'flex', gap: 6, marginTop: 8,
+    borderTop: `1px solid ${C.border2}`, paddingTop: 8,
+  },
+  fallbackAction: {
+    appearance: 'none', background: 'transparent', color: C.fg2,
+    border: `1px solid ${C.border2}`, borderRadius: 6,
+    padding: '3px 7px', fontSize: 10.5, lineHeight: 1.2,
+    display: 'inline-flex', alignItems: 'center', gap: 4, cursor: 'pointer',
   },
   rule: { borderTop: `1px solid ${C.border2}`, marginBottom: 8 },
 }

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -158,18 +158,8 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       }
 
       // Ensure common bin paths are available (Electron apps may have minimal PATH)
-      const homedir = process.env.HOME || '';
-      const extraPaths = [
-        `${homedir}/.local/bin`,
-        '/usr/local/bin',
-        '/opt/homebrew/bin',
-      ].filter(Boolean);
-      const currentPath = env.PATH || '';
-      for (const p of extraPaths) {
-        if (!currentPath.includes(p)) {
-          env.PATH = `${p}:${env.PATH}`;
-        }
-      }
+      const { withCommonBinPaths } = require('./env') as typeof import('./env');
+      withCommonBinPaths(env);
 
       const claudeBin = process.env.CLAUDE_BIN || 'claude';
       this.debug(`[claude-code] Spawning: ${claudeBin} ${args.slice(0, -1).join(' ')} "<prompt>"`);

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -146,8 +146,8 @@ export class CodexAdapter extends BaseAgentAdapter {
       }
       args.push(request.prompt);
 
-      const { applyModelEnv } = require('./env') as typeof import('./env');
-      const env = applyModelEnv({ ...process.env }, request.model, 'openai');
+      const { applyModelEnv, withCommonBinPaths } = require('./env') as typeof import('./env');
+      const env = withCommonBinPaths(applyModelEnv({ ...process.env }, request.model, 'openai'));
       if (request.extraEnv) Object.assign(env, request.extraEnv);
 
       const childProcess: ChildProcess = spawn('codex', args, {

--- a/packages/core/src/agents/env.test.ts
+++ b/packages/core/src/agents/env.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { withCommonBinPaths } from './env';
+
+describe('withCommonBinPaths', () => {
+  it('prepends the usual CLI bin dirs to a minimal GUI PATH', () => {
+    const env = { HOME: '/Users/tester', PATH: '/usr/bin:/bin:/usr/sbin:/sbin' };
+    const segments = (withCommonBinPaths(env).PATH || '').split(':');
+    expect(segments).toContain('/Users/tester/.local/bin');
+    expect(segments).toContain('/opt/homebrew/bin');
+    expect(segments).toContain('/usr/local/bin');
+    expect(segments.slice(-4)).toEqual(['/usr/bin', '/bin', '/usr/sbin', '/sbin']);
+  });
+
+  it('does not duplicate a path that is already present', () => {
+    const env = { HOME: '/Users/tester', PATH: '/opt/homebrew/bin:/usr/bin' };
+    const segments = (withCommonBinPaths(env).PATH || '').split(':');
+    expect(segments.filter(p => p === '/opt/homebrew/bin')).toHaveLength(1);
+  });
+
+  it('does not treat a substring match as already present', () => {
+    const env = { HOME: '/Users/tester', PATH: '/opt/homebrew/bin/inner:/usr/bin' };
+    const segments = (withCommonBinPaths(env).PATH || '').split(':');
+    expect(segments).toContain('/opt/homebrew/bin');
+  });
+});

--- a/packages/core/src/agents/env.ts
+++ b/packages/core/src/agents/env.ts
@@ -1,6 +1,28 @@
 import { ModelConfig } from '../types';
 
 /**
+ * Prepend the bin directories CLIs are usually installed into. A GUI-launched
+ * Electron app inherits a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), so a
+ * bare spawn('codex') fails with ENOENT even though the binary is installed.
+ * Mutates and returns the given env map.
+ */
+export function withCommonBinPaths(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const homedir = env.HOME || process.env.HOME || '';
+  const extraPaths = [
+    homedir ? `${homedir}/.local/bin` : '',
+    '/usr/local/bin',
+    '/opt/homebrew/bin',
+  ].filter(Boolean);
+  for (const p of extraPaths) {
+    const segments = (env.PATH || '').split(':');
+    if (!segments.includes(p)) {
+      env.PATH = env.PATH ? `${p}:${env.PATH}` : p;
+    }
+  }
+  return env;
+}
+
+/**
  * Apply model credentials to a child-process env map using the style
  * declared on ModelConfig.apiType. Does not mutate the caller's env.
  *

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -94,9 +94,9 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
 
       this.debug(`[opencode] Spawning: opencode ${args.slice(0, -1).join(' ')} "<prompt>"`);
 
-      const { applyModelEnv } = require('./env') as typeof import('./env');
+      const { applyModelEnv, withCommonBinPaths } = require('./env') as typeof import('./env');
       // OpenCode is provider-agnostic; default to openai if apiType unset.
-      const env = applyModelEnv({ ...process.env }, request.model, 'openai');
+      const env = withCommonBinPaths(applyModelEnv({ ...process.env }, request.model, 'openai'));
       if (request.extraEnv) Object.assign(env, request.extraEnv);
       // Deliberately after extraEnv: plugin MCP config must win even over a
       // user-supplied OPENCODE_CONFIG, or enabled plugins would silently vanish.

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -200,10 +200,10 @@ export class PiAdapter extends BaseAgentAdapter {
       const args = piArgs(request);
       this.debug(`[pi] Spawning: pi ${args.slice(0, -1).join(' ')} "<prompt>"`);
 
-      const { applyModelEnv } = require('./env') as typeof import('./env');
+      const { applyModelEnv, withCommonBinPaths } = require('./env') as typeof import('./env');
       // pi is provider-agnostic and picks the provider from the model pattern;
       // anthropic is the closest thing to a house default.
-      const env = applyModelEnv({ ...process.env }, request.model, 'anthropic');
+      const env = withCommonBinPaths(applyModelEnv({ ...process.env }, request.model, 'anthropic'));
       if (request.extraEnv) Object.assign(env, request.extraEnv);
 
       const childProcess: ChildProcess = spawn('pi', args, {


### PR DESCRIPTION
## Why

Launching the Mac app from Finder gives Electron a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). Only `claude-code.ts` patched PATH before spawning, so `codex` / `opencode` / `pi` failed with ENOENT even though they were installed in `~/.local/bin` / `/opt/homebrew/bin`.

The fallback hover popover also only showed the error text — no way to copy it or act on it.

## What

**Agent PATH**
- New shared `withCommonBinPaths()` in `packages/core/src/agents/env.ts`, prepending `~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`
- Applied in `codex.ts`, `opencode.ts`, `pi.ts`; `claude-code.ts` now uses the helper instead of its inline copy
- Fixes the old `includes()` dedup bug, which treated `/opt/homebrew/bin/inner` as an already-present entry
- 3 new cases in `env.test.ts`

**Fallback popover** (`TurnHeader.tsx`, `ChatTab.tsx`)
- **Copy** button (shows "Copied" for 1.4s) and **Ask Agent** button (rendered only when the parent passes a callback)
- Layer is now interactive; the old `top: calc(100% + 6px)` gap triggered `mouseleave` on the way down, so it's `top: 100%` + `paddingTop: 6`
- `onBlur` moved to the wrapper with a `contains(relatedTarget)` check, so tabbing between the icon and the buttons doesn't dismiss it; Escape still closes
- Error text is `pre-wrap` + selectable
- `askAgentAboutFallback` opens a new chat in the same workspace with a diagnostic prompt carrying the from/to agents and the raw error

## Testing

- `npm test -w @codey/core` — 478 passed (36 files)
- `npm test` (codey-mac) — 477 passed
- `tsc --noEmit` clean

Not verified on a real machine: the hover-to-button feel and where the new chat lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)