### PR TITLE
Show the latest version in the file-change viewer

### DIFF
--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -4,6 +4,7 @@ import { C } from '../theme'
 import { parseTeamMessage } from './teamMessageFormat'
 import { CombinedDiffView, normalizeTool } from './toolFormat'
 import { stepMatchIndex } from './diffSearch'
+import { foldFileChanges } from './foldChanges'
 import { ToolCallList } from './ToolCallList'
 import { QuickQuestionView } from './QuickQuestionView'
 import { TaskHud } from './TaskHud'
@@ -789,6 +790,13 @@ const FileChangesView: React.FC<{
 
       {order.map(path => {
         const group = byFile.get(path)!
+        // Edit/Write/Notebook edits to this file collapse into a single
+        // continuous diff showing the file's latest state: repeated edits to one
+        // region fold into one net hunk rather than stacking every intermediate
+        // version. Raw patches keep their own block.
+        const content = fileText[path]
+        const folded = foldFileChanges(group.filter(c => c.tool !== 'Patch'))
+        const patches = group.filter(c => c.tool === 'Patch')
         // An active search expands every file, so no hit stays hidden.
         const isCollapsed = collapsed.has(path) && !query
         const toggle = () => setCollapsed(prev => {
@@ -805,7 +813,12 @@ const FileChangesView: React.FC<{
                 </span>
               </span>
               <span style={fcStyles.filePath}>{displayPath(path, workingDir)}</span>
-              <span style={fcStyles.fileCount}>{group.length} edit{group.length === 1 ? '' : 's'}</span>
+              <span
+                style={fcStyles.fileCount}
+                title={folded.length < group.length
+                  ? `${group.length} edits folded into ${folded.length} net change${folded.length === 1 ? '' : 's'}`
+                  : undefined}
+              >{group.length} edit{group.length === 1 ? '' : 's'}</span>
               {path && path.startsWith('/') && (
                 <button
                   style={fcStyles.iconBtn}
@@ -815,17 +828,11 @@ const FileChangesView: React.FC<{
               )}
             </div>
             {!isCollapsed && (() => {
-              // All Edit/Write/Notebook edits to this file collapse into a
-              // single continuous diff; raw patches keep their own block.
-              const content = fileText[path]
-              const diffHunks = group
-                .filter(c => c.tool !== 'Patch')
-                .map(c => ({
-                  oldText: c.oldText,
-                  newText: c.newText,
-                  startLine: locateStartLine(content, c.oldText, c.newText),
-                }))
-              const patches = group.filter(c => c.tool === 'Patch')
+              const diffHunks = folded.map(c => ({
+                oldText: c.oldText,
+                newText: c.newText,
+                startLine: locateStartLine(content, c.oldText, c.newText),
+              }))
               return (
                 <div style={fcStyles.changeBody}>
                   {diffHunks.length > 0 && (
@@ -835,6 +842,11 @@ const FileChangesView: React.FC<{
                       filePath={path}
                       search={{ query, exact: exactMatch, idPrefix: path, activeId: activeMatchId, onMatches: handleMatches }}
                     />
+                  )}
+                  {diffHunks.length === 0 && patches.length === 0 && (
+                    <div style={fcStyles.noNetChange}>
+                      Edits cancelled out — the file matches its original text.
+                    </div>
                   )}
                   {patches.map(c => (
                     <pre key={`${c.msgId}::${c.callId}`} style={fcStyles.patchPre}>
@@ -954,6 +966,7 @@ const fcStyles: Record<string, React.CSSProperties> = {
   },
   readHeader: { color: C.fg2, fontSize: 10, fontWeight: 650, textTransform: 'uppercase' as const, letterSpacing: 0.5, marginBottom: 6 },
   changeBody: { padding: 9, background: C.bg, display: 'flex', flexDirection: 'column', gap: 7 },
+  noNetChange: { color: C.fg3, fontSize: 11, fontStyle: 'italic' },
   changeItem: {},
   patchPre: {
     margin: 0, fontSize: 11.5, color: C.fg,

--- a/codey-mac/src/components/foldChanges.test.ts
+++ b/codey-mac/src/components/foldChanges.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { foldFileChanges, type FoldableChange } from './foldChanges'
+
+const edit = (oldText: string, newText: string): FoldableChange => ({ tool: 'Edit', oldText, newText })
+const write = (newText: string): FoldableChange => ({ tool: 'Write', oldText: '', newText })
+
+describe('foldFileChanges', () => {
+  it('keeps unrelated edits as separate regions', () => {
+    const out = foldFileChanges([edit('a', 'A'), edit('b', 'B')])
+    expect(out.map(c => [c.oldText, c.newText])).toEqual([['a', 'A'], ['b', 'B']])
+  })
+
+  it('folds a rewrite of the same region into one net hunk', () => {
+    const out = foldFileChanges([edit('one', 'two'), edit('two', 'three')])
+    expect(out).toHaveLength(1)
+    expect(out[0].oldText).toBe('one')
+    expect(out[0].newText).toBe('three')
+    expect(out[0].sources).toHaveLength(2)
+  })
+
+  it('folds a later edit that rewrites part of an earlier result', () => {
+    const out = foldFileChanges([
+      edit('const a = 1', 'const a = 1\nconst b = 2'),
+      edit('const b = 2', 'const b = 22'),
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].oldText).toBe('const a = 1')
+    expect(out[0].newText).toBe('const a = 1\nconst b = 22')
+  })
+
+  it('folds a later edit whose region swallows an earlier one', () => {
+    const out = foldFileChanges([
+      edit('b', 'B'),
+      edit('a\nB\nc', 'X'),
+    ])
+    expect(out).toHaveLength(1)
+    // The wider before-text keeps the original 'b', not the intermediate 'B'.
+    expect(out[0].oldText).toBe('a\nb\nc')
+    expect(out[0].newText).toBe('X')
+  })
+
+  it('drops a region that was edited back to its original text', () => {
+    expect(foldFileChanges([edit('x', 'y'), edit('y', 'x')])).toEqual([])
+  })
+
+  it('lets a Write supersede earlier edits while keeping their count', () => {
+    const out = foldFileChanges([edit('a', 'A'), edit('b', 'B'), write('whole file')])
+    expect(out).toHaveLength(1)
+    expect(out[0].oldText).toBe('')
+    expect(out[0].newText).toBe('whole file')
+    expect(out[0].sources).toHaveLength(3)
+  })
+
+  it('folds edits that follow a Write into the written content', () => {
+    const out = foldFileChanges([write('line1\nline2'), edit('line2', 'line2b')])
+    expect(out).toHaveLength(1)
+    expect(out[0].oldText).toBe('')
+    expect(out[0].newText).toBe('line1\nline2b')
+  })
+
+  it('handles an insert-style edit with empty old text', () => {
+    const out = foldFileChanges([edit('', 'added')])
+    expect(out.map(c => [c.oldText, c.newText])).toEqual([['', 'added']])
+  })
+
+  it('returns nothing for no changes', () => {
+    expect(foldFileChanges([])).toEqual([])
+  })
+})

--- a/codey-mac/src/components/foldChanges.ts
+++ b/codey-mac/src/components/foldChanges.ts
@@ -1,0 +1,79 @@
+/**
+ * Folds a file's edit history into the net result — what the file actually looks
+ * like now — instead of stacking every intermediate edit on top of each other.
+ *
+ * Agents routinely rewrite the same region several times in a run. Rendering
+ * each edit separately shows the same lines two or three times, including text
+ * that no longer exists anywhere in the file. Folding chains those edits so one
+ * region produces one hunk: the text before the first edit touched it, and the
+ * text after the last one did.
+ */
+
+export interface FoldableChange {
+  tool: 'Edit' | 'Write' | 'Patch' | 'Notebook'
+  oldText: string
+  newText: string
+}
+
+export interface FoldedChange<T> {
+  /** The region as it was before the first edit in this chain. */
+  oldText: string
+  /** The region as it is after the last edit in this chain. */
+  newText: string
+  /** Edits folded into this region, oldest first. */
+  sources: T[]
+}
+
+/** Literal (non-regex) replacement of the first occurrence of `find`. */
+const replaceOnce = (text: string, find: string, replacement: string): string => {
+  const idx = text.indexOf(find)
+  if (idx < 0) return text
+  return text.slice(0, idx) + replacement + text.slice(idx + find.length)
+}
+
+/**
+ * Fold `changes` (chronological, single file, no Patch entries) into the net set
+ * of regions. A later edit joins an earlier chain when either text contains the
+ * other: rewriting part of what the chain produced, or replacing a wider region
+ * that swallows it. A Write supersedes everything before it, since it rewrites
+ * the whole file. Regions that end up unchanged are dropped.
+ */
+export const foldFileChanges = <T extends FoldableChange>(changes: T[]): Array<FoldedChange<T>> => {
+  let chains: Array<FoldedChange<T>> = []
+
+  for (const change of changes) {
+    if (change.tool === 'Write') {
+      // Prior edits are moot — keep them only as sources so edit counts stay honest.
+      const superseded = chains.flatMap(c => c.sources)
+      chains = [{ oldText: change.oldText, newText: change.newText, sources: [...superseded, change] }]
+      continue
+    }
+
+    // Prefer the most recent chain: repeated edits to one spot land there, and
+    // short strings are less likely to collide with an older, unrelated region.
+    let folded = false
+    for (let i = chains.length - 1; i >= 0; i--) {
+      const chain = chains[i]
+      if (change.oldText && chain.newText.includes(change.oldText)) {
+        chain.newText = replaceOnce(chain.newText, change.oldText, change.newText)
+        chain.sources.push(change)
+        folded = true
+        break
+      }
+      if (chain.newText && change.oldText.includes(chain.newText)) {
+        // This edit spans a wider region; the chain's own "before" text belongs
+        // inside the wider before-text.
+        chain.oldText = replaceOnce(change.oldText, chain.newText, chain.oldText)
+        chain.newText = change.newText
+        chain.sources.push(change)
+        folded = true
+        break
+      }
+    }
+    if (!folded) {
+      chains.push({ oldText: change.oldText, newText: change.newText, sources: [change] })
+    }
+  }
+
+  return chains.filter(c => c.oldText !== c.newText)
+}


### PR DESCRIPTION
## Problem

The file-change panel (`FileChangesView`) rendered every `Edit`/`Write`/`NotebookEdit` to a file as its own hunk. When an agent rewrote the same region twice — routine in a long run — the region showed up two or three times, including intermediate text that no longer exists anywhere in the file. The **All** scope in particular read as a pile of every edit ever made rather than what the file actually looks like now.

## Change

New `codey-mac/src/components/foldChanges.ts` — `foldFileChanges()` folds a file's edit history chronologically into its net result:

- A later edit whose `oldText` appears in a chain's `newText` folds into that chain (the chain's `newText` is updated in place).
- A later edit whose region swallows a chain's result widens the chain: the chain's original `oldText` is restored inside the wider before-text, `newText` takes the latest.
- A `Write` rewrites the whole file, so it supersedes everything before it — prior edits survive only as `sources` so counts stay honest.
- Regions edited back to their original text drop out entirely.
- Fold candidates are searched most-recent-first, so short strings don't collide with an older unrelated region.

`ChatContextPanel.tsx` now builds `diffHunks` from the folded result, so both **All** and **This turn** show one hunk per region at its latest state. The `N edits` badge keeps the real edit count and gains a hover note (`5 edits folded into 2 net changes`) when folding collapsed it; a file whose edits fully cancel out shows a note instead of an empty body.

## Testing

- `foldChanges.test.ts` — 9 cases covering unrelated regions, same-region rewrites, partial rewrites, swallowing edits, reverts, Write-supersedes, edits after a Write, empty-`oldText` inserts.
- Full `codey-mac` suite: 501 tests pass. `electron/browser-controller.test.ts` fails to import `electron` in this worktree (deps not installed there) — pre-existing, unrelated.
- `tsc --noEmit` clean under `src/components/`; the reported `Electron` namespace errors are the same missing-dependency issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)