### PR TITLE
Enforce foreground agent process lifecycle

### DIFF
--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -6,6 +6,7 @@ import { thinkingDeltaFrom } from './thinking-stream';
 import { writeClaudeMcpConfig } from './mcp-config';
 import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
 import { claudeEffortArgs } from './effort';
+import { agentSpawnOptions, cleanupProcessTreeAfterClose, terminateProcessTree, withForegroundPolicy } from './process-tree';
 
 export interface StreamEvent {
   type: string;
@@ -229,7 +230,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       }
 
       // -p with prompt must be last (matches tested CLI format)
-      args.push('-p', request.prompt);
+      args.push('-p', withForegroundPolicy(request.prompt));
 
       // Clean env: remove CLAUDECODE to avoid nested session detection
       const env = { ...process.env };
@@ -267,11 +268,13 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         stdio: [request.interactive ? 'inherit' : 'pipe', 'pipe', request.interactive ? 'inherit' : 'pipe'],
         cwd: request.context?.workingDir || undefined,
         env,
+        ...agentSpawnOptions(),
       });
       this.activeProcess = childProcess;
 
       childProcess.on('close', () => {
         mcpCleanup?.();
+        cleanupProcessTreeAfterClose(childProcess);
         this.activeProcess = undefined;
       });
 
@@ -302,10 +305,14 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       let userQuestion: AgentResponse['userQuestion'];
       let askUserInputJson = '';
       let collectingAskUser = false;
+      let timeoutTimer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
 
       const safeResolve = (response: AgentResponse) => {
         if (!resolved) {
           resolved = true;
+          if (timeoutTimer) clearTimeout(timeoutTimer);
+          if (abortHandler && request.signal) request.signal.removeEventListener('abort', abortHandler);
           resolve(response);
         }
       };
@@ -386,7 +393,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
                     .map((o: any) => ({ label: o.label, description: o.description })),
                   multiSelect: q.multiSelect === true,
                 };
-                childProcess.kill('SIGTERM');
+                terminateProcessTree(childProcess);
               }
             } catch { /* ignore parse failure */ }
           }
@@ -422,7 +429,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
                   };
                   // Kill the process — it's waiting for interactive input we can't provide.
                   // The gateway will resume the session with the user's answer on the next turn.
-                  childProcess.kill('SIGTERM');
+                  terminateProcessTree(childProcess);
                 }
               }
 
@@ -581,9 +588,9 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
 
       // Safety timeout so we don't hang forever if the CLI never responds.
       // Timeout (default 15 minutes)
