### PR TITLE
Show agent memory, and share one knowledge base across agents

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -19,6 +19,8 @@ import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
 import type { ScannedSkill } from './skills'
+import { AGENT_MEMORY, scanProjectMemory, scanUserMemory } from './memory'
+import { readSharedMemory, sharedMemoryPath, sharedMemoryTargets, syncSharedMemory, writeSharedMemory } from './shared-memory'
 import { scanSkillUsage } from './skill-usage'
 import type { SkillUsageMap, UsageCacheEntry } from './skill-usage'
 import { BROWSER_PARTITION, BrowserController, type BrowserBounds } from './browser-controller'
@@ -3715,6 +3717,97 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('skills:reveal', async (_e, dir: string) =>
     wrap(async () => { shell.showItemInFolder(dir) })
+  )
+
+  // ── Agent memory IPC ──────────────────────────────────────────────
+  // Read-only: the instruction files each agent CLI loads by itself. User
+  // memory (what an agent knows about the user, everywhere) is shown in the
+  // Agents settings; project memory belongs to a workspace.
+  function agentEnv(agent: string): Record<string, string> {
+    return coreConfigManager?.get().agents?.[agent as keyof ReturnType<ConfigManager['get']>['agents']]?.env ?? {}
+  }
+
+  ipcMain.handle('memory:user', async () =>
+    wrap(async () => {
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const osMod = await import('os')
+      const home = osMod.homedir()
+      return {
+        agents: Object.keys(AGENT_MEMORY).map(agent => ({
+          agent,
+          entries: scanUserMemory(fsMod, pathMod, agent, home, agentEnv(agent)),
+        })),
+      }
+    })
+  )
+
+  // ── Shared memory ─────────────────────────────────────────────────
+  // One text Codey owns, mirrored into every agent's own global memory file
+  // inside a marked block. Off until the user opts in, because the sync
+  // writes into files the user owns.
+  async function sharedMemoryState() {
+    const fsMod = await import('fs')
+    const pathMod = await import('path')
+    const osMod = await import('os')
+    const home = osMod.homedir()
+    const enabled = coreConfigManager?.get().sharedMemory?.enabled === true
+    return {
+      fsMod, pathMod, home, enabled,
+      content: readSharedMemory(fsMod, pathMod, home),
+      targets: sharedMemoryTargets(pathMod, home, agentEnv),
+    }
+  }
+
+  /** Push the current text (or clear it when disabled) into every agent file. */
+  async function applySharedMemory(): Promise<string[]> {
+    const { fsMod, pathMod, enabled, content, targets } = await sharedMemoryState()
+    return syncSharedMemory(fsMod, pathMod, targets, enabled ? content : '').written
+  }
+  // Agents read their memory files from disk when they spawn, so one sync per
+  // launch keeps the shared block current everywhere.
+  try {
+    await applySharedMemory()
+  } catch { /* best-effort: a stale block must not break startup */ }
+
+  ipcMain.handle('memory:shared:get', async () =>
+    wrap(async () => {
+      const { pathMod, home, enabled, content, targets } = await sharedMemoryState()
+      return { enabled, content, path: sharedMemoryPath(pathMod, home), targets }
+    })
+  )
+
+  ipcMain.handle('memory:shared:set', async (_e, content: string) =>
+    wrap(async () => {
+      const { fsMod, pathMod, home } = await sharedMemoryState()
+      writeSharedMemory(fsMod, pathMod, home, content)
+      return { synced: await applySharedMemory() }
+    })
+  )
+
+  ipcMain.handle('memory:shared:setEnabled', async (_e, enabled: boolean) =>
+    wrap(async () => {
+      if (!coreConfigManager) throw new Error('Config manager not initialized')
+      coreConfigManager.update({ sharedMemory: { enabled } })
+      return { synced: await applySharedMemory() }
+    })
+  )
+
+  ipcMain.handle('memory:project', async (_e, workspace?: string) =>
+    wrap(async () => {
+      const fsMod = await import('fs')
+      const pathMod = await import('path')
+      const osMod = await import('os')
+      const home = osMod.homedir()
+      const workingDir = getWorkingDir(fsMod, pathMod, workspace)
+      const agents = workingDir
+        ? Object.keys(AGENT_MEMORY).map(agent => ({
+            agent,
+            entries: scanProjectMemory(fsMod, pathMod, agent, home, agentEnv(agent), workingDir),
+          }))
+        : []
+      return { agents, workingDir }
+    })
   )
 
   // ── Playbooks (crystallizer SkillStore) — distinct from skills:* above,

