### PR TITLE
Base the merged-with-changes badge on commits, not a dirty tree

### DIFF
--- a/codey-mac/electron/delivery-status.test.ts
+++ b/codey-mac/electron/delivery-status.test.ts
@@ -19,20 +19,19 @@ describe('shouldRediscoverPr', () => {
 
 describe('deriveDeliveryState', () => {
   it('maps open and closed pull requests', () => {
-    expect(deriveDeliveryState({ providerState: 'OPEN', sameBranch: true, commitsAfterMerge: false, dirty: false })).toBe('pr-open')
-    expect(deriveDeliveryState({ providerState: 'CLOSED', sameBranch: true, commitsAfterMerge: false, dirty: false })).toBe('closed-unmerged')
+    expect(deriveDeliveryState({ providerState: 'OPEN', sameBranch: true, commitsAfterMerge: false })).toBe('pr-open')
+    expect(deriveDeliveryState({ providerState: 'CLOSED', sameBranch: true, commitsAfterMerge: false })).toBe('closed-unmerged')
   })
 
-  it('marks a clean merged checkout as merged', () => {
-    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: false, dirty: false })).toBe('merged')
+  it('marks a merged checkout with no new commits as merged', () => {
+    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: false })).toBe('merged')
   })
 
-  it('detects dirty files or commits added after merge', () => {
-    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: false, dirty: true })).toBe('merged-with-changes')
-    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: true, dirty: false })).toBe('merged-with-changes')
+  it('detects commits added after merge', () => {
+    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: true, commitsAfterMerge: true })).toBe('merged-with-changes')
   })
 
   it('does not treat a different checkout branch as post-merge work', () => {
-    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: false, commitsAfterMerge: true, dirty: true })).toBe('merged')
+    expect(deriveDeliveryState({ providerState: 'MERGED', sameBranch: false, commitsAfterMerge: true })).toBe('merged')
   })
 })

--- a/codey-mac/electron/delivery-status.ts
+++ b/codey-mac/electron/delivery-status.ts
@@ -14,15 +14,18 @@ export function shouldRediscoverPr(input: {
   return pinnedHeadBranch !== currentBranch
 }
 
+/** Post-merge work is commits, not a dirty tree. A dirty working tree belongs to
+ *  the checkout, not to one chat: chats sharing a checkout would all go yellow
+ *  because of each other's edits (or build output), and since the state is
+ *  persisted and the watcher skips terminal PRs, that flip never reverses. */
 export function deriveDeliveryState(input: {
   providerState: string
   sameBranch: boolean
   commitsAfterMerge: boolean
-  dirty: boolean
 }): DeliveryState {
   const state = input.providerState.toUpperCase()
   if (state === 'OPEN') return 'pr-open'
   if (state !== 'MERGED') return 'closed-unmerged'
   if (!input.sameBranch) return 'merged'
-  return input.dirty || input.commitsAfterMerge ? 'merged-with-changes' : 'merged'
+  return input.commitsAfterMerge ? 'merged-with-changes' : 'merged'
 }

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2322,10 +2322,9 @@ app.whenReady().then(async () => {
         JSON.parse(await run(gh, ['pr', 'view', ...(prUrl ? [prUrl] : []), '--json', PR_FIELDS], 15_000))
 
       let view = await view$(url)
-      const [localHead, currentBranch, porcelain] = await Promise.all([
+      const [localHead, currentBranch] = await Promise.all([
         run('git', ['rev-parse', 'HEAD'], 3_000),
         run('git', ['branch', '--show-current'], 3_000),
-        run('git', ['status', '--porcelain'], 3_000),
       ])
       // The caller's stored url can outlive the branch it belongs to: finish a
       // chat's PR, start the next branch in the same checkout, and the old
@@ -2349,7 +2348,6 @@ app.whenReady().then(async () => {
           providerState: view.state,
           sameBranch,
           commitsAfterMerge,
-          dirty: sameBranch && porcelain.length > 0,
         }),
         headBranch: view.headRefName,
         baseBranch: view.baseRefName,


### PR DESCRIPTION
## Problem

A merged chat's delivery badge in the chat list flipped from purple (`merged`) to yellow (`merged-with-changes`) as soon as you clicked the chat open — and never flipped back.

Why: `usePullRequestWatcher` deliberately skips terminal-state PRs, so the `merged` state recorded at merge time just sat there. Opening the chat mounts `ChatTab`, which unconditionally re-runs `git:prStatus`, and that recomputation counted a dirty working tree as post-merge work.

## Fix

`deriveDeliveryState` now derives `merged-with-changes` from `commitsAfterMerge` alone.

A dirty working tree is a property of the checkout, not of one chat:

- **Attribution** — chats sharing a checkout all went yellow because of each other's edits, or of untracked build output. `headRefOid..HEAD` only counts real commits on that branch.
- **Signal** — a dirty tree is near-permanently true in a shared checkout, so it carried no information.
- **Stability** — the state is persisted via `setPullRequest` and the watcher won't re-check it, so a transient dirty tree caused a one-way flip. Commits are monotonic.

Also drops the now-unused `git status --porcelain` call from `git:prStatus`, saving a subprocess per check.

Already-yellow chats correct themselves to purple the next time they're opened.

## Testing

- `npx tsc --noEmit -p tsconfig.electron.json` — clean
- `npx vitest run electron/delivery-status.test.ts` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)