### PR TITLE
Add an Agent Teams switch to Claude Code's agent settings

### DIFF
--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
-import { fieldStyle, pageStyle, pillButton, Section, selectStyle, unwrap } from './settingsAtoms'
+import { fieldStyle, pageStyle, pillButton, Section, selectStyle, Toggle, unwrap } from './settingsAtoms'
 import {
   AGENT_INSTALL_URL,
   AGENT_NAMES,
@@ -8,6 +8,13 @@ import {
   EnvEditor,
 } from './SettingsTab'
 import { refreshInstalledAgents, useInstalledAgents } from './installedAgents'
+import {
+  AGENT_TEAMS_AGENT,
+  envWithoutAgentTeams,
+  isAgentTeamsOn,
+  mergeEnvKeepingAgentTeams,
+  setAgentTeams,
+} from './agentTeams'
 
 interface Props {
   isGatewayRunning: boolean
@@ -34,6 +41,16 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
     if (!isGatewayRunning) return
     void reload()
   }, [isGatewayRunning, reload])
+
+  // agents:set merges shallowly, so sending just the touched agent's slot is
+  // enough — no need to re-send the others.
+  const saveSlot = useCallback(async (name: string, patch: Partial<AgentSlot>) => {
+    const slot = { ...(agents[name] ?? {}), ...patch }
+    setAgents(prev => ({ ...prev, [name]: slot }))
+    try {
+      unwrap(await window.codey.agents.set({ [name]: slot }))
+    } catch (e: any) { setError(e?.message ?? String(e)) }
+  }, [agents])
 
   if (!isGatewayRunning) {
     return (
@@ -69,17 +86,7 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
               <span style={{ color: C.fg3, fontSize: 12 }}>Effort</span>
               <select
                 value={agents[a]?.defaultEffort ?? 'medium'}
-                onChange={async e => {
-                  const next = e.target.value
-                  const updated: Record<string, AgentSlot> = {
-                    ...agents,
-                    [a]: { ...(agents[a] ?? {}), defaultEffort: next },
-                  }
-                  setAgents(updated)
-                  // agents:set merges shallowly, so sending just this agent's
-                  // slot is enough — no need to re-send the others.
-                  await unwrap(await window.codey.agents.set({ [a]: updated[a] }))
-                }}
+                onChange={e => { void saveSlot(a, { defaultEffort: e.target.value }) }}
                 style={{ ...selectStyle, width: 180 }}
                 title="Thinking effort used when neither the chat nor a worker overrides it"
               >
@@ -88,17 +95,27 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
                 ))}
               </select>
             </div>
+            {a === AGENT_TEAMS_AGENT && (
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, marginTop: 10 }}>
+                <div>
+                  <div style={{ color: C.fg3, fontSize: 12 }}>Agent Teams</div>
+                  <div style={{ color: C.fg3, fontSize: 11, opacity: 0.8, marginTop: 2 }}>
+                    Experimental — lets Claude Code run a team of teammate agents.
+                  </div>
+                </div>
+                <Toggle
+                  on={isAgentTeamsOn(env)}
+                  label="Agent Teams"
+                  onChange={v => { void saveSlot(a, { env: setAgentTeams(env, v) }) }}
+                />
+              </div>
+            )}
             <EnvEditor
