### PR TITLE
Give dictation a way out, and settle the playbook chevron

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2744,6 +2744,17 @@ export const ChatTab: React.FC<Props> = ({
                       color={voiceBusy && voice.mode === 'dictate' ? '#fff' : C.fg2}
                     />}
               </button>}
+              {/* While dictating, the mic slot is the stop button, so the way
+                  out of the recording needs a control of its own — same thing
+                  Esc does: drop the audio instead of transcribing it. */}
+              {voiceActiveHere && voice.state === 'recording' && voice.mode === 'dictate' && <button
+                onClick={() => voice.abandon()}
+                style={{ ...styles.voiceButton, background: 'transparent', cursor: 'pointer' }}
+                title="Cancel dictation (Esc)"
+                aria-label="Cancel dictation"
+              >
+                <UIIcon name="close" size={15} color={C.fg3} />
+              </button>}
               {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'dictate') && <button
                 onClick={() => voice.toggle('converse')}
                 disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere}

--- a/codey-mac/src/components/PlaybooksTab.tsx
+++ b/codey-mac/src/components/PlaybooksTab.tsx
@@ -198,9 +198,11 @@ export const PlaybooksTab: React.FC<{ searchQuery?: string }> = ({ searchQuery =
               aria-label={isExpanded ? 'Collapse playbook details' : 'Expand playbook details'}
               aria-expanded={isExpanded}
               onClick={event => { event.stopPropagation(); void toggleExpand(s) }}
-              style={{ ...expandButtonStyle, transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+              style={expandButtonStyle}
             >
-              <UIIcon name="chevron" size={16} />
+              <span style={{ ...expandChevronStyle, transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+                <UIIcon name="chevron" size={16} />
+              </span>
             </button>
           </div>
           {s.description && (
@@ -316,5 +318,13 @@ const expandButtonStyle: React.CSSProperties = {
   placeItems: 'center',
   cursor: 'pointer',
   flexShrink: 0,
-  transition: 'transform 160ms ease, border-color 160ms ease, background 160ms ease',
+  transition: 'border-color 0.15s ease, background 0.15s ease',
+}
+
+// Only the chevron turns; spinning the whole button spun its border and
+// background too, which read as a different animation from every other
+// disclosure in the app.
+const expandChevronStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  transition: 'transform 0.15s ease',
 }

--- a/codey-mac/src/hooks/useVoiceTurn.tsx
+++ b/codey-mac/src/hooks/useVoiceTurn.tsx
@@ -35,6 +35,11 @@ export interface VoiceTurnValue extends VoiceApi {
    * back when it arrives.
    */
   beginSpokenTurn: (chatId: string, spoken: string) => void
+  /**
+   * What Esc does: drop the capture (or stop the reply) and close the turn.
+   * `cancel` alone leaves the turn state armed, so UI affordances use this.
+   */
+  abandon: () => void
 }
 
 const VoiceTurnContext = createContext<VoiceTurnValue | null>(null)
@@ -220,7 +225,7 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     return () => window.removeEventListener('keydown', onKey, true)
   }, [voice.state, turn.phase, abandonTurn])
 
-  const value: VoiceTurnValue = { ...voice, toggle, ownerChatId, setTranscriptHandler, beginSpokenTurn }
+  const value: VoiceTurnValue = { ...voice, toggle, ownerChatId, setTranscriptHandler, beginSpokenTurn, abandon: abandonTurn }
   return <VoiceTurnContext.Provider value={value}>{children}</VoiceTurnContext.Provider>
 }
 


### PR DESCRIPTION
Two small composer/playbook UI fixes.

## Cancel a dictation without the keyboard

While dictating, the mic slot turns into the stop button — which finishes the recording and inserts the text. Throwing the recording away was Esc-only, with nothing on screen to say so. A small grey `x` now appears next to the stop button, in the slot the conversation button vacates during dictation, and takes the same path Esc does.

That path is `abandon`, newly exposed on the voice-turn context: `cancel` alone drops the audio but leaves the turn state armed, so a cancelled turn could still leave the capsule up.

## Playbook disclosure animation

The expand button rotated the whole 30x30 control, border and background with it, which read as a different animation from every other disclosure in the app. Only the chevron turns now, at the same `0.15s ease` used in ChatListPanel / TurnHeader / StatusSidecar.

## Testing

- `npx tsc --noEmit -p codey-mac/tsconfig.json` clean
- `npm test -w codey-mac` — 559 tests pass
- Not yet exercised in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)