### PR TITLE
Let the automation one-pager change where a run happens (0.12.6)

### DIFF
--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/AutomationChatCreate.tsx
+++ b/codey-mac/src/components/AutomationChatCreate.tsx
@@ -309,19 +309,19 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
             )}
             <div style={switchRow}>
               <div>
-                <div style={switchTitle}>Checkout</div>
+                <div style={switchTitle}>Where it runs</div>
                 <div style={switchDescription}>{draft.target?.sandbox
                   ? 'Every run gets its own worktree, branched from the workspace’s latest commit'
                   : 'Runs in the workspace checkout, alongside your own work'}</div>
               </div>
               <button
-                type="button" role="switch" aria-label="Automation checkout"
+                type="button" role="switch" aria-label="Automation run location"
                 aria-checked={!!draft.target?.sandbox} disabled={locked || !draft.target}
                 style={modeControl(locked || !draft.target)}
                 onClick={() => setSandbox(!draft.target?.sandbox)}
               >
-                <span style={modeOption(!draft.target?.sandbox)}>Shared</span>
-                <span style={modeOption(!!draft.target?.sandbox)}>Sandbox</span>
+                <span style={modeOption(!draft.target?.sandbox)}>Your checkout</span>
+                <span style={modeOption(!!draft.target?.sandbox)}>Fresh copy</span>
               </button>
             </div>
           </SetupSection>

--- a/codey-mac/src/components/AutomationOnePager.tsx
+++ b/codey-mac/src/components/AutomationOnePager.tsx
@@ -194,6 +194,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
         // its times. A never-scheduled automation remains schedule-free.
         schedule: knobs.scheduleOn ? schedule! : a.schedule,
         report: { ...a.report, notify: knobs.notify },
+        target: { ...a.target, sandbox: knobs.isolated },
       }))
       const shouldEnable = knobs.scheduleOn || !updated.schedule
       const fresh: Automation = updated.enabled === shouldEnable
@@ -252,7 +253,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
     a.target.kind === 'team'
       ? `Team · ${a.target.workspaceName}`
       : [a.target.agent ?? 'Default agent', a.target.model].filter(Boolean).join(' · '),
-    a.target.sandbox && 'Sandbox',
+    a.target.sandbox && 'Fresh copy',
   ].filter(Boolean).join(' · ')
   const notifyTitle = NOTIFY_OPTIONS.find(option => option.value === a.report.notify)?.label ?? 'Never'
 
@@ -418,7 +419,21 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
               {a.report.channel && <div style={infoRow}><span>Channel delivery</span><strong>{a.report.channel.platform}</strong></div>}
             </DetailCard>
 
-            <DetailCard title="Details" description="Execution target and record metadata.">
+            <DetailCard title="Details" description="Where runs happen, plus record metadata.">
+              <div style={settingRow}>
+                <span style={settingLabel}>Where it runs</span>
+                <button
+                  type="button" role="switch" aria-label="Automation run location"
+                  aria-checked={knobs.isolated} style={modeControl}
+                  onClick={() => setKnobs({ ...knobs, isolated: !knobs.isolated })}
+                >
+                  <span style={modeOption(!knobs.isolated)}>Your checkout</span>
+                  <span style={modeOption(knobs.isolated)}>Fresh copy</span>
+                </button>
+              </div>
+              <div style={settingHint}>{knobs.isolated
+                ? 'Every run gets its own worktree, branched from the workspace\u2019s latest commit'
+                : 'Runs in the workspace checkout, alongside your own work'}</div>
               <div style={infoRow}><span>Target</span><strong>{targetTitle}</strong></div>
               <div style={infoRow}><span>Created</span><strong>{new Date(a.createdAt).toLocaleDateString()}</strong></div>
               <div style={infoRow}><span>Updated</span><strong>{new Date(a.updatedAt).toLocaleDateString()}</strong></div>
