### PR TITLE
Show playbooks from every workspace in the Playbooks tab

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3610,31 +3610,38 @@ app.whenReady().then(async () => {
 
   // ── Playbooks (crystallizer SkillStore) — distinct from skills:* above,
   //    which manages agent-skill directories on disk. ──────────────────────────
-  function playbookStore() {
+  // The gateway's OWN workspace manager — not main.ts's workspaceManager singleton.
+  function playbookWorkspaces() {
     if (!inProcessGateway) throw new Error('Gateway not initialized');
-    // The gateway's OWN workspace manager — not main.ts's workspaceManager singleton.
-    return inProcessGateway.getWorkspaceManager().getSkillStore();
+    return inProcessGateway.getWorkspaceManager();
+  }
+  // Playbooks are per-workspace state shown in a global tab, so every action
+  // resolves the store of the workspace the renderer named. An empty name
+  // falls back to the active workspace (getSkillStoreFor's own behaviour).
+  function playbookStore(workspace: string) {
+    return playbookWorkspaces().getSkillStoreFor(workspace)
   }
   ipcMain.handle('playbooks:list', async () =>
-    wrap(async () => listPlaybooks(playbookStore())));
-  ipcMain.handle('playbooks:history', async (_e, name: string) =>
-    wrap(async () => playbookHistory(playbookStore(), name)));
-  ipcMain.handle('playbooks:forget', async (_e, name: string) =>
-    wrap(async () => forgetPlaybook(playbookStore(), name)));
-  ipcMain.handle('playbooks:restore', async (_e, name: string) =>
-    wrap(async () => restorePlaybook(playbookStore(), name)));
-  ipcMain.handle('playbooks:rollback', async (_e, name: string) =>
-    wrap(async () => rollbackPlaybook(playbookStore(), name)));
-  ipcMain.handle('playbooks:promote', async (_e, name: string) =>
+    wrap(async () => listPlaybooks(await playbookWorkspaces().getAllSkillStores())));
+  ipcMain.handle('playbooks:history', async (_e, workspace: string, name: string) =>
+    wrap(async () => playbookHistory(await playbookStore(workspace), name)));
+  ipcMain.handle('playbooks:forget', async (_e, workspace: string, name: string) =>
+    wrap(async () => forgetPlaybook(await playbookStore(workspace), name)));
+  ipcMain.handle('playbooks:restore', async (_e, workspace: string, name: string) =>
+    wrap(async () => restorePlaybook(await playbookStore(workspace), name)));
+  ipcMain.handle('playbooks:rollback', async (_e, workspace: string, name: string) =>
+    wrap(async () => rollbackPlaybook(await playbookStore(workspace), name)));
+  ipcMain.handle('playbooks:promote', async (_e, workspace: string, name: string) =>
     wrap(async () => {
       const pathMod = await import('path')
-      if (!inProcessGateway) throw new Error('Gateway not initialized')
-      const workingDir = inProcessGateway.getWorkspaceManager().getWorkingDir()
-      if (!workingDir) throw new Error('The active workspace has no working directory.')
+      // The skill belongs beside the code it describes: use the working dir of
+      // the playbook's OWN workspace, not whichever one is currently active.
+      const workingDir = playbookWorkspaces().getWorkingDirFor(workspace)
+      if (!workingDir) throw new Error(`Workspace "${workspace}" has no working directory.`)
       const agent = coreConfigManager?.getDefaultAgent() ?? 'claude-code'
       const paths = skillPaths[agent] ?? skillPaths['claude-code']
       const targetRoot = pathMod.join(workingDir, paths.projectSubdirs[0])
-      return promotePlaybook(playbookStore(), name, targetRoot)
+      return promotePlaybook(await playbookStore(workspace), name, targetRoot)
     }));
 
   // ── Conversations IPC ─────────────────────────────────────────────

--- a/codey-mac/electron/playbooks.test.ts
+++ b/codey-mac/electron/playbooks.test.ts
@@ -25,14 +25,39 @@ describe('playbooks IPC module', () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
+  /** The single-workspace view most assertions here care about. */
+  const listed = () => listPlaybooks([{ workspace: 'alpha', store }]);
+
   it('lists summaries with canRollback derived from the rollback stack', () => {
-    const list = listPlaybooks(store);
+    const list = listed();
     expect(list.length).toBe(1);
     expect(list[0]).toMatchObject({
-      name: 'rel', version: 2, archived: false, canRollback: true,
+      workspace: 'alpha', name: 'rel', version: 2, archived: false, canRollback: true,
     });
     store.rollback('rel');
-    expect(listPlaybooks(store)[0]).toMatchObject({ version: 1, canRollback: false });
+    expect(listed()[0]).toMatchObject({ version: 1, canRollback: false });
+  });
+
+  it('aggregates across workspaces, tagging each entry with its own', async () => {
+    const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-playbooks-test-b-'));
+    const other = new SkillStore(otherDir);
+    await other.load();
+    // Same NAME as the alpha playbook: names are unique only within a workspace,
+    // so both must survive aggregation as distinct entries.
+    other.add({ name: 'rel', description: 'Other release notes', whenToUse: 'w', steps: 's1' });
+    other.add({ name: 'deploy', description: 'Deploy', whenToUse: 'w', steps: 's1' });
+
+    const list = listPlaybooks([{ workspace: 'alpha', store }, { workspace: 'beta', store: other }]);
+    expect(list.map(p => `${p.workspace}/${p.name}`)).toEqual(['alpha/rel', 'beta/rel', 'beta/deploy']);
+    expect(list[0].description).toBe('Release notes');
+    expect(list[1].description).toBe('Other release notes');
+
+    await other.flush();
+    fs.rmSync(otherDir, { recursive: true, force: true });
+  });
+
+  it('lists nothing when no workspace has playbooks', () => {
+    expect(listPlaybooks([])).toEqual([]);
   });
 
   it('returns the evolution trail for a skill', () => {
@@ -48,9 +73,9 @@ describe('playbooks IPC module', () => {
 
   it('forget archives, restore unarchives', () => {
     forgetPlaybook(store, 'rel');
-    expect(listPlaybooks(store)[0].archived).toBe(true);
+    expect(listed()[0].archived).toBe(true);
     restorePlaybook(store, 'rel');
-    expect(listPlaybooks(store)[0].archived).toBe(false);
+    expect(listed()[0].archived).toBe(false);
   });
 
   it('forget/restore throw for unknown skill', () => {
@@ -60,7 +85,7 @@ describe('playbooks IPC module', () => {
 
   it('rollback restores the prior version and returns it', () => {
     expect(rollbackPlaybook(store, 'rel')).toBe(1);
-    expect(listPlaybooks(store)[0].version).toBe(1);
+    expect(listed()[0].version).toBe(1);
   });
 
   it('rollback throws when there is no prior version', () => {
@@ -76,7 +101,7 @@ describe('playbooks IPC module', () => {
     expect(md).toContain('description: "Release notes"');
     expect(md).toContain('## When to use\n\nw');
     expect(md).toContain('## Procedure\n\ns2');
-    expect(listPlaybooks(store)[0].promotedToSkill).toBe(true);
+    expect(listed()[0].promotedToSkill).toBe(true);
     expect(store.archive('rel')).toBe(false);
   });
 
@@ -86,6 +111,6 @@ describe('playbooks IPC module', () => {
     fs.writeFileSync(path.join(root, 'rel', 'SKILL.md'), 'existing');
     await expect(promotePlaybook(store, 'rel', root)).rejects.toThrow(/already exists/i);
     expect(fs.readFileSync(path.join(root, 'rel', 'SKILL.md'), 'utf-8')).toBe('existing');
-    expect(listPlaybooks(store)[0].promotedToSkill).toBe(false);
+    expect(listed()[0].promotedToSkill).toBe(false);
   });
 });

--- a/codey-mac/electron/playbooks.ts
+++ b/codey-mac/electron/playbooks.ts
@@ -5,7 +5,16 @@ import type { SkillStore, SkillEvolutionEvent } from '@codey/core';
 import * as fs from 'fs';
 import * as path from 'path';
 
+/** A store paired with the workspace it belongs to. The Playbooks tab is a
+ *  global view, so every summary and every action carries its workspace. */
+export interface WorkspaceStore {
+  workspace: string;
+  store: SkillStore;
+}
+
 export interface PlaybookSummary {
+  /** Owning workspace — names are only unique within one. */
+  workspace: string;
   name: string;
   description: string;
   version: number;
@@ -17,8 +26,12 @@ export interface PlaybookSummary {
   canRollback: boolean;
 }
 
-export function listPlaybooks(store: SkillStore): PlaybookSummary[] {
-  return store.getAll().map(s => ({
+/** Aggregate every workspace's playbooks into one list, grouped by workspace
+ *  in the order given. Two workspaces may hold same-named playbooks — they are
+ *  distinct entries, so consumers must key on (workspace, name). */
+export function listPlaybooks(stores: WorkspaceStore[]): PlaybookSummary[] {
+  return stores.flatMap(({ workspace, store }) => store.getAll().map(s => ({
+    workspace,
     name: s.name,
     description: s.description,
     version: s.version,
@@ -28,7 +41,7 @@ export function listPlaybooks(store: SkillStore): PlaybookSummary[] {
     promotedToSkill: s.promotedToSkill === true,
     successSignals: s.successSignals,
     canRollback: s.history.length > 0,
-  }));
+  })));
 }
 
 export function playbookHistory(store: SkillStore, name: string): SkillEvolutionEvent[] {

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -135,11 +135,11 @@ contextBridge.exposeInMainWorld('codey', {
   },
   playbooks: {
     list: () => ipcRenderer.invoke('playbooks:list'),
-    history: (name: string) => ipcRenderer.invoke('playbooks:history', name),
-    forget: (name: string) => ipcRenderer.invoke('playbooks:forget', name),
-    restore: (name: string) => ipcRenderer.invoke('playbooks:restore', name),
-    rollback: (name: string) => ipcRenderer.invoke('playbooks:rollback', name),
-    promote: (name: string) => ipcRenderer.invoke('playbooks:promote', name),
+    history: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:history', workspace, name),
+    forget: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:forget', workspace, name),
+    restore: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:restore', workspace, name),
+    rollback: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:rollback', workspace, name),
+    promote: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:promote', workspace, name),
   },
   agents: {
     get: () => ipcRenderer.invoke('agents:get'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -257,13 +257,15 @@ declare global {
         reveal: (dir: string) => Promise<IpcResult<void>>
       }
       playbooks: {
+        /** Aggregated across ALL workspaces — entries are keyed by (workspace, name). */
         list: () => Promise<IpcResult<Array<{
+          workspace: string;
           name: string; description: string; version: number; useCount: number;
           lastUsedAt: number; archived: boolean; promotedToSkill: boolean;
           successSignals: { cleanRuns: number; corrections: number };
           canRollback: boolean;
         }>>>
-        history: (name: string) => Promise<IpcResult<Array<{
+        history: (workspace: string, name: string) => Promise<IpcResult<Array<{
           at: number;
           kind: 'created' | 'evolved' | 'rolled-back';
           fromVersion?: number;
@@ -271,10 +273,10 @@ declare global {
           trigger?: { runId: string; promptSummary: string };
           steps: string;
         }>>>
-        forget: (name: string) => Promise<IpcResult<void>>
-        restore: (name: string) => Promise<IpcResult<void>>
-        rollback: (name: string) => Promise<IpcResult<number>>
-        promote: (name: string) => Promise<IpcResult<{ name: string; dir: string }>>
+        forget: (workspace: string, name: string) => Promise<IpcResult<void>>
+        restore: (workspace: string, name: string) => Promise<IpcResult<void>>
+        rollback: (workspace: string, name: string) => Promise<IpcResult<number>>
+        promote: (workspace: string, name: string) => Promise<IpcResult<{ name: string; dir: string }>>
       }
       agents: {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>>>

--- a/codey-mac/src/components/PlaybooksTab.tsx
+++ b/codey-mac/src/components/PlaybooksTab.tsx
@@ -6,6 +6,9 @@ import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
 
 interface Summary {
+  /** Owning workspace — the list spans all of them, and names collide across
+   *  workspaces, so every row and every action is keyed by (workspace, name). */
+  workspace: string
   name: string
   description: string
   version: number
@@ -17,6 +20,8 @@ interface Summary {
   canRollback: boolean
 }
 
+const rowKey = (s: { workspace: string; name: string }) => `${s.workspace}/${s.name}`
+
 export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [playbooks, setPlaybooks] = useState<Summary[]>([])
   const [expanded, setExpanded] = useState<string | null>(null)
@@ -25,8 +30,13 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const filteredPlaybooks = useMemo(
-    () => playbooks.filter(playbook => matchesToolSearch(searchQuery, playbook.name, playbook.description)),
+    () => playbooks.filter(playbook => matchesToolSearch(searchQuery, playbook.name, playbook.description, playbook.workspace)),
     [playbooks, searchQuery],
+  )
+  // Only worth labelling rows by workspace when more than one contributes.
+  const showWorkspace = useMemo(
+    () => new Set(playbooks.map(p => p.workspace)).size > 1,
+    [playbooks],
   )
 
   const reload = useCallback(async () => {
@@ -43,42 +53,42 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
 
   useEffect(() => { void reload() }, [reload])
 
-  const toggleExpand = useCallback(async (name: string) => {
-    if (expanded === name) { setExpanded(null); return }
+  const toggleExpand = useCallback(async (s: Summary) => {
+    if (expanded === rowKey(s)) { setExpanded(null); return }
     try {
-      const events = unwrap(await window.codey.playbooks.history(name))
+      const events = unwrap(await window.codey.playbooks.history(s.workspace, s.name))
       setTrail(timelineRows(events, Date.now()))
       setOpenSteps(null)
-      setExpanded(name)
+      setExpanded(rowKey(s))
     } catch (e: any) {
       setError(e?.message ?? String(e))
     }
   }, [expanded])
 
-  const act = useCallback(async (kind: 'forget' | 'restore' | 'rollback', name: string) => {
+  const act = useCallback(async (kind: 'forget' | 'restore' | 'rollback', s: Summary) => {
     const messages = {
-      forget: `Archive playbook "${name}"? It stops being applied but can be restored.`,
-      restore: `Restore playbook "${name}"?`,
-      rollback: `Roll back "${name}" to its previous version?`,
+      forget: `Archive playbook "${s.name}"? It stops being applied but can be restored.`,
+      restore: `Restore playbook "${s.name}"?`,
+      rollback: `Roll back "${s.name}" to its previous version?`,
     } as const
     if (!confirm(messages[kind])) return
     try {
       // Widen: rollback returns data: number, forget/restore data: void — the
       // raw union collapses unwrap's generic to void and rejects number.
       const res: { ok: true; data: unknown } | { ok: false; error: string } =
-        await window.codey.playbooks[kind](name)
+        await window.codey.playbooks[kind](s.workspace, s.name)
       unwrap(res)
       await reload()
-      if (expanded === name) setExpanded(null) // trail is stale after a mutation
+      if (expanded === rowKey(s)) setExpanded(null) // trail is stale after a mutation
     } catch (e: any) {
       setError(e?.message ?? String(e))
     }
   }, [reload, expanded])
 
-  const promote = useCallback(async (name: string) => {
-    if (!confirm(`Turn "${name}" into a project skill? The playbook will no longer be archived automatically.`)) return
+  const promote = useCallback(async (s: Summary) => {
+    if (!confirm(`Turn "${s.name}" into a project skill? The playbook will no longer be archived automatically.`)) return
     try {
-      unwrap(await window.codey.playbooks.promote(name))
+      unwrap(await window.codey.playbooks.promote(s.workspace, s.name))
       await reload()
     } catch (e: any) {
       setError(e?.message ?? String(e))
@@ -125,11 +135,11 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
 
   const renderCard = (s: Summary) => {
     const actions = playbookActions(s)
-    const isExpanded = expanded === s.name
+    const isExpanded = expanded === rowKey(s)
     return (
-      <div key={s.name} style={{ ...cardStyle, opacity: s.archived ? 0.65 : 1 }}>
+      <div key={rowKey(s)} style={{ ...cardStyle, opacity: s.archived ? 0.65 : 1 }}>
         <div
-          onClick={() => void toggleExpand(s.name)}
+          onClick={() => void toggleExpand(s)}
           style={{ cursor: 'pointer' }}
           title={isExpanded ? 'Hide evolution timeline' : 'Show evolution timeline'}
         >
@@ -165,6 +175,11 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
             </div>
           )}
           <div style={{ color: C.fg3, fontSize: 11, display: 'flex', gap: 12 }}>
+            {showWorkspace && (
+              <span title="Workspace this playbook belongs to" style={{ display: 'inline-flex', alignItems: 'center', gap: 3, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                <UIIcon name="folder" size={11} />{s.workspace}
+              </span>
+            )}
             <span>used {s.useCount}×</span>
             <span>last {relativeTime(s.lastUsedAt, Date.now())}</span>
             <span title="Clean runs / corrections" style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}><UIIcon name="check" size={12} />{s.successSignals.cleanRuns}<UIIcon name="close" size={11} />{s.successSignals.corrections}</span>
@@ -172,16 +187,16 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
         </div>
         <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
           {actions.promote && (
-            <button onClick={() => void promote(s.name)} style={pillButton('primary')}>Turn into skill</button>
+            <button onClick={() => void promote(s)} style={pillButton('primary')}>Turn into skill</button>
           )}
           {actions.forget && (
-            <button onClick={() => void act('forget', s.name)} style={{ ...pillButton('ghost'), color: C.red }}>Forget</button>
+            <button onClick={() => void act('forget', s)} style={{ ...pillButton('ghost'), color: C.red }}>Forget</button>
           )}
           {actions.restore && (
-            <button onClick={() => void act('restore', s.name)} style={pillButton('primary')}>Restore</button>
+            <button onClick={() => void act('restore', s)} style={pillButton('primary')}>Restore</button>
           )}
           {actions.rollback && (
-            <button onClick={() => void act('rollback', s.name)} style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="refresh" size={14} />Roll back</button>
+            <button onClick={() => void act('rollback', s)} style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="refresh" size={14} />Roll back</button>
           )}
         </div>
         {isExpanded && renderTimeline()}

--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -250,6 +250,28 @@ describe('WorkspaceManager SkillStore', () => {
     const proj = await manager.getSkillStoreFor('proj');
     expect(proj.getActive()[0].name).toBe('weekly-digest');
   });
+
+  it('getAllSkillStores covers every workspace, sharing the live active store', async () => {
+    const all = await manager.getAllSkillStores();
+    expect(all.map(e => e.workspace).sort()).toEqual(['other', 'proj']);
+    const proj = all.find(e => e.workspace === 'proj')!;
+    expect(proj.store).toBe(manager.getSkillStore());
+    expect(proj.store.getActive()[0].name).toBe('weekly-digest');
+    expect(all.find(e => e.workspace === 'other')!.store.getActive()).toEqual([]);
+  });
+
+  it('getWorkingDirFor reads the named workspace, falling back for unknown ones', () => {
+    const otherDir = path.join(root, 'elsewhere');
+    fs.writeFileSync(
+      path.join(wsDir, 'other', 'workspace.json'),
+      JSON.stringify({ workingDir: otherDir }),
+    );
+    expect(manager.getWorkingDirFor('other')).toBe(otherDir);
+    expect(manager.getWorkingDirFor('proj')).toBe(root);
+    // Unknown / empty names fall back to the active workspace rather than throw.
+    expect(manager.getWorkingDirFor('nope')).toBe(manager.getWorkingDir());
+    expect(manager.getWorkingDirFor('')).toBe(manager.getWorkingDir());
+  });
 });
 
 describe('normalizeTeam graph', () => {

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -335,6 +335,35 @@ export class WorkspaceManager {
     return store;
   }
 
+  /** Every workspace's SkillStore, keyed by workspace name. Skills are stored
+   *  per-workspace but the Mac app's Playbooks tab is a global view, so it has
+   *  to aggregate rather than read whichever store happens to be active. Loads
+   *  each store lazily through `getSkillStoreFor`, so repeat calls are cheap. */
+  async getAllSkillStores(): Promise<Array<{ workspace: string; store: SkillStore }>> {
+    const out: Array<{ workspace: string; store: SkillStore }> = [];
+    for (const name of this.listWorkspaces()) {
+      try {
+        out.push({ workspace: name, store: await this.getSkillStoreFor(name) });
+      } catch (error) {
+        // A single unreadable workspace must not blank the whole global view.
+        this.logger.warn(`[Workspace] Skipping skills for "${name}": ${(error as Error).message}`);
+      }
+    }
+    return out;
+  }
+
+  /** Working directory of a NAMED workspace. Falls back to the active one's
+   *  when the name is empty or its `workspace.json` is missing/unreadable. */
+  getWorkingDirFor(workspaceName: string): string {
+    if (!workspaceName || workspaceName === this.currentWorkspace) return this.getWorkingDir();
+    try {
+      const configPath = path.join(this.workspacesDir, workspaceName, 'workspace.json');
+      const data = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as WorkspaceJson;
+      if (data.workingDir) return data.workingDir;
+    } catch { /* fall through to the active workspace */ }
+    return this.getWorkingDir();
+  }
+
   /**
    * User-global memory store, rooted at `~/.codey/` (override via
    * `CODEY_GLOBAL_MEMORY_DIR`). Lazily instantiated and survives workspace


### PR DESCRIPTION
## Problem

"Skill saved, it will be auto-applied on matching tasks" — and then the playbook never shows up in the Playbooks tab.

Playbooks are per-workspace state. Saving resolves the store for the **chat's** workspace (`gateway.ts` → `resolveSkillStore(chat.workspaceName)` → `getSkillStoreFor`), but the tab read only the **active** workspace's store (`playbooks:list` → `getSkillStore()`). Confirm a suggestion in a chat bound to workspace A while the app sits on workspace B and the skill is written to `workspaces/A/skills/` correctly — then never rendered. `/skills` in chat *did* show it, since that path is workspace-scoped too.

The same asymmetry hit every action: forget/restore/rollback/promote all operated on the active store regardless of which workspace's playbook you clicked.

## Change

- `WorkspaceManager.getAllSkillStores()` — one store per workspace, loaded lazily through the existing `getSkillStoreFor` cache so the active workspace shares the live instance rather than a stale copy. An unreadable workspace is logged and skipped instead of blanking the list.
- `listPlaybooks` takes `WorkspaceStore[]` and stamps each summary with its `workspace`.
- Every playbook IPC takes `(workspace, name)` and resolves that workspace's store.
- Rows keyed by `(workspace, name)` — two workspaces can hold same-named playbooks, which previously collided on the React key.
- `promote` writes `SKILL.md` under the playbook's own workspace working dir (`getWorkingDirFor`), so the skill lands beside the code it describes.
- Workspace shown in the card meta line when more than one contributes; search matches it too.

## Verification

`npm test` green (491 + 309 + 539), both `codey-mac` tsconfigs typecheck, lint clean.

New tests cover cross-workspace aggregation with a name collision, the empty case, `getAllSkillStores` sharing the live active store, and `getWorkingDirFor` fallbacks.

Also run in the real app: a sandboxed build with two workspaces (`alpha` active, `beta` not), one playbook each. Both cards render with their workspace labels, and `playbooks:forget('beta', …)` archived the entry in `workspaces/beta/skills/index.json` while leaving `alpha` untouched.

## Known gap (not fixed here)

`PlaybooksTab` still only loads on mount, so confirming a suggestion with the tab already open leaves it stale until you switch tabs and back.

A follow-up branch adds a user-global playbook scope that applies in every workspace; kept separate deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)