### PR TITLE
Make Codey skills global and fold them into the Skills tab

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -30,7 +30,7 @@ import * as pty from 'node-pty'
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
 ])
-import { CODEY_SKILLS_SUBDIR, syncCodeyProjectSkills, WorkerManager, WorkspaceManager } from '@codey/core'
+import { CODEY_GLOBAL_SKILLS_SUBDIR, CODEY_SKILLS_SUBDIR, syncCodeyGlobalSkills, syncCodeyProjectSkills, WorkerManager, WorkspaceManager } from '@codey/core'
 import { listPlaybooks, playbookDetail, playbookHistory, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
@@ -1611,6 +1611,17 @@ app.whenReady().then(async () => {
     app.quit()
     return
   }
+
+  // Global Codey skills live in ~/.codey/skills regardless of where the rest
+  // of the data root sits, so the folder exists (and is linked into every
+  // agent's discovery path) before the first agent run.
+  try {
+    const fsMod = await import('fs')
+    const osMod = await import('os')
+    const pathMod = await import('path')
+    await fsMod.promises.mkdir(pathMod.join(osMod.homedir(), CODEY_GLOBAL_SKILLS_SUBDIR), { recursive: true })
+    await syncCodeyGlobalSkills()
+  } catch { /* best-effort: skills stay listed even if linking fails */ }
 
   const browserSession = session.fromPartition(BROWSER_PARTITION, { cache: true })
   browserSitePermissions = new BrowserSitePermissionManager(
@@ -3364,7 +3375,9 @@ app.whenReady().then(async () => {
 
   // ── Skills IPC ────────────────────────────────────────────────────
   const skillPaths: Record<string, { userDirs: string[]; projectSubdirs: string[] }> = {
-    'codey':       { userDirs: [], projectSubdirs: [CODEY_SKILLS_SUBDIR] },
+    // Codey's own skills live globally in ~/.codey/skills and, for skills that
+    // belong to one repository, in <project>/.codey/skills.
+    'codey':       { userDirs: [CODEY_GLOBAL_SKILLS_SUBDIR], projectSubdirs: [CODEY_SKILLS_SUBDIR] },
     'claude-code': { userDirs: ['.claude/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.claude/skills'] },
     // Codex and OpenCode also discover the cross-agent .agents convention.
     'codex':       { userDirs: ['.codex/skills', '.agents/skills'], projectSubdirs: [CODEY_SKILLS_SUBDIR, '.codex/skills', '.agents/skills'] },
@@ -3513,8 +3526,13 @@ app.whenReady().then(async () => {
 
       const home = osMod.homedir()
       let projectWorkingDir: string | undefined
+      // Codey skills are exposed to the agents through compatibility links, so
+      // every install refreshes the links for whichever root it wrote into.
+      const relink = async () => {
+        if (projectWorkingDir) await syncCodeyProjectSkills(projectWorkingDir)
+        else if (agentKey === 'codey') await syncCodeyGlobalSkills(home)
+      }
       const getTargetRoot = async (): Promise<string> => {
-        if (agentKey === 'codey' && payload.scope !== 'project') throw new Error('Codey skills are workspace-scoped')
         if (payload.scope === 'user') return configuredUserSkillDirs(agentKey, home, pathMod)[0]
         if (!workspaceManager) throw new Error('No workspace manager')
         const wsName = workspaceManager.getCurrentWorkspace()
@@ -3534,7 +3552,7 @@ app.whenReady().then(async () => {
         const src = resolveUserPath(pathMod, payload.localDir, home)
         if (!fsMod.existsSync(src) || !fsMod.statSync(src).isDirectory()) throw new Error(`Not a directory: ${src}`)
         if (samePath(fsMod, pathMod, src, targetRoot)) {
-          if (projectWorkingDir) await syncCodeyProjectSkills(projectWorkingDir)
+          await relink()
           return { name: pathMod.basename(targetRoot), dir: targetRoot }
         }
         const rootSkillFile = pathMod.join(src, SKILL_FILE)
@@ -3572,7 +3590,7 @@ app.whenReady().then(async () => {
           await fsMod.promises.cp(source.dir, dest, { recursive: true })
           installed.push({ name: source.name, dir: dest })
         }
-        if (projectWorkingDir) await syncCodeyProjectSkills(projectWorkingDir)
+        await relink()
         return installed.length === 1 ? installed[0] : { name: `${installed.length} skills`, dir: targetRoot }
       }
 
@@ -3585,7 +3603,7 @@ app.whenReady().then(async () => {
         const dest = pathMod.join(targetRoot, name)
         if (fsMod.existsSync(dest)) throw new Error(`Skill already exists: ${name}`)
         await execFileAsync('git', ['clone', '--depth', '1', url, dest])
-        if (projectWorkingDir) await syncCodeyProjectSkills(projectWorkingDir)
+        await relink()
         return { name, dir: dest }
       }
 
@@ -3611,6 +3629,7 @@ app.whenReady().then(async () => {
       await fsMod.promises.rm(dir, { recursive: true, force: true })
       const workingDir = getWorkingDir(fsMod, pathMod)
       if (workingDir) await syncCodeyProjectSkills(workingDir)
+      await syncCodeyGlobalSkills()
     })
   )
 

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -15,6 +15,10 @@ const AGENTS: { key: AgentFilter; label: string }[] = [
   { key: 'pi',          label: 'Pi' },
 ]
 
+/** Codey's own skills are global; a workspace can still hold repo-local ones. */
+const CODEY_GLOBAL_SKILLS_HINT = '~/.codey/skills'
+const CODEY_PROJECT_SKILLS_HINT = '.codey/skills'
+
 const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
   'claude-code': '~/.claude/skills/',
   'codex': '~/.codex/skills/',
@@ -22,12 +26,17 @@ const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
   'pi': '~/.pi/agent/skills/',
 }
 
-export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; codey?: boolean }> = ({ addRequest = 0, searchQuery = '', codey = false }) => {
+export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> = ({ addRequest = 0, searchQuery = '' }) => {
+  // Codey's own skills are the leftmost segment of the same switcher that
+  // selects a coding agent: one list, one source picker.
+  const [codey, setCodey] = useState(true)
   const [data, setData] = useState<SkillsListResult>({ skills: [], projectDir: null })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [adding, setAdding] = useState(false)
   const [addScope, setAddScope] = useState<'user' | 'project'>('user')
+  // Codey installs default to the global root; the project root is offered
+  // only when a workspace is open.
   const [addSource, setAddSource] = useState<'localDir' | 'gitUrl'>('localDir')
   const [addInput, setAddInput] = useState('')
   const [installing, setInstalling] = useState(false)
@@ -52,7 +61,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
   )
   const now = Date.now()
   const listKey = codey ? 'codey' : agentFilter
-  const canInstall = !codey || data.projectDir !== null
+  const canInstall = addScope === 'user' || data.projectDir !== null
 
   // The primary action lives in the parent Tools tab bar; this counter gives
   // that button a clean way to open the existing install form without a second
@@ -122,7 +131,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
     try {
       const payload: Parameters<typeof window.codey.skills.install>[0] = {
         agent: codey ? 'codey' : agentFilter,
-        scope: codey ? 'project' : addScope,
+        scope: addScope,
       }
       if (addSource === 'localDir') payload.localDir = addInput.trim()
       else payload.gitUrl = addInput.trim()
@@ -232,7 +241,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
           background: skill.scope === 'user' ? C.accentDim : C.surface3,
           color: skill.scope === 'user' ? C.accent : C.fg3,
         }}>
-          {codey ? 'Codey' : skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
+          {codey ? (skill.scope === 'user' ? 'Global' : 'Project') : skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
         </span>
       </div>
       {skill.description && (
@@ -289,7 +298,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
             background: skill.scope === 'user' ? C.accentDim : C.surface3,
             color: skill.scope === 'user' ? C.accent : C.fg3,
           }}>
-            {codey ? 'Codey' : skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
+            {codey ? (skill.scope === 'user' ? 'Global' : 'Project') : skill.managedBy ? 'Plugin' : skill.scope === 'user' ? 'User' : 'Project'}
           </span>
           <button onClick={() => setSelected(null)} style={{ ...iconBtn, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }} title="Close" aria-label="Close"><UIIcon name="close" size={14} /></button>
         </div>
@@ -381,35 +390,40 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
       {selected && renderDetail(selected)}
       <div style={styles.agentHeader}>
         <div style={{ minWidth: 0 }}>
-          <div style={styles.eyebrow}>{codey ? 'Shared across coding agents' : 'Coding agent'}</div>
-          {codey ? (
-            <div style={styles.codeyHeading}>
-              <span style={styles.codeyHeadingIcon}><UIIcon name="workspace" size={15} /></span>
-              <div>
-                <div style={styles.codeyHeadingTitle}>Workspace skills</div>
-                <div style={styles.codeyHeadingSubtitle}>Stored in .codey/skills and discovered by every coding agent</div>
-              </div>
-            </div>
-          ) : (
-            <div style={styles.agentSwitcher} role="tablist" aria-label="Coding agent">
-              {AGENTS.map(a => {
-                const isSelected = agentFilter === a.key
-                const isActive = activeAgent === a.key
-                return (
-                  <button
-                    key={a.key}
-                    role="tab"
-                    aria-selected={isSelected}
-                    onClick={() => setAgentFilter(a.key)}
-                    style={{ ...styles.agentButton, ...(isSelected ? styles.agentButtonSelected : undefined) }}
-                  >
-                    {isActive && <span style={styles.activeDot} title="Default agent" />}
-                    {a.label}
-                  </button>
-                )
-              })}
-            </div>
-          )}
+          <div style={styles.agentSwitcher} role="tablist" aria-label="Skill source">
+            <button
+              role="tab"
+              aria-selected={codey}
+              onClick={() => setCodey(true)}
+              title={`Shared with every coding agent — stored in ${CODEY_GLOBAL_SKILLS_HINT}`}
+              style={{ ...styles.agentButton, ...(codey ? styles.agentButtonSelected : undefined) }}
+            >
+              <UIIcon name="sparkle" size={13} />
+              Codey
+            </button>
+            <span style={styles.switcherDivider} />
+            {AGENTS.map(a => {
+              const isSelected = !codey && agentFilter === a.key
+              const isActive = activeAgent === a.key
+              return (
+                <button
+                  key={a.key}
+                  role="tab"
+                  aria-selected={isSelected}
+                  onClick={() => { setCodey(false); setAgentFilter(a.key) }}
+                  style={{ ...styles.agentButton, ...(isSelected ? styles.agentButtonSelected : undefined) }}
+                >
+                  {isActive && <span style={styles.activeDot} title="Default agent" />}
+                  {a.label}
+                </button>
+              )
+            })}
+          </div>
+          <div style={styles.sourceHint}>
+            {codey
+              ? `Stored in ${CODEY_GLOBAL_SKILLS_HINT} and discovered by every coding agent`
+              : `Installed for ${AGENTS.find(a => a.key === agentFilter)?.label} only`}
+          </div>
         </div>
         <div style={styles.agentMeta}>
           <div style={styles.smallSwitcher} role="tablist" aria-label="Sort skills">
@@ -450,7 +464,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
           <div style={styles.installHeader}>
             <div>
               <div style={styles.installTitle}>Install a skill</div>
-              <div style={styles.installSubtitle}>{codey ? 'Share it with every coding agent in this workspace' : `Add it to ${AGENTS.find(a => a.key === agentFilter)?.label}`}</div>
+              <div style={styles.installSubtitle}>{codey ? 'Share it with every coding agent' : `Add it to ${AGENTS.find(a => a.key === agentFilter)?.label}`}</div>
             </div>
             <button
               onClick={() => { setAdding(false); setAddInput(''); setError(null) }}
@@ -461,7 +475,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
           </div>
 
           <div style={styles.optionRow}>
-            {!codey && <div style={styles.optionGroup}>
+            <div style={styles.optionGroup}>
               <span style={styles.optionLabel}>Install to</span>
               <div style={styles.smallSwitcher}>
                 {(['user', 'project'] as const).map(s => {
@@ -478,12 +492,12 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
                       disabled={unavailable}
                       title={unavailable ? 'No active workspace' : s === 'user' ? 'Available across projects' : 'Only this project'}
                     >
-                      {s === 'user' ? 'User' : 'Project'}
+                      {s === 'user' ? (codey ? 'Global' : 'User') : 'Project'}
                     </button>
                   )
                 })}
               </div>
-            </div>}
+            </div>
 
             <div style={styles.optionGroup}>
               <span style={styles.optionLabel}>Source</span>
@@ -530,8 +544,10 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
             </button>
           </div>
           <div style={styles.destinationHint}>
-            Destination: <code style={styles.inlineCode}>{codey ? (data.projectDir ?? '.codey/skills') : addScope === 'project' && data.projectDir ? data.projectDir : AGENT_SKILL_HINTS[agentFilter]}</code>
-            {codey && !canInstall && <span style={{ color: C.red, marginLeft: 8 }}>Select a workspace first.</span>}
+            Destination: <code style={styles.inlineCode}>{addScope === 'project'
+              ? (data.projectDir ?? (codey ? CODEY_PROJECT_SKILLS_HINT : 'the current workspace'))
+              : codey ? CODEY_GLOBAL_SKILLS_HINT : AGENT_SKILL_HINTS[agentFilter]}</code>
+            {!canInstall && <span style={{ color: C.red, marginLeft: 8 }}>Select a workspace first.</span>}
           </div>
         </section>
       ) : null}
@@ -543,7 +559,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string; co
           <div style={{ width: 52, height: 52, margin: '0 auto 12px', borderRadius: 16, display: 'grid', placeItems: 'center', background: C.accentDim, color: C.accent }}><UIIcon name="sparkle" size={24} /></div>
           <div style={{ fontWeight: 650, color: C.fg, marginBottom: 5 }}>{codey ? 'No Codey skills found' : `No skills found for ${AGENTS.find(a => a.key === agentFilter)?.label}`}</div>
           <div style={{ fontSize: 12, lineHeight: 1.55 }}>
-            Add a skill or place one in <code style={styles.inlineCode}>{codey ? (data.projectDir ?? '.codey/skills') : AGENT_SKILL_HINTS[agentFilter]}</code>
+            Add a skill or place one in <code style={styles.inlineCode}>{codey ? CODEY_GLOBAL_SKILLS_HINT : AGENT_SKILL_HINTS[agentFilter]}</code>
           </div>
         </div>
       ) : filteredSkills.length === 0 ? (
@@ -593,12 +609,8 @@ const iconBtn: React.CSSProperties = {
 const styles: Record<string, React.CSSProperties> = {
   root: { height: '100%', overflowY: 'auto', position: 'relative' },
   agentHeader: {
-    display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between',
+    display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
     gap: 16, marginBottom: 18, flexWrap: 'wrap',
-  },
-  eyebrow: {
-    color: C.fg3, fontSize: 10, fontWeight: 750, letterSpacing: 0.75,
-    textTransform: 'uppercase', marginBottom: 7,
   },
   agentSwitcher: {
     display: 'inline-flex', alignItems: 'center', padding: 3, gap: 2,
@@ -617,15 +629,10 @@ const styles: Record<string, React.CSSProperties> = {
     width: 6, height: 6, borderRadius: '50%', background: C.accent,
     boxShadow: `0 0 0 3px ${C.accentDim}`, flexShrink: 0,
   },
-  codeyHeading: {
-    display: 'flex', alignItems: 'center', gap: 10,
+  switcherDivider: {
+    width: 1, alignSelf: 'stretch', margin: '4px 4px', background: C.border2, flexShrink: 0,
   },
-  codeyHeadingIcon: {
-    width: 34, height: 34, borderRadius: 9, display: 'grid', placeItems: 'center',
-    color: C.accent, background: C.accentDim, flexShrink: 0,
-  },
-  codeyHeadingTitle: { color: C.fg, fontSize: 13, fontWeight: 700 },
-  codeyHeadingSubtitle: { color: C.fg3, fontSize: 11, marginTop: 2 },
+  sourceHint: { color: C.fg3, fontSize: 11, marginTop: 7 },
   agentMeta: {
     display: 'flex', alignItems: 'center', gap: 8, color: C.fg3,
     fontSize: 11, paddingBottom: 1,

--- a/codey-mac/src/components/ToolsView.tsx
+++ b/codey-mac/src/components/ToolsView.tsx
@@ -9,11 +9,10 @@ import { UIIcon, type IconName } from './UIIcons'
 
 interface Props { onClose: () => void }
 
-type Tab = 'skills' | 'codeySkills' | 'playbooks' | 'plugins' | 'mcp'
+type Tab = 'skills' | 'playbooks' | 'plugins' | 'mcp'
 
 const TABS: { key: Tab; label: string; icon: IconName }[] = [
   { key: 'skills',  label: 'Skills',  icon: 'sparkle' },
-  { key: 'codeySkills', label: 'Codey Skills', icon: 'workspace' },
   { key: 'playbooks', label: 'Playbooks', icon: 'archive' },
   { key: 'plugins', label: 'Plugins', icon: 'tools' },
   { key: 'mcp', label: 'MCPs', icon: 'server' },
@@ -22,7 +21,6 @@ const TABS: { key: Tab; label: string; icon: IconName }[] = [
 export const ToolsView: React.FC<Props> = ({ onClose }) => {
   const [tab, setTab] = useState<Tab>('skills')
   const [addSkillRequest, setAddSkillRequest] = useState(0)
-  const [addCodeySkillRequest, setAddCodeySkillRequest] = useState(0)
   const [searchQuery, setSearchQuery] = useState('')
 
   return (
@@ -63,20 +61,17 @@ export const ToolsView: React.FC<Props> = ({ onClose }) => {
             ><UIIcon name="close" size={12} /></button>
           )}
         </div>
-        {(tab === 'skills' || tab === 'codeySkills') && (
+        {tab === 'skills' && (
           <button
             style={styles.addSkillBtn}
-            onClick={() => tab === 'codeySkills'
-              ? setAddCodeySkillRequest(v => v + 1)
-              : setAddSkillRequest(v => v + 1)}
+            onClick={() => setAddSkillRequest(v => v + 1)}
           >
             <UIIcon name="add" size={15} />Add skill
           </button>
         )}
       </div>
       <div style={styles.body}>
-        {tab === 'skills'  && <SkillsTab addRequest={addSkillRequest} searchQuery={searchQuery} />}
-        {tab === 'codeySkills' && <SkillsTab codey addRequest={addCodeySkillRequest} searchQuery={searchQuery} />}
+        {tab === 'skills' && <SkillsTab addRequest={addSkillRequest} searchQuery={searchQuery} />}
         {tab === 'playbooks' && <PlaybooksTab searchQuery={searchQuery} />}
         {tab === 'plugins' && <PluginsTab searchQuery={searchQuery} />}
         {tab === 'mcp' && <McpTab searchQuery={searchQuery} />}

--- a/packages/core/src/agents/codey-skills.test.ts
+++ b/packages/core/src/agents/codey-skills.test.ts
@@ -3,8 +3,10 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  CODEY_GLOBAL_SKILLS_SUBDIR,
   CODEY_SKILL_DISCOVERY_SUBDIRS,
   CODEY_SKILLS_SUBDIR,
+  syncCodeyGlobalSkills,
   syncCodeyProjectSkills,
 } from './codey-skills';
 import { AgentFactory } from './index';
@@ -93,6 +95,9 @@ describe('Codey project skills', () => {
 
   it('is synchronized by AgentFactory before the coding agent starts', async () => {
     const root = project();
+    // The factory also links the global root; keep that off the real home.
+    const previousHome = process.env.HOME;
+    process.env.HOME = project();
     fs.mkdirSync(path.join(root, CODEY_SKILLS_SUBDIR, 'one'), { recursive: true });
     const expected = path.join(root, CODEY_SKILL_DISCOVERY_SUBDIRS[0], 'one');
     let visibleAtRun = false;
@@ -106,12 +111,56 @@ describe('Codey project skills', () => {
     const factory = new AgentFactory();
     factory.register('codex', adapter);
 
-    await factory.run('codex', {
-      agent: 'codex',
-      prompt: 'work',
-      context: { workingDir: root },
-    });
+    try {
+      await factory.run('codex', {
+        agent: 'codex',
+        prompt: 'work',
+        context: { workingDir: root },
+      });
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
 
     expect(visibleAtRun).toBe(true);
+  });
+});
+
+describe('Codey global skills', () => {
+  it('links ~/.codey/skills into every user-level discovery convention', async () => {
+    const home = project();
+    const skill = path.join(home, CODEY_GLOBAL_SKILLS_SUBDIR, 'release');
+    fs.mkdirSync(skill, { recursive: true });
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: release\n---\n');
+
+    const result = await syncCodeyGlobalSkills(home);
+
+    expect(result.sourceRoot).toBe(path.join(home, CODEY_GLOBAL_SKILLS_SUBDIR));
+    expect(result.linked).toHaveLength(CODEY_SKILL_DISCOVERY_SUBDIRS.length);
+    for (const subdir of CODEY_SKILL_DISCOVERY_SUBDIRS) {
+      const linked = path.join(home, subdir, 'release');
+      expect(fs.realpathSync(linked)).toBe(fs.realpathSync(skill));
+    }
+  });
+
+  it('leaves a same-named skill installed directly under an agent home alone', async () => {
+    const home = project();
+    fs.mkdirSync(path.join(home, CODEY_GLOBAL_SKILLS_SUBDIR, 'one'), { recursive: true });
+    const native = path.join(home, CODEY_SKILL_DISCOVERY_SUBDIRS[0], 'one');
+    fs.mkdirSync(native, { recursive: true });
+
+    const result = await syncCodeyGlobalSkills(home);
+
+    expect(result.conflicts).toEqual([native]);
+    expect(fs.lstatSync(native).isSymbolicLink()).toBe(false);
+  });
+
+  it('does nothing when ~/.codey/skills does not exist', async () => {
+    const home = project();
+    const result = await syncCodeyGlobalSkills(home);
+    expect(result.linked).toEqual([]);
+    for (const subdir of CODEY_SKILL_DISCOVERY_SUBDIRS) {
+      expect(fs.existsSync(path.join(home, subdir))).toBe(false);
+    }
   });
 });

--- a/packages/core/src/agents/codey-skills.ts
+++ b/packages/core/src/agents/codey-skills.ts
@@ -1,13 +1,22 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 /** The project-owned source of truth for skills managed by Codey. */
 export const CODEY_SKILLS_SUBDIR = path.join('.codey', 'skills');
 
 /**
- * The smallest set of project skill roots covering every agent Codey runs.
+ * The user-owned source of truth for skills managed by Codey (`~/.codey/skills`).
+ * Global skills follow the user across every workspace; project skills stay
+ * with the repository that needs them.
+ */
+export const CODEY_GLOBAL_SKILLS_SUBDIR = CODEY_SKILLS_SUBDIR;
+
+/**
+ * The smallest set of skill roots covering every agent Codey runs.
  * Claude Code uses its own directory; Codex, OpenCode, and pi all understand
- * the cross-agent `.agents/skills` convention.
+ * the cross-agent `.agents/skills` convention. The same two conventions apply
+ * at project level and under the home directory.
  */
 export const CODEY_SKILL_DISCOVERY_SUBDIRS = [
   path.join('.claude', 'skills'),
@@ -37,17 +46,15 @@ function pointsTo(linkPath: string, sourcePath: string): boolean {
 }
 
 /**
- * Make every top-level Codey skill/collection visible through the native
- * project directories watched by the supported coding agents.
+ * Make every top-level Codey skill/collection under `sourceRoot` visible
+ * through the native discovery directories below `discoveryBase`.
  *
  * Links are created per top-level entry instead of replacing an agent's whole
  * skills directory, so hand-written/native skills remain untouched. Existing
  * names are never overwritten. Relative links keep working when a project is
  * moved as a unit (Windows junctions require an absolute target).
  */
-export async function syncCodeyProjectSkills(workingDir: string): Promise<CodeySkillSyncResult> {
-  const projectRoot = path.resolve(workingDir);
-  const sourceRoot = path.join(projectRoot, CODEY_SKILLS_SUBDIR);
+async function linkCodeySkills(sourceRoot: string, discoveryBase: string): Promise<CodeySkillSyncResult> {
   const result: CodeySkillSyncResult = { sourceRoot, linked: [], existing: [], conflicts: [], removed: [] };
 
   let entries: fs.Dirent[];
@@ -63,7 +70,7 @@ export async function syncCodeyProjectSkills(workingDir: string): Promise<CodeyS
     .map(entry => ({ name: entry.name, dir: path.join(sourceRoot, entry.name) }));
 
   for (const discoverySubdir of CODEY_SKILL_DISCOVERY_SUBDIRS) {
-    const discoveryRoot = path.join(projectRoot, discoverySubdir);
+    const discoveryRoot = path.join(discoveryBase, discoverySubdir);
     await fs.promises.mkdir(discoveryRoot, { recursive: true });
 
     // Remove only broken links whose declared target is inside Codey's own
@@ -108,4 +115,23 @@ export async function syncCodeyProjectSkills(workingDir: string): Promise<CodeyS
   }
 
   return result;
+}
+
+/**
+ * Expose `<project>/.codey/skills` through the project-level directories
+ * watched by the supported coding agents.
+ */
+export async function syncCodeyProjectSkills(workingDir: string): Promise<CodeySkillSyncResult> {
+  const projectRoot = path.resolve(workingDir);
+  return linkCodeySkills(path.join(projectRoot, CODEY_SKILLS_SUBDIR), projectRoot);
+}
+
+/**
+ * Expose `~/.codey/skills` through the user-level directories watched by the
+ * supported coding agents, so a global Codey skill is available in every
+ * project without being copied into any of them.
+ */
+export async function syncCodeyGlobalSkills(home: string = os.homedir()): Promise<CodeySkillSyncResult> {
+  const homeRoot = path.resolve(home);
+  return linkCodeySkills(path.join(homeRoot, CODEY_GLOBAL_SKILLS_SUBDIR), homeRoot);
 }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -4,7 +4,7 @@ import { ClaudeCodeAdapter } from './claude-code';
 import { OpenCodeAdapter } from './opencode';
 import { CodexAdapter } from './codex';
 import { PiAdapter } from './pi';
-import { syncCodeyProjectSkills } from './codey-skills';
+import { syncCodeyGlobalSkills, syncCodeyProjectSkills } from './codey-skills';
 
 export type { CodingAgentAdapter } from './base';
 export { ClaudeCodeAdapter } from './claude-code';
@@ -155,9 +155,15 @@ export class AgentFactory {
     request = addCodeyBrowserMcp(request, this.pluginEnabledProvider?.('browser') === true);
     request = addExternalMcpServers(request, this.externalMcpProvider?.());
 
-    // `.codey/skills` is Codey's project-level source of truth. Refresh the
-    // lightweight compatibility links immediately before every CLI launch so
-    // skills added by hand are available without restarting Codey.
+    // `~/.codey/skills` and `<project>/.codey/skills` are Codey's global and
+    // project sources of truth. Refresh the lightweight compatibility links
+    // immediately before every CLI launch so skills added by hand are
+    // available without restarting Codey.
+    try {
+      await syncCodeyGlobalSkills();
+    } catch {
+      // See below: linking is best-effort.
+    }
     if (request.context?.workingDir) {
       try {
         await syncCodeyProjectSkills(request.context.workingDir);


### PR DESCRIPTION
## Why

Codey skills were workspace-only — every project needed its own copy under `.codey/skills` — and they were shown in a separate **Codey Skills** tab beside the per-agent one.

## What

**Global skills (`~/.codey/skills`)**
- `syncCodeyGlobalSkills(home)` links `~/.codey/skills/*` into `~/.claude/skills` and `~/.agents/skills` — the same two conventions that already cover Claude Code, Codex, OpenCode, and pi at project level — so one global skill is visible to every agent in every workspace.
- The per-entry linking logic is now shared between the global and project syncs (`linkCodeySkills`); it still never overwrites a same-named native skill and only cleans up its own broken links.
- `AgentFactory.run` refreshes both roots (best-effort) before each CLI launch; the Mac app creates and links `~/.codey/skills` on startup.
- Installing a Codey skill into a project root is still available for skills that belong to one repository — the install form now offers **Global** (default) / **Project**.

**Skills tab**
- The separate "Codey Skills" tab is gone. Codey is now the leftmost segment of the Skills tab's source switcher: `[✨ Codey │ Claude Code  OpenCode  Codex  Pi]`, selected by default.
- The `CODING AGENT` title above the switcher is replaced by a one-line hint naming where the selected source lives.
- Codey skill badges read `Global` / `Project` instead of a flat `Codey`.

## Testing

- `npm test` — 501 + 328 + 543 tests passing across the three workspaces, including four new sync tests (global linking, native-skill conflict, missing source root).
- `tsc --noEmit` on both the renderer and electron configs; `npm run lint`.
- Not run: the Mac app itself, so the new switcher is unexercised at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)