### PR TITLE
Stop caching a timed-out CLI probe as "agent not installed"

### DIFF
--- a/codey-mac/electron/agent-detect.test.ts
+++ b/codey-mac/electron/agent-detect.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { AGENT_BINARIES, createInstalledAgentsCache, detectInstalledAgents, parseProbeOutput } from './agent-detect'
+
+const BINS = Object.values(AGENT_BINARIES)
+
+/** Minimal stand-in for child_process.spawn's return value. */
+function fakeChild() {
+  const p: any = new EventEmitter()
+  p.stdout = new EventEmitter()
+  p.stderr = new EventEmitter()
+  p.kill = vi.fn()
+  return p
+}
+
+/** A spawn that emits `out`, then closes with `code`. */
+function spawnEmitting(out: string, code = 0) {
+  const calls: Array<{ shell: string; args: string[] }> = []
+  const spawn = ((shell: string, args: string[]) => {
+    calls.push({ shell, args })
+    const p = fakeChild()
+    queueMicrotask(() => { p.stdout.emit('data', Buffer.from(out)); p.emit('close', code) })
+    return p
+  }) as any
+  return { spawn, calls }
+}
+
+/** The exact stdout the real probe script produces for a given resolution map. */
+function probeStdout(resolved: Record<string, string>) {
+  return BINS.map(b => `codey-probe\t${b}\t${resolved[b] ?? ''}`).join('\n') + '\n'
+}
+
+describe('detectInstalledAgents', () => {
+  it('probes every binary in a single shell', async () => {
+    const { spawn, calls } = spawnEmitting(probeStdout({ claude: '/usr/local/bin/claude' }))
+    await detectInstalledAgents({ spawn, shell: '/bin/zsh' })
+    expect(calls).toHaveLength(1)
+    for (const bin of BINS) expect(calls[0].args.join(' ')).toContain(bin)
+  })
+
+  it('reports each binary that resolved, and is conclusive', async () => {
+    const { spawn } = spawnEmitting(probeStdout({
+      claude: '/Users/j/.local/bin/claude',
+      opencode: '/opt/homebrew/bin/opencode',
+    }))
+    const r = await detectInstalledAgents({ spawn, shell: '/bin/zsh' })
+    expect(r.conclusive).toBe(true)
+    expect(r.status['claude-code']).toEqual({ installed: true, path: '/Users/j/.local/bin/claude' })
+    expect(r.status['opencode']).toEqual({ installed: true, path: '/opt/homebrew/bin/opencode' })
+    expect(r.status['codex']).toEqual({ installed: false })
+  })
+
+  it('ignores chatter printed by interactive rc files, even unterminated', async () => {
+    const { spawn } = spawnEmitting(
+      'nvm: loading\nWelcome back!' + probeStdout({ claude: '/usr/local/bin/claude' }),
+    )
+    const r = await detectInstalledAgents({ spawn, shell: '/bin/zsh' })
+    expect(r.conclusive).toBe(true)
+    expect(r.status['claude-code']).toEqual({ installed: true, path: '/usr/local/bin/claude' })
+  })
+
+  it('is INCONCLUSIVE when the probe times out, and reports no negatives', async () => {
+    const spawn = ((_s: string, _a: string[]) => fakeChild()) as any  // never closes
+    const r = await detectInstalledAgents({ spawn, shell: '/bin/zsh', timeoutMs: 5 })
+    expect(r.conclusive).toBe(false)
+    expect(r.status).toEqual({})
+  })
+
+  it('is INCONCLUSIVE when the shell dies before emitting the full script output', async () => {
+    const { spawn } = spawnEmitting('codey-probe\tclaude\t/usr/local/bin/claude\n', 0)
+    const r = await detectInstalledAgents({ spawn, shell: '/bin/zsh' })
+    expect(r.conclusive).toBe(false)
+  })
+
+  it('is INCONCLUSIVE when the shell cannot be spawned', async () => {
+    const spawn = ((_s: string, _a: string[]) => {
+      const p = fakeChild()
+      queueMicrotask(() => p.emit('error', new Error('ENOENT')))
+      return p
+    }) as any
+    const r = await detectInstalledAgents({ spawn, shell: '/bin/zsh' })
+    expect(r.conclusive).toBe(false)
+  })
+})
+
+describe('parseProbeOutput', () => {
+  it('takes only the first line of a multi-line `command -v` result', () => {
+    const status = parseProbeOutput(['claude'], 'codey-probe\tclaude\t/usr/local/bin/claude\n')
+    expect(status).toEqual({ claude: { installed: true, path: '/usr/local/bin/claude' } })
+  })
+
+  it('returns null when a probed binary produced no line at all', () => {
+    expect(parseProbeOutput(['claude', 'codex'], 'codey-probe\tclaude\t/x\n')).toBeNull()
+  })
+})
+
+describe('createInstalledAgentsCache', () => {
+  it('caches a conclusive answer for the app lifetime', async () => {
+    const detect = vi.fn(async () => ({ status: { codex: { installed: true } }, conclusive: true }))
+    const get = createInstalledAgentsCache(detect)
+    await get(); await get()
+    expect(detect).toHaveBeenCalledTimes(1)
+  })
+
+  it('NEVER caches an inconclusive answer — the next caller re-probes', async () => {
+    const detect = vi.fn(async () => ({ status: {}, conclusive: false }))
+    const get = createInstalledAgentsCache(detect)
+    await get(); await get()
+    expect(detect).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-probes on force even when a conclusive answer is cached', async () => {
+    const detect = vi.fn(async () => ({ status: { codex: { installed: true } }, conclusive: true }))
+    const get = createInstalledAgentsCache(detect)
+    await get()
+    await get(true)
+    expect(detect).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces concurrent callers onto one probe', async () => {
+    const detect = vi.fn(async () => ({ status: { codex: { installed: true } }, conclusive: true }))
+    const get = createInstalledAgentsCache(detect)
+    await Promise.all([get(), get(), get()])
+    expect(detect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/codey-mac/electron/agent-detect.ts
+++ b/codey-mac/electron/agent-detect.ts
@@ -1,0 +1,118 @@
+/**
+ * Detecting which agent CLIs are on the user's PATH.
+ *
+ * We shell out via the user's *interactive* login shell so PATH includes
+ * whatever they set up in .zshrc/.bash_profile (homebrew, nvm, asdf, …); a bare
+ * spawn from Electron sees a much narrower PATH. That is also why this is
+ * expensive: sourcing a real dotfile chain costs seconds, so the whole probe
+ * runs as ONE shell that reports on every binary, not one shell per binary.
+ *
+ * The other half of the contract is that a failed probe is not an answer. A
+ * timeout or a broken shell tells us nothing about what is installed, so it is
+ * reported as `conclusive: false` with no statuses at all — never as a pile of
+ * `installed: false`, which the UI would render as "you have no agents".
+ */
+
+export const AGENT_BINARIES: Record<string, string> = {
+  'claude-code': 'claude',
+  'opencode': 'opencode',
+  'codex': 'codex',
+  'pi': 'pi',
+}
+
+export type InstallStatus = { installed: boolean; path?: string }
+
+export type ProbeResult = {
+  status: Record<string, InstallStatus>
+  /** False when the probe itself failed. Callers must not cache or display it. */
+  conclusive: boolean
+}
+
+/** Tags our lines so dotfile chatter (banners, nvm notices) can't be mistaken for output. */
+const MARKER = 'codey-probe'
+
+/** One shell command emitting exactly one `MARKER\tbin\tpath` line per binary. */
+export function buildProbeScript(bins: string[]): string {
+  return bins
+    .map(b => `printf '${MARKER}\\t${b}\\t%s\\n' "$(command -v ${b} 2>/dev/null | head -n1)"`)
+    .join('; ')
+}
+
+/**
+ * Parse probe stdout, or null if any binary is missing a line — which means the
+ * script did not run to completion and the run tells us nothing.
+ */
+export function parseProbeOutput(bins: string[], out: string): Record<string, InstallStatus> | null {
+  const seen = new Map<string, string>()
+  for (const line of out.split('\n')) {
+    const parts = line.split('\t')
+    // endsWith, not ===: an rc file that prints without a trailing newline
+    // leaves its text glued to the front of our first line.
+    if (parts.length < 3 || !parts[0].endsWith(MARKER)) continue
+    seen.set(parts[1], parts.slice(2).join('\t').trim())
+  }
+  if (bins.some(b => !seen.has(b))) return null
+  const status: Record<string, InstallStatus> = {}
+  for (const b of bins) {
+    const path = seen.get(b) as string
+    status[b] = path ? { installed: true, path } : { installed: false }
+  }
+  return status
+}
+
+export type SpawnLike = (cmd: string, args: string[], opts: any) => any
+
+export async function detectInstalledAgents(opts: {
+  spawn: SpawnLike
+  shell: string
+  timeoutMs?: number
+  binaries?: Record<string, string>
+}): Promise<ProbeResult> {
+  const binaries = opts.binaries ?? AGENT_BINARIES
+  const bins = Object.values(binaries)
+  // Generous: this is one shell, it runs about once per app launch, and the old
+  // budget was tight enough that launch-time load alone could blow through it.
+  const timeoutMs = opts.timeoutMs ?? 20_000
+
+  const out = await new Promise<string | null>(resolve => {
+    // -i so login dotfiles populate PATH the way they do in Terminal.
+    const p = opts.spawn(opts.shell, ['-i', '-c', buildProbeScript(bins)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let buf = ''
+    let done = false
+    const finish = (v: string | null) => { if (!done) { done = true; clearTimeout(timer); resolve(v) } }
+    const timer = setTimeout(() => { try { p.kill() } catch { /* already gone */ } finish(null) }, timeoutMs)
+    p.stdout?.on('data', (d: Buffer) => { buf += d.toString() })
+    p.on('close', () => finish(buf))
+    p.on('error', () => finish(null))
+  })
+
+  if (out === null) return { status: {}, conclusive: false }
+  const byBin = parseProbeOutput(bins, out)
+  if (!byBin) return { status: {}, conclusive: false }
+
+  const status: Record<string, InstallStatus> = {}
+  for (const [agent, bin] of Object.entries(binaries)) status[agent] = byBin[bin]
+  return { status, conclusive: true }
+}
+
+/**
+ * Lifetime cache over a probe. Conclusive answers stick; inconclusive ones are
+ * dropped so the next caller gets a real attempt instead of a cached failure.
+ */
+export function createInstalledAgentsCache(detect: () => Promise<ProbeResult>) {
+  let cached: Record<string, InstallStatus> | null = null
+  let inFlight: Promise<ProbeResult> | null = null
+
+  return function getInstalledAgents(force = false): Promise<ProbeResult> {
+    if (force) cached = null
+    if (cached) return Promise.resolve({ status: cached, conclusive: true })
+    if (!inFlight) {
+      inFlight = detect()
+        .then(r => { if (r.conclusive) cached = r.status; return r })
+        .finally(() => { inFlight = null })
+    }
+    return inFlight
+  }
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -11,6 +11,7 @@ import { decideNotification, createTurnTracker } from './chat-notifications'
 import { decideAutomationNotification, findUnseenRuns, findUnnotifiedRuns } from './automation-notifications'
 import { validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
+import { AGENT_BINARIES, createInstalledAgentsCache, detectInstalledAgents } from './agent-detect'
 import { SKILL_FILE, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
@@ -689,61 +690,15 @@ function resolveDataRoot(): string {
   return root
 }
 
-// Probing spawns an interactive login shell per agent, so it's too slow to run
-// on every dropdown render. Cache the result for the app's lifetime; the
-// Agents tab's "Recheck" button forces a fresh probe.
-let installedAgentsCache: Record<string, { installed: boolean; path?: string }> | null = null
-let installedAgentsInFlight: Promise<Record<string, { installed: boolean; path?: string }>> | null = null
-
-function getInstalledAgents(force = false): Promise<Record<string, { installed: boolean; path?: string }>> {
-  if (force) { installedAgentsCache = null; installedAgentsInFlight = null }
-  if (installedAgentsCache) return Promise.resolve(installedAgentsCache)
-  // Coalesce concurrent callers (chat picker + Agents tab on startup) onto one probe.
-  if (!installedAgentsInFlight) {
-    installedAgentsInFlight = detectInstalledAgents()
-      .then(r => { installedAgentsCache = r; return r })
-      .finally(() => { installedAgentsInFlight = null })
-  }
-  return installedAgentsInFlight
-}
-
-/**
- * One-shot probe for whether each agent's CLI binary is on PATH. Used by the
- * Settings tab to render an "Installed" chip vs. an "Install" link. We shell
- * out via the user's login shell so PATH includes whatever they've set up
- * interactively (homebrew, nvm, asdf, …); a bare child_process.spawn from
- * Electron sees a much narrower PATH.
- */
-async function detectInstalledAgents(): Promise<Record<string, { installed: boolean; path?: string }>> {
-  const { spawn } = await import('child_process')
-  const binaries: Record<string, string> = {
-    'claude-code': 'claude',
-    'opencode': 'opencode',
-    'codex': 'codex',
-    'pi': 'pi',
-  }
-  const shell = process.env.SHELL || '/bin/zsh'
-  const probe = (bin: string) => new Promise<string | null>(resolve => {
-    // -i -c so login dotfiles (.zshrc, .bash_profile) populate PATH the way
-    // the user expects when they run `claude` in Terminal.
-    const p = spawn(shell, ['-i', '-c', `command -v ${bin}`], { stdio: ['ignore', 'pipe', 'pipe'] })
-    let out = ''
-    p.stdout.on('data', d => { out += d.toString() })
-    const timer = setTimeout(() => { try { p.kill() } catch { /* already gone */ } resolve(null) }, 4000)
-    p.on('close', code => {
-      clearTimeout(timer)
-      const path = out.trim().split('\n').filter(Boolean).pop()
-      resolve(code === 0 && path ? path : null)
-    })
-    p.on('error', () => { clearTimeout(timer); resolve(null) })
+// Probing sources the user's dotfiles, which costs seconds, so the result is
+// cached for the app's lifetime; the Agents tab's "Recheck" button forces a
+// fresh probe. Only conclusive probes are cached — see agent-detect.ts.
+const getInstalledAgents = createInstalledAgentsCache(async () =>
+  detectInstalledAgents({
+    spawn: (await import('child_process')).spawn,
+    shell: process.env.SHELL || '/bin/zsh',
   })
-  const result: Record<string, { installed: boolean; path?: string }> = {}
-  await Promise.all(Object.entries(binaries).map(async ([agent, bin]) => {
-    const p = await probe(bin)
-    result[agent] = p ? { installed: true, path: p } : { installed: false }
-  }))
-  return result
-}
+)
 
 interface SlashCommand {
   name: string
@@ -852,13 +807,7 @@ function writeSlashCache(agent: string, commands: SlashCommand[]): void {
 async function fetchSlashCommands(agent: string): Promise<SlashCommand[]> {
   const { spawn } = await import('child_process')
   const shell = process.env.SHELL || '/bin/zsh'
-  const binaries: Record<string, string> = {
-    'claude-code': 'claude',
-    'opencode': 'opencode',
-    'codex': 'codex',
-    'pi': 'pi',
-  }
-  const bin = binaries[agent]
+  const bin = AGENT_BINARIES[agent]
   if (!bin) return []
 
   const commands: SlashCommand[] = []

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -292,7 +292,7 @@ declare global {
       agents: {
         get: () => Promise<IpcResult<Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>>>
         set: (updates: Record<string, { enabled?: boolean; defaultModel?: string; defaultEffort?: string; env?: Record<string, string> }>) => Promise<IpcResult<void>>
-        checkInstalled: (force?: boolean) => Promise<IpcResult<Record<string, { installed: boolean; path?: string }>>>
+        checkInstalled: (force?: boolean) => Promise<IpcResult<{ status: Record<string, { installed: boolean; path?: string }>; conclusive: boolean }>>
         slashCommands: (agent: string) => Promise<IpcResult<Array<{ name: string; description: string; source: 'agent' | 'gateway' | 'skill' }>>>
       }
       chats: {

--- a/codey-mac/src/components/installedAgents.ts
+++ b/codey-mac/src/components/installedAgents.ts
@@ -14,6 +14,11 @@ export type InstalledAgentsState = {
 let snapshot: InstalledAgentsState = { status: null, checking: false }
 const listeners = new Set<() => void>()
 let inFlight: Promise<void> | null = null
+// A probe that failed (timed out, shell broke) left `status` null, so every
+// subsequent mount would retry it. Space those retries out rather than letting
+// N mounting components each pay for a dotfile-sourcing shell.
+let lastFailedAt = 0
+const FAILED_PROBE_COOLDOWN_MS = 30_000
 
 const publish = (next: InstalledAgentsState) => {
   snapshot = next
@@ -34,12 +39,17 @@ export function refreshInstalledAgents(force = false): Promise<void> {
   // along on a call that may have been served from the cache.
   if (inFlight) return force ? inFlight.then(() => refreshInstalledAgents(true)) : inFlight
   if (!force && snapshot.status) return Promise.resolve()
+  if (!force && Date.now() - lastFailedAt < FAILED_PROBE_COOLDOWN_MS) return Promise.resolve()
   publish({ ...snapshot, checking: true })
   inFlight = (async () => {
     try {
       const r = await window.codey.agents.checkInstalled(force)
-      if (r.ok) { publish({ status: r.data, checking: false }); return }
+      // An inconclusive probe is not evidence that nothing is installed, so it
+      // is discarded: `status` stays null and the UI keeps saying "unknown"
+      // instead of greying out every agent until the user hits Recheck.
+      if (r.ok && r.data.conclusive) { publish({ status: r.data.status, checking: false }); return }
     } catch { /* keep whatever snapshot we already had */ }
+    lastFailedAt = Date.now()
     publish({ ...snapshot, checking: false })
   })().finally(() => { inFlight = null })
   return inFlight


### PR DESCRIPTION
Opening the chat often showed no coding agents in the picker until you went to Settings and hit **Recheck**.

## Root cause

The probe spawned **four concurrent interactive login shells** (`zsh -i -c command -v <bin>`), each capped at **4s**. Measured locally: one interactive zsh costs ~2.5s once dotfiles are sourced (nvm, homebrew), and four concurrent cost ~3.0s on an *idle* machine — 1s of headroom.

It fires exactly when the gateway starts (`useInstalledAgents(isGatewayRunning)`), the busiest moment of launch, so it regularly blew the budget. A timed-out probe resolved `null`, which became `{installed: false}` — indistinguishable from genuinely not installed — and `main.ts` cached that **for the app's lifetime**. `ChatTab.tsx` greys out any agent whose status is `false`. Recheck passes `force=true`, re-probing on a now-idle machine, so the agents reappeared.

## Fix

Probe logic moves to `codey-mac/electron/agent-detect.ts`, addressing both halves:

- **One shell instead of four.** A single `-i` shell prints one marker-tagged line per binary — 2.58s against a **20s** budget, and the self-contention is gone. The marker also makes parsing immune to dotfile chatter, which the old "take the last stdout line" logic could pick up.
- **A failed probe is no longer an answer.** Timeout, spawn error, or truncated output yields `{status: {}, conclusive: false}` instead of fabricated negatives, and neither the main-process cache nor the renderer store retains it. `status` stays `null`, so the UI reads "unknown" (blank chip, picker options *not* disabled) and retries, rather than locking in "no agents" until the user intervenes.

A 30s cooldown in the renderer store keeps a genuinely broken shell from causing a probe storm across mounts.

`agents:checkInstalled` now returns `{status, conclusive}`; `installedAgents.ts` is the only caller.

## Verification

- 12 new unit tests in `agent-detect.test.ts` covering single-shell probing, rc-file chatter, timeout/spawn-error/truncated-output inconclusiveness, and the cache's never-cache-a-failure and force-reprobe behaviour
- 560/560 tests pass across 58 files; electron typecheck and lint clean
- End-to-end check driving the real module through a real interactive shell: all four agents resolve, second call served from cache

Not yet exercised through the packaged Mac UI — the picker itself is worth a visual confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)