--- a/codey-mac/electron/memory.test.ts
+++ b/codey-mac/electron/memory.test.ts
@@ -1,0 +1,153 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  AGENT_MEMORY,
+  MAX_MEMORY_BYTES,
+  claudeProjectSlug,
+  projectMemoryDirs,
+  scanProjectMemory,
+  scanUserMemory,
+  userMemoryFiles,
+} from './memory'
+
+const roots: string[] = []
+const temp = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-agent-memory-'))
+  roots.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+})
+
+const write = (file: string, body: string) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, body)
+}
+
+describe('agent memory locations', () => {
+  it('covers every agent Codey can route to', () => {
+    expect(Object.keys(AGENT_MEMORY).sort()).toEqual(['claude-code', 'codex', 'opencode', 'pi'])
+  })
+
+  it('slugs a project path the way Claude Code does', () => {
+    expect(claudeProjectSlug('/Users/test/Documents/projects/codey'))
+      .toBe('-Users-test-Documents-projects-codey')
+  })
+
+  it('prefers a configured config dir over the default user file', () => {
+    const files = userMemoryFiles(path, 'claude-code', '/Users/test', { CLAUDE_CONFIG_DIR: '~/alt' })
+    expect(files[0]).toBe('/Users/test/alt/CLAUDE.md')
+    expect(files).toContain('/Users/test/.claude/CLAUDE.md')
+  })
+
+  it('resolves each agent default user file', () => {
+    const home = '/Users/test'
+    expect(userMemoryFiles(path, 'codex', home, {})).toEqual([`${home}/.codex/AGENTS.md`])
+    expect(userMemoryFiles(path, 'opencode', home, {})).toEqual([`${home}/.config/opencode/AGENTS.md`])
+    expect(userMemoryFiles(path, 'pi', home, {})).toEqual([`${home}/.pi/agent/AGENTS.md`])
+    expect(userMemoryFiles(path, 'opencode', home, { XDG_CONFIG_HOME: '/xdg' })[0])
+      .toBe('/xdg/opencode/AGENTS.md')
+  })
+
+  it('only claude-code has per-project memory directories', () => {
+    const home = '/Users/test'
+    expect(projectMemoryDirs(path, 'claude-code', home, {}, '/repo/app')).toEqual([
+      `${home}/.claude/projects/-repo-app/memory`,
+      '/repo/app/.claude/agent-memory',
+      '/repo/app/.claude/agent-memory-local',
+    ])
+    expect(projectMemoryDirs(path, 'codex', home, {}, '/repo/app')).toEqual([])
+  })
+})
+
+describe('scanUserMemory', () => {
+  it('reads only the global file, never the project or auto-memory ones', () => {
+    const home = temp()
+    const project = temp()
+    write(path.join(home, '.claude', 'CLAUDE.md'), 'global rules')
+    write(path.join(home, '.claude', 'projects', claudeProjectSlug(project), 'memory', 'a.md'), 'per project')
+    write(path.join(project, 'CLAUDE.md'), 'project rules')
+
+    const entries = scanUserMemory(fs, path, 'claude-code', home, {})
+    expect(entries.map(e => `${e.scope}:${e.label}`)).toEqual(['user:CLAUDE.md'])
+    expect(entries[0].content).toBe('global rules')
+  })
+
+  it('is empty when the agent has no global file yet', () => {
+    expect(scanUserMemory(fs, path, 'codex', temp(), {})).toEqual([])
+  })
+
+  it('truncates a very large memory file', () => {
+    const home = temp()
+    write(path.join(home, '.codex', 'AGENTS.md'), 'x'.repeat(MAX_MEMORY_BYTES + 10))
+    const entries = scanUserMemory(fs, path, 'codex', home, {})
+    expect(entries[0].truncated).toBe(true)
+    expect(entries[0].content).toHaveLength(MAX_MEMORY_BYTES)
+    expect(entries[0].bytes).toBe(MAX_MEMORY_BYTES + 10)
+  })
+})
+
+describe('scanProjectMemory', () => {
+  it('lists repository files, auto-memory and subagent memory for claude-code', () => {
+    const home = temp()
+    const project = temp()
+    write(path.join(home, '.claude', 'CLAUDE.md'), 'global rules')
+    const memDir = path.join(home, '.claude', 'projects', claudeProjectSlug(project), 'memory')
+    write(path.join(memDir, 'MEMORY.md'), '- index')
+    write(path.join(memDir, 'node-version.md'), 'use v22')
+    write(path.join(memDir, 'notes.txt'), 'ignored')
+    write(path.join(project, 'CLAUDE.md'), 'project rules')
+    write(path.join(project, '.claude', 'agent-memory', 'agent-architect', 'style.md'), 'shared')
+    write(path.join(project, '.claude', 'agent-memory-local', 'agent-architect', 'box.md'), 'local only')
+
+    const entries = scanProjectMemory(fs, path, 'claude-code', home, {}, project)
+    expect(entries.map(e => e.label)).toEqual([
+      'CLAUDE.md',
+      'memory/MEMORY.md',
+      'memory/node-version.md',
+      'agent-memory/agent-architect/style.md',
+      'agent-memory-local/agent-architect/box.md',
+    ])
+    expect(entries.every(e => e.scope === 'project')).toBe(true)
+    expect(entries.some(e => e.content === 'global rules')).toBe(false)
+  })
+
+  it('skips files that do not exist', () => {
+    const project = temp()
+    write(path.join(project, 'AGENTS.md'), 'codex rules')
+    const entries = scanProjectMemory(fs, path, 'codex', temp(), {}, project)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ scope: 'project', label: 'AGENTS.md', content: 'codex rules' })
+  })
+
+  it('reports nothing for an agent without memory files', () => {
+    expect(scanProjectMemory(fs, path, 'unknown-agent', temp(), {}, temp())).toEqual([])
+  })
+
+  it('lists only the override file for pi when one exists', () => {
+    const project = temp()
+    write(path.join(project, 'AGENTS.md'), 'normal')
+    write(path.join(project, 'CLAUDE.md'), 'normal too')
+    write(path.join(project, 'AGENTS.override.md'), 'override wins')
+    const labels = scanProjectMemory(fs, path, 'pi', temp(), {}, project).map(e => e.label)
+    expect(labels).toEqual(['AGENTS.override.md'])
+  })
+
+  it('lists the normal pi context files when no override exists', () => {
+    const project = temp()
+    write(path.join(project, 'AGENTS.md'), 'normal')
+    write(path.join(project, 'CLAUDE.md'), 'also read')
+    const labels = scanProjectMemory(fs, path, 'pi', temp(), {}, project).map(e => e.label)
+    expect(labels).toEqual(['AGENTS.md', 'CLAUDE.md'])
+  })
+
+  it('ignores an empty subagent memory directory', () => {
+    const project = temp()
+    fs.mkdirSync(path.join(project, '.claude', 'agent-memory', 'agent-architect'), { recursive: true })
+    expect(scanProjectMemory(fs, path, 'claude-code', temp(), {}, project)).toEqual([])
+  })
+})

