### PR TITLE
Balance tool-detail card padding

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -374,6 +374,10 @@ const Shell: React.FC = () => {
   /* User bubbles do not need a trailing Markdown block gap: it otherwise
      reads as extra bottom padding below short messages. */
   .md-user > :last-child { margin-bottom: 0 !important; }
+  /* Tool-detail labels carry a top margin to separate consecutive blocks. On the
+     first label that margin stacks with the card's padding and reads as a
+     lopsided top gap. */
+  .tool-detail > :first-child { margin-top: 0 !important; }
   /* Find-in-chat (⌘F). The ranges are registered from ChatFindBar via the CSS
      Custom Highlight API, which paints without touching the rendered Markdown.
      The current hit inverts to the accent so it reads apart from the rest. */

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -258,7 +258,7 @@ const LiveActivity: React.FC<{ toolCalls?: import('../types').ToolCallEntry[] }>
         <span style={styles.liveActivityText}>{headline}</span>
       </div>
       {expanded && canExpand && detailTarget && (
-        <div style={styles.liveActivityDetail}>
+        <div className="tool-detail" style={styles.liveActivityDetail}>
           <ToolDetail rawTool={detailTarget.tool} input={detailTarget.input} output={detailTarget.output} />
         </div>
       )}

--- a/codey-mac/src/components/ToolCallList.tsx
+++ b/codey-mac/src/components/ToolCallList.tsx
@@ -99,7 +99,7 @@ export const ToolCallList: React.FC<{ toolCalls: ToolCallEntry[]; emptyHint?: st
               )}
             </div>
             {hasDetail && isOpen && (
-              <div style={timelineStyles.detail}>
+              <div className="tool-detail" style={timelineStyles.detail}>
                 <ToolDetail rawTool={r.tool} input={r.input ?? {}} output={r.output} />
                 {!r.done && !r.output && (
                   <div style={timelineStyles.detailLabel}>(no result yet)</div>


### PR DESCRIPTION
展开的 tool call 详情卡片里，`INPUT` 上面的留白比代码块下面的大。

原因：block 标签有 `marginTop: 7`（`toolFormat.tsx:531`），用来分隔连续的 block（INPUT / OUTPUT）。第一个标签上面没有东西要分隔，这个 margin 直接叠在卡片的 `padding: 9` 上 —— 顶部 16、底部 9。

改法沿用已有的 `.md-roomy > :first-child` 套路：加一条 `.tool-detail > :first-child { margin-top: 0 !important; }`，并给 `ToolCallList` 和 `ChatTab` 的详情容器加 `className="tool-detail"`。block 之间的间距不变。

## 验证
- `npx tsc --noEmit -p codey-mac/tsconfig.json` 通过
- 视觉效果未在打包 app 里跑过

🤖 Generated with [Claude Code](https://claude.com/claude-code)