### PR TITLE
Improve playbook actions, playbook details, and chat follow-to-latest

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -31,7 +31,7 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
 ])
 import { WorkerManager, WorkspaceManager } from '@codey/core'
-import { listPlaybooks, playbookHistory, forgetPlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
+import { listPlaybooks, playbookHistory, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
 import { ApiServer } from '@codey/gateway/dist/health'
@@ -3625,10 +3625,12 @@ app.whenReady().then(async () => {
     wrap(async () => listPlaybooks(await playbookWorkspaces().getAllSkillStores())));
   ipcMain.handle('playbooks:history', async (_e, workspace: string, name: string) =>
     wrap(async () => playbookHistory(await playbookStore(workspace), name)));
-  ipcMain.handle('playbooks:forget', async (_e, workspace: string, name: string) =>
-    wrap(async () => forgetPlaybook(await playbookStore(workspace), name)));
+  ipcMain.handle('playbooks:archive', async (_e, workspace: string, name: string) =>
+    wrap(async () => archivePlaybook(await playbookStore(workspace), name)));
   ipcMain.handle('playbooks:restore', async (_e, workspace: string, name: string) =>
     wrap(async () => restorePlaybook(await playbookStore(workspace), name)));
+  ipcMain.handle('playbooks:delete', async (_e, workspace: string, name: string) =>
+    wrap(async () => deletePlaybook(await playbookStore(workspace), name)));
   ipcMain.handle('playbooks:rollback', async (_e, workspace: string, name: string) =>
     wrap(async () => rollbackPlaybook(await playbookStore(workspace), name)));
   ipcMain.handle('playbooks:promote', async (_e, workspace: string, name: string) =>

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -31,7 +31,7 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
 ])
 import { WorkerManager, WorkspaceManager } from '@codey/core'
-import { listPlaybooks, playbookHistory, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
+import { listPlaybooks, playbookDetail, playbookHistory, crossAgentSkillDirs, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
 import { ApiServer } from '@codey/gateway/dist/health'
@@ -3623,6 +3623,8 @@ app.whenReady().then(async () => {
   }
   ipcMain.handle('playbooks:list', async () =>
     wrap(async () => listPlaybooks(await playbookWorkspaces().getAllSkillStores())));
+  ipcMain.handle('playbooks:detail', async (_e, workspace: string, name: string) =>
+    wrap(async () => playbookDetail(await playbookStore(workspace), name)));
   ipcMain.handle('playbooks:history', async (_e, workspace: string, name: string) =>
     wrap(async () => playbookHistory(await playbookStore(workspace), name)));
   ipcMain.handle('playbooks:archive', async (_e, workspace: string, name: string) =>
@@ -3640,10 +3642,12 @@ app.whenReady().then(async () => {
       // the playbook's OWN workspace, not whichever one is currently active.
       const workingDir = playbookWorkspaces().getWorkingDirFor(workspace)
       if (!workingDir) throw new Error(`Workspace "${workspace}" has no working directory.`)
-      const agent = coreConfigManager?.getDefaultAgent() ?? 'claude-code'
-      const paths = skillPaths[agent] ?? skillPaths['claude-code']
-      const targetRoot = pathMod.join(workingDir, paths.projectSubdirs[0])
-      return promotePlaybook(await playbookStore(workspace), name, targetRoot)
+      // A promoted playbook is a coding skill for the PROJECT, not for whichever
+      // agent happens to be the default today — so write the smallest set of
+      // directories that every agent discovers.
+      const targetRoots = crossAgentSkillDirs(skillPaths)
+        .map(rel => pathMod.join(workingDir, rel))
+      return promotePlaybook(await playbookStore(workspace), name, targetRoots)
     }));
 
   // ── Conversations IPC ─────────────────────────────────────────────

--- a/codey-mac/electron/playbooks.test.ts
+++ b/codey-mac/electron/playbooks.test.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { SkillStore } from '@codey/core';
 import {
   listPlaybooks, playbookHistory,
-  forgetPlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook,
+  archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook,
 } from './playbooks';
 
 describe('playbooks IPC module', () => {
@@ -71,16 +71,22 @@ describe('playbooks IPC module', () => {
     expect(() => playbookHistory(store, 'nope')).toThrow(/not found/i);
   });
 
-  it('forget archives, restore unarchives', () => {
-    forgetPlaybook(store, 'rel');
+  it('archive archives, restore unarchives', () => {
+    archivePlaybook(store, 'rel');
     expect(listed()[0].archived).toBe(true);
     restorePlaybook(store, 'rel');
     expect(listed()[0].archived).toBe(false);
   });
 
-  it('forget/restore throw for unknown skill', () => {
-    expect(() => forgetPlaybook(store, 'nope')).toThrow(/not found/i);
+  it('archive/restore throw for unknown skill', () => {
+    expect(() => archivePlaybook(store, 'nope')).toThrow(/not found/i);
     expect(() => restorePlaybook(store, 'nope')).toThrow(/not found/i);
+  });
+
+  it('delete permanently removes a playbook', () => {
+    deletePlaybook(store, 'rel');
+    expect(listed()).toEqual([]);
+    expect(() => deletePlaybook(store, 'rel')).toThrow(/not found/i);
   });
 
   it('rollback restores the prior version and returns it', () => {

--- a/codey-mac/electron/playbooks.test.ts
+++ b/codey-mac/electron/playbooks.test.ts
@@ -4,8 +4,8 @@ import * as path from 'path';
 import * as os from 'os';
 import { SkillStore } from '@codey/core';
 import {
-  listPlaybooks, playbookHistory,
-  archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook,
+  listPlaybooks, playbookDetail, playbookHistory,
+  archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook, crossAgentSkillDirs,
 } from './playbooks';
 
 describe('playbooks IPC module', () => {
@@ -67,6 +67,20 @@ describe('playbooks IPC module', () => {
     expect(ev[1]).toMatchObject({ kind: 'evolved', toVersion: 2 });
   });
 
+  it('returns the complete current playbook version', () => {
+    expect(playbookDetail(store, 'rel')).toEqual({
+      name: 'rel',
+      description: 'Release notes',
+      whenToUse: 'w',
+      steps: 's2',
+      version: 2,
+    });
+  });
+
+  it('detail throws for an unknown skill', () => {
+    expect(() => playbookDetail(store, 'nope')).toThrow(/not found/i);
+  });
+
   it('history throws for unknown skill', () => {
     expect(() => playbookHistory(store, 'nope')).toThrow(/not found/i);
   });
@@ -99,24 +113,102 @@ describe('playbooks IPC module', () => {
     expect(() => rollbackPlaybook(store, 'rel')).toThrow(/no prior version/i);
   });
 
+  // Promotion targets every skill convention the agents read, so one click
+  // yields a coding skill all of them discover.
+  const agentRoots = (base: string) => [
+    path.join(base, '.agents', 'skills'),
+    path.join(base, '.claude', 'skills'),
+  ];
+
   it('promotes a playbook to a durable SKILL.md and pins it', async () => {
-    const root = path.join(tmp, '.agents', 'skills');
-    const result = await promotePlaybook(store, 'rel', root);
-    const md = fs.readFileSync(path.join(result.dir, 'SKILL.md'), 'utf-8');
-    expect(md).toContain('name: "rel"');
-    expect(md).toContain('description: "Release notes"');
-    expect(md).toContain('## When to use\n\nw');
-    expect(md).toContain('## Procedure\n\ns2');
+    const roots = agentRoots(tmp);
+    const result = await promotePlaybook(store, 'rel', roots);
+    expect(result.dirs.length).toBe(2);
+    for (const dir of result.dirs) {
+      const md = fs.readFileSync(path.join(dir, 'SKILL.md'), 'utf-8');
+      expect(md).toContain('name: "rel"');
+      expect(md).toContain('description: "Release notes"');
+      expect(md).toContain('## When to use\n\nw');
+      expect(md).toContain('## Procedure\n\ns2');
+    }
+    // Every requested convention got its own copy, none skipped.
+    expect(result.dirs).toEqual(roots.map(r => path.join(r, 'rel')));
     expect(listed()[0].promotedToSkill).toBe(true);
     expect(store.archive('rel')).toBe(false);
   });
 
   it('does not overwrite an existing skill during promotion', async () => {
-    const root = path.join(tmp, '.agents', 'skills');
-    fs.mkdirSync(path.join(root, 'rel'), { recursive: true });
-    fs.writeFileSync(path.join(root, 'rel', 'SKILL.md'), 'existing');
-    await expect(promotePlaybook(store, 'rel', root)).rejects.toThrow(/already exists/i);
-    expect(fs.readFileSync(path.join(root, 'rel', 'SKILL.md'), 'utf-8')).toBe('existing');
+    const roots = agentRoots(tmp);
+    fs.mkdirSync(path.join(roots[0], 'rel'), { recursive: true });
+    fs.writeFileSync(path.join(roots[0], 'rel', 'SKILL.md'), 'existing');
+    await expect(promotePlaybook(store, 'rel', roots)).rejects.toThrow(/already exists/i);
+    expect(fs.readFileSync(path.join(roots[0], 'rel', 'SKILL.md'), 'utf-8')).toBe('existing');
     expect(listed()[0].promotedToSkill).toBe(false);
+  });
+
+  it('rolls back every copy when a later convention collides', async () => {
+    const roots = agentRoots(tmp);
+    // First root is clear, second is taken — the write must not leave a skill
+    // behind in the first, or some agents would see a half-promoted playbook.
+    fs.mkdirSync(path.join(roots[1], 'rel'), { recursive: true });
+    fs.writeFileSync(path.join(roots[1], 'rel', 'SKILL.md'), 'existing');
+    await expect(promotePlaybook(store, 'rel', roots)).rejects.toThrow(/already exists/i);
+    expect(fs.existsSync(path.join(roots[0], 'rel'))).toBe(false);
+    expect(fs.readFileSync(path.join(roots[1], 'rel', 'SKILL.md'), 'utf-8')).toBe('existing');
+    expect(listed()[0].promotedToSkill).toBe(false);
+  });
+
+  it('refuses to promote with no target directories', async () => {
+    await expect(promotePlaybook(store, 'rel', [])).rejects.toThrow(/no skill directory/i);
+    expect(listed()[0].promotedToSkill).toBe(false);
+  });
+
+  describe('crossAgentSkillDirs', () => {
+    // Mirrors main.ts's skillPaths. Kept here so the covering-set rule is
+    // pinned against the real conventions, not a toy table.
+    const REAL = {
+      'claude-code': { projectSubdirs: ['.claude/skills'] },
+      'codex': { projectSubdirs: ['.codex/skills', '.agents/skills'] },
+      'opencode': { projectSubdirs: ['.opencode/skills', '.agents/skills'] },
+      'pi': { projectSubdirs: ['.pi/skills', '.agents/skills'] },
+    };
+
+    it('covers every agent with the fewest directories', () => {
+      // codex/opencode/pi all read .agents/skills, so they collapse to one;
+      // claude-code does not, so it needs its own.
+      expect(crossAgentSkillDirs(REAL)).toEqual(['.claude/skills', '.agents/skills']);
+    });
+
+    it('gives every agent a directory it actually reads', () => {
+      const dirs = crossAgentSkillDirs(REAL);
+      for (const [agent, paths] of Object.entries(REAL)) {
+        expect(
+          paths.projectSubdirs.some(sub => dirs.includes(sub)),
+          `${agent} cannot discover the promoted skill`,
+        ).toBe(true);
+      }
+    });
+
+    it('falls back to the agent-specific dir when there is no shared one', () => {
+      expect(crossAgentSkillDirs({ solo: { projectSubdirs: ['.solo/skills'] } }))
+        .toEqual(['.solo/skills']);
+      expect(crossAgentSkillDirs({ none: { projectSubdirs: [] } })).toEqual([]);
+    });
+
+    it('promotes into every computed directory for a real project tree', async () => {
+      const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-project-'));
+      const roots = crossAgentSkillDirs(REAL).map(rel => path.join(projectDir, rel));
+      const result = await promotePlaybook(store, 'rel', roots);
+      expect(result.dirs.length).toBe(2);
+      // Every agent's convention resolves to a readable SKILL.md on disk.
+      for (const paths of Object.values(REAL)) {
+        const found = paths.projectSubdirs
+          .map(sub => path.join(projectDir, sub, 'rel', 'SKILL.md'))
+          .filter(p => fs.existsSync(p));
+        expect(found.length).toBeGreaterThan(0);
+        expect(fs.readFileSync(found[0], 'utf-8')).toContain('name: "rel"');
+      }
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    });
   });
 });

--- a/codey-mac/electron/playbooks.ts
+++ b/codey-mac/electron/playbooks.ts
@@ -50,12 +50,16 @@ export function playbookHistory(store: SkillStore, name: string): SkillEvolution
   return [...skill.evolution];
 }
 
-export function forgetPlaybook(store: SkillStore, name: string): void {
+export function archivePlaybook(store: SkillStore, name: string): void {
   if (!store.archive(name)) throw new Error(`Playbook not found: ${name}`);
 }
 
 export function restorePlaybook(store: SkillStore, name: string): void {
   if (!store.restore(name)) throw new Error(`Playbook not found: ${name}`);
+}
+
+export function deletePlaybook(store: SkillStore, name: string): void {
+  if (!store.remove(name)) throw new Error(`Playbook not found: ${name}`);
 }
 
 export function rollbackPlaybook(store: SkillStore, name: string): number {

--- a/codey-mac/electron/playbooks.ts
+++ b/codey-mac/electron/playbooks.ts
@@ -26,6 +26,14 @@ export interface PlaybookSummary {
   canRollback: boolean;
 }
 
+export interface PlaybookDetail {
+  name: string;
+  description: string;
+  whenToUse: string;
+  steps: string;
+  version: number;
+}
+
 /** Aggregate every workspace's playbooks into one list, grouped by workspace
  *  in the order given. Two workspaces may hold same-named playbooks — they are
  *  distinct entries, so consumers must key on (workspace, name). */
@@ -50,6 +58,20 @@ export function playbookHistory(store: SkillStore, name: string): SkillEvolution
   return [...skill.evolution];
 }
 
+/** Return the complete current version without exposing the store's mutable
+ * internal SkillEntry (including rollback and provenance bookkeeping). */
+export function playbookDetail(store: SkillStore, name: string): PlaybookDetail {
+  const skill = store.get(name);
+  if (!skill) throw new Error(`Playbook not found: ${name}`);
+  return {
+    name: skill.name,
+    description: skill.description,
+    whenToUse: skill.whenToUse,
+    steps: skill.steps,
+    version: skill.version,
+  };
+}
+
 export function archivePlaybook(store: SkillStore, name: string): void {
   if (!store.archive(name)) throw new Error(`Playbook not found: ${name}`);
 }
@@ -67,6 +89,27 @@ export function rollbackPlaybook(store: SkillStore, name: string): number {
     throw new Error(`Playbook "${name}" has no prior version (or was not found).`);
   }
   return store.get(name)!.version;
+}
+
+/** The cross-agent skill convention: an agent that lists it discovers skills
+ *  any other such agent wrote. */
+const SHARED_SKILL_DIR = '.agents/skills';
+
+/** Smallest set of project-relative skill directories that EVERY agent
+ *  discovers. Agents honouring `.agents/skills` collapse onto that one entry;
+ *  the rest (claude-code) need their own. Takes the path table as an argument
+ *  so adding an agent there keeps promotion correct without touching this. */
+export function crossAgentSkillDirs(
+  skillPaths: Record<string, { projectSubdirs: string[] }>,
+): string[] {
+  const dirs = new Set<string>();
+  for (const paths of Object.values(skillPaths)) {
+    if (paths.projectSubdirs.length === 0) continue;
+    dirs.add(paths.projectSubdirs.includes(SHARED_SKILL_DIR)
+      ? SHARED_SKILL_DIR
+      : paths.projectSubdirs[0]);
+  }
+  return [...dirs];
 }
 
 function renderSkill(name: string, description: string, whenToUse: string, steps: string): string {
@@ -92,32 +135,41 @@ ${steps}
 export async function promotePlaybook(
   store: SkillStore,
   name: string,
-  targetRoot: string,
-): Promise<{ name: string; dir: string }> {
+  targetRoots: string[],
+): Promise<{ name: string; dirs: string[] }> {
   const playbook = store.get(name);
   if (!playbook) throw new Error(`Playbook not found: ${name}`);
   if (playbook.promotedToSkill) throw new Error(`Playbook "${name}" is already a skill.`);
   if (!/^[a-z][a-z0-9-]*$/.test(playbook.name)) {
     throw new Error(`Playbook "${playbook.name}" does not have a valid skill name.`);
   }
+  if (targetRoots.length === 0) throw new Error('No skill directory to promote into.');
 
-  const dir = path.join(targetRoot, playbook.name);
-  const skillPath = path.join(dir, 'SKILL.md');
-  await fs.promises.mkdir(targetRoot, { recursive: true });
+  const body = renderSkill(playbook.name, playbook.description, playbook.whenToUse, playbook.steps);
+  // Track only what WE create, so the cleanup below never deletes a directory
+  // that was already on disk.
+  const created: string[] = [];
   try {
-    await fs.promises.mkdir(dir);
-    await fs.promises.writeFile(
-      skillPath,
-      renderSkill(playbook.name, playbook.description, playbook.whenToUse, playbook.steps),
-      { encoding: 'utf-8', flag: 'wx' },
-    );
+    for (const targetRoot of targetRoots) {
+      const dir = path.join(targetRoot, playbook.name);
+      await fs.promises.mkdir(targetRoot, { recursive: true });
+      await fs.promises.mkdir(dir);
+      created.push(dir);
+      await fs.promises.writeFile(
+        path.join(dir, 'SKILL.md'), body, { encoding: 'utf-8', flag: 'wx' },
+      );
+    }
     if (!store.promoteToSkill(name)) throw new Error(`Playbook not found: ${name}`);
   } catch (error) {
+    // All-or-nothing: a skill half-written across agent conventions is worse
+    // than none, since only some agents would ever see it.
+    for (const dir of created) {
+      await fs.promises.rm(dir, { recursive: true, force: true });
+    }
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       throw new Error(`Skill already exists: ${playbook.name}`);
     }
-    await fs.promises.rm(dir, { recursive: true, force: true });
     throw error;
   }
-  return { name: playbook.name, dir };
+  return { name: playbook.name, dirs: created };
 }

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -136,8 +136,9 @@ contextBridge.exposeInMainWorld('codey', {
   playbooks: {
     list: () => ipcRenderer.invoke('playbooks:list'),
     history: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:history', workspace, name),
-    forget: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:forget', workspace, name),
+    archive: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:archive', workspace, name),
     restore: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:restore', workspace, name),
+    delete: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:delete', workspace, name),
     rollback: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:rollback', workspace, name),
     promote: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:promote', workspace, name),
   },

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -135,6 +135,7 @@ contextBridge.exposeInMainWorld('codey', {
   },
   playbooks: {
     list: () => ipcRenderer.invoke('playbooks:list'),
+    detail: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:detail', workspace, name),
     history: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:history', workspace, name),
     archive: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:archive', workspace, name),
     restore: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:restore', workspace, name),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -273,8 +273,9 @@ declare global {
           trigger?: { runId: string; promptSummary: string };
           steps: string;
         }>>>
-        forget: (workspace: string, name: string) => Promise<IpcResult<void>>
+        archive: (workspace: string, name: string) => Promise<IpcResult<void>>
         restore: (workspace: string, name: string) => Promise<IpcResult<void>>
+        delete: (workspace: string, name: string) => Promise<IpcResult<void>>
         rollback: (workspace: string, name: string) => Promise<IpcResult<number>>
         promote: (workspace: string, name: string) => Promise<IpcResult<{ name: string; dir: string }>>
       }

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -265,6 +265,13 @@ declare global {
           successSignals: { cleanRuns: number; corrections: number };
           canRollback: boolean;
         }>>>
+        detail: (workspace: string, name: string) => Promise<IpcResult<{
+          name: string;
+          description: string;
+          whenToUse: string;
+          steps: string;
+          version: number;
+        }>>
         history: (workspace: string, name: string) => Promise<IpcResult<Array<{
           at: number;
           kind: 'created' | 'evolved' | 'rolled-back';
@@ -277,7 +284,9 @@ declare global {
         restore: (workspace: string, name: string) => Promise<IpcResult<void>>
         delete: (workspace: string, name: string) => Promise<IpcResult<void>>
         rollback: (workspace: string, name: string) => Promise<IpcResult<number>>
-        promote: (workspace: string, name: string) => Promise<IpcResult<{ name: string; dir: string }>>
+        /** Writes SKILL.md into every skill dir the agents discover — `dirs`
+         *  is one entry per agent convention covered. */
+        promote: (workspace: string, name: string) => Promise<IpcResult<{ name: string; dirs: string[] }>>
       }
       agents: {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>>>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -819,6 +819,11 @@ const TeamRunGroup: React.FC<{
   )
 }
 
+// Slack-style scroll following: anything within this many pixels of the bottom
+// counts as "pinned to the latest message", so tiny sub-pixel gaps and the odd
+// rounding error don't break the follow.
+const BOTTOM_STICK_PX = 24
+
 export const ChatTab: React.FC<Props> = ({
   chatId, isGatewayRunning, coreFailed,
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
@@ -1157,32 +1162,46 @@ export const ChatTab: React.FC<Props> = ({
   // A fresh prompt clears any pending multi-select picks from a prior question.
   useEffect(() => { setMultiChoice([]) }, [chatId, lastMsg?.id])
 
+  // Whether the transcript is currently following new content. Kept in a ref so
+  // the growth effect below reads it without re-subscribing on every scroll.
+  const stickToBottomRef = useRef(true)
+
   const updateLatestMessageVisibility = useCallback(() => {
     const messages = messagesRef.current
     if (!messages) return
     const distanceFromBottom = messages.scrollHeight - messages.scrollTop - messages.clientHeight
-    setShowLatestMessage(distanceFromBottom > 2)
+    const pinned = distanceFromBottom <= BOTTOM_STICK_PX
+    stickToBottomRef.current = pinned
+    setShowLatestMessage(!pinned)
   }, [])
 
-  // ChatTab is remounted for every chat selection. This is the one place where
-  // the transcript deliberately jumps: entering a chat always opens at its
-  // latest message. Updates inside that chat only refresh the button below;
-  // they never take control of the user's scroll position.
+  // ChatTab is remounted for every chat selection: entering a chat always opens
+  // at its latest message, following from there.
   useLayoutEffect(() => {
     const messages = messagesRef.current
     if (!messages) return
     messages.scrollTop = messages.scrollHeight
+    stickToBottomRef.current = true
     setShowLatestMessage(false)
   }, [chatId])
 
+  // New messages and streaming growth: keep the view glued to the bottom while
+  // the user is already there, and otherwise leave their scroll position alone
+  // and offer the jump button instead.
   useEffect(() => {
-    const frame = requestAnimationFrame(updateLatestMessageVisibility)
+    const frame = requestAnimationFrame(() => {
+      const messages = messagesRef.current
+      if (messages && stickToBottomRef.current) messages.scrollTop = messages.scrollHeight
+      updateLatestMessageVisibility()
+    })
     return () => cancelAnimationFrame(frame)
   }, [chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length, chat?.contextPanelOpen, updateLatestMessageVisibility])
 
   const scrollToLatestMessage = useCallback(() => {
     const messages = messagesRef.current
     if (!messages) return
+    stickToBottomRef.current = true
+    setShowLatestMessage(false)
     messages.scrollTo({ top: messages.scrollHeight, behavior: 'smooth' })
   }, [])
   useEffect(() => {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -84,6 +84,12 @@ const StopIcon: React.FC<{ color: string }> = ({ color }) => (
   </svg>
 )
 
+const ArrowDownIcon: React.FC<{ color: string }> = ({ color }) => (
+  <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 5v14M6 13l6 6 6-6" />
+  </svg>
+)
+
 const fmtTime = (ts: number) =>
   new Date(ts).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 
@@ -2426,8 +2432,9 @@ export const ChatTab: React.FC<Props> = ({
             style={styles.latestMessageButton}
             onClick={scrollToLatestMessage}
             aria-label="Jump to latest message"
+            title="Jump to latest message"
           >
-            Lastest Message ↓
+            <ArrowDownIcon color={C.fg} />
           </button>
         )}
         {showSlashMenu && (
@@ -2916,12 +2923,13 @@ const styles: Record<string, React.CSSProperties> = {
   },
   inputContainer: { padding: '12px max(16px, 4%) 16px', borderTop: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column', gap: 6, flexShrink: 0, background: C.surface },
   latestMessageButton: {
-    position: 'absolute' as const, top: 0, left: '50%', zIndex: 20,
-    transform: 'translate(-50%, -50%)',
-    padding: '6px 12px', borderRadius: 999,
+    position: 'absolute' as const, bottom: 'calc(100% + 8px)', left: '50%', zIndex: 20,
+    transform: 'translateX(-50%)',
+    width: 32, height: 32, padding: 0, borderRadius: '50%',
     border: `1px solid ${C.border2}`, background: C.surface2, color: C.fg,
     boxShadow: '0 5px 16px rgba(0,0,0,0.24)',
-    fontSize: 11, fontWeight: 650, cursor: 'pointer', whiteSpace: 'nowrap' as const,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    cursor: 'pointer',
   },
   composer: {
     background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 14,

--- a/codey-mac/src/components/PlaybooksTab.tsx
+++ b/codey-mac/src/components/PlaybooksTab.tsx
@@ -65,15 +65,16 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
     }
   }, [expanded])
 
-  const act = useCallback(async (kind: 'forget' | 'restore' | 'rollback', s: Summary) => {
+  const act = useCallback(async (kind: 'archive' | 'restore' | 'delete' | 'rollback', s: Summary) => {
     const messages = {
-      forget: `Archive playbook "${s.name}"? It stops being applied but can be restored.`,
+      archive: `Archive playbook "${s.name}"? It will stop being applied but can be restored later.`,
       restore: `Restore playbook "${s.name}"?`,
+      delete: `Permanently delete playbook "${s.name}"? This removes its full history and cannot be undone.`,
       rollback: `Roll back "${s.name}" to its previous version?`,
     } as const
     if (!confirm(messages[kind])) return
     try {
-      // Widen: rollback returns data: number, forget/restore data: void — the
+      // Widen: rollback returns data: number, other mutations return void — the
       // raw union collapses unwrap's generic to void and rejects number.
       const res: { ok: true; data: unknown } | { ok: false; error: string } =
         await window.codey.playbooks[kind](s.workspace, s.name)
@@ -137,20 +138,20 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
     const actions = playbookActions(s)
     const isExpanded = expanded === rowKey(s)
     return (
-      <div key={rowKey(s)} style={{ ...cardStyle, opacity: s.archived ? 0.65 : 1 }}>
+      <div key={rowKey(s)} style={{ ...cardStyle, opacity: s.archived ? 0.72 : 1 }}>
         <div
           onClick={() => void toggleExpand(s)}
           style={{ cursor: 'pointer' }}
           title={isExpanded ? 'Hide evolution timeline' : 'Show evolution timeline'}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-            <span style={{ color: C.fg, fontSize: 13, fontWeight: 600, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span style={{ color: C.fg, fontSize: 15, fontWeight: 650, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {s.name}
             </span>
-            <span style={{ color: C.fg3, fontSize: 11, flexShrink: 0 }}>v{s.version}</span>
+            <span style={{ color: C.fg3, fontSize: 12, flexShrink: 0 }}>v{s.version}</span>
             {s.archived && (
               <span style={{
-                fontSize: 9, fontWeight: 600, letterSpacing: 0.3,
+                fontSize: 10, fontWeight: 650, letterSpacing: 0.3,
                 padding: '2px 6px', borderRadius: 4, flexShrink: 0,
                 background: C.surface3, color: C.fg3,
               }}>
@@ -159,7 +160,7 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
             )}
             {s.promotedToSkill && (
               <span style={{
-                fontSize: 9, fontWeight: 600, letterSpacing: 0.3,
+                fontSize: 10, fontWeight: 650, letterSpacing: 0.3,
                 padding: '2px 6px', borderRadius: 4, flexShrink: 0,
                 background: C.accentDim, color: C.accent,
               }}>
@@ -167,14 +168,22 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
               </span>
             )}
             <span style={{ flex: 1 }} />
-            <span style={{ color: C.fg3, fontSize: 11, flexShrink: 0 }}>{isExpanded ? '▾' : '▸'}</span>
+            <button
+              type="button"
+              aria-label={isExpanded ? 'Collapse playbook details' : 'Expand playbook details'}
+              aria-expanded={isExpanded}
+              onClick={event => { event.stopPropagation(); void toggleExpand(s) }}
+              style={{ ...expandButtonStyle, transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+            >
+              <UIIcon name="chevron" size={16} />
+            </button>
           </div>
           {s.description && (
-            <div style={{ color: C.fg3, fontSize: 12, lineHeight: '1.5', marginBottom: 6 }}>
+            <div style={{ color: C.fg2, fontSize: 13, lineHeight: '1.55', marginBottom: 8 }}>
               {s.description}
             </div>
           )}
-          <div style={{ color: C.fg3, fontSize: 11, display: 'flex', gap: 12 }}>
+          <div style={{ color: C.fg3, fontSize: 12, display: 'flex', gap: 14 }}>
             {showWorkspace && (
               <span title="Workspace this playbook belongs to" style={{ display: 'inline-flex', alignItems: 'center', gap: 3, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 <UIIcon name="folder" size={11} />{s.workspace}
@@ -185,19 +194,26 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
             <span title="Clean runs / corrections" style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}><UIIcon name="check" size={12} />{s.successSignals.cleanRuns}<UIIcon name="close" size={11} />{s.successSignals.corrections}</span>
           </div>
         </div>
-        <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
-          {actions.promote && (
-            <button onClick={() => void promote(s)} style={pillButton('primary')}>Turn into skill</button>
-          )}
-          {actions.forget && (
-            <button onClick={() => void act('forget', s)} style={{ ...pillButton('ghost'), color: C.red }}>Forget</button>
-          )}
-          {actions.restore && (
-            <button onClick={() => void act('restore', s)} style={pillButton('primary')}>Restore</button>
-          )}
-          {actions.rollback && (
-            <button onClick={() => void act('rollback', s)} style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="refresh" size={14} />Roll back</button>
-          )}
+        <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 12, marginTop: 14 }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {actions.promote && (
+              <button onClick={() => void promote(s)} style={pillButton('primary')}>Turn into skill</button>
+            )}
+            {actions.rollback && (
+              <button onClick={() => void act('rollback', s)} style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="refresh" size={14} />Roll back</button>
+            )}
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-end', gap: 8, marginLeft: 'auto' }}>
+            {actions.archive && (
+              <button onClick={() => void act('archive', s)} style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="archive" size={14} />Archive</button>
+            )}
+            {actions.restore && (
+              <button onClick={() => void act('restore', s)} style={pillButton('primary')}>Restore</button>
+            )}
+            {actions.delete && (
+              <button onClick={() => void act('delete', s)} style={{ ...pillButton('danger'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="trash" size={14} />Delete</button>
+            )}
+          </div>
         </div>
         {isExpanded && renderTimeline()}
       </div>
@@ -237,5 +253,20 @@ const cardStyle: React.CSSProperties = {
   background: C.surface,
   border: `1px solid ${C.border}`,
   borderRadius: 10,
-  padding: '14px 16px',
+  padding: '16px 18px',
+}
+
+const expandButtonStyle: React.CSSProperties = {
+  width: 30,
+  height: 30,
+  padding: 0,
+  borderRadius: 8,
+  border: `1px solid ${C.border2}`,
+  background: C.surface3,
+  color: C.fg2,
+  display: 'grid',
+  placeItems: 'center',
+  cursor: 'pointer',
+  flexShrink: 0,
+  transition: 'transform 160ms ease, border-color 160ms ease, background 160ms ease',
 }

--- a/codey-mac/src/components/PlaybooksTab.tsx
+++ b/codey-mac/src/components/PlaybooksTab.tsx
@@ -20,11 +20,20 @@ interface Summary {
   canRollback: boolean
 }
 
+interface Detail {
+  name: string
+  description: string
+  whenToUse: string
+  steps: string
+  version: number
+}
+
 const rowKey = (s: { workspace: string; name: string }) => `${s.workspace}/${s.name}`
 
 export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [playbooks, setPlaybooks] = useState<Summary[]>([])
   const [expanded, setExpanded] = useState<string | null>(null)
+  const [detail, setDetail] = useState<Detail | null>(null)
   const [trail, setTrail] = useState<TimelineRow[]>([])
   const [openSteps, setOpenSteps] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
@@ -54,9 +63,13 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
   useEffect(() => { void reload() }, [reload])
 
   const toggleExpand = useCallback(async (s: Summary) => {
-    if (expanded === rowKey(s)) { setExpanded(null); return }
+    if (expanded === rowKey(s)) { setExpanded(null); setDetail(null); return }
     try {
-      const events = unwrap(await window.codey.playbooks.history(s.workspace, s.name))
+      const [current, events] = await Promise.all([
+        window.codey.playbooks.detail(s.workspace, s.name).then(unwrap),
+        window.codey.playbooks.history(s.workspace, s.name).then(unwrap),
+      ])
+      setDetail(current)
       setTrail(timelineRows(events, Date.now()))
       setOpenSteps(null)
       setExpanded(rowKey(s))
@@ -64,6 +77,22 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
       setError(e?.message ?? String(e))
     }
   }, [expanded])
+
+  const renderCurrentVersion = () => detail && (
+    <div style={{ borderTop: `1px solid ${C.border}`, marginTop: 12, paddingTop: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+        <span style={{ color: C.fg, fontSize: 13, fontWeight: 650 }}>Current version</span>
+        <span style={{ color: C.accent, background: C.accentDim, borderRadius: 5, padding: '2px 6px', fontSize: 11, fontWeight: 650 }}>
+          v{detail.version}
+        </span>
+      </div>
+      <div style={{ display: 'grid', gap: 12 }}>
+        <DetailSection label="Description" content={detail.description} />
+        <DetailSection label="When to use" content={detail.whenToUse} />
+        <DetailSection label="Procedure" content={detail.steps} code />
+      </div>
+    </div>
+  )
 
   const act = useCallback(async (kind: 'archive' | 'restore' | 'delete' | 'rollback', s: Summary) => {
     const messages = {
@@ -87,7 +116,7 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
   }, [reload, expanded])
 
   const promote = useCallback(async (s: Summary) => {
-    if (!confirm(`Turn "${s.name}" into a project skill? The playbook will no longer be archived automatically.`)) return
+    if (!confirm(`Turn "${s.name}" into a project skill? It becomes a coding skill every agent can discover, and the playbook will no longer be archived automatically.`)) return
     try {
       unwrap(await window.codey.playbooks.promote(s.workspace, s.name))
       await reload()
@@ -97,7 +126,8 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
   }, [reload])
 
   const renderTimeline = () => (
-    <div style={{ borderTop: `1px solid ${C.border}`, marginTop: 12, paddingTop: 10 }}>
+    <div style={{ borderTop: `1px solid ${C.border}`, marginTop: 14, paddingTop: 12 }}>
+      <div style={{ color: C.fg, fontSize: 13, fontWeight: 650, marginBottom: 10 }}>Version history</div>
       {trail.length === 0 ? (
         <div style={{ color: C.fg3, fontSize: 12 }}>No recorded evolution events yet.</div>
       ) : trail.map((row, i) => (
@@ -142,7 +172,7 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
         <div
           onClick={() => void toggleExpand(s)}
           style={{ cursor: 'pointer' }}
-          title={isExpanded ? 'Hide evolution timeline' : 'Show evolution timeline'}
+          title={isExpanded ? 'Hide playbook details' : 'Show playbook details'}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
             <span style={{ color: C.fg, fontSize: 15, fontWeight: 650, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -215,7 +245,12 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
             )}
           </div>
         </div>
-        {isExpanded && renderTimeline()}
+        {isExpanded && (
+          <>
+            {renderCurrentVersion()}
+            {renderTimeline()}
+          </>
+        )}
       </div>
     )
   }
@@ -248,6 +283,26 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
     </div>
   )
 }
+
+const DetailSection: React.FC<{ label: string; content: string; code?: boolean }> = ({ label, content, code = false }) => (
+  <div>
+    <div style={{ color: C.fg3, fontSize: 11, fontWeight: 650, letterSpacing: 0.2, marginBottom: 5 }}>{label}</div>
+    <div style={{
+      margin: 0,
+      padding: code ? '10px 12px' : 0,
+      borderRadius: code ? 7 : 0,
+      background: code ? C.surface3 : 'transparent',
+      color: C.fg2,
+      fontSize: 12,
+      lineHeight: '1.55',
+      fontFamily: code ? 'monospace' : 'inherit',
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+    }}>
+      {content || '—'}
+    </div>
+  </div>
+)
 
 const cardStyle: React.CSSProperties = {
   background: C.surface,

--- a/codey-mac/src/components/playbooksModel.test.ts
+++ b/codey-mac/src/components/playbooksModel.test.ts
@@ -43,18 +43,18 @@ describe('timelineRows', () => {
 describe('playbookActions', () => {
   it('derives which action buttons are enabled', () => {
     expect(playbookActions({ archived: false, canRollback: true, promotedToSkill: false }))
-      .toEqual({ forget: true, restore: false, rollback: true, promote: true })
+      .toEqual({ archive: true, restore: false, delete: true, rollback: true, promote: true })
     expect(playbookActions({ archived: true, canRollback: false, promotedToSkill: false }))
-      .toEqual({ forget: false, restore: true, rollback: false, promote: true })
+      .toEqual({ archive: false, restore: true, delete: true, rollback: false, promote: true })
   })
 
   it('allows rollback on archived skills, matching the gateway', () => {
     expect(playbookActions({ archived: true, canRollback: true, promotedToSkill: false }))
-      .toEqual({ forget: false, restore: true, rollback: true, promote: true })
+      .toEqual({ archive: false, restore: true, delete: true, rollback: true, promote: true })
   })
 
   it('hides archive and promotion actions after promotion', () => {
     expect(playbookActions({ archived: false, canRollback: true, promotedToSkill: true }))
-      .toEqual({ forget: false, restore: false, rollback: true, promote: false })
+      .toEqual({ archive: false, restore: false, delete: true, rollback: true, promote: false })
   })
 })

--- a/codey-mac/src/components/playbooksModel.ts
+++ b/codey-mac/src/components/playbooksModel.ts
@@ -45,13 +45,14 @@ export function timelineRows(events: EvolutionEventLike[], now: number): Timelin
 }
 
 export function playbookActions(s: { archived: boolean; canRollback: boolean; promotedToSkill: boolean }): {
-  forget: boolean; restore: boolean; rollback: boolean; promote: boolean
+  archive: boolean; restore: boolean; delete: boolean; rollback: boolean; promote: boolean
 } {
   // Rollback is gated only on available history — archived skills can roll
   // back too, matching the gateway's /skill rollback behavior.
   return {
-    forget: !s.archived && !s.promotedToSkill,
+    archive: !s.archived && !s.promotedToSkill,
     restore: s.archived,
+    delete: true,
     rollback: s.canRollback,
     promote: !s.promotedToSkill,
   }

--- a/packages/core/src/skill-crystallizer.test.ts
+++ b/packages/core/src/skill-crystallizer.test.ts
@@ -90,6 +90,18 @@ describe('SkillStore', () => {
     expect(store.getActive().length).toBe(1);
   });
 
+  it('remove() permanently deletes a skill entry', async () => {
+    store.add({ name: 's', description: 'd', whenToUse: 'w', steps: 'st' });
+    expect(store.remove('s')).toBe(true);
+    expect(store.remove('s')).toBe(false);
+    expect(store.get('s')).toBeUndefined();
+
+    await store.flush();
+    const reloaded = new SkillStore(tmp);
+    await reloaded.load();
+    expect(reloaded.get('s')).toBeUndefined();
+  });
+
   it('recordUse bumps useCount and lastUsedAt', () => {
     store.add({ name: 'test', description: 'd', whenToUse: 'w', steps: 's' });
     const before = Date.now();

--- a/packages/core/src/skill-crystallizer.ts
+++ b/packages/core/src/skill-crystallizer.ts
@@ -292,6 +292,15 @@ export class SkillStore {
     return true;
   }
 
+  /** Permanently remove a playbook and all of its stored version/evolution data. */
+  remove(name: string): boolean {
+    const index = this.index.entries.findIndex(e => e.name === name);
+    if (index === -1) return false;
+    this.index.entries.splice(index, 1);
+    this.markIndexDirty();
+    return true;
+  }
+
   /** Mark a playbook as a durable agent skill. Promotion also restores a
    *  previously archived playbook so it can continue to be matched/evolved. */
   promoteToSkill(name: string): boolean {


### PR DESCRIPTION
## What changed

**Playbook actions & typography (first commit)**
- refresh the playbook card typography and make the expand control more visible
- add archive support for active playbooks and permanent deletion for all playbooks
- move restore/delete actions to the lower-right action area
- replace the "Latest Message" label with a spaced, circular down-arrow button

**Playbook detail view (second commit)**
- new `playbooks:detail` IPC returns the current version (description / whenToUse / steps / version) without exposing the store's mutable `SkillEntry`; the Playbooks tab renders it above the evolution timeline when a row expands

**Cross-agent promotion (second commit)**
- promoting a playbook used to write SKILL.md only into the *current default agent's* skill dir. It now writes the smallest set of dirs every agent discovers — `.agents/skills` for agents honouring the shared convention, plus per-agent dirs for the rest (claude-code). `promote` returns `dirs: string[]` instead of a single `dir`.

**Chat follows the latest message (second commit)**
- the transcript now stays pinned to the newest message while you're already at the bottom (within 24px), including during streaming
- scroll up and it stops following and shows the jump-to-latest button instead — previously the button appeared at a 2px gap and the view never auto-followed
- clicking the button re-enters follow mode; switching chats still opens at the latest message

## Why

The playbook controls needed clearer hierarchy and distinct lifecycle actions; promotion shouldn't be tied to whichever agent happens to be the default; and the chat transcript should behave like every other chat UI — follow when you're at the bottom, stay put when you're not.

## Validation

- `npm test -w @codey/core -- --run` — 492 tests passed
- `npx vitest run` in `codey-mac` — 57 files / 548 tests passed, including new `playbooks.test.ts` coverage for `playbookDetail`, `crossAgentSkillDirs`, and multi-dir promotion
- `npx tsc --noEmit -p codey-mac/tsconfig.json` — passed

Not verified on a real run: the scroll-follow feel during live streaming in the packaged Mac app, and promotion writing into an actual project tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)