### PR TITLE
Share Codey skills across coding agents

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -30,8 +30,8 @@ import * as pty from 'node-pty'
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
 ])
-import { WorkerManager, WorkspaceManager } from '@codey/core'
-import { listPlaybooks, playbookDetail, playbookHistory, crossAgentSkillDirs, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
+import { CODEY_SKILLS_SUBDIR, syncCodeyProjectSkills, WorkerManager, WorkspaceManager } from '@codey/core'
+import { listPlaybooks, playbookDetail, playbookHistory, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
 import { ApiServer } from '@codey/gateway/dist/health'
@@ -3364,11 +3364,11 @@ app.whenReady().then(async () => {
 
   // ── Skills IPC ────────────────────────────────────────────────────
   const skillPaths: Record<string, { userDirs: string[]; projectSubdirs: string[] }> = {
-    'claude-code': { userDirs: ['.claude/skills'], projectSubdirs: ['.claude/skills'] },
+    'claude-code': { userDirs: ['.claude/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.claude/skills'] },
     // Codex and OpenCode also discover the cross-agent .agents convention.
-    'codex':       { userDirs: ['.codex/skills', '.agents/skills'], projectSubdirs: ['.codex/skills', '.agents/skills'] },
-    'opencode':    { userDirs: ['.config/opencode/skills', '.opencode/skills', '.agents/skills'], projectSubdirs: ['.opencode/skills', '.agents/skills'] },
-    'pi':          { userDirs: ['.pi/agent/skills', '.agents/skills'], projectSubdirs: ['.pi/skills', '.agents/skills'] },
+    'codex':       { userDirs: ['.codex/skills', '.agents/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.codex/skills', '.agents/skills'] },
+    'opencode':    { userDirs: ['.config/opencode/skills', '.opencode/skills', '.agents/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.opencode/skills', '.agents/skills'] },
+    'pi':          { userDirs: ['.pi/agent/skills', '.agents/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.pi/skills', '.agents/skills'] },
   }
 
   function configuredUserSkillDirs(agentKey: string, home: string, pathMod: typeof import('path')): string[] {
@@ -3511,6 +3511,7 @@ app.whenReady().then(async () => {
       const paths = skillPaths[agentKey] ?? skillPaths['claude-code']
 
       const home = osMod.homedir()
+      let projectWorkingDir: string | undefined
       const getTargetRoot = async (): Promise<string> => {
         if (payload.scope === 'user') return configuredUserSkillDirs(agentKey, home, pathMod)[0]
         if (!workspaceManager) throw new Error('No workspace manager')
@@ -3520,6 +3521,7 @@ app.whenReady().then(async () => {
         const configPath = pathMod.join(root, wsName, 'workspace.json')
         const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
         if (!data.workingDir) throw new Error('Workspace has no working directory')
+        projectWorkingDir = data.workingDir
         return pathMod.join(data.workingDir, paths.projectSubdirs[0])
       }
 
@@ -3530,6 +3532,7 @@ app.whenReady().then(async () => {
         const src = resolveUserPath(pathMod, payload.localDir, home)
         if (!fsMod.existsSync(src) || !fsMod.statSync(src).isDirectory()) throw new Error(`Not a directory: ${src}`)
         if (samePath(fsMod, pathMod, src, targetRoot)) {
+          if (projectWorkingDir) await syncCodeyProjectSkills(projectWorkingDir)
           return { name: pathMod.basename(targetRoot), dir: targetRoot }
         }
         const rootSkillFile = pathMod.join(src, SKILL_FILE)
@@ -3567,6 +3570,7 @@ app.whenReady().then(async () => {
           await fsMod.promises.cp(source.dir, dest, { recursive: true })
           installed.push({ name: source.name, dir: dest })
         }
+        if (projectWorkingDir) await syncCodeyProjectSkills(projectWorkingDir)
         return installed.length === 1 ? installed[0] : { name: `${installed.length} skills`, dir: targetRoot }
       }
 
@@ -3579,6 +3583,7 @@ app.whenReady().then(async () => {
         const dest = pathMod.join(targetRoot, name)
         if (fsMod.existsSync(dest)) throw new Error(`Skill already exists: ${name}`)
         await execFileAsync('git', ['clone', '--depth', '1', url, dest])
+        if (projectWorkingDir) await syncCodeyProjectSkills(projectWorkingDir)
         return { name, dir: dest }
       }
 
@@ -3600,7 +3605,10 @@ app.whenReady().then(async () => {
     wrap(async () => {
       if (typeof dir !== 'string' || !dir) throw new Error('Invalid path')
       const fsMod = await import('fs')
+      const pathMod = await import('path')
       await fsMod.promises.rm(dir, { recursive: true, force: true })
+      const workingDir = getWorkingDir(fsMod, pathMod)
+      if (workingDir) await syncCodeyProjectSkills(workingDir)
     })
   )
 
@@ -3642,12 +3650,15 @@ app.whenReady().then(async () => {
       // the playbook's OWN workspace, not whichever one is currently active.
       const workingDir = playbookWorkspaces().getWorkingDirFor(workspace)
       if (!workingDir) throw new Error(`Workspace "${workspace}" has no working directory.`)
-      // A promoted playbook is a coding skill for the PROJECT, not for whichever
-      // agent happens to be the default today — so write the smallest set of
-      // directories that every agent discovers.
-      const targetRoots = crossAgentSkillDirs(skillPaths)
-        .map(rel => pathMod.join(workingDir, rel))
-      return promotePlaybook(await playbookStore(workspace), name, targetRoots)
+      // The durable copy lives once under `.codey/skills`; compatibility links
+      // expose it through every agent's native discovery convention.
+      const result = await promotePlaybook(
+        await playbookStore(workspace),
+        name,
+        [pathMod.join(workingDir, CODEY_SKILLS_SUBDIR)],
+      )
+      await syncCodeyProjectSkills(workingDir)
+      return result
     }));
 
   // ── Conversations IPC ─────────────────────────────────────────────

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3364,6 +3364,7 @@ app.whenReady().then(async () => {
 
   // ── Skills IPC ────────────────────────────────────────────────────
   const skillPaths: Record<string, { userDirs: string[]; projectSubdirs: string[] }> = {
+    'codey':       { userDirs: [], projectSubdirs: [CODEY_SKILLS_SUBDIR] },
     'claude-code': { userDirs: ['.claude/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.claude/skills'] },
     // Codex and OpenCode also discover the cross-agent .agents convention.
     'codex':       { userDirs: ['.codex/skills', '.agents/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.codex/skills', '.agents/skills'] },
@@ -3513,6 +3514,7 @@ app.whenReady().then(async () => {
       const home = osMod.homedir()
       let projectWorkingDir: string | undefined
       const getTargetRoot = async (): Promise<string> => {
+        if (agentKey === 'codey' && payload.scope !== 'project') throw new Error('Codey skills are workspace-scoped')
         if (payload.scope === 'user') return configuredUserSkillDirs(agentKey, home, pathMod)[0]
         if (!workspaceManager) throw new Error('No workspace manager')
         const wsName = workspaceManager.getCurrentWorkspace()

--- a/codey-mac/electron/playbooks.test.ts
+++ b/codey-mac/electron/playbooks.test.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { SkillStore } from '@codey/core';
 import {
   listPlaybooks, playbookDetail, playbookHistory,
-  archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook, crossAgentSkillDirs,
+  archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook,
 } from './playbooks';
 
 describe('playbooks IPC module', () => {
@@ -113,17 +113,14 @@ describe('playbooks IPC module', () => {
     expect(() => rollbackPlaybook(store, 'rel')).toThrow(/no prior version/i);
   });
 
-  // Promotion targets every skill convention the agents read, so one click
-  // yields a coding skill all of them discover.
-  const agentRoots = (base: string) => [
-    path.join(base, '.agents', 'skills'),
-    path.join(base, '.claude', 'skills'),
-  ];
+  // Promotion writes one durable copy. Core's Codey-skill synchronizer exposes
+  // that source through each agent's native discovery directory.
+  const agentRoots = (base: string) => [path.join(base, '.codey', 'skills')];
 
   it('promotes a playbook to a durable SKILL.md and pins it', async () => {
     const roots = agentRoots(tmp);
     const result = await promotePlaybook(store, 'rel', roots);
-    expect(result.dirs.length).toBe(2);
+    expect(result.dirs.length).toBe(1);
     for (const dir of result.dirs) {
       const md = fs.readFileSync(path.join(dir, 'SKILL.md'), 'utf-8');
       expect(md).toContain('name: "rel"');
@@ -131,7 +128,7 @@ describe('playbooks IPC module', () => {
       expect(md).toContain('## When to use\n\nw');
       expect(md).toContain('## Procedure\n\ns2');
     }
-    // Every requested convention got its own copy, none skipped.
+    // There is exactly one source copy under Codey's project directory.
     expect(result.dirs).toEqual(roots.map(r => path.join(r, 'rel')));
     expect(listed()[0].promotedToSkill).toBe(true);
     expect(store.archive('rel')).toBe(false);
@@ -146,69 +143,8 @@ describe('playbooks IPC module', () => {
     expect(listed()[0].promotedToSkill).toBe(false);
   });
 
-  it('rolls back every copy when a later convention collides', async () => {
-    const roots = agentRoots(tmp);
-    // First root is clear, second is taken — the write must not leave a skill
-    // behind in the first, or some agents would see a half-promoted playbook.
-    fs.mkdirSync(path.join(roots[1], 'rel'), { recursive: true });
-    fs.writeFileSync(path.join(roots[1], 'rel', 'SKILL.md'), 'existing');
-    await expect(promotePlaybook(store, 'rel', roots)).rejects.toThrow(/already exists/i);
-    expect(fs.existsSync(path.join(roots[0], 'rel'))).toBe(false);
-    expect(fs.readFileSync(path.join(roots[1], 'rel', 'SKILL.md'), 'utf-8')).toBe('existing');
-    expect(listed()[0].promotedToSkill).toBe(false);
-  });
-
   it('refuses to promote with no target directories', async () => {
     await expect(promotePlaybook(store, 'rel', [])).rejects.toThrow(/no skill directory/i);
     expect(listed()[0].promotedToSkill).toBe(false);
-  });
-
-  describe('crossAgentSkillDirs', () => {
-    // Mirrors main.ts's skillPaths. Kept here so the covering-set rule is
-    // pinned against the real conventions, not a toy table.
-    const REAL = {
-      'claude-code': { projectSubdirs: ['.claude/skills'] },
-      'codex': { projectSubdirs: ['.codex/skills', '.agents/skills'] },
-      'opencode': { projectSubdirs: ['.opencode/skills', '.agents/skills'] },
-      'pi': { projectSubdirs: ['.pi/skills', '.agents/skills'] },
-    };
-
-    it('covers every agent with the fewest directories', () => {
-      // codex/opencode/pi all read .agents/skills, so they collapse to one;
-      // claude-code does not, so it needs its own.
-      expect(crossAgentSkillDirs(REAL)).toEqual(['.claude/skills', '.agents/skills']);
-    });
-
-    it('gives every agent a directory it actually reads', () => {
-      const dirs = crossAgentSkillDirs(REAL);
-      for (const [agent, paths] of Object.entries(REAL)) {
-        expect(
-          paths.projectSubdirs.some(sub => dirs.includes(sub)),
-          `${agent} cannot discover the promoted skill`,
-        ).toBe(true);
-      }
-    });
-
-    it('falls back to the agent-specific dir when there is no shared one', () => {
-      expect(crossAgentSkillDirs({ solo: { projectSubdirs: ['.solo/skills'] } }))
-        .toEqual(['.solo/skills']);
-      expect(crossAgentSkillDirs({ none: { projectSubdirs: [] } })).toEqual([]);
-    });
-
-    it('promotes into every computed directory for a real project tree', async () => {
-      const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-project-'));
-      const roots = crossAgentSkillDirs(REAL).map(rel => path.join(projectDir, rel));
-      const result = await promotePlaybook(store, 'rel', roots);
-      expect(result.dirs.length).toBe(2);
-      // Every agent's convention resolves to a readable SKILL.md on disk.
-      for (const paths of Object.values(REAL)) {
-        const found = paths.projectSubdirs
-          .map(sub => path.join(projectDir, sub, 'rel', 'SKILL.md'))
-          .filter(p => fs.existsSync(p));
-        expect(found.length).toBeGreaterThan(0);
-        expect(fs.readFileSync(found[0], 'utf-8')).toContain('name: "rel"');
-      }
-      fs.rmSync(projectDir, { recursive: true, force: true });
-    });
   });
 });

--- a/codey-mac/electron/playbooks.ts
+++ b/codey-mac/electron/playbooks.ts
@@ -91,27 +91,6 @@ export function rollbackPlaybook(store: SkillStore, name: string): number {
   return store.get(name)!.version;
 }
 
-/** The cross-agent skill convention: an agent that lists it discovers skills
- *  any other such agent wrote. */
-const SHARED_SKILL_DIR = '.agents/skills';
-
-/** Smallest set of project-relative skill directories that EVERY agent
- *  discovers. Agents honouring `.agents/skills` collapse onto that one entry;
- *  the rest (claude-code) need their own. Takes the path table as an argument
- *  so adding an agent there keeps promotion correct without touching this. */
-export function crossAgentSkillDirs(
-  skillPaths: Record<string, { projectSubdirs: string[] }>,
-): string[] {
-  const dirs = new Set<string>();
-  for (const paths of Object.values(skillPaths)) {
-    if (paths.projectSubdirs.length === 0) continue;
-    dirs.add(paths.projectSubdirs.includes(SHARED_SKILL_DIR)
-      ? SHARED_SKILL_DIR
-      : paths.projectSubdirs[0]);
-  }
-  return [...dirs];
-}
-
 function renderSkill(name: string, description: string, whenToUse: string, steps: string): string {
   return `---
 name: ${JSON.stringify(name)}
@@ -161,8 +140,7 @@ export async function promotePlaybook(
     }
     if (!store.promoteToSkill(name)) throw new Error(`Playbook not found: ${name}`);
   } catch (error) {
-    // All-or-nothing: a skill half-written across agent conventions is worse
-    // than none, since only some agents would ever see it.
+    // Track and clean up only paths created during this attempt.
     for (const dir of created) {
       await fs.promises.rm(dir, { recursive: true, force: true });
     }

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -284,8 +284,8 @@ declare global {
         restore: (workspace: string, name: string) => Promise<IpcResult<void>>
         delete: (workspace: string, name: string) => Promise<IpcResult<void>>
         rollback: (workspace: string, name: string) => Promise<IpcResult<number>>
-        /** Writes SKILL.md into every skill dir the agents discover — `dirs`
-         *  is one entry per agent convention covered. */
+        /** Writes one durable SKILL.md under the project's `.codey/skills`.
+         *  Codey exposes it to agents through compatibility links. */
         promote: (workspace: string, name: string) => Promise<IpcResult<{ name: string; dirs: string[] }>>
       }
       agents: {

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -22,7 +22,7 @@ const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
   'pi': '~/.pi/agent/skills/',
 }
 
-export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> = ({ addRequest = 0, searchQuery = '' }) => {
+export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; codey?: boolean }> = ({ addRequest = 0, searchQuery = '', codey = false }) => {
   const [data, setData] = useState<SkillsListResult>({ skills: [], projectDir: null })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -51,6 +51,8 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     [data.skills, searchQuery, sortMode, usage],
   )
   const now = Date.now()
+  const listKey = codey ? 'codey' : agentFilter
+  const canInstall = !codey || data.projectDir !== null
 
   // The primary action lives in the parent Tools tab bar; this counter gives
   // that button a clean way to open the existing install form without a second
@@ -62,7 +64,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     }
   }, [addRequest])
 
-  const reload = useCallback(async (agent: AgentFilter) => {
+  const reload = useCallback(async (agent: AgentFilter | 'codey') => {
     setLoading(true)
     setError(null)
     try {
@@ -77,7 +79,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     // The token drops a slow scan whose agent is no longer the selected one.
     const token = ++usageToken.current
     try {
-      const next = unwrap(await window.codey.skills.usage(agent))
+      const next = agent === 'codey' ? {} : unwrap(await window.codey.skills.usage(agent))
       if (token === usageToken.current) setUsage(next)
     } catch {
       if (token === usageToken.current) setUsage({})
@@ -97,7 +99,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     }
   }, [])
 
-  useEffect(() => { void reload(agentFilter) }, [agentFilter, reload])
+  useEffect(() => { void reload(listKey) }, [listKey, reload])
 
   useEffect(() => {
     if (!copyMenuOpen) return
@@ -118,13 +120,16 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     setInstalling(true)
     setError(null)
     try {
-      const payload: Parameters<typeof window.codey.skills.install>[0] = { agent: agentFilter, scope: addScope }
+      const payload: Parameters<typeof window.codey.skills.install>[0] = {
+        agent: codey ? 'codey' : agentFilter,
+        scope: codey ? 'project' : addScope,
+      }
       if (addSource === 'localDir') payload.localDir = addInput.trim()
       else payload.gitUrl = addInput.trim()
       unwrap(await window.codey.skills.install(payload))
       setAddInput('')
       setAdding(false)
-      await reload(agentFilter)
+      await reload(listKey)
     } catch (e: any) {
       setError(e?.message ?? String(e))
     } finally {
@@ -137,7 +142,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     setError(null)
     try {
       unwrap(await window.codey.skills.remove(skill.dir))
-      await reload(agentFilter)
+      await reload(listKey)
     } catch (e: any) {
       setError(e?.message ?? String(e))
     }
@@ -227,7 +232,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           background: skill.scope === 'user' ? C.accentDim : C.surface3,
           color: skill.scope === 'user' ? C.accent : C.fg3,
         }}>
-          {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
+          {codey ? 'Codey' : skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
         </span>
       </div>
       {skill.description && (
@@ -284,7 +289,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
             background: skill.scope === 'user' ? C.accentDim : C.surface3,
             color: skill.scope === 'user' ? C.accent : C.fg3,
           }}>
-            {skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
+            {codey ? 'Codey' : skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
           </span>
           <button onClick={() => setSelected(null)} style={{ ...iconBtn, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }} title="Close" aria-label="Close"><UIIcon name="close" size={14} /></button>
         </div>
@@ -308,7 +313,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
 
         {error && <div style={{ ...styles.errorBanner, marginBottom: 12 }}>{error}</div>}
 
-        {copyState && (
+        {!codey && copyState && (
           <div style={{
             fontSize: 11, marginBottom: 12,
             color: copyState.status === 'error' ? C.red : copyState.status === 'done' ? C.accent : C.fg3,
@@ -320,7 +325,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
         )}
 
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          <div ref={copyRef} style={{ position: 'relative', display: 'flex' }}>
+          {!codey && <div ref={copyRef} style={{ position: 'relative', display: 'flex' }}>
             <button
               onClick={() => handleCopyTo(skill, AGENTS.filter(a => a.key !== agentFilter).map(a => a.key), 'all agents')}
               disabled={copyState?.status === 'copying'}
@@ -357,7 +362,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
                 ))}
               </div>
             )}
-          </div>
+          </div>}
           <span style={{ flex: 1 }} />
           <button onClick={() => handleReveal(skill.dir)} style={{ ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', gap: 6 }}><UIIcon name="folder" size={14} />Reveal in Finder</button>
           {!skill.managedBy && (
@@ -376,25 +381,35 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
       {selected && renderDetail(selected)}
       <div style={styles.agentHeader}>
         <div style={{ minWidth: 0 }}>
-          <div style={styles.eyebrow}>Coding agent</div>
-          <div style={styles.agentSwitcher} role="tablist" aria-label="Coding agent">
-            {AGENTS.map(a => {
-              const isSelected = agentFilter === a.key
-              const isActive = activeAgent === a.key
-              return (
-                <button
-                  key={a.key}
-                  role="tab"
-                  aria-selected={isSelected}
-                  onClick={() => setAgentFilter(a.key)}
-                  style={{ ...styles.agentButton, ...(isSelected ? styles.agentButtonSelected : undefined) }}
-                >
-                  {isActive && <span style={styles.activeDot} title="Default agent" />}
-                  {a.label}
-                </button>
-              )
-            })}
-          </div>
+          <div style={styles.eyebrow}>{codey ? 'Shared across coding agents' : 'Coding agent'}</div>
+          {codey ? (
+            <div style={styles.codeyHeading}>
+              <span style={styles.codeyHeadingIcon}><UIIcon name="workspace" size={15} /></span>
+              <div>
+                <div style={styles.codeyHeadingTitle}>Workspace skills</div>
+                <div style={styles.codeyHeadingSubtitle}>Stored in .codey/skills and discovered by every coding agent</div>
+              </div>
+            </div>
+          ) : (
+            <div style={styles.agentSwitcher} role="tablist" aria-label="Coding agent">
+              {AGENTS.map(a => {
+                const isSelected = agentFilter === a.key
+                const isActive = activeAgent === a.key
+                return (
+                  <button
+                    key={a.key}
+                    role="tab"
+                    aria-selected={isSelected}
+                    onClick={() => setAgentFilter(a.key)}
+                    style={{ ...styles.agentButton, ...(isSelected ? styles.agentButtonSelected : undefined) }}
+                  >
+                    {isActive && <span style={styles.activeDot} title="Default agent" />}
+                    {a.label}
+                  </button>
+                )
+              })}
+            </div>
+          )}
         </div>
         <div style={styles.agentMeta}>
           <div style={styles.smallSwitcher} role="tablist" aria-label="Sort skills">
@@ -415,7 +430,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
             ? `${filteredSkills.length} of ${data.skills.length} skills`
             : `${data.skills.length} skill${data.skills.length === 1 ? '' : 's'}`}</span>
           <button
-            onClick={() => void reload(agentFilter)}
+            onClick={() => void reload(listKey)}
             disabled={loading || busyDirs.size > 0}
             style={{ ...styles.iconButton, opacity: loading || busyDirs.size > 0 ? 0.5 : 1 }}
             title="Rescan skills"
@@ -435,7 +450,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           <div style={styles.installHeader}>
             <div>
               <div style={styles.installTitle}>Install a skill</div>
-              <div style={styles.installSubtitle}>Add it to {AGENTS.find(a => a.key === agentFilter)?.label}</div>
+              <div style={styles.installSubtitle}>{codey ? 'Share it with every coding agent in this workspace' : `Add it to ${AGENTS.find(a => a.key === agentFilter)?.label}`}</div>
             </div>
             <button
               onClick={() => { setAdding(false); setAddInput(''); setError(null) }}
@@ -446,7 +461,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           </div>
 
           <div style={styles.optionRow}>
-            <div style={styles.optionGroup}>
+            {!codey && <div style={styles.optionGroup}>
               <span style={styles.optionLabel}>Install to</span>
               <div style={styles.smallSwitcher}>
                 {(['user', 'project'] as const).map(s => {
@@ -468,7 +483,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
                   )
                 })}
               </div>
-            </div>
+            </div>}
 
             <div style={styles.optionGroup}>
               <span style={styles.optionLabel}>Source</span>
@@ -508,14 +523,15 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
             </div>
             <button
               onClick={handleInstall}
-              style={{ ...styles.installButton, opacity: installing || !addInput.trim() ? 0.45 : 1 }}
-              disabled={installing || !addInput.trim()}
+              style={{ ...styles.installButton, opacity: installing || !addInput.trim() || !canInstall ? 0.45 : 1 }}
+              disabled={installing || !addInput.trim() || !canInstall}
             >
               {installing ? 'Installing…' : <><UIIcon name="add" size={14} />Install skill</>}
             </button>
           </div>
           <div style={styles.destinationHint}>
-            Destination: <code style={styles.inlineCode}>{addScope === 'project' && data.projectDir ? data.projectDir : AGENT_SKILL_HINTS[agentFilter]}</code>
+            Destination: <code style={styles.inlineCode}>{codey ? (data.projectDir ?? '.codey/skills') : addScope === 'project' && data.projectDir ? data.projectDir : AGENT_SKILL_HINTS[agentFilter]}</code>
+            {codey && !canInstall && <span style={{ color: C.red, marginLeft: 8 }}>Select a workspace first.</span>}
           </div>
         </section>
       ) : null}
@@ -525,9 +541,9 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
       ) : data.skills.length === 0 ? (
         <div style={styles.emptyState}>
           <div style={{ width: 52, height: 52, margin: '0 auto 12px', borderRadius: 16, display: 'grid', placeItems: 'center', background: C.accentDim, color: C.accent }}><UIIcon name="sparkle" size={24} /></div>
-          <div style={{ fontWeight: 650, color: C.fg, marginBottom: 5 }}>No skills found for {AGENTS.find(a => a.key === agentFilter)?.label}</div>
+          <div style={{ fontWeight: 650, color: C.fg, marginBottom: 5 }}>{codey ? 'No Codey skills found' : `No skills found for ${AGENTS.find(a => a.key === agentFilter)?.label}`}</div>
           <div style={{ fontSize: 12, lineHeight: 1.55 }}>
-            Add a skill or place one in <code style={styles.inlineCode}>{AGENT_SKILL_HINTS[agentFilter]}</code>
+            Add a skill or place one in <code style={styles.inlineCode}>{codey ? (data.projectDir ?? '.codey/skills') : AGENT_SKILL_HINTS[agentFilter]}</code>
           </div>
         </div>
       ) : filteredSkills.length === 0 ? (
@@ -601,6 +617,15 @@ const styles: Record<string, React.CSSProperties> = {
     width: 6, height: 6, borderRadius: '50%', background: C.accent,
     boxShadow: `0 0 0 3px ${C.accentDim}`, flexShrink: 0,
   },
+  codeyHeading: {
+    display: 'flex', alignItems: 'center', gap: 10,
+  },
+  codeyHeadingIcon: {
+    width: 34, height: 34, borderRadius: 9, display: 'grid', placeItems: 'center',
+    color: C.accent, background: C.accentDim, flexShrink: 0,
+  },
+  codeyHeadingTitle: { color: C.fg, fontSize: 13, fontWeight: 700 },
+  codeyHeadingSubtitle: { color: C.fg3, fontSize: 11, marginTop: 2 },
   agentMeta: {
     display: 'flex', alignItems: 'center', gap: 8, color: C.fg3,
     fontSize: 11, paddingBottom: 1,

--- a/codey-mac/src/components/ToolsView.tsx
+++ b/codey-mac/src/components/ToolsView.tsx
@@ -9,10 +9,11 @@ import { UIIcon, type IconName } from './UIIcons'
 
 interface Props { onClose: () => void }
 
-type Tab = 'skills' | 'playbooks' | 'plugins' | 'mcp'
+type Tab = 'skills' | 'codeySkills' | 'playbooks' | 'plugins' | 'mcp'
 
 const TABS: { key: Tab; label: string; icon: IconName }[] = [
   { key: 'skills',  label: 'Skills',  icon: 'sparkle' },
+  { key: 'codeySkills', label: 'Codey Skills', icon: 'workspace' },
   { key: 'playbooks', label: 'Playbooks', icon: 'archive' },
   { key: 'plugins', label: 'Plugins', icon: 'tools' },
   { key: 'mcp', label: 'MCPs', icon: 'server' },
@@ -21,6 +22,7 @@ const TABS: { key: Tab; label: string; icon: IconName }[] = [
 export const ToolsView: React.FC<Props> = ({ onClose }) => {
   const [tab, setTab] = useState<Tab>('skills')
   const [addSkillRequest, setAddSkillRequest] = useState(0)
+  const [addCodeySkillRequest, setAddCodeySkillRequest] = useState(0)
   const [searchQuery, setSearchQuery] = useState('')
 
   return (
@@ -61,14 +63,20 @@ export const ToolsView: React.FC<Props> = ({ onClose }) => {
             ><UIIcon name="close" size={12} /></button>
           )}
         </div>
-        {tab === 'skills' && (
-          <button style={styles.addSkillBtn} onClick={() => setAddSkillRequest(v => v + 1)}>
+        {(tab === 'skills' || tab === 'codeySkills') && (
+          <button
+            style={styles.addSkillBtn}
+            onClick={() => tab === 'codeySkills'
+              ? setAddCodeySkillRequest(v => v + 1)
+              : setAddSkillRequest(v => v + 1)}
+          >
             <UIIcon name="add" size={15} />Add skill
           </button>
         )}
       </div>
       <div style={styles.body}>
         {tab === 'skills'  && <SkillsTab addRequest={addSkillRequest} searchQuery={searchQuery} />}
+        {tab === 'codeySkills' && <SkillsTab codey addRequest={addCodeySkillRequest} searchQuery={searchQuery} />}
         {tab === 'playbooks' && <PlaybooksTab searchQuery={searchQuery} />}
         {tab === 'plugins' && <PluginsTab searchQuery={searchQuery} />}
         {tab === 'mcp' && <McpTab searchQuery={searchQuery} />}

--- a/packages/core/src/agents/codey-skills.test.ts
+++ b/packages/core/src/agents/codey-skills.test.ts
@@ -1,0 +1,117 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  CODEY_SKILL_DISCOVERY_SUBDIRS,
+  CODEY_SKILLS_SUBDIR,
+  syncCodeyProjectSkills,
+} from './codey-skills';
+import { AgentFactory } from './index';
+import type { CodingAgentAdapter } from './base';
+
+const roots: string[] = [];
+
+function project(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-shared-skills-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('Codey project skills', () => {
+  it('links one source skill into every agent discovery convention', async () => {
+    const root = project();
+    const skill = path.join(root, CODEY_SKILLS_SUBDIR, 'release');
+    fs.mkdirSync(skill, { recursive: true });
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: release\n---\n');
+
+    const result = await syncCodeyProjectSkills(root);
+
+    expect(result.linked).toHaveLength(CODEY_SKILL_DISCOVERY_SUBDIRS.length);
+    for (const subdir of CODEY_SKILL_DISCOVERY_SUBDIRS) {
+      const linked = path.join(root, subdir, 'release');
+      expect(fs.lstatSync(linked).isSymbolicLink()).toBe(true);
+      expect(fs.realpathSync(linked)).toBe(fs.realpathSync(skill));
+      expect(fs.readFileSync(path.join(linked, 'SKILL.md'), 'utf-8')).toContain('name: release');
+    }
+  });
+
+  it('is idempotent', async () => {
+    const root = project();
+    fs.mkdirSync(path.join(root, CODEY_SKILLS_SUBDIR, 'one'), { recursive: true });
+
+    await syncCodeyProjectSkills(root);
+    const second = await syncCodeyProjectSkills(root);
+
+    expect(second.linked).toEqual([]);
+    expect(second.existing).toHaveLength(CODEY_SKILL_DISCOVERY_SUBDIRS.length);
+    expect(second.conflicts).toEqual([]);
+    expect(second.removed).toEqual([]);
+  });
+
+  it('does not overwrite an agent-native skill with the same name', async () => {
+    const root = project();
+    fs.mkdirSync(path.join(root, CODEY_SKILLS_SUBDIR, 'one'), { recursive: true });
+    const native = path.join(root, CODEY_SKILL_DISCOVERY_SUBDIRS[0], 'one');
+    fs.mkdirSync(native, { recursive: true });
+    fs.writeFileSync(path.join(native, 'SKILL.md'), 'native');
+
+    const result = await syncCodeyProjectSkills(root);
+
+    expect(result.conflicts).toEqual([native]);
+    expect(fs.lstatSync(native).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(native, 'SKILL.md'), 'utf-8')).toBe('native');
+  });
+
+  it('cleans up its broken links after a Codey skill is removed', async () => {
+    const root = project();
+    const skill = path.join(root, CODEY_SKILLS_SUBDIR, 'one');
+    fs.mkdirSync(skill, { recursive: true });
+    await syncCodeyProjectSkills(root);
+    fs.rmSync(skill, { recursive: true });
+
+    const result = await syncCodeyProjectSkills(root);
+
+    expect(result.removed).toHaveLength(CODEY_SKILL_DISCOVERY_SUBDIRS.length);
+    for (const subdir of CODEY_SKILL_DISCOVERY_SUBDIRS) {
+      expect(() => fs.lstatSync(path.join(root, subdir, 'one'))).toThrow();
+    }
+  });
+
+  it('does nothing when the project has no Codey skills directory', async () => {
+    const root = project();
+    const result = await syncCodeyProjectSkills(root);
+    expect(result.linked).toEqual([]);
+    for (const subdir of CODEY_SKILL_DISCOVERY_SUBDIRS) {
+      expect(fs.existsSync(path.join(root, subdir))).toBe(false);
+    }
+  });
+
+  it('is synchronized by AgentFactory before the coding agent starts', async () => {
+    const root = project();
+    fs.mkdirSync(path.join(root, CODEY_SKILLS_SUBDIR, 'one'), { recursive: true });
+    const expected = path.join(root, CODEY_SKILL_DISCOVERY_SUBDIRS[0], 'one');
+    let visibleAtRun = false;
+    const adapter: CodingAgentAdapter = {
+      name: 'codex',
+      run: async () => {
+        visibleAtRun = fs.existsSync(expected);
+        return { success: true, output: 'ok' };
+      },
+    };
+    const factory = new AgentFactory();
+    factory.register('codex', adapter);
+
+    await factory.run('codex', {
+      agent: 'codex',
+      prompt: 'work',
+      context: { workingDir: root },
+    });
+
+    expect(visibleAtRun).toBe(true);
+  });
+});

--- a/packages/core/src/agents/codey-skills.ts
+++ b/packages/core/src/agents/codey-skills.ts
@@ -1,0 +1,111 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** The project-owned source of truth for skills managed by Codey. */
+export const CODEY_SKILLS_SUBDIR = path.join('.codey', 'skills');
+
+/**
+ * The smallest set of project skill roots covering every agent Codey runs.
+ * Claude Code uses its own directory; Codex, OpenCode, and pi all understand
+ * the cross-agent `.agents/skills` convention.
+ */
+export const CODEY_SKILL_DISCOVERY_SUBDIRS = [
+  path.join('.claude', 'skills'),
+  path.join('.agents', 'skills'),
+] as const;
+
+export interface CodeySkillSyncResult {
+  sourceRoot: string;
+  linked: string[];
+  existing: string[];
+  conflicts: string[];
+  removed: string[];
+}
+
+function isDirectory(entryPath: string): boolean {
+  try { return fs.statSync(entryPath).isDirectory(); } catch { return false; }
+}
+
+function pointsTo(linkPath: string, sourcePath: string): boolean {
+  try {
+    if (!fs.lstatSync(linkPath).isSymbolicLink()) return false;
+    const target = fs.readlinkSync(linkPath);
+    return path.resolve(path.dirname(linkPath), target) === path.resolve(sourcePath);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Make every top-level Codey skill/collection visible through the native
+ * project directories watched by the supported coding agents.
+ *
+ * Links are created per top-level entry instead of replacing an agent's whole
+ * skills directory, so hand-written/native skills remain untouched. Existing
+ * names are never overwritten. Relative links keep working when a project is
+ * moved as a unit (Windows junctions require an absolute target).
+ */
+export async function syncCodeyProjectSkills(workingDir: string): Promise<CodeySkillSyncResult> {
+  const projectRoot = path.resolve(workingDir);
+  const sourceRoot = path.join(projectRoot, CODEY_SKILLS_SUBDIR);
+  const result: CodeySkillSyncResult = { sourceRoot, linked: [], existing: [], conflicts: [], removed: [] };
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(sourceRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return result;
+    throw error;
+  }
+
+  const sources = entries
+    .filter(entry => entry.isDirectory() || (entry.isSymbolicLink() && isDirectory(path.join(sourceRoot, entry.name))))
+    .map(entry => ({ name: entry.name, dir: path.join(sourceRoot, entry.name) }));
+
+  for (const discoverySubdir of CODEY_SKILL_DISCOVERY_SUBDIRS) {
+    const discoveryRoot = path.join(projectRoot, discoverySubdir);
+    await fs.promises.mkdir(discoveryRoot, { recursive: true });
+
+    // Remove only broken links whose declared target is inside Codey's own
+    // source root. Native links and real directories are never touched.
+    const discoveryEntries = await fs.promises.readdir(discoveryRoot, { withFileTypes: true });
+    for (const entry of discoveryEntries) {
+      if (!entry.isSymbolicLink()) continue;
+      const linkPath = path.join(discoveryRoot, entry.name);
+      let target: string;
+      try {
+        target = path.resolve(discoveryRoot, await fs.promises.readlink(linkPath));
+      } catch {
+        continue;
+      }
+      const belongsToCodey = target.startsWith(`${sourceRoot}${path.sep}`);
+      if (belongsToCodey && !fs.existsSync(target)) {
+        await fs.promises.unlink(linkPath);
+        result.removed.push(linkPath);
+      }
+    }
+
+    for (const source of sources) {
+      const linkPath = path.join(discoveryRoot, source.name);
+      if (pointsTo(linkPath, source.dir)) {
+        result.existing.push(linkPath);
+        continue;
+      }
+      try {
+        await fs.promises.lstat(linkPath);
+        result.conflicts.push(linkPath);
+        continue;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+
+      const target = process.platform === 'win32'
+        ? source.dir
+        : path.relative(discoveryRoot, source.dir);
+      await fs.promises.symlink(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+      result.linked.push(linkPath);
+    }
+  }
+
+  return result;
+}

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -4,6 +4,7 @@ import { ClaudeCodeAdapter } from './claude-code';
 import { OpenCodeAdapter } from './opencode';
 import { CodexAdapter } from './codex';
 import { PiAdapter } from './pi';
+import { syncCodeyProjectSkills } from './codey-skills';
 
 export type { CodingAgentAdapter } from './base';
 export { ClaudeCodeAdapter } from './claude-code';
@@ -11,6 +12,7 @@ export { OpenCodeAdapter } from './opencode';
 export { CodexAdapter } from './codex';
 export { PiAdapter } from './pi';
 export { applyModelEnv } from './env';
+export * from './codey-skills';
 
 /**
  * Attach the in-app browser MCP server to a task-performing agent turn.
@@ -152,6 +154,18 @@ export class AgentFactory {
 
     request = addCodeyBrowserMcp(request, this.pluginEnabledProvider?.('browser') === true);
     request = addExternalMcpServers(request, this.externalMcpProvider?.());
+
+    // `.codey/skills` is Codey's project-level source of truth. Refresh the
+    // lightweight compatibility links immediately before every CLI launch so
+    // skills added by hand are available without restarting Codey.
+    if (request.context?.workingDir) {
+      try {
+        await syncCodeyProjectSkills(request.context.workingDir);
+      } catch {
+        // Skill-link setup must never prevent the user's actual task from
+        // running (read-only projects and restricted filesystems are valid).
+      }
+    }
 
     return adapter.run(request);
   }


### PR DESCRIPTION
## What changed

- Add `.codey/skills` as the single project-level source of truth for Codey-managed skills.
- Synchronize per-skill compatibility symlinks into `.claude/skills` and `.agents/skills` before each coding-agent request.
- Preserve existing native skills with the same name and remove stale Codey-owned links.
- Install project skills and promote playbooks into `.codey/skills`, then refresh discovery links.
- Add coverage for linking, idempotency, conflicts, stale-link cleanup, missing directories, and request-time synchronization.

## Why

Project skills previously needed separate copies in agent-specific discovery directories. A shared Codey-owned location avoids duplication while keeping every supported coding agent native discovery behavior working.

## Impact

Users can add a skill once under `.codey/skills` and have Claude Code, Codex, OpenCode, and pi discover it automatically. Existing agent-native skills are not overwritten.

## Validation

- Core: 498 tests passed
- Codey Mac: 543 tests passed
- Core TypeScript build passed
- Gateway TypeScript build passed
- Lint passed
- `git diff --check` passed