### PR TITLE
Let the chat agent picker offer every agent

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -689,6 +689,24 @@ function resolveDataRoot(): string {
   return root
 }
 
+// Probing spawns an interactive login shell per agent, so it's too slow to run
+// on every dropdown render. Cache the result for the app's lifetime; the
+// Agents tab's "Recheck" button forces a fresh probe.
+let installedAgentsCache: Record<string, { installed: boolean; path?: string }> | null = null
+let installedAgentsInFlight: Promise<Record<string, { installed: boolean; path?: string }>> | null = null
+
+function getInstalledAgents(force = false): Promise<Record<string, { installed: boolean; path?: string }>> {
+  if (force) { installedAgentsCache = null; installedAgentsInFlight = null }
+  if (installedAgentsCache) return Promise.resolve(installedAgentsCache)
+  // Coalesce concurrent callers (chat picker + Agents tab on startup) onto one probe.
+  if (!installedAgentsInFlight) {
+    installedAgentsInFlight = detectInstalledAgents()
+      .then(r => { installedAgentsCache = r; return r })
+      .finally(() => { installedAgentsInFlight = null })
+  }
+  return installedAgentsInFlight
+}
+
 /**
  * One-shot probe for whether each agent's CLI binary is on PATH. Used by the
  * Settings tab to render an "Installed" chip vs. an "Install" link. We shell
@@ -3340,8 +3358,8 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('agents:checkInstalled', async () =>
-    wrap(async () => detectInstalledAgents())
+  ipcMain.handle('agents:checkInstalled', async (_e, force?: boolean) =>
+    wrap(async () => getInstalledAgents(force === true))
   )
 
   // ── Skills IPC ────────────────────────────────────────────────────

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -144,7 +144,7 @@ contextBridge.exposeInMainWorld('codey', {
   agents: {
     get: () => ipcRenderer.invoke('agents:get'),
     set: (updates: any) => ipcRenderer.invoke('agents:set', updates),
-    checkInstalled: () => ipcRenderer.invoke('agents:checkInstalled'),
+    checkInstalled: (force?: boolean) => ipcRenderer.invoke('agents:checkInstalled', force),
     slashCommands: (agent: string) => ipcRenderer.invoke('agents:slashCommands', agent),
   },
   chats: {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -279,7 +279,7 @@ declare global {
       agents: {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>>>
         set: (updates: Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>) => Promise<IpcResult<void>>
-        checkInstalled: () => Promise<IpcResult<Record<string, { installed: boolean; path?: string }>>>
+        checkInstalled: (force?: boolean) => Promise<IpcResult<Record<string, { installed: boolean; path?: string }>>>
         slashCommands: (agent: string) => Promise<IpcResult<Array<{ name: string; description: string; source: 'agent' | 'gateway' | 'skill' }>>>
       }
       chats: {

--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -6,8 +6,8 @@ import {
   AGENT_NAMES,
   AgentInstallChip,
   EnvEditor,
-  InstallStatus,
 } from './SettingsTab'
+import { refreshInstalledAgents, useInstalledAgents } from './installedAgents'
 
 interface Props {
   isGatewayRunning: boolean
@@ -19,18 +19,8 @@ const EFFORT_OPTIONS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
 
 export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
   const [agents, setAgents] = useState<Record<string, AgentSlot>>({})
-  const [installStatus, setInstallStatus] = useState<Record<string, InstallStatus>>({})
-  const [checkingInstalls, setCheckingInstalls] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  const refreshInstallStatus = useCallback(async () => {
-    setCheckingInstalls(true)
-    try {
-      const r = await window.codey.agents.checkInstalled()
-      if (r.ok) setInstallStatus(r.data)
-    } catch { /* leave previous status as-is */ }
-    finally { setCheckingInstalls(false) }
-  }, [])
+  const { status: installStatus, checking: checkingInstalls } = useInstalledAgents(isGatewayRunning)
 
   const reload = useCallback(async () => {
     setError(null)
@@ -43,8 +33,7 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
   useEffect(() => {
     if (!isGatewayRunning) return
     void reload()
-    void refreshInstallStatus()
-  }, [isGatewayRunning, reload, refreshInstallStatus])
+  }, [isGatewayRunning, reload])
 
   if (!isGatewayRunning) {
     return (
@@ -59,12 +48,12 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
       {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
 
       <Section first title="Installed agents" description="CLI availability and environment variables for each coding agent." right={
-        <button onClick={refreshInstallStatus} style={pillButton('ghost')} disabled={checkingInstalls} title="Re-check whether each agent's CLI is installed">
+        <button onClick={() => void refreshInstalledAgents(true)} style={pillButton('ghost')} disabled={checkingInstalls} title="Re-check whether each agent's CLI is installed">
           {checkingInstalls ? 'Checking…' : '↻ Recheck'}
         </button>
       } />
       {AGENT_NAMES.map(a => {
-        const status = installStatus[a]
+        const status = installStatus?.[a]
         const env = agents[a]?.env ?? {}
         return (
           <div key={a} style={{ ...fieldStyle, display: 'block' }}>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -29,6 +29,7 @@ import { statusLine } from './checklistView'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
 import { AGENT_API_TYPE, AGENT_NAMES, ApiType, modelFitsApiType } from './modelApiType'
+import { useInstalledAgents } from './installedAgents'
 import { applyMention, filterEntries, findActiveMention, splitMentionSegments } from './mentions'
 import { ChatFindBar } from './ChatFindBar'
 import type { ActiveMention, MentionFile } from './mentions'
@@ -851,8 +852,11 @@ export const ChatTab: React.FC<Props> = ({
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   const [teamNames, setTeamNames] = useState<string[]>([])
   const [models, setModels] = useState<ModelEntry[]>([])
-  const [enabledAgents, setEnabledAgents] = useState<string[]>([...AGENT_NAMES])
   const [defaultAgent, setDefaultAgent] = useState<string | null>(null)
+  // Shared install-probe store — an agent whose CLI isn't on PATH is greyed
+  // out (and unselectable) in the agent picker. `status` is null until the
+  // probe answers, so nothing is disabled until then.
+  const { status: installStatus } = useInstalledAgents(isGatewayRunning)
   const [agentDefaultModels, setAgentDefaultModels] = useState<Record<string, string | undefined>>({})
   // Per-agent default effort lives in the agents config, not in fallback.order
   // (which carries no effort), so it needs its own lookup.
@@ -1112,13 +1116,12 @@ export const ChatTab: React.FC<Props> = ({
           window.codey.fallback.get(),
         ])
         if (m.ok) setModels(m.data as ModelEntry[])
-        // Everything we need (which agents are usable, which is the default,
-        // and per-agent default model) is encoded in fallback.order. Membership
-        // == enabled; order[0] is the gateway default; first entry per agent
-        // that pins a model is that agent's default model.
+        // fallback.order carries the defaults: order[0] is the gateway default
+        // agent; the first entry per agent that pins a model is that agent's
+        // default model. Membership does not gate the agent picker — every
+        // agent is selectable as a per-chat override.
         if (fb.ok) {
           const order = fb.data.order ?? []
-          setEnabledAgents(AGENT_NAMES.filter(n => order.some(e => e.agent === n)))
           setDefaultAgent(order[0]?.agent ?? null)
           const defaults: Record<string, string | undefined> = {}
           for (const n of AGENT_NAMES) {
@@ -1972,8 +1975,8 @@ export const ChatTab: React.FC<Props> = ({
                         title={`Agent: ${effectiveAgent}${chat.agent ? ' (override)' : workerAgent ? ` (worker: ${selectedWorker!.name})` : ' (default)'}`}
                       >
                         <option value="">{inheritedAgent ? `${inheritedAgent} (default)` : 'default agent'}</option>
-                        {AGENT_NAMES.filter(n => (enabledAgents.includes(n) || n === chat.agent) && (n !== inheritedAgent || n === chat.agent)).map(n => (
-                          <option key={n} value={n}>{n}</option>
+                        {AGENT_NAMES.filter(n => n !== inheritedAgent || n === chat.agent).map(n => (
+                          <option key={n} value={n} disabled={installStatus?.[n]?.installed === false && n !== chat.agent}>{n}</option>
                         ))}
                       </select>
                     </label>

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -417,7 +417,9 @@ const FallbackList: React.FC<{
 
 // ── Main Settings tab ────────────────────────────────────────────────
 
-export type InstallStatus = { installed: boolean; path?: string }
+// Re-exported so existing importers keep working; the type (and the store
+// behind it) lives in installedAgents.ts.
+export type { InstallStatus } from './installedAgents'
 
 export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) => {
   const [models, setModels] = useState<ModelEntry[]>([])
@@ -508,9 +510,8 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
       .sort((a, b) => a.model.localeCompare(b.model))
   })()
 
-  // Enablement is derived from priority-list membership now; the chat header
-  // and fallback "+ Add step" both use this to decide what an agent looks
-  // like in dropdown menus.
+  // Agents already in the fallback chain — used to seed "+ Add step" with a
+  // sensible default. It does not gate what the chat agent picker offers.
   const enabledAgents = AGENT_NAMES.filter(a =>
     fallback.order.some(e => e.agent === a)
   )
@@ -615,7 +616,7 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
         .sort((a, b) => a.apiType.localeCompare(b.apiType) || a.model.localeCompare(b.model))
         .map(m => <ModelRow key={m.model} entry={m} apis={apis} onSave={saveModel} onDelete={deleteModel}/>)}
 
-      <Section title="Agent priority" description="Default agent order and fallback behavior." right={
+      <Section title="Agent fallback" description="Default agent order and fallback behavior." right={
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ color: C.fg3, fontSize: 11 }}>{fallback.enabled ? 'Enabled' : 'Disabled'}</span>
           <Toggle on={fallback.enabled} onChange={enabled => updateFallback({ ...fallback, enabled })}/>

--- a/codey-mac/src/components/installedAgents.ts
+++ b/codey-mac/src/components/installedAgents.ts
@@ -1,0 +1,53 @@
+import { useEffect, useSyncExternalStore } from 'react'
+
+export type InstallStatus = { installed: boolean; path?: string }
+export type InstalledAgentsState = {
+  /** null until the first probe answers — callers must not treat it as "nothing installed". */
+  status: Record<string, InstallStatus> | null
+  checking: boolean
+}
+
+// The single renderer-side mirror of the main process's CLI probe (which is
+// itself cached there for the app's lifetime). Every consumer reads this store
+// instead of keeping its own copy, so a "Recheck" in the Agents tab also
+// updates the chat agent picker, and mounting N chats fires one probe, not N.
+let snapshot: InstalledAgentsState = { status: null, checking: false }
+const listeners = new Set<() => void>()
+let inFlight: Promise<void> | null = null
+
+const publish = (next: InstalledAgentsState) => {
+  snapshot = next
+  for (const l of listeners) l()
+}
+
+const subscribe = (l: () => void) => {
+  listeners.add(l)
+  return () => { listeners.delete(l) }
+}
+
+/**
+ * Fetch install status into the shared store. Without `force` this is a no-op
+ * once a probe has landed; with `force` it re-probes even if cached.
+ */
+export function refreshInstalledAgents(force = false): Promise<void> {
+  // A forced request that lands mid-probe waits its turn rather than riding
+  // along on a call that may have been served from the cache.
+  if (inFlight) return force ? inFlight.then(() => refreshInstalledAgents(true)) : inFlight
+  if (!force && snapshot.status) return Promise.resolve()
+  publish({ ...snapshot, checking: true })
+  inFlight = (async () => {
+    try {
+      const r = await window.codey.agents.checkInstalled(force)
+      if (r.ok) { publish({ status: r.data, checking: false }); return }
+    } catch { /* keep whatever snapshot we already had */ }
+    publish({ ...snapshot, checking: false })
+  })().finally(() => { inFlight = null })
+  return inFlight
+}
+
+/** Subscribe to the shared store, kicking off the first probe when enabled. */
+export function useInstalledAgents(enabled = true): InstalledAgentsState {
+  const state = useSyncExternalStore(subscribe, () => snapshot)
+  useEffect(() => { if (enabled) void refreshInstalledAgents() }, [enabled])
+  return state
+}


### PR DESCRIPTION
## What

- **Chat run settings → Agent** now lists every agent instead of only those in the fallback chain. Agents whose CLI isn't on PATH are `disabled` (natively greyed out, no extra label); the chat's current agent is never disabled so the selected value stays valid.
- **One source of install status.** The main process caches `detectInstalledAgents()` for the app's lifetime and coalesces concurrent probes; `agents:checkInstalled(force)` re-probes on demand. The renderer mirrors it in a single module store (`installedAgents.ts`, `useSyncExternalStore`), so:
  - "↻ Recheck" in the Agents tab immediately updates the chat picker,
  - opening N chats triggers one probe, not N,
  - nothing is disabled until the first probe lands (or if it fails).
- **Settings:** section "Agent priority" renamed to "Agent fallback".

`InstallStatus` moved to `installedAgents.ts`; `SettingsTab` re-exports it so existing imports are unchanged.

## Test

- `npx tsc --noEmit` for both the renderer and electron configs — clean.
- `npm test` (codey-mac): 517 passed.
- `npm run lint` — clean.
- Not yet exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)