--- a/codey-mac/electron/memory.ts
+++ b/codey-mac/electron/memory.ts
@@ -1,0 +1,255 @@
+import type * as Fs from 'fs'
+import type * as Path from 'path'
+import { resolveUserPath } from './skills'
+
+/**
+ * Agent "memory" — the instruction files each CLI loads on its own before a
+ * prompt is sent. Every agent Codey drives supports at least one such file:
+ *
+ *   claude-code  ~/.claude/CLAUDE.md, <project>/CLAUDE.md (+ its auto-memory
+ *                directory ~/.claude/projects/<slug>/memory/*.md)
+ *   codex        ~/.codex/AGENTS.md, <project>/AGENTS.md
+ *   opencode     ~/.config/opencode/AGENTS.md, <project>/AGENTS.md
+ *   pi           ~/.pi/agent/AGENTS.md, <project>/AGENTS.md or CLAUDE.md
+ *
+ * This module only reads: memory is owned by the CLIs and by the user.
+ */
+
+export type MemoryScope = 'user' | 'project'
+
+export interface MemoryEntry {
+  scope: MemoryScope
+  /** Absolute path of the file. */
+  path: string
+  /** Short label shown in the UI, e.g. "CLAUDE.md" or "memory/node.md". */
+  label: string
+  bytes: number
+  mtimeMs: number
+  /** File contents, capped at MAX_MEMORY_BYTES. */
+  content: string
+  truncated: boolean
+}
+
+export interface AgentMemorySpec {
+  /** Files below the user's home directory, most global first. */
+  userFiles: string[]
+  /** Files below the workspace working directory. */
+  projectFiles: string[]
+  /** Directories of loose memory files below the home directory. */
+  userDirs?: string[]
+}
+
+/** Read no more than this per file — memory files are prose, not payloads. */
+export const MAX_MEMORY_BYTES = 20000
+/** Cap on files listed from one memory directory. */
+export const MAX_DIR_FILES = 200
+
+export const AGENT_MEMORY: Record<string, AgentMemorySpec> = {
+  'claude-code': {
+    userFiles: ['.claude/CLAUDE.md'],
+    projectFiles: ['CLAUDE.md', 'CLAUDE.local.md', '.claude/CLAUDE.md'],
+  },
+  'codex': {
+    userFiles: ['.codex/AGENTS.md'],
+    projectFiles: ['AGENTS.md'],
+  },
+  'opencode': {
+    userFiles: ['.config/opencode/AGENTS.md'],
+    projectFiles: ['AGENTS.md', '.opencode/AGENTS.md'],
+  },
+  'pi': {
+    // pi prefers AGENTS.override.md when a directory has one.
+    userFiles: ['.pi/agent/AGENTS.md'],
+    projectFiles: ['AGENTS.override.md', 'AGENTS.md', 'CLAUDE.md'],
+  },
+}
+
+/**
+ * Claude Code stores a project's auto-memory under a slug of its absolute
+ * path, with every non-alphanumeric character replaced by a dash.
+ */
+export function claudeProjectSlug(workingDir: string): string {
+  return workingDir.replace(/[^a-zA-Z0-9]/g, '-')
+}
+
+/** Home-directory root an agent's user-level config lives under, honouring env overrides. */
+export function agentConfigRoot(
+  pathMod: typeof Path,
+  agent: string,
+  home: string,
+  env: Record<string, string>,
+): string | null {
+  if (agent === 'claude-code' && env.CLAUDE_CONFIG_DIR) {
+    return resolveUserPath(pathMod, env.CLAUDE_CONFIG_DIR, home)
+  }
+  if (agent === 'codex' && env.CODEX_HOME) {
+    return resolveUserPath(pathMod, env.CODEX_HOME, home)
+  }
+  if (agent === 'opencode' && env.XDG_CONFIG_HOME) {
+    return pathMod.join(resolveUserPath(pathMod, env.XDG_CONFIG_HOME, home), 'opencode')
+  }
+  return null
+}
+
+/** Absolute user-scope memory files for an agent, most global first. */
+export function userMemoryFiles(
+  pathMod: typeof Path,
+  agent: string,
+  home: string,
+  env: Record<string, string>,
+): string[] {
+  const spec = AGENT_MEMORY[agent]
+  if (!spec) return []
+  const root = agentConfigRoot(pathMod, agent, home, env)
+  const files = spec.userFiles.map(rel => pathMod.join(home, rel))
+  if (!root) return files
+  // An override replaces the default location rather than adding to it.
+  const overridden = spec.userFiles.map(rel => pathMod.join(root, pathMod.basename(rel)))
+  return [...overridden, ...files.filter(f => !overridden.includes(f))]
+}
+
+/**
+ * Per-project memory directories claude-code keeps for a working directory:
+ * its own auto-memory (kept under the home config dir but keyed by project
+ * path) and the subagent memory dirs that live inside the repository.
+ */
+export function projectMemoryDirs(
+  pathMod: typeof Path,
+  agent: string,
+  home: string,
+  env: Record<string, string>,
+  workingDir: string,
+): string[] {
+  if (agent !== 'claude-code') return []
+  const root = agentConfigRoot(pathMod, agent, home, env) ?? pathMod.join(home, '.claude')
+  return [
+    pathMod.join(root, 'projects', claudeProjectSlug(workingDir), 'memory'),
+    // Official subagent memory: agent-memory is committed, -local is not.
+    pathMod.join(workingDir, '.claude', 'agent-memory'),
+    pathMod.join(workingDir, '.claude', 'agent-memory-local'),
+  ]
+}
+
+function readEntry(
+  fsMod: typeof Fs,
+  file: string,
+  scope: MemoryScope,
+  label: string,
+): MemoryEntry | null {
+  let stat: Fs.Stats
+  try {
+    stat = fsMod.statSync(file)
+  } catch { return null }
+  if (!stat.isFile()) return null
+  let content = ''
+  try {
+    content = fsMod.readFileSync(file, 'utf-8')
+  } catch { return null }
+  const truncated = content.length > MAX_MEMORY_BYTES
+  return {
+    scope,
+    path: file,
+    label,
+    bytes: stat.size,
+    mtimeMs: stat.mtimeMs,
+    content: truncated ? content.slice(0, MAX_MEMORY_BYTES) : content,
+    truncated,
+  }
+}
+
+/**
+ * Markdown files inside a memory directory, name-sorted. Subagent memory nests
+ * one level deeper (agent-memory/<agent>/note.md), so a shallow tree is walked
+ * and labels stay relative to the directory the scan started from.
+ */
+export function scanMemoryDir(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  dir: string,
+  scope: MemoryScope,
+  depth = 1,
+): MemoryEntry[] {
+  let names: string[]
+  try {
+    names = fsMod.readdirSync(dir)
+  } catch { return [] }
+  const base = pathMod.basename(dir)
+  const files: MemoryEntry[] = []
+  for (const name of names.sort((a, b) => a.localeCompare(b))) {
+    if (files.length >= MAX_DIR_FILES) break
+    const full = pathMod.join(dir, name)
+    if (name.toLowerCase().endsWith('.md')) {
+      const entry = readEntry(fsMod, full, scope, `${base}/${name}`)
+      if (entry) files.push(entry)
+      continue
+    }
+    if (depth <= 0 || name.startsWith('.')) continue
+    let isDir = false
+    try { isDir = fsMod.statSync(full).isDirectory() } catch { continue }
+    if (!isDir) continue
+    for (const nested of scanMemoryDir(fsMod, pathMod, full, scope, depth - 1)) {
+      files.push({ ...nested, label: `${base}/${nested.label}` })
+    }
+  }
+  return files.slice(0, MAX_DIR_FILES)
+}
+
+/**
+ * What an agent knows about the USER, independent of any project: the one
+ * global instruction file each CLI reads from the home directory.
+ */
+export function scanUserMemory(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  agent: string,
+  home: string,
+  env: Record<string, string>,
+): MemoryEntry[] {
+  if (!AGENT_MEMORY[agent]) return []
+  const entries: MemoryEntry[] = []
+  const seen = new Set<string>()
+  for (const file of userMemoryFiles(pathMod, agent, home, env)) {
+    if (seen.has(file)) continue
+    seen.add(file)
+    const entry = readEntry(fsMod, file, 'user', pathMod.basename(file))
+    if (entry) entries.push(entry)
+  }
+  return entries
+}
+
+/**
+ * What an agent knows about ONE project: the repository's own instruction
+ * files plus, for claude-code, its per-project memory directories.
+ */
+export function scanProjectMemory(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  agent: string,
+  home: string,
+  env: Record<string, string>,
+  workingDir: string,
+): MemoryEntry[] {
+  const spec = AGENT_MEMORY[agent]
+  if (!spec) return []
+  const seen = new Set<string>()
+  const entries: MemoryEntry[] = []
+  const push = (entry: MemoryEntry | null) => {
+    if (!entry || seen.has(entry.path)) return
+    seen.add(entry.path)
+    entries.push(entry)
+  }
+
+  // pi loads AGENTS.override.md *instead of* the other context files in a
+  // directory, so listing them all would misreport what pi actually reads.
+  const override = agent === 'pi'
+    && spec.projectFiles.includes('AGENTS.override.md')
+    && fsMod.existsSync(pathMod.join(workingDir, 'AGENTS.override.md'))
+  const files = override ? ['AGENTS.override.md'] : spec.projectFiles.filter(rel => rel !== 'AGENTS.override.md')
+  for (const rel of files) {
+    push(readEntry(fsMod, pathMod.join(workingDir, rel), 'project', rel))
+  }
+  for (const dir of projectMemoryDirs(pathMod, agent, home, env, workingDir)) {
+    for (const entry of scanMemoryDir(fsMod, pathMod, dir, 'project')) push(entry)
+  }
+  return entries
+}

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -136,6 +136,15 @@ contextBridge.exposeInMainWorld('codey', {
     setEnabled: (dir: string, enabled: boolean) => ipcRenderer.invoke('skills:setEnabled', dir, enabled),
     reveal: (dir: string) => ipcRenderer.invoke('skills:reveal', dir),
   },
+  memory: {
+    user: () => ipcRenderer.invoke('memory:user'),
+    project: (workspace?: string) => ipcRenderer.invoke('memory:project', workspace),
+    shared: {
+      get: () => ipcRenderer.invoke('memory:shared:get'),
+      set: (content: string) => ipcRenderer.invoke('memory:shared:set', content),
+      setEnabled: (enabled: boolean) => ipcRenderer.invoke('memory:shared:setEnabled', enabled),
+    },
+  },
   playbooks: {
     list: () => ipcRenderer.invoke('playbooks:list'),
     detail: (workspace: string, name: string) => ipcRenderer.invoke('playbooks:detail', workspace, name),

--- a/codey-mac/electron/shared-memory.test.ts
+++ b/codey-mac/electron/shared-memory.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  BLOCK_BEGIN,
+  BLOCK_END,
+  applyManagedBlock,
+  hasManagedBlock,
+  readSharedMemory,
+  sharedMemoryPath,
+  sharedMemoryTargets,
+  syncSharedMemory,
+  writeSharedMemory,
+} from './shared-memory'
+
+const roots: string[] = []
+const temp = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-shared-memory-'))
+  roots.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+})
+
+const noEnv = () => ({})
+
+describe('applyManagedBlock', () => {
+  it('appends the block after the user own text', () => {
+    const out = applyManagedBlock('# My rules\nBe brief.\n', 'Shared fact.')
+    expect(out.startsWith('# My rules\nBe brief.\n\n')).toBe(true)
+    expect(out).toContain(BLOCK_BEGIN)
+    expect(out).toContain('Shared fact.')
+    expect(out.trimEnd().endsWith(BLOCK_END)).toBe(true)
+  })
+
+  it('replaces only the block and keeps text on both sides', () => {
+    const first = applyManagedBlock('Top.\n', 'v1')
+    const withTail = `${first}\nBottom.\n`
+    const second = applyManagedBlock(withTail, 'v2')
+    expect(second).toContain('Top.')
+    expect(second).toContain('Bottom.')
+    expect(second).toContain('v2')
+    expect(second).not.toContain('v1')
+    expect(second.match(new RegExp(BLOCK_BEGIN, 'g'))).toHaveLength(1)
+  })
+
+  it('removes the block when the body is empty, keeping the user text', () => {
+    const withBlock = applyManagedBlock('Top.\n', 'shared')
+    const out = applyManagedBlock(withBlock, '')
+    expect(hasManagedBlock(out)).toBe(false)
+    expect(out.trim()).toBe('Top.')
+  })
+
+  it('returns an empty string when the block was the whole file', () => {
+    const withBlock = applyManagedBlock('', 'shared')
+    expect(applyManagedBlock(withBlock, '')).toBe('')
+  })
+
+  it('leaves a file without a block untouched when the body is empty', () => {
+    expect(applyManagedBlock('Just my notes.\n', '   ')).toBe('Just my notes.\n')
+  })
+
+  it('creates the file content from nothing', () => {
+    const out = applyManagedBlock('', 'shared')
+    expect(out.startsWith(BLOCK_BEGIN)).toBe(true)
+    expect(out).toContain('shared')
+  })
+})
+
+describe('sharedMemoryTargets', () => {
+  it('points at each agent global memory file', () => {
+    expect(sharedMemoryTargets(path, '/Users/test', noEnv)).toEqual([
+      { agent: 'claude-code', path: '/Users/test/.claude/CLAUDE.md' },
+      { agent: 'codex', path: '/Users/test/.codex/AGENTS.md' },
+      { agent: 'opencode', path: '/Users/test/.config/opencode/AGENTS.md' },
+      { agent: 'pi', path: '/Users/test/.pi/agent/AGENTS.md' },
+    ])
+  })
+
+  it('follows an agent configured config dir', () => {
+    const env = (agent: string): Record<string, string> => agent === 'codex' ? { CODEX_HOME: '/alt/codex' } : {}
+    const targets = sharedMemoryTargets(path, '/Users/test', env)
+    expect(targets.find(t => t.agent === 'codex')?.path).toBe('/alt/codex/AGENTS.md')
+  })
+})
+
+describe('syncSharedMemory', () => {
+  it('writes the block into every agent file, creating missing ones', () => {
+    const home = temp()
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true })
+    fs.writeFileSync(path.join(home, '.claude', 'CLAUDE.md'), 'My own rules.\n')
+
+    const targets = sharedMemoryTargets(path, home, noEnv)
+    const result = syncSharedMemory(fs, path, targets, 'Always use tabs.')
+    expect(result.written).toHaveLength(4)
+
+    for (const target of targets) {
+      const text = fs.readFileSync(target.path, 'utf-8')
+      expect(text).toContain('Always use tabs.')
+    }
+    expect(fs.readFileSync(path.join(home, '.claude', 'CLAUDE.md'), 'utf-8')).toContain('My own rules.')
+  })
+
+  it('is a no-op on a second run with the same body', () => {
+    const home = temp()
+    const targets = sharedMemoryTargets(path, home, noEnv)
+    syncSharedMemory(fs, path, targets, 'Same text.')
+    const again = syncSharedMemory(fs, path, targets, 'Same text.')
+    expect(again.written).toEqual([])
+    expect(again.unchanged).toHaveLength(4)
+  })
+
+  it('removes the block and deletes files it fully owned', () => {
+    const home = temp()
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true })
+    fs.writeFileSync(path.join(home, '.claude', 'CLAUDE.md'), 'Keep me.\n')
+    const targets = sharedMemoryTargets(path, home, noEnv)
+    syncSharedMemory(fs, path, targets, 'Shared.')
+
+    syncSharedMemory(fs, path, targets, '')
+
+    const claude = fs.readFileSync(path.join(home, '.claude', 'CLAUDE.md'), 'utf-8')
+    expect(claude.trim()).toBe('Keep me.')
+    expect(fs.existsSync(path.join(home, '.codex', 'AGENTS.md'))).toBe(false)
+  })
+
+  it('never creates a file for an empty body', () => {
+    const home = temp()
+    const targets = sharedMemoryTargets(path, home, noEnv)
+    expect(syncSharedMemory(fs, path, targets, '').written).toEqual([])
+    expect(fs.existsSync(path.join(home, '.codex', 'AGENTS.md'))).toBe(false)
+  })
+})
+
+describe('the Codey-owned file', () => {
+  it('round-trips through write and read', () => {
+    const home = temp()
+    expect(readSharedMemory(fs, path, home)).toBe('')
+    const file = writeSharedMemory(fs, path, home, 'Team knowledge.')
+    expect(file).toBe(sharedMemoryPath(path, home))
+    expect(readSharedMemory(fs, path, home)).toBe('Team knowledge.')
+  })
+})

