### PR TITLE
Use medium as the default thinking effort

### DIFF
--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -77,12 +77,11 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
               />
             </div>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, marginTop: 10 }}>
-              <span style={{ color: C.fg3, fontSize: 12 }}>Default effort</span>
+              <span style={{ color: C.fg3, fontSize: 12 }}>Effort</span>
               <select
-                value={agents[a]?.defaultEffort ?? ''}
+                value={agents[a]?.defaultEffort ?? 'medium'}
                 onChange={async e => {
-                  // Empty option clears the key rather than storing ''.
-                  const next = e.target.value || undefined
+                  const next = e.target.value
                   const updated: Record<string, AgentSlot> = {
                     ...agents,
                     [a]: { ...(agents[a] ?? {}), defaultEffort: next },
@@ -95,7 +94,6 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
                 style={{ ...selectStyle, width: 180 }}
                 title="Thinking effort used when neither the chat nor a worker overrides it"
               >
-                <option value="">Unset (CLI default)</option>
                 {EFFORT_OPTIONS.map(o => (
                   <option key={o} value={o}>{o}</option>
                 ))}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1134,7 +1134,7 @@ export const ChatTab: React.FC<Props> = ({
             for (const n of AGENT_NAMES) efforts[n] = slots[n]?.defaultEffort
             setAgentDefaultEfforts(efforts)
           }
-        } catch { /* leave the effort dropdown on its "CLI default" placeholder */ }
+        } catch { /* leave the effort dropdown on its medium baseline */ }
       } catch { /* surface via dropdown placeholders */ }
     })()
   }, [isGatewayRunning])
