### PR TITLE
Keep the browser in its slot when the window zooms, and call it "Zoom"

### DIFF
--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { describe, expect, it, vi } from 'vitest'
-import { BROWSER_PARTITION, BrowserController, isSafeBrowserNavigationUrl, normalizeBrowserUrl } from './browser-controller'
+import { BROWSER_PARTITION, BrowserController, isSafeBrowserNavigationUrl, normalizeBrowserUrl, sanitizeBounds } from './browser-controller'
 
 describe('normalizeBrowserUrl', () => {
   it('adds HTTPS to ordinary hosts', () => {
@@ -422,5 +422,29 @@ describe('BrowserController agent controls', () => {
       'https://maps.example.com/request',
       { requestingUrl: 'https://maps.example.com/request' },
     )
+  })
+})
+
+describe('sanitizeBounds', () => {
+  const win = { getContentBounds: () => ({ x: 0, y: 0, width: 1600, height: 1000 }) } as any
+
+  it('passes CSS px through unchanged at 100%', () => {
+    expect(sanitizeBounds({ x: 400, y: 60, width: 800, height: 600 }, win))
+      .toEqual({ x: 400, y: 60, width: 800, height: 600 })
+  })
+
+  it('scales renderer CSS px by the window zoom factor', () => {
+    expect(sanitizeBounds({ x: 400, y: 60, width: 800, height: 600 }, win, 1.25))
+      .toEqual({ x: 500, y: 75, width: 1000, height: 750 })
+  })
+
+  it('keeps the scaled view inside the window', () => {
+    expect(sanitizeBounds({ x: 400, y: 60, width: 1200, height: 900 }, win, 1.6))
+      .toEqual({ x: 640, y: 96, width: 960, height: 904 })
+  })
+
+  it('ignores a nonsense zoom factor', () => {
+    expect(sanitizeBounds({ x: 10, y: 10, width: 100, height: 100 }, win, 0))
+      .toEqual({ x: 10, y: 10, width: 100, height: 100 })
   })
 })

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -177,15 +177,22 @@ export function isSafeBrowserNavigationUrl(input: string): boolean {
   }
 }
 
