### PR TITLE
Let the Mac app's text be resized

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -5,6 +5,7 @@ import { captureAccelerator, screenshotAccelerator, resolveCaptureSubmit, normal
 import { hudStateCommand, hudLevelCommand, conversationToggleCommand } from './voice-hud'
 import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
+import { clampZoom, formatZoom, zoomIn, zoomOut, DEFAULT_ZOOM } from './zoom'
 import { initAutoUpdater, registerUpdaterIpc } from './updater'
 import { createCoreStateStore } from './core-state'
 import { decideNotification, createTurnTracker } from './chat-notifications'
@@ -281,6 +282,9 @@ function createWindow() {
   })
 
   mainWindow.webContents.on('did-finish-load', () => {
+    // Chromium resets the zoom factor on every navigation/reload, so re-apply
+    // the saved text size here rather than only when the config changes.
+    mainWindow?.webContents.setZoomFactor(currentZoom)
     flushPendingRendererMessages()
   })
 }
@@ -458,6 +462,34 @@ function applyUiPreferences(rawCfg: any) {
   }
   if (rawCfg?.ui?.dockless) app.dock?.hide()
   else app.dock?.show()
+  applyZoom(clampZoom(rawCfg?.ui?.zoom))
+}
+
+// Text size. Scales the main window only: Quick Capture is a fixed-width
+// floater that reports its own content height in CSS px, so zooming it would
+// desync that bottom-anchored resize.
+let currentZoom = DEFAULT_ZOOM
+function applyZoom(factor: number) {
+  const changed = factor !== currentZoom
+  currentZoom = factor
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.setZoomFactor(factor)
+  }
+  if (!changed) return
+  // Refresh the View menu's "Text Size: N%" readout, and keep the Settings
+  // stepper in sync when the change came from the menu.
+  createAppMenu()
+  sendToRenderer('ui:zoom', factor)
+}
+
+/** Persist a new text size; applyUiPreferences pushes it to the window. */
+function setZoom(factor: number) {
+  const next = clampZoom(factor)
+  if (!coreConfigManager) {
+    applyZoom(next)
+    return
+  }
+  coreConfigManager.update({ ui: { zoom: next } } as any)
 }
 
 let currentCaptureAccelerator: string | null = null
