### PR TITLE
Install the browser plugin as a skill the user owns

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -33,7 +33,7 @@ import * as pty from 'node-pty'
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
 ])
-import { browserSkillStatus, CODEY_GLOBAL_SKILLS_SUBDIR, CODEY_SKILL_DISCOVERY_SUBDIRS, CODEY_SKILLS_SUBDIR, installBrowserSkill, syncCodeyGlobalSkills, syncCodeyProjectSkills, uninstallBrowserSkill, WorkerManager, WorkspaceManager } from '@codey/core'
+import { browserSkillStatus, checkBrowserSkillUpdate, CODEY_GLOBAL_SKILLS_SUBDIR, CODEY_SKILL_DISCOVERY_SUBDIRS, CODEY_SKILLS_SUBDIR, installBrowserSkill, syncCodeyGlobalSkills, syncCodeyProjectSkills, uninstallBrowserSkill, WorkerManager, WorkspaceManager } from '@codey/core'
 import { listPlaybooks, playbookDetail, playbookHistory, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
@@ -3223,6 +3223,20 @@ app.whenReady().then(async () => {
       const result = await uninstallBrowserSkill(undefined, { force: force === true })
       if (result.removed) await syncCodeyGlobalSkills()
       return result
+    })
+  )
+
+  // "Is there an update?" never throws at the renderer: when the published
+  // folder cannot be reached the card quietly says nothing is known, rather
+  // than breaking the whole Plugins tab over a network blip.
+  ipcMain.handle('plugins:check', async (_e, id: string) =>
+    wrap(async () => {
+      if (!isKnownPlugin(id)) throw new Error(`Unknown plugin: ${id}`)
+      try {
+        return await checkBrowserSkillUpdate()
+      } catch {
+        return { needsUpdate: null }
+      }
     })
   )
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -957,6 +957,7 @@ async function bootInProcessCore() {
         await installBrowserSkill()
         await syncCodeyGlobalSkills()
       }
+
     } catch { /* best-effort: the Plugins tab can install it by hand */ }
     workerManager = new WorkerManager(join(root, 'workers'))
     await workerManager.loadWorkers()