@@ -427,7 +442,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
 
           {knobsDirty && (
             <div style={saveBar}>
-              <div style={noticeCopy}><strong>Unsaved settings</strong><span>Your schedule, variables, or notifications changed.</span></div>
+              <div style={noticeCopy}><strong>Unsaved settings</strong><span>Your schedule, variables, notifications, or run location changed.</span></div>
               <div style={{ display: 'flex', gap: 7 }}>
                 <button style={pillButton('ghost')} disabled={savingKnobs} onClick={() => setKnobs(knobsFrom(a))}>Discard</button>
                 <button style={pillButton('primary')} disabled={savingKnobs} onClick={() => void saveKnobs()}>{savingKnobs ? 'Saving…' : 'Save settings'}</button>
@@ -633,6 +648,7 @@ const slotHeader: React.CSSProperties = { display: 'flex', alignItems: 'center',
 const slotSummary: React.CSSProperties = { color: C.fg3, fontSize: 10, flex: 1 }
 const dayEditor: React.CSSProperties = { display: 'flex', gap: 4 }
 const dayButton = (active: boolean): React.CSSProperties => ({ width: 25, height: 25, borderRadius: 7, border: `1px solid ${active ? C.accent : C.border2}`, background: active ? C.accentDim : C.surface3, color: active ? C.accent : C.fg3, cursor: 'pointer', fontSize: 9, fontWeight: 750 })
+const settingHint: React.CSSProperties = { color: C.fg3, fontSize: 10.5, margin: '-2px 0 6px' }
 const infoRow: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', gap: 12, color: C.fg3, fontSize: 10.5, padding: '2px 0' }
 const emptyState: React.CSSProperties = { color: C.fg3, fontSize: 11, padding: '8px 0', fontStyle: 'italic' }
 const saveBar: React.CSSProperties = { gridColumn: '1 / -1', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, position: 'sticky', bottom: 8, zIndex: 2, padding: '11px 13px', border: `1px solid ${C.accent}`, borderRadius: 11, background: C.surface2, boxShadow: '0 8px 25px rgba(0,0,0,.22)', color: C.fg, fontSize: 11 }

--- a/codey-mac/src/components/AutomationsView.tsx
+++ b/codey-mac/src/components/AutomationsView.tsx
@@ -189,7 +189,7 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
     t.kind === 'team'
       ? `Team · ${t.teamName} · ${t.workspaceName}`
       : [t.workspaceName, t.agent && `${t.agent}${t.model ? ` · ${t.model}` : ''}`].filter(Boolean).join(' · '),
-    t.sandbox && 'Sandbox',
+    t.sandbox && 'Fresh copy',
   ].filter(Boolean).join(' · ')
 
   const attentionCount = automations.filter(a => {

--- a/codey-mac/src/components/automationsModel.test.ts
+++ b/codey-mac/src/components/automationsModel.test.ts
@@ -132,6 +132,7 @@ describe('knobsFrom', () => {
       scheduleOn: true,
       slots: [{ time: '09:05', days: [1, 3, 5] }, { time: '18:00', days: [1, 3, 5] }],
       notify: 'all',
+      isolated: false,
     })
   })
 
@@ -141,7 +142,12 @@ describe('knobsFrom', () => {
       scheduleOn: false,
       slots: [{ time: '09:00', days: [] }],
       notify: 'none',
+      isolated: false,
     })
+  })
+
+  it('reads the run location off the target', () => {
+    expect(knobsFrom({ ...base, target: { sandbox: true } }).isolated).toBe(true)
   })
 
   it('treats a disabled saved schedule as manual while preserving its slots', () => {
@@ -150,6 +156,7 @@ describe('knobsFrom', () => {
       scheduleOn: false,
       slots: [{ time: '09:05', days: [1, 3, 5] }, { time: '18:00', days: [1, 3, 5] }],
       notify: 'all',
+      isolated: false,
     })
   })
 
