### PR TITLE
Reserve the red notification badge for failures

### DIFF
--- a/codey-mac/src/components/NotificationCenter.tsx
+++ b/codey-mac/src/components/NotificationCenter.tsx
@@ -14,7 +14,7 @@ export const NotificationCenter: React.FC = () => {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
 
-  const { inProgress, completed, unreadCount } = deriveNotifications(
+  const { inProgress, completed, unreadCount, errorCount } = deriveNotifications(
     state.chats,
     state.inFlight as Record<string, InFlightLike>,
     state.unreadChats,
@@ -48,7 +48,14 @@ export const NotificationCenter: React.FC = () => {
         <span style={styles.bellGlyph}><UIIcon name="bell" size={16} /></span>
         {hasInProgress && <span style={styles.pulseDot} />}
         {unreadCount > 0 && (
-          <span style={styles.badge}>{unreadCount > 9 ? '9+' : unreadCount}</span>
+          // Red is reserved for failures; a plain finished turn gets the accent.
+          <span
+            style={errorCount > 0
+              ? { ...styles.badge, background: C.red, color: '#fff' }
+              : styles.badge}
+          >
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
         )}
       </button>
 
@@ -80,7 +87,9 @@ export const NotificationCenter: React.FC = () => {
               <div style={styles.sectionTitle}>Completed</div>
               {completed.map(item => (
                 <div key={item.chatId} style={styles.item} onClick={() => pick(item.chatId)}>
-                  <span style={styles.unreadDot} />
+                  {item.kind === 'error'
+                    ? <span style={styles.errorDot} title="Failed" aria-label="Failed" />
+                    : <span style={styles.unreadDot} title="Unread" aria-label="Unread" />}
                   <div style={styles.itemBody}>
                     <div style={styles.itemTitle}>{item.title}</div>
                     <div style={styles.itemMeta}>
@@ -142,8 +151,8 @@ const styles: Record<string, React.CSSProperties> = {
     height: 14,
     padding: '0 3px',
     borderRadius: 7,
-    background: '#E5484D',
-    color: '#fff',
+    background: C.accent,
+    color: C.onAccent,
     fontSize: 9,
     fontWeight: 700,
     lineHeight: '14px',
@@ -201,7 +210,15 @@ const styles: Record<string, React.CSSProperties> = {
     width: 6,
     height: 6,
     borderRadius: '50%',
-    background: '#E5484D',
+    background: C.accent,
+    flexShrink: 0,
+  },
+  errorDot: {
+    marginTop: 5,
+    width: 6,
+    height: 6,
+    borderRadius: '50%',
+    background: C.red,
     flexShrink: 0,
   },
   itemBody: { minWidth: 0, flex: 1 },

--- a/codey-mac/src/components/notificationLogic.test.ts
+++ b/codey-mac/src/components/notificationLogic.test.ts
@@ -32,7 +32,7 @@ describe('deriveNotifications', () => {
 
   it('lists unread-completed chats and counts them in unreadCount', () => {
     const chats = { a: chat('a'), b: chat('b') }
-    const r = deriveNotifications(chats, {}, { a: true, b: true })
+    const r = deriveNotifications(chats, {}, { a: 'done', b: 'done' })
     expect(r.completed).toHaveLength(2)
     expect(r.unreadCount).toBe(2)
     expect(r.inProgress).toHaveLength(0)
@@ -40,16 +40,30 @@ describe('deriveNotifications', () => {
 
   it('shows a chat that is both unread and in-flight only under inProgress', () => {
     const chats = { a: chat('a') }
-    const r = deriveNotifications(chats, { a: inflight() }, { a: true })
+    const r = deriveNotifications(chats, { a: inflight() }, { a: 'done' })
     expect(r.inProgress).toHaveLength(1)
     expect(r.completed).toHaveLength(0)
     expect(r.unreadCount).toBe(0)
   })
 
   it('skips ids that have no matching chat', () => {
-    const r = deriveNotifications({}, { ghost: inflight() }, { phantom: true })
+    const r = deriveNotifications({}, { ghost: inflight() }, { phantom: 'done' })
     expect(r.inProgress).toHaveLength(0)
     expect(r.completed).toHaveLength(0)
+  })
+
+  it('tags each completed item and counts only the failed ones as errors', () => {
+    const chats = { a: chat('a'), b: chat('b') }
+    const r = deriveNotifications(chats, {}, { a: 'done', b: 'error' })
+    expect(r.unreadCount).toBe(2)
+    expect(r.errorCount).toBe(1)
+    expect(r.completed.find(c => c.chatId === 'b')?.kind).toBe('error')
+    expect(r.completed.find(c => c.chatId === 'a')?.kind).toBe('done')
+  })
+
+  it('reports no errors when every unread chat merely finished', () => {
+    const r = deriveNotifications({ a: chat('a') }, {}, { a: 'done' })
+    expect(r.errorCount).toBe(0)
   })
 
   it('sorts each group by updatedAt descending', () => {
@@ -57,7 +71,7 @@ describe('deriveNotifications', () => {
       a: chat('a', { updatedAt: 1 }),
       b: chat('b', { updatedAt: 9 }),
     }
-    const r = deriveNotifications(chats, {}, { a: true, b: true })
+    const r = deriveNotifications(chats, {}, { a: 'done', b: 'done' })
     expect(r.completed.map(c => c.chatId)).toEqual(['b', 'a'])
   })
 })

--- a/codey-mac/src/components/notificationLogic.ts
+++ b/codey-mac/src/components/notificationLogic.ts
@@ -7,14 +7,18 @@ export interface InFlightLike {
   queuedPosition?: number
 }
 
+/** How a finished turn ended: normally, or with an error. */
+export type UnreadKind = 'done' | 'error'
+
 export interface NotificationItem {
   chatId: string
   title: string
   workspaceName: string
   updatedAt: number
+  kind: UnreadKind
 }
 
-export interface InProgressItem extends NotificationItem {
+export interface InProgressItem extends Omit<NotificationItem, 'kind'> {
   agentStatus: InFlightLike['agentStatus']
   queuedPosition?: number
 }
@@ -24,6 +28,8 @@ export interface NotificationData {
   completed: NotificationItem[]
   /** Badge count: number of unread-completed chats (in-progress is excluded). */
   unreadCount: number
+  /** How many of those ended in an error — drives the red (vs neutral) badge. */
+  errorCount: number
 }
 
 /**
@@ -33,6 +39,8 @@ export interface NotificationData {
  * - completed: unread-completed chats that are NOT currently back in flight
  *   (a re-sent chat shows only under inProgress).
  * - unreadCount: length of `completed`, used for the badge.
+ * - errorCount: how many of those failed; red is reserved for errors, a plain
+ *   finished turn gets the neutral accent instead.
  *
  * Each group is sorted by updatedAt descending. Ids with no matching chat
  * (e.g. a chat removed mid-flight) are skipped.
@@ -40,7 +48,7 @@ export interface NotificationData {
 export function deriveNotifications(
   chats: Record<string, Chat>,
   inFlight: Record<string, InFlightLike>,
-  unreadChats: Record<string, true>,
+  unreadChats: Record<string, UnreadKind>,
 ): NotificationData {
   const inProgress: InProgressItem[] = []
   for (const chatId of Object.keys(inFlight)) {
@@ -67,9 +75,15 @@ export function deriveNotifications(
       title: chat.title,
       workspaceName: chat.workspaceName,
       updatedAt: chat.updatedAt,
+      kind: unreadChats[chatId] === 'error' ? 'error' : 'done',
     })
   }
   completed.sort((a, b) => b.updatedAt - a.updatedAt)
 
-  return { inProgress, completed, unreadCount: completed.length }
+  return {
+    inProgress,
+    completed,
+    unreadCount: completed.length,
+    errorCount: completed.filter(c => c.kind === 'error').length,
+  }
 }

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -3,6 +3,7 @@ import { apiService } from '../services/api'
 import type { Chat, ChatSelection, ChatMessage, ChecklistItem, ToolCallEntry, FileAttachment, TaskBrief, TeamRunSummary } from '../types'
 import type { ChatStreamEvent } from '../../../packages/gateway/src/chat-runner'
 import { activityForTool, type AgentActivity } from '../components/agentActivity'
+import type { UnreadKind } from '../components/notificationLogic'
 
 interface InFlight {
   assistantMessageId: string
@@ -23,7 +24,9 @@ export interface State {
   // When a turn is interrupted, the prompt text is stashed here so ChatTab
   // can repopulate the input box for the matching chat.
   pendingRestores: Record<string, string>
-  unreadChats: Record<string, true>
+  // Unread chats, tagged with how the turn ended so the UI can reserve red for
+  // failures and use a neutral marker for a plain completion.
+  unreadChats: Record<string, UnreadKind>
   pendingPermissions: Record<string, string[]>
 }
 
@@ -404,7 +407,7 @@ export function reducer(state: State, action: Action): State {
       const inFlight = { ...state.inFlight }
       delete inFlight[action.chatId]
       const unreadChats = state.selectedChatId !== action.chatId
-        ? { ...state.unreadChats, [action.chatId]: true as const }
+        ? { ...state.unreadChats, [action.chatId]: 'done' as const }
         : state.unreadChats
       return {
         ...state,
@@ -450,7 +453,7 @@ export function reducer(state: State, action: Action): State {
       const inFlight = { ...state.inFlight }
       delete inFlight[action.chatId]
       const unreadChats = { ...state.unreadChats }
-      if (state.selectedChatId !== action.chatId) unreadChats[action.chatId] = true
+      if (state.selectedChatId !== action.chatId) unreadChats[action.chatId] = 'error'
       return {
         ...state,
         chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } },


### PR DESCRIPTION
## Problem

The notification bell showed the same red badge whether a chat merely finished or actually errored out. A completed run read as a problem.

## Change

`unreadChats` now records *how* the turn ended (`'done' | 'error'`) instead of a bare `true`, and the notification center branches on it:

- **Badge** — neutral accent for plain completions, red only when at least one unread chat failed.
- **Dropdown items** — accent dot labeled "Unread" for a completed chat, red dot labeled "Failed" for an errored one.

The accent dot matches what the chat sidebar already uses for unread chats, so the two surfaces now agree. Existing truthiness checks on `unreadChats` keep working since both values are truthy.

## Testing

- `npm test -w codey-mac` — 53 files / 501 tests pass, including two new cases covering the done/error split and `errorCount`.
- `tsc --noEmit` clean.
- Not eyeballed in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)