### PR TITLE
fix(mac): prevent floating UI from being obscured

### DIFF
--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -744,7 +744,7 @@ export const BrowserPanel: React.FC<Props> = ({
         </div>
       )}
 
-      <div ref={hostRef} style={styles.host}>
+      <div ref={hostRef} data-codey-browser-host style={styles.host}>
         {!state.url && !state.loading && (
           <div style={styles.empty}>
             <div style={styles.emptyIcon}><UIIcon name="globe" size={30} /></div>

--- a/codey-mac/src/components/ChatHoverCard.tsx
+++ b/codey-mac/src/components/ChatHoverCard.tsx
@@ -4,6 +4,7 @@ import { C } from '../theme'
 import { UIIcon } from './UIIcons'
 import { clampCardTop, type ChatHoverCardView } from './chatHoverCardView'
 import type { StatusTone } from './taskHudView'
+import { clampFloatingLeft, floatingViewportRight } from './floatingLayer'
 
 interface Props {
   view: ChatHoverCardView
@@ -24,10 +25,19 @@ const TONE: Record<StatusTone, string> = {
 export const ChatHoverCard: React.FC<Props> = ({ view, anchor }) => {
   const ref = useRef<HTMLDivElement | null>(null)
   const [top, setTop] = useState(anchor.top)
+  const [left, setLeft] = useState(anchor.right + 8)
 
   useLayoutEffect(() => {
     const height = ref.current?.offsetHeight ?? 0
+    const width = ref.current?.offsetWidth ?? 280
     setTop(clampCardTop(anchor.top, height, window.innerHeight))
+    // Right-align as a fallback when the preferred position beside the row
+    // would enter the native browser view (which DOM z-index cannot cover).
+    const preferredLeft = anchor.right + 8
+    const boundaryRight = floatingViewportRight()
+    setLeft(preferredLeft + width + 12 <= boundaryRight
+      ? preferredLeft
+      : clampFloatingLeft(boundaryRight, width, boundaryRight))
   }, [anchor.top, anchor.right, view])
 
   const tone = TONE[view.status.tone]
@@ -36,7 +46,7 @@ export const ChatHoverCard: React.FC<Props> = ({ view, anchor }) => {
   // descendants — a card left inside it renders behind the chat view and gets
   // measured against the sidebar's box instead of the viewport.
   return createPortal(
-    <div ref={ref} role="tooltip" style={{ ...styles.card, top, left: anchor.right + 8 }}>
+    <div ref={ref} role="tooltip" style={{ ...styles.card, top, left }}>
       <div style={styles.title}>{view.title}</div>
       <div style={{ ...styles.status, color: tone }}>
         <span style={{ ...styles.statusDot, background: tone }} />

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { ChatMessage, ChatSelection, FileAttachment, TeamRunSummary } from '../types'
 import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
@@ -33,6 +34,7 @@ import { useInstalledAgents } from './installedAgents'
 import { applyMention, filterEntries, findActiveMention, splitMentionSegments } from './mentions'
 import { ChatFindBar } from './ChatFindBar'
 import type { ActiveMention, MentionFile } from './mentions'
+import { clampFloatingLeft, floatingViewportRight } from './floatingLayer'
 import { useGitStatus } from '../hooks/useGitStatus'
 import { BranchPicker } from './BranchPicker'
 import { CreatePrModal } from './CreatePrModal'
@@ -896,6 +898,33 @@ export const ChatTab: React.FC<Props> = ({
   const [openingEditor, setOpeningEditor] = useState<string | null>(null)
   const [preferredEditorId, setPreferredEditorId] = useState(() => localStorage.getItem('codey.preferredEditor') ?? '')
   const [runSettingsOpen, setRunSettingsOpen] = useState(false)
+  const runSettingsButtonRef = useRef<HTMLButtonElement>(null)
+  const runSettingsMenuRef = useRef<HTMLDivElement>(null)
+  const [runSettingsPosition, setRunSettingsPosition] = useState({ top: 0, left: 0, ready: false })
+  useLayoutEffect(() => {
+    if (!runSettingsOpen) return
+    const button = runSettingsButtonRef.current
+    const menu = runSettingsMenuRef.current
+    if (!button || !menu) return
+    const place = () => {
+      const anchor = button.getBoundingClientRect()
+      const width = menu.offsetWidth
+      setRunSettingsPosition({
+        top: anchor.bottom + 6,
+        left: clampFloatingLeft(anchor.right, width, floatingViewportRight()),
+        ready: true,
+      })
+    }
+    place()
+    const observer = new ResizeObserver(place)
+    observer.observe(button)
+    observer.observe(menu)
+    window.addEventListener('resize', place)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', place)
+    }
+  }, [runSettingsOpen])
   useEffect(() => {
     if (!isGatewayRunning || !runSettingsOpen) return
     let stale = false
@@ -1997,6 +2026,7 @@ export const ChatTab: React.FC<Props> = ({
         </div>
         <div style={styles.runSettingsWrap}>
           <button
+            ref={runSettingsButtonRef}
             onClick={() => setRunSettingsOpen(open => !open)}
             style={styles.runSettingsButton}
             title="Configure worker, agent, model, and advisor"
@@ -2005,9 +2035,18 @@ export const ChatTab: React.FC<Props> = ({
             <span style={{ display: 'inline-flex', transform: runSettingsOpen ? 'rotate(-90deg)' : 'rotate(90deg)' }}><UIIcon name="chevron" size={12} /></span>
           </button>
           {runSettingsOpen && (
-            <>
+            createPortal(<>
               <div onClick={() => setRunSettingsOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 999 }} />
-              <div style={styles.runSettingsMenu} onClick={event => event.stopPropagation()}>
+              <div
+                ref={runSettingsMenuRef}
+                style={{
+                  ...styles.runSettingsMenu,
+                  top: runSettingsPosition.top,
+                  left: runSettingsPosition.left,
+                  visibility: runSettingsPosition.ready ? 'visible' : 'hidden',
+                }}
+                onClick={event => event.stopPropagation()}
+              >
                 <label style={styles.runSettingGroup}>
                   <span style={styles.runSettingLabel}>Worker</span>
                   <select value={selectionValue} onChange={e => void onSelectionChange(e.target.value)} style={styles.runSettingSelect}>
@@ -2089,7 +2128,7 @@ export const ChatTab: React.FC<Props> = ({
                   </>
                 )}
               </div>
-            </>
+            </>, document.body)
           )}
         </div>
         <div style={{ position: 'relative' }}>
@@ -2998,7 +3037,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   runSettingsButtonSummary: { color: C.fg2, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   runSettingsMenu: {
-    position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 1000, minWidth: 244,
+    position: 'fixed', zIndex: 1000, minWidth: 244,
     padding: 10, borderRadius: 9, background: C.surface2, border: `1px solid ${C.border2}`,
     boxShadow: '0 12px 28px rgba(0,0,0,0.3)', display: 'flex', flexDirection: 'column', gap: 9,
   },

--- a/codey-mac/src/components/floatingLayer.test.ts
+++ b/codey-mac/src/components/floatingLayer.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { clampFloatingLeft } from './floatingLayer'
+
+describe('clampFloatingLeft', () => {
+  it('right-aligns a layer to its anchor when there is room', () => {
+    expect(clampFloatingLeft(500, 240, 800)).toBe(260)
+  })
+
+  it('keeps a layer clear of a native browser boundary', () => {
+    expect(clampFloatingLeft(390, 280, 300)).toBe(12)
+  })
+
+  it('keeps a layer away from the left viewport edge', () => {
+    expect(clampFloatingLeft(100, 240, 800)).toBe(12)
+  })
+})

--- a/codey-mac/src/components/floatingLayer.ts
+++ b/codey-mac/src/components/floatingLayer.ts
@@ -1,0 +1,24 @@
+const DEFAULT_MARGIN = 12
+
+/** The embedded browser is an Electron WebContentsView, so it always paints
+ * above renderer DOM. Treat its left edge as the renderer's usable right edge
+ * when positioning floating UI. */
+export function floatingViewportRight(viewportWidth = window.innerWidth): number {
+  const browserHost = document.querySelector<HTMLElement>('[data-codey-browser-host]')
+  if (!browserHost) return viewportWidth
+  const rect = browserHost.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0 ? Math.min(viewportWidth, rect.left) : viewportWidth
+}
+
+/** Prefer right-aligning a floating layer to its anchor, then slide it back
+ * into the visible renderer region when either edge would be obscured. */
+export function clampFloatingLeft(
+  anchorRight: number,
+  layerWidth: number,
+  boundaryRight: number,
+  margin = DEFAULT_MARGIN,
+): number {
+  const preferred = anchorRight - layerWidth
+  const maxLeft = boundaryRight - layerWidth - margin
+  return Math.max(margin, Math.min(preferred, maxLeft))
+}


### PR DESCRIPTION
## Summary

- keep chat hover cards inside the renderer-visible area when the native browser view is open
- render the run settings menu through a top-level portal
- clamp floating layers to viewport and browser boundaries
- add positioning unit coverage

## Validation

- TypeScript check passed
- 637 tests passed
- Vite production build passed