@@ -3204,20 +3205,24 @@ app.whenReady().then(async () => {
   // it for every agent, so from here on the Skills tab owns it. Uninstalling
   // removes it; both are explicit user actions, and nothing rewrites the
   // directory in between.
-  ipcMain.handle('plugins:install', async (_e, id: string) =>
+  // `force` is the user having confirmed replacing or deleting a skill of the
+  // same name that Codey did not write. Without it the core refuses, and the
+  // card asks.
+  ipcMain.handle('plugins:install', async (_e, id: string, force?: boolean) =>
     wrap(async () => {
       if (!isKnownPlugin(id)) throw new Error(`Unknown plugin: ${id}`)
-      const result = await installBrowserSkill()
-      await syncCodeyGlobalSkills()
+      const result = await installBrowserSkill(undefined, { force: force === true })
+      if (result.installed) await syncCodeyGlobalSkills()
       return result
     })
   )
 
-  ipcMain.handle('plugins:uninstall', async (_e, id: string) =>
+  ipcMain.handle('plugins:uninstall', async (_e, id: string, force?: boolean) =>
     wrap(async () => {
       if (!isKnownPlugin(id)) throw new Error(`Unknown plugin: ${id}`)
-      await uninstallBrowserSkill()
-      await syncCodeyGlobalSkills()
+      const result = await uninstallBrowserSkill(undefined, { force: force === true })
+      if (result.removed) await syncCodeyGlobalSkills()
+      return result
     })
   )
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3207,8 +3207,9 @@ app.whenReady().then(async () => {
   ipcMain.handle('plugins:install', async (_e, id: string) =>
     wrap(async () => {
       if (!isKnownPlugin(id)) throw new Error(`Unknown plugin: ${id}`)
-      await installBrowserSkill()
+      const result = await installBrowserSkill()
       await syncCodeyGlobalSkills()
+      return result
     })
   )
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -13,7 +13,7 @@ import { decideAutomationNotification, findUnseenRuns, findUnnotifiedRuns } from
 import { validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
 import { AGENT_BINARIES, createInstalledAgentsCache, detectInstalledAgents } from './agent-detect'
-import { SKILL_FILE, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
+import { SKILL_FILE, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
@@ -33,7 +33,7 @@ import * as pty from 'node-pty'
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
 ])
-import { CODEY_GLOBAL_SKILLS_SUBDIR, CODEY_SKILLS_SUBDIR, syncCodeyGlobalSkills, syncCodeyProjectSkills, WorkerManager, WorkspaceManager } from '@codey/core'
+import { browserSkillStatus, CODEY_GLOBAL_SKILLS_SUBDIR, CODEY_SKILL_DISCOVERY_SUBDIRS, CODEY_SKILLS_SUBDIR, installBrowserSkill, syncCodeyGlobalSkills, syncCodeyProjectSkills, uninstallBrowserSkill, WorkerManager, WorkspaceManager } from '@codey/core'
 import { listPlaybooks, playbookDetail, playbookHistory, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
@@ -946,6 +946,18 @@ async function bootInProcessCore() {
   const root = resolveDataRoot()
   try {
     coreConfigManager = new ConfigManager(join(root, 'gateway.json'))
+    // Carry over an opt-in made before plugins were installed as skills: the
+    // user had the Browser plugin on, so install it once rather than let the
+    // capability disappear under them. From then on the skill on disk answers
+    // the question and this flag is never read again.
+    try {
+      const [fsMod, osMod, pathMod] = await Promise.all([import('fs'), import('os'), import('path')])
+      removeLegacyManagedSkills(fsMod, pathMod, osMod.homedir(), CODEY_SKILL_DISCOVERY_SUBDIRS)
+      if (coreConfigManager.isPluginEnabled('browser') && browserSkillStatus().state === 'absent') {
+        await installBrowserSkill()
+        await syncCodeyGlobalSkills()
+      }
+    } catch { /* best-effort: the Plugins tab can install it by hand */ }
     workerManager = new WorkerManager(join(root, 'workers'))
     await workerManager.loadWorkers()
     // Teams are defined globally in gateway.json; the workspace just stores
@@ -3185,14 +3197,26 @@ app.whenReady().then(async () => {
 
   // ── Plugins IPC ───────────────────────────────────────────────────
   ipcMain.handle('plugins:list', async () =>
-    wrap(async () => listPlugins(coreConfigManager?.get() as any))
+    wrap(async () => listPlugins(() => browserSkillStatus()))
   )
 
-  ipcMain.handle('plugins:setEnabled', async (_e, id: string, enabled: boolean) =>
+  // Installing writes the skill into the user's own ~/.codey/skills and links
+  // it for every agent, so from here on the Skills tab owns it. Uninstalling
+  // removes it; both are explicit user actions, and nothing rewrites the
+  // directory in between.
+  ipcMain.handle('plugins:install', async (_e, id: string) =>
     wrap(async () => {
-      if (!coreConfigManager) throw new Error('Config manager not initialized')
       if (!isKnownPlugin(id)) throw new Error(`Unknown plugin: ${id}`)
-      coreConfigManager.update({ plugins: { [id]: { enabled: enabled === true } } } as any)
+      await installBrowserSkill()
+      await syncCodeyGlobalSkills()
+    })
+  )
+
+  ipcMain.handle('plugins:uninstall', async (_e, id: string) =>
+    wrap(async () => {
+      if (!isKnownPlugin(id)) throw new Error(`Unknown plugin: ${id}`)
+      await uninstallBrowserSkill()
+      await syncCodeyGlobalSkills()
     })
   )
 

--- a/codey-mac/electron/plugins.test.ts
+++ b/codey-mac/electron/plugins.test.ts
@@ -8,11 +8,20 @@ describe('plugin registry', () => {
     expect(PLUGINS[0].description.length).toBeGreaterThan(10)
   })
 
-  it('merges enabled state from config', () => {
-    expect(listPlugins({ plugins: { browser: { enabled: true } } })[0].enabled).toBe(true)
-    expect(listPlugins({ plugins: { browser: { enabled: false } } })[0].enabled).toBe(false)
-    expect(listPlugins({})[0].enabled).toBe(false)
-    expect(listPlugins(undefined)[0].enabled).toBe(false)
+  it('reports the state the skill is actually in on disk', () => {
+    expect(listPlugins(() => ({ state: 'installed', updateAvailable: false }))[0].state).toBe('installed')
+    expect(listPlugins(() => ({ state: 'disabled', updateAvailable: false }))[0].state).toBe('disabled')
+    expect(listPlugins(() => ({ state: 'absent', updateAvailable: false }))[0].state).toBe('absent')
+  })
+
+  it('passes an available update through, so the card can offer it', () => {
+    expect(listPlugins(() => ({ state: 'installed', updateAvailable: true }))[0].updateAvailable).toBe(true)
+  })
+
+  it('asks about each registered plugin by id', () => {
+    const asked: string[] = []
+    listPlugins(id => { asked.push(id); return { state: 'absent', updateAvailable: false } })
+    expect(asked).toEqual(['browser'])
   })
 
   it('isKnownPlugin accepts registry ids and rejects others', () => {

--- a/codey-mac/electron/plugins.test.ts
+++ b/codey-mac/electron/plugins.test.ts
@@ -5,7 +5,6 @@ import { PLUGINS, isKnownPlugin, listPlugins } from './plugins'
 const status = (over: Partial<BrowserSkillStatus> = {}): BrowserSkillStatus => ({
   state: 'absent',
   dir: '/Users/test/.codey/skills/browser',
-  differsFromBundled: false,
   sourceUrl: 'https://github.com/its-ahoh/codey-skills',
   ...over,
 })
@@ -23,11 +22,11 @@ describe('plugin registry', () => {
     }
   })
 
-  it('carries where the copy lives and where it came from, so the card can say', () => {
-    const plugin = listPlugins(() => status({ state: 'installed', differsFromBundled: true }))[0]
+  it('carries where the copy lives, where it came from, and who wrote it', () => {
+    const plugin = listPlugins(() => status({ state: 'installed', origin: 'user' }))[0]
     expect(plugin.dir).toBe('/Users/test/.codey/skills/browser')
     expect(plugin.sourceUrl).toBe('https://github.com/its-ahoh/codey-skills')
-    expect(plugin.differsFromBundled).toBe(true)
+    expect(plugin.origin).toBe('user')
   })
 
   it('asks about each registered plugin by id', () => {

--- a/codey-mac/electron/plugins.test.ts
+++ b/codey-mac/electron/plugins.test.ts
@@ -22,8 +22,9 @@ describe('plugin registry', () => {
     }
   })
 
-  it('carries where the copy lives, where it came from, and who wrote it', () => {
-    const plugin = listPlugins(() => status({ state: 'installed', origin: 'user' }))[0]
+  it('carries where the copy lives, where it came from, who wrote it, and which version', () => {
+    const plugin = listPlugins(() => status({ state: 'installed', origin: 'user', version: '1.2.3' }))[0]
+    expect(plugin.version).toBe('1.2.3')
     expect(plugin.dir).toBe('/Users/test/.codey/skills/browser')
     expect(plugin.sourceUrl).toBe('https://github.com/its-ahoh/codey-skills')
     expect(plugin.origin).toBe('user')

--- a/codey-mac/electron/plugins.test.ts
+++ b/codey-mac/electron/plugins.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest'
+import type { BrowserSkillStatus } from '@codey/core'
 import { PLUGINS, isKnownPlugin, listPlugins } from './plugins'
+
+const status = (over: Partial<BrowserSkillStatus> = {}): BrowserSkillStatus => ({
+  state: 'absent',
+  dir: '/Users/test/.codey/skills/browser',
+  differsFromBundled: false,
+  sourceUrl: 'https://github.com/its-ahoh/codey-skills',
+  ...over,
+})
 
 describe('plugin registry', () => {
   it('registers exactly the browser plugin', () => {
@@ -9,18 +18,21 @@ describe('plugin registry', () => {
   })
 
   it('reports the state the skill is actually in on disk', () => {
-    expect(listPlugins(() => ({ state: 'installed', updateAvailable: false }))[0].state).toBe('installed')
-    expect(listPlugins(() => ({ state: 'disabled', updateAvailable: false }))[0].state).toBe('disabled')
-    expect(listPlugins(() => ({ state: 'absent', updateAvailable: false }))[0].state).toBe('absent')
+    for (const state of ['installed', 'disabled', 'absent'] as const) {
+      expect(listPlugins(() => status({ state }))[0].state).toBe(state)
+    }
   })
 
-  it('passes an available update through, so the card can offer it', () => {
-    expect(listPlugins(() => ({ state: 'installed', updateAvailable: true }))[0].updateAvailable).toBe(true)
+  it('carries where the copy lives and where it came from, so the card can say', () => {
+    const plugin = listPlugins(() => status({ state: 'installed', differsFromBundled: true }))[0]
+    expect(plugin.dir).toBe('/Users/test/.codey/skills/browser')
+    expect(plugin.sourceUrl).toBe('https://github.com/its-ahoh/codey-skills')
+    expect(plugin.differsFromBundled).toBe(true)
   })
 
   it('asks about each registered plugin by id', () => {
     const asked: string[] = []
-    listPlugins(id => { asked.push(id); return { state: 'absent', updateAvailable: false } })
+    listPlugins(id => { asked.push(id); return status() })
     expect(asked).toEqual(['browser'])
   })
 

--- a/codey-mac/electron/plugins.test.ts
+++ b/codey-mac/electron/plugins.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type { BrowserSkillStatus } from '@codey/core'
 import { PLUGINS, isKnownPlugin, listPlugins } from './plugins'
 
+const SHA = 'a'.repeat(40)
+
 const status = (over: Partial<BrowserSkillStatus> = {}): BrowserSkillStatus => ({
   state: 'absent',
   dir: '/Users/test/.codey/skills/browser',
@@ -22,9 +24,9 @@ describe('plugin registry', () => {
     }
   })
 
-  it('carries where the copy lives, where it came from, who wrote it, and which version', () => {
-    const plugin = listPlugins(() => status({ state: 'installed', origin: 'user', version: '1.2.3' }))[0]
-    expect(plugin.version).toBe('1.2.3')
+  it('carries where the copy lives, where it came from, who wrote it, and which hash', () => {
+    const plugin = listPlugins(() => status({ state: 'installed', origin: 'user', hash: SHA }))[0]
+    expect(plugin.hash).toBe(SHA)
     expect(plugin.dir).toBe('/Users/test/.codey/skills/browser')
     expect(plugin.sourceUrl).toBe('https://github.com/its-ahoh/codey-skills')
     expect(plugin.origin).toBe('user')

--- a/codey-mac/electron/plugins.ts
+++ b/codey-mac/electron/plugins.ts
@@ -1,12 +1,24 @@
+import type { BrowserSkillState } from '@codey/core'
+
+/**
+ * A plugin is a capability Codey installs as an ordinary skill. Installing is
+ * the only thing the Plugins tab does: once installed, the skill belongs to the
+ * user, and the Skills tab's own on/off and delete are the controls that act on
+ * it. That is why `state` is read from disk rather than from config — two tabs
+ * describe one directory, and neither may claim something the other contradicts.
+ */
 export interface PluginInfo {
   id: 'browser'
   name: string
   description: string
-  enabled: boolean
+  /** `absent` = not installed, `disabled` = installed but off in Skills. */
+  state: BrowserSkillState
+  /** The installed copy is older than the one this build ships. */
+  updateAvailable: boolean
 }
 
-/** Static registry of Codey plugins. Enablement lives in gateway config. */
-export const PLUGINS: Array<Omit<PluginInfo, 'enabled'>> = [
+/** Static registry of Codey plugins. */
+export const PLUGINS: Array<Omit<PluginInfo, 'state' | 'updateAvailable'>> = [
   {
     id: 'browser',
     name: 'Browser',
@@ -22,9 +34,8 @@ export function isKnownPlugin(id: string): boolean {
   return PLUGINS.some(plugin => plugin.id === id)
 }
 
-export function listPlugins(config: { plugins?: Record<string, { enabled?: boolean }> } | undefined): PluginInfo[] {
-  return PLUGINS.map(plugin => ({
-    ...plugin,
-    enabled: config?.plugins?.[plugin.id]?.enabled === true,
-  }))
+export function listPlugins(
+  status: (id: PluginInfo['id']) => { state: BrowserSkillState; updateAvailable: boolean },
+): PluginInfo[] {
+  return PLUGINS.map(plugin => ({ ...plugin, ...status(plugin.id) }))
 }

--- a/codey-mac/electron/plugins.ts
+++ b/codey-mac/electron/plugins.ts
@@ -1,24 +1,21 @@
-import type { BrowserSkillState } from '@codey/core'
+import type { BrowserSkillStatus } from '@codey/core'
 
 /**
- * A plugin is a capability Codey installs as an ordinary skill. Installing is
- * the only thing the Plugins tab does: once installed, the skill belongs to the
- * user, and the Skills tab's own on/off and delete are the controls that act on
- * it. That is why `state` is read from disk rather than from config — two tabs
- * describe one directory, and neither may claim something the other contradicts.
+ * A plugin is a capability Codey installs as an ordinary skill, pulled from the
+ * published skills repository. Installing is the only thing the Plugins tab
+ * does: once installed, the skill belongs to the user, and the Skills tab's own
+ * on/off and delete are the controls that act on it. That is why the state is
+ * read from disk rather than from config — two tabs describe one directory, and
+ * neither may claim something the other contradicts.
  */
-export interface PluginInfo {
+export interface PluginInfo extends BrowserSkillStatus {
   id: 'browser'
   name: string
   description: string
-  /** `absent` = not installed, `disabled` = installed but off in Skills. */
-  state: BrowserSkillState
-  /** The installed copy is older than the one this build ships. */
-  updateAvailable: boolean
 }
 
 /** Static registry of Codey plugins. */
-export const PLUGINS: Array<Omit<PluginInfo, 'state' | 'updateAvailable'>> = [
+export const PLUGINS: Array<Pick<PluginInfo, 'id' | 'name' | 'description'>> = [
   {
     id: 'browser',
     name: 'Browser',
@@ -34,8 +31,6 @@ export function isKnownPlugin(id: string): boolean {
   return PLUGINS.some(plugin => plugin.id === id)
 }
 
-export function listPlugins(
-  status: (id: PluginInfo['id']) => { state: BrowserSkillState; updateAvailable: boolean },
-): PluginInfo[] {
+export function listPlugins(status: (id: PluginInfo['id']) => BrowserSkillStatus): PluginInfo[] {
   return PLUGINS.map(plugin => ({ ...plugin, ...status(plugin.id) }))
 }

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -116,7 +116,8 @@ contextBridge.exposeInMainWorld('codey', {
   },
   plugins: {
     list: () => ipcRenderer.invoke('plugins:list'),
-    setEnabled: (id: string, enabled: boolean) => ipcRenderer.invoke('plugins:setEnabled', id, enabled),
+    install: (id: string) => ipcRenderer.invoke('plugins:install', id),
+    uninstall: (id: string) => ipcRenderer.invoke('plugins:uninstall', id),
   },
   mcp: {
     list: () => ipcRenderer.invoke('mcp:list'),

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -116,8 +116,8 @@ contextBridge.exposeInMainWorld('codey', {
   },
   plugins: {
     list: () => ipcRenderer.invoke('plugins:list'),
-    install: (id: string) => ipcRenderer.invoke('plugins:install', id),
-    uninstall: (id: string) => ipcRenderer.invoke('plugins:uninstall', id),
+    install: (id: string, force?: boolean) => ipcRenderer.invoke('plugins:install', id, force),
+    uninstall: (id: string, force?: boolean) => ipcRenderer.invoke('plugins:uninstall', id, force),
   },
   mcp: {
     list: () => ipcRenderer.invoke('mcp:list'),

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -118,6 +118,7 @@ contextBridge.exposeInMainWorld('codey', {
     list: () => ipcRenderer.invoke('plugins:list'),
     install: (id: string, force?: boolean) => ipcRenderer.invoke('plugins:install', id, force),
     uninstall: (id: string, force?: boolean) => ipcRenderer.invoke('plugins:uninstall', id, force),
+    check: (id: string) => ipcRenderer.invoke('plugins:check', id),
   },
   mcp: {
     list: () => ipcRenderer.invoke('mcp:list'),

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { qualifySkillName, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
+import { qualifySkillName, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 
 const roots: string[] = []
 const temp = () => {
@@ -193,5 +193,53 @@ describe('setSkillEnabled', () => {
 
     expect(fs.readFileSync(active, 'utf-8')).toBe('---\nname: one\ndescription: A skill\n---\n')
     expect(fs.readFileSync(disabled, 'utf-8')).toBe('---\nname: one\ndescription: A backup\n---\n')
+  })
+})
+
+describe('removeLegacyManagedSkills', () => {
+  const DISCOVERY = ['.claude/skills', '.agents/skills']
+
+  const legacyHome = () => {
+    const home = temp()
+    const skill = path.join(home, '.codey', 'managed-skills', 'browser')
+    fs.mkdirSync(skill, { recursive: true })
+    fs.writeFileSync(path.join(skill, 'SKILL.md'), '---\nname: browser\n---\n')
+    for (const subdir of DISCOVERY) {
+      const root = path.join(home, subdir)
+      fs.mkdirSync(root, { recursive: true })
+      fs.symlinkSync(path.relative(root, skill), path.join(root, 'browser'), 'dir')
+    }
+    return home
+  }
+
+  it('removes the legacy root and every link into it', () => {
+    const home = legacyHome()
+    removeLegacyManagedSkills(fs, path, home, DISCOVERY)
+    expect(fs.existsSync(path.join(home, '.codey', 'managed-skills'))).toBe(false)
+    for (const subdir of DISCOVERY) {
+      expect(fs.existsSync(path.join(home, subdir, 'browser'))).toBe(false)
+      // The link must be gone, not merely broken: a leftover reads as a
+      // conflict and blocks linking the installed skill of the same name.
+      expect(fs.readdirSync(path.join(home, subdir))).toEqual([])
+    }
+  })
+
+  it('leaves links to the user\'s own skills alone', () => {
+    const home = legacyHome()
+    const mine = path.join(home, '.codey', 'skills', 'mine')
+    fs.mkdirSync(mine, { recursive: true })
+    const root = path.join(home, '.claude', 'skills')
+    fs.symlinkSync(path.relative(root, mine), path.join(root, 'mine'), 'dir')
+    removeLegacyManagedSkills(fs, path, home, DISCOVERY)
+    expect(fs.existsSync(path.join(root, 'mine'))).toBe(true)
+  })
+
+  it('does nothing when there is no legacy root', () => {
+    const home = temp()
+    const root = path.join(home, '.claude', 'skills')
+    fs.mkdirSync(root, { recursive: true })
+    fs.writeFileSync(path.join(root, 'keep'), 'x')
+    removeLegacyManagedSkills(fs, path, home, DISCOVERY)
+    expect(fs.existsSync(path.join(root, 'keep'))).toBe(true)
   })
 })

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -196,3 +196,36 @@ export function uniqueSkills(fsMod: typeof Fs, pathMod: typeof Path, skills: Sca
     return true
   })
 }
+
+/**
+ * Delete the short-lived `~/.codey/managed-skills` root and the discovery links
+ * pointing into it. Skills Codey owned on the user's behalf lived there for one
+ * development build, before installing them into the user's own
+ * `~/.codey/skills` replaced the idea. A leftover link matters: it targets a
+ * directory outside the sync's source root, so `syncCodeyGlobalSkills` reads it
+ * as a conflict and declines to link the real skill — an install that reports
+ * success and reaches no agent.
+ */
+export function removeLegacyManagedSkills(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  home: string,
+  discoverySubdirs: readonly string[],
+): void {
+  const legacyRoot = pathMod.join(home, '.codey', 'managed-skills')
+  if (!fsMod.existsSync(legacyRoot)) return
+  for (const subdir of discoverySubdirs) {
+    const discoveryRoot = pathMod.join(home, subdir)
+    let entries: Fs.Dirent[]
+    try { entries = fsMod.readdirSync(discoveryRoot, { withFileTypes: true }) } catch { continue }
+    for (const entry of entries) {
+      if (!entry.isSymbolicLink()) continue
+      const linkPath = pathMod.join(discoveryRoot, entry.name)
+      try {
+        const target = pathMod.resolve(discoveryRoot, fsMod.readlinkSync(linkPath))
+        if (target.startsWith(`${legacyRoot}${pathMod.sep}`)) fsMod.unlinkSync(linkPath)
+      } catch { /* leave anything unreadable alone */ }
+    }
+  }
+  fsMod.rmSync(legacyRoot, { recursive: true, force: true })
+}

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -35,6 +35,8 @@ export interface PluginInfo {
   origin?: 'codey' | 'user'
   /** The repository Install pulls from. */
   sourceUrl: string
+  /** The version the installed copy declares. */
+  version?: string
 }
 
 /** Which copy an install wrote: 'bundled' means the repository was unreachable

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -28,7 +28,21 @@ export interface PluginInfo {
   /** Read from disk: a plugin is installed as an ordinary skill, and the
    *  Skills tab can disable ('disabled') or delete ('absent') it from there. */
   state: 'absent' | 'disabled' | 'installed'
-  updateAvailable: boolean
+  /** Where an installed copy lives. */
+  dir: string
+  /** The installed copy is not the one bundled with this build — expected
+   *  after a pull from the repository, and true when the user edits it too. */
+  differsFromBundled: boolean
+  /** The repository Install pulls from. */
+  sourceUrl: string
+}
+
+/** Which copy an install wrote: 'bundled' means the repository was unreachable
+ *  and `reason` says why. */
+export interface PluginInstallResult {
+  file: string
+  source: 'repository' | 'bundled'
+  reason?: string
 }
 
 export interface ExternalMcpServer {
@@ -257,7 +271,7 @@ declare global {
       }
       plugins: {
         list: () => Promise<IpcResult<PluginInfo[]>>
-        install: (id: string) => Promise<IpcResult<void>>
+        install: (id: string) => Promise<IpcResult<PluginInstallResult>>
         uninstall: (id: string) => Promise<IpcResult<void>>
       }
       mcp: {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -30,19 +30,23 @@ export interface PluginInfo {
   state: 'absent' | 'disabled' | 'installed'
   /** Where an installed copy lives. */
   dir: string
-  /** The installed copy is not the one bundled with this build — expected
-   *  after a pull from the repository, and true when the user edits it too. */
-  differsFromBundled: boolean
+  /** Who wrote what is there: 'codey' carries an install's stamp, 'user' is a
+   *  hand-written skill of the same name. Undefined when nothing is installed. */
+  origin?: 'codey' | 'user'
   /** The repository Install pulls from. */
   sourceUrl: string
 }
 
 /** Which copy an install wrote: 'bundled' means the repository was unreachable
- *  and `reason` says why. */
-export interface PluginInstallResult {
-  file: string
-  source: 'repository' | 'bundled'
-  reason?: string
+ *  and `reason` says why. `installed: false` means Codey refused to replace a
+ *  skill it did not write; retry with force once the user confirms. */
+export type PluginInstallResult =
+  | { installed: true; file: string; source: 'repository' | 'bundled'; reason?: string }
+  | { installed: false; conflict: 'user-copy'; dir: string }
+
+export interface PluginUninstallResult {
+  removed: boolean
+  conflict?: 'user-copy'
 }
 
 export interface ExternalMcpServer {
@@ -271,8 +275,8 @@ declare global {
       }
       plugins: {
         list: () => Promise<IpcResult<PluginInfo[]>>
-        install: (id: string) => Promise<IpcResult<PluginInstallResult>>
-        uninstall: (id: string) => Promise<IpcResult<void>>
+        install: (id: string, force?: boolean) => Promise<IpcResult<PluginInstallResult>>
+        uninstall: (id: string, force?: boolean) => Promise<IpcResult<PluginUninstallResult>>
       }
       mcp: {
         list: () => Promise<IpcResult<ExternalMcpServer[]>>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -35,8 +35,9 @@ export interface PluginInfo {
   origin?: 'codey' | 'user'
   /** The repository Install pulls from. */
   sourceUrl: string
-  /** The skill folder's tree hash an install recorded — the version the
-   *  ecosystem uses for a skill. Present only on a copy Codey wrote. */
+  /** The version an install recorded — the skill folder's tree hash, the
+   *  version the ecosystem uses for a skill, or 'bundled' for the copy shipped
+   *  with the app. Present only on a copy Codey wrote. */
   hash?: string
 }
 
@@ -56,7 +57,8 @@ export interface PluginUninstallResult {
  *  `needsUpdate: null` when the published folder could not be reached. */
 export interface PluginUpdateCheck {
   needsUpdate: boolean | null
-  /** The hash an install stamped, when this copy is Codey's. */
+  /** What the install stamped: a folder hash, or 'bundled' for the copy that
+   *  shipped with the app, which has no published version to compare. */
   recorded?: string
   /** The hash the published folder has right now. */
   current?: string

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -25,7 +25,10 @@ export interface PluginInfo {
   id: string
   name: string
   description: string
-  enabled: boolean
+  /** Read from disk: a plugin is installed as an ordinary skill, and the
+   *  Skills tab can disable ('disabled') or delete ('absent') it from there. */
+  state: 'absent' | 'disabled' | 'installed'
+  updateAvailable: boolean
 }
 
 export interface ExternalMcpServer {
@@ -254,7 +257,8 @@ declare global {
       }
       plugins: {
         list: () => Promise<IpcResult<PluginInfo[]>>
-        setEnabled: (id: string, enabled: boolean) => Promise<IpcResult<void>>
+        install: (id: string) => Promise<IpcResult<void>>
+        uninstall: (id: string) => Promise<IpcResult<void>>
       }
       mcp: {
         list: () => Promise<IpcResult<ExternalMcpServer[]>>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -35,8 +35,9 @@ export interface PluginInfo {
   origin?: 'codey' | 'user'
   /** The repository Install pulls from. */
   sourceUrl: string
-  /** The version the installed copy declares. */
-  version?: string
+  /** The skill folder's tree hash an install recorded — the version the
+   *  ecosystem uses for a skill. Present only on a copy Codey wrote. */
+  hash?: string
 }
 
 /** Which copy an install wrote: 'bundled' means the repository was unreachable
@@ -49,6 +50,16 @@ export type PluginInstallResult =
 export interface PluginUninstallResult {
   removed: boolean
   conflict?: 'user-copy'
+}
+
+/** Whether the published skill moved after the installed copy was written.
+ *  `needsUpdate: null` when the published folder could not be reached. */
+export interface PluginUpdateCheck {
+  needsUpdate: boolean | null
+  /** The hash an install stamped, when this copy is Codey's. */
+  recorded?: string
+  /** The hash the published folder has right now. */
+  current?: string
 }
 
 export interface ExternalMcpServer {
@@ -279,6 +290,7 @@ declare global {
         list: () => Promise<IpcResult<PluginInfo[]>>
         install: (id: string, force?: boolean) => Promise<IpcResult<PluginInstallResult>>
         uninstall: (id: string, force?: boolean) => Promise<IpcResult<PluginUninstallResult>>
+        check: (id: string) => Promise<IpcResult<PluginUpdateCheck>>
       }
       mcp: {
         list: () => Promise<IpcResult<ExternalMcpServer[]>>

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -123,7 +123,11 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                   {' '}<span style={styles.path}>{plugin.dir}</span>
                   {update[plugin.id]?.needsUpdate === true && (
                     <div style={styles.updateHint}>
-                      The published skill has moved since this copy was installed — Update to get it.
+                      {update[plugin.id]?.recorded === 'bundled'
+                        ? 'This copy came with the app, installed while the repository was '
+                          + 'unreachable — Update to pull the published one.'
+                        : 'The published skill has moved since this copy was installed — '
+                          + 'Update to get it.'}
                     </div>
                   )}
                 </div>

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -94,6 +94,7 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                 {installed && (
                   <span style={plugin.state === 'disabled' ? styles.badgeMuted : styles.badge}>
                     {plugin.state === 'disabled' ? 'Off in Skills' : 'Installed'}
+                    {plugin.version ? ` ${plugin.version}` : ''}
                   </span>
                 )}
               </div>

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -3,7 +3,7 @@ import { C } from '../theme'
 import { pillButton, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
-import type { PluginInfo, PluginInstallResult } from '../codey-api'
+import type { PluginInfo, PluginInstallResult, PluginUpdateCheck } from '../codey-api'
 
 /** Codey refused to touch a skill of this name it did not write. The user
  *  decides; nothing is replaced or deleted until they say so. */
@@ -17,22 +17,38 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
   // What the last install did, kept per plugin: which copy landed, and where.
   const [outcome, setOutcome] = useState<Record<string, PluginInstallResult>>({})
   const [pending, setPending] = useState<Record<string, Pending>>({})
+  // Whether the published skill moved since this copy was installed. `null`
+  // means nothing could be checked — the repo was unreachable, so no claim.
+  const [update, setUpdate] = useState<Record<string, PluginUpdateCheck>>({})
   const filteredPlugins = useMemo(
     () => plugins.filter(plugin => matchesToolSearch(searchQuery, plugin.name, plugin.description)),
     [plugins, searchQuery],
   )
 
+  const checkForUpdate = useCallback(async (plugin: PluginInfo) => {
+    try {
+      const result = unwrap(await window.codey.plugins.check(plugin.id))
+      setUpdate(prev => ({ ...prev, [plugin.id]: result }))
+    } catch {
+      // Offline or refused: say nothing rather than claim there is no update.
+    }
+  }, [])
+
   const reload = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      setPlugins(unwrap(await window.codey.plugins.list()))
+      const listed = unwrap(await window.codey.plugins.list())
+      setPlugins(listed)
+      for (const plugin of listed) {
+        if (plugin.state !== 'absent') void checkForUpdate(plugin)
+      }
     } catch (e: any) {
       setError(e?.message ?? String(e))
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [checkForUpdate])
 
   useEffect(() => { void reload() }, [reload])
 
@@ -94,7 +110,7 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                 {installed && (
                   <span style={plugin.state === 'disabled' ? styles.badgeMuted : styles.badge}>
                     {plugin.state === 'disabled' ? 'Off in Skills' : 'Installed'}
-                    {plugin.version ? ` ${plugin.version}` : ''}
+                    {plugin.hash ? ` ${plugin.hash.slice(0, 7)}` : ''}
                   </span>
                 )}
               </div>
@@ -105,6 +121,11 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                     ? 'Switched off in Skills, so no agent loads it. Turn it back on there.'
                     : 'Listed in Skills as "browser".'}
                   {' '}<span style={styles.path}>{plugin.dir}</span>
+                  {update[plugin.id]?.needsUpdate === true && (
+                    <div style={styles.updateHint}>
+                      The published skill has moved since this copy was installed — Update to get it.
+                    </div>
+                  )}
                 </div>
               ) : (
                 <div style={styles.cardHint}>
@@ -151,8 +172,10 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                     <button
                       onClick={() => { if (!working) void act(plugin, 'install') }}
                       disabled={working}
-                      style={pillButton('ghost')}
-                      title="Download the published skill again, replacing your copy"
+                      style={pillButton(update[plugin.id]?.needsUpdate === true ? 'primary' : 'ghost')}
+                      title={update[plugin.id]?.needsUpdate === true
+                        ? 'A newer published version is available — update now'
+                        : 'Download the published skill again, replacing your copy'}
                     >
                       Update
                     </button>
@@ -193,6 +216,7 @@ const styles: Record<string, React.CSSProperties> = {
   cardName: { color: C.fg, fontSize: 13, fontWeight: 700, marginBottom: 3 },
   cardDesc: { color: C.fg3, fontSize: 11.5, lineHeight: 1.45 },
   cardHint: { color: C.fg2, fontSize: 11, lineHeight: 1.45, marginTop: 5 },
+  updateHint: { color: C.accent, fontSize: 11, lineHeight: 1.45, marginTop: 4 },
   cardWarn: { color: C.fg2, fontSize: 11, lineHeight: 1.45, marginTop: 5, opacity: 0.9 },
   path: { fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 10.5, color: C.fg3 },
   badge: {

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -3,13 +3,15 @@ import { C } from '../theme'
 import { pillButton, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
-import type { PluginInfo } from '../codey-api'
+import type { PluginInfo, PluginInstallResult } from '../codey-api'
 
 export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [plugins, setPlugins] = useState<PluginInfo[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
+  // What the last install did, kept per plugin: which copy landed, and where.
+  const [outcome, setOutcome] = useState<Record<string, PluginInstallResult>>({})
   const filteredPlugins = useMemo(
     () => plugins.filter(plugin => matchesToolSearch(searchQuery, plugin.name, plugin.description)),
     [plugins, searchQuery],
@@ -33,7 +35,13 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
     setBusy(plugin.id)
     setError(null)
     try {
-      unwrap(await window.codey.plugins[action](plugin.id))
+      if (action === 'install') {
+        const result = unwrap(await window.codey.plugins.install(plugin.id))
+        setOutcome(prev => ({ ...prev, [plugin.id]: result }))
+      } else {
+        unwrap(await window.codey.plugins.uninstall(plugin.id))
+        setOutcome(prev => { const next = { ...prev }; delete next[plugin.id]; return next })
+      }
       await reload()
     } catch (e: any) {
       setError(e?.message ?? String(e))
@@ -47,35 +55,54 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
   return (
     <div>
       <div style={styles.intro}>
-        Plugins give agents extra capabilities. Installing one adds a skill to Skills,
-        where you can turn it off or remove it; changes apply to the next agent run.
+        Plugins give agents extra capabilities. Installing one downloads a skill into
+        your own skill folder, where the Skills tab can turn it off or remove it;
+        changes apply to the next agent run.
       </div>
       {error && <div style={styles.errorBanner}>{error}</div>}
       {filteredPlugins.map(plugin => {
         const installed = plugin.state !== 'absent'
         const working = busy === plugin.id
+        const last = outcome[plugin.id]
         return (
           <div key={plugin.id} style={styles.card}>
             <div style={styles.cardIcon}><UIIcon name="tools" size={18} /></div>
             <div style={styles.cardBody}>
-              <div style={styles.cardName}>{plugin.name}</div>
+              <div style={styles.cardName}>
+                {plugin.name}
+                {installed && (
+                  <span style={plugin.state === 'disabled' ? styles.badgeMuted : styles.badge}>
+                    {plugin.state === 'disabled' ? 'Off in Skills' : 'Installed'}
+                  </span>
+                )}
+              </div>
               <div style={styles.cardDesc}>{plugin.description}</div>
-              {plugin.state === 'disabled' && (
-                <div style={styles.cardHint}>Installed, but switched off in Skills.</div>
-              )}
-              {plugin.updateAvailable && (
+              {installed ? (
                 <div style={styles.cardHint}>
-                  Your copy is older than this version of Codey. Update it so it matches the
-                  commands the app ships.
+                  {plugin.state === 'disabled'
+                    ? 'Switched off in Skills, so no agent loads it. Turn it back on there.'
+                    : 'Listed in Skills as "browser".'}
+                  {' '}<span style={styles.path}>{plugin.dir}</span>
+                </div>
+              ) : (
+                <div style={styles.cardHint}>
+                  Downloads from <span style={styles.path}>{plugin.sourceUrl}</span>
+                </div>
+              )}
+              {last?.source === 'bundled' && (
+                <div style={styles.cardWarn}>
+                  Could not reach the skills repository, so Codey installed the copy it
+                  ships with. {last.reason}
                 </div>
               )}
             </div>
             <div style={styles.cardActions}>
-              {plugin.updateAvailable && (
+              {installed && (
                 <button
                   onClick={() => { if (!working) void act(plugin, 'install') }}
                   disabled={working}
-                  style={pillButton('primary')}
+                  style={pillButton('ghost')}
+                  title="Download the published skill again, replacing your copy"
                 >
                   Update
                 </button>
@@ -85,7 +112,7 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                 disabled={working}
                 style={pillButton(installed ? 'danger' : 'primary')}
               >
-                {installed ? 'Uninstall' : 'Install'}
+                {working ? (installed ? 'Working…' : 'Installing…') : installed ? 'Uninstall' : 'Install'}
               </button>
             </div>
           </div>
@@ -114,6 +141,16 @@ const styles: Record<string, React.CSSProperties> = {
   cardName: { color: C.fg, fontSize: 13, fontWeight: 700, marginBottom: 3 },
   cardDesc: { color: C.fg3, fontSize: 11.5, lineHeight: 1.45 },
   cardHint: { color: C.fg2, fontSize: 11, lineHeight: 1.45, marginTop: 5 },
+  cardWarn: { color: C.fg2, fontSize: 11, lineHeight: 1.45, marginTop: 5, opacity: 0.9 },
+  path: { fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 10.5, color: C.fg3 },
+  badge: {
+    marginLeft: 8, padding: '1px 7px', borderRadius: 20, fontSize: 10, fontWeight: 650,
+    background: C.accent + '22', color: C.accent, verticalAlign: 'middle',
+  },
+  badgeMuted: {
+    marginLeft: 8, padding: '1px 7px', borderRadius: 20, fontSize: 10, fontWeight: 650,
+    background: C.surface3, color: C.fg3, verticalAlign: 'middle',
+  },
   cardActions: { display: 'flex', gap: 8, alignItems: 'center', flexShrink: 0 },
   emptySearch: { color: C.fg3, fontSize: 12, textAlign: 'center', padding: '30px 16px' },
 }

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -5,6 +5,10 @@ import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
 import type { PluginInfo, PluginInstallResult } from '../codey-api'
 
+/** Codey refused to touch a skill of this name it did not write. The user
+ *  decides; nothing is replaced or deleted until they say so. */
+type Pending = { action: 'install' | 'uninstall'; dir: string }
+
 export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [plugins, setPlugins] = useState<PluginInfo[]>([])
   const [loading, setLoading] = useState(true)
@@ -12,6 +16,7 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
   const [busy, setBusy] = useState<string | null>(null)
   // What the last install did, kept per plugin: which copy landed, and where.
   const [outcome, setOutcome] = useState<Record<string, PluginInstallResult>>({})
+  const [pending, setPending] = useState<Record<string, Pending>>({})
   const filteredPlugins = useMemo(
     () => plugins.filter(plugin => matchesToolSearch(searchQuery, plugin.name, plugin.description)),
     [plugins, searchQuery],
@@ -31,17 +36,32 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
 
   useEffect(() => { void reload() }, [reload])
 
-  const act = async (plugin: PluginInfo, action: 'install' | 'uninstall') => {
+  const forget = (id: string, from: Record<string, any>) => {
+    const next = { ...from }
+    delete next[id]
+    return next
+  }
+
+  const act = async (plugin: PluginInfo, action: 'install' | 'uninstall', force = false) => {
     setBusy(plugin.id)
     setError(null)
     try {
       if (action === 'install') {
-        const result = unwrap(await window.codey.plugins.install(plugin.id))
+        const result = unwrap(await window.codey.plugins.install(plugin.id, force))
+        if (!result.installed) {
+          setPending(prev => ({ ...prev, [plugin.id]: { action, dir: result.dir } }))
+          return
+        }
         setOutcome(prev => ({ ...prev, [plugin.id]: result }))
       } else {
-        unwrap(await window.codey.plugins.uninstall(plugin.id))
-        setOutcome(prev => { const next = { ...prev }; delete next[plugin.id]; return next })
+        const result = unwrap(await window.codey.plugins.uninstall(plugin.id, force))
+        if (!result.removed && result.conflict) {
+          setPending(prev => ({ ...prev, [plugin.id]: { action, dir: plugin.dir } }))
+          return
+        }
+        setOutcome(prev => forget(plugin.id, prev))
       }
+      setPending(prev => forget(plugin.id, prev))
       await reload()
     } catch (e: any) {
       setError(e?.message ?? String(e))
@@ -64,6 +84,7 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
         const installed = plugin.state !== 'absent'
         const working = busy === plugin.id
         const last = outcome[plugin.id]
+        const ask = pending[plugin.id]
         return (
           <div key={plugin.id} style={styles.card}>
             <div style={styles.cardIcon}><UIIcon name="tools" size={18} /></div>
@@ -89,31 +110,61 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                   Downloads from <span style={styles.path}>{plugin.sourceUrl}</span>
                 </div>
               )}
-              {last?.source === 'bundled' && (
+              {last?.installed && last.source === 'bundled' && (
                 <div style={styles.cardWarn}>
                   Could not reach the skills repository, so Codey installed the copy it
                   ships with. {last.reason}
                 </div>
               )}
+              {ask && (
+                <div style={styles.cardWarn}>
+                  A skill named "browser" is already at <span style={styles.path}>{ask.dir}</span>,
+                  and Codey did not write it.{' '}
+                  {ask.action === 'install'
+                    ? 'Installing replaces it.'
+                    : 'Uninstalling deletes it.'} There is no undo.
+                </div>
+              )}
             </div>
             <div style={styles.cardActions}>
-              {installed && (
-                <button
-                  onClick={() => { if (!working) void act(plugin, 'install') }}
-                  disabled={working}
-                  style={pillButton('ghost')}
-                  title="Download the published skill again, replacing your copy"
-                >
-                  Update
-                </button>
+              {ask ? (
+                <>
+                  <button
+                    onClick={() => setPending(prev => forget(plugin.id, prev))}
+                    disabled={working}
+                    style={pillButton('ghost')}
+                  >
+                    Keep mine
+                  </button>
+                  <button
+                    onClick={() => { if (!working) void act(plugin, ask.action, true) }}
+                    disabled={working}
+                    style={pillButton('danger')}
+                  >
+                    {ask.action === 'install' ? 'Replace it' : 'Delete it'}
+                  </button>
+                </>
+              ) : (
+                <>
+                  {installed && (
+                    <button
+                      onClick={() => { if (!working) void act(plugin, 'install') }}
+                      disabled={working}
+                      style={pillButton('ghost')}
+                      title="Download the published skill again, replacing your copy"
+                    >
+                      Update
+                    </button>
+                  )}
+                  <button
+                    onClick={() => { if (!working) void act(plugin, installed ? 'uninstall' : 'install') }}
+                    disabled={working}
+                    style={pillButton(installed ? 'danger' : 'primary')}
+                  >
+                    {working ? (installed ? 'Working…' : 'Installing…') : installed ? 'Uninstall' : 'Install'}
+                  </button>
+                </>
               )}
-              <button
-                onClick={() => { if (!working) void act(plugin, installed ? 'uninstall' : 'install') }}
-                disabled={working}
-                style={pillButton(installed ? 'danger' : 'primary')}
-              >
-                {working ? (installed ? 'Working…' : 'Installing…') : installed ? 'Uninstall' : 'Install'}
-              </button>
             </div>
           </div>
         )

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { C } from '../theme'
-import { Toggle, unwrap } from './settingsAtoms'
+import { pillButton, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
 import type { PluginInfo } from '../codey-api'
@@ -29,11 +29,11 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
 
   useEffect(() => { void reload() }, [reload])
 
-  const toggle = async (plugin: PluginInfo) => {
+  const act = async (plugin: PluginInfo, action: 'install' | 'uninstall') => {
     setBusy(plugin.id)
     setError(null)
     try {
-      unwrap(await window.codey.plugins.setEnabled(plugin.id, !plugin.enabled))
+      unwrap(await window.codey.plugins[action](plugin.id))
       await reload()
     } catch (e: any) {
       setError(e?.message ?? String(e))
@@ -47,22 +47,50 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
   return (
     <div>
       <div style={styles.intro}>
-        Plugins give agents extra capabilities. Everything is off until you enable it;
-        changes apply to the next agent run.
+        Plugins give agents extra capabilities. Installing one adds a skill to Skills,
+        where you can turn it off or remove it; changes apply to the next agent run.
       </div>
       {error && <div style={styles.errorBanner}>{error}</div>}
-      {filteredPlugins.map(plugin => (
-        <div key={plugin.id} style={styles.card}>
-          <div style={styles.cardIcon}><UIIcon name="tools" size={18} /></div>
-          <div style={styles.cardBody}>
-            <div style={styles.cardName}>{plugin.name}</div>
-            <div style={styles.cardDesc}>{plugin.description}</div>
+      {filteredPlugins.map(plugin => {
+        const installed = plugin.state !== 'absent'
+        const working = busy === plugin.id
+        return (
+          <div key={plugin.id} style={styles.card}>
+            <div style={styles.cardIcon}><UIIcon name="tools" size={18} /></div>
+            <div style={styles.cardBody}>
+              <div style={styles.cardName}>{plugin.name}</div>
+              <div style={styles.cardDesc}>{plugin.description}</div>
+              {plugin.state === 'disabled' && (
+                <div style={styles.cardHint}>Installed, but switched off in Skills.</div>
+              )}
+              {plugin.updateAvailable && (
+                <div style={styles.cardHint}>
+                  Your copy is older than this version of Codey. Update it so it matches the
+                  commands the app ships.
+                </div>
+              )}
+            </div>
+            <div style={styles.cardActions}>
+              {plugin.updateAvailable && (
+                <button
+                  onClick={() => { if (!working) void act(plugin, 'install') }}
+                  disabled={working}
+                  style={pillButton('primary')}
+                >
+                  Update
+                </button>
+              )}
+              <button
+                onClick={() => { if (!working) void act(plugin, installed ? 'uninstall' : 'install') }}
+                disabled={working}
+                style={pillButton(installed ? 'danger' : 'primary')}
+              >
+                {installed ? 'Uninstall' : 'Install'}
+              </button>
+            </div>
           </div>
-          <div style={busy === plugin.id ? styles.toggleBusy : undefined}>
-            <Toggle on={plugin.enabled} onChange={() => { if (busy !== plugin.id) void toggle(plugin) }} />
-          </div>
-        </div>
-      ))}
+        )
+      })}
       {plugins.length > 0 && filteredPlugins.length === 0 && (
         <div style={styles.emptySearch}>No plugins match that name or description.</div>
       )}
@@ -85,6 +113,7 @@ const styles: Record<string, React.CSSProperties> = {
   cardBody: { flex: 1, minWidth: 0 },
   cardName: { color: C.fg, fontSize: 13, fontWeight: 700, marginBottom: 3 },
   cardDesc: { color: C.fg3, fontSize: 11.5, lineHeight: 1.45 },
-  toggleBusy: { opacity: 0.5, cursor: 'wait', pointerEvents: 'none' },
+  cardHint: { color: C.fg2, fontSize: 11, lineHeight: 1.45, marginTop: 5 },
+  cardActions: { display: 'flex', gap: 8, alignItems: 'center', flexShrink: 0 },
   emptySearch: { color: C.fg3, fontSize: 12, textAlign: 'center', padding: '30px 16px' },
 }

--- a/docs/superpowers/specs/2026-08-18-browser-skill-design.md
+++ b/docs/superpowers/specs/2026-08-18-browser-skill-design.md
@@ -81,10 +81,20 @@ over an MCP server.
 - A download is only accepted if its frontmatter names this skill. A raw URL can
   answer with a proxy's login page or someone else's file, and whatever lands in
   the skill root is read by every agent as instructions.
-- Every install stamps the file, after the frontmatter, with where the text came
-  from and when: `<!-- Installed by Codey from its-ahoh/codey-skills@<hash> on
-  <date>. ... -->`. The hash is the raw host's ETag for those bytes, so no second
-  request is needed to name the version.
+- Every published skill declares a `version:` in its frontmatter, and the
+  repository's CI fails a change to a `SKILL.md` that leaves that version alone.
+- Every install stamps the file, after the frontmatter, with that version, the
+  commit it came from, and the date: `<!-- Installed by Codey: browser 1.0.0
+  from its-ahoh/codey-skills@dd6509680769 on 2026-08-19. ... -->`. The version
+  answers "which text is this" on sight; the commit answers it exactly, and
+  opens at `github.com/its-ahoh/codey-skills/commit/<sha>`.
+- The commit costs a second request (`/repos/:repo/commits?path=…&per_page=1`)
+  because the raw host's ETag cannot do the job: it is an opaque per-encoding
+  fingerprint, different for the gzip and identity copies of identical bytes,
+  and equal to no hash anyone can look up. Best-effort — if it fails the stamp
+  names the branch, which is worse than a commit and better than a failed
+  install. Unauthenticated GitHub API calls are limited to 60/hour per IP, far
+  above how often anyone installs a skill.
 - Both run **only for an explicit user action**. Codey never rewrites the
   directory behind the user's back, which is what makes the Skills tab's own
   on/off and delete hold.

--- a/docs/superpowers/specs/2026-08-18-browser-skill-design.md
+++ b/docs/superpowers/specs/2026-08-18-browser-skill-design.md
@@ -67,10 +67,20 @@ over an MCP server.
 - `packages/core/src/skills/browser/SKILL.md` holds the text — plain markdown,
   copied into `dist/skills` at build time so `__dirname/../skills` resolves
   identically from source and from a packaged app.
-- `installBrowserSkill()` copies it into `~/.codey/skills/browser/`, the user's
-  own global skill root, which the existing `syncCodeyGlobalSkills()` already
-  links into `.claude/skills` and `.agents/skills`.
-  `uninstallBrowserSkill()` deletes the directory.
+- `installBrowserSkill()` downloads the published copy from
+  `github.com/its-ahoh/codey-skills` (`skills/<name>/SKILL.md` on `main`) and
+  writes it into `~/.codey/skills/browser/`, the user's own global skill root,
+  which the existing `syncCodeyGlobalSkills()` already links into
+  `.claude/skills` and `.agents/skills`. `uninstallBrowserSkill()` deletes the
+  directory.
+- The build still carries a copy, and it is the fallback when the repository
+  cannot be reached, so Install works offline and on a locked-down network. The
+  result says which copy landed, and the card says so too when it was the
+  fallback — an install that quietly gives you older text is the failure this
+  avoids.
+- A download is only accepted if its frontmatter names this skill. A raw URL can
+  answer with a proxy's login page or someone else's file, and whatever lands in
+  the skill root is read by every agent as instructions.
 - Both run **only for an explicit user action**. Codey never rewrites the
   directory behind the user's back, which is what makes the Skills tab's own
   on/off and delete hold.
@@ -100,8 +110,12 @@ source of the copy stops being the app bundle.
 ### State, read from disk
 
 `browserSkillStatus()` reports `absent` (not installed), `disabled` (installed,
-switched off in Skills) or `installed`, plus `updateAvailable` when the copy on
-disk differs from the one this build ships. There is no enabled flag in config:
+switched off in Skills) or `installed`, along with the directory the copy lives
+in, the repository it comes from, and `differsFromBundled`. That last one is
+stated, not acted on: the published copy is *expected* to move ahead of the
+app's, and the user may have edited theirs, which is their right. Update is
+always available while installed — it re-pulls — rather than appearing only when
+Codey thinks it knows better. There is no enabled flag in config:
 the Plugins tab, the Skills tab and a hand-run `rm` all write the same
 directory, and a second source of truth could only ever contradict it.
 
@@ -155,16 +169,24 @@ the filter would silently swallow a user's server of the same name.
   it fire.
 - **An agent with shell disabled** loses the browser. Nothing in Codey does
   that today.
+- **The published text and the app's CLI version independently.** The skill
+  documents a CLI that ships inside the app, so a repository ahead of an old
+  app can describe commands that app does not have. Accepted deliberately: the
+  gain is that wording can be fixed without an app release, and the skill tells
+  the agent to run `help` rather than trust remembered flags. Holding a skill
+  back means pinning `CODEY_SKILLS_REPO_REF` to a tag.
 - **Upgrades no longer update the text by themselves.** The copy is the user's,
-  so Codey must not overwrite it; instead the Plugins card compares it with the
-  bundled one and offers Update when they differ. The failure this guards
-  against is a stale copy documenting commands the shipped CLI no longer has.
+  so Codey must not overwrite it; Update is an explicit button.
 
 ## Verification
 
-- pi, unmodified, discovered the installed skill, ran the CLI, and reported a
-  page back through the bridge — the browser reached an agent that cannot use
-  MCP at all.
+- Installing pulled the live repository copy — byte-identical to the
+  repository's `main` — and pi, unmodified, discovered it, ran the CLI, and
+  reported a page back through the bridge: the browser reached an agent that
+  cannot use MCP at all.
+- The fallback path: an unreachable host, an HTTP error, a 200 that is not
+  markdown, and a well-formed skill under another name all install the bundled
+  copy instead, and say why.
 - The four state transitions, driven through the same functions the IPC calls:
   install → `installed`; disable in Skills → `disabled` and the capability gate
   reads inactive; install again → active with no `SKILL.md.disabled` left
@@ -181,11 +203,14 @@ drove the IPC handlers' functions rather than the rendered UI.
 
 ## Follow-ups
 
-- The installed copy comes from the app bundle, not a remote repo. Serving it
-  from a registry would let it update out of band, which is exactly the problem:
-  the skill documents an in-app CLI, so an independently-versioned copy can
-  describe commands the installed app does not have. Worth revisiting once
-  there are plugins that do not wrap an in-app binary.
+- Skills are published in one repository, not one per skill: nothing about a
+  skill needs its own version axis, while a shared repository can enforce one
+  shape (`scripts/check-skills.mjs` in CI) and distribute by name anyway. Split
+  a skill out only when it grows its own build, its own maintainer, or a release
+  cadence tied to something else.
+- Nothing verifies the download's provenance beyond "the frontmatter names this
+  skill". A signature, or pinning to a commit, is the next step if the skill
+  ever carries anything more dangerous than instructions.
 - The one-time startup migration (install for a user who had the old config
   flag on, and delete the `~/.codey/managed-skills` root a development build
   left behind) can be dropped a release or two after it ships.

--- a/docs/superpowers/specs/2026-08-18-browser-skill-design.md
+++ b/docs/superpowers/specs/2026-08-18-browser-skill-design.md
@@ -81,6 +81,10 @@ over an MCP server.
 - A download is only accepted if its frontmatter names this skill. A raw URL can
   answer with a proxy's login page or someone else's file, and whatever lands in
   the skill root is read by every agent as instructions.
+- Every install stamps the file, after the frontmatter, with where the text came
+  from and when: `<!-- Installed by Codey from its-ahoh/codey-skills@<hash> on
+  <date>. ... -->`. The hash is the raw host's ETag for those bytes, so no second
+  request is needed to name the version.
 - Both run **only for an explicit user action**. Codey never rewrites the
   directory behind the user's back, which is what makes the Skills tab's own
   on/off and delete hold.
@@ -111,17 +115,29 @@ source of the copy stops being the app bundle.
 
 `browserSkillStatus()` reports `absent` (not installed), `disabled` (installed,
 switched off in Skills) or `installed`, along with the directory the copy lives
-in, the repository it comes from, and `differsFromBundled`. That last one is
-stated, not acted on: the published copy is *expected* to move ahead of the
-app's, and the user may have edited theirs, which is their right. Update is
-always available while installed — it re-pulls — rather than appearing only when
-Codey thinks it knows better. There is no enabled flag in config:
+in, the repository it comes from, and `origin`. Update is always available while
+installed — it re-pulls — rather than appearing only when Codey thinks the copy
+is stale: the published text is *expected* to move ahead of the app's bundled
+one, so a staleness heuristic based on that comparison only cries wolf. There is
+no enabled flag in config:
 the Plugins tab, the Skills tab and a hand-run `rm` all write the same
 directory, and a second source of truth could only ever contradict it.
 
 `gateway.json`'s `plugins.browser.enabled` survives as a legacy marker, read
 once at startup: a user who had the plugin on before this change gets the skill
 installed for them rather than losing the capability silently.
+
+### Codey writes only what Codey wrote
+
+`origin` comes from the stamp: `codey` for a file an install left, `user` for
+anything else — a hand-written skill of the same name, or one predating the
+stamp. Install and uninstall refuse to touch a `user` copy and return
+`conflict: 'user-copy'`; the card then names the path, says what would happen,
+and offers **Replace it** / **Delete it** against **Keep mine**. The `force`
+flag exists for exactly that confirmation.
+
+The guard reads `SKILL.md.disabled` too. Turning a hand-written skill off in the
+Skills tab must not be what makes it overwritable.
 
 ### Capability: the environment
 
@@ -169,6 +185,10 @@ the filter would silently swallow a user's server of the same name.
   it fire.
 - **An agent with shell disabled** loses the browser. Nothing in Codey does
   that today.
+- **Publishing is not instant.** `raw.githubusercontent.com` sets
+  `max-age=300` and caches per content-encoding, so a push takes up to ~5
+  minutes to reach installs — and the gzip and identity variants can expire at
+  different moments. Observed while verifying this change.
 - **The published text and the app's CLI version independently.** The skill
   documents a CLI that ships inside the app, so a repository ahead of an old
   app can describe commands that app does not have. Accepted deliberately: the
@@ -209,8 +229,19 @@ drove the IPC handlers' functions rather than the rendered UI.
   a skill out only when it grows its own build, its own maintainer, or a release
   cadence tied to something else.
 - Nothing verifies the download's provenance beyond "the frontmatter names this
-  skill". A signature, or pinning to a commit, is the next step if the skill
-  ever carries anything more dangerous than instructions.
+  skill". Whoever can push to the repository can change the instructions every
+  agent reads; the repository allows no direct pushes but the owner's, and the
+  default branch cannot be force-pushed or deleted. Pinning
+  `CODEY_SKILLS_REPO_REF` to a tag, or signing, is the next step if a skill ever
+  carries more than instructions — at the cost of the reason for pulling at all.
+- Three clocks now exist: the repository, the app (its CLI and bundled copy),
+  and the user's installed copy, which is frozen until they press Update while
+  the app updates itself. The dangerous drift is not the command list — an
+  unknown command returns the CLI's full usage and the agent recovers — but the
+  structural conventions: the invocation prefix, the `CODEY_BROWSER_*` names,
+  the approval semantics, and `wait-login`'s "end your turn, Codey resumes the
+  chat" contract, where a stale skill makes an agent poll instead of stopping.
+  Those change with the CLI, in a release, not by publishing text.
 - The one-time startup migration (install for a user who had the old config
   flag on, and delete the `~/.codey/managed-skills` root a development build
   left behind) can be dropped a release or two after it ships.

--- a/docs/superpowers/specs/2026-08-18-browser-skill-design.md
+++ b/docs/superpowers/specs/2026-08-18-browser-skill-design.md
@@ -62,27 +62,60 @@ over an MCP server.
 
 ## Design
 
-### Discovery: the managed skill
+### Discovery: an installed skill
 
 - `packages/core/src/skills/browser/SKILL.md` holds the text — plain markdown,
   copied into `dist/skills` at build time so `__dirname/../skills` resolves
   identically from source and from a packaged app.
-- `installBrowserSkill()` writes it to `~/.codey/managed-skills/browser/`;
-  `removeBrowserSkill()` deletes that directory. `AgentFactory.run()` calls one
-  or the other on every run, so an upgrade always ships current instructions and
-  turning the plugin off takes the skill out of every agent's list.
-- The managed root is **not** `~/.codey/skills`. That directory is the user's;
-  a plugin that rewrites and deletes its own skill on every run must never
-  operate inside it.
-- `syncCodeyManagedSkills()` links the managed root into `.claude/skills` and
-  `.agents/skills`, reusing the existing link logic.
+- `installBrowserSkill()` copies it into `~/.codey/skills/browser/`, the user's
+  own global skill root, which the existing `syncCodeyGlobalSkills()` already
+  links into `.claude/skills` and `.agents/skills`.
+  `uninstallBrowserSkill()` deletes the directory.
+- Both run **only for an explicit user action**. Codey never rewrites the
+  directory behind the user's back, which is what makes the Skills tab's own
+  on/off and delete hold.
+
+### Why install, not a toggle
+
+A first pass had Codey own the skill: a `~/.codey/managed-skills` root, rewritten
+and removed on every agent run to follow a plugin switch. It worked, and the UX
+was incoherent. The skill was linked into the same directories the Skills tab
+scans, so it appeared there as an ordinary skill — with a delete button that
+`syncCodeyGlobalSkills()` undid on the next run, and an on/off toggle that
+renamed `SKILL.md` to `SKILL.md.disabled` only for the next install to write
+`SKILL.md` back beside it. Two controls for one capability, and the more
+obvious one silently lost.
+
+The cause was the middle state: a thing that lives in the user's skill
+directories but is not the user's. Removing that state removes the conflict.
+The Plugins tab now installs and uninstalls; between those two moments the
+skill is an ordinary user-owned skill, and the Skills tab is the only place
+that acts on it. Both tabs read the same directory, so they cannot disagree.
+
+This is also the interaction model users already have from `npx skills add`,
+package managers and editor extensions, and it is the prerequisite for ever
+serving plugins from a registry: the state machine does not change when the
+source of the copy stops being the app bundle.
+
+### State, read from disk
+
+`browserSkillStatus()` reports `absent` (not installed), `disabled` (installed,
+switched off in Skills) or `installed`, plus `updateAvailable` when the copy on
+disk differs from the one this build ships. There is no enabled flag in config:
+the Plugins tab, the Skills tab and a hand-run `rm` all write the same
+directory, and a second source of truth could only ever contradict it.
+
+`gateway.json`'s `plugins.browser.enabled` survives as a legacy marker, read
+once at startup: a user who had the plugin on before this change gets the skill
+installed for them rather than losing the capability silently.
 
 ### Capability: the environment
 
 `addCodeyBrowserTools()` (the name the pre-MCP function had, restored) puts
 `CODEY_BROWSER_{SOCKET,TOKEN,CLI,RUNTIME,CHAT_ID}` into `request.extraEnv`
-under the unchanged gating chain: plugin enabled, bridge present,
-`browserTools === true`, a working directory, and no `allowedTools`. All four
+under the unchanged gating chain: the skill installed and enabled, bridge
+present, `browserTools === true`, a working directory, and no `allowedTools`.
+All four
 adapters already merge `extraEnv` into the spawned process, pi included, so no
 adapter changed.
 
@@ -95,12 +128,10 @@ set that could reach it before; only the failure mode moved, from "the agent
 cannot see the tool" to "the agent sees it and is told the bridge is
 unavailable".
 
-### The toggle
-
-Unchanged: the same `browser` entry in `codey-mac/electron/plugins.ts`, the
-same `PluginsTab` switch, the same `gateway.json` persistence and default. Only
-its description text changed, since it no longer describes MCP tools. Existing
-enabled/disabled state carries over.
+Disabling the skill in the Skills tab also stops the env, because the gate asks
+for `installed` specifically. An agent holding bridge credentials for a skill it
+cannot read would be harmless — it does not know the command exists — but it is
+a state no user action asked for.
 
 ### `mcpServers` after this
 
@@ -124,27 +155,40 @@ the filter would silently swallow a user's server of the same name.
   it fire.
 - **An agent with shell disabled** loses the browser. Nothing in Codey does
   that today.
+- **Upgrades no longer update the text by themselves.** The copy is the user's,
+  so Codey must not overwrite it; instead the Plugins card compares it with the
+  bundled one and offers Update when they differ. The failure this guards
+  against is a stale copy documenting commands the shipped CLI no longer has.
 
 ## Verification
 
-- pi, unmodified, discovered the skill, ran the CLI, and reported a page back
-  through the bridge — the browser reached an agent that cannot use MCP at all.
-- Turning the plugin off removed the managed skill and both discovery links.
+- pi, unmodified, discovered the installed skill, ran the CLI, and reported a
+  page back through the bridge — the browser reached an agent that cannot use
+  MCP at all.
+- The four state transitions, driven through the same functions the IPC calls:
+  install → `installed`; disable in Skills → `disabled` and the capability gate
+  reads inactive; install again → active with no `SKILL.md.disabled` left
+  behind; uninstall → `absent`, and the next sync drops both discovery links.
 - The markdown survives packaging: present in the built app's asar under
   `node_modules/@codey/core/dist/skills`, and installing from the compiled
   `dist` writes and links identical bytes.
-- Full suite green (core 535 / gateway 328 / mac 544); build and lint pass.
+- Full suite green (core 538 / gateway 328 / mac 571); build and lint pass.
 
-Not covered: a run against the real in-app bridge with the plugin enabled. The
-verification above used a stand-in bridge, because the real token never leaves
-the app process's memory.
+Not covered: a run against the real in-app bridge with the plugin installed,
+and the Plugins tab's own buttons. The verification above used a stand-in
+bridge, because the real token never leaves the app process's memory, and
+drove the IPC handlers' functions rather than the rendered UI.
 
 ## Follow-ups
 
-- A third-party or user-authored managed skill would want its own repo and a
-  registry; deliberately not built for a single skill that documents our own
-  in-app CLI, where independent versioning would only introduce skew between
-  the documentation and the binary it describes.
+- The installed copy comes from the app bundle, not a remote repo. Serving it
+  from a registry would let it update out of band, which is exactly the problem:
+  the skill documents an in-app CLI, so an independently-versioned copy can
+  describe commands the installed app does not have. Worth revisiting once
+  there are plugins that do not wrap an in-app binary.
+- The one-time startup migration (install for a user who had the old config
+  flag on, and delete the `~/.codey/managed-skills` root a development build
+  left behind) can be dropped a release or two after it ships.
 - Whether Grok Code (not yet an adapter) honours `.agents/skills` is unverified.
   If it does not, that adapter can fall back to prompt injection without
   affecting this architecture.

--- a/packages/core/src/agents/browser-skill.test.ts
+++ b/packages/core/src/agents/browser-skill.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  BROWSER_SKILL_NAME,
   browserSkillMarkdown,
   browserSkillStatus,
   checkBrowserSkillUpdate,
@@ -243,6 +244,16 @@ describe('pulling the skill from the repository', () => {
     await install();
     expect(marker()).toMatch(/Installed by Codey: browser from its-ahoh\/codey-skills on 2026-08-19/);
   });
+
+  // The bundled copy is however old the app is. Recording that in the stamp is
+  // what lets the update check tell a known-current copy from an unknown one;
+  // without it an offline install looks up to date forever.
+  it('records a bundled install as bundled, its version being unknowable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('getaddrinfo ENOTFOUND') }));
+    await install();
+    expect(marker()).toContain(`${BROWSER_SKILL_NAME} bundled `);
+    expect(browserSkillStatus(home).hash).toBe('bundled');
+  });
 });
 
 describe('a skill of the same name that Codey did not write', () => {
@@ -305,6 +316,18 @@ describe('checking whether the published skill moved', () => {
     fs.writeFileSync(skillFile(), '---\nname: browser\ndescription: mine\n---\nMy own notes.\n', 'utf8');
     await expect(checkBrowserSkillUpdate(home)).resolves.toEqual({
       recorded: undefined, current: SHA, needsUpdate: false,
+    });
+  });
+
+  // An offline install left the app's own copy on disk. It is not the published
+  // text and cannot be compared to it, so the honest answer is "update", not
+  // the silent "you are current" that a missing hash used to produce.
+  it('offers an update for a bundled copy once the repository answers', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('getaddrinfo ENOTFOUND') }));
+    await install();
+    vi.stubGlobal('fetch', serve(PUBLISHED));
+    await expect(checkBrowserSkillUpdate(home)).resolves.toEqual({
+      recorded: 'bundled', current: SHA, needsUpdate: true,
     });
   });
 

--- a/packages/core/src/agents/browser-skill.test.ts
+++ b/packages/core/src/agents/browser-skill.test.ts
@@ -5,12 +5,13 @@ import * as path from 'path';
 import {
   browserSkillMarkdown,
   browserSkillStatus,
+  checkBrowserSkillUpdate,
   CODEY_INSTALL_MARKER,
   codeySkillDownloadUrl,
+  codeySkillTreeUrl,
   installBrowserSkill,
   isBrowserSkillActive,
   isCodeyInstalledSkill,
-  skillVersion,
   uninstallBrowserSkill,
 } from './browser-skill';
 import { syncCodeyGlobalSkills } from './codey-skills';
@@ -24,19 +25,23 @@ const skillFile = () => path.join(skillDir(), 'SKILL.md');
  *  skill, so "which copy landed" is visible in the file itself. */
 const PUBLISHED = `---
 name: browser
-version: 9.9.9
-description: ${'Published copy, long enough to pass the description check on its own.'}
+description: Published copy, long enough to pass the description check on its own.
 ---
 
 ${'Published body.\n'.repeat(40)}`;
 
 const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
 
-/** Install makes two calls: the raw file, then the commit that last touched it. */
+/** Install makes two calls: the raw file, then the skill folder's tree hash.
+ *  `sha: null` serves a broken tree so the stamp has to fall back. */
 const serve = (body: string, status = 200, sha: string | null = SHA) =>
   vi.fn(async (url: string) => (
     url.startsWith('https://api.github.com/')
-      ? new Response(sha === null ? 'nope' : JSON.stringify([{ sha }]), { status: sha === null ? 500 : 200 })
+      ? new Response(
+          sha === null ? 'nope' : JSON.stringify({ tree: [{ path: 'skills/browser', type: 'tree', sha }] }),
+          { status: sha === null ? 500 : 200 },
+        )
       : new Response(body, { status })
   ));
 
@@ -45,6 +50,7 @@ const written = () => fs.readFileSync(skillFile(), 'utf8');
 const unstamped = () => written()
   .split('\n').filter(line => !line.startsWith(CODEY_INSTALL_MARKER)).join('\n')
   .replace(/\n{3,}/g, '\n\n');
+const marker = () => written().split('\n').find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
 const install = async (opts = {}) => {
   const result = await installBrowserSkill(home, { today: '2026-08-19', ...opts });
   if (!result.installed) throw new Error(`install refused: ${result.conflict}`);
@@ -70,22 +76,22 @@ describe('installing the browser skill', () => {
   });
 
   // Which bytes the user actually has is the first question when an agent runs
-  // a command the installed CLI does not have.
-  it('stamps the file with where the text came from, after the frontmatter', async () => {
+  // a command the installed CLI does not have. The folder tree hash answers it
+  // exactly, and it is what an update compares against.
+  it('stamps the file with the skill folder\'s tree hash, after the frontmatter', async () => {
     await install();
     const lines = written().split('\n');
     expect(lines[0]).toBe('---');
-    const marker = lines.find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
-    expect(marker).toContain('browser 9.9.9');
-    expect(marker).toContain(`its-ahoh/codey-skills@${SHA.slice(0, 12)}`);
-    expect(marker).toContain('on 2026-08-19');
-    expect(lines.indexOf(marker)).toBeGreaterThan(lines.indexOf('---', 1));
+    expect(marker()).toContain(`browser ${SHA}`);
+    expect(marker()).toContain('its-ahoh/codey-skills');
+    expect(marker()).toContain('on 2026-08-19');
+    expect(lines.indexOf(marker())).toBeGreaterThan(lines.indexOf('---', 1));
     expect(isCodeyInstalledSkill(written())).toBe(true);
   });
 
-  it('names itself "browser" in frontmatter, with a version, so agents can address it', () => {
+  it('ships a skill with the standard frontmatter — a name and a description, no version', () => {
     expect(browserSkillMarkdown()).toMatch(/^---\nname: browser\n/);
-    expect(skillVersion(browserSkillMarkdown())).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(browserSkillMarkdown()).not.toContain('version:');
   });
 
   it('ships the command prefix, without which the body teaches nothing', () => {
@@ -150,10 +156,10 @@ describe('the state the capability gate reads', () => {
     expect(isBrowserSkillActive(home)).toBe(false);
   });
 
-  it('is installed, and Codey\'s, after one', async () => {
+  it('is installed, and Codey\'s, after one, with the hash it was stamped with', async () => {
     await install();
     expect(browserSkillStatus(home)).toMatchObject({
-      state: 'installed', dir: skillDir(), origin: 'codey', version: '9.9.9',
+      state: 'installed', dir: skillDir(), origin: 'codey', hash: SHA,
     });
     expect(isBrowserSkillActive(home)).toBe(true);
   });
@@ -217,21 +223,25 @@ describe('pulling the skill from the repository', () => {
     );
   });
 
-  // A stamp that cannot name the commit still names the version, which is the
-  // part a human reads.
-  it('falls back to the branch name when the commit cannot be read', async () => {
-    vi.stubGlobal('fetch', serve(PUBLISHED, 200, null));
-    await install();
-    const marker = written().split('\n').find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
-    expect(marker).toContain('browser 9.9.9');
-    expect(marker).toContain('its-ahoh/codey-skills@main');
+  it('reads the version from the skill folder\'s tree on main', () => {
+    expect(codeySkillTreeUrl('browser')).toBe(
+      'https://api.github.com/repos/its-ahoh/codey-skills/git/trees/main?recursive=1',
+    );
   });
 
-  it('ignores a commit response that is not a commit', async () => {
+  // A stamp that cannot name the hash still names the skill and the date, which
+  // is the part a human reads; Update still re-pulls whatever is published.
+  it('stamps without a hash when the tree cannot be read', async () => {
+    vi.stubGlobal('fetch', serve(PUBLISHED, 200, null));
+    await install();
+    expect(marker()).toMatch(/Installed by Codey: browser from its-ahoh\/codey-skills on 2026-08-19/);
+    expect(marker()).not.toContain(`browser ${SHA}`);
+  });
+
+  it('ignores a tree response that is not a tree', async () => {
     vi.stubGlobal('fetch', serve(PUBLISHED, 200, 'not-a-sha'));
     await install();
-    const marker = written().split('\n').find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
-    expect(marker).toContain('its-ahoh/codey-skills@main');
+    expect(marker()).toMatch(/Installed by Codey: browser from its-ahoh\/codey-skills on 2026-08-19/);
   });
 });
 
@@ -269,5 +279,38 @@ describe('a skill of the same name that Codey did not write', () => {
   it('is protected while switched off as well', async () => {
     fs.renameSync(skillFile(), path.join(skillDir(), 'SKILL.md.disabled'));
     expect((await installBrowserSkill(home, { today: '2026-08-19' })).installed).toBe(false);
+  });
+});
+
+describe('checking whether the published skill moved', () => {
+  it('reports no update while the installed hash matches the tree', async () => {
+    await install();
+    await expect(checkBrowserSkillUpdate(home)).resolves.toEqual({
+      recorded: SHA, current: SHA, needsUpdate: false,
+    });
+  });
+
+  it('reports an update when the folder hash moved on main', async () => {
+    await install();
+    vi.stubGlobal('fetch', serve(PUBLISHED, 200, OTHER_SHA));
+    await expect(checkBrowserSkillUpdate(home)).resolves.toEqual({
+      recorded: SHA, current: OTHER_SHA, needsUpdate: true,
+    });
+  });
+
+  // A copy without a stamp is the user's; nothing Codey does compares or
+  // replaces it.
+  it('treats an unstamped copy as nothing to update', async () => {
+    fs.mkdirSync(skillDir(), { recursive: true });
+    fs.writeFileSync(skillFile(), '---\nname: browser\ndescription: mine\n---\nMy own notes.\n', 'utf8');
+    await expect(checkBrowserSkillUpdate(home)).resolves.toEqual({
+      recorded: undefined, current: SHA, needsUpdate: false,
+    });
+  });
+
+  it('throws when the tree cannot be reached, so the caller can stay quiet', async () => {
+    await install();
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('getaddrinfo ENOTFOUND') }));
+    await expect(checkBrowserSkillUpdate(home)).rejects.toThrow('ENOTFOUND');
   });
 });

--- a/packages/core/src/agents/browser-skill.test.ts
+++ b/packages/core/src/agents/browser-skill.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
   browserSkillMarkdown,
   browserSkillStatus,
+  codeySkillDownloadUrl,
   installBrowserSkill,
   isBrowserSkillActive,
   uninstallBrowserSkill,
@@ -16,19 +17,33 @@ let home: string;
 const skillDir = () => path.join(home, '.codey', 'skills', 'browser');
 const skillFile = () => path.join(skillDir(), 'SKILL.md');
 
+/** What the repository serves in these tests: a valid but distinguishable
+ *  skill, so "which copy landed" is visible in the file itself. */
+const PUBLISHED = `---
+name: browser
+description: ${'Published copy, long enough to pass the description check on its own.'}
+---
+
+${'Published body.\n'.repeat(40)}`;
+
+const serve = (body: string, status = 200) => vi.fn(async () => new Response(body, { status }));
+
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-browser-skill-'));
+  vi.stubGlobal('fetch', serve(PUBLISHED));
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   fs.rmSync(home, { recursive: true, force: true });
 });
 
 describe('installing the browser skill', () => {
-  it('writes SKILL.md into the user\'s own skill root', async () => {
-    const file = await installBrowserSkill(home);
-    expect(file).toBe(skillFile());
-    expect(fs.readFileSync(file, 'utf8')).toBe(browserSkillMarkdown());
+  it('writes the published skill into the user\'s own skill root', async () => {
+    const result = await installBrowserSkill(home);
+    expect(result).toEqual({ file: skillFile(), source: 'repository', reason: undefined });
+    expect(fs.readFileSync(result.file, 'utf8')).toBe(PUBLISHED);
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(codeySkillDownloadUrl('browser'));
   });
 
   it('names itself "browser" in frontmatter so agents can address it', () => {
@@ -44,17 +59,15 @@ describe('installing the browser skill', () => {
     await syncCodeyGlobalSkills(home);
     for (const dir of ['.claude', '.agents']) {
       const link = path.join(home, dir, 'skills', 'browser');
-      expect(fs.readFileSync(path.join(link, 'SKILL.md'), 'utf8')).toBe(browserSkillMarkdown());
+      expect(fs.readFileSync(path.join(link, 'SKILL.md'), 'utf8')).toBe(PUBLISHED);
     }
   });
 
   it('refreshes a stale copy, which is what pressing Update asks for', async () => {
     await installBrowserSkill(home);
     fs.writeFileSync(skillFile(), '---\nname: browser\ndescription: stale\n---\n', 'utf8');
-    expect(browserSkillStatus(home).updateAvailable).toBe(true);
     await installBrowserSkill(home);
-    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
-    expect(browserSkillStatus(home).updateAvailable).toBe(false);
+    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(PUBLISHED);
   });
 
   it('installing an off skill turns it back on, leaving no disabled leftover', async () => {
@@ -93,15 +106,24 @@ describe('uninstalling the browser skill', () => {
 });
 
 describe('the state the capability gate reads', () => {
-  it('is absent before an install', () => {
-    expect(browserSkillStatus(home)).toEqual({ state: 'absent', updateAvailable: false });
+  it('is absent before an install, and still names where it would go', () => {
+    expect(browserSkillStatus(home)).toMatchObject({ state: 'absent', dir: skillDir(), differsFromBundled: false });
     expect(isBrowserSkillActive(home)).toBe(false);
   });
 
   it('is installed after one', async () => {
     await installBrowserSkill(home);
-    expect(browserSkillStatus(home)).toEqual({ state: 'installed', updateAvailable: false });
+    expect(browserSkillStatus(home)).toMatchObject({ state: 'installed', dir: skillDir() });
     expect(isBrowserSkillActive(home)).toBe(true);
+  });
+
+  // The published copy is expected to move ahead of the one in the app; saying
+  // so is useful, correcting it is not — the file is the user's.
+  it('reports a copy that is not the bundled one, without acting on it', async () => {
+    await installBrowserSkill(home);
+    expect(browserSkillStatus(home).differsFromBundled).toBe(true);
+    fs.writeFileSync(skillFile(), browserSkillMarkdown(), 'utf8');
+    expect(browserSkillStatus(home).differsFromBundled).toBe(false);
   });
 
   // Turning the skill off in the Skills tab renames SKILL.md; the browser env
@@ -118,5 +140,43 @@ describe('the state the capability gate reads', () => {
     await installBrowserSkill(home);
     fs.rmSync(skillDir(), { recursive: true, force: true });
     expect(isBrowserSkillActive(home)).toBe(false);
+  });
+});
+
+describe('pulling the skill from the repository', () => {
+  it('falls back to the bundled copy when the repository cannot be reached', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('getaddrinfo ENOTFOUND') }));
+    const result = await installBrowserSkill(home);
+    expect(result.source).toBe('bundled');
+    expect(result.reason).toContain('ENOTFOUND');
+    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
+  });
+
+  it('falls back on an HTTP error rather than writing the error page', async () => {
+    vi.stubGlobal('fetch', serve('<html>404</html>', 404));
+    const result = await installBrowserSkill(home);
+    expect(result.source).toBe('bundled');
+    expect(result.reason).toContain('404');
+    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
+  });
+
+  // A raw URL can answer with a proxy login page or someone else's file, and
+  // whatever lands here is read by every agent as instructions.
+  it('refuses a 200 that is not this skill', async () => {
+    vi.stubGlobal('fetch', serve('<html>Sign in to continue</html>'));
+    const result = await installBrowserSkill(home);
+    expect(result.source).toBe('bundled');
+    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
+  });
+
+  it('refuses a well-formed skill under another name', async () => {
+    vi.stubGlobal('fetch', serve(PUBLISHED.replace('name: browser', 'name: something-else')));
+    expect((await installBrowserSkill(home)).source).toBe('bundled');
+  });
+
+  it('downloads from the published repository path', () => {
+    expect(codeySkillDownloadUrl('browser')).toBe(
+      'https://raw.githubusercontent.com/its-ahoh/codey-skills/main/skills/browser/SKILL.md',
+    );
   });
 });

--- a/packages/core/src/agents/browser-skill.test.ts
+++ b/packages/core/src/agents/browser-skill.test.ts
@@ -2,12 +2,19 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { browserSkillMarkdown, installBrowserSkill, removeBrowserSkill } from './browser-skill';
-import { syncCodeyManagedSkills } from './codey-skills';
+import {
+  browserSkillMarkdown,
+  browserSkillStatus,
+  installBrowserSkill,
+  isBrowserSkillActive,
+  uninstallBrowserSkill,
+} from './browser-skill';
+import { syncCodeyGlobalSkills } from './codey-skills';
 
 let home: string;
 
-const skillFile = () => path.join(home, '.codey', 'managed-skills', 'browser', 'SKILL.md');
+const skillDir = () => path.join(home, '.codey', 'skills', 'browser');
+const skillFile = () => path.join(skillDir(), 'SKILL.md');
 
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-browser-skill-'));
@@ -17,8 +24,8 @@ afterEach(() => {
   fs.rmSync(home, { recursive: true, force: true });
 });
 
-describe('the managed browser skill', () => {
-  it('writes SKILL.md under the managed root', async () => {
+describe('installing the browser skill', () => {
+  it('writes SKILL.md into the user\'s own skill root', async () => {
     const file = await installBrowserSkill(home);
     expect(file).toBe(skillFile());
     expect(fs.readFileSync(file, 'utf8')).toBe(browserSkillMarkdown());
@@ -32,56 +39,84 @@ describe('the managed browser skill', () => {
     expect(browserSkillMarkdown()).toContain('$CODEY_BROWSER_CLI');
   });
 
-  it('overwrites an outdated copy, so an upgrade ships current instructions', async () => {
-    await installBrowserSkill(home);
-    fs.writeFileSync(skillFile(), '---\nname: browser\ndescription: stale\n---\n', 'utf8');
-    await installBrowserSkill(home);
-    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
-  });
-
-  it('is idempotent', async () => {
-    await installBrowserSkill(home);
-    const first = fs.statSync(skillFile()).mtimeMs;
-    await new Promise(resolve => setTimeout(resolve, 10));
-    await installBrowserSkill(home);
-    expect(fs.statSync(skillFile()).mtimeMs).toBe(first);
-  });
-
-  it('removes the skill when the plugin is turned off', async () => {
-    await installBrowserSkill(home);
-    await removeBrowserSkill(home);
-    expect(fs.existsSync(path.dirname(skillFile()))).toBe(false);
-  });
-
-  it('removing an absent skill is not an error', async () => {
-    await expect(removeBrowserSkill(home)).resolves.toBe(true);
-  });
-
   it('reaches every agent through both discovery directories', async () => {
     await installBrowserSkill(home);
-    await syncCodeyManagedSkills(home);
+    await syncCodeyGlobalSkills(home);
     for (const dir of ['.claude', '.agents']) {
       const link = path.join(home, dir, 'skills', 'browser');
       expect(fs.readFileSync(path.join(link, 'SKILL.md'), 'utf8')).toBe(browserSkillMarkdown());
     }
   });
 
-  it('drops the discovery links once the skill is gone', async () => {
+  it('refreshes a stale copy, which is what pressing Update asks for', async () => {
     await installBrowserSkill(home);
-    await syncCodeyManagedSkills(home);
-    await removeBrowserSkill(home);
-    await syncCodeyManagedSkills(home);
+    fs.writeFileSync(skillFile(), '---\nname: browser\ndescription: stale\n---\n', 'utf8');
+    expect(browserSkillStatus(home).updateAvailable).toBe(true);
+    await installBrowserSkill(home);
+    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
+    expect(browserSkillStatus(home).updateAvailable).toBe(false);
+  });
+
+  it('installing an off skill turns it back on, leaving no disabled leftover', async () => {
+    await installBrowserSkill(home);
+    fs.renameSync(skillFile(), path.join(skillDir(), 'SKILL.md.disabled'));
+    await installBrowserSkill(home);
+    expect(fs.existsSync(skillFile())).toBe(true);
+    expect(fs.existsSync(path.join(skillDir(), 'SKILL.md.disabled'))).toBe(false);
+  });
+});
+
+describe('uninstalling the browser skill', () => {
+  it('removes the skill and, on the next sync, its discovery links', async () => {
+    await installBrowserSkill(home);
+    await syncCodeyGlobalSkills(home);
+    await uninstallBrowserSkill(home);
+    await syncCodeyGlobalSkills(home);
+    expect(fs.existsSync(skillDir())).toBe(false);
     for (const dir of ['.claude', '.agents']) {
       expect(fs.existsSync(path.join(home, dir, 'skills', 'browser'))).toBe(false);
     }
   });
 
-  it('leaves the user-owned skill root alone', async () => {
-    const mine = path.join(home, '.codey', 'skills', 'browser');
+  it('uninstalling an absent skill is not an error', async () => {
+    await expect(uninstallBrowserSkill(home)).resolves.toBe(true);
+  });
+
+  it('leaves the user\'s other skills alone', async () => {
+    const mine = path.join(home, '.codey', 'skills', 'mine');
     fs.mkdirSync(mine, { recursive: true });
     fs.writeFileSync(path.join(mine, 'SKILL.md'), 'mine', 'utf8');
     await installBrowserSkill(home);
-    await removeBrowserSkill(home);
+    await uninstallBrowserSkill(home);
     expect(fs.readFileSync(path.join(mine, 'SKILL.md'), 'utf8')).toBe('mine');
+  });
+});
+
+describe('the state the capability gate reads', () => {
+  it('is absent before an install', () => {
+    expect(browserSkillStatus(home)).toEqual({ state: 'absent', updateAvailable: false });
+    expect(isBrowserSkillActive(home)).toBe(false);
+  });
+
+  it('is installed after one', async () => {
+    await installBrowserSkill(home);
+    expect(browserSkillStatus(home)).toEqual({ state: 'installed', updateAvailable: false });
+    expect(isBrowserSkillActive(home)).toBe(true);
+  });
+
+  // Turning the skill off in the Skills tab renames SKILL.md; the browser env
+  // has to stop with it, or an agent would hold bridge credentials for a skill
+  // it can no longer read.
+  it('is disabled — and inactive — once the Skills tab switches it off', async () => {
+    await installBrowserSkill(home);
+    fs.renameSync(skillFile(), path.join(skillDir(), 'SKILL.md.disabled'));
+    expect(browserSkillStatus(home).state).toBe('disabled');
+    expect(isBrowserSkillActive(home)).toBe(false);
+  });
+
+  it('is absent again after the Skills tab deletes the directory', async () => {
+    await installBrowserSkill(home);
+    fs.rmSync(skillDir(), { recursive: true, force: true });
+    expect(isBrowserSkillActive(home)).toBe(false);
   });
 });

--- a/packages/core/src/agents/browser-skill.test.ts
+++ b/packages/core/src/agents/browser-skill.test.ts
@@ -10,6 +10,7 @@ import {
   installBrowserSkill,
   isBrowserSkillActive,
   isCodeyInstalledSkill,
+  skillVersion,
   uninstallBrowserSkill,
 } from './browser-skill';
 import { syncCodeyGlobalSkills } from './codey-skills';
@@ -23,13 +24,21 @@ const skillFile = () => path.join(skillDir(), 'SKILL.md');
  *  skill, so "which copy landed" is visible in the file itself. */
 const PUBLISHED = `---
 name: browser
+version: 9.9.9
 description: ${'Published copy, long enough to pass the description check on its own.'}
 ---
 
 ${'Published body.\n'.repeat(40)}`;
 
-const serve = (body: string, status = 200, etag = '"0123456789abcdef"') =>
-  vi.fn(async () => new Response(body, { status, headers: status === 200 ? { etag } : {} }));
+const SHA = 'a'.repeat(40);
+
+/** Install makes two calls: the raw file, then the commit that last touched it. */
+const serve = (body: string, status = 200, sha: string | null = SHA) =>
+  vi.fn(async (url: string) => (
+    url.startsWith('https://api.github.com/')
+      ? new Response(sha === null ? 'nope' : JSON.stringify([{ sha }]), { status: sha === null ? 500 : 200 })
+      : new Response(body, { status })
+  ));
 
 /** Every install stamps the file, so assertions compare the text around it. */
 const written = () => fs.readFileSync(skillFile(), 'utf8');
@@ -67,14 +76,16 @@ describe('installing the browser skill', () => {
     const lines = written().split('\n');
     expect(lines[0]).toBe('---');
     const marker = lines.find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
-    expect(marker).toContain('its-ahoh/codey-skills@0123456789ab');
+    expect(marker).toContain('browser 9.9.9');
+    expect(marker).toContain(`its-ahoh/codey-skills@${SHA.slice(0, 12)}`);
     expect(marker).toContain('on 2026-08-19');
     expect(lines.indexOf(marker)).toBeGreaterThan(lines.indexOf('---', 1));
     expect(isCodeyInstalledSkill(written())).toBe(true);
   });
 
-  it('names itself "browser" in frontmatter so agents can address it', () => {
-    expect(browserSkillMarkdown()).toMatch(/^---\nname: browser\ndescription: .+/);
+  it('names itself "browser" in frontmatter, with a version, so agents can address it', () => {
+    expect(browserSkillMarkdown()).toMatch(/^---\nname: browser\n/);
+    expect(skillVersion(browserSkillMarkdown())).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
   it('ships the command prefix, without which the body teaches nothing', () => {
@@ -141,7 +152,9 @@ describe('the state the capability gate reads', () => {
 
   it('is installed, and Codey\'s, after one', async () => {
     await install();
-    expect(browserSkillStatus(home)).toMatchObject({ state: 'installed', dir: skillDir(), origin: 'codey' });
+    expect(browserSkillStatus(home)).toMatchObject({
+      state: 'installed', dir: skillDir(), origin: 'codey', version: '9.9.9',
+    });
     expect(isBrowserSkillActive(home)).toBe(true);
   });
 
@@ -202,6 +215,23 @@ describe('pulling the skill from the repository', () => {
     expect(codeySkillDownloadUrl('browser')).toBe(
       'https://raw.githubusercontent.com/its-ahoh/codey-skills/main/skills/browser/SKILL.md',
     );
+  });
+
+  // A stamp that cannot name the commit still names the version, which is the
+  // part a human reads.
+  it('falls back to the branch name when the commit cannot be read', async () => {
+    vi.stubGlobal('fetch', serve(PUBLISHED, 200, null));
+    await install();
+    const marker = written().split('\n').find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
+    expect(marker).toContain('browser 9.9.9');
+    expect(marker).toContain('its-ahoh/codey-skills@main');
+  });
+
+  it('ignores a commit response that is not a commit', async () => {
+    vi.stubGlobal('fetch', serve(PUBLISHED, 200, 'not-a-sha'));
+    await install();
+    const marker = written().split('\n').find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
+    expect(marker).toContain('its-ahoh/codey-skills@main');
   });
 });
 

--- a/packages/core/src/agents/browser-skill.test.ts
+++ b/packages/core/src/agents/browser-skill.test.ts
@@ -5,9 +5,11 @@ import * as path from 'path';
 import {
   browserSkillMarkdown,
   browserSkillStatus,
+  CODEY_INSTALL_MARKER,
   codeySkillDownloadUrl,
   installBrowserSkill,
   isBrowserSkillActive,
+  isCodeyInstalledSkill,
   uninstallBrowserSkill,
 } from './browser-skill';
 import { syncCodeyGlobalSkills } from './codey-skills';
@@ -26,7 +28,19 @@ description: ${'Published copy, long enough to pass the description check on its
 
 ${'Published body.\n'.repeat(40)}`;
 
-const serve = (body: string, status = 200) => vi.fn(async () => new Response(body, { status }));
+const serve = (body: string, status = 200, etag = '"0123456789abcdef"') =>
+  vi.fn(async () => new Response(body, { status, headers: status === 200 ? { etag } : {} }));
+
+/** Every install stamps the file, so assertions compare the text around it. */
+const written = () => fs.readFileSync(skillFile(), 'utf8');
+const unstamped = () => written()
+  .split('\n').filter(line => !line.startsWith(CODEY_INSTALL_MARKER)).join('\n')
+  .replace(/\n{3,}/g, '\n\n');
+const install = async (opts = {}) => {
+  const result = await installBrowserSkill(home, { today: '2026-08-19', ...opts });
+  if (!result.installed) throw new Error(`install refused: ${result.conflict}`);
+  return result;
+};
 
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-browser-skill-'));
@@ -40,10 +54,23 @@ afterEach(() => {
 
 describe('installing the browser skill', () => {
   it('writes the published skill into the user\'s own skill root', async () => {
-    const result = await installBrowserSkill(home);
-    expect(result).toEqual({ file: skillFile(), source: 'repository', reason: undefined });
-    expect(fs.readFileSync(result.file, 'utf8')).toBe(PUBLISHED);
+    const result = await install();
+    expect(result).toEqual({ installed: true, file: skillFile(), source: 'repository', reason: undefined });
+    expect(unstamped().trim()).toBe(PUBLISHED.trim());
     expect(vi.mocked(fetch).mock.calls[0][0]).toBe(codeySkillDownloadUrl('browser'));
+  });
+
+  // Which bytes the user actually has is the first question when an agent runs
+  // a command the installed CLI does not have.
+  it('stamps the file with where the text came from, after the frontmatter', async () => {
+    await install();
+    const lines = written().split('\n');
+    expect(lines[0]).toBe('---');
+    const marker = lines.find(line => line.startsWith(CODEY_INSTALL_MARKER))!;
+    expect(marker).toContain('its-ahoh/codey-skills@0123456789ab');
+    expect(marker).toContain('on 2026-08-19');
+    expect(lines.indexOf(marker)).toBeGreaterThan(lines.indexOf('---', 1));
+    expect(isCodeyInstalledSkill(written())).toBe(true);
   });
 
   it('names itself "browser" in frontmatter so agents can address it', () => {
@@ -59,19 +86,19 @@ describe('installing the browser skill', () => {
     await syncCodeyGlobalSkills(home);
     for (const dir of ['.claude', '.agents']) {
       const link = path.join(home, dir, 'skills', 'browser');
-      expect(fs.readFileSync(path.join(link, 'SKILL.md'), 'utf8')).toBe(PUBLISHED);
+      expect(fs.readFileSync(path.join(link, 'SKILL.md'), 'utf8')).toBe(written());
     }
   });
 
-  it('refreshes a stale copy, which is what pressing Update asks for', async () => {
-    await installBrowserSkill(home);
-    fs.writeFileSync(skillFile(), '---\nname: browser\ndescription: stale\n---\n', 'utf8');
-    await installBrowserSkill(home);
-    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(PUBLISHED);
+  it('refreshes its own stale copy, which is what pressing Update asks for', async () => {
+    await install();
+    fs.writeFileSync(skillFile(), `---\nname: browser\ndescription: stale\n---\n${CODEY_INSTALL_MARKER} old -->\n`, 'utf8');
+    await install();
+    expect(unstamped().trim()).toBe(PUBLISHED.trim());
   });
 
   it('installing an off skill turns it back on, leaving no disabled leftover', async () => {
-    await installBrowserSkill(home);
+    await install();
     fs.renameSync(skillFile(), path.join(skillDir(), 'SKILL.md.disabled'));
     await installBrowserSkill(home);
     expect(fs.existsSync(skillFile())).toBe(true);
@@ -81,9 +108,9 @@ describe('installing the browser skill', () => {
 
 describe('uninstalling the browser skill', () => {
   it('removes the skill and, on the next sync, its discovery links', async () => {
-    await installBrowserSkill(home);
+    await install();
     await syncCodeyGlobalSkills(home);
-    await uninstallBrowserSkill(home);
+    expect(await uninstallBrowserSkill(home)).toEqual({ removed: true });
     await syncCodeyGlobalSkills(home);
     expect(fs.existsSync(skillDir())).toBe(false);
     for (const dir of ['.claude', '.agents']) {
@@ -92,14 +119,14 @@ describe('uninstalling the browser skill', () => {
   });
 
   it('uninstalling an absent skill is not an error', async () => {
-    await expect(uninstallBrowserSkill(home)).resolves.toBe(true);
+    await expect(uninstallBrowserSkill(home)).resolves.toEqual({ removed: true });
   });
 
   it('leaves the user\'s other skills alone', async () => {
     const mine = path.join(home, '.codey', 'skills', 'mine');
     fs.mkdirSync(mine, { recursive: true });
     fs.writeFileSync(path.join(mine, 'SKILL.md'), 'mine', 'utf8');
-    await installBrowserSkill(home);
+    await install();
     await uninstallBrowserSkill(home);
     expect(fs.readFileSync(path.join(mine, 'SKILL.md'), 'utf8')).toBe('mine');
   });
@@ -107,23 +134,21 @@ describe('uninstalling the browser skill', () => {
 
 describe('the state the capability gate reads', () => {
   it('is absent before an install, and still names where it would go', () => {
-    expect(browserSkillStatus(home)).toMatchObject({ state: 'absent', dir: skillDir(), differsFromBundled: false });
+    expect(browserSkillStatus(home)).toMatchObject({ state: 'absent', dir: skillDir() });
+    expect(browserSkillStatus(home).origin).toBeUndefined();
     expect(isBrowserSkillActive(home)).toBe(false);
   });
 
-  it('is installed after one', async () => {
-    await installBrowserSkill(home);
-    expect(browserSkillStatus(home)).toMatchObject({ state: 'installed', dir: skillDir() });
+  it('is installed, and Codey\'s, after one', async () => {
+    await install();
+    expect(browserSkillStatus(home)).toMatchObject({ state: 'installed', dir: skillDir(), origin: 'codey' });
     expect(isBrowserSkillActive(home)).toBe(true);
   });
 
-  // The published copy is expected to move ahead of the one in the app; saying
-  // so is useful, correcting it is not — the file is the user's.
-  it('reports a copy that is not the bundled one, without acting on it', async () => {
-    await installBrowserSkill(home);
-    expect(browserSkillStatus(home).differsFromBundled).toBe(true);
-    fs.writeFileSync(skillFile(), browserSkillMarkdown(), 'utf8');
-    expect(browserSkillStatus(home).differsFromBundled).toBe(false);
+  it('calls an unstamped copy the user\'s', () => {
+    fs.mkdirSync(skillDir(), { recursive: true });
+    fs.writeFileSync(skillFile(), '---\nname: browser\ndescription: mine\n---\nMy own notes.\n', 'utf8');
+    expect(browserSkillStatus(home).origin).toBe('user');
   });
 
   // Turning the skill off in the Skills tab renames SKILL.md; the browser env
@@ -146,37 +171,73 @@ describe('the state the capability gate reads', () => {
 describe('pulling the skill from the repository', () => {
   it('falls back to the bundled copy when the repository cannot be reached', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('getaddrinfo ENOTFOUND') }));
-    const result = await installBrowserSkill(home);
+    const result = await install();
     expect(result.source).toBe('bundled');
     expect(result.reason).toContain('ENOTFOUND');
-    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
+    expect(unstamped().trim()).toBe(browserSkillMarkdown().trim());
   });
 
   it('falls back on an HTTP error rather than writing the error page', async () => {
     vi.stubGlobal('fetch', serve('<html>404</html>', 404));
-    const result = await installBrowserSkill(home);
+    const result = await install();
     expect(result.source).toBe('bundled');
     expect(result.reason).toContain('404');
-    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
+    expect(unstamped().trim()).toBe(browserSkillMarkdown().trim());
   });
 
   // A raw URL can answer with a proxy login page or someone else's file, and
   // whatever lands here is read by every agent as instructions.
   it('refuses a 200 that is not this skill', async () => {
     vi.stubGlobal('fetch', serve('<html>Sign in to continue</html>'));
-    const result = await installBrowserSkill(home);
-    expect(result.source).toBe('bundled');
-    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(browserSkillMarkdown());
+    expect((await install()).source).toBe('bundled');
+    expect(unstamped().trim()).toBe(browserSkillMarkdown().trim());
   });
 
   it('refuses a well-formed skill under another name', async () => {
     vi.stubGlobal('fetch', serve(PUBLISHED.replace('name: browser', 'name: something-else')));
-    expect((await installBrowserSkill(home)).source).toBe('bundled');
+    expect((await install()).source).toBe('bundled');
   });
 
   it('downloads from the published repository path', () => {
     expect(codeySkillDownloadUrl('browser')).toBe(
       'https://raw.githubusercontent.com/its-ahoh/codey-skills/main/skills/browser/SKILL.md',
     );
+  });
+});
+
+describe('a skill of the same name that Codey did not write', () => {
+  const MINE = '---\nname: browser\ndescription: my own\n---\nMy own notes.\n';
+
+  beforeEach(() => {
+    fs.mkdirSync(skillDir(), { recursive: true });
+    fs.writeFileSync(skillFile(), MINE, 'utf8');
+  });
+
+  it('is not replaced by an install', async () => {
+    const result = await installBrowserSkill(home, { today: '2026-08-19' });
+    expect(result).toEqual({ installed: false, conflict: 'user-copy', dir: skillDir() });
+    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(MINE);
+  });
+
+  it('is not deleted by an uninstall', async () => {
+    expect(await uninstallBrowserSkill(home)).toEqual({ removed: false, conflict: 'user-copy' });
+    expect(fs.readFileSync(skillFile(), 'utf8')).toBe(MINE);
+  });
+
+  it('is replaced once the user confirms', async () => {
+    expect((await installBrowserSkill(home, { force: true, today: '2026-08-19' })).installed).toBe(true);
+    expect(browserSkillStatus(home).origin).toBe('codey');
+  });
+
+  it('is deleted once the user confirms', async () => {
+    expect(await uninstallBrowserSkill(home, { force: true })).toEqual({ removed: true });
+    expect(browserSkillStatus(home).state).toBe('absent');
+  });
+
+  // Disabling in the Skills tab renames the file; the guard has to see it there
+  // too, or turning a hand-written skill off would make it overwritable.
+  it('is protected while switched off as well', async () => {
+    fs.renameSync(skillFile(), path.join(skillDir(), 'SKILL.md.disabled'));
+    expect((await installBrowserSkill(home, { today: '2026-08-19' })).installed).toBe(false);
   });
 });

--- a/packages/core/src/agents/browser-skill.ts
+++ b/packages/core/src/agents/browser-skill.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { CODEY_MANAGED_SKILLS_SUBDIR } from './codey-skills';
+import { CODEY_GLOBAL_SKILLS_SUBDIR } from './codey-skills';
 
 export const BROWSER_SKILL_NAME = 'browser';
 
@@ -12,6 +12,11 @@ export const BROWSER_SKILL_NAME = 'browser';
  * claude-code, codex, opencode and pi alike — including agents with no MCP
  * surface at all. Only the description stays in context; an agent reads the
  * body when a task actually needs the browser.
+ *
+ * Installing puts it in `~/.codey/skills`, the user's own skill root, so it is
+ * an ordinary skill from that moment on: the Skills tab can disable or delete
+ * it and those actions hold, because nothing rewrites it behind the user's
+ * back. Codey installs and uninstalls only when asked.
  *
  * The skill is discovery only. The capability gate is the environment:
  * `addCodeyBrowserTools` passes `CODEY_BROWSER_*` to task-performing turns
@@ -26,6 +31,31 @@ export const BROWSER_SKILL_SOURCE = path.join(
   __dirname, '..', 'skills', BROWSER_SKILL_NAME, 'SKILL.md',
 );
 
+/** Skill files are named by convention; a disabled skill keeps the second
+ *  name so agents stop scanning it. See the Skills tab's on/off toggle. */
+const SKILL_FILE = 'SKILL.md';
+const DISABLED_SKILL_FILE = 'SKILL.md.disabled';
+
+/**
+ * What the user's copy of the skill is doing right now, read from disk rather
+ * than from config: the Plugins tab, the Skills tab and a hand-run `rm` all
+ * change the same thing, so the disk is the only state that cannot disagree
+ * with itself.
+ *
+ * - `absent` — not installed; the plugin is off and no agent sees it.
+ * - `disabled` — installed but switched off in the Skills tab.
+ * - `installed` — active; agents discover it and the capability is on.
+ */
+export type BrowserSkillState = 'absent' | 'disabled' | 'installed';
+
+export interface BrowserSkillStatus {
+  state: BrowserSkillState;
+  /** The installed copy differs from the one this build ships. The CLI it
+   *  documents ships with the app, so a stale copy can describe commands that
+   *  no longer exist. */
+  updateAvailable: boolean;
+}
+
 let cached: string | undefined;
 
 /** The skill's markdown, read once per process — it ships with the build and
@@ -35,38 +65,51 @@ export function browserSkillMarkdown(): string {
   return cached;
 }
 
-function browserSkillDir(home: string): string {
-  return path.join(path.resolve(home), CODEY_MANAGED_SKILLS_SUBDIR, BROWSER_SKILL_NAME);
+/** Where an installed copy lives: the user's own global skill root. */
+export function browserSkillDir(home: string = os.homedir()): string {
+  return path.join(path.resolve(home), CODEY_GLOBAL_SKILLS_SUBDIR, BROWSER_SKILL_NAME);
+}
+
+export function browserSkillStatus(home: string = os.homedir()): BrowserSkillStatus {
+  const dir = browserSkillDir(home);
+  for (const [file, state] of [[SKILL_FILE, 'installed'], [DISABLED_SKILL_FILE, 'disabled']] as const) {
+    let installed: string;
+    try {
+      installed = fs.readFileSync(path.join(dir, file), 'utf8');
+    } catch {
+      continue;
+    }
+    return { state, updateAvailable: installed !== browserSkillMarkdown() };
+  }
+  return { state: 'absent', updateAvailable: false };
+}
+
+/** True when agents can both find the skill and be handed the bridge. */
+export function isBrowserSkillActive(home: string = os.homedir()): boolean {
+  return browserSkillStatus(home).state === 'installed';
 }
 
 /**
- * Write the Browser skill into Codey's managed skill root, overwriting an
- * older copy so a Codey upgrade always ships the current instructions. The
- * managed root is separate from the user's own `~/.codey/skills` so nothing
- * hand-written is ever overwritten or removed.
+ * Install (or update) the user's copy. Only ever called for an explicit user
+ * action, so it overwrites: pressing Install on an installed-but-stale copy is
+ * how the user asks for the current text. A leftover `SKILL.md.disabled` is
+ * removed with it — installing means the user wants the skill on, and leaving
+ * both files behind would break the Skills tab's toggle.
  */
 export async function installBrowserSkill(home: string = os.homedir()): Promise<string> {
   const dir = browserSkillDir(home);
-  const file = path.join(dir, 'SKILL.md');
-  const markdown = browserSkillMarkdown();
-  let current: string | undefined;
-  try {
-    current = await fs.promises.readFile(file, 'utf8');
-  } catch {
-    // Missing or unreadable: write it below.
-  }
-  if (current === markdown) return file;
+  const file = path.join(dir, SKILL_FILE);
   await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.writeFile(file, markdown, 'utf8');
+  await fs.promises.writeFile(file, browserSkillMarkdown(), 'utf8');
+  await fs.promises.rm(path.join(dir, DISABLED_SKILL_FILE), { force: true });
   return file;
 }
 
-/** Remove the managed Browser skill. Turning the plugin off takes the
- *  capability out of every agent's skill list, not just out of its env. */
-export async function removeBrowserSkill(home: string = os.homedir()): Promise<boolean> {
-  const dir = browserSkillDir(home);
+/** Remove the user's copy. Uninstalling takes the capability out of every
+ *  agent's skill list, not just out of its env. */
+export async function uninstallBrowserSkill(home: string = os.homedir()): Promise<boolean> {
   try {
-    await fs.promises.rm(dir, { recursive: true, force: true });
+    await fs.promises.rm(browserSkillDir(home), { recursive: true, force: true });
     return true;
   } catch {
     return false;

--- a/packages/core/src/agents/browser-skill.ts
+++ b/packages/core/src/agents/browser-skill.ts
@@ -18,9 +18,14 @@ export const CODEY_SKILLS_REPO_REF = 'main';
 /** `owner/name`, the form both GitHub URLs and the install stamp use. */
 export const CODEY_SKILLS_REPO = CODEY_SKILLS_REPO_URL.replace('https://github.com/', '');
 
-/** Path of one published skill inside the repository. */
+/** Path of one published skill's directory inside the repository. */
+export function codeySkillDir(name: string): string {
+  return `skills/${name}`;
+}
+
+/** Path of one published skill's markdown inside the repository. */
 export function codeySkillPath(name: string): string {
-  return `skills/${name}/SKILL.md`;
+  return `${codeySkillDir(name)}/SKILL.md`;
 }
 
 /** Raw URL of one published skill's markdown. */
@@ -28,16 +33,11 @@ export function codeySkillDownloadUrl(name: string, ref: string = CODEY_SKILLS_R
   return `https://raw.githubusercontent.com/${CODEY_SKILLS_REPO}/${ref}/${codeySkillPath(name)}`;
 }
 
-/** API URL for the commit that last touched one published skill. */
-export function codeySkillCommitUrl(name: string, ref: string = CODEY_SKILLS_REPO_REF): string {
-  return `https://api.github.com/repos/${CODEY_SKILLS_REPO}/commits`
-    + `?path=${encodeURIComponent(codeySkillPath(name))}&sha=${ref}&per_page=1`;
-}
-
-/** The `version:` a published skill declares, or undefined if it has none. */
-export function skillVersion(markdown: string): string | undefined {
-  const frontmatter = /^---\n([\s\S]*?)\n---\n/.exec(markdown);
-  return frontmatter ? /^version:[ \t]*(\S+)[ \t]*$/m.exec(frontmatter[1])?.[1] : undefined;
+/** API URL for the recursive tree at `ref`, from which the skill folder's own
+ *  tree hash is read. That hash is the skill's version: it changes exactly when
+ *  the folder's files change, never for edits elsewhere in the repository. */
+export function codeySkillTreeUrl(name: string, ref: string = CODEY_SKILLS_REPO_REF): string {
+  return `https://api.github.com/repos/${CODEY_SKILLS_REPO}/git/trees/${ref}?recursive=1`;
 }
 
 /**
@@ -71,11 +71,12 @@ const SKILL_FILE = 'SKILL.md';
 const DISABLED_SKILL_FILE = 'SKILL.md.disabled';
 
 /**
- * An install stamps the file with the skill's version and the commit it came
- * from. Two jobs: it answers "which text does this user actually have" when an
- * agent runs a command the installed CLI does not have — on sight from the
- * version, and exactly from the commit — and it is how Codey recognises its own
- * copy. Anything without the stamp is treated as the user's, and is not
+ * An install stamps the file with the skill folder's tree hash — the same
+ * version the ecosystem uses for a skill: it changes exactly when the skill's
+ * text changes, never for edits elsewhere in the repository. Two jobs: it
+ * answers "which text does this user actually have" when an agent runs a
+ * command the installed CLI does not have, and it is how Codey recognises its
+ * own copy. Anything without the stamp is treated as the user's, and is not
  * overwritten or deleted without confirmation.
  *
  * It sits after the frontmatter (agents parse that from the first byte) and is
@@ -83,9 +84,16 @@ const DISABLED_SKILL_FILE = 'SKILL.md.disabled';
  */
 export const CODEY_INSTALL_MARKER = '<!-- Installed by Codey:';
 
-function stamp(markdown: string, from: string, today: string): string {
-  const version = skillVersion(markdown);
-  const line = `${CODEY_INSTALL_MARKER} ${BROWSER_SKILL_NAME}${version ? ` ${version}` : ''} `
+/** The folder tree hash an install recorded, or undefined when there is none. */
+const INSTALLED_HASH_RE = /<!-- Installed by Codey: browser ([0-9a-f]{40}) /;
+
+/** The hash a stamp recorded, when the file carries one. */
+function installedSkillHash(markdown: string): string | undefined {
+  return INSTALLED_HASH_RE.exec(markdown)?.[1];
+}
+
+function stamp(markdown: string, from: string, hash: string | undefined, today: string): string {
+  const line = `${CODEY_INSTALL_MARKER} ${BROWSER_SKILL_NAME}${hash ? ` ${hash}` : ''} `
     + `from ${from} on ${today}. `
     + 'Manage it in Tools -> Plugins; edits here are replaced by the next update. -->';
   const frontmatter = /^---\n[\s\S]*?\n---\n/.exec(markdown);
@@ -124,8 +132,8 @@ export interface BrowserSkillStatus {
   origin?: 'codey' | 'user';
   /** Where Install pulls from. */
   sourceUrl: string;
-  /** The `version:` the installed copy declares, when it has one. */
-  version?: string;
+  /** The skill folder's tree hash an install recorded, when there is one. */
+  hash?: string;
 }
 
 /** Which copy an install actually wrote. `bundled` means the repository could
@@ -164,7 +172,7 @@ export function browserSkillStatus(home: string = os.homedir()): BrowserSkillSta
       ...base,
       state,
       origin: isCodeyInstalledSkill(installed) ? 'codey' : 'user',
-      version: skillVersion(installed),
+      hash: installedSkillHash(installed),
     };
   }
   return { ...base, state: 'absent' };
@@ -190,27 +198,33 @@ function isPublishedSkill(text: string, name: string): boolean {
 }
 
 /**
- * The commit that last touched this skill, for the stamp. A separate request,
- * because the raw host's ETag is an opaque per-encoding fingerprint: it differs
- * between the gzip and identity copies of identical bytes and matches no hash
- * anyone can look up. Best-effort — a stamp naming the branch is better than a
- * failed install, and the rate limit on unauthenticated calls (60/hour) is far
- * above how often anyone installs a skill.
+ * The skill folder's tree hash on `main` — the skill's version. Read from the
+ * recursive tree, where the `sha` of the `skills/browser` entry changes exactly
+ * when the skill's own files change, never for edits elsewhere in the
+ * repository. Best-effort, like the commit call it replaced: a stamp without a
+ * hash still names the skill and the date, and Update re-pulls whatever is
+ * published. The unauthenticated rate limit (60/hour) is far above how often
+ * anyone installs or checks a skill.
  */
-async function downloadSkillCommit(timeoutMs: number): Promise<string> {
-  const url = codeySkillCommitUrl(BROWSER_SKILL_NAME);
+async function downloadSkillFolderHash(timeoutMs: number): Promise<string> {
+  const url = codeySkillTreeUrl(BROWSER_SKILL_NAME);
   const response = await fetch(url, {
     headers: { accept: 'application/vnd.github+json', 'user-agent': 'codey' },
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) throw new Error(`${url} returned ${response.status}`);
-  const commits = await response.json() as Array<{ sha?: unknown }>;
-  const sha = Array.isArray(commits) ? commits[0]?.sha : undefined;
-  if (typeof sha !== 'string' || !/^[0-9a-f]{40}$/.test(sha)) throw new Error('no commit for this path');
+  const tree = await response.json() as { tree?: Array<{ path?: unknown; type?: unknown; sha?: unknown }> };
+  const entry = Array.isArray(tree.tree)
+    ? tree.tree.find(e => e.path === codeySkillDir(BROWSER_SKILL_NAME) && e.type === 'tree')
+    : undefined;
+  const sha = typeof entry?.sha === 'string' ? entry.sha : undefined;
+  if (!sha || !/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`no ${BROWSER_SKILL_NAME} folder in the tree`);
+  }
   return sha;
 }
 
-async function downloadBrowserSkill(timeoutMs: number): Promise<{ text: string; from: string }> {
+async function downloadBrowserSkill(timeoutMs: number): Promise<{ text: string; from: string; hash?: string }> {
   const url = codeySkillDownloadUrl(BROWSER_SKILL_NAME);
   const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
   if (!response.ok) throw new Error(`${url} returned ${response.status}`);
@@ -218,13 +232,13 @@ async function downloadBrowserSkill(timeoutMs: number): Promise<{ text: string; 
   if (!isPublishedSkill(text, BROWSER_SKILL_NAME)) {
     throw new Error(`${url} did not return the ${BROWSER_SKILL_NAME} skill`);
   }
-  let at = CODEY_SKILLS_REPO_REF;
+  let hash: string | undefined;
   try {
-    at = (await downloadSkillCommit(timeoutMs)).slice(0, 12);
+    hash = await downloadSkillFolderHash(timeoutMs);
   } catch {
-    // Keep the branch name: the version in the stamp still says which text.
+    // Keep the stamp readable: the skill name and date still say which text.
   }
-  return { text, from: `${CODEY_SKILLS_REPO}@${at}` };
+  return { text, from: CODEY_SKILLS_REPO, hash };
 }
 
 /**
@@ -254,11 +268,13 @@ export async function installBrowserSkill(
   let markdown: string;
   let source: 'repository' | 'bundled' = 'repository';
   let from = 'the copy bundled with the app';
+  let hash: string | undefined;
   let reason: string | undefined;
   try {
     const downloaded = await downloadBrowserSkill(timeoutMs);
     markdown = downloaded.text;
     from = downloaded.from;
+    hash = downloaded.hash;
   } catch (error) {
     markdown = browserSkillMarkdown();
     source = 'bundled';
@@ -267,9 +283,40 @@ export async function installBrowserSkill(
 
   const file = path.join(dir, SKILL_FILE);
   await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.writeFile(file, stamp(markdown, from, today), 'utf8');
+  await fs.promises.writeFile(file, stamp(markdown, from, hash, today), 'utf8');
   await fs.promises.rm(path.join(dir, DISABLED_SKILL_FILE), { force: true });
   return { installed: true, file, source, reason };
+}
+
+export interface BrowserSkillUpdateCheck {
+  /** The hash an install stamped, when this copy is Codey's. */
+  recorded?: string;
+  /** The hash the published folder has right now. */
+  current: string;
+  /** True when the published skill moved after this copy was installed. */
+  needsUpdate: boolean;
+}
+
+/**
+ * Compare the installed copy against the published folder, without touching the
+ * disk. The Mac app shows "Update available" from this; Update itself is just
+ * Install again. A copy with no stamp is the user's — nothing compares or
+ * replaces it, and nothing installed updates nothing. Throws when the folder
+ * cannot be reached, so a caller that wants to stay quiet can.
+ */
+export async function checkBrowserSkillUpdate(
+  home: string = os.homedir(),
+  { timeoutMs = 5000 }: { timeoutMs?: number } = {},
+): Promise<BrowserSkillUpdateCheck> {
+  const current = await downloadSkillFolderHash(timeoutMs);
+  const file = path.join(browserSkillDir(home), SKILL_FILE);
+  let recorded: string | undefined;
+  try {
+    recorded = installedSkillHash(fs.readFileSync(file, 'utf8'));
+  } catch {
+    // Nothing installed: nothing to update.
+  }
+  return { recorded, current, needsUpdate: recorded !== undefined && recorded !== current };
 }
 
 /**

--- a/packages/core/src/agents/browser-skill.ts
+++ b/packages/core/src/agents/browser-skill.ts
@@ -7,6 +7,21 @@ import { CODEY_GLOBAL_SKILLS_SUBDIR } from './codey-skills';
 export const BROWSER_SKILL_NAME = 'browser';
 
 /**
+ * Where Codey's skills are published. Installing pulls from here, so the text
+ * can be corrected and read by anyone without shipping a new app build.
+ */
+export const CODEY_SKILLS_REPO_URL = 'https://github.com/its-ahoh/codey-skills';
+/** The ref installs pull from. A branch keeps fixes flowing; pin a tag here if
+ *  a skill ever needs to be held back from the published tip. */
+export const CODEY_SKILLS_REPO_REF = 'main';
+
+/** Raw URL of one published skill's markdown. */
+export function codeySkillDownloadUrl(name: string, ref: string = CODEY_SKILLS_REPO_REF): string {
+  const repo = CODEY_SKILLS_REPO_URL.replace('https://github.com/', '');
+  return `https://raw.githubusercontent.com/${repo}/${ref}/skills/${name}/SKILL.md`;
+}
+
+/**
  * The Browser plugin's discovery layer. Every agent Codey runs finds skills
  * through `.claude/skills` or `.agents/skills`, so one markdown file reaches
  * claude-code, codex, opencode and pi alike — including agents with no MCP
@@ -22,10 +37,10 @@ export const BROWSER_SKILL_NAME = 'browser';
  * `addCodeyBrowserTools` passes `CODEY_BROWSER_*` to task-performing turns
  * only, and the CLI refuses to do anything without them.
  *
- * The text lives in `src/skills/<name>/SKILL.md` rather than a template
- * literal: it is prose an agent reads, and prose is easier to get right when
- * it is written as markdown. `npm run build` copies the directory next to the
- * compiled JS, so this path resolves the same from `src` and from `dist`.
+ * A copy also ships with the build, at `src/skills/<name>/SKILL.md` (the build
+ * copies it next to the compiled JS, so the path resolves the same from `src`
+ * and `dist`). It is the fallback when the repository cannot be reached, which
+ * keeps Install working offline and on a locked-down network.
  */
 export const BROWSER_SKILL_SOURCE = path.join(
   __dirname, '..', 'skills', BROWSER_SKILL_NAME, 'SKILL.md',
@@ -50,16 +65,29 @@ export type BrowserSkillState = 'absent' | 'disabled' | 'installed';
 
 export interface BrowserSkillStatus {
   state: BrowserSkillState;
-  /** The installed copy differs from the one this build ships. The CLI it
-   *  documents ships with the app, so a stale copy can describe commands that
-   *  no longer exist. */
-  updateAvailable: boolean;
+  /** Where an installed copy lives, so the UI can point at it whether or not
+   *  it is installed yet. */
+  dir: string;
+  /** The installed copy is not the one this build ships. Expected after a pull
+   *  from the repository, and true as well when the user has edited it — which
+   *  is their right, so this is stated, not corrected. */
+  differsFromBundled: boolean;
+  /** Where Install pulls from. */
+  sourceUrl: string;
+}
+
+/** Which copy an install actually wrote. `bundled` means the repository could
+ *  not be used, and `reason` says why. */
+export interface BrowserSkillInstallResult {
+  file: string;
+  source: 'repository' | 'bundled';
+  reason?: string;
 }
 
 let cached: string | undefined;
 
-/** The skill's markdown, read once per process — it ships with the build and
- *  cannot change under a running Codey. */
+/** The skill's markdown as it ships with this build — the fallback copy, read
+ *  once per process, since it cannot change under a running Codey. */
 export function browserSkillMarkdown(): string {
   if (cached === undefined) cached = fs.readFileSync(BROWSER_SKILL_SOURCE, 'utf8');
   return cached;
@@ -72,6 +100,7 @@ export function browserSkillDir(home: string = os.homedir()): string {
 
 export function browserSkillStatus(home: string = os.homedir()): BrowserSkillStatus {
   const dir = browserSkillDir(home);
+  const base = { dir, sourceUrl: CODEY_SKILLS_REPO_URL };
   for (const [file, state] of [[SKILL_FILE, 'installed'], [DISABLED_SKILL_FILE, 'disabled']] as const) {
     let installed: string;
     try {
@@ -79,9 +108,9 @@ export function browserSkillStatus(home: string = os.homedir()): BrowserSkillSta
     } catch {
       continue;
     }
-    return { state, updateAvailable: installed !== browserSkillMarkdown() };
+    return { ...base, state, differsFromBundled: installed !== browserSkillMarkdown() };
   }
-  return { state: 'absent', updateAvailable: false };
+  return { ...base, state: 'absent', differsFromBundled: false };
 }
 
 /** True when agents can both find the skill and be handed the bridge. */
@@ -90,19 +119,56 @@ export function isBrowserSkillActive(home: string = os.homedir()): boolean {
 }
 
 /**
- * Install (or update) the user's copy. Only ever called for an explicit user
- * action, so it overwrites: pressing Install on an installed-but-stale copy is
- * how the user asks for the current text. A leftover `SKILL.md.disabled` is
- * removed with it — installing means the user wants the skill on, and leaving
- * both files behind would break the Skills tab's toggle.
+ * Reject a download that is not the skill we asked for. A raw URL can answer
+ * with a redirect page, a proxy's login form or someone else's file, and
+ * writing that into the user's skill root would hand every agent whatever it
+ * said. Frontmatter naming this skill is the cheap check that it is ours.
  */
-export async function installBrowserSkill(home: string = os.homedir()): Promise<string> {
+function isPublishedSkill(text: string, name: string): boolean {
+  return new RegExp(`^---\\nname: ${name}\\ndescription: \\S`).test(text) && text.length > 400;
+}
+
+async function downloadBrowserSkill(timeoutMs: number): Promise<string> {
+  const url = codeySkillDownloadUrl(BROWSER_SKILL_NAME);
+  const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+  const text = await response.text();
+  if (!isPublishedSkill(text, BROWSER_SKILL_NAME)) {
+    throw new Error(`${url} did not return the ${BROWSER_SKILL_NAME} skill`);
+  }
+  return text;
+}
+
+/**
+ * Install (or update) the user's copy, pulled from the skills repository and
+ * falling back to the copy bundled with this build.
+ *
+ * Only ever called for an explicit user action, so it overwrites: pressing
+ * Install or Update is how the user asks for the published text. A leftover
+ * `SKILL.md.disabled` is removed with it — installing means the user wants the
+ * skill on, and leaving both files behind would break the Skills tab's toggle.
+ */
+export async function installBrowserSkill(
+  home: string = os.homedir(),
+  timeoutMs = 10000,
+): Promise<BrowserSkillInstallResult> {
+  let markdown: string;
+  let source: BrowserSkillInstallResult['source'] = 'repository';
+  let reason: string | undefined;
+  try {
+    markdown = await downloadBrowserSkill(timeoutMs);
+  } catch (error) {
+    markdown = browserSkillMarkdown();
+    source = 'bundled';
+    reason = error instanceof Error ? error.message : String(error);
+  }
+
   const dir = browserSkillDir(home);
   const file = path.join(dir, SKILL_FILE);
   await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.writeFile(file, browserSkillMarkdown(), 'utf8');
+  await fs.promises.writeFile(file, markdown, 'utf8');
   await fs.promises.rm(path.join(dir, DISABLED_SKILL_FILE), { force: true });
-  return file;
+  return { file, source, reason };
 }
 
 /** Remove the user's copy. Uninstalling takes the capability out of every

--- a/packages/core/src/agents/browser-skill.ts
+++ b/packages/core/src/agents/browser-skill.ts
@@ -84,8 +84,20 @@ const DISABLED_SKILL_FILE = 'SKILL.md.disabled';
  */
 export const CODEY_INSTALL_MARKER = '<!-- Installed by Codey:';
 
-/** The folder tree hash an install recorded, or undefined when there is none. */
-const INSTALLED_HASH_RE = /<!-- Installed by Codey: browser ([0-9a-f]{40}) /;
+/**
+ * What a bundled install records where a hash would go. The copy shipped with
+ * the app has no published version to name — it is as old as the build — so
+ * the stamp says so rather than staying silent. A silent stamp reads as "no
+ * version recorded" and the update check cannot tell it from a copy it simply
+ * could not fingerprint, which is how an offline install used to look current
+ * forever.
+ */
+export const BUNDLED_SKILL_MARK = 'bundled';
+
+/** The version an install recorded: a folder tree hash, or `bundled`. */
+const INSTALLED_HASH_RE = new RegExp(
+  `<!-- Installed by Codey: ${BROWSER_SKILL_NAME} ([0-9a-f]{40}|${BUNDLED_SKILL_MARK}) `,
+);
 
 /** The hash a stamp recorded, when the file carries one. */
 function installedSkillHash(markdown: string): string | undefined {
@@ -132,7 +144,9 @@ export interface BrowserSkillStatus {
   origin?: 'codey' | 'user';
   /** Where Install pulls from. */
   sourceUrl: string;
-  /** The skill folder's tree hash an install recorded, when there is one. */
+  /** The version an install recorded: the skill folder's tree hash, or
+   *  `bundled` for the copy shipped with the app, whose published version is
+   *  unknowable. Absent on a copy Codey did not write. */
   hash?: string;
 }
 
@@ -267,7 +281,7 @@ export async function installBrowserSkill(
 
   let markdown: string;
   let source: 'repository' | 'bundled' = 'repository';
-  let from = 'the copy bundled with the app';
+  let from = 'the copy shipped with the app';
   let hash: string | undefined;
   let reason: string | undefined;
   try {
@@ -278,6 +292,7 @@ export async function installBrowserSkill(
   } catch (error) {
     markdown = browserSkillMarkdown();
     source = 'bundled';
+    hash = BUNDLED_SKILL_MARK;
     reason = error instanceof Error ? error.message : String(error);
   }
 
@@ -301,8 +316,10 @@ export interface BrowserSkillUpdateCheck {
  * Compare the installed copy against the published folder, without touching the
  * disk. The Mac app shows "Update available" from this; Update itself is just
  * Install again. A copy with no stamp is the user's — nothing compares or
- * replaces it, and nothing installed updates nothing. Throws when the folder
- * cannot be reached, so a caller that wants to stay quiet can.
+ * replaces it, and nothing installed updates nothing. A bundled copy records
+ * `bundled` rather than a hash, which never equals the published one, so it
+ * always offers the update it cannot rule out. Throws when the folder cannot
+ * be reached, so a caller that wants to stay quiet can.
  */
 export async function checkBrowserSkillUpdate(
   home: string = os.homedir(),

--- a/packages/core/src/agents/browser-skill.ts
+++ b/packages/core/src/agents/browser-skill.ts
@@ -52,6 +52,33 @@ const SKILL_FILE = 'SKILL.md';
 const DISABLED_SKILL_FILE = 'SKILL.md.disabled';
 
 /**
+ * An install stamps the file with where the text came from. Two jobs: it
+ * answers "which version of this text does the user actually have" when an
+ * agent runs a command the CLI does not have, and it is how Codey recognises
+ * its own copy. Anything without the stamp is treated as the user's, and is
+ * not overwritten or deleted without confirmation.
+ *
+ * It sits after the frontmatter (agents parse that from the first byte) and is
+ * an HTML comment, so it renders as nothing and reads as nothing.
+ */
+export const CODEY_INSTALL_MARKER = '<!-- Installed by Codey from';
+
+function stamp(markdown: string, from: string, today: string): string {
+  const line = `${CODEY_INSTALL_MARKER} ${from} on ${today}. `
+    + 'Manage it in Tools -> Plugins; edits here are replaced by the next update. -->';
+  const frontmatter = /^---\n[\s\S]*?\n---\n/.exec(markdown);
+  if (!frontmatter) return `${line}\n\n${markdown}`;
+  const head = markdown.slice(0, frontmatter[0].length);
+  const body = markdown.slice(frontmatter[0].length).replace(/^\n+/, '');
+  return `${head}\n${line}\n\n${body}`;
+}
+
+/** True for a file an install wrote. */
+export function isCodeyInstalledSkill(markdown: string): boolean {
+  return markdown.includes(CODEY_INSTALL_MARKER);
+}
+
+/**
  * What the user's copy of the skill is doing right now, read from disk rather
  * than from config: the Plugins tab, the Skills tab and a hand-run `rm` all
  * change the same thing, so the disk is the only state that cannot disagree
@@ -68,21 +95,22 @@ export interface BrowserSkillStatus {
   /** Where an installed copy lives, so the UI can point at it whether or not
    *  it is installed yet. */
   dir: string;
-  /** The installed copy is not the one this build ships. Expected after a pull
-   *  from the repository, and true as well when the user has edited it — which
-   *  is their right, so this is stated, not corrected. */
-  differsFromBundled: boolean;
+  /** Who wrote the copy that is there: `codey` if it carries the stamp an
+   *  install leaves, `user` for anything else — a hand-written skill of the
+   *  same name, or one from before stamping. Codey overwrites its own copy
+   *  freely and asks before touching the user's. */
+  origin?: 'codey' | 'user';
   /** Where Install pulls from. */
   sourceUrl: string;
 }
 
 /** Which copy an install actually wrote. `bundled` means the repository could
  *  not be used, and `reason` says why. */
-export interface BrowserSkillInstallResult {
-  file: string;
-  source: 'repository' | 'bundled';
-  reason?: string;
-}
+export type BrowserSkillInstallResult =
+  | { installed: true; file: string; source: 'repository' | 'bundled'; reason?: string }
+  /** Refused: a skill of this name is already there and Codey did not write
+   *  it. The caller confirms with `force` — never silently. */
+  | { installed: false; conflict: 'user-copy'; dir: string };
 
 let cached: string | undefined;
 
@@ -108,9 +136,9 @@ export function browserSkillStatus(home: string = os.homedir()): BrowserSkillSta
     } catch {
       continue;
     }
-    return { ...base, state, differsFromBundled: installed !== browserSkillMarkdown() };
+    return { ...base, state, origin: isCodeyInstalledSkill(installed) ? 'codey' : 'user' };
   }
-  return { ...base, state: 'absent', differsFromBundled: false };
+  return { ...base, state: 'absent' };
 }
 
 /** True when agents can both find the skill and be handed the bridge. */
@@ -128,7 +156,7 @@ function isPublishedSkill(text: string, name: string): boolean {
   return new RegExp(`^---\\nname: ${name}\\ndescription: \\S`).test(text) && text.length > 400;
 }
 
-async function downloadBrowserSkill(timeoutMs: number): Promise<string> {
+async function downloadBrowserSkill(timeoutMs: number): Promise<{ text: string; from: string }> {
   const url = codeySkillDownloadUrl(BROWSER_SKILL_NAME);
   const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
   if (!response.ok) throw new Error(`${url} returned ${response.status}`);
@@ -136,48 +164,78 @@ async function downloadBrowserSkill(timeoutMs: number): Promise<string> {
   if (!isPublishedSkill(text, BROWSER_SKILL_NAME)) {
     throw new Error(`${url} did not return the ${BROWSER_SKILL_NAME} skill`);
   }
-  return text;
+  // The raw host answers with the blob's hash as its ETag, so the stamp can
+  // name the exact bytes without a second request for the commit. It may be
+  // weak (`W/"..."`, when the body was compressed); the hash is the same.
+  const version = response.headers.get('etag')?.replace(/^W\//, '').replace(/[^\w]/g, '')
+    || CODEY_SKILLS_REPO_REF;
+  const repo = CODEY_SKILLS_REPO_URL.replace('https://github.com/', '');
+  return { text, from: `${repo}@${version.slice(0, 12)}` };
 }
 
 /**
  * Install (or update) the user's copy, pulled from the skills repository and
  * falling back to the copy bundled with this build.
  *
- * Only ever called for an explicit user action, so it overwrites: pressing
- * Install or Update is how the user asks for the published text. A leftover
- * `SKILL.md.disabled` is removed with it — installing means the user wants the
- * skill on, and leaving both files behind would break the Skills tab's toggle.
+ * Overwrites Codey's own copy without ceremony — pressing Install or Update is
+ * how the user asks for the published text. Refuses when the file there is not
+ * one Codey wrote: a hand-written skill of the same name is the user's work,
+ * and replacing it silently is not a thing an install may do. `force` is the
+ * caller's confirmation.
+ *
+ * A leftover `SKILL.md.disabled` is removed on success — installing means the
+ * user wants the skill on, and leaving both files behind would break the
+ * Skills tab's toggle.
  */
 export async function installBrowserSkill(
   home: string = os.homedir(),
-  timeoutMs = 10000,
+  { force = false, timeoutMs = 10000, today = new Date().toISOString().slice(0, 10) }: {
+    force?: boolean; timeoutMs?: number; today?: string;
+  } = {},
 ): Promise<BrowserSkillInstallResult> {
+  const dir = browserSkillDir(home);
+  const existing = browserSkillStatus(home);
+  if (!force && existing.origin === 'user') return { installed: false, conflict: 'user-copy', dir };
+
   let markdown: string;
-  let source: BrowserSkillInstallResult['source'] = 'repository';
+  let source: 'repository' | 'bundled' = 'repository';
+  let from = 'the copy bundled with the app';
   let reason: string | undefined;
   try {
-    markdown = await downloadBrowserSkill(timeoutMs);
+    const downloaded = await downloadBrowserSkill(timeoutMs);
+    markdown = downloaded.text;
+    from = downloaded.from;
   } catch (error) {
     markdown = browserSkillMarkdown();
     source = 'bundled';
     reason = error instanceof Error ? error.message : String(error);
   }
 
-  const dir = browserSkillDir(home);
   const file = path.join(dir, SKILL_FILE);
   await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.writeFile(file, markdown, 'utf8');
+  await fs.promises.writeFile(file, stamp(markdown, from, today), 'utf8');
   await fs.promises.rm(path.join(dir, DISABLED_SKILL_FILE), { force: true });
-  return { file, source, reason };
+  return { installed: true, file, source, reason };
 }
 
-/** Remove the user's copy. Uninstalling takes the capability out of every
- *  agent's skill list, not just out of its env. */
-export async function uninstallBrowserSkill(home: string = os.homedir()): Promise<boolean> {
+/**
+ * Remove the user's copy. Uninstalling takes the capability out of every
+ * agent's skill list, not just out of its env.
+ *
+ * Like install, this deletes what Codey wrote and asks first about anything
+ * else: the directory may hold a skill the user wrote, and there is no undo.
+ */
+export async function uninstallBrowserSkill(
+  home: string = os.homedir(),
+  { force = false }: { force?: boolean } = {},
+): Promise<{ removed: boolean; conflict?: 'user-copy' }> {
+  const dir = browserSkillDir(home);
+  const existing = browserSkillStatus(home);
+  if (!force && existing.origin === 'user') return { removed: false, conflict: 'user-copy' };
   try {
-    await fs.promises.rm(browserSkillDir(home), { recursive: true, force: true });
-    return true;
+    await fs.promises.rm(dir, { recursive: true, force: true });
+    return { removed: true };
   } catch {
-    return false;
+    return { removed: false };
   }
 }

--- a/packages/core/src/agents/browser-skill.ts
+++ b/packages/core/src/agents/browser-skill.ts
@@ -15,10 +15,29 @@ export const CODEY_SKILLS_REPO_URL = 'https://github.com/its-ahoh/codey-skills';
  *  a skill ever needs to be held back from the published tip. */
 export const CODEY_SKILLS_REPO_REF = 'main';
 
+/** `owner/name`, the form both GitHub URLs and the install stamp use. */
+export const CODEY_SKILLS_REPO = CODEY_SKILLS_REPO_URL.replace('https://github.com/', '');
+
+/** Path of one published skill inside the repository. */
+export function codeySkillPath(name: string): string {
+  return `skills/${name}/SKILL.md`;
+}
+
 /** Raw URL of one published skill's markdown. */
 export function codeySkillDownloadUrl(name: string, ref: string = CODEY_SKILLS_REPO_REF): string {
-  const repo = CODEY_SKILLS_REPO_URL.replace('https://github.com/', '');
-  return `https://raw.githubusercontent.com/${repo}/${ref}/skills/${name}/SKILL.md`;
+  return `https://raw.githubusercontent.com/${CODEY_SKILLS_REPO}/${ref}/${codeySkillPath(name)}`;
+}
+
+/** API URL for the commit that last touched one published skill. */
+export function codeySkillCommitUrl(name: string, ref: string = CODEY_SKILLS_REPO_REF): string {
+  return `https://api.github.com/repos/${CODEY_SKILLS_REPO}/commits`
+    + `?path=${encodeURIComponent(codeySkillPath(name))}&sha=${ref}&per_page=1`;
+}
+
+/** The `version:` a published skill declares, or undefined if it has none. */
+export function skillVersion(markdown: string): string | undefined {
+  const frontmatter = /^---\n([\s\S]*?)\n---\n/.exec(markdown);
+  return frontmatter ? /^version:[ \t]*(\S+)[ \t]*$/m.exec(frontmatter[1])?.[1] : undefined;
 }
 
 /**
@@ -52,19 +71,22 @@ const SKILL_FILE = 'SKILL.md';
 const DISABLED_SKILL_FILE = 'SKILL.md.disabled';
 
 /**
- * An install stamps the file with where the text came from. Two jobs: it
- * answers "which version of this text does the user actually have" when an
- * agent runs a command the CLI does not have, and it is how Codey recognises
- * its own copy. Anything without the stamp is treated as the user's, and is
- * not overwritten or deleted without confirmation.
+ * An install stamps the file with the skill's version and the commit it came
+ * from. Two jobs: it answers "which text does this user actually have" when an
+ * agent runs a command the installed CLI does not have — on sight from the
+ * version, and exactly from the commit — and it is how Codey recognises its own
+ * copy. Anything without the stamp is treated as the user's, and is not
+ * overwritten or deleted without confirmation.
  *
  * It sits after the frontmatter (agents parse that from the first byte) and is
  * an HTML comment, so it renders as nothing and reads as nothing.
  */
-export const CODEY_INSTALL_MARKER = '<!-- Installed by Codey from';
+export const CODEY_INSTALL_MARKER = '<!-- Installed by Codey:';
 
 function stamp(markdown: string, from: string, today: string): string {
-  const line = `${CODEY_INSTALL_MARKER} ${from} on ${today}. `
+  const version = skillVersion(markdown);
+  const line = `${CODEY_INSTALL_MARKER} ${BROWSER_SKILL_NAME}${version ? ` ${version}` : ''} `
+    + `from ${from} on ${today}. `
     + 'Manage it in Tools -> Plugins; edits here are replaced by the next update. -->';
   const frontmatter = /^---\n[\s\S]*?\n---\n/.exec(markdown);
   if (!frontmatter) return `${line}\n\n${markdown}`;
@@ -102,6 +124,8 @@ export interface BrowserSkillStatus {
   origin?: 'codey' | 'user';
   /** Where Install pulls from. */
   sourceUrl: string;
+  /** The `version:` the installed copy declares, when it has one. */
+  version?: string;
 }
 
 /** Which copy an install actually wrote. `bundled` means the repository could
@@ -136,7 +160,12 @@ export function browserSkillStatus(home: string = os.homedir()): BrowserSkillSta
     } catch {
       continue;
     }
-    return { ...base, state, origin: isCodeyInstalledSkill(installed) ? 'codey' : 'user' };
+    return {
+      ...base,
+      state,
+      origin: isCodeyInstalledSkill(installed) ? 'codey' : 'user',
+      version: skillVersion(installed),
+    };
   }
   return { ...base, state: 'absent' };
 }
@@ -153,7 +182,32 @@ export function isBrowserSkillActive(home: string = os.homedir()): boolean {
  * said. Frontmatter naming this skill is the cheap check that it is ours.
  */
 function isPublishedSkill(text: string, name: string): boolean {
-  return new RegExp(`^---\\nname: ${name}\\ndescription: \\S`).test(text) && text.length > 400;
+  const frontmatter = /^---\n([\s\S]*?)\n---\n/.exec(text)?.[1];
+  if (!frontmatter) return false;
+  return new RegExp(`^name:[ \t]*${name}[ \t]*$`, 'm').test(frontmatter)
+    && /^description:[ \t]*\S/m.test(frontmatter)
+    && text.length > 400;
+}
+
+/**
+ * The commit that last touched this skill, for the stamp. A separate request,
+ * because the raw host's ETag is an opaque per-encoding fingerprint: it differs
+ * between the gzip and identity copies of identical bytes and matches no hash
+ * anyone can look up. Best-effort — a stamp naming the branch is better than a
+ * failed install, and the rate limit on unauthenticated calls (60/hour) is far
+ * above how often anyone installs a skill.
+ */
+async function downloadSkillCommit(timeoutMs: number): Promise<string> {
+  const url = codeySkillCommitUrl(BROWSER_SKILL_NAME);
+  const response = await fetch(url, {
+    headers: { accept: 'application/vnd.github+json', 'user-agent': 'codey' },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+  const commits = await response.json() as Array<{ sha?: unknown }>;
+  const sha = Array.isArray(commits) ? commits[0]?.sha : undefined;
+  if (typeof sha !== 'string' || !/^[0-9a-f]{40}$/.test(sha)) throw new Error('no commit for this path');
+  return sha;
 }
 
 async function downloadBrowserSkill(timeoutMs: number): Promise<{ text: string; from: string }> {
@@ -164,13 +218,13 @@ async function downloadBrowserSkill(timeoutMs: number): Promise<{ text: string; 
   if (!isPublishedSkill(text, BROWSER_SKILL_NAME)) {
     throw new Error(`${url} did not return the ${BROWSER_SKILL_NAME} skill`);
   }
-  // The raw host answers with the blob's hash as its ETag, so the stamp can
-  // name the exact bytes without a second request for the commit. It may be
-  // weak (`W/"..."`, when the body was compressed); the hash is the same.
-  const version = response.headers.get('etag')?.replace(/^W\//, '').replace(/[^\w]/g, '')
-    || CODEY_SKILLS_REPO_REF;
-  const repo = CODEY_SKILLS_REPO_URL.replace('https://github.com/', '');
-  return { text, from: `${repo}@${version.slice(0, 12)}` };
+  let at = CODEY_SKILLS_REPO_REF;
+  try {
+    at = (await downloadSkillCommit(timeoutMs)).slice(0, 12);
+  } catch {
+    // Keep the branch name: the version in the stamp still says which text.
+  }
+  return { text, from: `${CODEY_SKILLS_REPO}@${at}` };
 }
 
 /**

--- a/packages/core/src/agents/codey-skills.ts
+++ b/packages/core/src/agents/codey-skills.ts
@@ -13,13 +13,6 @@ export const CODEY_SKILLS_SUBDIR = path.join('.codey', 'skills');
 export const CODEY_GLOBAL_SKILLS_SUBDIR = CODEY_SKILLS_SUBDIR;
 
 /**
- * Skills Codey itself ships and owns (`~/.codey/managed-skills`), kept apart
- * from the user's own `~/.codey/skills` so a plugin can rewrite or delete its
- * skill without ever touching a hand-written one.
- */
-export const CODEY_MANAGED_SKILLS_SUBDIR = path.join('.codey', 'managed-skills');
-
-/**
  * The smallest set of skill roots covering every agent Codey runs.
  * Claude Code uses its own directory; Codex, OpenCode, and pi all understand
  * the cross-agent `.agents/skills` convention. The same two conventions apply
@@ -143,12 +136,3 @@ export async function syncCodeyGlobalSkills(home: string = os.homedir()): Promis
   return linkCodeySkills(path.join(homeRoot, CODEY_GLOBAL_SKILLS_SUBDIR), homeRoot);
 }
 
-/**
- * Expose `~/.codey/managed-skills` the same way. A managed skill appears and
- * disappears with the plugin that owns it; the links it leaves behind are
- * cleaned up on the next sync because they point back into this root.
- */
-export async function syncCodeyManagedSkills(home: string = os.homedir()): Promise<CodeySkillSyncResult> {
-  const homeRoot = path.resolve(home);
-  return linkCodeySkills(path.join(homeRoot, CODEY_MANAGED_SKILLS_SUBDIR), homeRoot);
-}

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -4,8 +4,8 @@ import { ClaudeCodeAdapter } from './claude-code';
 import { OpenCodeAdapter } from './opencode';
 import { CodexAdapter } from './codex';
 import { PiAdapter } from './pi';
-import { syncCodeyGlobalSkills, syncCodeyManagedSkills, syncCodeyProjectSkills } from './codey-skills';
-import { installBrowserSkill, removeBrowserSkill } from './browser-skill';
+import { syncCodeyGlobalSkills, syncCodeyProjectSkills } from './codey-skills';
+import { isBrowserSkillActive } from './browser-skill';
 
 export type { CodingAgentAdapter } from './base';
 export { ClaudeCodeAdapter } from './claude-code';
@@ -18,26 +18,26 @@ export * from './browser-skill';
 
 /**
  * Hand the in-app browser's bridge credentials to a task-performing agent
- * turn. Requires the user-enabled Browser plugin AND a live bridge (the Mac
- * app exports CODEY_BROWSER_* on the gateway process). Advisor, housekeeping,
- * and tool-restricted turns are excluded via the same browserTools /
- * allowedTools gating the earlier MCP server used.
+ * turn. Requires the installed and enabled `browser` skill AND a live bridge
+ * (the Mac app exports CODEY_BROWSER_* on the gateway process). Advisor,
+ * housekeeping, and tool-restricted turns are excluded via the same
+ * browserTools / allowedTools gating the earlier MCP server used.
  *
- * The agent learns the commands from the managed `browser` skill, and reaches
- * them through its own shell tool — the one capability every coding agent has,
- * MCP or not. That makes this env the real gate: a turn without it gets a CLI
- * that refuses to run, whatever the skill list says.
+ * The agent learns the commands from the `browser` skill, and reaches them
+ * through its own shell tool — the one capability every coding agent has, MCP
+ * or not. That makes this env the real gate: a turn without it gets a CLI that
+ * refuses to run, whatever the skill list says.
  */
 export function addCodeyBrowserTools(
   request: AgentRequest,
-  pluginEnabled: boolean,
+  skillActive: boolean,
   env: NodeJS.ProcessEnv = process.env,
 ): AgentRequest {
   const socket = env.CODEY_BROWSER_SOCKET;
   const token = env.CODEY_BROWSER_TOKEN;
   const runtime = env.CODEY_BROWSER_RUNTIME;
   const cli = env.CODEY_BROWSER_CLI;
-  if (!pluginEnabled || !socket || !token || !runtime || !cli) return request;
+  if (!skillActive || !socket || !token || !runtime || !cli) return request;
   if (request.browserTools !== true || !request.context?.workingDir || request.allowedTools) {
     return request;
   }
@@ -80,7 +80,6 @@ export function addExternalMcpServers(
 export class AgentFactory {
   private agents: Map<CodingAgent, CodingAgentAdapter> = new Map();
   private envProvider?: (agent: CodingAgent) => Record<string, string> | undefined;
-  private pluginEnabledProvider?: (plugin: string) => boolean;
   private externalMcpProvider?: () => Record<string, McpServerSpec> | undefined;
 
   constructor() {
@@ -105,14 +104,6 @@ export class AgentFactory {
    */
   setAgentEnvProvider(provider: (agent: CodingAgent) => Record<string, string> | undefined): void {
     this.envProvider = provider;
-  }
-
-  /**
-   * Inject a callback that answers "is this plugin enabled?" from the live
-   * config, so toggles in the renderer take effect on the next request.
-   */
-  setPluginEnabledProvider(provider: (plugin: string) => boolean): void {
-    this.pluginEnabledProvider = provider;
   }
 
   /**
@@ -154,19 +145,18 @@ export class AgentFactory {
       }
     }
 
-    const browserEnabled = this.pluginEnabledProvider?.('browser') === true;
-    request = addCodeyBrowserTools(request, browserEnabled);
-    request = addExternalMcpServers(request, this.externalMcpProvider?.());
-
-    // The Browser plugin's skill follows its switch: written on the way into a
-    // run so an upgrade ships current instructions, removed once the plugin is
-    // off so it stops appearing in every agent's skill list.
+    // Read the skill's state from disk on every run: installing from the
+    // Plugins tab, disabling from the Skills tab and deleting the directory by
+    // hand are the same fact, and the agent must see whichever the user did
+    // last without a restart.
+    let browserActive = false;
     try {
-      if (browserEnabled) await installBrowserSkill();
-      else await removeBrowserSkill();
+      browserActive = isBrowserSkillActive();
     } catch {
-      // Best-effort, like the linking below.
+      // Unreadable home: no skill, so no capability.
     }
+    request = addCodeyBrowserTools(request, browserActive);
+    request = addExternalMcpServers(request, this.externalMcpProvider?.());
 
     // `~/.codey/skills` and `<project>/.codey/skills` are Codey's global and
     // project sources of truth. Refresh the lightweight compatibility links
@@ -174,7 +164,6 @@ export class AgentFactory {
     // available without restarting Codey.
     try {
       await syncCodeyGlobalSkills();
-      await syncCodeyManagedSkills();
     } catch {
       // See below: linking is best-effort.
     }

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: browser
+version: 1.0.0
 description: Use when a task needs the live web or a real UI - open, read, screenshot, or click through pages in the user-visible Codey Browser, including pages behind the user's existing logins. Triggers - "open this page", "check the site", "log in and", "what does the page say", "click the button", "fill the form", "test the UI".
 ---
 

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -3,9 +3,6 @@ name: browser
 description: Use when a task needs the live web or a real UI - open, read, screenshot, or click through pages in the user-visible Codey Browser, including pages behind the user's existing logins. Triggers - "open this page", "check the site", "log in and", "what does the page say", "click the button", "fill the form", "test the UI".
 ---
 
-<!-- Managed by Codey. Edits are overwritten; this file is removed when the
-     Browser plugin is turned off. -->
-
 # Codey Browser
 
 Drive the browser window the user can see. Every command is one shell call:

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: browser
-version: 1.0.0
 description: Use when a task needs the live web or a real UI - open, read, screenshot, or click through pages in the user-visible Codey Browser, including pages behind the user's existing logins. Triggers - "open this page", "check the site", "log in and", "what does the page say", "click the button", "fill the form", "test the UI".
 ---
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -122,9 +122,10 @@ export interface GatewayConfigJson {
   };
 
   /**
-   * Optional capability packs ("plugins") exposed to agents as MCP servers.
-   * Everything is off by default; the user enables plugins explicitly in the
-   * Mac app's Tools → Plugins tab.
+   * Legacy opt-in marker for the Browser plugin, from when enablement lived in
+   * config. A plugin is now installed as an ordinary skill and its presence on
+   * disk is the source of truth; this field is read once at startup to carry a
+   * pre-existing opt-in over, and is written no more.
    */
   plugins?: {
     browser?: { enabled: boolean };
@@ -548,7 +549,8 @@ export class ConfigManager extends EventEmitter {
     this.save();
   }
 
-  /** True only when the user has explicitly enabled the named plugin. */
+  /** Legacy: the pre-install-model opt-in flag. Only the one-time migration
+   *  that installs the skill for an existing user reads this. */
   isPluginEnabled(name: 'browser'): boolean {
     return this.config.plugins?.[name]?.enabled === true;
   }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -672,12 +672,8 @@ export class Codey {
       const slot = this.configManager?.getAgentConfig(a);
       return slot?.env;
     });
-    // Plugins are opt-in: the factory only attaches plugin MCP servers when
-    // the user has enabled them in config. Read live so toggling in the
-    // renderer applies on the next agent spawn without a restart.
-    this.agentFactory.setPluginEnabledProvider((plugin) =>
-      plugin === 'browser' && this.configManager?.isPluginEnabled('browser') === true
-    );
+    // The Browser plugin needs no provider: the factory reads the installed
+    // skill from disk, which is what the Plugins and Skills tabs both write.
     // User-configured external MCP servers ride the same live-read pattern.
     this.agentFactory.setExternalMcpProvider(() =>
       this.configManager?.getEnabledExternalMcpServers()


### PR DESCRIPTION
Stacked on #313 — review that first, or read this one's diff alone.

## The problem this fixes

#313 gave the Browser plugin a skill, but Codey owned it: written to
`~/.codey/managed-skills` and rewritten on every agent run. That root is linked
into the same directories the Skills tab scans, so the skill appeared there as
an ordinary skill — with controls that did not hold:

- **Delete** removes the link; the next agent run links it straight back.
- **Off** renames `SKILL.md` to `SKILL.md.disabled`; the next run writes
  `SKILL.md` back beside it, and a second press then fails with
  `Cannot disable: SKILL.md.disabled already exists`.

One capability, two switches, and the more discoverable one silently loses.

## What changed

The middle state — a thing in the user's skill directories that is not the
user's — is gone. The Plugins tab installs and uninstalls; in between, the copy
in `~/.codey/skills/browser` is an ordinary user-owned skill and the Skills tab
is the only thing that acts on it. Nothing rewrites it behind the user's back.

- **State is read from disk**: `installed`, `disabled`, `absent`. Both tabs read
  the same directory, so they cannot disagree. This deletes the
  plugin-enabled provider chain from `AgentFactory` through the gateway.
- **Disabling in Skills also stops `CODEY_BROWSER_*`**, since the gate asks for
  `installed` specifically.
- **Two one-time startup migrations**: install for a user who had the old
  config flag on, and delete the `~/.codey/managed-skills` root left by a
  development build. The second is not cosmetic — a leftover link there points
  outside the sync's source root, so the sync treats it as a conflict and
  declines to link the real skill: an install that reports success and reaches
  no agent.

`gateway.json`'s `plugins.browser.enabled` survives only as the legacy marker
that migration reads.

## Where the skill comes from, and how it is versioned

Install pulls from the published repository, `its-ahoh/codey-skills`, so the
text can be corrected without shipping an app build; the copy bundled with the
build is the fallback when the network or the repository is unavailable, which
keeps Install working offline. A download that is not this skill — a proxy
login page, someone else's file — is refused before anything is written.

Versioning follows the ecosystem `npx skills` established rather than a
frontmatter semver: **a skill's version is its folder's Git tree hash**, which
moves exactly when the skill's files move and never for edits elsewhere in the
repository. A hand-bumped semver only means something if someone bumps it, and
an unbumped one lies about which text a user is running.

- The install **stamps** that hash into the file it writes, as an HTML comment
  after the frontmatter. The stamp does two jobs: it answers "which text does
  this user actually have" when an agent runs a command the installed CLI does
  not have, and it is how Codey recognises its own copy.
- **Anything without the stamp is the user's.** Install will not replace it and
  uninstall will not delete it without explicit confirmation, and the card asks
  before either.
- The plugin card **checks** the recorded hash against the published folder and
  says when an update is waiting. An unreachable repository reports "unknown"
  and the card stays quiet rather than claiming the copy is current.

## Verification

- pi, unmodified, discovered the installed skill, ran the CLI and reached the
  bridge.
- install → disable → reinstall → uninstall, driven through the functions the
  IPC handlers call: each leaves the state and the discovery links the design
  describes, and reinstalling clears a leftover `SKILL.md.disabled`.
- A real install against the live repository (in a throwaway home) pulled the
  published skill and stamped its actual folder hash, `ba9b6da`; the update
  check then compared equal.
- Full suite green (core 557 / gateway 328 / mac 571); build, typecheck and
  lint pass.

Not covered: the Plugins tab's own buttons in a running app, a run against the
real in-app bridge, and the "update available" banner lighting up — that needs
the published skill to actually move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)