### PR TITLE
Add an exact-match toggle to the file-change search

### DIFF
--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -616,6 +616,8 @@ const FileChangesView: React.FC<{
   // ── Search (⌘F) ───────────────────────────────────────────────────────────
   const [searchOpen, setSearchOpen] = React.useState(false)
   const [query, setQuery] = React.useState('')
+  // Off: case-insensitive. On: only exactly-cased hits count.
+  const [exactMatch, setExactMatch] = React.useState(false)
   // Match ids reported by each file's diff view, in that view's display order.
   const [matchesByPath, setMatchesByPath] = React.useState<Record<string, string[]>>({})
   const [activeIndex, setActiveIndex] = React.useState(0)
@@ -718,38 +720,49 @@ const FileChangesView: React.FC<{
     <div>
       {searchOpen && (
         <div style={fcStyles.searchBar}>
-          <input
-            ref={searchInputRef}
-            style={fcStyles.searchInput}
-            value={query}
-            placeholder="Search in file changes"
-            aria-label="Search in file changes"
-            onChange={e => { setQuery(e.target.value); setActiveIndex(0) }}
-            onKeyDown={onSearchKeyDown}
-          />
-          <span style={fcStyles.searchCount}>
-            {!query ? '' : allMatches.length === 0 ? 'No results' : `${activeMatchIndex + 1}/${allMatches.length}`}
-          </span>
-          <button
-            style={fcStyles.searchNavBtn}
-            onClick={() => goToMatch(-1)}
-            disabled={allMatches.length === 0}
-            title="Previous match (Shift+Enter)"
-            aria-label="Previous match"
-          >↑</button>
-          <button
-            style={fcStyles.searchNavBtn}
-            onClick={() => goToMatch(1)}
-            disabled={allMatches.length === 0}
-            title="Next match (Enter)"
-            aria-label="Next match"
-          >↓</button>
-          <button
-            style={fcStyles.searchNavBtn}
-            onClick={closeSearch}
-            title="Close search (Esc)"
-            aria-label="Close search"
-          >×</button>
+          <div style={fcStyles.searchFilters}>
+            <button
+              style={{ ...fcStyles.searchFilterBtn, ...(exactMatch ? fcStyles.searchFilterBtnActive : null) }}
+              onClick={() => { setExactMatch(v => !v); setActiveIndex(0) }}
+              aria-pressed={exactMatch}
+              aria-label="Exact match"
+              title={exactMatch ? 'Exact match on — case-sensitive' : 'Exact match off — case-insensitive'}
+            ><UIIcon name="match-case" size={13} /></button>
+          </div>
+          <div style={fcStyles.searchRow}>
+            <input
+              ref={searchInputRef}
+              style={fcStyles.searchInput}
+              value={query}
+              placeholder="Search in file changes"
+              aria-label="Search in file changes"
+              onChange={e => { setQuery(e.target.value); setActiveIndex(0) }}
+              onKeyDown={onSearchKeyDown}
+            />
+            <span style={fcStyles.searchCount}>
+              {!query ? '' : allMatches.length === 0 ? 'No results' : `${activeMatchIndex + 1}/${allMatches.length}`}
+            </span>
+            <button
+              style={fcStyles.searchNavBtn}
+              onClick={() => goToMatch(-1)}
+              disabled={allMatches.length === 0}
+              title="Previous match (Shift+Enter)"
+              aria-label="Previous match"
+            >↑</button>
+            <button
+              style={fcStyles.searchNavBtn}
+              onClick={() => goToMatch(1)}
+              disabled={allMatches.length === 0}
+              title="Next match (Enter)"
+              aria-label="Next match"
+            >↓</button>
+            <button
+              style={fcStyles.searchNavBtn}
+              onClick={closeSearch}
+              title="Close search (Esc)"
+              aria-label="Close search"
+            >×</button>
+          </div>
         </div>
       )}
       <div style={fcStyles.toolbar}>
@@ -822,7 +835,7 @@ const FileChangesView: React.FC<{
                       hunks={diffHunks}
                       fileContent={content}
                       filePath={path}
-                      search={{ query, idPrefix: path, activeId: activeMatchId, onMatches: handleMatches }}
+                      search={{ query, exact: exactMatch, idPrefix: path, activeId: activeMatchId, onMatches: handleMatches }}
                     />
                   )}
                   {patches.map(c => (
@@ -864,10 +877,19 @@ const fcStyles: Record<string, React.CSSProperties> = {
   // scrolls to the current hit. -14 cancels the panel body's top padding.
   searchBar: {
     position: 'sticky', top: -14, zIndex: 6,
-    display: 'flex', alignItems: 'center', gap: 4,
+    display: 'flex', flexDirection: 'column', gap: 6,
     margin: '-14px -14px 10px', padding: '10px 14px',
     background: C.surface2, borderBottom: `1px solid ${C.border}`,
   },
+  // Match filters sit above the field, so the field keeps its full width.
+  searchFilters: { display: 'flex', alignItems: 'center', gap: 4 },
+  searchFilterBtn: {
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    width: 22, height: 20, padding: 0, borderRadius: 5,
+    background: C.surface, border: `1px solid ${C.border2}`, color: C.fg3, cursor: 'pointer',
+  },
+  searchFilterBtnActive: { background: C.accentDim, borderColor: C.accent, color: C.fg },
+  searchRow: { display: 'flex', alignItems: 'center', gap: 4 },
   searchInput: {
     flex: 1, minWidth: 0,
     background: C.surface, border: `1px solid ${C.border2}`, borderRadius: 6,

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 export type IconName =
   | 'activity' | 'add' | 'alert' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
   | 'clock' | 'code' | 'copy' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
-  | 'waveform' | 'git-branch' | 'git-merge' | 'pull-request' | 'globe' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
+  | 'waveform' | 'git-branch' | 'git-merge' | 'pull-request' | 'globe' | 'match-case' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
   | 'telegram' | 'discord' | 'imessage'
 
 interface Props {
@@ -56,6 +56,8 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     plus: <path {...common} d="M12 5v14M5 12h14" />,
     refresh: <><path {...common} d="M20 11a8 8 0 00-14.7-4.4L3 9" /><path {...common} d="M3 4v5h5M4 13a8 8 0 0014.7 4.4L21 15" /><path {...common} d="M21 20v-5h-5" /></>,
     search: <><circle {...common} cx="11" cy="11" r="7" /><path {...common} d="M16.5 16.5L21 21" /></>,
+    // "Aa" — the familiar match-case glyph from editor search bars.
+    'match-case': <><path {...common} d="M2.5 17.5L7 6.5l4.5 11M4.3 14h5.4" /><circle {...common} cx="17" cy="14" r="3.4" /><path {...common} d="M20.4 10.2v7.3" /></>,
     server: <><rect {...common} x="3" y="4" width="18" height="6" rx="2" /><rect {...common} x="3" y="14" width="18" height="6" rx="2" /><path {...common} d="M7 7h.01M7 17h.01" /></>,
     settings: <><path {...common} d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.09a2 2 0 011 1.74v.5a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.38a2 2 0 00-.73-2.73l-.15-.09a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z" /><circle {...common} cx="12" cy="12" r="3" /></>,
     sparkle: <path {...common} d="M12 3l1.5 5.5L19 10l-5.5 1.5L12 17l-1.5-5.5L5 10l5.5-1.5L12 3zM19 16l.7 2.3L22 19l-2.3.7L19 22l-.7-2.3L16 19l2.3-.7L19 16z" />,

--- a/codey-mac/src/components/diffSearch.test.ts
+++ b/codey-mac/src/components/diffSearch.test.ts
@@ -17,6 +17,12 @@ describe('findMatchRanges', () => {
     ])
   })
 
+  it('keeps only the exactly-cased occurrences in exact mode', () => {
+    expect(findMatchRanges('Foo foo FOO', 'foo', true)).toEqual([{ start: 4, end: 7 }])
+    expect(findMatchRanges('Foo foo FOO', 'Foo', true)).toEqual([{ start: 0, end: 3 }])
+    expect(findMatchRanges('foo', 'FOO', true)).toEqual([])
+  })
+
   it('returns nothing for an empty query or empty text', () => {
     expect(findMatchRanges('hello', '')).toEqual([])
     expect(findMatchRanges('', 'hello')).toEqual([])

--- a/codey-mac/src/components/diffSearch.ts
+++ b/codey-mac/src/components/diffSearch.ts
@@ -3,13 +3,14 @@
 export type MatchRange = { start: number; end: number }
 
 /**
- * All case-insensitive, non-overlapping occurrences of `query` in `text`.
- * An empty query matches nothing.
+ * All non-overlapping occurrences of `query` in `text`. Case-insensitive by
+ * default; `exact` narrows it to a case-sensitive match. An empty query
+ * matches nothing.
  */
-export const findMatchRanges = (text: string, query: string): MatchRange[] => {
+export const findMatchRanges = (text: string, query: string, exact = false): MatchRange[] => {
   if (!query || !text) return []
-  const haystack = text.toLowerCase()
-  const needle = query.toLowerCase()
+  const haystack = exact ? text : text.toLowerCase()
+  const needle = exact ? query : query.toLowerCase()
   const out: MatchRange[] = []
   let from = 0
   for (;;) {

--- a/codey-mac/src/components/toolFormat.tsx
+++ b/codey-mac/src/components/toolFormat.tsx
@@ -200,6 +200,8 @@ const diffStyles: Record<string, React.CSSProperties> = {
 /** Search wiring for a diff view: what to look for, and which hit is current. */
 export type DiffSearch = {
   query: string
+  /** Exact (case-sensitive) matching. Off means case-insensitive. */
+  exact: boolean
   /** Namespace for this view's match ids (the file path, in the Files tab). */
   idPrefix: string
   /** Id of the match to render as the current hit, if it lives in this view. */
@@ -412,13 +414,14 @@ export const CombinedDiffView: React.FC<{
   // This view's match ids, in display order. Recomputed each render; the effect
   // below only notifies the owner when the list actually changed.
   const query = search?.query ?? ''
+  const exact = search?.exact ?? false
   const idPrefix = search?.idPrefix
   const rangesByKey = new Map<string, MatchRange[]>()
   const matchIds: string[] = []
   if (query && idPrefix != null) {
     for (const item of items) {
       if (item.kind !== 'line') continue
-      const ranges = findMatchRanges(item.text, query)
+      const ranges = findMatchRanges(item.text, query, exact)
       if (ranges.length === 0) continue
       rangesByKey.set(item.key, ranges)
       ranges.forEach((_, i) => matchIds.push(matchId(idPrefix, item.key, i)))


### PR DESCRIPTION
Follow-up to #266.

The Files-panel search bar now has a filter row above the input with one icon button — the familiar "Aa" match-case glyph — that switches matching between **case-insensitive** (default) and **exact / case-sensitive**. The button shows its state with the accent fill and an `aria-pressed`; toggling recounts hits and restarts navigation at the first one.

`findMatchRanges` takes an `exact` flag (defaulting to the old case-insensitive behavior), and `DiffSearch` carries it down to each diff view.

## Notes

- I read "exact match" as case-sensitive matching, the usual meaning of that toggle. If you meant whole-word matching instead, that's a small follow-up on the same flag.
- Placed above the field, per the request. Easy to move inline to the left of the input if that reads better.

## Verification

`tsc --noEmit` clean, 517 codey-mac tests pass (3 new exact-mode cases), `vite build` succeeds, `npm run lint` clean. Not eyeballed in the running Electron app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)