### PR TITLE
Adjust chat latest-message scrolling

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { ChatMessage, ChatSelection, FileAttachment, TeamRunSummary } from '../types'
 import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
@@ -926,8 +926,9 @@ export const ChatTab: React.FC<Props> = ({
   const dragDepthRef = useRef(0)
   const composerResizeRef = useRef<{ y: number; h: number } | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesRef = useRef<HTMLDivElement>(null)
   const taRef = useRef<HTMLTextAreaElement>(null)
+  const [showLatestMessage, setShowLatestMessage] = useState(false)
 
   useEffect(() => {
     if (composerHeight != null) localStorage.setItem('codey.composerHeight', String(composerHeight))
@@ -1141,13 +1142,35 @@ export const ChatTab: React.FC<Props> = ({
   const lastMsg = chat?.messages?.[chat.messages.length - 1]
   // A fresh prompt clears any pending multi-select picks from a prior question.
   useEffect(() => { setMultiChoice([]) }, [chatId, lastMsg?.id])
-  const prevChatIdRef = useRef<string | null>(null)
+
+  const updateLatestMessageVisibility = useCallback(() => {
+    const messages = messagesRef.current
+    if (!messages) return
+    const distanceFromBottom = messages.scrollHeight - messages.scrollTop - messages.clientHeight
+    setShowLatestMessage(distanceFromBottom > 2)
+  }, [])
+
+  // ChatTab is remounted for every chat selection. This is the one place where
+  // the transcript deliberately jumps: entering a chat always opens at its
+  // latest message. Updates inside that chat only refresh the button below;
+  // they never take control of the user's scroll position.
+  useLayoutEffect(() => {
+    const messages = messagesRef.current
+    if (!messages) return
+    messages.scrollTop = messages.scrollHeight
+    setShowLatestMessage(false)
+  }, [chatId])
+
   useEffect(() => {
-    if (!followLatest) return
-    const switched = prevChatIdRef.current !== chatId
-    prevChatIdRef.current = chatId
-    messagesEndRef.current?.scrollIntoView(switched ? { block: 'end' } : { behavior: 'smooth' })
-  }, [chatId, chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length, chat?.contextPanelOpen, followLatest])
+    const frame = requestAnimationFrame(updateLatestMessageVisibility)
+    return () => cancelAnimationFrame(frame)
+  }, [chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length, chat?.contextPanelOpen, updateLatestMessageVisibility])
+
+  const scrollToLatestMessage = useCallback(() => {
+    const messages = messagesRef.current
+    if (!messages) return
+    messages.scrollTo({ top: messages.scrollHeight, behavior: 'smooth' })
+  }, [])
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && flight) stopChat(chatId)
@@ -2090,7 +2113,9 @@ export const ChatTab: React.FC<Props> = ({
       </div>
 
       <div
+        ref={messagesRef}
         style={{ ...styles.messages, position: 'relative' }}
+        onScroll={updateLatestMessageVisibility}
       >
         {groupMessages(chat.messages).map((item, idx) => {
           if (item.kind === 'team') {
@@ -2374,7 +2399,6 @@ export const ChatTab: React.FC<Props> = ({
             <ShimmerStatus label={statusLabel} />
           </div>
         )}
-        <div ref={messagesEndRef} />
       </div>
 
       {orphaned && (
@@ -2383,6 +2407,16 @@ export const ChatTab: React.FC<Props> = ({
         </div>
       )}
       <div style={{ ...styles.inputContainer, position: 'relative' as const }}>
+        {showLatestMessage && (
+          <button
+            type="button"
+            style={styles.latestMessageButton}
+            onClick={scrollToLatestMessage}
+            aria-label="Jump to latest message"
+          >
+            Lastest Message ↓
+          </button>
+        )}
         {showSlashMenu && (
           <div ref={slashMenuRef} style={styles.slashMenu}>
             {filteredSlash.map((cmd, i) => (
@@ -2868,6 +2902,14 @@ const styles: Record<string, React.CSSProperties> = {
     maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
   inputContainer: { padding: '12px max(16px, 4%) 16px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 6, flexShrink: 0, background: C.surface },
+  latestMessageButton: {
+    position: 'absolute' as const, top: 0, left: '50%', zIndex: 20,
+    transform: 'translate(-50%, -50%)',
+    padding: '6px 12px', borderRadius: 999,
+    border: `1px solid ${C.border2}`, background: C.surface2, color: C.fg,
+    boxShadow: '0 5px 16px rgba(0,0,0,0.24)',
+    fontSize: 11, fontWeight: 650, cursor: 'pointer', whiteSpace: 'nowrap' as const,
+  },
   composer: {
     background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 14,
     display: 'flex', flexDirection: 'column', overflow: 'hidden',


### PR DESCRIPTION
## Summary

- jump to the latest message only when switching chats
- preserve the user's scroll position while the active chat updates
- show a floating “Lastest Message” button when newer content is below the viewport

## Verification

- Vite production build passes
- 492 existing tests pass
- 1 unrelated suite cannot load because the local `electron` package is missing