-              env={env}
-              onChange={async (next) => {
-                const updated: Record<string, AgentSlot> = {
-                  ...agents,
-                  [a]: { ...(agents[a] ?? {}), env: next },
-                }
-                setAgents(updated)
-                // agents:set merges shallowly, so sending just this agent's
-                // slot is enough — no need to re-send the others.
-                await unwrap(await window.codey.agents.set({ [a]: updated[a] }))
+              env={a === AGENT_TEAMS_AGENT ? envWithoutAgentTeams(env) : env}
+              onChange={next => {
+                void saveSlot(a, {
+                  env: a === AGENT_TEAMS_AGENT ? mergeEnvKeepingAgentTeams(env, next) : next,
+                })
               }}
             />
           </div>

--- a/codey-mac/src/components/agentTeams.test.ts
+++ b/codey-mac/src/components/agentTeams.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_TEAMS_ENV_KEY,
+  envWithoutAgentTeams,
+  isAgentTeamsOn,
+  mergeEnvKeepingAgentTeams,
+  setAgentTeams,
+} from './agentTeams'
+
+describe('isAgentTeamsOn', () => {
+  it('is off when unset or empty', () => {
+    expect(isAgentTeamsOn(undefined)).toBe(false)
+    expect(isAgentTeamsOn({})).toBe(false)
+    expect(isAgentTeamsOn({ [AGENT_TEAMS_ENV_KEY]: '' })).toBe(false)
+  })
+  it('reads hand-written falsey values as off', () => {
+    expect(isAgentTeamsOn({ [AGENT_TEAMS_ENV_KEY]: '0' })).toBe(false)
+    expect(isAgentTeamsOn({ [AGENT_TEAMS_ENV_KEY]: 'False' })).toBe(false)
+  })
+  it('is on for 1 or any other value', () => {
+    expect(isAgentTeamsOn({ [AGENT_TEAMS_ENV_KEY]: '1' })).toBe(true)
+    expect(isAgentTeamsOn({ [AGENT_TEAMS_ENV_KEY]: 'true' })).toBe(true)
+  })
+})
+
+describe('setAgentTeams', () => {
+  it('writes 1 when turned on and keeps other vars', () => {
+    expect(setAgentTeams({ FOO: 'bar' }, true)).toEqual({ FOO: 'bar', [AGENT_TEAMS_ENV_KEY]: '1' })
+  })
+  it('removes the key when turned off rather than writing 0', () => {
+    expect(setAgentTeams({ FOO: 'bar', [AGENT_TEAMS_ENV_KEY]: '1' }, false)).toEqual({ FOO: 'bar' })
+  })
+  it('does not mutate the input', () => {
+    const env = { [AGENT_TEAMS_ENV_KEY]: '1' }
+    setAgentTeams(env, false)
+    expect(env).toEqual({ [AGENT_TEAMS_ENV_KEY]: '1' })
+  })
+})
+
+describe('env editor round-trip', () => {
+  it('hides the flag from the editor', () => {
+    expect(envWithoutAgentTeams({ FOO: 'bar', [AGENT_TEAMS_ENV_KEY]: '1' })).toEqual({ FOO: 'bar' })
+  })
+  it('keeps the flag when the editor commits without it', () => {
+    const prev = { FOO: 'bar', [AGENT_TEAMS_ENV_KEY]: '1' }
+    expect(mergeEnvKeepingAgentTeams(prev, { FOO: 'baz' })).toEqual({ FOO: 'baz', [AGENT_TEAMS_ENV_KEY]: '1' })
+  })
+  it('leaves the flag absent when it was never set', () => {
+    expect(mergeEnvKeepingAgentTeams({ FOO: 'bar' }, { FOO: 'baz' })).toEqual({ FOO: 'baz' })
+  })
+  it('ignores a stale copy typed into the editor', () => {
+    const prev = { [AGENT_TEAMS_ENV_KEY]: '1' }
+    expect(mergeEnvKeepingAgentTeams(prev, { [AGENT_TEAMS_ENV_KEY]: '0' })).toEqual({ [AGENT_TEAMS_ENV_KEY]: '1' })
+  })
+})

--- a/codey-mac/src/components/agentTeams.ts
+++ b/codey-mac/src/components/agentTeams.ts
@@ -1,0 +1,46 @@
+// Claude Code hides its multi-agent "Agent Teams" mode behind an experimental
+// env flag (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, equivalent to the CLI's
+// `--agent-teams`). The gateway already forwards each agent's configured env
+// to the spawned CLI, so the switch in Agents settings is just a nicer face on
+// that one variable — these helpers keep it out of the raw env editor so the
+// same key can't be edited from two places at once.
+export const AGENT_TEAMS_ENV_KEY = 'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'
+
+// The agent slot whose CLI understands the flag. Other agents never show it.
+export const AGENT_TEAMS_AGENT = 'claude-code'
+
+type Env = Record<string, string>
+
+// Claude Code treats the variable as set/unset, but a user who typed it by
+// hand may well have written `0` or `false` — read those as off.
+export function isAgentTeamsOn(env: Env | undefined): boolean {
+  const v = (env ?? {})[AGENT_TEAMS_ENV_KEY]
+  if (v === undefined) return false
+  const t = v.trim().toLowerCase()
+  return t !== '' && t !== '0' && t !== 'false'
+}
+
+// Off removes the key rather than writing `0`, so turning the switch off
+// leaves the env exactly as it was before it was ever turned on.
+export function setAgentTeams(env: Env | undefined, on: boolean): Env {
+  const next = { ...(env ?? {}) }
+  if (on) next[AGENT_TEAMS_ENV_KEY] = '1'
+  else delete next[AGENT_TEAMS_ENV_KEY]
+  return next
+}
+
+// What the raw env editor should show: everything except the switch's key.
+export function envWithoutAgentTeams(env: Env | undefined): Env {
+  const next = { ...(env ?? {}) }
+  delete next[AGENT_TEAMS_ENV_KEY]
+  return next
+}
+
+// The env editor only ever sees the filtered rows, so committing its result
+// verbatim would silently clear the flag. Carry the previous value across.
+export function mergeEnvKeepingAgentTeams(prev: Env | undefined, edited: Env): Env {
+  const next = envWithoutAgentTeams(edited)
+  const flag = (prev ?? {})[AGENT_TEAMS_ENV_KEY]
+  if (flag !== undefined) next[AGENT_TEAMS_ENV_KEY] = flag
+  return next
+}


### PR DESCRIPTION
Claude Code gates its multi-agent teammate mode behind an experimental env flag — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, the same thing the CLI's `--agent-teams` does. The gateway already forwards each agent's configured env to the spawned CLI, so this is a nicer face on that one variable rather than new plumbing.

**What changed**

- Agents settings → `claude-code` now has an **Agent Teams** toggle, marked experimental.
- On writes `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` into that agent's env. Off deletes the key rather than writing `0`, so the env goes back to exactly what it was before the switch was ever touched.
- The key is hidden from the raw env editor for `claude-code`, so the same fact can't be edited from two places and disagree. The editor's commits carry the flag across instead of silently clearing it.
- A hand-written `0`/`false`/empty value reads as off.
- Only `claude-code` shows the switch — no other agent CLI understands the flag.
- Drive-by: the tab's three near-identical "merge slot, setState, send" blocks collapsed into one `saveSlot` helper.

**Testing**

- `agentTeams.test.ts` — 10 tests covering on/off reads, set/unset, no input mutation, and the env-editor round trip. All pass.
- `tsc --noEmit` clean for these files.
- Not yet exercised in the packaged Mac app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)