### PR TITLE
fix(mac): remove white gap around skills overlay

### DIFF
--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -641,7 +641,10 @@ const iconBtn: React.CSSProperties = {
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  root: { height: '100%', overflowY: 'auto', position: 'relative' },
+  root: {
+    height: '100%', overflowY: 'auto', position: 'relative',
+    padding: 20, boxSizing: 'border-box',
+  },
   agentHeader: {
     display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
     gap: 16, marginBottom: 18, flexWrap: 'wrap',

--- a/codey-mac/src/components/ToolsView.tsx
+++ b/codey-mac/src/components/ToolsView.tsx
@@ -70,7 +70,7 @@ export const ToolsView: React.FC<Props> = ({ onClose }) => {
           </button>
         )}
       </div>
-      <div style={styles.body}>
+      <div style={{ ...styles.body, ...(tab === 'skills' ? styles.skillsBody : null) }}>
         {tab === 'skills' && <SkillsTab addRequest={addSkillRequest} searchQuery={searchQuery} />}
         {tab === 'playbooks' && <PlaybooksTab searchQuery={searchQuery} />}
         {tab === 'plugins' && <PluginsTab searchQuery={searchQuery} />}
@@ -110,4 +110,5 @@ const styles: Record<string, React.CSSProperties> = {
   },
   addSkillBtn: { display: 'inline-flex', alignItems: 'center', gap: 6, border: 'none', borderRadius: 9, padding: '9px 12px', color: C.onAccent, background: C.accent, cursor: 'pointer', fontSize: 12, fontWeight: 700, boxShadow: `0 5px 13px ${C.accentDim}` },
   body: { flex: 1, overflowY: 'auto', padding: 20, background: C.bg },
+  skillsBody: { padding: 0 },
 }


### PR DESCRIPTION
## Summary

- let the Skills view dark overlay fill the full content area
- move the existing 20px spacing into the Skills tab content so the page layout stays unchanged

## Verification

- `npm run build`