-function sanitizeBounds(bounds: BrowserBounds, win: BrowserWindow): BrowserBounds {
+/**
+ * The renderer measures the browser slot with getBoundingClientRect, which is
+ * CSS px inside a window that may be zoomed. The native view is
+ * laid out in the window's own units, so every incoming rect has to be scaled
+ * by the same zoom factor or the browser drifts out of its slot.
+ */
+export function sanitizeBounds(bounds: BrowserBounds, win: BrowserWindow, zoom = 1): BrowserBounds {
   const content = win.getContentBounds()
-  const x = Math.max(0, Math.round(Number(bounds.x) || 0))
-  const y = Math.max(0, Math.round(Number(bounds.y) || 0))
+  const scale = Number.isFinite(zoom) && zoom > 0 ? zoom : 1
+  const x = Math.max(0, Math.round((Number(bounds.x) || 0) * scale))
+  const y = Math.max(0, Math.round((Number(bounds.y) || 0) * scale))
   return {
     x,
     y,
-    width: Math.max(0, Math.min(Math.round(Number(bounds.width) || 0), content.width - x)),
-    height: Math.max(0, Math.min(Math.round(Number(bounds.height) || 0), content.height - y)),
+    width: Math.max(0, Math.min(Math.round((Number(bounds.width) || 0) * scale), content.width - x)),
+    height: Math.max(0, Math.min(Math.round((Number(bounds.height) || 0) * scale), content.height - y)),
   }
 }
 
@@ -200,6 +207,8 @@ export class BrowserController {
   private tabSequence = 0
   private attachedTo: BrowserWindow | null = null
   private lastBounds: BrowserBounds | null = null
+  /** Main-window zoom factor; lastBounds arrives in the renderer's CSS px. */
+  private zoom = 1
   private state: BrowserState = { ...EMPTY_STATE }
   private downloads: BrowserDownload[] = []
   private downloadSessionBound = false
@@ -261,7 +270,7 @@ export class BrowserController {
     if (win && !win.isDestroyed()) {
       win.contentView.addChildView(tab.view)
       this.attachedTo = win
-      if (this.lastBounds) tab.view.setBounds(sanitizeBounds(this.lastBounds, win))
+      if (this.lastBounds) tab.view.setBounds(sanitizeBounds(this.lastBounds, win, this.zoom))
     }
     return this.refreshState()
   }
@@ -284,7 +293,7 @@ export class BrowserController {
       if (win && !win.isDestroyed()) {
         win.contentView.addChildView(next.view)
         this.attachedTo = win
-        if (this.lastBounds) next.view.setBounds(sanitizeBounds(this.lastBounds, win))
+        if (this.lastBounds) next.view.setBounds(sanitizeBounds(this.lastBounds, win, this.zoom))
       }
     }
     return this.refreshState()
@@ -299,7 +308,7 @@ export class BrowserController {
       this.attachedTo = win
     }
     this.lastBounds = { ...bounds }
-    view.setBounds(sanitizeBounds(bounds, win))
+    view.setBounds(sanitizeBounds(bounds, win, this.zoom))
     return this.getState()
   }
 
@@ -307,10 +316,23 @@ export class BrowserController {
     this.detach()
   }
 
+  /**
+   * Re-places the view when the window's zoom changes: the last bounds
+   * were measured in the old scale, and the renderer may not re-measure.
+   */
+  setZoomFactor(zoom: number): void {
+    const next = Number.isFinite(zoom) && zoom > 0 ? zoom : 1
+    if (next === this.zoom) return
+    this.zoom = next
+    if (this.lastBounds && this.view && this.attachedTo && !this.attachedTo.isDestroyed()) {
+      this.view.setBounds(sanitizeBounds(this.lastBounds, this.attachedTo, this.zoom))
+    }
+  }
+
   setBounds(bounds: BrowserBounds): void {
     this.lastBounds = { ...bounds }
     if (!this.view || !this.attachedTo) return
-    this.view.setBounds(sanitizeBounds(bounds, this.attachedTo))
+    this.view.setBounds(sanitizeBounds(bounds, this.attachedTo, this.zoom))
   }
 
   async navigate(input: string): Promise<BrowserState> {
@@ -1052,7 +1074,7 @@ export class BrowserController {
       if (win && !win.isDestroyed()) {
         win.contentView.addChildView(view)
         this.attachedTo = win
-        if (this.lastBounds) view.setBounds(sanitizeBounds(this.lastBounds, win))
+        if (this.lastBounds) view.setBounds(sanitizeBounds(this.lastBounds, win, this.zoom))
       }
     }
     return tab

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -283,7 +283,7 @@ function createWindow() {
 
   mainWindow.webContents.on('did-finish-load', () => {
     // Chromium resets the zoom factor on every navigation/reload, so re-apply
-    // the saved text size here rather than only when the config changes.
+    // the saved zoom here rather than only when the config changes.
     mainWindow?.webContents.setZoomFactor(currentZoom)
     flushPendingRendererMessages()
   })
@@ -465,7 +465,7 @@ function applyUiPreferences(rawCfg: any) {
   applyZoom(clampZoom(rawCfg?.ui?.zoom))
 }
 
-// Text size. Scales the main window only: Quick Capture is a fixed-width
+// Zoom. Scales the main window only: Quick Capture is a fixed-width
 // floater that reports its own content height in CSS px, so zooming it would
 // desync that bottom-anchored resize.
 let currentZoom = DEFAULT_ZOOM
@@ -475,14 +475,17 @@ function applyZoom(factor: number) {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.setZoomFactor(factor)
   }
+  // The browser is a native view positioned from renderer CSS px, so it needs
+  // the new scale to stay inside its slot.
+  browserController.setZoomFactor(factor)
   if (!changed) return
-  // Refresh the View menu's "Text Size: N%" readout, and keep the Settings
+  // Refresh the View menu's "Zoom: N%" readout, and keep the Settings
   // stepper in sync when the change came from the menu.
   createAppMenu()
   sendToRenderer('ui:zoom', factor)
 }
 
-/** Persist a new text size; applyUiPreferences pushes it to the window. */
+/** Persist a new zoom level; applyUiPreferences pushes it to the window. */
 function setZoom(factor: number) {
   const next = clampZoom(factor)
   if (!coreConfigManager) {
@@ -1554,12 +1557,12 @@ function createAppMenu() {
     {
       label: 'View',
       submenu: [
-        { label: `Text Size: ${formatZoom(currentZoom)}`, enabled: false },
-        { label: 'Bigger Text', accelerator: 'CommandOrControl+Plus', click: () => setZoom(zoomIn(currentZoom)) },
+        { label: `Zoom: ${formatZoom(currentZoom)}`, enabled: false },
+        { label: 'Zoom In', accelerator: 'CommandOrControl+Plus', click: () => setZoom(zoomIn(currentZoom)) },
         // Same action on the unshifted key, so ⌘= works like it does elsewhere
         // on macOS. Hidden because one accelerator per menu item is displayable.
-        { label: 'Bigger Text', accelerator: 'CommandOrControl+=', visible: false, click: () => setZoom(zoomIn(currentZoom)) },
-        { label: 'Smaller Text', accelerator: 'CommandOrControl+-', click: () => setZoom(zoomOut(currentZoom)) },
+        { label: 'Zoom In', accelerator: 'CommandOrControl+=', visible: false, click: () => setZoom(zoomIn(currentZoom)) },
+        { label: 'Zoom Out', accelerator: 'CommandOrControl+-', click: () => setZoom(zoomOut(currentZoom)) },
         { label: 'Actual Size', accelerator: 'CommandOrControl+0', click: () => setZoom(DEFAULT_ZOOM) },
         { type: 'separator' },
         { role: 'reload' },

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -385,7 +385,7 @@ contextBridge.exposeInMainWorld('codey', {
   },
   app: {
     version: () => ipcRenderer.invoke('app:version'),
-    // Text size changed from the View menu (⌘+ / ⌘− / ⌘0).
+    // Zoom changed from the View menu (⌘+ / ⌘− / ⌘0).
     onZoom: (handler: (factor: number) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, factor: number) => handler(factor)
       ipcRenderer.on('ui:zoom', listener)

--- a/codey-mac/electron/zoom.ts
+++ b/codey-mac/electron/zoom.ts
@@ -1,6 +1,6 @@
 // codey-mac/electron/zoom.ts
 //
-// UI scale ("Text size") shared by the main window and the View menu. The
+// UI scale ("Zoom") shared by the main window and the View menu. The
 // window is scaled with Chromium's zoom factor rather than a
 // CSS font-size cascade: the app's type sizes are hard-coded px inside inline
 // styles, so only a real zoom moves all of them together without reflowing

--- a/codey-mac/src/components/AppearanceTab.tsx
+++ b/codey-mac/src/components/AppearanceTab.tsx
@@ -162,14 +162,14 @@ export const AppearanceTab: React.FC = () => {
 
       <div style={styles.settingRow}>
         <div style={{ ...styles.label, width: 'auto', flex: 1 }}>
-          <div>Text size</div>
+          <div>Zoom</div>
           <div style={styles.settingDesc}>
-            Scale the whole interface, chat text included. ⌘+ and ⌘− adjust it from anywhere in the app; ⌘0 goes back to 100%.
+            Scale the whole interface — text, spacing and icons together. ⌘+ and ⌘− adjust it from anywhere in the app; ⌘0 goes back to 100%.
           </div>
         </div>
         <div style={styles.stepper}>
           <button
-            aria-label="Smaller text"
+            aria-label="Zoom out"
             disabled={zoom <= ZOOM_STEPS[0]}
             onClick={() => changeZoom(zoomOut(zoom))}
             style={{ ...styles.stepBtn, opacity: zoom <= ZOOM_STEPS[0] ? 0.35 : 1 }}
@@ -177,7 +177,7 @@ export const AppearanceTab: React.FC = () => {
             −
           </button>
           <button
-            aria-label={`Text size ${formatZoom(zoom)}, click to reset`}
+            aria-label={`Zoom ${formatZoom(zoom)}, click to reset`}
             title="Reset to 100%"
             onClick={() => changeZoom(DEFAULT_ZOOM)}
             style={styles.stepValue}
@@ -185,7 +185,7 @@ export const AppearanceTab: React.FC = () => {
             {formatZoom(zoom)}
           </button>
           <button
-            aria-label="Bigger text"
+            aria-label="Zoom in"
             disabled={zoom >= ZOOM_STEPS[ZOOM_STEPS.length - 1]}
             onClick={() => changeZoom(zoomIn(zoom))}
             style={{ ...styles.stepBtn, opacity: zoom >= ZOOM_STEPS[ZOOM_STEPS.length - 1] ? 0.35 : 1 }}


### PR DESCRIPTION
## What

Two related fixes on top of #314 (which added text resizing via Chromium zoom):

1. **The browser no longer drifts out of the right panel when the window is zoomed.**
   The renderer measures its browser slot with `getBoundingClientRect`, which returns
   CSS px inside a zoomed window. The native `WebContentsView` is laid out in the
   window's own units. At any zoom ≠ 100% these two don't match, so the view was
   placed at the wrong offset/size. Now every incoming bounds is scaled by the window's
   zoom factor (`sanitizeBounds`), and `BrowserController.setZoomFactor()` re-places the
   view when the zoom changes (lastBounds were measured in the old scale and the
   renderer may not re-measure).

2. **The setting is called "Zoom", not "Text size".** It scales the whole interface
   (text, spacing, icons) — it never changed fonts alone. Renamed in Settings ›
   Appearance, the View menu (Zoom In / Zoom Out / Actual Size), and IPC/comment refs.

## Verification

- Unit tests: 585 pass (`npx vitest run`)
- `tsc --noEmit` clean, `npm run lint` clean
- **Real-device smoke test not yet run** — the sandbox recipe for screenshotting
  the app is currently wedged (main process stalls at `whenReady`). Please verify
  on your machine: `cd codey-mac && npm run dev`, open the right-side Browser panel,
  then ⌘+ / ⌘− and confirm the browser stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)