### PR TITLE
Add POST /v1/prompt and GET /v1/capabilities (Router API P2)

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -42,6 +42,7 @@ import { listPlaybooks, playbookDetail, playbookHistory, archivePlaybook, delete
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
 import { ApiServer } from '@codey/gateway/dist/health'
+import { RouterApi } from '@codey/gateway/dist/router-api'
 
 let mainWindow: BrowserWindow | null = null
 let captureWindow: BrowserWindow | null = null
@@ -1083,6 +1084,10 @@ async function bootInProcessCore() {
         // so it asks the app to open its own settings window instead.
         () => { mainWindow?.show(); mainWindow?.focus(); sendToRenderer('notify:openSettings') },
       )
+      apiServer.setRouterApi(new RouterApi(inProcessGateway!.asRouterApiHost(), () => ({
+        timeoutSec: coreConfigManager!.getApiTimeoutSec(),
+        rateLimitPerMin: coreConfigManager!.getApiRateLimitPerMin(),
+      })))
       void apiServer.start().then(() => {
         sendToRenderer('gateway-log', `[core] API server listening on ${apiPort}`)
       }).catch((err: any) => {

--- a/docs/superpowers/specs/2026-08-22-router-api-design.md
+++ b/docs/superpowers/specs/2026-08-22-router-api-design.md
@@ -1,6 +1,6 @@
 # Spec: Router API — 让别的应用调用 Codey 的 agent
 
-状态：P1 已实现；P2–P4 待做
+状态：P1、P2 已实现；P3–P4 待做
 分支：`router-mode`
 路径：`docs/superpowers/specs/2026-08-22-router-api-design.md`
 
@@ -42,7 +42,6 @@
 ```jsonc
 {
   "api": {
-    "enabled": false,          // 默认关。开了才注册 /v1/*
     "bindHost": "127.0.0.1",   // 用户可改。默认只监听本机
     "allowedOrigins": [],      // 留空 = 拒绝所有带 Origin 的请求
     "timeoutSec": 300,
@@ -54,7 +53,9 @@
 规则：
 
 - 所有 `/v1/*` 要求 `Authorization: Bearer <token>`。
-- `api.enabled !== true` 时 `/v1/*` 一律 404（不是 403，不泄露存在性）。
+- ~~`api.enabled` 开关~~ **实现时去掉了**（2026-08-22）。原打算默认关闭 `/v1/*`，
+  但 token 才是真正的门：没有 token 谁也进不来，而"存在但未启用"这个额外状态
+  只会让调用方分不清 404 是路由不存在还是开关没开。没有 token 时 `/v1/*` 一律 401。
 - 带 `Origin` 且不在 `allowedOrigins` 里 → 403，沿用 `/voice/*` 的写法。
 - 顺手把现有 `/config` GET/POST 也挪到同一把锁后面（**这是本期的安全修复项，不是可选项**）。
 - CORS `Allow-Origin: *` 改为按 `allowedOrigins` 回显；没配就不发 CORS 头。
@@ -213,7 +214,7 @@ npm run api-token -- revoke <id>
 - 同 session 并发 → 409
 - 未知 workspace / team → 404
 - 超时 → 504
-- 回归：`api.enabled = false` 时旧行为不变
+- 回归：没挂 RouterApi 时 `/v1/*` 认证后 404（Mac/CLI 之外的嵌入场景）
 
 ## 6. 分期
 
@@ -221,7 +222,9 @@ npm run api-token -- revoke <id>
    + `api-tokens.ts` + `api-token` CLI。`/v1/*` 已挂在鉴权后面但还没有任何路由（认证后 404）。
    附带修了 Swift helper 的 Settings 菜单：原先它在浏览器里打开 `/config`
    （等于把全部凭据倒进浏览器），现在 POST `/voice/open-settings`，由 Mac app 打开自己的设置窗口。
-2. **P2** — `/v1/prompt` 非流式 + `/v1/capabilities`。
+2. **P2 — 已实现**（2026-08-22）。`/v1/prompt`（非流式）+ `/v1/capabilities`，
+   `router-api.ts` + `kind: 'api'` 隐藏 chat + session 复用 + 409/429/504/413。
+   `stream: true` 显式返回 400 而不是假装支持。真机验过：curl 进去，agent 真回了。
 3. **P3** — 流式 + session 端点。
 4. **P4**（另开）— MCP server，内部转调 `/v1/prompt`。
 

--- a/gateway.json.example
+++ b/gateway.json.example
@@ -67,7 +67,9 @@
   },
   "api": {
     "bindHost": "127.0.0.1",
-    "allowedOrigins": []
+    "allowedOrigins": [],
+    "timeoutSec": 300,
+    "rateLimitPerMin": 60
   },
   "dev": {
     "logLevel": "info",

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -135,8 +135,12 @@ export interface Chat {
   id: string;
   title: string;
   workspaceName: string;
-  /** 'automation' marks a hidden system chat owned by an automation; absent = normal user chat. */
-  kind?: 'automation';
+  /**
+   * Marks a hidden system chat; absent = normal user chat.
+   * 'automation' — owned by an automation. 'api' — owned by a Router API session.
+   * Both are excluded from the chat list the user sees.
+   */
+  kind?: 'automation' | 'api';
   selection: ChatSelection;
   messages: ChatMessage[];
   createdAt: number;

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -10,8 +10,8 @@ export interface CreateChatInput {
   workspaceName: string;
   selection?: ChatSelection;
   title?: string;
-  /** 'automation' = hidden system chat (excluded from list() by default). */
-  kind?: 'automation';
+  /** Hidden system chat (excluded from list() by default). */
+  kind?: 'automation' | 'api';
   /** Per-chat agent/model overrides, set at creation (used by automations). */
   agent?: Chat['agent'];
   model?: string;
@@ -130,8 +130,10 @@ export class ChatManager {
 
   list(workspaceName?: string, opts?: { includeAutomation?: boolean }): Chat[] {
     this.ensureLoaded();
+    // Any `kind` marks a system-owned chat (automation, Router API session).
+    // The user's chat list shows only chats the user created.
     const all = [...this.cache.values()]
-      .filter(c => opts?.includeAutomation || c.kind !== 'automation');
+      .filter(c => opts?.includeAutomation || c.kind === undefined);
     const filtered = workspaceName
       ? all.filter(c => c.workspaceName === workspaceName)
       : all;
@@ -547,7 +549,7 @@ export class ChatManager {
     chat.messages.push(message);
     chat.updatedAt = Date.now();
     // Automation chats keep their authoritative "Automation: <name>" title.
-    if (chat.messages.length === 1 && message.role === 'user' && chat.kind !== 'automation') {
+    if (chat.messages.length === 1 && message.role === 'user' && chat.kind === undefined) {
       chat.title = deriveTitle(message.content);
     }
     this.persist(chat);

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -17,6 +17,9 @@ export interface ExternalMcpServerConfig {
 
 /** Loopback only. Exposing the HTTP server has to be an explicit choice. */
 export const DEFAULT_API_BIND_HOST = '127.0.0.1';
+/** Matches the agent adapters' own 5-minute process ceiling. */
+export const DEFAULT_API_TIMEOUT_SEC = 300;
+export const DEFAULT_API_RATE_LIMIT_PER_MIN = 60;
 
 export interface GatewayConfigJson {
   gateway: {
@@ -127,6 +130,14 @@ export interface GatewayConfigJson {
     bindHost?: string;
     /** Browser origins allowed to call the server. Empty = none. */
     allowedOrigins?: string[];
+    /**
+     * How long a single `/v1/prompt` call waits for the agent. Mirrors the
+     * adapters' own 5-minute ceiling. On expiry the caller gets 504 but the run
+     * is left alone — its result still lands in the session.
+     */
+    timeoutSec?: number;
+    /** Requests per minute per token. */
+    rateLimitPerMin?: number;
   };
   /** Voice input helper (native macOS app) configuration. */
   voice?: {
@@ -363,6 +374,12 @@ export class ConfigManager extends EventEmitter {
 
   /** Browser origins allowed to call the HTTP server. Empty = block all. */
   getApiAllowedOrigins(): string[] { return this.config.api?.allowedOrigins ?? []; }
+
+  /** Seconds a single `/v1/prompt` call waits before returning 504. */
+  getApiTimeoutSec(): number { return this.config.api?.timeoutSec ?? DEFAULT_API_TIMEOUT_SEC; }
+
+  /** Requests per minute per token. */
+  getApiRateLimitPerMin(): number { return this.config.api?.rateLimitPerMin ?? DEFAULT_API_RATE_LIMIT_PER_MIN; }
   getSkipPermissions(): boolean { return this.config.gateway.skipPermissions ?? true; }
 
   /** Canonical default = first entry in fallback.order. */
@@ -890,6 +907,8 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
     } as GatewayConfigJson['voice'];
   }
   if (raw.api && typeof raw.api === 'object') {
+    const positive = (v: unknown): number | undefined =>
+      typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : undefined;
     out.api = {
       bindHost: typeof raw.api.bindHost === 'string' && raw.api.bindHost.trim()
         ? raw.api.bindHost.trim()
@@ -897,6 +916,8 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
       allowedOrigins: Array.isArray(raw.api.allowedOrigins)
         ? raw.api.allowedOrigins.filter((o: unknown): o is string => typeof o === 'string' && !!o.trim())
         : undefined,
+      timeoutSec: positive(raw.api.timeoutSec),
+      rateLimitPerMin: positive(raw.api.rateLimitPerMin),
     };
   }
   if (raw.notifications && typeof raw.notifications === 'object') {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -29,6 +29,7 @@ import { resolveEffort } from './effort-resolve';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
+import { RouterApiHost } from './router-api';
 import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildChatCatchupPrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
@@ -772,6 +773,25 @@ export class Codey {
 
   getWorkspaceManager(): WorkspaceManager { return this.workspaceManager; }
   getChatManager(): ChatManager { return this.chatManager; }
+
+  /**
+   * The Router API's view of this gateway (`RouterApiHost`). Built here rather
+   * than handing `router-api.ts` the whole Codey instance, so the HTTP layer
+   * can only reach what it actually needs — and so its tests can stand in a
+   * plain object.
+   */
+  asRouterApiHost(): RouterApiHost {
+    return {
+      getWorkspaceList: () => this.getWorkspaceList(),
+      getTeamNames: () => Object.keys(this.configManager?.getTeams() ?? {}),
+      getModelNames: () => (this.configManager?.listModels() ?? []).map(m => m.model),
+      getDefaultAgent: () => this.configManager?.getDefaultAgent() ?? this.config.defaultAgent,
+      getDefaultModel: () => this.configManager?.getDefaultModel() ?? '',
+      createApiChat: (input) => this.chatManager.create({ ...input, kind: 'api' }),
+      hasChat: (chatId) => !!this.chatManager.get(chatId),
+      sendToChat: (chatId, text, sink) => this.sendToChat(chatId, text, sink),
+    };
+  }
 
   /** New chats begin in the shared checkout. A worktree is created either by
    *  the explicit Branch Selector action or when the running agent opts in. */

--- a/packages/gateway/src/health.ts
+++ b/packages/gateway/src/health.ts
@@ -1,6 +1,7 @@
 import * as http from 'http';
 import { ConfigManager } from './config';
-import { ApiTokenStore, parseBearer } from './api-tokens';
+import { ApiTokenRecord, ApiTokenStore, parseBearer } from './api-tokens';
+import { RouterApi } from './router-api';
 import { VoiceConverseEvent } from '@codey/core';
 
 /**
@@ -58,6 +59,7 @@ export class ApiServer {
   private onConverseHotkey?: () => void;
   private onOpenSettings?: () => void;
   private tokens: ApiTokenStore;
+  private routerApi?: RouterApi;
 
   constructor(
     port: number,
@@ -89,21 +91,32 @@ export class ApiServer {
   }
 
   /**
-   * Authorize a request, writing the error response itself when it fails.
-   * Returns false when the caller should stop handling the request.
+   * Attach the Router API. Separate from the constructor because the gateway
+   * and the server are built in either order depending on the surface (CLI
+   * daemon vs. the Mac app's in-process gateway).
    */
-  private authorize(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+  setRouterApi(routerApi: RouterApi): void {
+    this.routerApi = routerApi;
+  }
+
+  /**
+   * Authorize a request, writing the error response itself when it fails.
+   * Returns the matched token (its id keys per-token rate limiting), or null
+   * when the caller should stop handling the request.
+   */
+  private authorize(req: http.IncomingMessage, res: http.ServerResponse): ApiTokenRecord | null {
     // Re-read the store per request: `api-token create` runs in a separate
     // process, so a long-lived gateway would otherwise reject tokens minted
     // after it booted until restarted.
     this.tokens.reload();
-    if (this.tokens.verify(parseBearer(req.headers.authorization))) return true;
+    const matched = this.tokens.verify(parseBearer(req.headers.authorization));
+    if (matched) return matched;
     res.writeHead(401, { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' });
     res.end(JSON.stringify({
       error: 'Unauthorized',
       hint: 'Send Authorization: Bearer <token>. Create one with: npm run api-token -- create <name>',
     }));
-    return false;
+    return null;
   }
 
   async start(): Promise<void> {
@@ -137,7 +150,17 @@ export class ApiServer {
         return;
       }
 
-      if (requiresAuth(url) && !this.authorize(req, res)) return;
+      let token: ApiTokenRecord | null = null;
+      if (requiresAuth(url)) {
+        token = this.authorize(req, res);
+        if (!token) return;
+      }
+
+      // `/v1/*` is the Router API. It is delegated wholesale so this file stays
+      // the transport + auth layer rather than growing a second router.
+      if (url?.startsWith('/v1/') && this.routerApi) {
+        if (await this.routerApi.handle(req, res, url, token!.id)) return;
+      }
 
       if (url === '/health' || url === '/') {
         const status = this.getStatus();

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -5,6 +5,7 @@ import { handleCommand } from './cli';
 import { GatewayConfig } from '@codey/core';
 import { Codey } from './gateway';
 import { ApiServer, HealthStatusType } from './health';
+import { RouterApi } from './router-api';
 import { assertNoLegacyLayout } from './startup-guard';
 
 dotenv.config();
@@ -74,6 +75,10 @@ function startGateway(): void {
       (transcript, conversationId, emit) => gateway.runVoiceConverse(transcript, conversationId, emit),
       (text, emit, conversationId) => gateway.runVoiceSpeak(text, emit, conversationId),
     );
+    apiServer.setRouterApi(new RouterApi(gateway.asRouterApiHost(), () => ({
+      timeoutSec: configManager.getApiTimeoutSec(),
+      rateLimitPerMin: configManager.getApiRateLimitPerMin(),
+    })));
     await apiServer.start();
 
     // Apply config changes to the running gateway at runtime

--- a/packages/gateway/src/router-api.test.ts
+++ b/packages/gateway/src/router-api.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ApiServer } from './health';
+import { ApiTokenStore } from './api-tokens';
+import { RouterApi, RouterApiHost } from './router-api';
+
+describe('Router API /v1', () => {
+  let dir: string;
+  let store: ApiTokenStore;
+  let server: ApiServer;
+  let port: number;
+  let token: string;
+  let opts: { timeoutSec: number; rateLimitPerMin: number };
+
+  /** Records what the host was asked to do so tests can assert on routing. */
+  let created: Array<Parameters<RouterApiHost['createApiChat']>[0]>;
+  let sent: Array<{ chatId: string; text: string }>;
+  let chats: Set<string>;
+  let respond: (chatId: string, text: string) => Promise<{
+    response: string; chatId: string; tokens?: number; durationSec?: number;
+  }>;
+
+  const host = (): RouterApiHost => ({
+    getWorkspaceList: () => ['alpha', 'beta'],
+    getTeamNames: () => ['reviewers'],
+    getModelNames: () => ['claude-opus-5', 'gpt-5'],
+    getDefaultAgent: () => 'claude-code',
+    getDefaultModel: () => 'claude-opus-5',
+    createApiChat: (input) => {
+      created.push(input);
+      const id = `chat-${created.length}`;
+      chats.add(id);
+      return { id };
+    },
+    hasChat: (chatId) => chats.has(chatId),
+    sendToChat: async (chatId, text) => {
+      sent.push({ chatId, text });
+      return respond(chatId, text);
+    },
+  });
+
+  const fakeStatus = () => ({
+    status: 'healthy' as const,
+    uptime: 1,
+    timestamp: 'now',
+    channels: { telegram: false, discord: false, imessage: false },
+    stats: { messagesProcessed: 0, activeConversations: 0, errors: 0 },
+  });
+
+  const fakeConfigManager = () => ({
+    get: () => ({ gateway: { port: 0 } }),
+    getApiBindHost: () => '127.0.0.1',
+    getApiAllowedOrigins: () => [],
+    update: () => { /* no-op */ },
+    getResolvedVoiceConfig: () => undefined,
+  }) as any;
+
+  const url = (p: string) => `http://127.0.0.1:${port}${p}`;
+  const json = async (res: Response): Promise<any> => res.json();
+
+  const post = (body: unknown, headers: Record<string, string> = {}) =>
+    fetch(url('/v1/prompt'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...headers },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    });
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-routerapi-'));
+    store = new ApiTokenStore(path.join(dir, 'api-tokens.json'));
+    token = store.create('test').token;
+    created = [];
+    sent = [];
+    chats = new Set();
+    opts = { timeoutSec: 5, rateLimitPerMin: 60 };
+    respond = async (chatId) => ({ response: 'done', chatId, tokens: 42, durationSec: 1.5 });
+
+    server = new ApiServer(0, fakeStatus, fakeConfigManager(), undefined, undefined, undefined, undefined, store);
+    server.setRouterApi(new RouterApi(host(), () => opts));
+    await server.start();
+    port = (server as any).server.address().port;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  // ── capabilities ────────────────────────────────────────────────
+
+  it('reports what a client can ask for', async () => {
+    const res = await fetch(url('/v1/capabilities'), { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.workspaces).toEqual(['alpha', 'beta']);
+    expect(body.teams).toEqual(['reviewers']);
+    expect(body.agents).toContain('claude-code');
+    expect(body.defaults).toEqual({ agent: 'claude-code', model: 'claude-opus-5' });
+  });
+
+  it('still requires a token for capabilities', async () => {
+    expect((await fetch(url('/v1/capabilities'))).status).toBe(401);
+  });
+
+  // ── happy path ──────────────────────────────────────────────────
+
+  it('runs a prompt and returns the agent response', async () => {
+    const res = await post({ prompt: 'hello' });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.response).toBe('done');
+    expect(body.tokens).toBe(42);
+    expect(body.durationSec).toBe(1.5);
+    expect(body.sessionId).toMatch(/^sess_/);
+    expect(sent).toEqual([{ chatId: 'chat-1', text: 'hello' }]);
+  });
+
+  it('defaults to the first workspace and creates a hidden api chat', async () => {
+    await post({ prompt: 'hi' });
+    expect(created[0].workspaceName).toBe('alpha');
+    expect(created[0].selection).toEqual({ type: 'none' });
+  });
+
+  it('honours workspace, team, agent and model', async () => {
+    await post({ prompt: 'hi', workspace: 'beta', team: 'reviewers', agent: 'codex', model: 'gpt-5' });
+    expect(created[0]).toMatchObject({
+      workspaceName: 'beta',
+      selection: { type: 'team', name: 'reviewers' },
+      agent: 'codex',
+      model: 'gpt-5',
+    });
+  });
+
+  // ── sessions ────────────────────────────────────────────────────
+
+  it('reuses one chat across calls with the same sessionId', async () => {
+    await post({ prompt: 'first', sessionId: 's1' });
+    await post({ prompt: 'second', sessionId: 's1' });
+    expect(created).toHaveLength(1);
+    expect(sent.map(s => s.chatId)).toEqual(['chat-1', 'chat-1']);
+  });
+
+  it('gives each anonymous call its own chat', async () => {
+    await post({ prompt: 'a' });
+    await post({ prompt: 'b' });
+    expect(created).toHaveLength(2);
+  });
+
+  it('re-creates a chat that was deleted behind the session', async () => {
+    const first = await json(await post({ prompt: 'a', sessionId: 's1' }));
+    chats.clear();
+    const second = await json(await post({ prompt: 'b', sessionId: 's1' }));
+    expect(created).toHaveLength(2);
+    expect(second.sessionId).toBe(first.sessionId);
+  });
+
+  it('rejects a concurrent request on the same session with 409', async () => {
+    let release!: () => void;
+    respond = (chatId) => new Promise(resolve => {
+      release = () => resolve({ response: 'done', chatId });
+    });
+
+    const first = post({ prompt: 'a', sessionId: 's1' });
+    // Let the first request reach sendToChat before the second arrives.
+    await vi.waitFor(() => expect(sent).toHaveLength(1));
+
+    const second = await post({ prompt: 'b', sessionId: 's1' });
+    expect(second.status).toBe(409);
+
+    release();
+    expect((await first).status).toBe(200);
+  });
+
+  it('frees the session again after the request finishes', async () => {
+    await post({ prompt: 'a', sessionId: 's1' });
+    expect((await post({ prompt: 'b', sessionId: 's1' })).status).toBe(200);
+  });
+
+  it('frees the session even when the agent throws', async () => {
+    respond = async () => { throw new Error('agent exploded'); };
+    expect((await post({ prompt: 'a', sessionId: 's1' })).status).toBe(500);
+
+    respond = async (chatId) => ({ response: 'ok', chatId });
+    expect((await post({ prompt: 'b', sessionId: 's1' })).status).toBe(200);
+  });
+
+  // ── validation ──────────────────────────────────────────────────
+
+  it('rejects a missing prompt', async () => {
+    expect((await post({})).status).toBe(400);
+    expect((await post({ prompt: '   ' })).status).toBe(400);
+  });
+
+  it('rejects invalid JSON and an empty body', async () => {
+    expect((await post('not json')).status).toBe(400);
+    expect((await post('')).status).toBe(400);
+  });
+
+  it('404s an unknown workspace, team or model', async () => {
+    expect((await post({ prompt: 'x', workspace: 'nope' })).status).toBe(404);
+    expect((await post({ prompt: 'x', team: 'nope' })).status).toBe(404);
+    expect((await post({ prompt: 'x', model: 'nope' })).status).toBe(404);
+  });
+
+  it('400s an unknown agent', async () => {
+    expect((await post({ prompt: 'x', agent: 'nope' })).status).toBe(400);
+  });
+
+  it('rejects stream:true rather than silently not streaming', async () => {
+    const res = await post({ prompt: 'x', stream: true });
+    expect(res.status).toBe(400);
+    expect((await json(res)).error).toMatch(/[Ss]treaming/);
+  });
+
+  it('never reaches the agent when validation fails', async () => {
+    await post({ prompt: 'x', workspace: 'nope' });
+    expect(sent).toHaveLength(0);
+  });
+
+  it('404s an unknown /v1 route', async () => {
+    const res = await fetch(url('/v1/nonsense'), { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(404);
+  });
+
+  it('404s /v1/prompt on the wrong method', async () => {
+    const res = await fetch(url('/v1/prompt'), { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(404);
+  });
+
+  // ── limits ──────────────────────────────────────────────────────
+
+  it('504s when the agent outruns the timeout', async () => {
+    opts = { timeoutSec: 0.05, rateLimitPerMin: 60 };
+    respond = () => new Promise(resolve => setTimeout(() => resolve({ response: 'late', chatId: 'chat-1' }), 500));
+
+    const res = await post({ prompt: 'slow' });
+    expect(res.status).toBe(504);
+    expect((await json(res)).error).toMatch(/did not respond/);
+  });
+
+  it('429s past the per-minute rate limit', async () => {
+    opts = { timeoutSec: 5, rateLimitPerMin: 2 };
+    expect((await post({ prompt: 'a' })).status).toBe(200);
+    expect((await post({ prompt: 'b' })).status).toBe(200);
+
+    const third = await post({ prompt: 'c' });
+    expect(third.status).toBe(429);
+    expect((await json(third)).error).toMatch(/[Rr]ate limit/);
+  });
+
+  it('rejects an oversized body', async () => {
+    const res = await post({ prompt: 'x'.repeat(2 * 1024 * 1024) });
+    expect(res.status).toBe(413);
+  });
+});

--- a/packages/gateway/src/router-api.ts
+++ b/packages/gateway/src/router-api.ts
@@ -1,0 +1,321 @@
+import * as http from 'http';
+import { CodingAgent } from '@codey/core';
+import { ChatStreamSink } from './chat-runner';
+
+/**
+ * The Router API: `/v1/*`, the entry point for programs rather than people.
+ *
+ * It deliberately owns no execution machinery. A request maps to a hidden chat
+ * (`kind: 'api'`) and goes through `Gateway.sendToChat` — the same call the Mac
+ * app, the channels and the automations make. Automations already proved this
+ * path works with nobody watching; this is that path with an HTTP shell.
+ *
+ * Auth, CORS and origin checks happen upstream in `health.ts` before anything
+ * here runs.
+ */
+
+/** The slice of `Codey` this module needs. Keeps the tests free of the real gateway. */
+export interface RouterApiHost {
+  getWorkspaceList(): string[];
+  getTeamNames(): string[];
+  getModelNames(): string[];
+  getDefaultAgent(): string;
+  getDefaultModel(): string;
+  createApiChat(input: {
+    workspaceName: string;
+    title: string;
+    selection?: { type: 'team'; name: string } | { type: 'none' };
+    agent?: CodingAgent;
+    model?: string;
+  }): { id: string };
+  hasChat(chatId: string): boolean;
+  sendToChat(
+    chatId: string,
+    text: string,
+    sink: ChatStreamSink,
+  ): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }>;
+}
+
+export interface RouterApiOptions {
+  timeoutSec: number;
+  rateLimitPerMin: number;
+}
+
+const AGENTS: readonly CodingAgent[] = ['claude-code', 'opencode', 'codex', 'pi'];
+const MAX_BODY_BYTES = 1024 * 1024;
+
+interface PromptRequest {
+  prompt: string;
+  workspace?: string;
+  agent?: CodingAgent;
+  model?: string;
+  team?: string;
+  sessionId?: string;
+}
+
+/** Thrown for any request we can answer without running an agent. */
+class HttpError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+  }
+}
+
+export class RouterApi {
+  private readonly host: RouterApiHost;
+  private readonly options: () => RouterApiOptions;
+  /** sessionId → chatId. A session IS a hidden chat; this is just the lookup. */
+  private readonly sessions = new Map<string, string>();
+  /** Sessions with a request in flight. Concurrency on one session is a 409. */
+  private readonly inFlight = new Set<string>();
+  /** tokenId → recent request timestamps, trimmed to the last minute. */
+  private readonly recentRequests = new Map<string, number[]>();
+
+  constructor(host: RouterApiHost, options: () => RouterApiOptions) {
+    this.host = host;
+    this.options = options;
+  }
+
+  /**
+   * Handle a `/v1/*` request. Returns false when the path is not one of ours,
+   * so the caller can fall through to its own 404.
+   */
+  async handle(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    url: string,
+    tokenId: string,
+  ): Promise<boolean> {
+    if (url === '/v1/capabilities' && req.method === 'GET') {
+      send(res, 200, {
+        workspaces: this.host.getWorkspaceList(),
+        teams: this.host.getTeamNames(),
+        agents: AGENTS,
+        models: this.host.getModelNames(),
+        defaults: { agent: this.host.getDefaultAgent(), model: this.host.getDefaultModel() },
+      });
+      return true;
+    }
+
+    if (url === '/v1/prompt' && req.method === 'POST') {
+      await this.handlePrompt(req, res, tokenId);
+      return true;
+    }
+
+    return false;
+  }
+
+  private async handlePrompt(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    tokenId: string,
+  ): Promise<void> {
+    let sessionId: string | undefined;
+    let claimed = false;
+    try {
+      this.enforceRateLimit(tokenId);
+      const body = await readBody(req);
+      const parsed = this.validate(body);
+
+      sessionId = parsed.sessionId ?? `sess_${randomId()}`;
+      // Claim before any await that could interleave with a second request for
+      // the same session.
+      if (this.inFlight.has(sessionId)) {
+        throw new HttpError(409, `Session ${sessionId} already has a request in flight`);
+      }
+      this.inFlight.add(sessionId);
+      claimed = true;
+
+      const chatId = this.resolveChat(sessionId, parsed);
+      const result = await this.runWithTimeout(chatId, parsed.prompt);
+
+      send(res, 200, {
+        sessionId,
+        response: result.response,
+        tokens: result.tokens,
+        durationSec: result.durationSec,
+      });
+    } catch (err) {
+      if (err instanceof HttpError) {
+        send(res, err.status, { error: err.message, ...(sessionId ? { sessionId } : {}) });
+        return;
+      }
+      send(res, 500, {
+        error: (err as Error).message ?? 'Internal error',
+        ...(sessionId ? { sessionId } : {}),
+      });
+    } finally {
+      if (claimed && sessionId) this.inFlight.delete(sessionId);
+    }
+  }
+
+  private enforceRateLimit(tokenId: string): void {
+    const limit = this.options().rateLimitPerMin;
+    const now = Date.now();
+    const cutoff = now - 60_000;
+    const recent = (this.recentRequests.get(tokenId) ?? []).filter(t => t > cutoff);
+    if (recent.length >= limit) {
+      throw new HttpError(429, `Rate limit exceeded (${limit} requests/minute)`);
+    }
+    recent.push(now);
+    this.recentRequests.set(tokenId, recent);
+  }
+
+  private validate(body: unknown): PromptRequest {
+    if (!body || typeof body !== 'object') throw new HttpError(400, 'Body must be a JSON object');
+    const b = body as Record<string, unknown>;
+
+    const prompt = typeof b.prompt === 'string' ? b.prompt.trim() : '';
+    if (!prompt) throw new HttpError(400, 'prompt is required');
+
+    // Streaming is P3. Accepting `stream: true` silently and answering with a
+    // single JSON blob would look like a working stream that never streams.
+    if (b.stream === true) {
+      throw new HttpError(400, 'Streaming is not implemented yet; omit `stream` or set it to false');
+    }
+
+    const workspaces = this.host.getWorkspaceList();
+    let workspace: string | undefined;
+    if (b.workspace !== undefined) {
+      if (typeof b.workspace !== 'string') throw new HttpError(400, 'workspace must be a string');
+      if (!workspaces.includes(b.workspace)) {
+        throw new HttpError(404, `Unknown workspace: ${b.workspace}. Known: ${workspaces.join(', ') || '(none)'}`);
+      }
+      workspace = b.workspace;
+    } else {
+      if (workspaces.length === 0) throw new HttpError(503, 'No workspaces are configured');
+      workspace = workspaces[0];
+    }
+
+    let team: string | undefined;
+    if (b.team !== undefined) {
+      if (typeof b.team !== 'string') throw new HttpError(400, 'team must be a string');
+      const teams = this.host.getTeamNames();
+      if (!teams.includes(b.team)) {
+        throw new HttpError(404, `Unknown team: ${b.team}. Known: ${teams.join(', ') || '(none)'}`);
+      }
+      team = b.team;
+    }
+
+    let agent: CodingAgent | undefined;
+    if (b.agent !== undefined) {
+      if (!AGENTS.includes(b.agent as CodingAgent)) {
+        throw new HttpError(400, `Unknown agent: ${String(b.agent)}. Known: ${AGENTS.join(', ')}`);
+      }
+      agent = b.agent as CodingAgent;
+    }
+
+    let model: string | undefined;
+    if (b.model !== undefined) {
+      if (typeof b.model !== 'string') throw new HttpError(400, 'model must be a string');
+      const models = this.host.getModelNames();
+      if (!models.includes(b.model)) {
+        throw new HttpError(404, `Unknown model: ${b.model}. Known: ${models.join(', ') || '(none)'}`);
+      }
+      model = b.model;
+    }
+
+    let sessionId: string | undefined;
+    if (b.sessionId !== undefined) {
+      if (typeof b.sessionId !== 'string' || !b.sessionId.trim()) {
+        throw new HttpError(400, 'sessionId must be a non-empty string');
+      }
+      sessionId = b.sessionId.trim();
+    }
+
+    return { prompt, workspace, agent, model, team, sessionId };
+  }
+
+  /**
+   * Map a session to its chat, creating one on first use. A session whose chat
+   * has since been deleted gets a fresh chat rather than a 404: the caller's
+   * session id stays valid, it just loses the old context.
+   */
+  private resolveChat(sessionId: string, parsed: PromptRequest): string {
+    const existing = this.sessions.get(sessionId);
+    if (existing && this.host.hasChat(existing)) return existing;
+
+    const chat = this.host.createApiChat({
+      workspaceName: parsed.workspace!,
+      title: `API: ${sessionId}`,
+      selection: parsed.team ? { type: 'team', name: parsed.team } : { type: 'none' },
+      agent: parsed.agent,
+      model: parsed.model,
+    });
+    this.sessions.set(sessionId, chat.id);
+    return chat.id;
+  }
+
+  /**
+   * The agent is NOT cancelled on timeout — it keeps running and its answer
+   * lands in the session's chat. Only this HTTP response gives up waiting.
+   */
+  private async runWithTimeout(
+    chatId: string,
+    prompt: string,
+  ): Promise<{ response: string; tokens?: number; durationSec?: number }> {
+    const timeoutSec = this.options().timeoutSec;
+    const noop: ChatStreamSink = () => { /* P2 is request/response; P3 streams these */ };
+
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () => reject(new HttpError(504, `Agent did not respond within ${timeoutSec}s; the run continues in session context`)),
+        timeoutSec * 1000,
+      );
+    });
+
+    try {
+      return await Promise.race([this.host.sendToChat(chatId, prompt, noop), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}
+
+function send(res: http.ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+function randomId(): string {
+  // Session ids are handed back to the caller, not used as credentials — the
+  // chat behind one is only reachable through an authenticated request.
+  return Math.random().toString(36).slice(2, 10) + Math.random().toString(36).slice(2, 10);
+}
+
+function readBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let tooLarge = false;
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        // Keep draining instead of destroying the socket: tearing it down
+        // mid-upload reaches the client as a connection reset, not as the 413
+        // that explains what went wrong.
+        tooLarge = true;
+        chunks.length = 0;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (tooLarge) {
+        reject(new HttpError(413, `Request body exceeds ${MAX_BODY_BYTES} bytes`));
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString('utf-8');
+      if (!raw.trim()) {
+        reject(new HttpError(400, 'Body must be a JSON object'));
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(new HttpError(400, 'Invalid JSON'));
+      }
+    });
+    req.on('error', err => reject(err));
+  });
+}


### PR DESCRIPTION
## Why

P1 (#328) locked the HTTP server down and added bearer tokens. That was the lock. This is the door: programs — scripts, CI, other apps — can now hand Codey a prompt over HTTP and get the agent's answer back.

Second phase of the [Router API design](docs/superpowers/specs/2026-08-22-router-api-design.md).

## Approach

`router-api.ts` owns no execution machinery. A request maps to a hidden chat (`kind: 'api'`) and goes through `Gateway.sendToChat` — the same call the Mac app, the channels and the automations already make. Automations had already proved that path works with nobody watching; this is that path with an HTTP shell around it.

The gateway hands the HTTP layer a narrow `RouterApiHost` view rather than the whole `Codey` instance, so the endpoint can only reach what it needs and its tests can stand in a plain object.

## Endpoints

**`POST /v1/prompt`** — `{prompt, workspace?, agent?, model?, team?, sessionId?}` → `{sessionId, response, tokens, durationSec}`. Reusing a `sessionId` reuses its chat, so callers get conversation context across calls. Omitting it gives a one-shot chat.

**`GET /v1/capabilities`** — workspaces, teams, agents, models and the defaults, so a client doesn't have to guess what it may ask for.

## Decisions worth flagging

**`stream: true` returns 400.** Streaming is P3. Accepting the flag and answering with a single JSON blob would look like a working stream that never streams — a clear refusal is better than a silent lie.

**409 rather than queueing** when a session already has a request in flight. A queued request looks identical to a hung one from the caller's side.

**504 does not kill the agent.** Only this HTTP response gives up waiting; the run continues and its answer still lands in the session's chat, retrievable on the next call.

**Dropped the planned `api.enabled` flag.** The token is the real gate — without one nobody gets in — and an extra "exists but disabled" state would leave callers unable to tell a 404 for a missing route from a 404 for an unflipped switch. Recorded in §3.1 of the spec.

Other limits: 429 past `api.rateLimitPerMin` (default 60), 504 past `api.timeoutSec` (default 300, matching the adapters' own ceiling), 413 over 1 MB. The oversized-body path drains the request instead of destroying the socket, so the client actually receives the 413 rather than a connection reset.

## Incidental

Chats carrying any `kind` are now excluded from the user-facing chat list and from title derivation. Both previously keyed on `'automation'` alone, so a Router API session would have shown up in the sidebar and burned an Aide call naming itself.

## Verification

Verified against a real gateway, not only mocks: booted `Codey` with the real config and workspaces, `POST`ed a prompt over real HTTP, and the agent answered `PONG` in 12s (`tokens: 234`). Auth (401 without a token), validation (400 on a missing prompt, 404 on an unknown workspace) and `/v1/capabilities` were checked the same way.

- Full suite: **1597 passed / 0 failed**, including 22 new Router API tests.
- `tsc` clean for core, gateway and the Electron main process.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)