### PR TITLE
Scope voice activity to its originating chat

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -11,6 +11,7 @@ import { UIIcon } from './UIIcons'
 import { moveWorkspace, reconcileWorkspaceOrder } from './workspaceOrder'
 import { ChatHoverCard } from './ChatHoverCard'
 import { buildChatHoverCard } from './chatHoverCardView'
+import { useVoiceTurn } from '../hooks/useVoiceTurn'
 
 /** How long the pointer has to rest on a row before its info card appears —
  *  long enough that sweeping the list to reach the footer stays quiet. */
@@ -53,6 +54,7 @@ const DeliveryBadge: React.FC<{ pullRequest?: Chat['pullRequest'] }> = ({ pullRe
 
 export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomations, onOpenBrowser, onOpenTools, onSelectChat, automationsUnseenCount, activeChatId }) => {
   const { state, createChat, selectChat, renameChat, deleteChat, toggleWorkspace, refreshWorkspaces, refreshChats, linkChannel, unlinkChannel } = useChats()
+  const voice = useVoiceTurn()
   const [addingWorkspace, setAddingWorkspace] = useState(false)
   const [workspaces, setWorkspaces] = useState<string[]>([])
   const [lastWorkspace, setLastWorkspace] = useState<string>('')
@@ -568,7 +570,14 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                         style={styles.renameInput}
                       />
                     ) : (
-                      <span style={styles.title}>{chat.title?.trim() || 'New Chat'}</span>
+                      <span style={styles.titleGroup}>
+                        <span style={styles.title}>{chat.title?.trim() || 'New Chat'}</span>
+                        {voice.state === 'speaking' && voice.ownerChatId === chat.id && (
+                          <span style={styles.speakingIcon} title="Speaking" aria-label="Speaking">
+                            <UIIcon name="waveform" size={14} strokeWidth={2} />
+                          </span>
+                        )}
+                      </span>
                     )}
                     <RouteIcons routes={chat.routes} />
                     {!isRenaming && (
@@ -810,7 +819,12 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 12, color: C.fg2, margin: '2px 2px 2px 20px', border: '1px solid transparent',
   },
   activitySlot: { width: 8, flexShrink: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' },
-  title: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  titleGroup: { flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 5 },
+  title: { minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  speakingIcon: {
+    color: C.accent, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    flexShrink: 0, animation: 'codey-pulse-dot 1.2s infinite',
+  },
   renameInput: {
     flex: 1, background: C.surface3, border: `1px solid ${C.border2}`,
     borderRadius: 4, padding: '2px 6px', color: C.fg, fontSize: 12, outline: 'none',

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1761,7 +1761,9 @@ export const ChatTab: React.FC<Props> = ({
   }, [input]) // eslint-disable-line react-hooks/exhaustive-deps
 
 
-  const voiceBusy = voice.state === 'recording' || voice.state === 'transcribing'
+  const voiceActiveHere = voice.ownerChatId === chatId && voice.state !== 'idle'
+  const voiceActiveElsewhere = voice.state !== 'idle' && voice.ownerChatId !== chatId
+  const voiceBusy = voiceActiveHere && (voice.state === 'recording' || voice.state === 'transcribing')
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
   const canSend = isGatewayRunning && !coreFailed && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
@@ -2519,7 +2521,7 @@ export const ChatTab: React.FC<Props> = ({
               </button>
             </div>
             <div style={styles.voiceIndicatorSlot}>
-              {voice.state !== 'idle' && (
+              {voiceActiveHere && (
                 <div
                   style={styles.voiceIndicator}
                   role="status"
@@ -2541,16 +2543,17 @@ export const ChatTab: React.FC<Props> = ({
             <div style={styles.composerActions}>
               {/* Two ways to use your voice: dictate into the composer, or
                   hold a spoken conversation that reads the reply back. */}
-              {!(voice.state === 'recording' && voice.mode === 'converse') && <button
+              {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'converse') && <button
                 onClick={() => voice.toggle('dictate')}
-                disabled={!isGatewayRunning || !!coreFailed}
+                disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere}
                 style={{
                   ...styles.voiceButton,
                   background: voiceBusy && voice.mode === 'dictate' ? C.red : 'transparent',
-                  cursor: isGatewayRunning && !coreFailed ? 'pointer' : 'default',
+                  cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere ? 'pointer' : 'default',
                 }}
                 title={
-                  voiceBusy && voice.mode === 'dictate'
+                  voiceActiveElsewhere ? 'Voice is active in another chat'
+                  : voiceBusy && voice.mode === 'dictate'
                     ? (voice.state === 'transcribing' ? 'Transcribing…' : 'Stop — text goes to the box')
                     : 'Dictate into the message box'
                 }
@@ -2563,18 +2566,19 @@ export const ChatTab: React.FC<Props> = ({
                       color={voiceBusy && voice.mode === 'dictate' ? '#fff' : C.fg2}
                     />}
               </button>}
-              {!(voice.state === 'recording' && voice.mode === 'dictate') && <button
+              {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'dictate') && <button
                 onClick={() => voice.toggle('converse')}
-                disabled={!isGatewayRunning || !!coreFailed}
+                disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere}
                 style={{
                   ...styles.voiceButton,
-                  background: voice.state === 'recording' && voice.mode === 'converse' ? C.red
-                    : voice.state === 'speaking' ? C.accent
+                  background: voiceActiveHere && voice.state === 'recording' && voice.mode === 'converse' ? C.red
+                    : voiceActiveHere && voice.state === 'speaking' ? C.accent
                     : 'transparent',
-                  cursor: isGatewayRunning && !coreFailed ? 'pointer' : 'default',
+                  cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere ? 'pointer' : 'default',
                 }}
                 title={
-                  voice.state === 'speaking' ? 'Speaking — click to interrupt and talk'
+                  voiceActiveElsewhere ? 'Voice is active in another chat'
+                  : voiceActiveHere && voice.state === 'speaking' ? 'Speaking — click to interrupt and talk'
                   : voiceBusy && voice.mode === 'converse'
                     ? (voice.state === 'transcribing' ? 'Transcribing…' : 'Stop and send')
                     : 'Talk to this chat — the reply is read back'
@@ -2585,7 +2589,7 @@ export const ChatTab: React.FC<Props> = ({
                   : <UIIcon
                       name="waveform"
                       size={19}
-                      color={voice.state === 'speaking' ? C.onAccent : C.fg2}
+                      color={voiceActiveHere && voice.state === 'speaking' ? C.onAccent : C.fg2}
                     />}
               </button>}
               {isSending ? (

--- a/codey-mac/src/hooks/useVoiceTurn.tsx
+++ b/codey-mac/src/hooks/useVoiceTurn.tsx
@@ -22,6 +22,8 @@ type TranscriptHandler = (text: string, mode: ChatVoiceMode) => void
 type VoiceApi = ReturnType<typeof useChatVoice>
 
 export interface VoiceTurnValue extends VoiceApi {
+  /** Chat that owns the current capture / spoken reply. */
+  ownerChatId: string | null
   /**
    * Where finished transcripts go. The mounted chat registers its composer;
    * a transcript that arrives with nothing registered is dropped rather than
@@ -49,6 +51,8 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   // Which chat the running turn belongs to, and how far along it is. Held
   // together because a phase without its chat can't find the reply to read.
   const [turn, setTurn] = useState<{ chatId: string | null; phase: SpokenTurnPhase }>({ chatId: null, phase: 'off' })
+  const [ownerChatId, setOwnerChatId] = useState<string | null>(null)
+  const ownerChatIdRef = useRef<string | null>(null)
   const spokenTurnRef = useRef(false)
   const prevFlightRef = useRef<unknown>(null)
   const ackGenerationRef = useRef(0)
@@ -61,6 +65,8 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   const beginSpokenTurn = useCallback((chatId: string, spoken: string) => {
     spokenTurnRef.current = true
+    ownerChatIdRef.current = chatId
+    setOwnerChatId(chatId)
     setTurn({ chatId, phase: 'working' })
     // Acknowledge immediately. An agent turn routinely runs for 30s to
     // several minutes, and unbroken silence in a voice interface reads as
@@ -93,6 +99,8 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i]
       if (message.role === 'assistant' && message.content?.trim()) {
+        ownerChatIdRef.current = chatId
+        setOwnerChatId(chatId)
         setTurn({ chatId, phase: 'replying' })
         void voice.speak(message.content, chatId ?? undefined)
         return
@@ -108,7 +116,11 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   // same delay is the safety net for a speak that never starts at all.
   useEffect(() => {
     if (!spokenTurnSettled({ turn: turn.phase, voiceState: voice.state, agentInFlight: !!flight })) return
-    const timer = setTimeout(() => setTurn({ chatId: null, phase: 'off' }), 1500)
+    const timer = setTimeout(() => {
+      setTurn({ chatId: null, phase: 'off' })
+      ownerChatIdRef.current = null
+      setOwnerChatId(null)
+    }, 1500)
     return () => clearTimeout(timer)
   }, [turn.phase, voice.state, flight])
 
@@ -143,6 +155,8 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     // Clear the marker so the settle effect never reads back an abandoned reply.
     spokenTurnRef.current = false
     setTurn({ chatId: null, phase: 'off' })
+    ownerChatIdRef.current = null
+    setOwnerChatId(null)
   }, [voice.cancel])
   const abandonRef = useRef(abandonTurn)
   abandonRef.current = abandonTurn
@@ -151,8 +165,36 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   // callbacks change as recording state updates; using a ref avoids a brief
   // unsubscribe/re-subscribe gap exactly when the second hotkey press is meant
   // to stop and send the recording.
-  const toggleRef = useRef(voice.toggle)
-  toggleRef.current = voice.toggle
+  const toggle = useCallback<VoiceApi['toggle']>((mode, opts) => {
+    // Latch the destination at the moment capture starts. The selected chat
+    // can change while recording, transcribing, or playing the reply, but the
+    // voice UI must continue to belong to the chat where the turn began.
+    if (voice.state === 'idle' || voice.state === 'speaking') {
+      ownerChatIdRef.current = state.selectedChatId
+      setOwnerChatId(state.selectedChatId)
+    }
+    voice.toggle(mode, opts)
+  }, [voice.state, voice.toggle, state.selectedChatId])
+
+  const toggleRef = useRef(toggle)
+  toggleRef.current = toggle
+
+  // Fn shortcuts can be handled entirely by the native helper, bypassing the
+  // toggle above. Detect that idle → active edge and claim the selected chat
+  // here too. A capture-only owner is cleared when capture settles; a spoken
+  // turn keeps its owner until reply playback settles.
+  const previousVoiceStateRef = useRef(voice.state)
+  useEffect(() => {
+    const previous = previousVoiceStateRef.current
+    previousVoiceStateRef.current = voice.state
+    if (previous === 'idle' && voice.state !== 'idle' && ownerChatIdRef.current === null) {
+      ownerChatIdRef.current = state.selectedChatId
+      setOwnerChatId(state.selectedChatId)
+    } else if (previous !== 'idle' && voice.state === 'idle' && turn.phase === 'off') {
+      ownerChatIdRef.current = null
+      setOwnerChatId(null)
+    }
+  }, [voice.state, state.selectedChatId, turn.phase])
   useEffect(() => window.codey.voice.onConverseHotkey(() => {
     toggleRef.current('converse', { fromHotkey: true })
   }), [])
@@ -178,7 +220,7 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     return () => window.removeEventListener('keydown', onKey, true)
   }, [voice.state, turn.phase, abandonTurn])
 
-  const value: VoiceTurnValue = { ...voice, setTranscriptHandler, beginSpokenTurn }
+  const value: VoiceTurnValue = { ...voice, toggle, ownerChatId, setTranscriptHandler, beginSpokenTurn }
   return <VoiceTurnContext.Provider value={value}>{children}</VoiceTurnContext.Provider>
 }
 


### PR DESCRIPTION
## Summary

- bind recording, transcription, and playback UI to the chat where the voice turn started
- keep button and native Fn-hotkey launches aligned with the selected chat
- show an animated speaking indicator beside the owning chat in the sidebar
- disable voice controls in other chats while a voice turn is active

## Verification

- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run src/components/voiceCapsule.test.ts electron/voice-hud.test.ts` (19 tests)
- `npx vite build`