--- a/codey-mac/electron/shared-memory.ts
+++ b/codey-mac/electron/shared-memory.ts
@@ -1,0 +1,148 @@
+import type * as Fs from 'fs'
+import type * as Path from 'path'
+import { AGENT_MEMORY, userMemoryFiles } from './memory'
+
+/**
+ * Shared knowledge: one text Codey owns, mirrored into every agent's own
+ * global memory file so all four CLIs read the same thing.
+ *
+ * The mirror is a marked block rather than a whole-file copy, because those
+ * files belong to the user — anything outside the markers is never touched.
+ * Symlinking is deliberately avoided: an agent's global memory is a single
+ * file the user also writes to, so it cannot be replaced by a link.
+ *
+ * Syncing is one-way (Codey → agents). Nothing an agent writes flows back.
+ */
+
+export const SHARED_MEMORY_SUBDIR = '.codey/memory'
+export const SHARED_MEMORY_FILENAME = 'MEMORY.md'
+
+export const BLOCK_BEGIN = '<!-- BEGIN CODEY SHARED MEMORY -->'
+export const BLOCK_END = '<!-- END CODEY SHARED MEMORY -->'
+const BLOCK_NOTE = '<!-- Managed by Codey. Edit it in Codey: Settings > Agents > Shared memory. -->'
+
+/** Absolute path of the text the user edits in Codey. */
+export function sharedMemoryPath(pathMod: typeof Path, home: string): string {
+  return pathMod.join(home, ...SHARED_MEMORY_SUBDIR.split('/'), SHARED_MEMORY_FILENAME)
+}
+
+/**
+ * The agent files the block is mirrored into: each agent's effective global
+ * memory file, so an agent-specific config-dir override is respected.
+ */
+export function sharedMemoryTargets(
+  pathMod: typeof Path,
+  home: string,
+  envFor: (agent: string) => Record<string, string>,
+): Array<{ agent: string; path: string }> {
+  return Object.keys(AGENT_MEMORY).flatMap(agent => {
+    const file = userMemoryFiles(pathMod, agent, home, envFor(agent))[0]
+    return file ? [{ agent, path: file }] : []
+  })
+}
+
+function findBlock(text: string): { start: number; end: number } | null {
+  const start = text.indexOf(BLOCK_BEGIN)
+  if (start < 0) return null
+  const endMarker = text.indexOf(BLOCK_END, start)
+  if (endMarker < 0) return null
+  return { start, end: endMarker + BLOCK_END.length }
+}
+
+/** True when a file already carries Codey's block. */
+export function hasManagedBlock(text: string): boolean {
+  return findBlock(text) !== null
+}
+
+/**
+ * Replace, insert, or (with an empty body) drop Codey's block in a file the
+ * user owns. The block is appended at the end so the user's own opening
+ * instructions keep their position.
+ */
+export function applyManagedBlock(existing: string, body: string): string {
+  const trimmedBody = body.trim()
+  const found = findBlock(existing)
+  const block = trimmedBody ? [BLOCK_BEGIN, BLOCK_NOTE, '', trimmedBody, BLOCK_END].join('\n') : ''
+
+  if (found) {
+    const before = existing.slice(0, found.start)
+    const after = existing.slice(found.end)
+    if (!block) {
+      // Removing the block should not leave the blank lines that framed it.
+      const joined = `${before.replace(/\n*$/, '')}\n${after.replace(/^\n*/, '')}`
+      return joined.trim() ? joined.replace(/\n{3,}/g, '\n\n') : ''
+    }
+    return `${before}${block}${after}`
+  }
+
+  if (!block) return existing
+  if (!existing.trim()) return `${block}\n`
+  return `${existing.replace(/\n*$/, '')}\n\n${block}\n`
+}
+
+export interface SharedMemorySyncResult {
+  /** Files the block was written into or removed from. */
+  written: string[]
+  /** Files left untouched because they already matched. */
+  unchanged: string[]
+}
+
+/**
+ * Mirror `body` into every agent's global memory file. An empty body (or a
+ * disabled feature) removes the block again, and deletes a file that Codey's
+ * block was the only content of.
+ */
+export function syncSharedMemory(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  targets: Array<{ agent: string; path: string }>,
+  body: string,
+): SharedMemorySyncResult {
+  const result: SharedMemorySyncResult = { written: [], unchanged: [] }
+  for (const target of targets) {
+    let existing = ''
+    let exists = true
+    try {
+      existing = fsMod.readFileSync(target.path, 'utf-8')
+    } catch { exists = false }
+
+    // Never create a file just to say the shared memory is empty.
+    if (!exists && !body.trim()) continue
+
+    const next = applyManagedBlock(existing, body)
+    if (exists && next === existing) {
+      result.unchanged.push(target.path)
+      continue
+    }
+    if (exists && !next.trim()) {
+      // The block was all the file held — leave no empty leftovers behind.
+      try { fsMod.unlinkSync(target.path) } catch { /* already gone */ }
+      result.written.push(target.path)
+      continue
+    }
+    fsMod.mkdirSync(pathMod.dirname(target.path), { recursive: true })
+    fsMod.writeFileSync(target.path, next, 'utf-8')
+    result.written.push(target.path)
+  }
+  return result
+}
+
+/** Read the shared text, or an empty string when it has never been written. */
+export function readSharedMemory(fsMod: typeof Fs, pathMod: typeof Path, home: string): string {
+  try {
+    return fsMod.readFileSync(sharedMemoryPath(pathMod, home), 'utf-8')
+  } catch { return '' }
+}
+
+/** Write the shared text Codey owns. */
+export function writeSharedMemory(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  home: string,
+  content: string,
+): string {
+  const file = sharedMemoryPath(pathMod, home)
+  fsMod.mkdirSync(pathMod.dirname(file), { recursive: true })
+  fsMod.writeFileSync(file, content, 'utf-8')
+  return file
+}

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -7,6 +7,7 @@ import type { UpdaterEvent } from './hooks/updaterState'
 import type { CoreState } from '../electron/core-state'
 import type { ScannedSkill } from '../electron/skills'
 import type { SkillUsage, SkillUsageMap } from '../electron/skill-usage'