-      setTimeout(() => {
+      timeoutTimer = setTimeout(() => {
         if (!resolved) {
-          childProcess.kill();
+          terminateProcessTree(childProcess);
           const duration = Math.round((Date.now() - startTime) / 1000);
           safeResolve(this.createResponse(`Timeout after ${Math.round(timeout / 60000)} minutes`, false, undefined, duration));
         }
@@ -591,15 +598,15 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
 
       // Caller-driven cancellation
       if (request.signal) {
-        const onAbort = () => {
+        abortHandler = () => {
           if (resolved) return;
           this.sessionId = undefined;
-          try { childProcess.kill('SIGTERM'); } catch { /* already dead */ }
+          terminateProcessTree(childProcess);
           const duration = Math.round((Date.now() - startTime) / 1000);
           safeResolve(this.createResponse('Stopped', false, undefined, duration, statusUpdates, states));
         };
-        if (request.signal.aborted) onAbort();
-        else request.signal.addEventListener('abort', onAbort, { once: true });
+        if (request.signal.aborted) abortHandler();
+        else request.signal.addEventListener('abort', abortHandler, { once: true });
       }
     });
   }
@@ -610,7 +617,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
 
   dispose(): void {
     if (this.activeProcess) {
-      this.activeProcess.kill('SIGTERM');
+      terminateProcessTree(this.activeProcess);
       this.activeProcess = undefined;
     }
   }

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -10,6 +10,7 @@ import { ToolCallCollector } from './tool-events';
 import { ChecklistTracker, checklistFromCodexItem } from './checklist';
 import { codexMcpArgs } from './mcp-config';
 import { codexEffortArgs, shouldDegradeEffort, withDegradeNotice, type EffortRetryable } from './effort';
+import { agentSpawnOptions, cleanupProcessTreeAfterClose, terminateProcessTree, withForegroundPolicy } from './process-tree';
 
 /**
  * Codex emits JSONL events to stdout when invoked with `--json`.
@@ -144,7 +145,7 @@ export class CodexAdapter extends BaseAgentAdapter {
       if (request.mcpServers && Object.keys(request.mcpServers).length > 0) {
         args.push(...codexMcpArgs(request.mcpServers));
       }
-      args.push(request.prompt);
+      args.push(withForegroundPolicy(request.prompt));
 
       const { applyModelEnv, withCommonBinPaths } = require('./env') as typeof import('./env');
       const env = withCommonBinPaths(applyModelEnv({ ...process.env }, request.model, 'openai'));
@@ -154,10 +155,12 @@ export class CodexAdapter extends BaseAgentAdapter {
         stdio: ['ignore', 'pipe', 'pipe'],
         env,
         cwd: request.context?.workingDir || undefined,
+        ...agentSpawnOptions(),
       });
       this.activeProcess = childProcess;
 
       childProcess.on('close', () => {
+        cleanupProcessTreeAfterClose(childProcess);
         this.activeProcess = undefined;
       });
 
@@ -169,6 +172,8 @@ export class CodexAdapter extends BaseAgentAdapter {
       let streamedText = '';
       let errorMessage: string | undefined;
       let tokens: AgentResponse['tokens'];
+      let timeoutTimer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
       // codex reports finished work, so the collector synthesizes the
       // tool_start the chat surface needs to see a procedure.
       const tools = new ToolCallCollector(request.onStatus);
@@ -179,6 +184,8 @@ export class CodexAdapter extends BaseAgentAdapter {
       const safeResolve = (response: AgentResponse) => {
         if (resolved) return;
         resolved = true;
+        if (timeoutTimer) clearTimeout(timeoutTimer);
+        if (abortHandler && request.signal) request.signal.removeEventListener('abort', abortHandler);
         try { fs.unlinkSync(outFile); } catch { /* best-effort cleanup */ }
         resolve(response);
       };
@@ -335,9 +342,9 @@ export class CodexAdapter extends BaseAgentAdapter {
       });
 
       const timeout = request.timeout || 900000;
