### PR TITLE
Let pi and opencode take models of either protocol

### DIFF
--- a/codey-mac/src/components/modelApiType.test.ts
+++ b/codey-mac/src/components/modelApiType.test.ts
@@ -21,14 +21,27 @@ describe('modelFitsApiType', () => {
     expect(modelFitsApiType('openai', undefined)).toBe(true)
     expect(modelFitsApiType('all', undefined)).toBe(true)
   })
+
+  it('lets a provider-agnostic agent take either protocol', () => {
+    expect(modelFitsApiType('anthropic', 'all')).toBe(true)
+    expect(modelFitsApiType('openai', 'all')).toBe(true)
+    expect(modelFitsApiType('all', 'all')).toBe(true)
+  })
 })
 
 describe('modelFitsAgent', () => {
   it('routes each known agent to its protocol', () => {
     expect(modelFitsAgent('anthropic', 'claude-code')).toBe(true)
+    expect(modelFitsAgent('openai', 'claude-code')).toBe(false)
+    expect(modelFitsAgent('openai', 'codex')).toBe(true)
     expect(modelFitsAgent('anthropic', 'codex')).toBe(false)
-    expect(modelFitsAgent('openai', 'opencode')).toBe(true)
-    expect(modelFitsAgent('openai', 'pi')).toBe(false)
+  })
+
+  it('lets the provider-agnostic agents take either protocol', () => {
+    for (const agent of ['opencode', 'pi']) {
+      expect(modelFitsAgent('anthropic', agent)).toBe(true)
+      expect(modelFitsAgent('openai', agent)).toBe(true)
+    }
   })
 
   it('makes an "all" model available to every known agent', () => {

--- a/codey-mac/src/components/modelApiType.ts
+++ b/codey-mac/src/components/modelApiType.ts
@@ -8,23 +8,28 @@
 
 export type ApiType = 'anthropic' | 'openai' | 'all'
 
-/** Each agent's CLI authenticates against exactly one protocol. */
+/**
+ * The protocol each agent's CLI authenticates against. 'all' marks a
+ * provider-agnostic CLI (it picks the provider from the model name), so it
+ * accepts models of either protocol.
+ */
 export const AGENT_API_TYPE: Record<string, ApiType> = {
   'claude-code': 'anthropic',
-  'opencode': 'openai',
+  'opencode': 'all',
   'codex': 'openai',
-  'pi': 'anthropic',
+  'pi': 'all',
 }
 
 export const AGENT_NAMES = ['claude-code', 'opencode', 'codex', 'pi'] as const
 
 /**
  * True when a model can drive an agent that speaks `want`. An 'all' model
- * (third-party provider exposing both protocols) fits every agent; an
- * undefined `want` means the agent declares no protocol, so anything goes.
+ * (third-party provider exposing both protocols) fits every agent, and an
+ * 'all' agent (provider-agnostic CLI) accepts every model; an undefined
+ * `want` means the agent declares no protocol, so anything goes.
  */
 export function modelFitsApiType(modelApiType: ApiType, want?: ApiType): boolean {
-  if (!want) return true
+  if (!want || want === 'all') return true
   return modelApiType === 'all' || modelApiType === want
 }
 

--- a/packages/core/src/types/index.test.ts
+++ b/packages/core/src/types/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isApiType, modelFitsApiType } from './index';
+
+describe('isApiType', () => {
+  it('accepts the three protocol values and nothing else', () => {
+    expect(isApiType('anthropic')).toBe(true);
+    expect(isApiType('openai')).toBe(true);
+    expect(isApiType('all')).toBe(true);
+    expect(isApiType('gemini')).toBe(false);
+    expect(isApiType(undefined)).toBe(false);
+  });
+});
+
+describe('modelFitsApiType', () => {
+  it('matches a model against an agent that speaks the same protocol', () => {
+    expect(modelFitsApiType('anthropic', 'anthropic')).toBe(true);
+    expect(modelFitsApiType('openai', 'openai')).toBe(true);
+  });
+
+  it('rejects a protocol mismatch', () => {
+    expect(modelFitsApiType('anthropic', 'openai')).toBe(false);
+    expect(modelFitsApiType('openai', 'anthropic')).toBe(false);
+  });
+
+  it("lets an 'all' model drive any agent", () => {
+    expect(modelFitsApiType('all', 'anthropic')).toBe(true);
+    expect(modelFitsApiType('all', 'openai')).toBe(true);
+  });
+
+  it("lets an 'all' agent take any model", () => {
+    expect(modelFitsApiType('anthropic', 'all')).toBe(true);
+    expect(modelFitsApiType('openai', 'all')).toBe(true);
+    expect(modelFitsApiType('all', 'all')).toBe(true);
+  });
+
+  it('accepts anything when the agent declares no protocol', () => {
+    expect(modelFitsApiType('anthropic', undefined)).toBe(true);
+    expect(modelFitsApiType('openai', undefined)).toBe(true);
+  });
+});

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -56,11 +56,12 @@ export function isApiType(v: unknown): v is ApiType {
 
 /**
  * True when a model of `modelApiType` can drive an agent that speaks
- * `agentApiType`. 'all' fits everything; an undefined want (agent with no
- * declared protocol) accepts anything.
+ * `agentApiType`. 'all' fits everything on either side — an 'all' model
+ * serves any agent, and an 'all' agent (provider-agnostic CLI) accepts any
+ * model; an undefined want (agent with no declared protocol) accepts anything.
  */
 export function modelFitsApiType(modelApiType: ApiType, agentApiType?: ApiType): boolean {
-  if (!agentApiType) return true;
+  if (!agentApiType || agentApiType === 'all') return true;
   return modelApiType === 'all' || modelApiType === agentApiType;
 }
 


### PR DESCRIPTION
## What

`AGENT_API_TYPE` pinned each agent to one wire protocol. pi was `anthropic` and opencode was `openai`, which filtered half the model catalog out of every model picker (Chat, Workers, Settings fallback chain, Advisor/Aide) for those two agents.

That restriction had no runtime basis. Both CLIs are provider-agnostic — they pick the provider from the model name, and the adapters only pass `--model <name>` through without validating it. Credentials are already routed by the **model's** `apiType` in `applyModelEnv`, so an openai model under pi correctly gets `OPENAI_BASE_URL` + `OPENAI_API_KEY`. The per-adapter default there (`'anthropic'` for pi, `'openai'` for opencode) is only a fallback for models that declare no `apiType` at all.

## Changes

- `AGENT_API_TYPE`: pi and opencode → `'all'`.
- `modelFitsApiType` (both copies): `'all'` is now a wildcard on the **agent** side too. It was only handled on the model side, so a `want` of `'all'` would have fallen through to the equality check and left just `'all'` models selectable — the opposite of the intent. This was the non-obvious half of the change.
- Tests for the core copy of `modelFitsApiType`, which had none. It mirrors the renderer's copy by hand (the renderer must not import core, or the packaged window blanks), so the two drifting apart is a live risk.

## Deliberately unchanged

- **claude-code and codex stay pinned.** Their CLIs authenticate against exactly one protocol (`ANTHROPIC_*` / `OPENAI_*` respectively), so relaxing them would only surface combinations that cannot work.
- **The `applyModelEnv` per-adapter fallbacks stay.** `config.ts` normalizes every model entry to a valid `apiType`, so the path is unreachable in practice — kept as defence.

## Testing

`npm test -w @codey/core` → 507 passed. `npm test -w codey-mac` → 548 passed.

Not exercised on a real run: actually driving pi with an openai-protocol model end to end. The reasoning above is from reading the adapters, not from a live invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)