+import type { MemoryEntry } from '../electron/memory'
 import type { Automation, AutomationRun, AutomationEvent } from '../../packages/core/src/types/automation'
 import type { AutomationDraft } from '../../packages/core/src/aide-automation'
 import type { ChatStep } from '../../packages/gateway/src/automations/chat'
@@ -15,6 +16,30 @@ type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
 export type SkillEntry = ScannedSkill
 export type { SkillUsage, SkillUsageMap }
+
+export type { MemoryEntry }
+
+export interface AgentMemoryGroup { agent: string; entries: MemoryEntry[] }
+
+export interface UserMemoryResult {
+  agents: AgentMemoryGroup[]
+}
+
+export interface SharedMemoryResult {
+  /** Whether Codey mirrors the shared text into the agents' own memory files. */
+  enabled: boolean
+  content: string
+  /** Where Codey keeps the shared text. */
+  path: string
+  /** The agent files the text is mirrored into. */
+  targets: Array<{ agent: string; path: string }>
+}
+
+export interface ProjectMemoryResult {
+  agents: AgentMemoryGroup[]
+  /** Working directory the project files were read from, if any. */
+  workingDir: string | null
+}
 
 export interface SkillsListResult {
   skills: SkillEntry[]
@@ -310,6 +335,19 @@ declare global {
         remove: (dir: string) => Promise<IpcResult<void>>
         setEnabled: (dir: string, enabled: boolean) => Promise<IpcResult<void>>
         reveal: (dir: string) => Promise<IpcResult<void>>
+      }
+      memory: {
+        /** Read-only: what each agent knows about the user, in every project. */
+        user: () => Promise<IpcResult<UserMemoryResult>>
+        /** Read-only: what each agent knows about one workspace's project. */
+        project: (workspace?: string) => Promise<IpcResult<ProjectMemoryResult>>
+        /** One knowledge base shared by every agent. */
+        shared: {
+          get: () => Promise<IpcResult<SharedMemoryResult>>
+          /** Saves the text and re-syncs; returns the files written. */
+          set: (content: string) => Promise<IpcResult<{ synced: string[] }>>
+          setEnabled: (enabled: boolean) => Promise<IpcResult<{ synced: string[] }>>
+        }
       }
       playbooks: {
         /** Aggregated across ALL workspaces — entries are keyed by (workspace, name). */

--- a/codey-mac/src/components/AgentMemorySection.tsx
+++ b/codey-mac/src/components/AgentMemorySection.tsx
@@ -1,0 +1,250 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { C } from '../theme'
+import { Section, Toggle, fieldStyle, pillButton, unwrap } from './settingsAtoms'
+import { formatBytes, memoryPreview, summarizeMemory } from './agentMemoryView'
+import type { AgentMemoryGroup, MemoryEntry } from '../codey-api'
+
+/**
+ * Read-only views of what each agent CLI remembers — the instruction files it
+ * loads on its own before any prompt. Memory splits by who it is about:
+ *
+ *   user     what the agent knows about the user everywhere (~/.claude/CLAUDE.md,
+ *            ~/.codex/AGENTS.md, …) — shown in Settings ▸ Agents.
+ *   project  what it knows about one repository (CLAUDE.md, AGENTS.md, Claude
+ *            Code's per-project memory and subagent memory) — shown on the
+ *            workspace that owns that repository.
+ */
+
+const MemoryRow: React.FC<{ entry: MemoryEntry }> = ({ entry }) => {
+  const [open, setOpen] = useState(false)
+  const preview = memoryPreview(entry.content)
+  return (
+    <div style={{ borderTop: `1px solid ${C.border}`, padding: '8px 0' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          onClick={() => setOpen(o => !o)}
+          style={{ background: 'none', border: 'none', color: C.fg, fontSize: 12, cursor: 'pointer', padding: 0, textAlign: 'left', flex: 1 }}
+          title={entry.path}
+        >
+          <span style={{ color: C.fg3, marginRight: 6 }}>{open ? '▾' : '▸'}</span>
+          {entry.label}
+        </button>
+        <span style={{ color: C.fg3, fontSize: 11 }}>{formatBytes(entry.bytes)}</span>
+        <button
+          onClick={() => void window.codey.skills.reveal(entry.path)}
+          style={{ ...pillButton('ghost'), padding: '3px 8px', fontSize: 11 }}
+          title="Show this file in Finder"
+        >Reveal</button>
+      </div>
+      {!open && preview && (
+        <div style={{ color: C.fg3, fontSize: 11, marginTop: 3, marginLeft: 16, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{preview}</div>
+      )}
+      {open && (
+        <pre style={{
+          margin: '6px 0 0 16px', padding: 10, background: C.surface3, borderRadius: 8,
+          color: C.fg2, fontSize: 11, lineHeight: 1.5, maxHeight: 280, overflow: 'auto', whiteSpace: 'pre-wrap',
+        }}>
+          {entry.content}
+          {entry.truncated && <span style={{ color: C.fg3 }}>{'\n\n… truncated — open the file to read the rest.'}</span>}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+/** One card per agent, with its files below. Agents with nothing are still
+ *  listed so the absence of memory is visible rather than ambiguous. */
+const MemoryGroups: React.FC<{ groups: AgentMemoryGroup[] }> = ({ groups }) => (
+  <>
+    {groups.map(({ agent, entries }) => (
+      <div key={agent} style={{ ...fieldStyle, display: 'block' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+          <span style={{ color: C.fg, fontSize: 13 }}>{agent}</span>
+          <span style={{ color: C.fg3, fontSize: 11 }}>{summarizeMemory(entries)}</span>
+        </div>
+        {entries.map(entry => <MemoryRow key={entry.path} entry={entry} />)}
+      </div>
+    ))}
+  </>
+)
+
+function useMemory(load: () => Promise<AgentMemoryGroup[]>, enabled: boolean) {
+  const [groups, setGroups] = useState<AgentMemoryGroup[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try { setGroups(await load()) }
+    catch (e: any) { setError(e?.message ?? String(e)) }
+    finally { setLoading(false) }
+  }, [load])
+
+  useEffect(() => {
+    if (!enabled) return
+    void reload()
+  }, [enabled, reload])
+
+  return { groups, loading, error, reload }
+}
+
+const ErrorBox: React.FC<{ message: string }> = ({ message }) => (
+  <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{message}</div>
+)
+
+/** Settings ▸ Agents: what each agent knows about the user, in every project. */
+export const UserMemorySection: React.FC<{ isGatewayRunning: boolean }> = ({ isGatewayRunning }) => {
+  const load = useCallback(async () => unwrap(await window.codey.memory.user()).agents, [])
+  const { groups, loading, error, reload } = useMemory(load, isGatewayRunning)
+
+  return (
+    <>
+      <Section
+        title="Memory"
+        description="What each agent has been told about you — the global instruction file it loads in every project. Project memory lives on the workspace."
+        right={
+          <button onClick={() => void reload()} style={pillButton('ghost')} disabled={loading} title="Re-read the memory files from disk">
+            {loading ? 'Reading…' : '↻ Refresh'}
+          </button>
+        }
+      />
+      {error && <ErrorBox message={error} />}
+      <MemoryGroups groups={groups} />
+    </>
+  )
+}
+
+/** Workspaces tab: what each agent knows about this workspace's repository. */
+export const ProjectMemorySection: React.FC<{ workspace: string }> = ({ workspace }) => {
+  const load = useCallback(async () => unwrap(await window.codey.memory.project(workspace)).agents, [workspace])
+  const { groups, loading, error, reload } = useMemory(load, true)
+  const withFiles = groups.filter(g => g.entries.length > 0)
+
+  return (
+    <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 600 }}>Agent memory</div>
+          <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>
+            Instruction files the agents read from this project. Read-only.
+          </div>
+        </div>
+        <button
+          onClick={() => void reload()}
+          disabled={loading}
+          style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, cursor: 'pointer' }}
+        >{loading ? 'Reading…' : '↻ Refresh'}</button>
+      </div>
+      {error && <ErrorBox message={error} />}
+      {!loading && withFiles.length === 0 && !error && (
+        <div style={{ fontSize: 12, color: C.fg3 }}>No agent memory in this project yet.</div>
+      )}
+      <MemoryGroups groups={withFiles} />
+    </div>
+  )
+}
+
+/**
+ * Settings ▸ Agents: one knowledge base every agent reads. Codey keeps the
+ * text and mirrors it into each agent's own global memory file inside a marked
+ * block, so all four CLIs see the same thing. Off until the user opts in —
+ * syncing writes into files the user owns.
+ */
+export const SharedMemorySection: React.FC<{ isGatewayRunning: boolean }> = ({ isGatewayRunning }) => {
+  const [enabled, setEnabled] = useState(false)
+  const [content, setContent] = useState('')
+  const [draft, setDraft] = useState('')
+  const [filePath, setFilePath] = useState('')
+  const [targets, setTargets] = useState<Array<{ agent: string; path: string }>>([])
+  const [loaded, setLoaded] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [savedAt, setSavedAt] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setError(null)
+    try {
+      const res = unwrap(await window.codey.memory.shared.get())
+      setEnabled(res.enabled)
+      setContent(res.content)
+      setDraft(res.content)
+      setFilePath(res.path)
+      setTargets(res.targets)
+      setLoaded(true)
+    } catch (e: any) { setError(e?.message ?? String(e)) }
+  }, [])
+
+  useEffect(() => {
+    if (!isGatewayRunning) return
+    void reload()
+  }, [isGatewayRunning, reload])
+
+  const toggle = async (next: boolean) => {
+    setEnabled(next)
+    setError(null)
+    try { unwrap(await window.codey.memory.shared.setEnabled(next)) }
+    catch (e: any) { setEnabled(!next); setError(e?.message ?? String(e)) }
+  }
+
+  const save = async () => {
+    if (saving || draft === content) return
+    setSaving(true)
+    setError(null)
+    try {
+      unwrap(await window.codey.memory.shared.set(draft))
+      setContent(draft)
+      setSavedAt(Date.now())
+    } catch (e: any) { setError(e?.message ?? String(e)) } finally { setSaving(false) }
+  }
+
+  return (
+    <>
+      <Section
+        title="Shared memory"
+        description="One knowledge base for every agent. Codey mirrors it into each agent's own memory file, inside a marked block — anything you wrote around that block is left alone."
+      />
+      {error && <ErrorBox message={error} />}
+      <div style={{ ...fieldStyle, display: 'block' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+          <div>
+            <div style={{ color: C.fg, fontSize: 13 }}>Share this knowledge with every agent</div>
+            <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>
+              {enabled
+                ? `Synced into ${targets.length} agent file${targets.length === 1 ? '' : 's'} on every launch and every save.`
+                : 'Off — the block is removed from the agent files while this is off.'}
+            </div>
+          </div>
+          <Toggle on={enabled} onChange={v => void toggle(v)} label="Share memory with every agent" />
+        </div>
+
+        <div style={{ marginTop: 12 }}>
+          <textarea
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            spellCheck={false}
+            disabled={!loaded}
+            placeholder="What should every agent know? e.g. how you like commits written, which node version this machine needs."
+            style={{
+              width: '100%', minHeight: 160, resize: 'vertical', boxSizing: 'border-box',
+              background: C.surface3, color: C.fg, border: `1px solid ${C.border2}`, borderRadius: 8,
+              padding: 10, fontSize: 12, outline: 'none',
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            }}
+          />
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, marginTop: 8 }}>
+            <code style={{ color: C.fg3, fontSize: 11 }}>{filePath}</code>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              {savedAt > 0 && Date.now() - savedAt < 4000 && <span style={{ fontSize: 11, color: C.green }}>✓ Saved and synced</span>}
+              <button
+                onClick={() => void save()}
+                disabled={saving || draft === content || !loaded}
+                style={{ ...pillButton('primary'), opacity: (saving || draft === content) ? 0.5 : 1 }}
+              >{saving ? 'Saving…' : 'Save'}</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -8,6 +8,7 @@ import {
   EnvEditor,
 } from './SettingsTab'
 import { refreshInstalledAgents, useInstalledAgents } from './installedAgents'
+import { SharedMemorySection, UserMemorySection } from './AgentMemorySection'
 import {
   AGENT_TEAMS_AGENT,
   envWithoutAgentTeams,
@@ -121,6 +122,10 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
           </div>
         )
       })}
+
+      <UserMemorySection isGatewayRunning={isGatewayRunning} />
+
+      <SharedMemorySection isGatewayRunning={isGatewayRunning} />
     </div>
   )
 }

--- a/codey-mac/src/components/WorkspacesTab.tsx
+++ b/codey-mac/src/components/WorkspacesTab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { apiService } from '../services/api'
 import { C } from '../theme'
 import { emitWorkspacesChanged } from './workspacesChanged'
+import { ProjectMemorySection } from './AgentMemorySection'
 
 interface WorkspacesTabProps {
   isGatewayRunning: boolean
@@ -215,6 +216,10 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning }
 
                     <div style={{ marginTop: 12 }}>
                       <MemorySection workspace={ws} />
+                    </div>
+
+                    <div style={{ marginTop: 12 }}>
+                      <ProjectMemorySection workspace={ws} />
                     </div>
                   </div>
                 )}

