### PR TITLE
List the MCP servers already configured in each coding agent

### DIFF
--- a/codey-mac/electron/agent-mcp-scan.test.ts
+++ b/codey-mac/electron/agent-mcp-scan.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import * as nodePath from 'path'
+import { parseCodexMcpServers, scanAgentMcpServers, stripJsonComments, type ScanFs } from './agent-mcp-scan'
+
+const HOME = '/home/u'
+
+/** In-memory disk: keys are absolute paths, values are file contents. */
+const fakeFs = (files: Record<string, string>): ScanFs => ({
+  existsSync: (p: string) => Object.prototype.hasOwnProperty.call(files, p),
+  readFileSync: (p: string) => {
+    const content = files[p]
+    if (content === undefined) throw new Error(`ENOENT: ${p}`)
+    return content
+  },
+})
+
+const scan = (files: Record<string, string>, extra: Partial<Parameters<typeof scanAgentMcpServers>[0]> = {}) =>
+  scanAgentMcpServers({ fs: fakeFs(files), path: nodePath, home: HOME, ...extra })
+
+describe('scanAgentMcpServers — Claude Code', () => {
+  it('reads user, project and .mcp.json servers with their transports', () => {
+    const servers = scan({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: { figma: { type: 'http', url: 'https://mcp.figma.com/mcp' } },
+        projects: {
+          '/repo': {
+            mcpServers: { playwright: { type: 'stdio', command: 'npx', args: ['@playwright/mcp@latest'] } },
+            disabledMcpjsonServers: ['linear'],
+          },
+        },
+      }),
+      '/repo/.mcp.json': JSON.stringify({ mcpServers: { linear: { url: 'https://mcp.linear.app/sse' } } }),
+    }, { workingDir: '/repo' })
+
+    expect(servers.map(s => [s.agent, s.name, s.transport, s.scope, s.enabled])).toEqual([
+      ['claude-code', 'figma', 'remote', 'user', true],
+      ['claude-code', 'linear', 'remote', 'project', false],
+      ['claude-code', 'playwright', 'stdio', 'project', true],
+    ])
+    expect(servers[2].args).toEqual(['@playwright/mcp@latest'])
+    expect(servers[1].source).toBe('/repo/.mcp.json')
+  })
+
+  it('honours CLAUDE_CONFIG_DIR and skips project scope without a working dir', () => {
+    const files = {
+      '/home/u/alt/.claude.json': JSON.stringify({ mcpServers: { a: { command: 'a' } } }),
+      [`${HOME}/.claude.json`]: JSON.stringify({ mcpServers: { ignored: { command: 'x' } } }),
+    }
+    const servers = scan(files, { agentEnv: { 'claude-code': { CLAUDE_CONFIG_DIR: '~/alt' } } })
+    expect(servers.map(s => s.name)).toEqual(['a'])
+  })
+
+  it('yields nothing for a malformed config instead of throwing', () => {
+    expect(scan({ [`${HOME}/.claude.json`]: '{ not json' })).toEqual([])
+  })
+})
+
+describe('scanAgentMcpServers — Codex', () => {
+  it('parses mcp_servers tables and skips their env sub-tables', () => {
+    const servers = scan({
+      [`${HOME}/.codex/config.toml`]: [
+        'model = "gpt-5"',
+        '',
+        '[mcp_servers.node_repl]',
+        'command = "/bin/node_repl"',
+        'args = []',
+        'startup_timeout_sec = 120',
+        '',
+        '[mcp_servers.node_repl.env]',
+        'command = "not-a-server-field"',
+        '',
+        '[mcp_servers."computer-use"]',
+        'command = "./client"  # inline comment',
+        'args = ["mcp", "--flag"]',
+        'enabled = false',
+        '',
+        '[desktop]',
+        'command = "unrelated"',
+      ].join('\n'),
+    })
+
+    expect(servers.map(s => [s.agent, s.name, s.command, s.enabled])).toEqual([
+      ['codex', 'computer-use', './client', false],
+      ['codex', 'node_repl', '/bin/node_repl', true],
+    ])
+    expect(servers[0].args).toEqual(['mcp', '--flag'])
+    expect(servers[1].args).toEqual([])
+  })
+
+  it('treats a url entry as a remote server and honours CODEX_HOME', () => {
+    const servers = scan(
+      { '/home/u/cx/config.toml': '[mcp_servers.linear]\nurl = "https://mcp.linear.app/sse"\n' },
+      { agentEnv: { codex: { CODEX_HOME: '/home/u/cx' } } },
+    )
+    expect(servers).toHaveLength(1)
+    expect(servers[0]).toMatchObject({ agent: 'codex', transport: 'remote', url: 'https://mcp.linear.app/sse' })
+  })
+})
+
+describe('parseCodexMcpServers', () => {
+  it('ignores comments, blank lines and unparseable values', () => {
+    const parsed = parseCodexMcpServers([
+      '# leading comment',
+      '[mcp_servers.a]',
+      'command = "x"',
+      'timeout = 30',
+      'nested = { k = 1 }',
+      'no-equals-here',
+    ].join('\n'))
+    expect(parsed).toEqual({ a: { command: 'x' } })
+  })
+})
+
+describe('scanAgentMcpServers — OpenCode', () => {
+  it('splits command arrays and prefers .json over .jsonc', () => {
+    const servers = scan({
+      [`${HOME}/.config/opencode/opencode.json`]: JSON.stringify({
+        mcp: {
+          local: { type: 'local', command: ['npx', '-y', 'srv'], enabled: false },
+          remote: { type: 'remote', url: 'https://example.com/mcp' },
+        },
+      }),
+      [`${HOME}/.config/opencode/opencode.jsonc`]: JSON.stringify({ mcp: { skipped: { type: 'local', command: ['x'] } } }),
+    })
+    expect(servers.map(s => [s.name, s.transport, s.command, s.enabled])).toEqual([
+      ['local', 'stdio', 'npx', false],
+      ['remote', 'remote', undefined, true],
+    ])
+    expect(servers[0].args).toEqual(['-y', 'srv'])
+  })
+
+  it('falls through to .jsonc and reads project config', () => {
+    const servers = scan({
+      [`${HOME}/.config/opencode/opencode.jsonc`]: '{ // user config\n "mcp": { "u": { "type": "local", "command": ["u"] } } }',
+      '/repo/opencode.json': JSON.stringify({ mcp: { p: { type: 'local', command: ['p'] } } }),
+    }, { workingDir: '/repo' })
+    expect(servers.map(s => [s.name, s.scope])).toEqual([['p', 'project'], ['u', 'user']])
+  })
+
+  it('honours XDG_CONFIG_HOME', () => {
+    const servers = scan(
+      { '/home/u/xdg/opencode/opencode.json': JSON.stringify({ mcp: { x: { type: 'local', command: ['x'] } } }) },
+      { agentEnv: { opencode: { XDG_CONFIG_HOME: '/home/u/xdg' } } },
+    )
+    expect(servers.map(s => s.name)).toEqual(['x'])
+  })
+})
+
+describe('stripJsonComments', () => {
+  it('leaves comment-like text inside strings alone', () => {
+    expect(JSON.parse(stripJsonComments('{"url": "https://a/b" /* c */, "p": "a//b" // t\n}')))
+      .toEqual({ url: 'https://a/b', p: 'a//b' })
+  })
+
+  it('keeps escaped quotes from ending a string', () => {
+    expect(JSON.parse(stripJsonComments('{"a": "x\\"//y"}'))).toEqual({ a: 'x"//y' })
+  })
+})
+
+describe('scanAgentMcpServers', () => {
+  it('returns nothing when no agent config exists', () => {
+    expect(scan({}, { workingDir: '/repo' })).toEqual([])
+  })
+})

