### PR TITLE
Name the endpoint an "all" model's key is missing

### DIFF
--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -3,7 +3,7 @@ import { apiService } from '../services/api'
 import { C } from '../theme'
 import { fieldStyle, inputStyle, pageStyle, selectStyle, pillButton, Section, Toggle, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
-import { AGENT_API_TYPE, AGENT_NAMES, ApiType, modelFitsApiType } from './modelApiType'
+import { AGENT_API_TYPE, AGENT_NAMES, ApiType, agentsPinnedTo, missingAllEndpoints, modelFitsApiType } from './modelApiType'
 
 interface SettingsTabProps {
   isGatewayRunning: boolean
@@ -172,6 +172,29 @@ export const EnvEditor: React.FC<{
 
 // ── Model row (view + edit) ─────────────────────────────────────────
 
+// What an 'all' model's bound key actually covers. An 'all' model claims both
+// protocols, but each one is only wired up when the key defines its base URL —
+// the other half stays on the ambient environment, which surfaces at run time
+// as an authentication failure rather than a configuration one. This is the
+// only place that gap is visible before a run, so it's stated plainly.
+const AllEndpointsHint: React.FC<{ keyEntry?: ApiKeyEntry }> = ({ keyEntry }) => {
+  const missing = missingAllEndpoints('all', keyEntry)
+  const generic = 'Usable by every agent. Each protocol is wired up only if the selected API key defines its base URL — set both on the key to cover all agents.'
+  if (!keyEntry || missing.length === 0) {
+    return <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.45 }}>{generic}</div>
+  }
+  const stranded = missing.flatMap(agentsPinnedTo)
+  return (
+    <div style={{ color: C.warningFg, fontSize: 11, lineHeight: 1.45 }}>
+      Key "{keyEntry.name}" defines no {missing.join(' or ')} base URL
+      {missing.length === 2
+        ? ' at all, so nothing is wired up and every agent falls back to the ambient environment.'
+        : `, so that protocol falls back to the ambient environment${stranded.length ? ` and ${stranded.join(', ')} cannot use this model` : ''}.`}
+      {' '}Add it under API Keys, or give this model a single-protocol API Type.
+    </div>
+  )
+}
+
 const ModelRow: React.FC<{
   entry: ModelEntry
   apis: ApiKeyEntry[]
@@ -246,13 +269,6 @@ const ModelRow: React.FC<{
           <option value="openai">openai (OPENAI_BASE_URL + OPENAI_API_KEY)</option>
           <option value="all">all (third-party providers &amp; proxies)</option>
         </select>
-        {draft.apiType === 'all' && <>
-          <span />
-          <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.45 }}>
-            Usable by every agent. Each protocol is wired up only if the selected
-            API key defines its base URL — set both on the key to cover all agents.
-          </div>
-        </>}
         <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
         <select
           value={draft.apiKeyRef ?? ''}
@@ -264,6 +280,10 @@ const ModelRow: React.FC<{
             <option key={a.name} value={a.name}>{a.name}</option>
           ))}
         </select>
+        {draft.apiType === 'all' && <>
+          <span />
+          <AllEndpointsHint keyEntry={apis.find(a => a.name === draft.apiKeyRef)} />
+        </>}
       </div>
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>