@@ -1334,7 +1334,7 @@ export const ChatTab: React.FC<Props> = ({
   const effectiveAgent: string = chat.agent ?? workerAgent ?? defaultAgent ?? 'claude-code'
   const effectiveModel: string | undefined = chat.model ?? workerModel ?? agentDefaultModels[effectiveAgent]
   const workerEffort = selectedWorker?.config.effort
-  const effectiveEffort: string | undefined = chat.effort ?? workerEffort ?? agentDefaultEfforts[effectiveAgent]
+  const effectiveEffort: string = chat.effort ?? workerEffort ?? agentDefaultEfforts[effectiveAgent] ?? 'medium'
   // What each run setting resolves to with no per-chat override — the value the
   // dropdown's first entry stands for, and the entry the list below it omits so
   // the same name never shows up twice.
@@ -1343,7 +1343,7 @@ export const ChatTab: React.FC<Props> = ({
   // configured default.
   const inheritedAgent: string | undefined = workerAgent ?? defaultAgent ?? undefined
   const inheritedModel: string | undefined = workerModel ?? agentDefaultModels[effectiveAgent]
-  const inheritedEffort: string | undefined = workerEffort ?? agentDefaultEfforts[effectiveAgent]
+  const inheritedEffort: string = workerEffort ?? agentDefaultEfforts[effectiveAgent] ?? 'medium'
   const effectiveAdvisorAgent = advisorConfig.agent ?? defaultAgent ?? 'claude-code'
   const effectiveAdvisorModel = advisorConfig.model ?? agentDefaultModels[effectiveAdvisorAgent] ?? 'Default model'
   // Seeds the streaming turn's header. A team run has no single identity — its
@@ -1970,9 +1970,9 @@ export const ChatTab: React.FC<Props> = ({
                         value={chat.effort ?? ''}
                         onChange={e => void onEffortChange(e.target.value)}
                         style={styles.runSettingSelect}
-                        title={`Effort: ${effectiveEffort ?? 'CLI default'}${chat.effort ? ' (override)' : workerEffort ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
+                        title={`Effort: ${effectiveEffort}${chat.effort ? ' (override)' : workerEffort ? ` (worker: ${selectedWorker!.name})` : ''}`}
                       >
-                        <option value="">{inheritedEffort ? `${inheritedEffort} (default)` : 'CLI default'}</option>
+                        <option value="">{inheritedEffort}</option>
                         {['low', 'medium', 'high', 'xhigh', 'max']
                           .filter(e => e !== inheritedEffort || e === chat.effort)
                           .map(e => <option key={e} value={e}>{e}</option>)}

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -98,9 +98,16 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [models, setModels] = useState<ModelEntry[]>([])
+  const [agentEfforts, setAgentEfforts] = useState<Record<string, string | undefined>>({})
 
   useEffect(() => {
     window.codey.models.list().then(r => { if (r.ok) setModels(r.data as ModelEntry[]) }).catch(() => {})
+    window.codey.agents.get().then(r => {
+      if (!r.ok) return
+      const efforts: Record<string, string | undefined> = {}
+      for (const [agent, slot] of Object.entries(r.data ?? {})) efforts[agent] = slot.defaultEffort
+      setAgentEfforts(efforts)
+    }).catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -111,6 +118,7 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
   }, [worker.name])
 
   const filteredModels = models.filter(m => modelFitsApiType(m.apiType, AGENT_API_TYPE[codingAgent]))
+  const inheritedEffort = agentEfforts[codingAgent] ?? 'medium'
 
   const save = async () => {
     setSaving(true); setError(null)
@@ -185,12 +193,10 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
 
       <label style={labelStyle}>Effort</label>
       <select value={effort} onChange={e => setEffort(e.target.value)} style={fieldStyle}>
-        <option value="">Unset (inherit)</option>
-        <option value="low">low</option>
-        <option value="medium">medium</option>
-        <option value="high">high</option>
-        <option value="xhigh">xhigh</option>
-        <option value="max">max</option>
+        <option value="">{inheritedEffort}</option>
+        {['low', 'medium', 'high', 'xhigh', 'max']
+          .filter(value => value !== inheritedEffort || value === effort)
+          .map(value => <option key={value} value={value}>{value}</option>)}
       </select>
 
       <label style={labelStyle}>Tools (comma-separated)</label>

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -95,6 +95,9 @@ export interface ApiKeyEntry {
  */
 export type ThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
+/** Balanced baseline used when no chat, worker, or agent effort is configured. */
+export const DEFAULT_THINKING_EFFORT: ThinkingEffort = 'medium';
+
 /** Runtime guard for values arriving from JSON config or chat commands. */
 export function isThinkingEffort(v: unknown): v is ThinkingEffort {
   return v === 'low' || v === 'medium' || v === 'high' || v === 'xhigh' || v === 'max';

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -436,9 +436,9 @@ export class Codey {
     return this.getModelConfig(agent, modelName);
   }
 
-  /** The per-agent configured default effort, if any. */
-  private getDefaultEffort(agent: CodingAgent): ThinkingEffort | undefined {
-    return this.config.agents?.[agent]?.defaultEffort;
+  /** The per-agent configured effort, falling back to the balanced baseline. */
+  private getDefaultEffort(agent: CodingAgent): ThinkingEffort {
+    return this.config.agents?.[agent]?.defaultEffort ?? DEFAULT_THINKING_EFFORT;
   }
 
   private getAdvisorAgentAndModel(): { agent: CodingAgent; model?: ModelConfig } {
@@ -2742,7 +2742,7 @@ export class Codey {
       await this.sendResponse({
         chatId,
         channel,
-        text: `Current effort for **${agent}**: ${current ?? 'unset (CLI default)'}\n\n` +
+        text: `Current effort for **${agent}**: ${current}\n\n` +
           `Set with: /effort <low|medium|high|xhigh|max>\nClear with: /effort clear`,
       });
       return;
@@ -2754,7 +2754,7 @@ export class Codey {
       await this.sendResponse({
         chatId,
         channel,
-        text: `✅ Cleared effort for **${agent}** — using the CLI default.`,
+        text: `✅ Reset effort for **${agent}** to **${DEFAULT_THINKING_EFFORT}**.`,
       });
       return;
     }


### PR DESCRIPTION
## What changed

- use `medium` as the balanced fallback when no chat, worker, or agent effort is configured
- show the resolved effort directly across Chat, Worker, and Agent settings
- remove `default`, `inherit`, and `CLI default` wording from effort controls and command responses
- make `/effort clear` reset the effective value to `medium`

## Why

The effort selector should start from a concrete, consistent value instead of exposing implementation-specific inheritance/default terminology. This gives users a predictable baseline while preserving explicit effort overrides.

## Impact

Existing explicit `low`, `medium`, `high`, `xhigh`, and `max` values continue to take precedence. Unconfigured effort now resolves to `medium` throughout the UI and gateway.

## Validation

- `npm run build:core`
- `npm run build:gateway`
- `npm test` (1,310 tests passed)
- `npx vite build` in `codey-mac`
- `git diff --check`