-      setTimeout(() => {
+      timeoutTimer = setTimeout(() => {
         if (resolved) return;
-        childProcess.kill();
+        terminateProcessTree(childProcess);
         const duration = Math.round((Date.now() - startTime) / 1000);
         safeResolve({
           success: false,
@@ -348,9 +355,9 @@ export class CodexAdapter extends BaseAgentAdapter {
       }, timeout);
 
       if (request.signal) {
-        const onAbort = () => {
+        abortHandler = () => {
           if (resolved) return;
-          try { childProcess.kill('SIGTERM'); } catch { /* already dead */ }
+          terminateProcessTree(childProcess);
           const duration = Math.round((Date.now() - startTime) / 1000);
           safeResolve({
             success: false,
@@ -361,15 +368,15 @@ export class CodexAdapter extends BaseAgentAdapter {
             states,
           });
         };
-        if (request.signal.aborted) onAbort();
-        else request.signal.addEventListener('abort', onAbort, { once: true });
+        if (request.signal.aborted) abortHandler();
+        else request.signal.addEventListener('abort', abortHandler, { once: true });
       }
     });
   }
 
   dispose(): void {
     if (this.activeProcess) {
-      this.activeProcess.kill('SIGTERM');
+      terminateProcessTree(this.activeProcess);
       this.activeProcess = undefined;
     }
   }

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -6,6 +6,7 @@ import { writeOpenCodeMcpConfig } from './mcp-config';
 import { ObservedToolEvent, ToolCallCollector } from './tool-events';
 import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
 import { opencodeEffortArgs } from './effort';
+import { agentSpawnOptions, cleanupProcessTreeAfterClose, terminateProcessTree, withForegroundPolicy } from './process-tree';
 
 export interface OpenCodeEvent {
   type: string;
@@ -53,6 +54,14 @@ export function opencodeToolEvent(part: NonNullable<OpenCodeEvent['part']>): Obs
   };
 }
 
+export function isBackgroundOpenCodeTool(part: NonNullable<OpenCodeEvent['part']>): boolean {
+  const input = part.state?.input;
+  if (!input) return false;
+  return input.run_in_background === true
+    || input.background === true
+    || input.detach === true;
+}
+
 export class OpenCodeAdapter extends BaseAgentAdapter {
   name = 'opencode';
   private debug: (msg: string) => void;
@@ -65,7 +74,10 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
 
   async run(request: AgentRequest): Promise<AgentResponse> {
     return new Promise((resolve) => {
-      const args = ['run', '--format', 'json'];
+      // --pure is an official OpenCode boundary: Codey cannot supervise task
+      // IDs owned by external plugins, so external plugins are not loaded in
+      // a foreground-only gateway turn.
+      const args = ['run', '--format', 'json', '--pure'];
       if (request.skipPermissions) {
         args.push('--dangerously-skip-permissions');
       }
@@ -90,7 +102,7 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
         mcpEnv = mcp.env;
         mcpCleanup = mcp.cleanup;
       }
-      args.push(request.prompt);
+      args.push(withForegroundPolicy(request.prompt));
 
       this.debug(`[opencode] Spawning: opencode ${args.slice(0, -1).join(' ')} "<prompt>"`);
 
@@ -98,6 +110,9 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       // OpenCode is provider-agnostic; default to openai if apiType unset.
       const env = withCommonBinPaths(applyModelEnv({ ...process.env }, request.model, 'openai'));
       if (request.extraEnv) Object.assign(env, request.extraEnv);
+      // User/plugin config must not re-enable OpenCode's own experimental
+      // background-subagent facility for a Codey-owned foreground turn.
+      env.OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS = 'false';
       // Deliberately after extraEnv: plugin MCP config must win even over a
       // user-supplied OPENCODE_CONFIG, or enabled plugins would silently vanish.
       Object.assign(env, mcpEnv);
@@ -105,11 +120,13 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: request.context?.workingDir || undefined,
         env,
+        ...agentSpawnOptions(),
       });
       this.activeProcess = childProcess;
 
       childProcess.on('close', () => {
         mcpCleanup?.();
+        cleanupProcessTreeAfterClose(childProcess);
         this.activeProcess = undefined;
       });
 
@@ -128,10 +145,26 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
       // (e.g. `step_start`, `text`, `step_finish`). The first event we see
       // tells us which session OpenCode opened so the gateway can resume it.
       let capturedSessionId: string | undefined;
+      let backgroundViolation: string | undefined;
+      let timeoutTimer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
+
+      const activityTimer = setInterval(() => {
+        if (!resolved) {
+          request.onStatus?.({
+            type: 'info',
+            message: 'OpenCode is still working; this CLI reports tool details when each tool finishes.',
+          });
+        }
+      }, 15_000);
+      activityTimer.unref?.();
 
       const safeResolve = (response: AgentResponse) => {
         if (!resolved) {
           resolved = true;
+          clearInterval(activityTimer);
+          if (timeoutTimer) clearTimeout(timeoutTimer);
+          if (abortHandler && request.signal) request.signal.removeEventListener('abort', abortHandler);
           resolve(response);
         }
       };
@@ -161,6 +194,10 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
             }
 
             if (event.type === 'tool_use' && event.part) {
+              if (isBackgroundOpenCodeTool(event.part)) {
+                backgroundViolation = `Blocked background tool request: ${event.part.tool ?? 'tool_use'}`;
+                terminateProcessTree(childProcess);
+              }
               const observed = opencodeToolEvent(event.part);
               if (observed) tools.record(observed);
               if (isChecklistTool(event.part.tool)) {
@@ -237,7 +274,11 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
         const duration = Math.round((Date.now() - startTime) / 1000);
 
         const output = textParts.join('');
-        if (output) {
+        if (backgroundViolation) {
+          const resp = this.createResponse(backgroundViolation, false, undefined, duration, statusUpdates, states);
+          resp.sessionId = capturedSessionId;
+          safeResolve(resp);
+        } else if (output) {
           const resp = this.createResponse(output, true, tokens, duration, statusUpdates, states);
           resp.sessionId = capturedSessionId;
           safeResolve(resp);
@@ -260,30 +301,30 @@ export class OpenCodeAdapter extends BaseAgentAdapter {
 
       // Timeout (default 15 minutes)
       const timeout = request.timeout || 900000;
-      setTimeout(() => {
+      timeoutTimer = setTimeout(() => {
         if (!resolved) {
-          childProcess.kill();
+          terminateProcessTree(childProcess);
           const duration = Math.round((Date.now() - startTime) / 1000);
           safeResolve(this.createResponse(`Timeout after ${Math.round(timeout / 60000)} minutes`, false, undefined, duration));
         }
       }, timeout);
 
       if (request.signal) {
-        const onAbort = () => {
+        abortHandler = () => {
           if (resolved) return;
-          try { childProcess.kill('SIGTERM'); } catch { /* already dead */ }
+          terminateProcessTree(childProcess);
           const duration = Math.round((Date.now() - startTime) / 1000);
           safeResolve(this.createResponse('Stopped', false, undefined, duration, statusUpdates, states));
         };
-        if (request.signal.aborted) onAbort();
-        else request.signal.addEventListener('abort', onAbort, { once: true });
+        if (request.signal.aborted) abortHandler();
+        else request.signal.addEventListener('abort', abortHandler, { once: true });
       }
     });
   }
 
   dispose(): void {
     if (this.activeProcess) {
-      this.activeProcess.kill('SIGTERM');
+      terminateProcessTree(this.activeProcess);
       this.activeProcess = undefined;
     }
   }

--- a/packages/core/src/agents/pi.test.ts
+++ b/packages/core/src/agents/pi.test.ts
@@ -21,7 +21,7 @@ describe('piArgs', () => {
   it('always asks for the JSON event stream and puts the prompt last', () => {
     const args = piArgs(base);
     expect(args.slice(0, 2)).toEqual(['--mode', 'json']);
-    expect(args[args.length - 1]).toBe('hello');
+    expect(args[args.length - 1]).toMatch(/^hello\n\n<codey-runtime-policy>/);
   });
 
   it('resumes a session by id', () => {

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -5,6 +5,7 @@ import { AgentSpawnError } from '../errors';
 import { ObservedToolEvent, ToolCallCollector } from './tool-events';
 import { ChecklistTracker, checklistFromTodos, isChecklistTool } from './checklist';
 import { piEffortArgs } from './effort';
+import { agentSpawnOptions, cleanupProcessTreeAfterClose, terminateProcessTree, withForegroundPolicy } from './process-tree';
 
 /**
  * pi (https://pi.dev) adapter.
@@ -97,7 +98,7 @@ export function piArgs(
   if (request.skipPermissions) {
     args.push('-a');
   }
-  args.push(request.prompt);
+  args.push(withForegroundPolicy(request.prompt));
   return args;
 }
 
@@ -210,9 +211,13 @@ export class PiAdapter extends BaseAgentAdapter {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: request.context?.workingDir || undefined,
         env,
+        ...agentSpawnOptions(),
       });
       this.activeProcess = childProcess;
-      childProcess.on('close', () => { this.activeProcess = undefined; });
+      childProcess.on('close', () => {
+        cleanupProcessTreeAfterClose(childProcess);
+        this.activeProcess = undefined;
+      });
 
       const startTime = Date.now();
       let resolved = false;
@@ -224,6 +229,8 @@ export class PiAdapter extends BaseAgentAdapter {
       let errorMessage: string | undefined;
       let capturedSessionId: string | undefined;
       let tokens: AgentResponse['tokens'];
+      let timeoutTimer: NodeJS.Timeout | undefined;
+      let abortHandler: (() => void) | undefined;
       const tools = new ToolCallCollector(request.onStatus);
       const statusUpdates = tools.statusUpdates;
       const states = tools.states;
@@ -232,6 +239,8 @@ export class PiAdapter extends BaseAgentAdapter {
       const safeResolve = (response: AgentResponse) => {
         if (resolved) return;
         resolved = true;
+        if (timeoutTimer) clearTimeout(timeoutTimer);
+        if (abortHandler && request.signal) request.signal.removeEventListener('abort', abortHandler);
         resolve(response);
       };
 
@@ -333,9 +342,9 @@ export class PiAdapter extends BaseAgentAdapter {
       });
 
       const timeout = request.timeout || 900000;
-      setTimeout(() => {
+      timeoutTimer = setTimeout(() => {
         if (resolved) return;
-        childProcess.kill();
+        terminateProcessTree(childProcess);
         const duration = Math.round((Date.now() - startTime) / 1000);
         safeResolve({
           success: false,
@@ -346,9 +355,9 @@ export class PiAdapter extends BaseAgentAdapter {
       }, timeout);
 
       if (request.signal) {
-        const onAbort = () => {
+        abortHandler = () => {
           if (resolved) return;
-          try { childProcess.kill('SIGTERM'); } catch { /* already dead */ }
+          terminateProcessTree(childProcess);
           const duration = Math.round((Date.now() - startTime) / 1000);
           safeResolve({
             success: false,
@@ -359,15 +368,15 @@ export class PiAdapter extends BaseAgentAdapter {
             states,
           });
         };
-        if (request.signal.aborted) onAbort();
-        else request.signal.addEventListener('abort', onAbort, { once: true });
+        if (request.signal.aborted) abortHandler();
+        else request.signal.addEventListener('abort', abortHandler, { once: true });
       }
     });
   }
 
   dispose(): void {
     if (this.activeProcess) {
-      this.activeProcess.kill('SIGTERM');
+      terminateProcessTree(this.activeProcess);
       this.activeProcess = undefined;
     }
   }

--- a/packages/core/src/agents/process-tree.test.ts
+++ b/packages/core/src/agents/process-tree.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  agentSpawnOptions,
+  terminateProcessTree,
+  withForegroundPolicy,
+} from './process-tree';
+import { isBackgroundOpenCodeTool } from './opencode';
+
+const active: ChildProcess[] = [];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const child of active.splice(0)) terminateProcessTree(child, 'SIGKILL');
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+async function waitForFile(file: string, timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!fs.existsSync(file) && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  if (!fs.existsSync(file)) throw new Error(`Timed out waiting for ${file}`);
+}
+
+describe('agent process lifecycle', () => {
+  it.skipIf(process.platform === 'win32')('terminates a CLI and its spawned tool process', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-process-tree-'));
+    tempDirs.push(dir);
+    const ready = path.join(dir, 'ready');
+    const orphanMarker = path.join(dir, 'orphan-ran');
+
+    const toolScript = `setTimeout(() => require('fs').writeFileSync(${JSON.stringify(orphanMarker)}, 'orphan'), 800)`;
+    const cliScript = [
+      `require('child_process').spawn(process.execPath, ['-e', ${JSON.stringify(toolScript)}], { stdio: 'ignore' })`,
+      `require('fs').writeFileSync(${JSON.stringify(ready)}, 'ready')`,
+      'setInterval(() => {}, 1000)',
+    ].join(';');
+
+    const cli = spawn(process.execPath, ['-e', cliScript], {
+      stdio: 'ignore',
+      ...agentSpawnOptions(),
+    });
+    active.push(cli);
+    await waitForFile(ready);
+
+    terminateProcessTree(cli);
+    await new Promise<void>(resolve => cli.once('close', () => resolve()));
+    await new Promise(resolve => setTimeout(resolve, 1_000));
+
+    expect(fs.existsSync(orphanMarker)).toBe(false);
+  });
+
+  it('adds a foreground-only instruction that covers detach mechanisms', () => {
+    const prompt = withForegroundPolicy('do the work');
+    expect(prompt).toContain('do the work');
+    expect(prompt).toContain('run_in_background');
+    expect(prompt).toContain('nohup');
+    expect(prompt).toContain('tmux');
+  });
+
+  it('detects background flags in OpenCode tool input', () => {
+    expect(isBackgroundOpenCodeTool({
+      type: 'tool',
+      tool: 'task',
+      state: { input: { run_in_background: true } },
+    })).toBe(true);
+    expect(isBackgroundOpenCodeTool({
+      type: 'tool',
+      tool: 'task',
+      state: { input: { run_in_background: false } },
+    })).toBe(false);
+  });
+
+  it('wires every adapter to grouped spawning and tree termination', () => {
+    for (const file of ['claude-code.ts', 'codex.ts', 'opencode.ts', 'pi.ts']) {
+      const source = fs.readFileSync(path.join(__dirname, file), 'utf8');
+      expect(source, file).toContain('...agentSpawnOptions()');
+      expect(source, file).toContain('terminateProcessTree(');
+      expect(source, file).toContain('cleanupProcessTreeAfterClose(');
+      expect(source, file).toContain('withForegroundPolicy(request.prompt)');
+    }
+  });
+
+  it('runs OpenCode without external plugins', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'opencode.ts'), 'utf8');
+    expect(source).toContain("['run', '--format', 'json', '--pure']");
+    expect(source).toContain("OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS = 'false'");
+  });
+});

--- a/packages/core/src/agents/process-tree.ts
+++ b/packages/core/src/agents/process-tree.ts
@@ -1,0 +1,80 @@
+import { ChildProcess, SpawnOptions, spawn } from 'child_process';
+
+/**
+ * Codey owns every process started for an agent turn. On POSIX, putting the
+ * CLI in its own process group lets timeout/abort/dispose terminate tools it
+ * spawned as well as the CLI itself. Windows uses taskkill /T for the same
+ * process-tree semantics.
+ */
+export function agentSpawnOptions(): Pick<SpawnOptions, 'detached' | 'windowsHide'> {
+  return process.platform === 'win32'
+    ? { windowsHide: true }
+    : { detached: true };
+}
+
+export function terminateProcessTree(
+  child: Pick<ChildProcess, 'pid' | 'kill'>,
+  signal: NodeJS.Signals = 'SIGTERM',
+): void {
+  const pid = child.pid;
+  if (!pid) return;
+
+  if (signal === 'SIGTERM') {
+    const forceTimer = setTimeout(() => {
+      if (process.platform === 'win32') {
+        try {
+          const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+            stdio: 'ignore',
+            windowsHide: true,
+          });
+          killer.unref();
+        } catch { /* process tree is already gone */ }
+      } else {
+        try { process.kill(-pid, 'SIGKILL'); } catch { /* process group is already gone */ }
+      }
+    }, 1_500);
+    forceTimer.unref?.();
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      const args = ['/PID', String(pid), '/T'];
+      if (signal === 'SIGKILL') args.push('/F');
+      const killer = spawn('taskkill', args, { stdio: 'ignore', windowsHide: true });
+      killer.unref();
+      return;
+    } catch {
+      // Fall through to the direct-child fallback below.
+    }
+  } else {
+    try {
+      process.kill(-pid, signal);
+      return;
+    } catch {
+      // The process may have exited before its group was established. A
+      // direct kill is still better than leaving it alive.
+    }
+  }
+
+  try { child.kill(signal); } catch { /* already exited */ }
+}
+
+/** Clean up descendants that outlived a normally exited CLI. On POSIX the
+ * process-group id remains addressable while any member is still alive. */
+export function cleanupProcessTreeAfterClose(child: Pick<ChildProcess, 'pid' | 'kill'>): void {
+  if (process.platform === 'win32') return;
+  terminateProcessTree(child);
+}
+
+const FOREGROUND_POLICY = [
+  '<codey-runtime-policy>',
+  'Run every command and delegated task in the foreground and wait for it to finish.',
+  'Do not detach work with run_in_background/background-task options, shell &, nohup, disown, setsid, tmux, or screen.',
+  '</codey-runtime-policy>',
+].join('\n');
+
+/** Advisory guard for detach mechanisms that can deliberately escape a
+ * process group. The hard lifecycle boundary remains terminateProcessTree. */
+export function withForegroundPolicy(prompt: string): string {
+  return `${prompt}\n\n${FOREGROUND_POLICY}`;
+}


### PR DESCRIPTION
## Summary

- add shared process-tree lifecycle management for all coding-agent adapters
- enforce foreground-only execution and block OpenCode background-task requests
- run OpenCode in `--pure` mode and emit periodic activity updates
- add regression coverage for descendant cleanup and foreground policy wiring

## Why

Agent CLIs were terminated only at the top-level process. On timeout, cancellation, or disposal, spawned build/test processes could survive as orphans while Codey had already stopped showing the turn as working. OpenCode also allowed external plugins and background-agent options that Codey could not track or resume.

## Impact

Codey now owns the full process tree for an agent turn. Timeout, abort, disposal, and normal CLI exit clean up descendants, while prompts explicitly require foreground work. OpenCode no longer loads external plugins for gateway turns, rejects background task flags, and reports ongoing activity during long-running tools.

## Validation

- `npm test --workspace packages/core` — 39 files, 524 tests passed
- `npm run build --workspace packages/core`
- `npm run build --workspace packages/gateway`
- `git diff --check`