--- a/codey-mac/src/components/modelApiType.test.ts
+++ b/codey-mac/src/components/modelApiType.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { AGENT_API_TYPE, modelFitsAgent, modelFitsApiType } from './modelApiType'
+import { AGENT_API_TYPE, agentsPinnedTo, missingAllEndpoints, modelFitsAgent, modelFitsApiType } from './modelApiType'
 
 describe('modelFitsApiType', () => {
   it('matches like-for-like protocols', () => {
@@ -52,5 +52,44 @@ describe('modelFitsAgent', () => {
 
   it('accepts an unknown agent name', () => {
     expect(modelFitsAgent('openai', 'some-future-agent')).toBe(true)
+  })
+})
+
+describe('missingAllEndpoints', () => {
+  const both = { anthropicBaseUrl: 'https://a', openaiBaseUrl: 'https://o' }
+
+  it('is satisfied when the key covers both protocols', () => {
+    expect(missingAllEndpoints('all', both)).toEqual([])
+  })
+
+  it('names the protocol whose endpoint the key lacks', () => {
+    expect(missingAllEndpoints('all', { openaiBaseUrl: 'https://o' })).toEqual(['anthropic'])
+    expect(missingAllEndpoints('all', { anthropicBaseUrl: 'https://a' })).toEqual(['openai'])
+  })
+
+  it('names both when the key defines no endpoint at all', () => {
+    expect(missingAllEndpoints('all', {})).toEqual(['anthropic', 'openai'])
+    expect(missingAllEndpoints('all', { anthropicBaseUrl: '  ' })).toEqual(['anthropic', 'openai'])
+  })
+
+  it('says nothing about single-protocol models — a bare base URL is normal there', () => {
+    expect(missingAllEndpoints('anthropic', {})).toEqual([])
+    expect(missingAllEndpoints('openai', {})).toEqual([])
+  })
+
+  it('says nothing when no key is bound — that is opting into the ambient env', () => {
+    expect(missingAllEndpoints('all', undefined)).toEqual([])
+  })
+})
+
+describe('agentsPinnedTo', () => {
+  it('lists only the agents with no other protocol to fall back on', () => {
+    expect(agentsPinnedTo('anthropic')).toEqual(['claude-code'])
+    expect(agentsPinnedTo('openai')).toEqual(['codex'])
+  })
+
+  it('excludes the provider-agnostic agents, which run on either protocol', () => {
+    expect(agentsPinnedTo('anthropic')).not.toContain('pi')
+    expect(agentsPinnedTo('openai')).not.toContain('opencode')
   })
 })

--- a/codey-mac/src/components/modelApiType.ts
+++ b/codey-mac/src/components/modelApiType.ts
@@ -37,3 +37,40 @@ export function modelFitsApiType(modelApiType: ApiType, want?: ApiType): boolean
 export function modelFitsAgent(modelApiType: ApiType, agent?: string): boolean {
   return modelFitsApiType(modelApiType, agent ? AGENT_API_TYPE[agent] : undefined)
 }
+
+/** The base URLs an API key entry defines, as far as this check cares. */
+export interface KeyEndpoints {
+  anthropicBaseUrl?: string
+  openaiBaseUrl?: string
+}
+
+/**
+ * Which protocols an 'all' model promises that its bound key cannot deliver.
+ *
+ * An 'all' model claims both endpoints, but `applyModelEnv` wires each protocol
+ * up only when the key defines that protocol's base URL — the other half is
+ * silently left on the ambient environment, so the spawned CLI aims a
+ * third-party token at the real api.anthropic.com / api.openai.com and fails in
+ * a way that reads like a broken key. Naming the missing halves before the
+ * model is saved is the only place that mismatch is visible.
+ *
+ * Only meaningful for 'all'. A single-protocol model with no base URL is the
+ * ordinary "talk to the official endpoint" case, and a model bound to no key at
+ * all is explicitly opting into the ambient environment.
+ */
+export function missingAllEndpoints(apiType: ApiType, key?: KeyEndpoints): ApiType[] {
+  if (apiType !== 'all' || !key) return []
+  const missing: ApiType[] = []
+  if (!key.anthropicBaseUrl?.trim()) missing.push('anthropic')
+  if (!key.openaiBaseUrl?.trim()) missing.push('openai')
+  return missing
+}
+
+/**
+ * Agents that speak `protocol` and nothing else — the ones with no other
+ * protocol to fall back on when its endpoint is missing. An 'all' agent is
+ * excluded: it can still run on whichever protocol did get wired up.
+ */
+export function agentsPinnedTo(protocol: ApiType): string[] {
+  return AGENT_NAMES.filter(a => AGENT_API_TYPE[a] === protocol)
+}

--- a/packages/core/src/agents/env.test.ts
+++ b/packages/core/src/agents/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyModelEnv, nvmBinDirs, withCommonBinPaths } from './env';
+import { applyModelEnv, nvmBinDirs, unwiredAllProtocols, withCommonBinPaths } from './env';
 
 describe('nvmBinDirs', () => {
   it('orders installed versions newest-first', () => {
@@ -118,5 +118,38 @@ describe('applyModelEnv', () => {
 
   it('does not mutate anything for an absent model', () => {
     expect(applyModelEnv({ PATH: '/usr/bin' }, undefined, 'anthropic')).toEqual({ PATH: '/usr/bin' });
+  });
+});
+
+describe('unwiredAllProtocols', () => {
+  const all = { provider: 'acme', model: 'acme-max', apiKey: 'sk-both', apiType: 'all' as const };
+
+  it('is satisfied when both endpoints are present', () => {
+    expect(unwiredAllProtocols({
+      ...all, anthropicBaseUrl: 'https://a', openaiBaseUrl: 'https://o',
+    })).toEqual([]);
+  });
+
+  it('names the half that applyModelEnv will leave on the ambient environment', () => {
+    expect(unwiredAllProtocols({ ...all, openaiBaseUrl: 'https://o' })).toEqual(['anthropic']);
+    expect(unwiredAllProtocols({ ...all, anthropicBaseUrl: 'https://a' })).toEqual(['openai']);
+    expect(unwiredAllProtocols(all)).toEqual(['anthropic', 'openai']);
+  });
+
+  it('agrees with what applyModelEnv actually wires up', () => {
+    const model = { ...all, openaiBaseUrl: 'https://o' };
+    const env = applyModelEnv({}, model, 'anthropic');
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(unwiredAllProtocols(model)).toContain('anthropic');
+  });
+
+  it('says nothing about single-protocol models — a bare baseUrl is the official API', () => {
+    expect(unwiredAllProtocols({ provider: 'anthropic', model: 'm', apiKey: 'k', apiType: 'anthropic' })).toEqual([]);
+    expect(unwiredAllProtocols({ provider: 'openai', model: 'm', apiKey: 'k', apiType: 'openai' })).toEqual([]);
+  });
+
+  it('says nothing when there is no key to wire up', () => {
+    expect(unwiredAllProtocols({ provider: 'acme', model: 'm', apiType: 'all' })).toEqual([]);
+    expect(unwiredAllProtocols(undefined)).toEqual([]);
   });
 });

--- a/packages/core/src/agents/env.ts
+++ b/packages/core/src/agents/env.ts
@@ -69,6 +69,24 @@ export function withCommonBinPaths(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 }
 
 /**
+ * The protocols an 'all' model claims but has no base URL for, and so leaves
+ * on the ambient environment. Mirrors the wiring rule in `applyModelEnv` —
+ * change one and this goes stale.
+ *
+ * Only 'all' models can be half-wired: a single-protocol model carries its one
+ * endpoint on `baseUrl`, and an absent `baseUrl` there is the ordinary "talk to
+ * the official API" case rather than a gap. A model with no credentials at all
+ * is likewise opting into the ambient environment on purpose.
+ */
+export function unwiredAllProtocols(model: ModelConfig | undefined): Array<'anthropic' | 'openai'> {
+  if (!model || model.apiType !== 'all' || !model.apiKey) return [];
+  const missing: Array<'anthropic' | 'openai'> = [];
+  if (!model.anthropicBaseUrl) missing.push('anthropic');
+  if (!model.openaiBaseUrl) missing.push('openai');
+  return missing;
+}
+
+/**
  * Apply model credentials to a child-process env map using the style
  * declared on ModelConfig.apiType. Does not mutate the caller's env.
  *

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -11,7 +11,7 @@ export { ClaudeCodeAdapter } from './claude-code';
 export { OpenCodeAdapter } from './opencode';
 export { CodexAdapter } from './codex';
 export { PiAdapter } from './pi';
-export { applyModelEnv } from './env';
+export { applyModelEnv, unwiredAllProtocols } from './env';
 export * from './codey-skills';
 
 /**

--- a/packages/gateway/src/gateway.model-binding.test.ts
+++ b/packages/gateway/src/gateway.model-binding.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { bindModelToApiKey } from './gateway';
+
+const key = {
+  apiKey: 'sk-shared',
+  anthropicBaseUrl: 'https://proxy.test/anthropic',
+  openaiBaseUrl: 'https://proxy.test/openai',
+};
+
+describe('bindModelToApiKey', () => {
+  it('gives an "all" model both endpoints so either protocol can be wired up', () => {
+    const cfg = bindModelToApiKey({ model: 'acme-max', apiType: 'all' }, key);
+    expect(cfg.anthropicBaseUrl).toBe('https://proxy.test/anthropic');
+    expect(cfg.openaiBaseUrl).toBe('https://proxy.test/openai');
+    expect(cfg.apiKey).toBe('sk-shared');
+  });
+
+  it('carries whichever endpoint an "all" model\'s key actually defines', () => {
+    const cfg = bindModelToApiKey(
+      { model: 'acme-max', apiType: 'all' },
+      { apiKey: 'sk-shared', openaiBaseUrl: 'https://proxy.test/openai' },
+    );
+    expect(cfg.anthropicBaseUrl).toBeUndefined();
+    expect(cfg.openaiBaseUrl).toBe('https://proxy.test/openai');
+  });
+
+  it('withholds the dual endpoints from single-protocol models', () => {
+    for (const apiType of ['anthropic', 'openai'] as const) {
+      const cfg = bindModelToApiKey({ model: 'm', apiType }, key);
+      expect(cfg.anthropicBaseUrl).toBeUndefined();
+      expect(cfg.openaiBaseUrl).toBeUndefined();
+    }
+  });
+
+  it('points baseUrl at the model\'s own protocol', () => {
+    expect(bindModelToApiKey({ model: 'm', apiType: 'anthropic' }, key).baseUrl)
+      .toBe('https://proxy.test/anthropic');
+    expect(bindModelToApiKey({ model: 'm', apiType: 'openai' }, key).baseUrl)
+      .toBe('https://proxy.test/openai');
+  });
+
+  it('resolves an "all" model\'s baseUrl anthropic-first for single-protocol callers', () => {
+    expect(bindModelToApiKey({ model: 'm', apiType: 'all' }, key).baseUrl)
+      .toBe('https://proxy.test/anthropic');
+    expect(bindModelToApiKey({ model: 'm', apiType: 'all' }, { apiKey: 'k', openaiBaseUrl: 'https://o' }).baseUrl)
+      .toBe('https://o');
+  });
+
+  it('leaves every endpoint unset when the model is bound to no key', () => {
+    const cfg = bindModelToApiKey({ model: 'm', apiType: 'all' });
+    expect(cfg.apiKey).toBeUndefined();
+    expect(cfg.baseUrl).toBeUndefined();
+    expect(cfg.anthropicBaseUrl).toBeUndefined();
+    expect(cfg.openaiBaseUrl).toBeUndefined();
+  });
+
+  it('keeps an explicit provider label and defaults the rest by protocol', () => {
+    expect(bindModelToApiKey({ model: 'm', apiType: 'all', provider: 'acme' }).provider).toBe('acme');
+    expect(bindModelToApiKey({ model: 'm', apiType: 'openai' }).provider).toBe('openai');
+    expect(bindModelToApiKey({ model: 'm', apiType: 'anthropic' }).provider).toBe('anthropic');
+  });
+});

--- a/packages/gateway/src/gateway.model-binding.test.ts
+++ b/packages/gateway/src/gateway.model-binding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { bindModelToApiKey } from './gateway';
+import { bindModelToApiKey, unwiredAllModelWarning } from './gateway';
 
 const key = {
   apiKey: 'sk-shared',
@@ -58,5 +58,33 @@ describe('bindModelToApiKey', () => {
     expect(bindModelToApiKey({ model: 'm', apiType: 'all', provider: 'acme' }).provider).toBe('acme');
     expect(bindModelToApiKey({ model: 'm', apiType: 'openai' }).provider).toBe('openai');
     expect(bindModelToApiKey({ model: 'm', apiType: 'anthropic' }).provider).toBe('anthropic');
+  });
+});
+
+describe('unwiredAllModelWarning', () => {
+  it('says nothing when the key covers both protocols', () => {
+    expect(unwiredAllModelWarning(bindModelToApiKey({ model: 'acme-max', apiType: 'all' }, key))).toBeUndefined();
+  });
+
+  it('names the missing protocol and the key it is missing from', () => {
+    const cfg = bindModelToApiKey(
+      { model: 'acme-max', apiType: 'all' },
+      { apiKey: 'sk-shared', openaiBaseUrl: 'https://proxy.test/openai' },
+    );
+    const warning = unwiredAllModelWarning(cfg, 'acme-proxy');
+    expect(warning).toContain('acme-max');
+    expect(warning).toContain('"acme-proxy"');
+    expect(warning).toContain('no anthropic base URL');
+    expect(warning).not.toContain('openai base URL');
+  });
+
+  it('reports both halves when the key defines no endpoint at all', () => {
+    const cfg = bindModelToApiKey({ model: 'acme-max', apiType: 'all' }, { apiKey: 'sk-shared' });
+    expect(unwiredAllModelWarning(cfg)).toContain('neither protocol is wired up');
+  });
+
+  it('says nothing about single-protocol models or unbound ones', () => {
+    expect(unwiredAllModelWarning(bindModelToApiKey({ model: 'm', apiType: 'anthropic' }, key))).toBeUndefined();
+    expect(unwiredAllModelWarning(bindModelToApiKey({ model: 'm', apiType: 'all' }))).toBeUndefined();
   });
 });

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -75,6 +75,40 @@ export function summarizeFailure(response: AgentResponse): string | undefined {
   const raw = (response.error ?? response.output ?? '').trim();
   if (!raw) return undefined;
   return raw.length > FALLBACK_REASON_MAX ? `${raw.slice(0, FALLBACK_REASON_MAX).trimEnd()}…` : raw;
+}
+
+/**
+ * Expand a catalog model row plus its bound API key into the ModelConfig an
+ * adapter receives. Split out of `getModelConfig` because this is the single
+ * place a dual-protocol ('all') model gets its two endpoints — if it stopped
+ * populating them, `applyModelEnv` would wire up nothing and every 'all' model
+ * would silently degrade to the ambient environment, with both of its own
+ * tests still green.
+ *
+ * `anthropicBaseUrl` / `openaiBaseUrl` are deliberately confined to 'all'
+ * models: a single-protocol model's endpoint belongs on `baseUrl`, which stays
+ * the anthropic-first pick for callers (like text-completion) that can only
+ * speak one protocol at a time.
+ */
+export function bindModelToApiKey(
+  entry: { model: string; apiType: ApiType; provider?: string },
+  apiKey?: { apiKey: string; anthropicBaseUrl?: string; openaiBaseUrl?: string },
+): ModelConfig {
+  const isAll = entry.apiType === 'all';
+  const baseUrl = apiKey
+    ? (entry.apiType === 'anthropic' ? apiKey.anthropicBaseUrl
+      : entry.apiType === 'openai' ? apiKey.openaiBaseUrl
+      : apiKey.anthropicBaseUrl ?? apiKey.openaiBaseUrl)
+    : undefined;
+  return {
+    provider: entry.provider ?? (entry.apiType === 'openai' ? 'openai' : 'anthropic'),
+    model: entry.model,
+    apiKey: apiKey?.apiKey,
+    baseUrl,
+    anthropicBaseUrl: isAll ? apiKey?.anthropicBaseUrl : undefined,
+    openaiBaseUrl: isAll ? apiKey?.openaiBaseUrl : undefined,
+    apiType: entry.apiType,
+  };
 }
 
 /** Explicit `/skill <name> <task>` invocation. Threaded per-turn: handleMessage
@@ -5406,24 +5440,7 @@ Example: /model gpt-4.1 write a Python script`;
           `Model "${catalogEntry.model}" references API key "${catalogEntry.apiKeyRef}" which no longer exists. Open Settings → API Keys to add it, or rebind the model.`
         );
       }
-      // 'all' models carry both endpoints so the adapter can wire up whichever
-      // protocol its CLI speaks; `baseUrl` stays the anthropic-first pick for
-      // callers (like text-completion) that only speak one at a time.
-      const isAll = catalogEntry.apiType === 'all';
-      const baseUrl = apiKey
-        ? (catalogEntry.apiType === 'anthropic' ? apiKey.anthropicBaseUrl
-          : catalogEntry.apiType === 'openai' ? apiKey.openaiBaseUrl
-          : apiKey.anthropicBaseUrl ?? apiKey.openaiBaseUrl)
-        : undefined;
-      return {
-        provider: catalogEntry.provider ?? (catalogEntry.apiType === 'openai' ? 'openai' : 'anthropic'),
-        model: catalogEntry.model,
-        apiKey: apiKey?.apiKey,
-        baseUrl,
-        anthropicBaseUrl: isAll ? apiKey?.anthropicBaseUrl : undefined,
-        openaiBaseUrl: isAll ? apiKey?.openaiBaseUrl : undefined,
-        apiType: catalogEntry.apiType,
-      };
+      return bindModelToApiKey(catalogEntry, apiKey);
     }
 
     // 2. Check if model is in the agent's model list

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType } from '@codey/core';
+import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType, unwiredAllProtocols } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -75,6 +75,31 @@ export function summarizeFailure(response: AgentResponse): string | undefined {
   const raw = (response.error ?? response.output ?? '').trim();
   if (!raw) return undefined;
   return raw.length > FALLBACK_REASON_MAX ? `${raw.slice(0, FALLBACK_REASON_MAX).trimEnd()}…` : raw;
+}
+
+/**
+ * The log line for an 'all' model whose key covers only one protocol, or
+ * undefined when there is nothing to say.
+ *
+ * `applyModelEnv` wires up a protocol only when its base URL is known, so the
+ * missing half silently stays on the ambient environment: the CLI aims a
+ * third-party token at the real api.anthropic.com / api.openai.com and fails
+ * as what reads like a broken key. The model editor warns while editing, but a
+ * model written by `models:save` or by hand into gateway.json never passes
+ * through it — `getModelConfig` is the one point every path converges on
+ * before a CLI is spawned.
+ */
+export function unwiredAllModelWarning(model: ModelConfig, keyRef?: string): string | undefined {
+  const missing = unwiredAllProtocols(model);
+  if (missing.length === 0) return undefined;
+  const where = keyRef ? `API key "${keyRef}"` : 'its API key';
+  const consequence = missing.length === 2
+    ? 'neither protocol is wired up'
+    : 'that protocol is not wired up';
+  return `Model "${model.model}" has apiType "all" but ${where} defines no ${missing.join(' or ')} `
+    + `base URL, so ${consequence} and the ambient environment is used instead. `
+    + `Agents pinned to ${missing.join('/')} will authenticate against the official endpoint and likely fail. `
+    + `Add the base URL under API Keys, or give this model a single-protocol API Type.`;
 }
 
 /**
@@ -152,6 +177,7 @@ export class Codey {
 
   // Rate limiting: userId -> last request timestamp
   private userCooldowns: Map<string, number> = new Map();
+  private warnedUnwiredModels: Set<string> = new Set();
   private readonly COOLDOWN_MS: number;
 
   // Response chunking
@@ -5423,6 +5449,18 @@ Example: /model gpt-4.1 write a Python script`;
     return Date.now() - lastRequest >= this.COOLDOWN_MS;
   }
 
+  /**
+   * Emit `unwiredAllModelWarning` at most once per model per process.
+   * getModelConfig runs on every turn and every fallback resolution, so a
+   * per-turn line would bury the rest of the log.
+   */
+  private warnUnwiredAllModel(model: ModelConfig, keyRef?: string): void {
+    const warning = unwiredAllModelWarning(model, keyRef);
+    if (!warning || this.warnedUnwiredModels.has(model.model)) return;
+    this.warnedUnwiredModels.add(model.model);
+    this.logger.warn(warning);
+  }
+
   getModelConfig(agent: CodingAgent, modelName: string): ModelConfig | undefined {
     // 1. Check the global model catalog. Credentials live on the referenced
     //    ApiKeyEntry, not on the model itself — walk apiKeyRef to load them.
@@ -5440,7 +5478,9 @@ Example: /model gpt-4.1 write a Python script`;
           `Model "${catalogEntry.model}" references API key "${catalogEntry.apiKeyRef}" which no longer exists. Open Settings → API Keys to add it, or rebind the model.`
         );
       }
-      return bindModelToApiKey(catalogEntry, apiKey);
+      const bound = bindModelToApiKey(catalogEntry, apiKey);
+      this.warnUnwiredAllModel(bound, catalogEntry.apiKeyRef);
+      return bound;
     }
 
     // 2. Check if model is in the agent's model list


### PR DESCRIPTION
Stacked on #297 — review that one first.

## What

An `apiType: 'all'` model promises both protocols, but `applyModelEnv` wires each one up only when the bound API key defines that protocol's base URL. The missing half is **deliberately** left on the ambient environment (`env.ts:80-84`) rather than aiming a third-party token at the real `api.anthropic.com` / `api.openai.com`.

Nothing upstream enforced the pairing, though. `models:save` validates the `apiType` string but not the key it references, `modelFitsApiType` passes `'all'` unconditionally to every agent, and the hint in the model editor was static text shown regardless of what the key actually contained. So "all model + key with one URL" was a saveable, selectable configuration whose only symptom arrived at run time, as an auth failure that reads like a broken key.

#297 widened the exposure: pi and opencode now accept models of either protocol, so twice as many agents can land on the unwired half.

## Changes

**Warn, with specifics.** The model editor resolves the selected key and names the protocol whose base URL is absent, plus the agents pinned to it (`claude-code` for anthropic, `codex` for openai — the provider-agnostic ones are excluded, since they can still run on whichever protocol did get wired). The hint moved below the API Key row, which is what it now depends on.

It stays a **warning, not a validation error**. The ambient environment may legitimately carry the other half, and blocking the save would break that setup. Two new pure helpers in `modelApiType.ts` (`missingAllEndpoints`, `agentsPinnedTo`) carry the logic and the tests.

**Cover the binding.** `bindModelToApiKey` is extracted out of `Gateway.getModelConfig` and tested. It is the only place an 'all' model's two endpoints get populated, and it had none — the downstream 'all' tests in `env.test.ts` and `text-completion.test.ts` both hand-construct their `ModelConfig`, so this regressing would leave every 'all' model silently degraded to the ambient environment with both suites still green. Pure extraction, no behaviour change.

## Not addressed

`bindModelToApiKey` labels an 'all' model's `provider` as `'anthropic'` (the ternary has no branch for `'all'`). It's a wrong-looking label with no runtime effect — `ModelConfig.provider` has zero consumers in the adapters — so it's left alone rather than churned.

## Testing

`npm test -w codey-mac` → 555 passed. `npm test -w @codey/gateway` → 335 passed. `npm run lint` clean, `tsc` clean for both workspaces.

Not verified: the warning has not been looked at in the running app — the copy and layout are reasoned from the surrounding code, not seen rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: the same check at run time (commit 2)

The editor warning only covers the Mac app. A model written by `models:save`, hand-edited into `gateway.json`, or one whose key loses a base URL after the fact still reached a CLI silently.

`unwiredAllProtocols` (core, `agents/env.ts`) mirrors the wiring rule in `applyModelEnv`, and `unwiredAllModelWarning` + `Gateway.getModelConfig` log the missing half — that is the one point every path converges on before a CLI is spawned. Once per model per process, since `getModelConfig` runs on every turn and every fallback resolution.

Rebased onto `main` (`2be81bd`). `@codey/core` 529 passed, `@codey/gateway` 339 passed, `codey-mac` 588 passed, lint and `tsc` clean. The editor warning is still unverified in a running app.