@@ -194,6 +201,13 @@ describe('knobsEqual', () => {
 
   it('is false when scheduleOn differs', () => {
     expect(knobsEqual({ ...knobsFrom(auto), scheduleOn: false }, auto)).toBe(false)
+  })
+
+  it('is false when the run location differs', () => {
+    expect(knobsEqual({ ...knobsFrom(auto), isolated: true }, auto)).toBe(false)
+    const isolatedAuto = { ...auto, target: { sandbox: true } }
+    expect(knobsEqual(knobsFrom(isolatedAuto), isolatedAuto)).toBe(true)
+    expect(knobsEqual({ ...knobsFrom(isolatedAuto), isolated: false }, isolatedAuto)).toBe(false)
   })
 
   it('matches manual mode for a disabled saved schedule', () => {

--- a/codey-mac/src/components/automationsModel.ts
+++ b/codey-mac/src/components/automationsModel.ts
@@ -169,6 +169,8 @@ export interface Knobs {
   scheduleOn: boolean
   slots: ScheduleSlotInput[]
   notify: NotifyMode
+  /** true = each run gets a throwaway worktree; false = the workspace checkout. */
+  isolated: boolean
 }
 
 interface KnobSource {
@@ -176,6 +178,7 @@ interface KnobSource {
   params: Record<string, string>
   schedule?: ScheduleLike
   report: { notify: NotifyMode }
+  target?: { sandbox?: boolean }
 }
 
 /** Seed knobs from an automation. Days are sorted so an unsorted persisted
@@ -188,6 +191,7 @@ export function knobsFrom(a: KnobSource): Knobs {
       ? a.schedule.slots.map(slot => ({ time: formatHHMM(slot.hour, slot.minute), days: [...(slot.daysOfWeek ?? [])].sort((x, y) => x - y) }))
       : [{ time: '09:00', days: [] }],
     notify: a.report.notify,
+    isolated: !!a.target?.sandbox,
   }
 }
 
@@ -202,6 +206,7 @@ export function knobsEqual(k: Knobs, a: KnobSource): boolean {
     const actual = (a.schedule?.slots ?? []).map(slot => ({ time: formatHHMM(slot.hour, slot.minute), days: [...(slot.daysOfWeek ?? [])] }))
     if (JSON.stringify(canonical(k.slots)) !== JSON.stringify(canonical(actual))) return false
   }
+  if (k.isolated !== !!a.target?.sandbox) return false
   return k.notify === a.report.notify
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -22,7 +22,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.12.5",
+      "version": "0.12.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2610,7 +2610,7 @@
       }
     },
     "node_modules/@types/caseless": {
-      "version": "0.12.5",
+      "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "dev": true,
@@ -10991,7 +10991,7 @@
       }
     },
     "node_modules/unzipper": {
-      "version": "0.12.5",
+      "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
       "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
       "dev": true,
@@ -11739,7 +11739,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -11751,7 +11751,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.12.5",
+  "version": "0.12.6",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codey/core",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codey/core",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What

The sandbox/shared toggle only existed in the automation setup flow. On the one-pager the choice showed as static text in the "Runs in" tile, so changing it meant reopening **Edit setup**.

- The toggle now lives in the **Details** card on the one-pager, staged through the same knobs → **Save settings** path as schedule, variables, and notifications (`Knobs.isolated`, seeded from `target.sandbox`, compared in `knobsEqual`, saved as a `target` patch).
- Save-bar copy mentions run location.

## Wording

"Shared" read as shared-with-other-people and wasn't on the same axis as "Sandbox". Renamed in all three surfaces (setup, one-pager, list chip):

| before | after |
|---|---|
| Checkout | Where it runs |
| Shared | Your checkout |
| Sandbox | Fresh copy |

Persisted data is untouched — still `target.sandbox`.

## Version

0.12.5 → 0.12.6 across the four `package.json` files and three lockfiles.

## Testing

`npm test -w codey-mac` — 546 passed, including new cases for seeding `isolated` and for the dirty-check. `tsc --noEmit` clean. Not exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)