### PR TITLE
Find nvm-installed agent CLIs from a GUI launch

### DIFF
--- a/packages/core/src/agents/env.test.ts
+++ b/packages/core/src/agents/env.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { applyModelEnv, withCommonBinPaths } from './env';
+import { applyModelEnv, nvmBinDirs, withCommonBinPaths } from './env';
+
+describe('nvmBinDirs', () => {
+  it('orders installed versions newest-first', () => {
+    expect(nvmBinDirs('/Users/tester', ['v18.20.8', 'v24.18.1', 'v22.17.0', 'v22.17.1'])).toEqual([
+      '/Users/tester/.nvm/versions/node/v24.18.1/bin',
+      '/Users/tester/.nvm/versions/node/v22.17.1/bin',
+      '/Users/tester/.nvm/versions/node/v22.17.0/bin',
+      '/Users/tester/.nvm/versions/node/v18.20.8/bin',
+    ]);
+  });
+
+  it('sorts numerically, not lexically', () => {
+    const dirs = nvmBinDirs('/h', ['v9.0.0', 'v10.0.0']);
+    expect(dirs[0]).toContain('v10.0.0');
+  });
+
+  it('drops alias entries that are not versions', () => {
+    expect(nvmBinDirs('/h', ['node', 'lts/*', 'v20.19.4'])).toEqual([
+      '/h/.nvm/versions/node/v20.19.4/bin',
+    ]);
+  });
+
+  it('is empty when nvm has nothing installed', () => {
+    expect(nvmBinDirs('/h', [])).toEqual([]);
+  });
+});
 
 describe('withCommonBinPaths', () => {
   it('prepends the usual CLI bin dirs to a minimal GUI PATH', () => {
@@ -8,7 +34,20 @@ describe('withCommonBinPaths', () => {
     expect(segments).toContain('/Users/tester/.local/bin');
     expect(segments).toContain('/opt/homebrew/bin');
     expect(segments).toContain('/usr/local/bin');
-    expect(segments.slice(-4)).toEqual(['/usr/bin', '/bin', '/usr/sbin', '/sbin']);
+    // The inherited system dirs stay intact and in order after the prepends.
+    // (nvm bin dirs, if this machine has any, are appended after them.)
+    const first = segments.indexOf('/usr/bin');
+    expect(segments.slice(first, first + 4)).toEqual(['/usr/bin', '/bin', '/usr/sbin', '/sbin']);
+  });
+
+  it('appends nvm bin dirs rather than prepending them', () => {
+    // Appending keeps a terminal-launched gateway on the node the user picked.
+    const env = { HOME: '/Users/tester', PATH: '/usr/bin:/bin' };
+    const segments = (withCommonBinPaths(env).PATH || '').split(':');
+    const nvm = segments.filter(p => p.includes('/.nvm/versions/node/'));
+    for (const p of nvm) {
+      expect(segments.indexOf(p)).toBeGreaterThan(segments.indexOf('/usr/bin'));
+    }
   });
 
   it('does not duplicate a path that is already present', () => {

--- a/packages/core/src/agents/env.ts
+++ b/packages/core/src/agents/env.ts
@@ -1,10 +1,40 @@
+import * as fs from 'fs';
 import { ModelConfig } from '../types';
+
+/**
+ * Order nvm's installed node versions newest-first and turn them into bin
+ * directories. Split out from the fs read so the ordering is testable.
+ *
+ * Names that do not parse as `vMAJOR.MINOR.PATCH` are dropped rather than
+ * sorted to one end: `~/.nvm/versions/node` also holds alias symlinks, and a
+ * non-version entry is not a directory we want on PATH.
+ */
+export function nvmBinDirs(homedir: string, versions: string[]): string[] {
+  const parsed = versions
+    .map(name => ({ name, parts: /^v(\d+)\.(\d+)\.(\d+)$/.exec(name) }))
+    .filter((v): v is { name: string; parts: RegExpExecArray } => v.parts !== null)
+    .map(v => ({ name: v.name, key: [+v.parts[1], +v.parts[2], +v.parts[3]] }));
+  parsed.sort((a, b) => b.key[0] - a.key[0] || b.key[1] - a.key[1] || b.key[2] - a.key[2]);
+  return parsed.map(v => `${homedir}/.nvm/versions/node/${v.name}/bin`);
+}
 
 /**
  * Prepend the bin directories CLIs are usually installed into. A GUI-launched
  * Electron app inherits a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), so a
  * bare spawn('codex') fails with ENOENT even though the binary is installed.
  * Mutates and returns the given env map.
+ *
+ * nvm's version bins are APPENDED, not prepended, and every installed version
+ * is added rather than just the default one. Both choices are deliberate:
+ *
+ *   - Appending keeps a terminal-launched gateway behaving exactly as before.
+ *     The user's active nvm bin is already first on PATH there, so these
+ *     entries only ever come into play as a fallback; prepending could hand a
+ *     spawned CLI a different node than the one the user selected.
+ *   - Every version, because agent CLIs get npm-installed under whichever node
+ *     was active at the time and end up scattered — on this machine pi lives
+ *     under v24.18.1 while codex and agent-browser live under v22.17.1. Adding
+ *     only nvm's default version would still leave half of them unfindable.
  */
 export function withCommonBinPaths(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const homedir = env.HOME || process.env.HOME || '';
@@ -19,6 +49,22 @@ export function withCommonBinPaths(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
       env.PATH = env.PATH ? `${p}:${env.PATH}` : p;
     }
   }
+
+  if (homedir) {
+    let versions: string[] = [];
+    try {
+      versions = fs.readdirSync(`${homedir}/.nvm/versions/node`);
+    } catch {
+      // No nvm installed, or unreadable — nothing to add.
+    }
+    for (const p of nvmBinDirs(homedir, versions)) {
+      const segments = (env.PATH || '').split(':');
+      if (!segments.includes(p)) {
+        env.PATH = env.PATH ? `${env.PATH}:${p}` : p;
+      }
+    }
+  }
+
   return env;
 }
 


### PR DESCRIPTION
## The bug

`withCommonBinPaths` exists because a GUI-launched Electron app inherits a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), so a bare `spawn('codex')` ENOENTs even though the binary is installed. Its three directories — `~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin` — miss nvm entirely, so **every agent CLI installed under nvm is invisible to the Mac app.**

Verified by spawning under a simulated minimal PATH:

```
pi     minimal PATH: ENOENT | withCommonBinPaths: found -> 0.83.0
codex  minimal PATH: ENOENT | withCommonBinPaths: found -> codex-cli 0.145.0
```

Not pi-specific — codex was equally broken.

## Two deliberate choices

**Appended, not prepended.** A terminal-launched gateway already has the user's active nvm bin first on PATH, so these entries only ever act as a fallback and can't hand a spawned CLI a different node than the one selected.

**Every installed version, not just the default.** Agent CLIs get npm-installed under whichever node was active at the time and end up scattered — on the machine this was found on, `pi` lives under v24.18.1 while `codex` and `agent-browser` live under v22.17.1. nvm's `default` alias resolves to `node` (newest), so a default-only fix would have found pi and left codex broken.

`nvmBinDirs` is split out from the fs read so the newest-first ordering is testable, and it drops non-version entries (`~/.nvm/versions/node` also holds alias symlinks).

## Verification

`npm test` green across all workspaces (core 491, gateway 309, codey-mac 537), `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)