### PR TITLE
Reveal a user message's timestamp and actions on hover

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -905,6 +905,15 @@ export const ChatTab: React.FC<Props> = ({
     return () => { stale = true }
   }, [isGatewayRunning, runSettingsOpen])
   const [followLatest, setFollowLatest] = useState(true)
+  // A user bubble keeps its footer (timestamp + actions) hidden until the
+  // pointer is on that message, so a quiet transcript stays quiet.
+  const [hoveredMsgId, setHoveredMsgId] = useState<string | null>(null)
+  // The message being edited in place, plus its working text. Saving sends the
+  // edited text as a fresh turn; the original stays in the transcript.
+  const [editingMsgId, setEditingMsgId] = useState<string | null>(null)
+  const [editDraft, setEditDraft] = useState('')
+  // Id of the message whose copy button just fired, so the icon can confirm.
+  const [copiedMsgId, setCopiedMsgId] = useState<string | null>(null)
   // Selected option labels for the active multi-select AskUserQuestion. Reset
   // whenever a new message arrives (the prompt is always the last message).
   const [multiChoice, setMultiChoice] = useState<string[]>([])
@@ -1823,6 +1832,34 @@ export const ChatTab: React.FC<Props> = ({
   const voiceBusy = voiceActiveHere && (voice.state === 'recording' || voice.state === 'transcribing')
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
+  // Retry and edit-and-resend both re-run a past user message. They append a
+  // new turn rather than rewriting history: the agent keeps the whole
+  // conversation as context, and the transcript stays an honest record.
+  const canResend = isGatewayRunning && !coreFailed && !isSending && !orphaned
+  const resendMessage = async (text: string, attachments?: FileAttachment[]) => {
+    if (!canResend) return
+    if (!text.trim() && !attachments?.length) return
+    setFollowLatest(true)
+    await sendMessage(chat.id, text, attachments, turnIdentity)
+  }
+  const copyMessage = async (msg: ChatMessage) => {
+    try {
+      await navigator.clipboard.writeText(msg.content)
+      setCopiedMsgId(msg.id)
+      setTimeout(() => setCopiedMsgId(id => (id === msg.id ? null : id)), 1200)
+    } catch {
+      /* Clipboard denied — nothing useful to say, and an alert would be worse. */
+    }
+  }
+  const startEdit = (msg: ChatMessage) => {
+    setEditingMsgId(msg.id)
+    setEditDraft(msg.content)
+  }
+  const saveEdit = async (msg: ChatMessage) => {
+    const text = editDraft
+    setEditingMsgId(null)
+    await resendMessage(text, msg.attachments)
+  }
   const canSend = isGatewayRunning && !coreFailed && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
   // Three layers when the agent gave us its task list: what it is on, the tool
   // it is running right now, and how far through it is — a bare "Editing…"
@@ -2168,8 +2205,11 @@ export const ChatTab: React.FC<Props> = ({
           const msg = item.message
           const isUser = msg.role === 'user'
           const isSelected = !isUser && msg.id === selectedTurnId && overviewOpen
+          const isEditing = isUser && editingMsgId === msg.id
           return (
             <div key={msg.id}
+              onMouseEnter={isUser ? () => setHoveredMsgId(msg.id) : undefined}
+              onMouseLeave={isUser ? () => setHoveredMsgId(id => (id === msg.id ? null : id)) : undefined}
               onDoubleClick={isUser ? undefined : () => {
                 setSelectedTurnIdState(msg.id)
                 setFollowLatest(false)
@@ -2258,7 +2298,33 @@ export const ChatTab: React.FC<Props> = ({
                   <LiveActivity toolCalls={msg.toolCalls} />
                 )}
                 {(msg.content || (!isUser && msg.userQuestion?.question)) && (() => {
-                  if (isUser) return <UserMessageContent content={msg.content} />
+                  if (isUser) {
+                    if (isEditing) return (
+                      <div style={styles.msgEditBox}>
+                        <textarea
+                          autoFocus
+                          value={editDraft}
+                          onChange={e => setEditDraft(e.target.value)}
+                          onKeyDown={e => {
+                            if (e.key === 'Escape') { e.preventDefault(); setEditingMsgId(null) }
+                            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); void saveEdit(msg) }
+                          }}
+                          rows={Math.min(12, Math.max(2, editDraft.split('\n').length))}
+                          style={styles.msgEditArea}
+                        />
+                        <div style={styles.msgEditActions}>
+                          <button style={styles.msgEditCancel} onClick={() => setEditingMsgId(null)}>Cancel</button>
+                          <button
+                            style={{ ...styles.msgEditSave, opacity: canResend && editDraft.trim() ? 1 : 0.5 }}
+                            disabled={!canResend || !editDraft.trim()}
+                            onClick={() => { void saveEdit(msg) }}
+                            title="Send the edited message (⌘↵)"
+                          >Save & send</button>
+                        </div>
+                      </div>
+                    )
+                    return <UserMessageContent content={msg.content} />
+                  }
                   const text = msg.content || msg.userQuestion?.question || ''
                   const parsed = parseTeamMessage(text)
                   const isStreaming = !!flight && msg === lastMsg
@@ -2424,8 +2490,48 @@ export const ChatTab: React.FC<Props> = ({
                   // MESSAGE_ROW_INSET, so only the remainder is needed there.
                   paddingLeft: isUser ? 0 : TURN_TEXT_INSET - MESSAGE_ROW_INSET,
                   paddingRight: isUser ? USER_BUBBLE_PADDING_X : 0,
+                  // A user footer is revealed on hover. It stays in the layout
+                  // at zero opacity so hovering never nudges the transcript.
+                  ...(isUser ? {
+                    // Pinned to the bubble's right text edge: actions first,
+                    // timestamp last, so the row ends where the bubble ends.
+                    justifyContent: 'flex-end' as const,
+                    opacity: hoveredMsgId === msg.id || isEditing ? 1 : 0,
+                    pointerEvents: (hoveredMsgId === msg.id || isEditing ? 'auto' : 'none') as React.CSSProperties['pointerEvents'],
+                    transition: 'opacity 0.12s ease',
+                  } : null),
                 }}
               >
+                {isUser && !isEditing && (
+                  <div style={styles.msgActions}>
+                    <button
+                      style={styles.msgActionBtn}
+                      onClick={() => { void copyMessage(msg) }}
+                      title="Copy message"
+                      aria-label="Copy message"
+                    >
+                      <UIIcon name={copiedMsgId === msg.id ? 'check' : 'copy'} size={13} color={C.fg3} />
+                    </button>
+                    <button
+                      style={{ ...styles.msgActionBtn, opacity: canResend ? 1 : 0.4, cursor: canResend ? 'pointer' : 'default' }}
+                      disabled={!canResend}
+                      onClick={() => { void resendMessage(msg.content, msg.attachments) }}
+                      title={canResend ? 'Send this message again' : 'Wait for the current turn to finish'}
+                      aria-label="Retry message"
+                    >
+                      <UIIcon name="refresh" size={13} color={C.fg3} />
+                    </button>
+                    <button
+                      style={{ ...styles.msgActionBtn, opacity: canResend ? 1 : 0.4, cursor: canResend ? 'pointer' : 'default' }}
+                      disabled={!canResend}
+                      onClick={() => startEdit(msg)}
+                      title={canResend ? 'Edit and send again' : 'Wait for the current turn to finish'}
+                      aria-label="Edit message"
+                    >
+                      <UIIcon name="edit" size={13} color={C.fg3} />
+                    </button>
+                  </div>
+                )}
                 <span>{fmtTime(msg.timestamp)}</span>
               </div>
               )}
@@ -2932,6 +3038,28 @@ const styles: Record<string, React.CSSProperties> = {
   // line up with the reply above it, which is inset differently (and from the
   // opposite edge) for user and assistant.
   tsLabel: { color: C.fg3, fontSize: 10, marginTop: 6, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  // Hover actions on a user bubble. They share the timestamp's footer row so
+  // revealing them costs no vertical space.
+  msgActions: { display: 'flex', alignItems: 'center', gap: 2 },
+  msgActionBtn: {
+    display: 'grid', placeItems: 'center', width: 20, height: 20, padding: 0,
+    border: 'none', borderRadius: 5, background: 'transparent', cursor: 'pointer',
+  },
+  msgEditBox: { display: 'flex', flexDirection: 'column', gap: 6, minWidth: 260 },
+  msgEditArea: {
+    width: '100%', boxSizing: 'border-box', resize: 'vertical',
+    background: C.bg, color: C.fg, border: `1px solid ${C.border}`, borderRadius: 8,
+    padding: '6px 8px', fontSize: 13, lineHeight: 1.5, fontFamily: 'inherit', outline: 'none',
+  },
+  msgEditActions: { display: 'flex', justifyContent: 'flex-end', gap: 6 },
+  msgEditCancel: {
+    background: 'transparent', color: C.onAccent, border: `1px solid ${C.onAccent}55`,
+    borderRadius: 6, padding: '3px 9px', fontSize: 11, cursor: 'pointer',
+  },
+  msgEditSave: {
+    background: C.bg, color: C.fg, border: 'none',
+    borderRadius: 6, padding: '3px 9px', fontSize: 11, cursor: 'pointer', fontWeight: 600,
+  },
   // modelBadge is still used by team worker messages; tsRight, tsMeta and
   // fallbackBadge moved into TurnHeader with the metadata they styled.
   modelBadge: {

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export type IconName =
   | 'activity' | 'add' | 'alert' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
-  | 'clock' | 'code' | 'copy' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
+  | 'clock' | 'code' | 'copy' | 'edit' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
   | 'waveform' | 'git-branch' | 'git-merge' | 'pull-request' | 'globe' | 'match-case' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
   | 'telegram' | 'discord' | 'imessage'
 
@@ -33,6 +33,7 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     disclosure: <path fill="currentColor" stroke="none" d="M9 6.5L16 12l-7 5.5z" />,
     code: <><path {...common} d="M8 9l-3 3 3 3M16 9l3 3-3 3M14 6l-4 12" /></>,
     copy: <><rect {...common} x="9" y="9" width="11" height="11" rx="2" /><path {...common} d="M5 15V5a2 2 0 012-2h10" /></>,
+    edit: <><path {...common} d="M4 20h4l10.5-10.5a2.12 2.12 0 00-3-3L5 17v3z" /><path {...common} d="M13.5 6.5l4 4" /></>,
     folder: <path {...common} d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />,
     'folder-open': <><path {...common} d="M3 18V7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v1" /><path {...common} d="M3.2 19h15.2a2 2 0 001.94-1.51l1.25-5A2 2 0 0019.65 10H8l-2 3H3" /></>,
     'git-branch': <><circle {...common} cx="6" cy="5" r="2" /><circle {...common} cx="6" cy="19" r="2" /><circle {...common} cx="18" cy="7" r="2" /><path {...common} d="M6 7v10M8 13h3a7 7 0 007-4" /></>,


### PR DESCRIPTION
## What

The timestamp under every user bubble was permanent furniture — metadata repeated on every turn, read once and then ignored. It now appears only when the pointer is on that message, and brings three icon actions with it:

- **copy** — writes the message to the clipboard; the icon flips to a check for a moment.
- **retry** — sends the same text and attachments again.
- **edit** — the bubble becomes a textarea in place; `Save & send` or ⌘↵ sends the edited text, Esc/Cancel backs out.

The footer stays in the layout at zero opacity, so hovering never nudges the transcript. Assistant timestamps are unchanged.

## Semantics

Retry and edit **append a new turn** rather than truncating history. The agent keeps the whole conversation as context, and the transcript stays an honest record of what was asked. (ChatGPT-style truncate-and-resend would need a message-deletion path in `useChats` and the gateway; not built here.)

Both are disabled while a turn is in flight, when the gateway is down, or when the workspace is orphaned.

## Files

- `codey-mac/src/components/ChatTab.tsx` — hover state, the action row, the inline edit box.
- `codey-mac/src/components/UIIcons.tsx` — new `edit` (pencil) glyph; `copy` and `refresh` reused.

## Testing

`tsc --noEmit` clean; 58 test files / 559 tests pass. Not yet exercised in the running app — worth a look at the edit box's colours against the accent-filled bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)