### PR TITLE
Lock down the HTTP server and add bearer tokens (Router API P1)

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1078,6 +1078,10 @@ async function bootInProcessCore() {
         // Fn-based converse bindings are pressed in the Swift helper, which
         // reports them over HTTP; hand them to the chat like a local press.
         forwardConverseHotkey,
+        // The helper's Settings menu item used to open /config in a browser.
+        // That endpoint now needs a bearer token (and always leaked every key),
+        // so it asks the app to open its own settings window instead.
+        () => { mainWindow?.show(); mainWindow?.focus(); sendToRenderer('notify:openSettings') },
       )
       void apiServer.start().then(() => {
         sendToRenderer('gateway-log', `[core] API server listening on ${apiPort}`)

--- a/docs/superpowers/specs/2026-08-22-router-api-design.md
+++ b/docs/superpowers/specs/2026-08-22-router-api-design.md
@@ -1,0 +1,241 @@
+# Spec: Router API — 让别的应用调用 Codey 的 agent
+
+状态：P1 已实现；P2–P4 待做
+分支：`router-mode`
+路径：`docs/superpowers/specs/2026-08-22-router-api-design.md`
+
+## 1. 目标
+
+让 Codey Gateway 除了聊天渠道（Telegram / Discord / iMessage / TUI / voice）之外，
+再多一个**程序入口**：任何应用、脚本、CI 都能用 HTTP 把一个 prompt 交给 Codey，
+由 Codey 选 workspace、选 agent、选 team，跑完把结果还回去。
+
+非目标（本期不做）：
+- 不做 MCP server（可以之后在这层之上薄薄套一层）
+- 不做多租户 / 用户体系 / 计费
+- 不改任何聊天渠道的行为
+
+## 2. 现状（代码事实）
+
+- HTTP 服务器已存在：`packages/gateway/src/health.ts` 的 `ApiServer`，
+  监听 `port + 1`，路由是手写的 `if (url === ...)` 链。
+- 已有端点：`/health` `/metrics` `/ready` `/config` `/voice/*`。**没有** prompt 端点。
+- CORS 目前是 `Access-Control-Allow-Origin: *`，且**没有任何鉴权**。
+  `/config` GET 现在就能裸读整份配置（含 API key）——加 prompt 端点之前必须先修这个。
+- `/voice/*` 已有一个防浏览器的模式：带 `Origin` 头就 403（原生客户端不带 Origin）。
+  Router API 复用同一招。
+- 真正的执行入口是 `Gateway.sendToChat(chatId, text, sink, attachments?, origin?)`
+  （`packages/gateway/src/gateway.ts:5813`），返回
+  `{ response, chatId, tokens?, durationSec? }`。
+- 流式事件类型已存在：`ChatStreamEvent`（`packages/gateway/src/chat-runner.ts:17`），
+  sink 是 `(e: ChatStreamEvent) => void`。
+- Automation 已经跑通"无人值守调用 sendToChat"的完整套路
+  （`ensureAutomationChat` + collecting sink，`gateway.ts:1593`）。
+  **Router API 就是把这套复用成 HTTP 版本**，不是新造一条执行路径。
+
+## 3. 设计
+
+### 3.1 鉴权
+
+`gateway.json` 新增（**不含任何 token**）：
+
+```jsonc
+{
+  "api": {
+    "enabled": false,          // 默认关。开了才注册 /v1/*
+    "bindHost": "127.0.0.1",   // 用户可改。默认只监听本机
+    "allowedOrigins": [],      // 留空 = 拒绝所有带 Origin 的请求
+    "timeoutSec": 300,
+    "rateLimitPerMin": 60
+  }
+}
+```
+
+规则：
+
+- 所有 `/v1/*` 要求 `Authorization: Bearer <token>`。
+- `api.enabled !== true` 时 `/v1/*` 一律 404（不是 403，不泄露存在性）。
+- 带 `Origin` 且不在 `allowedOrigins` 里 → 403，沿用 `/voice/*` 的写法。
+- 顺手把现有 `/config` GET/POST 也挪到同一把锁后面（**这是本期的安全修复项，不是可选项**）。
+- CORS `Allow-Origin: *` 改为按 `allowedOrigins` 回显；没配就不发 CORS 头。
+
+#### bindHost
+
+`ApiServer.start()` 现在是 `server.listen(this.port)` —— 监听所有网卡，局域网可见。
+改成 `server.listen(this.port, config.api?.bindHost ?? '127.0.0.1')`。
+
+注意这个 host 对**整个** ApiServer 生效，`/health` `/voice/*` 也跟着只绑本机。
+这是想要的：这些端点本来就没有跨机使用场景。
+若有人真的要暴露到局域网，显式改 `bindHost` 为 `0.0.0.0`，
+并且启动时打一条 warn 日志说明风险。
+
+#### Token 存储：只存哈希，不存明文
+
+Token **不进 `gateway.json`**。单独放 `~/.codey/api-tokens.json`
+（沿用 `CODEY_HOME` 覆盖，同 `packages/core/src/workspace.ts:71`）：
+
+```jsonc
+{
+  "version": 1,
+  "tokens": [
+    {
+      "id": "tok_7f3a",              // 前缀，用于展示和吊销，不是秘密
+      "name": "my-script",
+      "hash": "<sha256 hex>",        // sha256(token)，只存这个
+      "createdAt": 1755800000000,
+      "lastUsedAt": 1755900000000
+    }
+  ]
+}
+```
+
+- 文件用 `fs.writeFileSync(p, s, { mode: 0o600 })` 创建，并在每次读取时
+  `fs.chmodSync(p, 0o600)` 兜底。读到权限不是 600 时打 warn。
+- Token 明文格式 `codey_<32字节 base64url>`（`crypto.randomBytes(32)`）。
+  **只在生成的那一刻打印一次**，之后任何地方都拿不回来。
+- 校验：`sha256(收到的token)` 与存的 hash 逐一 `timingSafeEqual`。
+  因为 token 是 256 bit 高熵随机串，不需要 bcrypt/argon2 那种慢哈希
+  ——慢哈希是防低熵口令被爆破的，这里没有低熵口令。
+- 额外覆盖：环境变量 `CODEY_API_TOKEN`。为 CI/容器准备，
+  设了就作为一个额外的有效 token（同样只比对哈希）。
+
+**为什么不用 macOS Keychain**：Gateway 要能跑在 headless daemon、
+Linux、容器里；Keychain 只有 macOS，而且需要已解锁的登录会话。
+代码库现在也没有任何 keychain/safeStorage 基础设施
+（`grep safeStorage|keytar` 无命中），为此新引一套依赖不划算。
+"哈希 + 0600" 已经挡住了本期真正的威胁：
+配置文件被误提交 / 被日志打印 / 被 `/config` 端点读走。
+
+#### CLI
+
+```bash
+npm run api-token -- create <name>   # 生成，打印一次明文
+npm run api-token -- list            # 只列 id / name / 时间
+npm run api-token -- revoke <id>
+```
+
+### 3.2 端点
+
+#### `POST /v1/prompt` — 一发一收
+
+请求：
+```jsonc
+{
+  "prompt": "把 README 的安装章节翻成日文",
+  "workspace": "codey",        // 可选，默认 gateway 默认 workspace
+  "agent": "claude-code",      // 可选
+  "model": "claude-opus-5",    // 可选
+  "team": "reviewers",         // 可选，走 team 而不是单 agent
+  "sessionId": "abc-123",      // 可选，见 3.3
+  "stream": false              // 可选，true 见下
+}
+```
+
+响应 `200`：
+```jsonc
+{
+  "sessionId": "abc-123",
+  "response": "…agent 的最终回复…",
+  "tokens": 12345,
+  "durationSec": 42.1
+}
+```
+
+错误：`400` 参数错、`401` token 错、`404` workspace/team 不存在、
+`409` 该 session 正在跑、`503` gateway 未就绪、`504` 超时。
+
+#### `POST /v1/prompt` with `"stream": true` — 流式
+
+响应 `200`，`Content-Type: application/x-ndjson`，每行一个 `ChatStreamEvent` 的 JSON。
+沿用 `/voice/converse` 已有的 NDJSON 写法（`health.ts` 里那段），**不引入 SSE**。
+最后一行一定是 `{"type":"done",...}` 或 `{"type":"error",...}`。
+
+#### `GET /v1/sessions/:id` — 查一个 session 的最近消息
+
+用于客户端断线后补历史。返回 chat 的 `messages` 尾部（上限 40，同 `CHAT_CONTEXT_WINDOW`）。
+
+#### `DELETE /v1/sessions/:id` — 丢弃 session
+
+#### `GET /v1/capabilities` — 客户端发现
+
+返回可用 workspace 名、team 名、agent 名、默认 agent/model。
+让调用方不用猜。
+
+### 3.3 Session 模型
+
+- 一个 API session **就是一个 kind 为 `api` 的 chat**，
+  照抄 `ensureAutomationChat` 的做法建立（`chatManager.create({ kind: 'api', ... })`）。
+- 不传 `sessionId` → 每次新建一个一次性 chat，跑完保留（可查、可删）。
+- 传 `sessionId` → 复用，带上下文。
+- 这些 chat 在 Mac app 里默认隐藏，跟 automation chat 一样处理。
+
+### 3.4 并发与限流
+
+- 复用现有的 `RunSemaphore` / `MAX_CONCURRENT_AGENTS = 4`，不新开一套池子。
+- 同一个 `sessionId` 已有 in-flight 请求 → `409`，不排队（排队会让调用方看起来是挂死）。
+- 每 token 每分钟请求数上限，可配，默认 60。
+
+### 3.5 超时
+
+- 单次请求默认 300s（对齐 agent adapter 的 5 分钟），可用 `api.timeoutSec` 改。
+- 非流式超时 → `504`，但 agent **不杀**，session 里能查到最终结果。
+- 流式超时 → 发一条 `error` 事件后 `res.end()`。
+
+## 4. 实现落点
+
+| 改动 | 文件 |
+|---|---|
+| `ApiConfig` 类型 | `packages/core/src/types/index.ts` |
+| 配置读取 + 默认值 | `packages/gateway/src/config.ts` |
+| 新增 `api-tokens.ts`：读写 `~/.codey/api-tokens.json`、生成/校验/吊销 | `packages/gateway/src/api-tokens.ts`（新） |
+| `listen(port)` → `listen(port, bindHost)` | `packages/gateway/src/health.ts` |
+| bearer / origin 中间件、`/v1/*` 路由 | `packages/gateway/src/health.ts` |
+| token CLI | `scripts/` + `package.json` 的 `api-token` 脚本 |
+| 新增 `router-api.ts`：session→chat 映射、参数校验、调 `sendToChat` | `packages/gateway/src/router-api.ts`（新） |
+| 把 gateway 实例传进 `ApiServer` 构造函数 | `packages/gateway/src/index.ts` |
+| `kind: 'api'` chat 类型 | `packages/gateway/src/chats.ts` |
+
+`health.ts` 现在的 if-链已经 335 行了，`/v1/*` 全部下沉到 `router-api.ts`，
+`health.ts` 里只留一行 `if (url?.startsWith('/v1/')) return this.routerApi.handle(req, res)`。
+
+## 5. 测试
+
+- 鉴权：无 token / 错 token / 关闭时 → 401 / 401 / 404
+- token 文件：生成后明文不落盘（读回文件断言只有 hash）
+- token 文件权限被创建为 `0o600`；权限被改宽时打 warn
+- `CODEY_API_TOKEN` 环境变量作为额外有效 token
+- 吊销后立刻 401
+- `bindHost` 默认 `127.0.0.1`；设成 `0.0.0.0` 时打 warn
+- Origin 被拒
+- `/v1/prompt` 非流式：mock `sendToChat`，校验返回结构
+- `/v1/prompt` 流式：校验 NDJSON 逐行可解析、末行是 done
+- session 复用：两次请求打到同一个 chatId
+- 同 session 并发 → 409
+- 未知 workspace / team → 404
+- 超时 → 504
+- 回归：`api.enabled = false` 时旧行为不变
+
+## 6. 分期
+
+1. **P1 — 已实现**（2026-08-22）。鉴权层 + `/config` 上锁 + CORS 收紧 + `bindHost`
+   + `api-tokens.ts` + `api-token` CLI。`/v1/*` 已挂在鉴权后面但还没有任何路由（认证后 404）。
+   附带修了 Swift helper 的 Settings 菜单：原先它在浏览器里打开 `/config`
+   （等于把全部凭据倒进浏览器），现在 POST `/voice/open-settings`，由 Mac app 打开自己的设置窗口。
+2. **P2** — `/v1/prompt` 非流式 + `/v1/capabilities`。
+3. **P3** — 流式 + session 端点。
+4. **P4**（另开）— MCP server，内部转调 `/v1/prompt`。
+
+## 7. 已决
+
+- **bindHost**：用户设置项，默认 `127.0.0.1`。（2026-08-22 定）
+- **Token 存储**：`~/.codey/api-tokens.json`，`0600`，**只存 sha256 哈希**，
+  明文只在生成时打印一次。不上 Keychain（headless / Linux 跑不了）。（2026-08-22 定）
+
+## 8. 后续（已确认要做，不在本 spec 范围）
+
+- **统一密钥管理**（2026-08-22 用户确认）：Router API 落地后，单开一个 PR，
+  把 `gateway.json` 里现存的第三方 API key（Anthropic / OpenAI / Google、
+  Telegram / Discord bot token 等）也收进 `~/.codey` 下的 0600 密钥库，
+  与 `api-tokens.json` 复用同一套读写原语（`secret-store.ts`）。
+  本期先不动它们（改动面大、与 Router API 正交），
+  但 `/config` 上锁后它们至少不再能被 HTTP 裸读。

--- a/gateway.json.example
+++ b/gateway.json.example
@@ -65,6 +65,10 @@
     "enabled": true,
     "autoExtract": true
   },
+  "api": {
+    "bindHost": "127.0.0.1",
+    "allowedOrigins": []
+  },
   "dev": {
     "logLevel": "info",
     "logFile": "gateway.log"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "description": "Codey — a multi-agent workbench and control plane for coding agents (Claude Code, Codex, OpenCode, pi): per-project workspaces, worker teams, parallel runs, and access from a macOS app, Telegram/Discord/iMessage, or voice.",
+  "description": "Codey \u2014 a multi-agent workbench and control plane for coding agents (Claude Code, Codex, OpenCode, pi): per-project workspaces, worker teams, parallel runs, and access from a macOS app, Telegram/Discord/iMessage, or voice.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -29,7 +29,8 @@
     "set-model": "npm run set-model -w @codey/gateway",
     "tui": "npm run tui -w @codey/gateway",
     "verify-workers": "npm run build && ts-node scripts/verify-workers.ts",
-    "verify-gateway": "npm run build && ts-node scripts/verify-gateway.ts"
+    "verify-gateway": "npm run build && ts-node scripts/verify-gateway.ts",
+    "api-token": "npm run api-token -w @codey/gateway --"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -17,7 +17,8 @@
     "status": "cd ../.. && ts-node packages/gateway/src/index.ts status",
     "set-agent": "cd ../.. && ts-node packages/gateway/src/index.ts set-agent",
     "set-model": "cd ../.. && ts-node packages/gateway/src/index.ts set-model",
-    "tui": "cd ../.. && ts-node packages/gateway/src/index.ts tui"
+    "tui": "cd ../.. && ts-node packages/gateway/src/index.ts tui",
+    "api-token": "cd ../.. && ts-node packages/gateway/src/index.ts api-token"
   },
   "dependencies": {
     "@codey/core": "*",

--- a/packages/gateway/src/api-tokens.test.ts
+++ b/packages/gateway/src/api-tokens.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ApiTokenStore, TOKEN_PREFIX } from './api-tokens';
+
+describe('ApiTokenStore', () => {
+  let dir: string;
+  let file: string;
+  let store: ApiTokenStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-tokens-'));
+    file = path.join(dir, 'api-tokens.json');
+    store = new ApiTokenStore(file);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    delete process.env.CODEY_API_TOKEN;
+  });
+
+  it('returns the plaintext exactly once and never stores it', () => {
+    const { token, record } = store.create('my-script');
+
+    expect(token.startsWith(TOKEN_PREFIX)).toBe(true);
+    expect(record.name).toBe('my-script');
+
+    const raw = fs.readFileSync(file, 'utf-8');
+    expect(raw).not.toContain(token);
+    // The secret part alone must not leak either.
+    expect(raw).not.toContain(token.slice(TOKEN_PREFIX.length));
+    expect(JSON.parse(raw).tokens[0].hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('creates the file with 0600 permissions', () => {
+    store.create('a');
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it('tightens permissions that were widened behind its back', () => {
+    store.create('a');
+    fs.chmodSync(file, 0o644);
+
+    const reopened = new ApiTokenStore(file);
+    expect(reopened.list()).toHaveLength(1);
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it('verifies a real token and rejects everything else', () => {
+    const { token, record } = store.create('a');
+
+    expect(store.verify(token)?.id).toBe(record.id);
+    expect(store.verify(token + 'x')).toBeNull();
+    expect(store.verify('')).toBeNull();
+    expect(store.verify(undefined)).toBeNull();
+  });
+
+  it('verifies against a store reloaded from disk', () => {
+    const { token } = store.create('a');
+    expect(new ApiTokenStore(file).verify(token)).not.toBeNull();
+  });
+
+  it('records lastUsedAt on a successful verify', () => {
+    const { token } = store.create('a');
+    expect(store.list()[0].lastUsedAt).toBeUndefined();
+
+    store.verify(token);
+    expect(store.list()[0].lastUsedAt).toBeGreaterThan(0);
+  });
+
+  it('rejects a revoked token', () => {
+    const { token, record } = store.create('a');
+    expect(store.revoke(record.id)).toBe(true);
+    expect(store.verify(token)).toBeNull();
+    expect(store.revoke(record.id)).toBe(false);
+  });
+
+  it('list() never exposes hashes', () => {
+    store.create('a');
+    expect(store.list()[0]).not.toHaveProperty('hash');
+  });
+
+  it('accepts CODEY_API_TOKEN as an extra valid token', () => {
+    process.env.CODEY_API_TOKEN = 'from-the-environment';
+    expect(store.verify('from-the-environment')?.id).toBe('env');
+    expect(store.verify('something-else')).toBeNull();
+  });
+
+  it('has no valid tokens when the file is missing and no env var is set', () => {
+    expect(store.list()).toEqual([]);
+    expect(store.verify('anything')).toBeNull();
+    expect(store.isEmpty()).toBe(true);
+  });
+
+  it('survives a corrupt file instead of throwing', () => {
+    fs.writeFileSync(file, 'not json at all');
+    const reopened = new ApiTokenStore(file);
+    expect(reopened.list()).toEqual([]);
+    expect(reopened.verify('anything')).toBeNull();
+  });
+
+  it('issues distinct tokens', () => {
+    const a = store.create('a').token;
+    const b = store.create('b').token;
+    expect(a).not.toBe(b);
+    expect(store.list()).toHaveLength(2);
+  });
+});

--- a/packages/gateway/src/api-tokens.ts
+++ b/packages/gateway/src/api-tokens.ts
@@ -1,0 +1,194 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Bearer tokens for the Router API.
+ *
+ * The plaintext token exists exactly once — at creation, when it is printed to
+ * the operator. On disk we keep only `sha256(token)`, so a leaked
+ * `api-tokens.json` (committed by accident, copied into a log, read through the
+ * `/config` endpoint) yields nothing usable.
+ *
+ * A slow hash (bcrypt/argon2) is deliberately NOT used: those defend low-entropy
+ * human passwords against offline brute force. These tokens are 256 bits of
+ * `crypto.randomBytes`, so there is nothing to brute-force and a slow hash would
+ * only tax every request.
+ *
+ * The file lives outside `gateway.json` so that config — which is dumped to
+ * disk, watched, diffed and served over HTTP — never carries a credential.
+ */
+
+export const TOKEN_PREFIX = 'codey_';
+const FILE_MODE = 0o600;
+const STORE_VERSION = 1;
+
+/** A token as persisted. `hash` never leaves this module. */
+interface StoredToken {
+  id: string;
+  name: string;
+  hash: string;
+  createdAt: number;
+  lastUsedAt?: number;
+}
+
+/** A token as shown to the operator — same fields minus the secret material. */
+export type ApiTokenRecord = Omit<StoredToken, 'hash'>;
+
+interface TokenFile {
+  version: number;
+  tokens: StoredToken[];
+}
+
+/** Base dir mirrors workspace.ts / gateway.ts: CODEY_HOME override, else ~/.codey. */
+export function defaultTokenFilePath(): string {
+  const home = process.env.CODEY_HOME ?? path.join(os.homedir(), '.codey');
+  return path.join(home, 'api-tokens.json');
+}
+
+function sha256(input: string): string {
+  return crypto.createHash('sha256').update(input, 'utf-8').digest('hex');
+}
+
+/**
+ * Constant-time compare of two hex digests. Both sides are fixed-length sha256
+ * output, so a length mismatch can only mean a malformed store — treat it as a
+ * non-match rather than letting timingSafeEqual throw.
+ */
+function hashesEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(a, 'utf-8'), Buffer.from(b, 'utf-8'));
+}
+
+export class ApiTokenStore {
+  private readonly filePath: string;
+  private file: TokenFile;
+
+  constructor(filePath: string = defaultTokenFilePath()) {
+    this.filePath = filePath;
+    this.file = this.read();
+  }
+
+  private read(): TokenFile {
+    try {
+      if (!fs.existsSync(this.filePath)) return { version: STORE_VERSION, tokens: [] };
+      // The file may have been created by an older build, restored from a
+      // backup, or copied around — re-assert 0600 on every read rather than
+      // trusting whatever mode it arrived with.
+      this.enforceMode();
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
+      const tokens = Array.isArray(parsed?.tokens) ? parsed.tokens : [];
+      return {
+        version: typeof parsed?.version === 'number' ? parsed.version : STORE_VERSION,
+        tokens: tokens.filter((t: unknown): t is StoredToken =>
+          !!t && typeof (t as StoredToken).id === 'string' && typeof (t as StoredToken).hash === 'string'),
+      };
+    } catch (err) {
+      // A broken token file must not take the gateway down; it means "no valid
+      // tokens", which the auth layer already handles as 401.
+      console.error(`[api-tokens] unreadable ${this.filePath}: ${(err as Error).message}`);
+      return { version: STORE_VERSION, tokens: [] };
+    }
+  }
+
+  private enforceMode(): void {
+    try {
+      const mode = fs.statSync(this.filePath).mode & 0o777;
+      if (mode !== FILE_MODE) {
+        console.warn(`[api-tokens] ${this.filePath} was mode ${mode.toString(8)}; tightening to 600`);
+        fs.chmodSync(this.filePath, FILE_MODE);
+      }
+    } catch { /* best effort — a filesystem without POSIX modes is not a failure */ }
+  }
+
+  private write(): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    // `mode` only applies when the file is created, so chmod afterwards too:
+    // an existing file keeps its old (possibly wider) mode otherwise.
+    fs.writeFileSync(this.filePath, JSON.stringify(this.file, null, 2), { mode: FILE_MODE });
+    this.enforceMode();
+  }
+
+  /**
+   * Mint a token. The returned plaintext is the only copy that will ever
+   * exist — the caller must show it to the operator and then drop it.
+   */
+  create(name: string): { token: string; record: ApiTokenRecord } {
+    const secret = crypto.randomBytes(32).toString('base64url');
+    const token = `${TOKEN_PREFIX}${secret}`;
+    const hash = sha256(token);
+    const stored: StoredToken = {
+      // Derived from the hash, not the token: an id is displayed freely, so it
+      // must not be a prefix of the secret.
+      id: `tok_${hash.slice(0, 8)}`,
+      name,
+      hash,
+      createdAt: Date.now(),
+    };
+    this.file.tokens.push(stored);
+    this.write();
+    return { token, record: redact(stored) };
+  }
+
+  list(): ApiTokenRecord[] {
+    return this.file.tokens.map(redact);
+  }
+
+  isEmpty(): boolean {
+    return this.file.tokens.length === 0 && !process.env.CODEY_API_TOKEN;
+  }
+
+  revoke(id: string): boolean {
+    const before = this.file.tokens.length;
+    this.file.tokens = this.file.tokens.filter(t => t.id !== id);
+    if (this.file.tokens.length === before) return false;
+    this.write();
+    return true;
+  }
+
+  /**
+   * Returns the matching record, or null. `CODEY_API_TOKEN` is honoured as an
+   * additional valid token so containers and CI can inject one without a
+   * writable home directory; it reports as the synthetic id `env`.
+   */
+  verify(presented: string | undefined | null): ApiTokenRecord | null {
+    if (!presented) return null;
+    const presentedHash = sha256(presented);
+
+    const envToken = process.env.CODEY_API_TOKEN;
+    if (envToken && hashesEqual(presentedHash, sha256(envToken))) {
+      return { id: 'env', name: 'CODEY_API_TOKEN', createdAt: 0 };
+    }
+
+    // Compare against every entry rather than returning early, so the work done
+    // does not depend on which token was presented.
+    let matched: StoredToken | undefined;
+    for (const t of this.file.tokens) {
+      if (hashesEqual(presentedHash, t.hash)) matched = t;
+    }
+    if (!matched) return null;
+
+    matched.lastUsedAt = Date.now();
+    try { this.write(); } catch { /* a read-only home must not break auth */ }
+    return redact(matched);
+  }
+
+  /** Re-read from disk. Used after the CLI mints a token in another process. */
+  reload(): void {
+    this.file = this.read();
+  }
+}
+
+function redact(t: StoredToken): ApiTokenRecord {
+  const { hash: _hash, ...rest } = t;
+  return rest;
+}
+
+/** Pulls the bearer token out of an Authorization header. */
+export function parseBearer(header: string | string[] | undefined): string | null {
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (!raw) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(raw.trim());
+  return match ? match[1].trim() : null;
+}

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -1,6 +1,7 @@
 import * as readline from 'readline';
 import { ConfigManager } from './config';
 import { Logger } from './logger';
+import { ApiTokenStore, defaultTokenFilePath } from './api-tokens';
 
 export class CLI {
   private config: ConfigManager;
@@ -258,6 +259,10 @@ export async function handleCommand(args: string[], config: ConfigManager, logge
       }
       break;
 
+    case 'api-token':
+      handleApiTokenCommand(args.slice(1), logger);
+      break;
+
     case 'set-loglevel':
       if (args[1]) {
         config.setLogLevel(args[1] as 'debug' | 'info' | 'warn' | 'error');
@@ -310,9 +315,68 @@ function showHelp(): void {
 ║  set-discord <token>       Set Discord bot token           ║
 ║  set-imessage <senders>    Set iMessage allowed senders    ║
 ║  set-loglevel <level>      Set log level                   ║
+║  api-token <sub>           Manage HTTP API bearer tokens    ║
 ║  enable <channel>          Enable a channel                 ║
 ║  disable <channel>         Disable a channel               ║
 ║  help                       Show this help                  ║
 ╚════════════════════════════════════════════════════════════╝
   `);
+}
+
+/**
+ * `api-token create|list|revoke`. Tokens are stored hashed, so `create` is the
+ * one and only moment the plaintext exists — print it loudly and never again.
+ */
+function handleApiTokenCommand(args: string[], logger: Logger): void {
+  const store = new ApiTokenStore();
+  const sub = args[0];
+
+  switch (sub) {
+    case 'create': {
+      const name = args.slice(1).join(' ').trim();
+      if (!name) {
+        logger.error('Usage: api-token create <name>');
+        return;
+      }
+      const { token, record } = store.create(name);
+      console.log('');
+      console.log(`Created ${record.id} (${record.name})`);
+      console.log('');
+      console.log(`  ${token}`);
+      console.log('');
+      console.log('This is the only time the token is shown. Copy it now.');
+      console.log(`Stored (hashed) in ${defaultTokenFilePath()}`);
+      console.log('');
+      console.log('  curl -H "Authorization: Bearer <token>" http://127.0.0.1:3000/config');
+      console.log('');
+      return;
+    }
+
+    case 'list': {
+      const tokens = store.list();
+      if (tokens.length === 0) {
+        console.log('No API tokens. Create one with: api-token create <name>');
+        return;
+      }
+      for (const t of tokens) {
+        const used = t.lastUsedAt ? new Date(t.lastUsedAt).toISOString() : 'never';
+        console.log(`${t.id}  ${t.name}  created ${new Date(t.createdAt).toISOString()}  last used ${used}`);
+      }
+      return;
+    }
+
+    case 'revoke': {
+      const id = args[1];
+      if (!id) {
+        logger.error('Usage: api-token revoke <id>');
+        return;
+      }
+      if (store.revoke(id)) logger.info(`Revoked ${id}`);
+      else logger.error(`No such token: ${id}`);
+      return;
+    }
+
+    default:
+      logger.error('Usage: api-token <create <name> | list | revoke <id>>');
+  }
 }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -15,6 +15,9 @@ export interface ExternalMcpServerConfig {
   enabled: boolean;
 }
 
+/** Loopback only. Exposing the HTTP server has to be an explicit choice. */
+export const DEFAULT_API_BIND_HOST = '127.0.0.1';
+
 export interface GatewayConfigJson {
   gateway: {
     port: number;
@@ -109,6 +112,22 @@ export interface GatewayConfigJson {
    * `teams: string[]` field.
    */
   teams?: Record<string, TeamConfigRaw>;
+  /**
+   * HTTP API surface (health/metrics/config today, Router API next). Contains
+   * no credentials: bearer tokens live in `~/.codey/api-tokens.json` so that
+   * this file — which is watched, diffed and served over HTTP — never carries
+   * one. See `api-tokens.ts`.
+   */
+  api?: {
+    /**
+     * Which interface the HTTP server binds. Default `127.0.0.1` (this machine
+     * only). Set `0.0.0.0` to expose it on the LAN — deliberately explicit,
+     * because every endpoint including `/config` becomes reachable.
+     */
+    bindHost?: string;
+    /** Browser origins allowed to call the server. Empty = none. */
+    allowedOrigins?: string[];
+  };
   /** Voice input helper (native macOS app) configuration. */
   voice?: {
     /** Legacy aggregate kept true while either global hotkey is enabled. */
@@ -333,6 +352,17 @@ export class ConfigManager extends EventEmitter {
 
   // ── Gateway settings ───────────────────────────────────────────────
   getPort(): number { return this.config.gateway.port; }
+
+  /**
+   * Interface for the HTTP server. Defaults to loopback: none of these
+   * endpoints has a cross-machine use case, and `/config` in particular used to
+   * be reachable from the whole LAN because `listen()` was called without a
+   * host.
+   */
+  getApiBindHost(): string { return this.config.api?.bindHost?.trim() || DEFAULT_API_BIND_HOST; }
+
+  /** Browser origins allowed to call the HTTP server. Empty = block all. */
+  getApiAllowedOrigins(): string[] { return this.config.api?.allowedOrigins ?? []; }
   getSkipPermissions(): boolean { return this.config.gateway.skipPermissions ?? true; }
 
   /** Canonical default = first entry in fallback.order. */
@@ -858,6 +888,16 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
       ...(voice.converseHotkey === 'Control+Fn' ? { converseHotkey: 'Shift+Fn' } : {}),
       ...(rawTts && typeof rawTts === 'object' ? { tts } : {}),
     } as GatewayConfigJson['voice'];
+  }
+  if (raw.api && typeof raw.api === 'object') {
+    out.api = {
+      bindHost: typeof raw.api.bindHost === 'string' && raw.api.bindHost.trim()
+        ? raw.api.bindHost.trim()
+        : undefined,
+      allowedOrigins: Array.isArray(raw.api.allowedOrigins)
+        ? raw.api.allowedOrigins.filter((o: unknown): o is string => typeof o === 'string' && !!o.trim())
+        : undefined,
+    };
   }
   if (raw.notifications && typeof raw.notifications === 'object') {
     out.notifications = { enabled: raw.notifications.enabled };

--- a/packages/gateway/src/health.auth.test.ts
+++ b/packages/gateway/src/health.auth.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ApiServer } from './health';
+import { ApiTokenStore } from './api-tokens';
+
+/**
+ * Covers the P1 security change: `/config` used to be world-readable to anyone
+ * who could reach the port, and the port was bound on every interface.
+ */
+describe('ApiServer auth', () => {
+  let dir: string;
+  let store: ApiTokenStore;
+  let server: ApiServer;
+  let port: number;
+  let apiSettings: { bindHost?: string; allowedOrigins?: string[] };
+
+  const fakeStatus = () => ({
+    status: 'healthy' as const,
+    uptime: 1,
+    timestamp: 'now',
+    channels: { telegram: false, discord: false, imessage: false },
+    stats: { messagesProcessed: 0, activeConversations: 0, errors: 0 },
+  });
+
+  // Minimal stand-in: the server only needs these three methods.
+  const fakeConfigManager = () => ({
+    get: () => ({ gateway: { port: 0 }, apiKeys: [{ name: 'anthropic', apiKey: 'sk-super-secret' }] }),
+    getApiBindHost: () => apiSettings.bindHost ?? '127.0.0.1',
+    getApiAllowedOrigins: () => apiSettings.allowedOrigins ?? [],
+    update: () => { /* no-op */ },
+    getResolvedVoiceConfig: () => undefined,
+  }) as any;
+
+  async function listenOnFreePort(): Promise<void> {
+    // Port 0 lets the OS pick; read back what it chose.
+    server = new ApiServer(0, fakeStatus, fakeConfigManager(), undefined, undefined, undefined, undefined, store);
+    await server.start();
+    port = (server as any).server.address().port;
+  }
+
+  const url = (p: string) => `http://127.0.0.1:${port}${p}`;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-health-'));
+    store = new ApiTokenStore(path.join(dir, 'api-tokens.json'));
+    apiSettings = {};
+    await listenOnFreePort();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('serves /health without a token', async () => {
+    const res = await fetch(url('/health'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe('healthy');
+  });
+
+  it('rejects /config with no token', async () => {
+    const res = await fetch(url('/config'));
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toBe('Bearer');
+    expect(await res.text()).not.toContain('sk-super-secret');
+  });
+
+  it('rejects /config with a wrong token', async () => {
+    store.create('real');
+    const res = await fetch(url('/config'), { headers: { Authorization: 'Bearer codey_nope' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('serves /config with a valid token', async () => {
+    const { token } = store.create('real');
+    const res = await fetch(url('/config'), { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).apiKeys[0].apiKey).toBe('sk-super-secret');
+  });
+
+  it('rejects POST /config with no token', async () => {
+    const res = await fetch(url('/config'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts a token minted after the server booted', async () => {
+    // The CLI runs in another process, so the server must re-read the store.
+    const { token } = store.create('later');
+    const res = await fetch(url('/config'), { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a revoked token', async () => {
+    const { token, record } = store.create('a');
+    expect((await fetch(url('/config'), { headers: { Authorization: `Bearer ${token}` } })).status).toBe(200);
+
+    store.revoke(record.id);
+    expect((await fetch(url('/config'), { headers: { Authorization: `Bearer ${token}` } })).status).toBe(401);
+  });
+
+  it('refuses a browser origin on /config even with a valid token', async () => {
+    const { token } = store.create('a');
+    const res = await fetch(url('/config'), {
+      headers: { Authorization: `Bearer ${token}`, Origin: 'https://evil.example' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('allows a configured origin', async () => {
+    apiSettings.allowedOrigins = ['https://app.example'];
+    const { token } = store.create('a');
+    const res = await fetch(url('/config'), {
+      headers: { Authorization: `Bearer ${token}`, Origin: 'https://app.example' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin')).toBe('https://app.example');
+  });
+
+  it('never sends a wildcard CORS header', async () => {
+    const res = await fetch(url('/health'), { headers: { Origin: 'https://evil.example' } });
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('404s unknown /v1 routes only after authenticating', async () => {
+    expect((await fetch(url('/v1/prompt'), { method: 'POST' })).status).toBe(401);
+
+    const { token } = store.create('a');
+    const res = await fetch(url('/v1/prompt'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('binds loopback by default', async () => {
+    expect((server as any).server.address().address).toBe('127.0.0.1');
+  });
+});

--- a/packages/gateway/src/health.auth.test.ts
+++ b/packages/gateway/src/health.auth.test.ts
@@ -41,6 +41,8 @@ describe('ApiServer auth', () => {
   }
 
   const url = (p: string) => `http://127.0.0.1:${port}${p}`;
+  // fetch().json() is typed `unknown`; these are our own responses.
+  const json = async (res: Response): Promise<any> => res.json();
 
   beforeEach(async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-health-'));
@@ -57,7 +59,7 @@ describe('ApiServer auth', () => {
   it('serves /health without a token', async () => {
     const res = await fetch(url('/health'));
     expect(res.status).toBe(200);
-    expect((await res.json()).status).toBe('healthy');
+    expect((await json(res)).status).toBe('healthy');
   });
 
   it('rejects /config with no token', async () => {
@@ -77,7 +79,7 @@ describe('ApiServer auth', () => {
     const { token } = store.create('real');
     const res = await fetch(url('/config'), { headers: { Authorization: `Bearer ${token}` } });
     expect(res.status).toBe(200);
-    expect((await res.json()).apiKeys[0].apiKey).toBe('sk-super-secret');
+    expect((await json(res)).apiKeys[0].apiKey).toBe('sk-super-secret');
   });
 
   it('rejects POST /config with no token', async () => {

--- a/packages/gateway/src/health.ts
+++ b/packages/gateway/src/health.ts
@@ -1,6 +1,24 @@
 import * as http from 'http';
 import { ConfigManager } from './config';
+import { ApiTokenStore, parseBearer } from './api-tokens';
 import { VoiceConverseEvent } from '@codey/core';
+
+/**
+ * Endpoints that require a bearer token.
+ *
+ * `/config` serves the whole gateway configuration — provider API keys, bot
+ * tokens, the lot — and used to be readable, and writable, by anyone who could
+ * reach the port. `/health`, `/metrics` and `/ready` stay open: they are what
+ * process supervisors poll, and they expose only counters.
+ *
+ * `/voice/*` is not listed because it has its own guard (no-Origin native
+ * clients only) and is called by the Swift helper, which has no way to hold a
+ * token yet.
+ */
+function requiresAuth(url: string | undefined): boolean {
+  if (!url) return false;
+  return url === '/config' || url.startsWith('/v1/');
+}
 
 export type HealthStatusType = 'healthy' | 'degraded' | 'down';
 
@@ -38,6 +56,8 @@ export class ApiServer {
     verbatim?: boolean,
   ) => Promise<void>;
   private onConverseHotkey?: () => void;
+  private onOpenSettings?: () => void;
+  private tokens: ApiTokenStore;
 
   constructor(
     port: number,
@@ -55,6 +75,8 @@ export class ApiServer {
       verbatim?: boolean,
     ) => Promise<void>,
     onConverseHotkey?: () => void,
+    onOpenSettings?: () => void,
+    tokens?: ApiTokenStore,
   ) {
     this.port = port;
     this.getStatus = getStatus;
@@ -62,22 +84,60 @@ export class ApiServer {
     this.runVoiceConverse = runVoiceConverse;
     this.runVoiceSpeak = runVoiceSpeak;
     this.onConverseHotkey = onConverseHotkey;
+    this.onOpenSettings = onOpenSettings;
+    this.tokens = tokens ?? new ApiTokenStore();
+  }
+
+  /**
+   * Authorize a request, writing the error response itself when it fails.
+   * Returns false when the caller should stop handling the request.
+   */
+  private authorize(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+    // Re-read the store per request: `api-token create` runs in a separate
+    // process, so a long-lived gateway would otherwise reject tokens minted
+    // after it booted until restarted.
+    this.tokens.reload();
+    if (this.tokens.verify(parseBearer(req.headers.authorization))) return true;
+    res.writeHead(401, { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' });
+    res.end(JSON.stringify({
+      error: 'Unauthorized',
+      hint: 'Send Authorization: Bearer <token>. Create one with: npm run api-token -- create <name>',
+    }));
+    return false;
   }
 
   async start(): Promise<void> {
     this.server = http.createServer(async (req, res) => {
-      // CORS headers
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      // CORS: reflect only configured origins. The former blanket `*` let any
+      // web page the user had open read `/config` — including every API key in
+      // it — straight out of the browser.
+      const origin = req.headers.origin;
+      const allowedOrigins = this.configManager.getApiAllowedOrigins();
+      if (origin && allowedOrigins.includes(origin)) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Vary', 'Origin');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+      }
 
       if (req.method === 'OPTIONS') {
-        res.writeHead(200);
+        res.writeHead(origin && !allowedOrigins.includes(origin) ? 403 : 200);
         res.end();
         return;
       }
 
       const url = req.url?.split('?')[0];
+
+      // A browser-origin request to a protected endpoint is refused outright,
+      // regardless of the token: a page that can reach this port is not a
+      // client we have any reason to serve.
+      if (requiresAuth(url) && origin && !allowedOrigins.includes(origin)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Origin not allowed' }));
+        return;
+      }
+
+      if (requiresAuth(url) && !this.authorize(req, res)) return;
 
       if (url === '/health' || url === '/') {
         const status = this.getStatus();
@@ -271,6 +331,21 @@ export class ApiServer {
         return;
       }
 
+      // The helper's "Settings" menu item used to open `/config` in a browser,
+      // which both dumped every credential into the browser and now returns
+      // 401. It asks the app to open its own settings window instead.
+      if (url === '/voice/open-settings' && req.method === 'POST') {
+        if (!this.onOpenSettings) {
+          res.writeHead(503, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'No settings UI is attached to this gateway' }));
+          return;
+        }
+        this.onOpenSettings();
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
       // ── Existing endpoints ────────────────────────────────────────
 
       if (url === '/config' && req.method === 'GET') {
@@ -312,12 +387,19 @@ export class ApiServer {
       // instead of rejecting this promise.
       const onBindError = (err: Error) => reject(err);
       server.once('error', onBindError);
-      server.listen(this.port, () => {
+      const host = this.configManager.getApiBindHost();
+      if (host !== '127.0.0.1' && host !== 'localhost') {
+        console.warn(
+          `[API] Binding ${host} — the HTTP server is reachable from other machines. ` +
+          'Every protected endpoint relies on bearer tokens alone.',
+        );
+      }
+      server.listen(this.port, host, () => {
         server.removeListener('error', onBindError);
         server.on('error', (err: Error) => {
           console.error(`[API] Server error: ${err.message}`);
         });
-        console.log(`[API] Server running on port ${this.port}`);
+        console.log(`[API] Server running on ${host}:${this.port}`);
         resolve();
       });
     });

--- a/voice/Sources/CodeyVoice/GatewayClient.swift
+++ b/voice/Sources/CodeyVoice/GatewayClient.swift
@@ -49,6 +49,17 @@ final class GatewayClient {
         _ = try? await session.data(for: request)
     }
 
+    /// Ask the Mac app to open its settings window. Replaces opening
+    /// `/config` in a browser: that endpoint now requires a bearer token, and
+    /// it always dumped every stored credential into the browser.
+    func openSettings() async {
+        var request = URLRequest(url: baseURL.appendingPathComponent("voice/open-settings"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data("{}".utf8)
+        _ = try? await session.data(for: request)
+    }
+
     /// Report current status to gateway.
     func reportStatus(_ status: String) async {
         var request = URLRequest(url: baseURL.appendingPathComponent("voice/status"))

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -824,7 +824,6 @@ final class VoiceCoordinator {
     // MARK: - Settings
 
     private func openSettings() {
-        let url = URL(string: "http://127.0.0.1:\(gatewayPort)/config")!
-        NSWorkspace.shared.open(url)
+        Task { await gateway.openSettings() }
     }
 }


### PR DESCRIPTION
## Why

`/config` served the entire gateway configuration — provider API keys, bot tokens, everything — to anyone who could reach the port. Three things stacked up:

- No authentication of any kind on `GET`/`POST /config`.
- `server.listen(port)` was called without a host, so the port was bound on **every** interface — the whole LAN, not just this machine.
- `Access-Control-Allow-Origin: *`, so any web page the user happened to have open could read it straight out of the browser.

This is P1 of the [Router API design](docs/superpowers/specs/2026-08-22-router-api-design.md) — the security floor that has to exist before a `/v1/prompt` endpoint can. It ships on its own because the hole is live today and shouldn't wait on new features.

## What changed

**`packages/gateway/src/api-tokens.ts` (new)** — bearer tokens in `~/.codey/api-tokens.json` (honours `CODEY_HOME`), mode `0600`, storing only `sha256(token)`. The plaintext exists exactly once, at creation, and is printed then. Deliberately *not* a slow hash: bcrypt/argon2 defend low-entropy human passwords against offline brute force, but these are 256 bits of `crypto.randomBytes` — there is nothing to brute-force, and a slow hash would tax every request. Tokens live outside `gateway.json` so that config — which is watched, diffed and served over HTTP — never carries a credential. `CODEY_API_TOKEN` is honoured as an extra valid token for CI and containers.

**Auth** — `/config` and `/v1/*` now require `Authorization: Bearer`. `/health`, `/metrics` and `/ready` stay open: process supervisors poll them and they expose only counters. The store is re-read per request, so a token minted by the CLI in another process works without restarting the gateway.

**CORS** — reflects only `api.allowedOrigins` (default: none). A browser origin on a protected endpoint is refused outright, valid token or not.

**`api.bindHost`** — defaults to `127.0.0.1`. Binding anything else is an explicit choice and logs a warning.

**CLI** — `npm run api-token -- create <name> | list | revoke <id>`.

## Drive-by fix

The Swift voice helper's Settings menu item opened `/config` in a browser, which both dumped every stored credential into the browser and would now return 401. It POSTs a new `/voice/open-settings` instead, and the Mac app opens its own settings window.

## Not in this PR

`/v1/*` is wired behind auth but has no routes yet — it authenticates, then 404s. `/v1/prompt` is P2.

Unifying secret storage (moving the third-party API keys currently in `gateway.json` into the same `0600` store) is agreed as a follow-up PR; see §8 of the spec.

## Verification

- Full suite: **1011 passed / 0 failed**, including 24 new tests (12 token store, 12 auth layer).
- `tsc` clean for gateway and for the Electron main process.
- Swift helper `swift build` succeeds.
- Manually exercised the CLI: on-disk file is `-rw-------` and contains only the hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)