### PR TITLE
Go back to Shared/Sandbox for the automation checkout toggle

### DIFF
--- a/codey-mac/src/components/AutomationChatCreate.tsx
+++ b/codey-mac/src/components/AutomationChatCreate.tsx
@@ -309,19 +309,19 @@ export const AutomationChatCreate: React.FC<Props> = ({ mode, automationId, onDo
             )}
             <div style={switchRow}>
               <div>
-                <div style={switchTitle}>Where it runs</div>
+                <div style={switchTitle}>Checkout</div>
                 <div style={switchDescription}>{draft.target?.sandbox
                   ? 'Every run gets its own worktree, branched from the workspace’s latest commit'
                   : 'Runs in the workspace checkout, alongside your own work'}</div>
               </div>
               <button
-                type="button" role="switch" aria-label="Automation run location"
+                type="button" role="switch" aria-label="Automation checkout"
                 aria-checked={!!draft.target?.sandbox} disabled={locked || !draft.target}
                 style={modeControl(locked || !draft.target)}
                 onClick={() => setSandbox(!draft.target?.sandbox)}
               >
-                <span style={modeOption(!draft.target?.sandbox)}>Your checkout</span>
-                <span style={modeOption(!!draft.target?.sandbox)}>Fresh copy</span>
+                <span style={modeOption(!draft.target?.sandbox)}>Shared</span>
+                <span style={modeOption(!!draft.target?.sandbox)}>Sandbox</span>
               </button>
             </div>
           </SetupSection>

--- a/codey-mac/src/components/AutomationOnePager.tsx
+++ b/codey-mac/src/components/AutomationOnePager.tsx
@@ -253,7 +253,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
     a.target.kind === 'team'
       ? `Team · ${a.target.workspaceName}`
       : [a.target.agent ?? 'Default agent', a.target.model].filter(Boolean).join(' · '),
-    a.target.sandbox && 'Fresh copy',
+    a.target.sandbox && 'Sandbox',
   ].filter(Boolean).join(' · ')
   const notifyTitle = NOTIFY_OPTIONS.find(option => option.value === a.report.notify)?.label ?? 'Never'
 
@@ -419,16 +419,16 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
               {a.report.channel && <div style={infoRow}><span>Channel delivery</span><strong>{a.report.channel.platform}</strong></div>}
             </DetailCard>
 
-            <DetailCard title="Details" description="Where runs happen, plus record metadata.">
+            <DetailCard title="Details" description="Execution target and record metadata.">
               <div style={settingRow}>
-                <span style={settingLabel}>Where it runs</span>
+                <span style={settingLabel}>Checkout</span>
                 <button
-                  type="button" role="switch" aria-label="Automation run location"
+                  type="button" role="switch" aria-label="Automation checkout"
                   aria-checked={knobs.isolated} style={modeControl}
                   onClick={() => setKnobs({ ...knobs, isolated: !knobs.isolated })}
                 >
-                  <span style={modeOption(!knobs.isolated)}>Your checkout</span>
-                  <span style={modeOption(knobs.isolated)}>Fresh copy</span>
+                  <span style={modeOption(!knobs.isolated)}>Shared</span>
+                  <span style={modeOption(knobs.isolated)}>Sandbox</span>
                 </button>
               </div>
               <div style={settingHint}>{knobs.isolated
@@ -442,7 +442,7 @@ export const AutomationOnePager: React.FC<Props> = ({ id, onEditInChat, onOpenRu
 
           {knobsDirty && (
             <div style={saveBar}>
-              <div style={noticeCopy}><strong>Unsaved settings</strong><span>Your schedule, variables, notifications, or run location changed.</span></div>
+              <div style={noticeCopy}><strong>Unsaved settings</strong><span>Your schedule, variables, notifications, or checkout changed.</span></div>
               <div style={{ display: 'flex', gap: 7 }}>
                 <button style={pillButton('ghost')} disabled={savingKnobs} onClick={() => setKnobs(knobsFrom(a))}>Discard</button>
                 <button style={pillButton('primary')} disabled={savingKnobs} onClick={() => void saveKnobs()}>{savingKnobs ? 'Saving…' : 'Save settings'}</button>

--- a/codey-mac/src/components/AutomationsView.tsx
+++ b/codey-mac/src/components/AutomationsView.tsx
@@ -189,7 +189,7 @@ const AutomationList: React.FC<ListProps> = ({ automations, loading, onRefresh, 
     t.kind === 'team'
       ? `Team · ${t.teamName} · ${t.workspaceName}`
       : [t.workspaceName, t.agent && `${t.agent}${t.model ? ` · ${t.model}` : ''}`].filter(Boolean).join(' · '),
-    t.sandbox && 'Fresh copy',
+    t.sandbox && 'Sandbox',
   ].filter(Boolean).join(' · ')
 
   const attentionCount = automations.filter(a => {

--- a/codey-mac/src/components/automationsModel.test.ts
+++ b/codey-mac/src/components/automationsModel.test.ts
@@ -146,7 +146,7 @@ describe('knobsFrom', () => {
     })
   })
 
-  it('reads the run location off the target', () => {
+  it('reads the checkout mode off the target', () => {
     expect(knobsFrom({ ...base, target: { sandbox: true } }).isolated).toBe(true)
   })
 
@@ -203,7 +203,7 @@ describe('knobsEqual', () => {
     expect(knobsEqual({ ...knobsFrom(auto), scheduleOn: false }, auto)).toBe(false)
   })
 
-  it('is false when the run location differs', () => {
+  it('is false when the checkout mode differs', () => {
     expect(knobsEqual({ ...knobsFrom(auto), isolated: true }, auto)).toBe(false)
     const isolatedAuto = { ...auto, target: { sandbox: true } }
     expect(knobsEqual(knobsFrom(isolatedAuto), isolatedAuto)).toBe(true)


### PR DESCRIPTION
Reverts the wording change from #294 — the labels read better as they were.

| now | back to |
|---|---|
| Where it runs | Checkout |
| Your checkout | Shared |
| Fresh copy | Sandbox |

Applied to all three surfaces (setup flow, one-pager Details card, list chip) plus the aria-labels. The toggle itself — including the new one on the one-pager — is unchanged, and persisted data was never affected (`target.sandbox` throughout).

`npm test -w codey-mac` — 546 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)