--- a/codey-mac/src/components/agentMemoryView.test.ts
+++ b/codey-mac/src/components/agentMemoryView.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { formatBytes, memoryPreview, summarizeMemory } from './agentMemoryView'
+import type { MemoryEntry } from '../codey-api'
+
+const entry = (over: Partial<MemoryEntry>): MemoryEntry => ({
+  scope: 'user', path: '/tmp/CLAUDE.md', label: 'CLAUDE.md',
+  bytes: 100, mtimeMs: 0, content: '', truncated: false, ...over,
+})
+
+describe('formatBytes', () => {
+  it('keeps small files in bytes and drops decimals on bigger ones', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(1023)).toBe('1023 B')
+    expect(formatBytes(2048)).toBe('2.0 KB')
+    expect(formatBytes(40 * 1024)).toBe('40 KB')
+    expect(formatBytes(3 * 1024 * 1024)).toBe('3.0 MB')
+  })
+})
+
+describe('summarizeMemory', () => {
+  it('says so when an agent has no memory', () => {
+    expect(summarizeMemory([])).toBe('No memory files yet')
+  })
+
+  it('spells out the split only when both scopes are present', () => {
+    expect(summarizeMemory([
+      entry({ scope: 'user', bytes: 500 }),
+      entry({ scope: 'user', bytes: 500 }),
+      entry({ scope: 'project', bytes: 24 }),
+    ])).toBe('3 files · 2 user + 1 project · 1.0 KB')
+  })
+
+  it('leaves the split out for a single-scope list', () => {
+    expect(summarizeMemory([
+      entry({ scope: 'project', bytes: 500 }),
+      entry({ scope: 'project', bytes: 524 }),
+    ])).toBe('2 files · 1.0 KB')
+  })
+
+  it('uses the singular for one file', () => {
+    expect(summarizeMemory([entry({ scope: 'project', bytes: 10 })])).toBe('1 file · 10 B')
+  })
+})
+
+describe('memoryPreview', () => {
+  it('skips frontmatter and heading markers', () => {
+    expect(memoryPreview('---\nname: node\n---\n\n# Node version\nuse v22\n')).toBe('Node version')
+  })
+
+  it('strips a bullet marker', () => {
+    expect(memoryPreview('- [Title](file.md) — hook')).toBe('[Title](file.md) — hook')
+  })
+
+  it('truncates a long line', () => {
+    expect(memoryPreview('x'.repeat(200), 10)).toBe('xxxxxxxxx…')
+  })
+
+  it('returns an empty string for an empty file', () => {
+    expect(memoryPreview('')).toBe('')
+  })
+})