@@ -1522,6 +1554,14 @@ function createAppMenu() {
     {
       label: 'View',
       submenu: [
+        { label: `Text Size: ${formatZoom(currentZoom)}`, enabled: false },
+        { label: 'Bigger Text', accelerator: 'CommandOrControl+Plus', click: () => setZoom(zoomIn(currentZoom)) },
+        // Same action on the unshifted key, so ⌘= works like it does elsewhere
+        // on macOS. Hidden because one accelerator per menu item is displayable.
+        { label: 'Bigger Text', accelerator: 'CommandOrControl+=', visible: false, click: () => setZoom(zoomIn(currentZoom)) },
+        { label: 'Smaller Text', accelerator: 'CommandOrControl+-', click: () => setZoom(zoomOut(currentZoom)) },
+        { label: 'Actual Size', accelerator: 'CommandOrControl+0', click: () => setZoom(DEFAULT_ZOOM) },
+        { type: 'separator' },
         { role: 'reload' },
         { role: 'forceReload' },
         { role: 'toggleDevTools' },

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -385,6 +385,12 @@ contextBridge.exposeInMainWorld('codey', {
   },
   app: {
     version: () => ipcRenderer.invoke('app:version'),
+    // Text size changed from the View menu (⌘+ / ⌘− / ⌘0).
+    onZoom: (handler: (factor: number) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, factor: number) => handler(factor)
+      ipcRenderer.on('ui:zoom', listener)
+      return () => ipcRenderer.removeListener('ui:zoom', listener)
+    },
   },
   terminal: {
     list: (chatId: string) => ipcRenderer.invoke('terminal:list', chatId),

--- a/codey-mac/electron/zoom.test.ts
+++ b/codey-mac/electron/zoom.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { ZOOM_STEPS, DEFAULT_ZOOM, clampZoom, zoomIn, zoomOut, formatZoom } from './zoom'
+
+describe('zoom steps', () => {
+  it('is ascending and contains 100%', () => {
+    expect([...ZOOM_STEPS].sort((a, b) => a - b)).toEqual(ZOOM_STEPS)
+    expect(ZOOM_STEPS).toContain(DEFAULT_ZOOM)
+  })
+})
+
+describe('clampZoom', () => {
+  it('keeps listed steps as-is', () => {
+    for (const step of ZOOM_STEPS) expect(clampZoom(step)).toBe(step)
+  })
+
+  it('falls back to 100% for junk', () => {
+    for (const bad of [undefined, null, 'big', NaN, Infinity, 0, -1]) {
+      expect(clampZoom(bad)).toBe(DEFAULT_ZOOM)
+    }
+  })
+
+  it('accepts numeric strings', () => {
+    expect(clampZoom('1.25')).toBe(1.25)
+  })
+
+  it('clamps out-of-range values into the supported band', () => {
+    expect(clampZoom(0.1)).toBe(ZOOM_STEPS[0])
+    expect(clampZoom(12)).toBe(ZOOM_STEPS[ZOOM_STEPS.length - 1])
+  })
+
+  it('snaps a hand-edited value to the nearest step', () => {
+    expect(clampZoom(1.12)).toBe(1.1)
+    expect(clampZoom(1.2)).toBe(1.25)
+  })
+})
+
+describe('zoomIn / zoomOut', () => {
+  it('walks one step at a time', () => {
+    expect(zoomIn(1)).toBe(1.1)
+    expect(zoomOut(1)).toBe(0.9)
+    expect(zoomIn(zoomOut(1))).toBe(1)
+  })
+
+  it('saturates at both ends instead of wrapping', () => {
+    const min = ZOOM_STEPS[0]
+    const max = ZOOM_STEPS[ZOOM_STEPS.length - 1]
+    expect(zoomOut(min)).toBe(min)
+    expect(zoomIn(max)).toBe(max)
+  })
+
+  it('recovers from an unlisted stored value', () => {
+    expect(zoomIn(1.12)).toBe(1.25)
+  })
+})
+
+describe('formatZoom', () => {
+  it('renders whole percentages', () => {
+    expect(formatZoom(1)).toBe('100%')
+    expect(formatZoom(1.25)).toBe('125%')
+    expect(formatZoom(undefined)).toBe('100%')
+  })
+})

--- a/codey-mac/electron/zoom.ts
+++ b/codey-mac/electron/zoom.ts
@@ -1,0 +1,47 @@
+// codey-mac/electron/zoom.ts
+//
+// UI scale ("Text size") shared by the main window and the View menu. The
+// window is scaled with Chromium's zoom factor rather than a
+// CSS font-size cascade: the app's type sizes are hard-coded px inside inline
+// styles, so only a real zoom moves all of them together without reflowing
+// each component by hand.
+
+/** Selectable zoom factors, ascending. 1 (100%) is always one of them. */
+export const ZOOM_STEPS = [0.8, 0.9, 1, 1.1, 1.25, 1.4, 1.6]
+
+export const DEFAULT_ZOOM = 1
+
+const MIN_ZOOM = ZOOM_STEPS[0]
+const MAX_ZOOM = ZOOM_STEPS[ZOOM_STEPS.length - 1]
+
+/**
+ * Coerces a persisted/IPC value to a usable zoom factor. Unknown, non-finite,
+ * or out-of-range input falls back to the nearest listed step rather than
+ * leaving a window at an unreadable scale. Snapping also keeps ⌘+/⌘− landing
+ * on listed values when the stored config was hand-edited.
+ */
+export function clampZoom(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_ZOOM
+  if (n <= MIN_ZOOM) return MIN_ZOOM
+  if (n >= MAX_ZOOM) return MAX_ZOOM
+  return ZOOM_STEPS.reduce((best, step) =>
+    Math.abs(step - n) < Math.abs(best - n) ? step : best, DEFAULT_ZOOM)
+}
+
+/** Next step up; stays put at the maximum. */
+export function zoomIn(current: unknown): number {
+  const index = ZOOM_STEPS.indexOf(clampZoom(current))
+  return ZOOM_STEPS[Math.min(index + 1, ZOOM_STEPS.length - 1)]
+}
+
+/** Next step down; stays put at the minimum. */
+export function zoomOut(current: unknown): number {
+  const index = ZOOM_STEPS.indexOf(clampZoom(current))
+  return ZOOM_STEPS[Math.max(index - 1, 0)]
+}
+
+/** "110%" — the label shown in Settings and the View menu. */
+export function formatZoom(value: unknown): string {
+  return `${Math.round(clampZoom(value) * 100)}%`
+}

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -438,6 +438,7 @@ declare global {
       }
       app: {
         version: () => Promise<string>
+        onZoom: (handler: (factor: number) => void) => () => void
       }
       terminal: {
         list: (chatId: string) => Promise<IpcResult<Array<{ sessionId: string; chatId: string; cwd: string; pid: number; alive: boolean }>>>

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { C, ThemeMode, PaletteName, PaletteDefinition, PALETTES, useThemeMode, useEffectiveTheme, usePaletteName } from '../theme'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import { Section, pageStyle, Toggle } from './settingsAtoms'
+import { ZOOM_STEPS, DEFAULT_ZOOM, clampZoom, formatZoom, zoomIn, zoomOut } from '../../electron/zoom'
 import { getStatusPanelEnabled, setStatusPanelEnabled } from './statusPanelPref'
 
 const OPTIONS: { value: ThemeMode; label: string }[] = [
@@ -26,6 +27,7 @@ export const AppearanceTab: React.FC = () => {
   const [launchAtLogin, setLaunchAtLogin] = React.useState<boolean>(false)
   const [dockless, setDockless] = React.useState<boolean>(false)
   const [statusPanel, setStatusPanel] = React.useState<boolean>(getStatusPanelEnabled)
+  const [zoom, setZoomState] = React.useState<number>(DEFAULT_ZOOM)
   const [loaded, setLoaded] = React.useState(false)
 
   React.useEffect(() => {
@@ -38,9 +40,20 @@ export const AppearanceTab: React.FC = () => {
       setScreenshotHotkey(cfg?.capture?.screenshotHotkey ?? 'Control+Alt+Space')
       setLaunchAtLogin(cfg?.ui?.launchAtLogin ?? false)
       setDockless(cfg?.ui?.dockless ?? false)
+      setZoomState(clampZoom(cfg?.ui?.zoom))
       setLoaded(true)
     }).catch(() => { setLoaded(true) })
   }, [])
+
+  // ⌘+ / ⌘− / ⌘0 from the View menu change the same setting, so mirror it back
+  // into the stepper instead of letting this row drift out of date.
+  React.useEffect(() => window.codey?.app?.onZoom?.(f => setZoomState(clampZoom(f))), [])
+
+  const changeZoom = (v: number) => {
+    const next = clampZoom(v)
+    setZoomState(next)
+    window.codey?.config?.set?.({ ui: { zoom: next } }).catch(() => { /* ignore */ })
+  }
 
   const toggleSkipPerms = (v: boolean) => {
     if (v && !skipPerms && !window.confirm(
@@ -144,6 +157,41 @@ export const AppearanceTab: React.FC = () => {
               </button>
             )
           })}
+        </div>
+      </div>
+
+      <div style={styles.settingRow}>
+        <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
+          <div>Text size</div>
+          <div style={styles.settingDesc}>
+            Scale the whole interface, chat text included. ⌘+ and ⌘− adjust it from anywhere in the app; ⌘0 goes back to 100%.
+          </div>
+        </div>
+        <div style={styles.stepper}>
+          <button
+            aria-label="Smaller text"
+            disabled={zoom <= ZOOM_STEPS[0]}
+            onClick={() => changeZoom(zoomOut(zoom))}
+            style={{ ...styles.stepBtn, opacity: zoom <= ZOOM_STEPS[0] ? 0.35 : 1 }}
+          >
+            −
+          </button>
+          <button
+            aria-label={`Text size ${formatZoom(zoom)}, click to reset`}
+            title="Reset to 100%"
+            onClick={() => changeZoom(DEFAULT_ZOOM)}
+            style={styles.stepValue}
+          >
+            {formatZoom(zoom)}
+          </button>
+          <button
+            aria-label="Bigger text"
+            disabled={zoom >= ZOOM_STEPS[ZOOM_STEPS.length - 1]}
+            onClick={() => changeZoom(zoomIn(zoom))}
+            style={{ ...styles.stepBtn, opacity: zoom >= ZOOM_STEPS[ZOOM_STEPS.length - 1] ? 0.35 : 1 }}
+          >
+            +
+          </button>
         </div>
       </div>
 
@@ -275,6 +323,19 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer',
   },
   themeRow: { flexDirection: 'column', alignItems: 'stretch', gap: 12 },
+  stepper: {
+    display: 'inline-flex', alignItems: 'center', flexShrink: 0,
+    background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8, padding: 2, gap: 2,
+  },
+  stepBtn: {
+    border: 'none', borderRadius: 6, background: 'transparent', color: C.fg,
+    width: 28, height: 24, fontSize: 14, fontWeight: 600, cursor: 'pointer', lineHeight: 1,
+  },
+  stepValue: {
+    border: 'none', borderRadius: 6, background: 'transparent', color: C.fg2,
+    minWidth: 46, height: 24, fontSize: 12, fontWeight: 600, cursor: 'pointer',
+    fontVariantNumeric: 'tabular-nums',
+  },
   paletteGrid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 8 },
   paletteCard: {
     minWidth: 0, display: 'flex', alignItems: 'center', gap: 10, position: 'relative',

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -137,7 +137,7 @@ export interface GatewayConfigJson {
   mcpServers?: Record<string, ExternalMcpServerConfig>;
   notifications?: { enabled?: boolean };
   capture?: { hotkey?: string };
-  ui?: { launchAtLogin?: boolean; dockless?: boolean };
+  ui?: { launchAtLogin?: boolean; dockless?: boolean; zoom?: number };
 }
 
 /**
@@ -835,7 +835,7 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
     out.capture = { hotkey: raw.capture.hotkey };
   }
   if (raw.ui && typeof raw.ui === 'object') {
-    out.ui = { launchAtLogin: raw.ui.launchAtLogin, dockless: raw.ui.dockless };
+    out.ui = { launchAtLogin: raw.ui.launchAtLogin, dockless: raw.ui.dockless, zoom: raw.ui.zoom };
   }
   return out;
 }


### PR DESCRIPTION
## What

Adds a "Text size" control to the Mac app. The app's type sizes are hard-coded px inside inline styles, so there was no way to scale the interface without reflowing every component by hand — this scales the main window with Chromium's zoom factor instead.

- **View menu**: `⌘+` / `⌘−` step through 80% → 160%, `⌘0` resets to 100%. The menu shows the current `Text Size: N%`.
- **Settings › Appearance**: a stepper on the same setting; clicking the percentage resets it.
- Persisted as `ui.zoom` in `gateway.json`; re-applied on `did-finish-load` because Chromium drops the zoom factor on every navigation/reload.
- Menu changes push back to the renderer over a new `ui:zoom` IPC event, so the Settings stepper never drifts.

Quick Capture deliberately stays at 100% — it reports its own content height in CSS px for the bottom-anchored resize, and zooming it would desync that.

## Notes

`clampZoom` snaps unknown / out-of-range / hand-edited config values to the nearest listed step, so a bad `gateway.json` can't leave a window at an unreadable scale.

## Testing

- `npm test` — all workspaces green (new `codey-mac/electron/zoom.test.ts` covers clamping, stepping, saturation, and formatting).
- `tsc --noEmit` clean for `codey-mac`.
- Not yet exercised in a real app run — the menu items, live re-zoom, and persistence round-trip still want a manual smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)