--- a/codey-mac/electron/agent-mcp-scan.ts
+++ b/codey-mac/electron/agent-mcp-scan.ts
@@ -1,0 +1,316 @@
+/**
+ * Read-only discovery of MCP servers that are already configured inside the
+ * coding agents themselves (Claude Code, Codex, OpenCode).
+ *
+ * Codey's own `mcpServers` config only knows about servers added through the
+ * MCP tab; anything a user set up with `claude mcp add`, `~/.codex/config.toml`
+ * or an opencode config stays invisible. This module scans those native config
+ * files so the tab can show the full picture, tagged with the owning agent.
+ *
+ * Everything here is read-only and best-effort: an unreadable or malformed
+ * config yields no entries rather than an error, because one broken agent
+ * config must not blank out the whole list.
+ *
+ * pi is deliberately absent — it has no MCP surface (see agents/pi.ts).
+ */
+
+export type McpAgentKey = 'claude-code' | 'codex' | 'opencode'
+
+export interface AgentMcpServer {
+  /** Which coding agent's own config this server came from. */
+  agent: McpAgentKey
+  name: string
+  transport: 'stdio' | 'remote'
+  command?: string
+  args?: string[]
+  url?: string
+  /** 'user' = the agent's global config, 'project' = the workspace's repo. */
+  scope: 'user' | 'project'
+  /** false when the agent's own config marks the server disabled. */
+  enabled: boolean
+  /** Absolute path of the config file it was read from, for the tooltip. */
+  source: string
+}
+
+/** Minimal fs surface, injected so the scan is testable without a real disk. */
+export interface ScanFs {
+  existsSync(path: string): boolean
+  readFileSync(path: string, encoding: 'utf-8'): string
+}
+
+export interface ScanPath {
+  join(...parts: string[]): string
+  isAbsolute(p: string): boolean
+}
+
+export interface ScanOptions {
+  fs: ScanFs
+  path: ScanPath
+  home: string
+  /** Working directory of the active workspace; enables project-scope entries. */
+  workingDir?: string | null
+  /** Per-agent env overrides from Codey's config (CLAUDE_CONFIG_DIR, …). */
+  agentEnv?: Partial<Record<McpAgentKey, Record<string, string> | undefined>>
+}
+
+function readJson(fs: ScanFs, file: string): any {
+  if (!fs.existsSync(file)) return null
+  try {
+    return JSON.parse(stripJsonComments(fs.readFileSync(file, 'utf-8')))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * OpenCode accepts .jsonc, and hand-edited .json files often carry comments
+ * too. Strips line and block comments outside of strings; leaves
+ * everything else intact.
+ */
+export function stripJsonComments(text: string): string {
+  let out = ''
+  let inString = false
+  let inLine = false
+  let inBlock = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    const next = text[i + 1]
+    if (inLine) {
+      if (ch === '\n') { inLine = false; out += ch }
+      continue
+    }
+    if (inBlock) {
+      if (ch === '*' && next === '/') { inBlock = false; i++ }
+      continue
+    }
+    if (inString) {
+      out += ch
+      if (ch === '\\') { out += next ?? ''; i++ }
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') { inString = true; out += ch; continue }
+    if (ch === '/' && next === '/') { inLine = true; i++; continue }
+    if (ch === '/' && next === '*') { inBlock = true; i++; continue }
+    out += ch
+  }
+  return out
+}
+
+/** `~/x` and relative paths in agent env vars resolve against home. */
+function resolveDir(path: ScanPath, value: string, home: string): string {
+  if (value.startsWith('~/')) return path.join(home, value.slice(2))
+  if (path.isAbsolute(value)) return value
+  return path.join(home, value)
+}
+
+/** Claude Code's `mcpServers` map: `{ type?, url?, command?, args?, env? }`. */
+function claudeEntries(
+  raw: any,
+  scope: 'user' | 'project',
+  source: string,
+  disabled: Set<string>,
+): AgentMcpServer[] {
+  if (!raw || typeof raw !== 'object') return []
+  const out: AgentMcpServer[] = []
+  for (const [name, cfg] of Object.entries<any>(raw)) {
+    if (!cfg || typeof cfg !== 'object') continue
+    const url = typeof cfg.url === 'string' ? cfg.url : undefined
+    out.push({
+      agent: 'claude-code',
+      name,
+      transport: url ? 'remote' : 'stdio',
+      command: typeof cfg.command === 'string' ? cfg.command : undefined,
+      args: Array.isArray(cfg.args) ? cfg.args.map(String) : undefined,
+      url,
+      scope,
+      enabled: !disabled.has(name),
+      source,
+    })
+  }
+  return out
+}
+
+function scanClaudeCode(opts: ScanOptions): AgentMcpServer[] {
+  const { fs, path, home, workingDir } = opts
+  const configDir = opts.agentEnv?.['claude-code']?.CLAUDE_CONFIG_DIR
+  const configFile = configDir
+    ? path.join(resolveDir(path, configDir, home), '.claude.json')
+    : path.join(home, '.claude.json')
+
+  const config = readJson(fs, configFile)
+  const out: AgentMcpServer[] = []
+  out.push(...claudeEntries(config?.mcpServers, 'user', configFile, new Set()))
+
+  if (!workingDir) return out
+  const project = config?.projects?.[workingDir]
+  // A project-scoped .mcp.json is opt-in per server; the toggles live in the
+  // user config, so both files have to be read together.
+  const disabled = new Set<string>(
+    Array.isArray(project?.disabledMcpjsonServers) ? project.disabledMcpjsonServers.map(String) : [],
+  )
+  out.push(...claudeEntries(project?.mcpServers, 'project', configFile, new Set()))
+
+  const mcpJsonFile = path.join(workingDir, '.mcp.json')
+  out.push(...claudeEntries(readJson(fs, mcpJsonFile)?.mcpServers, 'project', mcpJsonFile, disabled))
+  return out
+}
+
+/**
+ * Just enough TOML to read `[mcp_servers.<name>]` tables out of a Codex
+ * config: table headers (including the `.env` sub-table, which is skipped),
+ * quoted/bare keys, string, bool and flat string-array values. Anything more
+ * exotic is ignored rather than guessed at.
+ */
+export function parseCodexMcpServers(toml: string): Record<string, Record<string, unknown>> {
+  const servers: Record<string, Record<string, unknown>> = {}
+  let current: Record<string, unknown> | null = null
+  for (const rawLine of toml.split('\n')) {
+    const line = rawLine.replace(/^\s+|\s+$/g, '')
+    if (!line || line.startsWith('#')) continue
+    const header = /^\[([^\]]+)\]$/.exec(line)
+    if (header) {
+      const parts = splitTomlKey(header[1])
+      if (parts.length === 2 && parts[0] === 'mcp_servers') {
+        const name = parts[1]
+        current = servers[name] ?? (servers[name] = {})
+      } else {
+        // `[mcp_servers.x.env]` and every unrelated table: stop collecting.
+        current = null
+      }
+      continue
+    }
+    if (!current) continue
+    const eq = line.indexOf('=')
+    if (eq < 0) continue
+    const key = unquote(line.slice(0, eq).trim())
+    const value = parseTomlValue(line.slice(eq + 1).trim())
+    if (value !== undefined) current[key] = value
+  }
+  return servers
+}
+
+/** Split a dotted TOML key, honouring quoted segments like `"my-server"`. */
+function splitTomlKey(key: string): string[] {
+  const parts: string[] = []
+  let buf = ''
+  let inString = false
+  for (let i = 0; i < key.length; i++) {
+    const ch = key[i]
+    if (ch === '"') { inString = !inString; continue }
+    if (ch === '.' && !inString) { parts.push(buf.trim()); buf = ''; continue }
+    buf += ch
+  }
+  parts.push(buf.trim())
+  return parts.filter(p => p.length > 0)
+}
+
+function unquote(value: string): string {
+  const m = /^"(.*)"$/.exec(value) ?? /^'(.*)'$/.exec(value)
+  return m ? m[1] : value
+}
+
+function parseTomlValue(raw: string): unknown {
+  const value = raw.replace(/\s+#.*$/, '').trim()
+  if (value === 'true') return true
+  if (value === 'false') return false
+  if (value.startsWith('[')) {
+    const inner = value.replace(/^\[/, '').replace(/\]$/, '')
+    if (!inner.trim()) return []
+    return inner
+      .split(',')
+      .map(part => unquote(part.trim()))
+      .filter(part => part.length > 0)
+  }
+  if (value.startsWith('"') || value.startsWith("'")) return unquote(value)
+  return undefined
+}
+
+function scanCodex(opts: ScanOptions): AgentMcpServer[] {
+  const { fs, path, home } = opts
+  const codexHome = opts.agentEnv?.codex?.CODEX_HOME
+  const file = path.join(codexHome ? resolveDir(path, codexHome, home) : path.join(home, '.codex'), 'config.toml')
+  if (!fs.existsSync(file)) return []
+  let servers: Record<string, Record<string, unknown>>
+  try {
+    servers = parseCodexMcpServers(fs.readFileSync(file, 'utf-8'))
+  } catch {
+    return []
+  }
+  return Object.entries(servers).map(([name, cfg]) => {
+    const url = typeof cfg.url === 'string' ? cfg.url : undefined
+    return {
+      agent: 'codex' as const,
+      name,
+      transport: url ? ('remote' as const) : ('stdio' as const),
+      command: typeof cfg.command === 'string' ? cfg.command : undefined,
+      args: Array.isArray(cfg.args) ? cfg.args.map(String) : undefined,
+      url,
+      scope: 'user' as const,
+      enabled: cfg.enabled !== false,
+      source: file,
+    }
+  })
+}
+
+/** OpenCode's `mcp` map: `{ type: 'local' | 'remote', command: [], url, enabled }`. */
+function opencodeEntries(raw: any, scope: 'user' | 'project', source: string): AgentMcpServer[] {
+  if (!raw || typeof raw !== 'object') return []
+  const out: AgentMcpServer[] = []
+  for (const [name, cfg] of Object.entries<any>(raw)) {
+    if (!cfg || typeof cfg !== 'object') continue
+    const url = typeof cfg.url === 'string' ? cfg.url : undefined
+    const command = Array.isArray(cfg.command) ? cfg.command.map(String) : []
+    out.push({
+      agent: 'opencode',
+      name,
+      transport: cfg.type === 'remote' || url ? 'remote' : 'stdio',
+      command: command[0],
+      args: command.slice(1),
+      url,
+      scope,
+      enabled: cfg.enabled !== false,
+      source,
+    })
+  }
+  return out
+}
+
+function scanOpenCode(opts: ScanOptions): AgentMcpServer[] {
+  const { fs, path, home, workingDir } = opts
+  const xdg = opts.agentEnv?.opencode?.XDG_CONFIG_HOME
+  const configRoot = xdg ? resolveDir(path, xdg, home) : path.join(home, '.config')
+  const out: AgentMcpServer[] = []
+  for (const file of candidates(path, path.join(configRoot, 'opencode'))) {
+    const found = opencodeEntries(readJson(fs, file)?.mcp, 'user', file)
+    if (found.length > 0) { out.push(...found); break }
+  }
+  if (workingDir) {
+    for (const file of candidates(path, workingDir)) {
+      const found = opencodeEntries(readJson(fs, file)?.mcp, 'project', file)
+      if (found.length > 0) { out.push(...found); break }
+    }
+  }
+  return out
+}
+
+function candidates(path: ScanPath, dir: string): string[] {
+  return [path.join(dir, 'opencode.json'), path.join(dir, 'opencode.jsonc')]
+}
+
+/**
+ * Every MCP server already configured inside the coding agents, sorted by
+ * agent then name. The same server name may legitimately appear more than
+ * once (different agents, or user vs project scope) — each entry is kept so
+ * the user can see where it comes from.
+ */
+export function scanAgentMcpServers(opts: ScanOptions): AgentMcpServer[] {
+  const scans: Array<(o: ScanOptions) => AgentMcpServer[]> = [scanClaudeCode, scanCodex, scanOpenCode]
+  const all: AgentMcpServer[] = []
+  for (const scan of scans) {
+    try { all.push(...scan(opts)) } catch { /* one broken config must not blank the list */ }
+  }
+  const order: Record<McpAgentKey, number> = { 'claude-code': 0, codex: 1, opencode: 2 }
+  return all.sort((a, b) =>
+    order[a.agent] - order[b.agent] || a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope))
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -14,6 +14,7 @@ import { applyEvent, clearAttention, summarize } from './tray-state'
 import { SKILL_FILE, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
+import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
 import type { ScannedSkill } from './skills'
 import { scanSkillUsage } from './skill-usage'
@@ -3216,6 +3217,29 @@ app.whenReady().then(async () => {
         // A hand-edited codey-browser entry can never reach agents; hide it here too.
         .filter(([name]) => name !== 'codey-browser')
         .map(([name, cfg]) => ({ name, ...(cfg as object) }))
+    })
+  )
+
+  // Servers the user already configured inside the coding agents themselves.
+  // Read-only: Codey does not own these files, it only reports what is there.
+  ipcMain.handle('mcp:listAgent', async () =>
+    wrap(async () => {
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const osMod = await import('os')
+      const agents = coreConfigManager?.get().agents as Record<string, { env?: Record<string, string> }> | undefined
+      const agentEnv: Partial<Record<McpAgentKey, Record<string, string> | undefined>> = {
+        'claude-code': agents?.['claude-code']?.env,
+        codex: agents?.codex?.env,
+        opencode: agents?.opencode?.env,
+      }
+      return scanAgentMcpServers({
+        fs: fsMod,
+        path: pathMod,
+        home: osMod.homedir(),
+        workingDir: getWorkingDir(fsMod, pathMod),
+        agentEnv,
+      }) satisfies AgentMcpServer[]
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -120,6 +120,7 @@ contextBridge.exposeInMainWorld('codey', {
   },
   mcp: {
     list: () => ipcRenderer.invoke('mcp:list'),
+    listAgent: () => ipcRenderer.invoke('mcp:listAgent'),
     save: (draft: any) => ipcRenderer.invoke('mcp:save', draft),
     remove: (name: string) => ipcRenderer.invoke('mcp:remove', name),
     setEnabled: (name: string, enabled: boolean) => ipcRenderer.invoke('mcp:setEnabled', name, enabled),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -38,6 +38,20 @@ export interface ExternalMcpServer {
   enabled: boolean
 }
 
+/** An MCP server discovered inside a coding agent's own config (read-only). */
+export interface AgentMcpServer {
+  agent: 'claude-code' | 'codex' | 'opencode'
+  name: string
+  transport: 'stdio' | 'remote'
+  command?: string
+  args?: string[]
+  url?: string
+  scope: 'user' | 'project'
+  enabled: boolean
+  /** Config file it was read from. */
+  source: string
+}
+
 export interface ModelEntry {
   /** 'all' = dual-protocol provider, usable by every agent. */
   apiType: 'anthropic' | 'openai' | 'all'
@@ -244,6 +258,8 @@ declare global {
       }
       mcp: {
         list: () => Promise<IpcResult<ExternalMcpServer[]>>
+        /** Servers already configured in the coding agents; not managed by Codey. */
+        listAgent: () => Promise<IpcResult<AgentMcpServer[]>>
         save: (draft: Omit<ExternalMcpServer, 'enabled'> & { enabled?: boolean }) => Promise<IpcResult<void>>
         remove: (name: string) => Promise<IpcResult<void>>
         setEnabled: (name: string, enabled: boolean) => Promise<IpcResult<void>>

--- a/codey-mac/src/components/McpTab.tsx
+++ b/codey-mac/src/components/McpTab.tsx
@@ -4,7 +4,7 @@ import { inputStyle, pillButton, Toggle, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { parseArgsLine, parseEnvLines } from './mcp-form'
 import { matchesToolSearch } from './tools-search'
-import type { ExternalMcpServer } from '../codey-api'
+import type { AgentMcpServer, ExternalMcpServer } from '../codey-api'
 
 interface FormState {
   name: string
@@ -17,6 +17,18 @@ interface FormState {
 
 const EMPTY_FORM: FormState = { name: '', transport: 'stdio', command: '', args: '', env: '', url: '' }
 
+const AGENT_LABELS: Record<AgentMcpServer['agent'], string> = {
+  'claude-code': 'Claude Code',
+  'codex': 'Codex',
+  'opencode': 'OpenCode',
+}
+
+/** One line of "what does this server actually run", for the card subtitle. */
+const serverTarget = (server: { transport: string; url?: string; command?: string; args?: string[] }): string =>
+  server.transport === 'remote'
+    ? server.url ?? ''
+    : [server.command, ...(server.args ?? [])].filter(Boolean).join(' ')
+
 const toForm = (server: ExternalMcpServer): FormState => ({
   name: server.name,
   transport: server.transport,
@@ -28,6 +40,7 @@ const toForm = (server: ExternalMcpServer): FormState => ({
 
 export const McpTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [servers, setServers] = useState<ExternalMcpServer[]>([])
+  const [agentServers, setAgentServers] = useState<AgentMcpServer[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
@@ -35,19 +48,26 @@ export const McpTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' })
   const [editing, setEditing] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const filteredServers = useMemo(
-    () => servers.filter(server => matchesToolSearch(
-      searchQuery,
-      server.name,
-      server.transport === 'remote' ? server.url : [server.command, ...(server.args ?? [])].join(' '),
-    )),
+    () => servers.filter(server => matchesToolSearch(searchQuery, server.name, serverTarget(server))),
     [servers, searchQuery],
+  )
+  const filteredAgentServers = useMemo(
+    () => agentServers.filter(server => matchesToolSearch(
+      searchQuery, server.name, serverTarget(server), AGENT_LABELS[server.agent],
+    )),
+    [agentServers, searchQuery],
   )
 
   const reload = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      setServers(unwrap(await window.codey.mcp.list()))
+      const [own, discovered] = await Promise.all([
+        window.codey.mcp.list(),
+        window.codey.mcp.listAgent(),
+      ])
+      setServers(unwrap(own))
+      setAgentServers(unwrap(discovered))
     } catch (e: any) {
       setError(e?.message ?? String(e))
     } finally {
@@ -134,11 +154,7 @@ export const McpTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' })
               {server.name}
               <span style={styles.badge}>{server.transport}</span>
             </div>
-            <div style={styles.cardDesc}>
-              {server.transport === 'remote'
-                ? server.url
-                : [server.command, ...(server.args ?? [])].join(' ')}
-            </div>
+            <div style={styles.cardDesc}>{serverTarget(server)}</div>
           </div>
           <button
             style={pillButton('ghost')}
@@ -154,7 +170,7 @@ export const McpTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' })
           </div>
         </div>
       ))}
-      {servers.length > 0 && filteredServers.length === 0 && !form && (
+      {servers.length > 0 && filteredServers.length === 0 && filteredAgentServers.length === 0 && !form && (
         <div style={styles.emptySearch}>No MCP servers match that name or configuration.</div>
       )}
 
@@ -236,6 +252,34 @@ export const McpTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' })
           <UIIcon name="add" size={15} /> Add MCP server
         </button>
       )}
+
+      {agentServers.length > 0 && (
+        <div style={styles.section}>
+          <div style={styles.sectionTitle}>Already in your coding agents</div>
+          <div style={styles.sectionNote}>
+            Servers each agent loads from its own config. Codey reads these but does not manage
+            them — edit them where the agent keeps them.
+          </div>
+          {filteredAgentServers.map(server => (
+            <div key={`${server.agent}:${server.scope}:${server.name}`} style={styles.agentCard}>
+              <div style={styles.cardIcon}><UIIcon name="server" size={18} /></div>
+              <div style={styles.cardBody}>
+                <div style={styles.cardName}>
+                  {server.name}
+                  <span style={styles.agentBadge}>{AGENT_LABELS[server.agent]}</span>
+                  <span style={styles.badge}>{server.transport}</span>
+                  {server.scope === 'project' && <span style={styles.badge}>project</span>}
+                  {!server.enabled && <span style={styles.badge}>off</span>}
+                </div>
+                <div style={styles.cardDesc} title={server.source}>{serverTarget(server)}</div>
+              </div>
+            </div>
+          ))}
+          {filteredAgentServers.length === 0 && (
+            <div style={styles.emptySearch}>No agent MCP servers match that name or configuration.</div>
+          )}
+        </div>
+      )}
     </div>
   )
 }
@@ -251,6 +295,11 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px',
     border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface2, marginBottom: 10,
   },
+  // Read-only twin of `card`: flat background, so it does not read as actionable.
+  agentCard: {
+    display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px',
+    border: `1px solid ${C.border}`, borderRadius: 12, background: 'transparent', marginBottom: 8,
+  },
   cardIcon: { color: C.accent, flexShrink: 0 },
   cardBody: { flex: 1, minWidth: 0 },
   cardName: { color: C.fg, fontSize: 13, fontWeight: 700, marginBottom: 3, display: 'flex', alignItems: 'center', gap: 8 },
@@ -262,6 +311,13 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 9.5, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5,
     color: C.fg3, border: `1px solid ${C.border2}`, borderRadius: 5, padding: '1px 6px',
   },
+  agentBadge: {
+    fontSize: 9.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5,
+    color: C.accent, border: `1px solid ${C.accent}`, borderRadius: 5, padding: '1px 6px',
+  },
+  section: { marginTop: 26 },
+  sectionTitle: { color: C.fg, fontSize: 12.5, fontWeight: 700, marginBottom: 5 },
+  sectionNote: { color: C.fg3, fontSize: 11.5, lineHeight: 1.5, marginBottom: 12 },
   toggleBusy: { opacity: 0.5, cursor: 'wait', pointerEvents: 'none' },
   emptySearch: { color: C.fg3, fontSize: 12, textAlign: 'center', padding: '30px 16px' },
   form: {


### PR DESCRIPTION
Fixes #299

## Problem

The MCP tab only showed servers added through Codey itself. MCP servers a user had already set up inside their coding agents — via `claude mcp add`, `~/.codex/config.toml`, or an opencode config — were invisible, so the tab never reflected what agents actually load.

## Change

A read-only scan of the agents' own config files, listed in a new **"Already in your coding agents"** section, each card badged with the agent it belongs to (plus `project` / `off` badges where relevant, and the source file path as a tooltip).

Sources covered:

| Agent | Read from |
| --- | --- |
| Claude Code | `~/.claude.json` (user `mcpServers` + `projects[<dir>].mcpServers`) and the workspace's `.mcp.json`, honoring `disabledMcpjsonServers` |
| Codex | `~/.codex/config.toml` `[mcp_servers.*]`, honoring `enabled = false` |
| OpenCode | user and project `opencode.json` / `opencode.jsonc` (`mcp` key) |

`CLAUDE_CONFIG_DIR`, `CODEX_HOME` and `XDG_CONFIG_HOME` overrides are resolved the same way the skills scan already does. pi is deliberately skipped — it has no MCP surface.

Notes:
- Codex needs TOML and the app has no TOML dependency, so `parseCodexMcpServers` reads just the `[mcp_servers.<name>]` tables (quoted names, string/bool/flat-array values, `.env` sub-tables skipped) and ignores anything more exotic rather than guessing.
- The scan is best-effort per agent: a malformed or unreadable config contributes no entries instead of blanking the list or surfacing an error.
- Nothing is written. These files belong to the agents, so the cards have no toggle, edit, or delete.

## Verification

- New `agent-mcp-scan.test.ts`: 12 cases over an injected in-memory fs (all three agents, user vs project scope, env-var overrides, disabled flags, malformed input, JSONC comment stripping).
- Full suite green: 1,394 tests across the three workspaces; `npm run lint` and `tsc --noEmit` clean.
- Ran the scanner against this machine's real configs: it found Claude Code's project-scoped `playwright` and both Codex servers, correctly reporting the `enabled = false` one as off.

Not yet exercised in the running app — the section's rendering is unverified on a real launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)