--- a/codey-mac/src/components/agentMemoryView.ts
+++ b/codey-mac/src/components/agentMemoryView.ts
@@ -1,0 +1,31 @@
+import type { MemoryEntry } from '../codey-api'
+
+/** Compact size label for a memory file. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/**
+ * One-line summary of what an agent currently remembers. A view usually shows
+ * one scope at a time, so the scope split is only spelled out when both are
+ * present.
+ */
+export function summarizeMemory(entries: MemoryEntry[]): string {
+  if (entries.length === 0) return 'No memory files yet'
+  const total = entries.reduce((sum, e) => sum + e.bytes, 0)
+  const user = entries.filter(e => e.scope === 'user').length
+  const project = entries.length - user
+  const count = `${entries.length} file${entries.length === 1 ? '' : 's'}`
+  const split = user && project ? ` · ${user} user + ${project} project` : ''
+  return `${count}${split} · ${formatBytes(total)}`
+}
+
+/** First non-empty, non-frontmatter line — what the file is about, at a glance. */
+export function memoryPreview(content: string, max = 120): string {
+  const body = content.replace(/^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/, '')
+  const line = body.split('\n').map(l => l.trim()).find(l => l.length > 0) ?? ''
+  const clean = line.replace(/^#+\s*/, '').replace(/^[-*]\s*/, '')
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean
+}

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -81,6 +81,15 @@ export interface GatewayConfigJson {
     induction?: boolean;
   };
   /**
+   * One shared knowledge base that every agent reads. Codey keeps the text in
+   * `~/.codey/memory/MEMORY.md` and mirrors it into each agent's own global
+   * memory file inside a marked block. Off until the user opts in, because
+   * syncing writes into files the user owns.
+   */
+  sharedMemory?: {
+    enabled?: boolean;
+  };
+  /**
    * Global team library. Each entry maps a team name to its members + dispatch
    * mode. Workspaces opt into teams by listing their names in workspace.json's
    * `teams: string[]` field.
@@ -281,6 +290,9 @@ export class ConfigManager extends EventEmitter {
     if (partial.advisor !== undefined) this.config.advisor = partial.advisor;
     if (partial.aide !== undefined) this.config.aide = partial.aide;
     if (partial.teams !== undefined) this.config.teams = partial.teams;
+    if (partial.sharedMemory !== undefined) {
+      this.config.sharedMemory = { ...this.config.sharedMemory, ...partial.sharedMemory };
+    }
     if (partial.plugins !== undefined) {
       this.config.plugins = { ...this.config.plugins, ...partial.plugins };
     }


### PR DESCRIPTION
## What

Every agent Codey drives loads instruction files of its own before a prompt, and none of it was visible from the app:

| agent | user scope | project scope |
| --- | --- | --- |
| claude-code | `~/.claude/CLAUDE.md` | `CLAUDE.md`, `CLAUDE.local.md`, per-project memory (`~/.claude/projects/<slug>/memory/`), subagent memory (`.claude/agent-memory[-local]/<agent>/`) |
| codex | `~/.codex/AGENTS.md` | `AGENTS.md` |
| opencode | `~/.config/opencode/AGENTS.md` | `AGENTS.md`, `.opencode/AGENTS.md` |
| pi | `~/.pi/agent/AGENTS.md` | `AGENTS.override.md`, else `AGENTS.md` / `CLAUDE.md` |

Per-agent config-dir overrides (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `XDG_CONFIG_HOME`) are honoured.

## Changes

**Two read-only views, split by who the memory is about**
- Settings > Agents > **Memory** — what each agent has been told about the user.
- Workspaces > (expand a workspace) > **Agent memory** — what the agents read from that repository. Agents with nothing there are hidden.
- Each file expands to its content, with a Reveal button.

**Settings > Agents > Shared memory** — one knowledge base for every agent
- Codey owns the text in `~/.codey/memory/MEMORY.md` and mirrors it into each agent's global memory file inside a marked block.
- Text outside the block is never touched; a second sync with the same body is a no-op.
- Turning it off removes the block, and deletes a file the block was the sole content of.
- One-way (Codey to agents), synced once per launch and on every save.
- Off by default (`sharedMemory.enabled` in `gateway.json`), because syncing writes into files the user owns.

Symlinking was rejected here: an agent's global memory is a single file the user also writes to, so it cannot be replaced by a link the way `~/.codey/skills` can.

## Testing

- `npm test -w codey-mac` — all suites pass, including 27 new unit tests for path resolution, scanning, and the managed-block edit rules.
- `npx tsc -p codey-mac/tsconfig.json --noEmit` and `vite build` clean on this branch.
- Scans verified against the real home directory and this repo.
- Not yet exercised in the running app: no manual UI pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)