### PR TITLE
Let a project skill install target any workspace

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3401,9 +3401,19 @@ app.whenReady().then(async () => {
     return [...configured, ...paths.userDirs.map(rel => pathMod.join(home, rel))]
   }
 
-  function getWorkingDir(fsMod: typeof import('fs'), pathMod: typeof import('path')): string | null {
+  /**
+   * Working directory of a NAMED workspace, or of the active one when no name
+   * is given. Unlike WorkspaceManager.getWorkingDirFor this does not fall back
+   * to the active workspace for an unknown name: an install must never write
+   * into a repository the user did not pick.
+   */
+  function getWorkingDir(
+    fsMod: typeof import('fs'),
+    pathMod: typeof import('path'),
+    workspace?: string,
+  ): string | null {
     if (!workspaceManager) return null
-    const wsName = workspaceManager.getCurrentWorkspace()
+    const wsName = workspace || workspaceManager.getCurrentWorkspace()
     if (!wsName) return null
     const configPath = pathMod.join(workspaceManager.getWorkspacesRoot(), wsName, 'workspace.json')
     if (!fsMod.existsSync(configPath)) return null
@@ -3413,7 +3423,7 @@ app.whenReady().then(async () => {
     } catch { return null }
   }
 
-  async function listAgentSkills(agentKey: string): Promise<{ skills: ScannedSkill[]; projectDir: string | null }> {
+  async function listAgentSkills(agentKey: string, workspace?: string): Promise<{ skills: ScannedSkill[]; projectDir: string | null }> {
     const fsMod = await import('fs')
     const pathMod = await import('path')
     const osMod = await import('os')
@@ -3437,7 +3447,7 @@ app.whenReady().then(async () => {
     }
 
     let projectDir: string | null = null
-    const workingDir = getWorkingDir(fsMod, pathMod)
+    const workingDir = getWorkingDir(fsMod, pathMod, workspace)
     if (workingDir) {
       for (const rel of paths.projectSubdirs) {
         const dir = pathMod.join(workingDir, rel)
@@ -3488,10 +3498,10 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('skills:list', async (_e, agent?: string) =>
+  ipcMain.handle('skills:list', async (_e, agent?: string, workspace?: string) =>
     wrap(async () => {
       const agentKey = agent ?? 'claude-code'
-      return listAgentSkills(agentKey)
+      return listAgentSkills(agentKey, workspace)
     })
   )
 
@@ -3516,7 +3526,7 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('skills:install', async (_e, payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) =>
+  ipcMain.handle('skills:install', async (_e, payload: { agent?: string; scope: 'user' | 'project'; workspace?: string; localDir?: string; gitUrl?: string }) =>
     wrap(async () => {
       const fsMod = await import('fs')
       const pathMod = await import('path')
@@ -3535,14 +3545,17 @@ app.whenReady().then(async () => {
       const getTargetRoot = async (): Promise<string> => {
         if (payload.scope === 'user') return configuredUserSkillDirs(agentKey, home, pathMod)[0]
         if (!workspaceManager) throw new Error('No workspace manager')
-        const wsName = workspaceManager.getCurrentWorkspace()
+        // A project install targets whichever workspace the user picked, not
+        // whichever one happens to be active.
+        const wsName = payload.workspace || workspaceManager.getCurrentWorkspace()
         if (!wsName) throw new Error('No active workspace')
-        const root = workspaceManager.getWorkspacesRoot()
-        const configPath = pathMod.join(root, wsName, 'workspace.json')
-        const data = JSON.parse(fsMod.readFileSync(configPath, 'utf-8'))
-        if (!data.workingDir) throw new Error('Workspace has no working directory')
-        projectWorkingDir = data.workingDir
-        return pathMod.join(data.workingDir, paths.projectSubdirs[0])
+        if (!workspaceManager.listWorkspaces().includes(wsName)) {
+          throw new Error(`Unknown workspace: ${wsName}`)
+        }
+        const workingDir = getWorkingDir(fsMod, pathMod, wsName)
+        if (!workingDir) throw new Error(`Workspace "${wsName}" has no working directory`)
+        projectWorkingDir = workingDir
+        return pathMod.join(workingDir, paths.projectSubdirs[0])
       }
 
       const targetRoot = await getTargetRoot()
@@ -3627,7 +3640,14 @@ app.whenReady().then(async () => {
       const fsMod = await import('fs')
       const pathMod = await import('path')
       await fsMod.promises.rm(dir, { recursive: true, force: true })
-      const workingDir = getWorkingDir(fsMod, pathMod)
+      // Relink the project the skill actually lived in, which is not
+      // necessarily the active workspace once installs can target any of them.
+      const removed = pathMod.resolve(dir)
+      const owning = (workspaceManager?.listWorkspaces() ?? [])
+        .map(name => getWorkingDir(fsMod, pathMod, name))
+        .filter((wd): wd is string => wd !== null)
+        .find(wd => removed.startsWith(`${pathMod.resolve(wd)}${pathMod.sep}`))
+      const workingDir = owning ?? getWorkingDir(fsMod, pathMod)
       if (workingDir) await syncCodeyProjectSkills(workingDir)
       await syncCodeyGlobalSkills()
     })

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -125,9 +125,9 @@ contextBridge.exposeInMainWorld('codey', {
     setEnabled: (name: string, enabled: boolean) => ipcRenderer.invoke('mcp:setEnabled', name, enabled),
   },
   skills: {
-    list: (agent?: string) => ipcRenderer.invoke('skills:list', agent),
+    list: (agent?: string, workspace?: string) => ipcRenderer.invoke('skills:list', agent, workspace),
     usage: (agent?: string) => ipcRenderer.invoke('skills:usage', agent),
-    install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) =>
+    install: (payload: { agent?: string; scope: 'user' | 'project'; workspace?: string; localDir?: string; gitUrl?: string }) =>
       ipcRenderer.invoke('skills:install', payload),
     remove: (dir: string) => ipcRenderer.invoke('skills:remove', dir),
     setEnabled: (dir: string, enabled: boolean) => ipcRenderer.invoke('skills:setEnabled', dir, enabled),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -249,9 +249,10 @@ declare global {
         setEnabled: (name: string, enabled: boolean) => Promise<IpcResult<void>>
       }
       skills: {
-        list: (agent?: string) => Promise<IpcResult<SkillsListResult>>
+        /** `workspace` selects which project's skills are included; defaults to the active one. */
+        list: (agent?: string, workspace?: string) => Promise<IpcResult<SkillsListResult>>
         usage: (agent?: string) => Promise<IpcResult<SkillUsageMap>>
-        install: (payload: { agent?: string; scope: 'user' | 'project'; localDir?: string; gitUrl?: string }) => Promise<IpcResult<{ name: string; dir: string }>>
+        install: (payload: { agent?: string; scope: 'user' | 'project'; workspace?: string; localDir?: string; gitUrl?: string }) => Promise<IpcResult<{ name: string; dir: string }>>
         remove: (dir: string) => Promise<IpcResult<void>>
         setEnabled: (dir: string, enabled: boolean) => Promise<IpcResult<void>>
         reveal: (dir: string) => Promise<IpcResult<void>>

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -37,6 +37,11 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   const [addScope, setAddScope] = useState<'user' | 'project'>('user')
   // Codey installs default to the global root; the project root is offered
   // only when a workspace is open.
+  // Which workspace the "Project" scope means. Empty until the workspace list
+  // loads, at which point it settles on the active one; the user can point it
+  // at any other workspace without switching the whole app over to it.
+  const [workspaces, setWorkspaces] = useState<string[]>([])
+  const [projectWorkspace, setProjectWorkspace] = useState('')
   const [addSource, setAddSource] = useState<'localDir' | 'gitUrl'>('localDir')
   const [addInput, setAddInput] = useState('')
   const [installing, setInstalling] = useState(false)
@@ -61,7 +66,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   )
   const now = Date.now()
   const listKey = codey ? 'codey' : agentFilter
-  const canInstall = addScope === 'user' || data.projectDir !== null
+  const canInstall = addScope === 'user' || (projectWorkspace !== '' && data.projectDir !== null)
 
   // The primary action lives in the parent Tools tab bar; this counter gives
   // that button a clean way to open the existing install form without a second
@@ -73,11 +78,11 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     }
   }, [addRequest])
 
-  const reload = useCallback(async (agent: AgentFilter | 'codey') => {
+  const reload = useCallback(async (agent: AgentFilter | 'codey', workspace: string) => {
     setLoading(true)
     setError(null)
     try {
-      setData(unwrap(await window.codey.skills.list(agent)))
+      setData(unwrap(await window.codey.skills.list(agent, workspace || undefined)))
     } catch (e: any) {
       setError(e?.message ?? String(e))
     } finally {
@@ -105,10 +110,18 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           setAgentFilter(agent)
         }
       }).catch(() => {})
+      Promise.all([window.codey.workspaces.list(), window.codey.workspaces.current()])
+        .then(([all, current]) => {
+          const names = all.ok ? all.data : []
+          setWorkspaces(names)
+          const active = current.ok ? current.data : ''
+          setProjectWorkspace(active && names.includes(active) ? active : names[0] ?? '')
+        })
+        .catch(() => {})
     }
   }, [])
 
-  useEffect(() => { void reload(listKey) }, [listKey, reload])
+  useEffect(() => { void reload(listKey, projectWorkspace) }, [listKey, projectWorkspace, reload])
 
   useEffect(() => {
     if (!copyMenuOpen) return
@@ -133,12 +146,13 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
         agent: codey ? 'codey' : agentFilter,
         scope: addScope,
       }
+      if (addScope === 'project') payload.workspace = projectWorkspace
       if (addSource === 'localDir') payload.localDir = addInput.trim()
       else payload.gitUrl = addInput.trim()
       unwrap(await window.codey.skills.install(payload))
       setAddInput('')
       setAdding(false)
-      await reload(listKey)
+      await reload(listKey, projectWorkspace)
     } catch (e: any) {
       setError(e?.message ?? String(e))
     } finally {
@@ -151,7 +165,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
     setError(null)
     try {
       unwrap(await window.codey.skills.remove(skill.dir))
-      await reload(listKey)
+      await reload(listKey, projectWorkspace)
     } catch (e: any) {
       setError(e?.message ?? String(e))
     }
@@ -199,7 +213,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
         failures.push(`${tgt}: ${e?.message ?? String(e)}`)
       }
     }
-    if (targets.includes(agentFilter)) await reload(agentFilter)
+    if (targets.includes(agentFilter)) await reload(agentFilter, projectWorkspace)
     if (failures.length) setCopyState({ label, status: 'error', msg: failures.join('  •  ') })
     else setCopyState({ label, status: 'done' })
   }
@@ -423,6 +437,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
             {codey
               ? `Stored in ${CODEY_GLOBAL_SKILLS_HINT} and discovered by every coding agent`
               : `Installed for ${AGENTS.find(a => a.key === agentFilter)?.label} only`}
+            {projectWorkspace && ` · project skills from ${projectWorkspace}`}
           </div>
         </div>
         <div style={styles.agentMeta}>
@@ -444,7 +459,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
             ? `${filteredSkills.length} of ${data.skills.length} skills`
             : `${data.skills.length} skill${data.skills.length === 1 ? '' : 's'}`}</span>
           <button
-            onClick={() => void reload(listKey)}
+            onClick={() => void reload(listKey, projectWorkspace)}
             disabled={loading || busyDirs.size > 0}
             style={{ ...styles.iconButton, opacity: loading || busyDirs.size > 0 ? 0.5 : 1 }}
             title="Rescan skills"
@@ -479,7 +494,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
               <span style={styles.optionLabel}>Install to</span>
               <div style={styles.smallSwitcher}>
                 {(['user', 'project'] as const).map(s => {
-                  const unavailable = s === 'project' && !data.projectDir
+                  const unavailable = s === 'project' && workspaces.length === 0
                   return (
                     <button
                       key={s}
@@ -490,7 +505,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
                         opacity: unavailable ? 0.38 : 1,
                       }}
                       disabled={unavailable}
-                      title={unavailable ? 'No active workspace' : s === 'user' ? 'Available across projects' : 'Only this project'}
+                      title={unavailable ? 'No workspaces yet' : s === 'user' ? 'Available across projects' : 'Only the selected workspace'}
                     >
                       {s === 'user' ? (codey ? 'Global' : 'User') : 'Project'}
                     </button>
@@ -498,6 +513,23 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
                 })}
               </div>
             </div>
+
+            {addScope === 'project' && (
+              <div style={styles.optionGroup}>
+                <label style={styles.optionLabel} htmlFor="skill-workspace-select">Workspace</label>
+                <select
+                  id="skill-workspace-select"
+                  value={projectWorkspace}
+                  onChange={e => setProjectWorkspace(e.target.value)}
+                  style={styles.workspaceSelect}
+                  title="Install into this workspace's project directory"
+                >
+                  {workspaces.map(name => (
+                    <option key={name} value={name}>{name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             <div style={styles.optionGroup}>
               <span style={styles.optionLabel}>Source</span>
@@ -545,9 +577,15 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           </div>
           <div style={styles.destinationHint}>
             Destination: <code style={styles.inlineCode}>{addScope === 'project'
-              ? (data.projectDir ?? (codey ? CODEY_PROJECT_SKILLS_HINT : 'the current workspace'))
+              ? (data.projectDir ?? (codey ? CODEY_PROJECT_SKILLS_HINT : 'the selected workspace'))
               : codey ? CODEY_GLOBAL_SKILLS_HINT : AGENT_SKILL_HINTS[agentFilter]}</code>
-            {!canInstall && <span style={{ color: C.red, marginLeft: 8 }}>Select a workspace first.</span>}
+            {!canInstall && (
+              <span style={{ color: C.red, marginLeft: 8 }}>
+                {projectWorkspace
+                  ? `"${projectWorkspace}" has no working directory.`
+                  : 'Select a workspace first.'}
+              </span>
+            )}
           </div>
         </section>
       ) : null}
@@ -659,6 +697,11 @@ const styles: Record<string, React.CSSProperties> = {
   optionRow: { display: 'flex', alignItems: 'center', gap: 22, flexWrap: 'wrap', marginBottom: 14 },
   optionGroup: { display: 'flex', alignItems: 'center', gap: 9 },
   optionLabel: { color: C.fg3, fontSize: 11, fontWeight: 600, whiteSpace: 'nowrap' },
+  workspaceSelect: {
+    minHeight: 31, border: `1px solid ${C.border}`, borderRadius: 8, padding: '4px 8px',
+    background: C.bg, color: C.fg, cursor: 'pointer', fontSize: 11, fontWeight: 650,
+    fontFamily: 'inherit', maxWidth: 220,
+  },
   smallSwitcher: {
     display: 'inline-flex', alignItems: 'center', padding: 2, gap: 2,
     borderRadius: 8, background: C.bg, border: `1px solid ${C.border}`,

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -3,6 +3,7 @@ import { C } from '../theme'
 import { pillButton, Toggle, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
+import { WorkspaceSelect } from './WorkspaceSelect'
 import { SKILL_SORT_MODES, sortSkills, usageFor, usageLabel } from './skillsSort'
 import type { SkillSortMode } from './skillsSort'
 import type { SkillEntry, SkillUsageMap, SkillsListResult } from '../codey-api'
@@ -516,18 +517,13 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
 
             {addScope === 'project' && (
               <div style={styles.optionGroup}>
-                <label style={styles.optionLabel} htmlFor="skill-workspace-select">Workspace</label>
-                <select
+                <span style={styles.optionLabel}>Workspace</span>
+                <WorkspaceSelect
                   id="skill-workspace-select"
                   value={projectWorkspace}
-                  onChange={e => setProjectWorkspace(e.target.value)}
-                  style={styles.workspaceSelect}
-                  title="Install into this workspace's project directory"
-                >
-                  {workspaces.map(name => (
-                    <option key={name} value={name}>{name}</option>
-                  ))}
-                </select>
+                  options={workspaces}
+                  onChange={setProjectWorkspace}
+                />
               </div>
             )}
 
@@ -697,11 +693,6 @@ const styles: Record<string, React.CSSProperties> = {
   optionRow: { display: 'flex', alignItems: 'center', gap: 22, flexWrap: 'wrap', marginBottom: 14 },
   optionGroup: { display: 'flex', alignItems: 'center', gap: 9 },
   optionLabel: { color: C.fg3, fontSize: 11, fontWeight: 600, whiteSpace: 'nowrap' },
-  workspaceSelect: {
-    minHeight: 31, border: `1px solid ${C.border}`, borderRadius: 8, padding: '4px 8px',
-    background: C.bg, color: C.fg, cursor: 'pointer', fontSize: 11, fontWeight: 650,
-    fontFamily: 'inherit', maxWidth: 220,
-  },
   smallSwitcher: {
     display: 'inline-flex', alignItems: 'center', padding: 2, gap: 2,
     borderRadius: 8, background: C.bg, border: `1px solid ${C.border}`,

--- a/codey-mac/src/components/WorkspaceSelect.tsx
+++ b/codey-mac/src/components/WorkspaceSelect.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { C } from '../theme'
+import { UIIcon } from './UIIcons'
+import { matchesToolSearch } from './tools-search'
+
+/** Above this many workspaces the popup gets a filter field. */
+const SEARCH_THRESHOLD = 8
+
+interface Props {
+  value: string
+  options: string[]
+  onChange: (value: string) => void
+  disabled?: boolean
+  label?: string
+  id?: string
+}
+
+/**
+ * A workspace picker styled like the rest of the app's controls. A native
+ * `<select>` renders as the macOS system popup, which reads as a foreign
+ * control beside the segmented switchers it sits next to, and offers no way to
+ * filter a long workspace list.
+ */
+export const WorkspaceSelect: React.FC<Props> = ({ value, options, onChange, disabled = false, label = 'Workspace', id }) => {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false)
+    }
+    const onKey = (event: KeyboardEvent) => { if (event.key === 'Escape') setOpen(false) }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  // A stale query would silently hide options the next time the popup opens.
+  useEffect(() => { if (!open) setQuery('') }, [open])
+
+  const searchable = options.length > SEARCH_THRESHOLD
+  const visible = useMemo(
+    () => (searchable ? options.filter(name => matchesToolSearch(query, name)) : options),
+    [options, query, searchable],
+  )
+
+  return (
+    <div ref={ref} style={styles.root}>
+      <button
+        id={id}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={label}
+        onClick={() => setOpen(o => !o)}
+        title={value ? `Install into "${value}"` : label}
+        style={{ ...styles.trigger, opacity: disabled ? 0.45 : 1 }}
+      >
+        <span style={styles.triggerLabel}>{value || 'Select…'}</span>
+        <span style={{ ...styles.caret, transform: open ? 'rotate(-90deg)' : 'rotate(90deg)' }}>
+          <UIIcon name="chevron" size={11} />
+        </span>
+      </button>
+
+      {open && (
+        <div style={styles.menu} role="listbox" aria-label={label}>
+          {searchable && (
+            <input
+              type="search"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Filter workspaces…"
+              aria-label="Filter workspaces"
+              style={styles.search}
+              autoFocus
+            />
+          )}
+          <div style={styles.scroll}>
+            {visible.length === 0 ? (
+              <div style={styles.empty}>No matching workspace</div>
+            ) : visible.map(name => (
+              <button
+                key={name}
+                type="button"
+                role="option"
+                aria-selected={name === value}
+                onClick={() => { onChange(name); setOpen(false) }}
+                style={{ ...styles.item, ...(name === value ? styles.itemSelected : undefined) }}
+                title={name}
+              >
+                <span style={styles.checkSlot}>
+                  {name === value && <UIIcon name="check" size={12} />}
+                </span>
+                <span style={styles.itemName}>{name}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: { position: 'relative', display: 'inline-flex' },
+  trigger: {
+    minHeight: 31, maxWidth: 220, display: 'inline-flex', alignItems: 'center', gap: 6,
+    border: `1px solid ${C.border}`, borderRadius: 8, padding: '4px 8px',
+    background: C.bg, color: C.fg, cursor: 'pointer',
+    fontSize: 11, fontWeight: 650, fontFamily: 'inherit',
+  },
+  triggerLabel: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 },
+  caret: {
+    color: C.fg3, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    width: 12, height: 12, flexShrink: 0, transformOrigin: 'center', transition: 'transform 0.15s ease',
+  },
+  menu: {
+    position: 'absolute', top: 'calc(100% + 6px)', left: 0, zIndex: 20, minWidth: 220,
+    background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
+    boxShadow: '0 14px 30px rgba(0,0,0,0.26)', padding: 6,
+    display: 'flex', flexDirection: 'column', gap: 6,
+  },
+  search: {
+    background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 6,
+    color: C.fg, fontSize: 12, padding: '5px 8px', outline: 'none', fontFamily: 'inherit',
+  },
+  scroll: { maxHeight: 240, overflowY: 'auto', display: 'flex', flexDirection: 'column' },
+  item: {
+    width: '100%', textAlign: 'left', background: 'transparent', border: 'none',
+    color: C.fg, fontSize: 12, padding: '6px 8px', borderRadius: 6, cursor: 'pointer',
+    display: 'flex', alignItems: 'center', gap: 5, minWidth: 0, fontFamily: 'inherit',
+  },
+  itemSelected: { background: C.accentDim, color: C.accent },
+  itemName: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  checkSlot: { width: 14, flexShrink: 0, display: 'inline-flex', alignItems: 'center' },
+  empty: { color: C.fg3, fontSize: 11, padding: '12px 8px', textAlign: 'center' },
+}


### PR DESCRIPTION
Follow-up to #292.

## Why

A project-scope skill install wrote into whichever workspace happened to be active:

```ts
const wsName = workspaceManager.getCurrentWorkspace()
```

So putting a skill in another project meant switching the whole app over to that workspace first. Playbooks already resolve their own workspace by name (`playbooks:promote` → `getWorkingDirFor(workspace)`) for exactly this reason; skills should behave the same.

## What

- The install form gains a **Workspace** dropdown, shown when scope is `Project` and populated from `workspaces:list`, defaulting to the active workspace.
- `skills:install` takes an optional `workspace`. Unknown names are rejected rather than silently falling back to the active workspace — an install must never write into a repository the user did not pick (this is why it does not use `getWorkingDirFor`, which falls back by design).
- The same selection drives `skills:list`, so a skill installed into another workspace shows up in the list where it landed instead of vanishing. The switcher hint names the workspace the listed project skills come from.
- `skills:remove` now relinks the project the removed skill actually lived in, found by matching the removed path against each workspace's working directory, instead of assuming the active one.
- The `Project` segment is disabled when there are no workspaces at all, and the destination line explains when a chosen workspace has no working directory.

## Testing

- `npm test` — 501 + 328 + 544 passing across the three workspaces.
- `tsc --noEmit` on both the renderer and electron configs; `npm run lint`.
- Not run: the Mac app itself. The picker and the cross-workspace install path are unexercised at runtime — worth a manual check with two workspaces before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)