### PR TITLE
Polish skill usage and plugin update UI

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -13,7 +13,7 @@ import { decideAutomationNotification, findUnseenRuns, findUnnotifiedRuns } from
 import { validateAutomationChatPatch, validateAutomationDraft, validateAutomationPatch } from './automation-validate'
 import { applyEvent, clearAttention, summarize } from './tray-state'
 import { AGENT_BINARIES, createInstalledAgentsCache, detectInstalledAgents } from './agent-detect'
-import { SKILL_FILE, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
+import { SKILL_FILE, markSkillManagedBy, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
@@ -3511,7 +3511,12 @@ app.whenReady().then(async () => {
       }
     }
 
-    return { skills: uniqueSkills(fsMod, pathMod, skills), projectDir }
+    let listed = uniqueSkills(fsMod, pathMod, skills)
+    const browser = browserSkillStatus(home)
+    if (browser.origin === 'codey') {
+      listed = markSkillManagedBy(fsMod, pathMod, listed, browser.dir, 'codey')
+    }
+    return { skills: listed, projectDir }
   }
 
   ipcMain.handle('agents:slashCommands', async (_e, agent: string) =>

--- a/codey-mac/electron/skills.test.ts
+++ b/codey-mac/electron/skills.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { qualifySkillName, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
+import { markSkillManagedBy, qualifySkillName, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 
 const roots: string[] = []
 const temp = () => {
@@ -94,6 +94,23 @@ describe('agent skill discovery', () => {
   it('does not duplicate an explicit namespace from frontmatter', () => {
     expect(qualifySkillName(path, '/skills', '/skills/superpowers/brainstorming', 'superpowers:brainstorming'))
       .toBe('superpowers:brainstorming')
+  })
+
+  it('marks a managed skill when it is discovered through a symlink', () => {
+    const root = temp()
+    const managed = path.join(root, 'managed', 'browser')
+    const discovery = path.join(root, 'discovery')
+    fs.mkdirSync(managed, { recursive: true })
+    fs.mkdirSync(discovery, { recursive: true })
+    fs.writeFileSync(path.join(managed, 'SKILL.md'), '---\nname: browser\n---\n')
+    fs.symlinkSync(managed, path.join(discovery, 'browser'), 'dir')
+
+    const skills = scanSkillsDir(fs, path, discovery, 'user')
+    expect(markSkillManagedBy(fs, path, skills, managed, 'codey')[0]).toMatchObject({
+      name: 'browser',
+      qualifiedName: 'browser',
+      managedBy: 'codey',
+    })
   })
 
   it('uses the Claude plugin id as the skill collection namespace', () => {

--- a/codey-mac/electron/skills.ts
+++ b/codey-mac/electron/skills.ts
@@ -197,6 +197,23 @@ export function uniqueSkills(fsMod: typeof Fs, pathMod: typeof Path, skills: Sca
   })
 }
 
+/** Tag one installed skill with the product/plugin that owns its lifecycle.
+ *  Path identity follows symlinks so the same Codey skill is labelled when it
+ *  is viewed through any agent's discovery directory. */
+export function markSkillManagedBy(
+  fsMod: typeof Fs,
+  pathMod: typeof Path,
+  skills: ScannedSkill[],
+  managedDir: string,
+  managedBy: string,
+): ScannedSkill[] {
+  return skills.map(skill => (
+    samePath(fsMod, pathMod, skill.dir, managedDir)
+      ? { ...skill, managedBy }
+      : skill
+  ))
+}
+
 /**
  * Delete the short-lived `~/.codey/managed-skills` root and the discovery links
  * pointing into it. Skills Codey owned on the user's behalf lived there for one

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -26,6 +26,13 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
   )
 
   const checkForUpdate = useCallback(async (plugin: PluginInfo) => {
+    // Hide any stale result while re-checking. If the check cannot complete,
+    // we do not know that an update exists and should not offer the action.
+    setUpdate(prev => {
+      const next = { ...prev }
+      delete next[plugin.id]
+      return next
+    })
     try {
       const result = unwrap(await window.codey.plugins.check(plugin.id))
       setUpdate(prev => ({ ...prev, [plugin.id]: result }))
@@ -119,8 +126,7 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                 <div style={styles.cardHint}>
                   {plugin.state === 'disabled'
                     ? 'Switched off in Skills, so no agent loads it. Turn it back on there.'
-                    : 'Listed in Skills as "browser".'}
-                  {' '}<span style={styles.path}>{plugin.dir}</span>
+                    : 'Listed in Skills as "codey:browser".'}
                   {update[plugin.id]?.needsUpdate === true && (
                     <div style={styles.updateHint}>
                       {update[plugin.id]?.recorded === 'bundled'
@@ -172,14 +178,12 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
                 </>
               ) : (
                 <>
-                  {installed && (
+                  {installed && update[plugin.id]?.needsUpdate === true && (
                     <button
                       onClick={() => { if (!working) void act(plugin, 'install') }}
                       disabled={working}
-                      style={pillButton(update[plugin.id]?.needsUpdate === true ? 'primary' : 'ghost')}
-                      title={update[plugin.id]?.needsUpdate === true
-                        ? 'A newer published version is available — update now'
-                        : 'Download the published skill again, replacing your copy'}
+                      style={pillButton('primary')}
+                      title="A newer published version is available — update now"
                     >
                       Update
                     </button>

--- a/codey-mac/src/components/SkillsTab.tsx
+++ b/codey-mac/src/components/SkillsTab.tsx
@@ -4,7 +4,7 @@ import { pillButton, Toggle, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
 import { WorkspaceSelect } from './WorkspaceSelect'
-import { SKILL_SORT_MODES, sortSkills, usageFor, usageLabel } from './skillsSort'
+import { SKILL_SORT_MODES, sortSkills, usageFor, usageLabel, usageMeta } from './skillsSort'
 import type { SkillSortMode } from './skillsSort'
 import type { SkillEntry, SkillUsageMap, SkillsListResult } from '../codey-api'
 
@@ -25,6 +25,14 @@ const AGENT_SKILL_HINTS: Record<AgentFilter, string> = {
   'codex': '~/.codex/skills/',
   'opencode': '~/.config/opencode/skills/',
   'pi': '~/.pi/agent/skills/',
+}
+
+/** Keep the on-disk skill name compatible with every agent while making its
+ *  Codey-owned origin obvious in the UI. */
+export function skillDisplayName(skill: Pick<SkillEntry, 'qualifiedName' | 'managedBy'>): string {
+  return skill.managedBy === 'codey' && !skill.qualifiedName.startsWith('codey:')
+    ? `codey:${skill.qualifiedName}`
+    : skill.qualifiedName
 }
 
 export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> = ({ addRequest = 0, searchQuery = '' }) => {
@@ -59,7 +67,13 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   const usageToken = useRef(0)
   const filteredSkills = useMemo(
     () => sortSkills(
-      data.skills.filter(skill => matchesToolSearch(searchQuery, skill.name, skill.qualifiedName, skill.description)),
+      data.skills.filter(skill => matchesToolSearch(
+        searchQuery,
+        skill.name,
+        skill.qualifiedName,
+        skillDisplayName(skill),
+        skill.description,
+      )),
       sortMode,
       usage,
     ),
@@ -220,7 +234,9 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
   }
 
   const renderCard = (skill: SkillEntry) => {
-    const meta = usageLabel(usageFor(usage, skill), now)
+    const skillUsage = usageFor(usage, skill)
+    const meta = usageMeta(skillUsage, now)
+    const displayName = skillDisplayName(skill)
     return (
     <button
       key={skill.dir}
@@ -233,7 +249,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
           color: C.fg, fontSize: 13, fontWeight: 600,
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: 1,
         }}>
-          {skill.qualifiedName}
+          {displayName}
         </span>
         <span
           onClick={e => e.stopPropagation()}
@@ -269,7 +285,20 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
         </div>
       )}
       {meta && (
-        <div style={{ color: C.fg3, fontSize: 10, opacity: 0.85, marginTop: 'auto', paddingTop: 6 }}>{meta}</div>
+        <div style={styles.usageRow} aria-label={usageLabel(skillUsage, now)}>
+          <span style={styles.usageItem} title="Total skill calls">
+            <strong style={styles.usageCount}>{meta.calls}</strong>
+          </span>
+          {meta.recency && (
+            <>
+              <span style={styles.usageDivider} aria-hidden="true" />
+              <span style={styles.usageItem} title="Last used">
+                <UIIcon name="clock" size={12} strokeWidth={2} />
+                <span>{meta.recency}</span>
+              </span>
+            </>
+          )}
+        </div>
       )}
     </button>
     )
@@ -293,7 +322,7 @@ export const SkillsTab: React.FC<{ addRequest?: number; searchQuery?: string }> 
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-          <span style={{ color: C.fg, fontSize: 15, fontWeight: 700, flex: 1, minWidth: 0 }}>{skill.qualifiedName}</span>
+          <span style={{ color: C.fg, fontSize: 15, fontWeight: 700, flex: 1, minWidth: 0 }}>{skillDisplayName(skill)}</span>
           <div
             style={{
               opacity: busyDirs.has(skill.dir) ? 0.5 : 1,
@@ -746,4 +775,12 @@ const styles: Record<string, React.CSSProperties> = {
     background: C.surface,
   },
   skillGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 10 },
+  usageRow: {
+    display: 'inline-flex', alignItems: 'center', gap: 8,
+    marginTop: 'auto', paddingTop: 10, color: C.fg3,
+    fontSize: 10, lineHeight: 1, fontVariantNumeric: 'tabular-nums',
+  },
+  usageItem: { display: 'inline-flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' },
+  usageCount: { color: C.fg2, fontSize: 11, fontWeight: 720 },
+  usageDivider: { width: 1, height: 11, background: C.border2, flexShrink: 0 },
 }

--- a/codey-mac/src/components/skillDisplay.test.ts
+++ b/codey-mac/src/components/skillDisplay.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { skillDisplayName } from './SkillsTab'
+
+describe('skillDisplayName', () => {
+  it('adds the Codey namespace to an official skill', () => {
+    expect(skillDisplayName({ qualifiedName: 'browser', managedBy: 'codey' })).toBe('codey:browser')
+  })
+
+  it('does not change user skills or duplicate an existing namespace', () => {
+    expect(skillDisplayName({ qualifiedName: 'browser' })).toBe('browser')
+    expect(skillDisplayName({ qualifiedName: 'codey:browser', managedBy: 'codey' })).toBe('codey:browser')
+  })
+})

--- a/codey-mac/src/components/skillsSort.test.ts
+++ b/codey-mac/src/components/skillsSort.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { usageMeta } from './skillsSort'
+
+describe('usageMeta', () => {
+  const now = Date.UTC(2026, 7, 19, 12)
+
+  it('omits skills that have never been called', () => {
+    expect(usageMeta({ count: 0, lastUsedAt: 0 }, now)).toBeNull()
+  })
+
+  it('formats a single call without inventing recency', () => {
+    expect(usageMeta({ count: 1, lastUsedAt: 0 }, now)).toEqual({ calls: '1 call' })
+  })
+
+  it('keeps call count and recency separate for the card layout', () => {
+    expect(usageMeta({ count: 12, lastUsedAt: now - 3 * 60 * 60 * 1000 }, now)).toEqual({
+      calls: '12 calls',
+      recency: '3h ago',
+    })
+  })
+})

--- a/codey-mac/src/components/skillsSort.ts
+++ b/codey-mac/src/components/skillsSort.ts
@@ -47,6 +47,15 @@ export function usageLabel(usage: SkillUsage, now: number): string {
   return `${times} · ${relativeTime(usage.lastUsedAt, now)}`
 }
 
+/** Structured copy lets the card give calls and recency their own visual weight. */
+export function usageMeta(usage: SkillUsage, now: number): { calls: string; recency?: string } | null {
+  if (usage.count === 0) return null
+  return {
+    calls: `${usage.count} ${usage.count === 1 ? 'call' : 'calls'}`,
+    recency: usage.lastUsedAt ? relativeTime(usage.lastUsedAt, now) : undefined,
+  }
+}
+
 function relativeTime(at: number, now: number): string {
   const seconds = Math.max(0, Math.round((now - at) / 1000))
   if (seconds < 60) return 'just now'


### PR DESCRIPTION
## Summary
- refine skill call-count and last-used metadata without a call-count icon
- label Codey-managed Browser as `codey:browser` in Skills while preserving its on-disk name
- show Update only when a newer published skill is confirmed, and remove the local path from plugin cards

## Verification
- `npm test --workspace codey-mac` (61 files, 588 tests)
- `npm exec tsc -- --noEmit` in `codey-mac`
- `npm exec vite -- build` in `codey-mac`