### PR TITLE
Quick-question polish: no streaming ellipsis, roomier dropdown arrows

### DIFF
--- a/codey-mac/index.html
+++ b/codey-mac/index.html
@@ -33,6 +33,21 @@
     </script>
     <style>
       body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      /* Chromium pins the native select arrow to the border edge and ignores
+         padding-right, so it always looks cramped. Draw our own chevron with a
+         real inset instead. The !important is load-bearing: select styles are
+         inline `background: <color>` shorthands, which would otherwise reset
+         background-image to none. Only the image is forced — the inline
+         background color still wins. */
+      select {
+        -webkit-appearance: none !important;
+        appearance: none !important;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='7' viewBox='0 0 10 7' fill='none' stroke='%238a8a8a' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M1 1.5 5 5.5 9 1.5'/%3E%3C/svg%3E") !important;
+        background-repeat: no-repeat !important;
+        background-position: right 10px center !important;
+        background-size: 10px 7px !important;
+        padding-right: 26px !important;
+      }
       .hljs-comment, .hljs-quote { color: var(--fg3); font-style: italic; }
       .hljs-keyword, .hljs-selector-tag, .hljs-section, .hljs-link { color: var(--accent); }
       .hljs-string, .hljs-title, .hljs-name, .hljs-type, .hljs-attribute,

--- a/codey-mac/src/components/QuickQuestionView.tsx
+++ b/codey-mac/src/components/QuickQuestionView.tsx
@@ -174,7 +174,7 @@ export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
               ? <span style={qqStyles.userText}>{m.content}</span>
               : m.error
                 ? <span style={qqStyles.errText}>{m.content}</span>
-                : <Markdown>{m.content || (m.streaming ? '…' : '')}</Markdown>}
+                : <Markdown>{m.content}</Markdown>}
             {m.attachments && m.attachments.length > 0 && (
               <div style={qqStyles.msgAttRow}>
                 {m.attachments.map(a => a.mimeType.startsWith('image/') ? (


### PR DESCRIPTION
Two small UI fixes.

**Quick question: drop the streaming ellipsis.** The `…` placeholder flashed in before the first token and read as part of the answer.

**Dropdowns: give the arrow room from the edge.** Chromium pins the native `select` arrow to the border edge and ignores `padding-right` (verified: 10px vs 30px right padding renders identically), so every picker in the app — Settings, model selection, chat run settings, Automations — looked cramped. One global rule in `index.html` turns off the native appearance and draws a chevron inset 10px from the edge, with 26px right padding so long values never run under it. All windows share `index.html`, so this covers every dropdown, current and future.

The `!important` is load-bearing: select styles set `background: <color>` inline, and that shorthand would reset `background-image` to none. Only the image, position, and padding are forced, so each select keeps its own background color, border, and radius.

## Testing

Chevron rendering verified in headless Chromium against the app's real select styles (a ~240px `selectStyle` field and a small 12px picker): inline background colors survive and the arrow sits clear of the edge in both. Not yet eyeballed in the packaged Electron app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)