### PR TITLE
Refine chat message spacing

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -371,6 +371,9 @@ const Shell: React.FC = () => {
   /* Same argument at the other end: the last block's bottom margin separates it
      from nothing, and it was the largest part of the gap before the timestamp. */
   .md-roomy > :last-child { margin-bottom: 0 !important; }
+  /* User bubbles do not need a trailing Markdown block gap: it otherwise
+     reads as extra bottom padding below short messages. */
+  .md-user > :last-child { margin-bottom: 0 !important; }
   body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; color: ${C.fg}; }
   * { box-sizing: border-box; }
   ::-webkit-scrollbar { width: 5px; height: 5px; }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2855,7 +2855,7 @@ const styles: Record<string, React.CSSProperties> = {
   // Horizontal padding is set per role at the render site — the timestamp has to
   // line up with the reply above it, which is inset differently (and from the
   // opposite edge) for user and assistant.
-  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  tsLabel: { color: C.fg3, fontSize: 10, marginTop: 6, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
   // modelBadge is still used by team worker messages; tsRight, tsMeta and
   // fallbackBadge moved into TurnHeader with the metadata they styled.
   modelBadge: {

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -229,7 +229,7 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
 
   return (
     <div
-      className={layout === 'roomy' ? 'md-roomy' : undefined}
+      className={onUser ? 'md-user' : layout === 'roomy' ? 'md-roomy' : undefined}
       style={{ minWidth: 0, maxWidth: '100%', fontSize: M.fontSize, lineHeight: M.lineHeight, overflowWrap: 'anywhere', wordBreak: 'break-word' }}
     >
       <ReactMarkdown


### PR DESCRIPTION
## Summary
- remove excess trailing Markdown spacing in user message bubbles
- increase the gap between a message bubble and its timestamp

## Validation
- `git diff --check`
- Mac app build (completed before this request)