### PR TITLE
Move provider keys and bot tokens into a 0600 secret store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,19 @@ Gateway config: `gateway.json` (see `gateway.json.example`)
 
 Environment variables override config: `PORT`, `DEFAULT_AGENT`, `DEFAULT_MODEL`, `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`.
 
+**Secrets do not live in `gateway.json`.** Provider API keys and bot tokens are
+stored in `~/.codey/secrets.json` (mode `0600`), and Router API bearer tokens in
+`~/.codey/api-tokens.json` — both via `secure-file.ts`. `gateway.json` keeps only
+the non-secret metadata (key name, base URL, purpose; channel enabled/disabled)
+with the secret field blanked. A config still holding inline secrets is migrated
+automatically on load: the value is written to the store first, then rewritten
+out of `gateway.json`. `ConfigManager` hydrates the values back into the
+in-memory config, so runtime readers see the shape they always saw.
+
+Tests must never build a `SecretStore` or `ApiTokenStore` on the default path —
+`packages/gateway/vitest.setup.ts` redirects `CODEY_HOME` to a temp dir so a
+fixture key cannot be migrated into a real credential store.
+
 ## TypeScript
 
 - Target: ES2020, Module: CommonJS, strict mode

--- a/docs/superpowers/specs/2026-08-22-router-api-design.md
+++ b/docs/superpowers/specs/2026-08-22-router-api-design.md
@@ -1,6 +1,6 @@
 # Spec: Router API — 让别的应用调用 Codey 的 agent
 
-状态：P1、P2 已实现；P3–P4 待做
+状态：P1、P2 已合并；统一密钥管理已实现；P3–P4 待做
 分支：`router-mode`
 路径：`docs/superpowers/specs/2026-08-22-router-api-design.md`
 
@@ -234,11 +234,31 @@ npm run api-token -- revoke <id>
 - **Token 存储**：`~/.codey/api-tokens.json`，`0600`，**只存 sha256 哈希**，
   明文只在生成时打印一次。不上 Keychain（headless / Linux 跑不了）。（2026-08-22 定）
 
-## 8. 后续（已确认要做，不在本 spec 范围）
+## 8. 统一密钥管理 — 已实现（2026-08-22）
 
-- **统一密钥管理**（2026-08-22 用户确认）：Router API 落地后，单开一个 PR，
-  把 `gateway.json` 里现存的第三方 API key（Anthropic / OpenAI / Google、
-  Telegram / Discord bot token 等）也收进 `~/.codey` 下的 0600 密钥库，
-  与 `api-tokens.json` 复用同一套读写原语（`secret-store.ts`）。
-  本期先不动它们（改动面大、与 Router API 正交），
-  但 `/config` 上锁后它们至少不再能被 HTTP 裸读。
+`gateway.json` 里的第三方 API key 和 bot token 已收进 `~/.codey/secrets.json`
+（`0600`），与 `api-tokens.json` 共用 `secure-file.ts` 的读写原语。
+
+- **按敏感度切分，不按功能切分**：非敏感元数据（key 名、base URL、purpose、
+  channel 开关）留在 `gateway.json`，只有密钥串搬走。
+- **密钥字段留空而不是删掉**，这样人打开文件能看出"配过，只是存别处"，
+  不会误以为从没配过。
+- **迁移是自动的、单向的**：老 config 里的内联密钥在加载时先写进密钥库，
+  **然后**才重写 `gateway.json`。顺序不能反——中途崩溃最坏是两边都有，下次加载自动收敛。
+- **`ConfigManager` 在内存里把密钥装回去**，所以 channels、adapters、Mac app
+  的 key 编辑器一行都不用改。存储位置是实现细节，不是 API 变更。
+- `/config` 端点额外做一次 redact：有 token 是"允许读配置"，不是"允许导出全部凭据"。
+- 明文存储，不加密。这跟 `~/.ssh/id_rsa`、`~/.aws/credentials` 是同一个信任模型：
+  只有进程属主能读。加密就要有密钥，密钥又要找地方放，绕回原问题。
+
+实现时抓到的两个真 bug（都是测试先发现的）：
+1. `adoptSecrets` 里直接调 `save()`，而构造函数此时还没给 `this.config` 赋值
+   → 迁移静默失败，密钥留在磁盘上。改成置标志、构造完再存。
+2. `normalize` 原本会丢掉 `apiKey` 为空的条目。剥离密钥后所有条目的 apiKey 都是空的，
+   **重启一次全部 key 条目就没了**。改成只丢没有 `name` 的条目。
+
+还加了 `vitest.setup.ts` 把 `CODEY_HOME` 指向临时目录：
+否则测试里的 fixture 密钥会被"迁移"进开发者真实的密钥库（实现过程中真的发生了一次）。
+
+**不在范围内**：`mcpServers[].env` 里的值仍是明文存在 `gateway.json`。
+那是用户自定义的任意 env，无法可靠判断哪个是密钥；要收也得先让用户显式标注。

--- a/packages/gateway/src/api-tokens.ts
+++ b/packages/gateway/src/api-tokens.ts
@@ -1,7 +1,6 @@
 import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
+import { codeyHome, readSecureJson, writeSecureJson } from './secure-file';
 
 /**
  * Bearer tokens for the Router API.
@@ -21,7 +20,6 @@ import * as path from 'path';
  */
 
 export const TOKEN_PREFIX = 'codey_';
-const FILE_MODE = 0o600;
 const STORE_VERSION = 1;
 
 /** A token as persisted. `hash` never leaves this module. */
@@ -41,10 +39,8 @@ interface TokenFile {
   tokens: StoredToken[];
 }
 
-/** Base dir mirrors workspace.ts / gateway.ts: CODEY_HOME override, else ~/.codey. */
 export function defaultTokenFilePath(): string {
-  const home = process.env.CODEY_HOME ?? path.join(os.homedir(), '.codey');
-  return path.join(home, 'api-tokens.json');
+  return path.join(codeyHome(), 'api-tokens.json');
 }
 
 function sha256(input: string): string {
@@ -71,43 +67,19 @@ export class ApiTokenStore {
   }
 
   private read(): TokenFile {
-    try {
-      if (!fs.existsSync(this.filePath)) return { version: STORE_VERSION, tokens: [] };
-      // The file may have been created by an older build, restored from a
-      // backup, or copied around — re-assert 0600 on every read rather than
-      // trusting whatever mode it arrived with.
-      this.enforceMode();
-      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
-      const tokens = Array.isArray(parsed?.tokens) ? parsed.tokens : [];
-      return {
-        version: typeof parsed?.version === 'number' ? parsed.version : STORE_VERSION,
-        tokens: tokens.filter((t: unknown): t is StoredToken =>
-          !!t && typeof (t as StoredToken).id === 'string' && typeof (t as StoredToken).hash === 'string'),
-      };
-    } catch (err) {
-      // A broken token file must not take the gateway down; it means "no valid
-      // tokens", which the auth layer already handles as 401.
-      console.error(`[api-tokens] unreadable ${this.filePath}: ${(err as Error).message}`);
-      return { version: STORE_VERSION, tokens: [] };
-    }
-  }
-
-  private enforceMode(): void {
-    try {
-      const mode = fs.statSync(this.filePath).mode & 0o777;
-      if (mode !== FILE_MODE) {
-        console.warn(`[api-tokens] ${this.filePath} was mode ${mode.toString(8)}; tightening to 600`);
-        fs.chmodSync(this.filePath, FILE_MODE);
-      }
-    } catch { /* best effort — a filesystem without POSIX modes is not a failure */ }
+    // A broken token file must not take the gateway down; it means "no valid
+    // tokens", which the auth layer already handles as 401.
+    const parsed = readSecureJson<Partial<TokenFile>>(this.filePath, {});
+    const tokens = Array.isArray(parsed.tokens) ? parsed.tokens : [];
+    return {
+      version: typeof parsed.version === 'number' ? parsed.version : STORE_VERSION,
+      tokens: tokens.filter((t: unknown): t is StoredToken =>
+        !!t && typeof (t as StoredToken).id === 'string' && typeof (t as StoredToken).hash === 'string'),
+    };
   }
 
   private write(): void {
-    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
-    // `mode` only applies when the file is created, so chmod afterwards too:
-    // an existing file keeps its old (possibly wider) mode otherwise.
-    fs.writeFileSync(this.filePath, JSON.stringify(this.file, null, 2), { mode: FILE_MODE });
-    this.enforceMode();
+    writeSecureJson(this.filePath, this.file);
   }
 
   /**

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -3,12 +3,15 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { ConfigManager } from './config';
+import { SecretStore } from './secret-store';
 
 function withTempConfig(initial: any, fn: (cm: ConfigManager, p: string) => void) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-cfg-'));
   const p = path.join(dir, 'gateway.json');
   fs.writeFileSync(p, JSON.stringify(initial));
-  const cm = new ConfigManager(p);
+  // Own secret store per case: the default one lives under CODEY_HOME and
+  // would carry state between tests.
+  const cm = new ConfigManager(p, new SecretStore(path.join(dir, 'secrets.json')));
   try { fn(cm, p); } finally { cm.stop(); fs.rmSync(dir, { recursive: true, force: true }); }
 }
 
@@ -24,7 +27,7 @@ describe('config normalize', () => {
     });
   });
 
-  it('parses apiKeys array and preserves valid entries', () => {
+  it('parses apiKeys array, dropping only entries without a name', () => {
     withTempConfig({
       apiKeys: [
         { name: 'main', apiKey: 'sk-1', anthropicBaseUrl: 'https://anthropic.example', openaiBaseUrl: 'https://openai.example' },
@@ -33,8 +36,10 @@ describe('config normalize', () => {
       ],
     }, cm => {
       const apiKeys = cm.listApiKeys();
-      expect(apiKeys).toHaveLength(1);
-      expect(apiKeys[0].name).toBe('main');
+      // 'noKey' is kept: a missing secret is the normal on-disk state now that
+      // the value lives in the 0600 store. Only a nameless entry is unusable.
+      expect(apiKeys.map(a => a.name)).toEqual(['main', 'noKey']);
+      expect(apiKeys[1].apiKey).toBe('');
     });
   });
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { EventEmitter } from 'events';
+import { SecretKey, SecretStore, apiKeySecret, channelSecret } from './secret-store';
 import { ApiKeyEntry, CodingAgent, FallbackConfig, FallbackEntry, isApiType, McpServerSpec, ModelEntry, TeamConfigRaw, ThinkingEffort } from '@codey/core';
 
 // ── Configuration types ─────────────────────────────────────────────
@@ -254,12 +255,23 @@ export class ConfigManager extends EventEmitter {
   private watcher?: fs.FSWatcher;
   private lastSerialized: string = '';
   private reloadTimer?: NodeJS.Timeout;
+  private secrets: SecretStore;
+  /** Set by adoptSecrets when it found inline secrets that must be rewritten out. */
+  private pendingMigration = false;
 
-  constructor(configPath?: string) {
+  constructor(configPath?: string, secrets?: SecretStore) {
     super();
     this.configPath = configPath || path.join(process.cwd(), 'gateway.json');
+    this.secrets = secrets ?? new SecretStore();
     this.config = this.loadConfig();
-    this.lastSerialized = JSON.stringify(this.config);
+    this.lastSerialized = JSON.stringify(stripSecrets(this.config));
+    // A migration is only complete once the secret is off disk. This cannot
+    // happen inside loadConfig(): save() reads this.config, which is not
+    // assigned until the line above.
+    if (this.pendingMigration) {
+      this.pendingMigration = false;
+      this.save();
+    }
     this.startWatching();
   }
 
@@ -267,12 +279,55 @@ export class ConfigManager extends EventEmitter {
     try {
       if (fs.existsSync(this.configPath)) {
         const data = fs.readFileSync(this.configPath, 'utf-8');
-        return normalize(JSON.parse(data));
+        return this.adoptSecrets(normalize(JSON.parse(data)));
       }
     } catch (error) {
       console.error('[Config] Error loading config:', error);
     }
-    return getDefaultConfig();
+    return this.adoptSecrets(getDefaultConfig());
+  }
+
+  /**
+   * Reconcile a freshly-parsed config with the secret store, in both
+   * directions:
+   *
+   * - **Migration.** A secret still written inline in `gateway.json` (an
+   *   existing install, a hand-edited file, `gateway.json.example`) is moved
+   *   into the store and the config is rewritten without it. This is the only
+   *   path that removes a secret from disk, so it must never drop one: the
+   *   store is written first, and only then is the config re-saved.
+   * - **Hydration.** Every secret the store knows about is put back into the
+   *   in-memory config. Existing readers — the channels, the agent adapters,
+   *   the Mac app's key editor — keep seeing the shape they always saw. The
+   *   split is a storage detail, not an API change.
+   */
+  private adoptSecrets(config: GatewayConfigJson): GatewayConfigJson {
+    const migrated: Array<[SecretKey, string]> = [];
+
+    for (const entry of config.apiKeys ?? []) {
+      if (entry.apiKey) migrated.push([apiKeySecret(entry.name), entry.apiKey]);
+    }
+    for (const channel of ['telegram', 'discord'] as const) {
+      const token = config.channels?.[channel]?.botToken;
+      if (token) migrated.push([channelSecret(channel), token]);
+    }
+    if (migrated.length > 0) {
+      this.secrets.setMany(migrated);
+      this.pendingMigration = true;
+      console.log(`[Config] Moved ${migrated.length} secret(s) out of ${this.configPath} into the 0600 secret store`);
+    }
+
+    // Hydrate after migrating so a value present in both places resolves to
+    // the config's — the file the user just edited wins over the cache.
+    for (const entry of config.apiKeys ?? []) {
+      if (!entry.apiKey) entry.apiKey = this.secrets.get(apiKeySecret(entry.name)) ?? '';
+    }
+    for (const channel of ['telegram', 'discord'] as const) {
+      const slot = config.channels?.[channel];
+      if (slot && !slot.botToken) slot.botToken = this.secrets.get(channelSecret(channel)) ?? '';
+    }
+
+    return config;
   }
 
   private startWatching(): void {
@@ -292,12 +347,21 @@ export class ConfigManager extends EventEmitter {
       if (!fs.existsSync(this.configPath)) return;
       const data = fs.readFileSync(this.configPath, 'utf-8');
       const next = normalize(JSON.parse(data));
-      const serialized = JSON.stringify(next);
+      // Compare stripped forms: the file never carries secrets, so including
+      // the hydrated values would make every reload look like a change.
+      const serialized = JSON.stringify(stripSecrets(next));
       if (serialized === this.lastSerialized) return;
-      this.config = next;
+      // Another process may have written a secret since we last read.
+      this.secrets.reload();
+      this.config = this.adoptSecrets(next);
       this.lastSerialized = serialized;
       console.log('[Config] Reloaded from disk');
-      this.emit('change', this.config);
+      if (this.pendingMigration) {
+        this.pendingMigration = false;
+        this.save();  // emits 'change' itself
+      } else {
+        this.emit('change', this.config);
+      }
     } catch (err) {
       console.error('[Config] reload failed:', err);
     }
@@ -312,14 +376,33 @@ export class ConfigManager extends EventEmitter {
 
   save(): void {
     try {
-      const serialized = JSON.stringify(this.config, null, 2);
-      fs.writeFileSync(this.configPath, serialized);
-      this.lastSerialized = JSON.stringify(this.config);
+      // Secrets are pushed to the 0600 store BEFORE the config is written, so
+      // a crash between the two loses nothing: the worst case is a secret in
+      // both places, which the next load reconciles.
+      this.persistSecrets();
+      const onDisk = stripSecrets(this.config);
+      fs.writeFileSync(this.configPath, JSON.stringify(onDisk, null, 2));
+      this.lastSerialized = JSON.stringify(onDisk);
       console.log('[Config] Saved to', this.configPath);
+      // Listeners get the live config, secrets included — they are runtime
+      // consumers (channels, adapters), not writers.
       this.emit('change', this.config);
     } catch (error) {
       console.error('[Config] Error saving config:', error);
     }
+  }
+
+  /** Mirror the in-memory secrets into the store. */
+  private persistSecrets(): void {
+    const entries: Array<[SecretKey, string]> = [];
+    for (const entry of this.config.apiKeys ?? []) {
+      if (entry.apiKey) entries.push([apiKeySecret(entry.name), entry.apiKey]);
+    }
+    for (const channel of ['telegram', 'discord'] as const) {
+      const token = this.config.channels?.[channel]?.botToken;
+      if (token) entries.push([channelSecret(channel), token]);
+    }
+    this.secrets.setMany(entries);
   }
 
   /** Bulk update from external source (e.g. renderer IPC). Merges, saves, emits change. */
@@ -508,6 +591,9 @@ export class ConfigManager extends EventEmitter {
     const idx = this.config.apiKeys.findIndex(a => a.name === oldName);
     if (idx < 0) return false;
     this.config.apiKeys[idx] = { ...this.config.apiKeys[idx], name: newName };
+    // The store is keyed by entry name; without this the secret is orphaned
+    // under the old key and the renamed entry silently loses its credential.
+    this.secrets.rename(apiKeySecret(oldName), apiKeySecret(newName));
     // Rewrite every model that referenced the old name so apiKeyRef stays valid.
     for (const m of this.config.models) {
       if (m.apiKeyRef === oldName) m.apiKeyRef = newName;
@@ -532,6 +618,9 @@ export class ConfigManager extends EventEmitter {
     const before = this.config.apiKeys.length;
     this.config.apiKeys = this.config.apiKeys.filter(a => a.name !== name);
     if (this.config.apiKeys.length !== before) {
+      // Deleting the entry has to delete the credential; `save()` only writes
+      // secrets it can still see in the config.
+      this.secrets.delete(apiKeySecret(name));
       this.save();
       return true;
     }
@@ -806,6 +895,25 @@ function getDefaultConfig(): GatewayConfigJson {
   };
 }
 
+/**
+ * The config as it is allowed to touch disk: same shape, secrets blanked.
+ *
+ * Blanked rather than deleted, so the JSON keeps the field and a reader
+ * (including a human opening the file) sees that a credential exists and is
+ * stored elsewhere — rather than concluding none was ever configured.
+ */
+export function stripSecrets(config: GatewayConfigJson): GatewayConfigJson {
+  return {
+    ...config,
+    apiKeys: (config.apiKeys ?? []).map(entry => ({ ...entry, apiKey: '' })),
+    channels: {
+      ...config.channels,
+      ...(config.channels?.telegram ? { telegram: { ...config.channels.telegram, botToken: '' } } : {}),
+      ...(config.channels?.discord ? { discord: { ...config.channels.discord, botToken: '' } } : {}),
+    },
+  };
+}
+
 /** Fill in any missing top-level fields with defaults so downstream code can assume shape. */
 function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: CodingAgent; model?: string }; planner?: { model?: string } }): GatewayConfigJson {
   const defaults = getDefaultConfig();
@@ -820,8 +928,13 @@ function normalize(raw: Partial<GatewayConfigJson> & { dispatcher?: { agent?: Co
     apiKeyRef: (m as any).apiKeyRef,
     provider: m.provider,
   }));
+  // `name` is the identity; an empty `apiKey` is now the normal on-disk state
+  // (the secret lives in the 0600 store) and must NOT drop the entry, or every
+  // saved key would vanish on the first reload after being stripped.
   const apiKeys: ApiKeyEntry[] = Array.isArray(raw.apiKeys)
-    ? raw.apiKeys.filter((a: any) => a && typeof a.name === 'string' && a.name.trim() && typeof a.apiKey === 'string' && a.apiKey.trim())
+    ? raw.apiKeys
+        .filter((a: any) => a && typeof a.name === 'string' && a.name.trim())
+        .map((a: any) => ({ ...a, apiKey: typeof a.apiKey === 'string' ? a.apiKey : '' }))
     : [];
   const out: GatewayConfigJson = {
     gateway: { ...defaults.gateway, ...(raw.gateway ?? {}) },

--- a/packages/gateway/src/health.auth.test.ts
+++ b/packages/gateway/src/health.auth.test.ts
@@ -26,7 +26,11 @@ describe('ApiServer auth', () => {
 
   // Minimal stand-in: the server only needs these three methods.
   const fakeConfigManager = () => ({
-    get: () => ({ gateway: { port: 0 }, apiKeys: [{ name: 'anthropic', apiKey: 'sk-super-secret' }] }),
+    get: () => ({
+      gateway: { port: 0 },
+      channels: { telegram: { enabled: true, botToken: 'bot-secret' } },
+      apiKeys: [{ name: 'anthropic', apiKey: 'sk-super-secret' }],
+    }),
     getApiBindHost: () => apiSettings.bindHost ?? '127.0.0.1',
     getApiAllowedOrigins: () => apiSettings.allowedOrigins ?? [],
     update: () => { /* no-op */ },
@@ -75,11 +79,18 @@ describe('ApiServer auth', () => {
     expect(res.status).toBe(401);
   });
 
-  it('serves /config with a valid token', async () => {
+  it('serves /config with a valid token, secrets redacted', async () => {
     const { token } = store.create('real');
     const res = await fetch(url('/config'), { headers: { Authorization: `Bearer ${token}` } });
     expect(res.status).toBe(200);
-    expect((await json(res)).apiKeys[0].apiKey).toBe('sk-super-secret');
+
+    const body = await res.text();
+    expect(body).not.toContain('sk-super-secret');
+    expect(body).not.toContain('bot-secret');
+    // The entry is still listed — the caller can see a credential exists.
+    const parsed = JSON.parse(body);
+    expect(parsed.apiKeys[0].name).toBe('anthropic');
+    expect(parsed.apiKeys[0].apiKey).toBe('');
   });
 
   it('rejects POST /config with no token', async () => {

--- a/packages/gateway/src/health.ts
+++ b/packages/gateway/src/health.ts
@@ -1,5 +1,5 @@
 import * as http from 'http';
-import { ConfigManager } from './config';
+import { ConfigManager, stripSecrets } from './config';
 import { ApiTokenRecord, ApiTokenStore, parseBearer } from './api-tokens';
 import { RouterApi } from './router-api';
 import { VoiceConverseEvent } from '@codey/core';
@@ -7,10 +7,11 @@ import { VoiceConverseEvent } from '@codey/core';
 /**
  * Endpoints that require a bearer token.
  *
- * `/config` serves the whole gateway configuration — provider API keys, bot
- * tokens, the lot — and used to be readable, and writable, by anyone who could
- * reach the port. `/health`, `/metrics` and `/ready` stay open: they are what
- * process supervisors poll, and they expose only counters.
+ * `/config` serves the whole gateway configuration and used to be readable,
+ * and writable, by anyone who could reach the port. It is now behind a token
+ * AND has its secrets redacted — the credentials themselves live in the 0600
+ * secret store and are never served. `/health`, `/metrics` and `/ready` stay
+ * open: they are what process supervisors poll, and expose only counters.
  *
  * `/voice/*` is not listed because it has its own guard (no-Origin native
  * clients only) and is called by the Swift helper, which has no way to hold a
@@ -374,7 +375,10 @@ export class ApiServer {
       if (url === '/config' && req.method === 'GET') {
         try {
           res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify(this.configManager.get(), null, 2));
+          // Serve the same shape that is written to disk — secrets blanked.
+          // A bearer token authorizes reading configuration, not exfiltrating
+          // every provider credential the user has stored.
+          res.end(JSON.stringify(stripSecrets(this.configManager.get()), null, 2));
         } catch (error) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: String(error) }));

--- a/packages/gateway/src/secret-store.test.ts
+++ b/packages/gateway/src/secret-store.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SecretStore, apiKeySecret, channelSecret } from './secret-store';
+import { ConfigManager, stripSecrets } from './config';
+
+describe('SecretStore', () => {
+  let dir: string;
+  let file: string;
+  let store: SecretStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-secrets-'));
+    file = path.join(dir, 'secrets.json');
+    store = new SecretStore(file);
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('round-trips a value', () => {
+    store.set(apiKeySecret('anthropic'), 'sk-abc');
+    expect(store.get(apiKeySecret('anthropic'))).toBe('sk-abc');
+    expect(new SecretStore(file).get(apiKeySecret('anthropic'))).toBe('sk-abc');
+  });
+
+  it('creates the file at 0600', () => {
+    store.set(apiKeySecret('a'), 'v');
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it('tightens permissions widened behind its back', () => {
+    store.set(apiKeySecret('a'), 'v');
+    fs.chmodSync(file, 0o644);
+    expect(new SecretStore(file).get(apiKeySecret('a'))).toBe('v');
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it('namespaces api keys apart from channel tokens', () => {
+    store.set(apiKeySecret('telegram'), 'a-key');
+    store.set(channelSecret('telegram'), 'a-bot-token');
+    expect(store.get(apiKeySecret('telegram'))).toBe('a-key');
+    expect(store.get(channelSecret('telegram'))).toBe('a-bot-token');
+  });
+
+  it('treats an empty value as a delete', () => {
+    store.set(apiKeySecret('a'), 'v');
+    store.set(apiKeySecret('a'), '');
+    expect(store.get(apiKeySecret('a'))).toBeUndefined();
+  });
+
+  it('renames without losing the value', () => {
+    store.set(apiKeySecret('old'), 'v');
+    store.rename(apiKeySecret('old'), apiKeySecret('new'));
+    expect(store.get(apiKeySecret('old'))).toBeUndefined();
+    expect(store.get(apiKeySecret('new'))).toBe('v');
+  });
+
+  it('deletes', () => {
+    store.set(apiKeySecret('a'), 'v');
+    expect(store.delete(apiKeySecret('a'))).toBe(true);
+    expect(store.delete(apiKeySecret('a'))).toBe(false);
+  });
+
+  it('survives a corrupt file', () => {
+    fs.writeFileSync(file, 'garbage');
+    const reopened = new SecretStore(file);
+    expect(reopened.keys()).toEqual([]);
+    reopened.set(apiKeySecret('a'), 'v');
+    expect(reopened.get(apiKeySecret('a'))).toBe('v');
+  });
+});
+
+describe('ConfigManager secret handling', () => {
+  let dir: string;
+  let configPath: string;
+  let secretPath: string;
+  const managers: ConfigManager[] = [];
+
+  const withConfig = (json: unknown): ConfigManager => {
+    fs.writeFileSync(configPath, JSON.stringify(json, null, 2));
+    const m = new ConfigManager(configPath, new SecretStore(secretPath));
+    managers.push(m);
+    return m;
+  };
+
+  const onDisk = () => JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-cfg-'));
+    configPath = path.join(dir, 'gateway.json');
+    secretPath = path.join(dir, 'secrets.json');
+  });
+
+  afterEach(() => {
+    for (const m of managers.splice(0)) m.stop();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('migrates inline secrets out of gateway.json on first load', () => {
+    const mgr = withConfig({
+      gateway: { port: 3000 },
+      channels: { telegram: { enabled: true, botToken: 'bot-123' } },
+      apiKeys: [{ name: 'anthropic', apiKey: 'sk-inline' }],
+    });
+
+    // Still usable in memory — nothing downstream has to change.
+    expect(mgr.getApiKey('anthropic')?.apiKey).toBe('sk-inline');
+    expect(mgr.get().channels.telegram?.botToken).toBe('bot-123');
+
+    // Gone from the config file.
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    expect(raw).not.toContain('sk-inline');
+    expect(raw).not.toContain('bot-123');
+    expect(onDisk().apiKeys[0].name).toBe('anthropic');
+
+    // Present in the 0600 store.
+    const secrets = new SecretStore(secretPath);
+    expect(secrets.get(apiKeySecret('anthropic'))).toBe('sk-inline');
+    expect(secrets.get(channelSecret('telegram'))).toBe('bot-123');
+    expect(fs.statSync(secretPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('survives a restart: the secret comes back from the store', () => {
+    withConfig({
+      gateway: { port: 3000 },
+      apiKeys: [{ name: 'anthropic', apiKey: 'sk-inline' }],
+    });
+
+    const restarted = new ConfigManager(configPath, new SecretStore(secretPath));
+    managers.push(restarted);
+    expect(restarted.getApiKey('anthropic')?.apiKey).toBe('sk-inline');
+  });
+
+  it('keeps a newly saved key out of the config file', () => {
+    const mgr = withConfig({ gateway: { port: 3000 }, apiKeys: [] });
+    mgr.saveApiKey({ name: 'openai', apiKey: 'sk-fresh' });
+
+    expect(fs.readFileSync(configPath, 'utf-8')).not.toContain('sk-fresh');
+    expect(mgr.getApiKey('openai')?.apiKey).toBe('sk-fresh');
+    expect(new SecretStore(secretPath).get(apiKeySecret('openai'))).toBe('sk-fresh');
+  });
+
+  it('moves the secret when an entry is renamed', () => {
+    const mgr = withConfig({ gateway: { port: 3000 }, apiKeys: [{ name: 'old', apiKey: 'sk-1' }] });
+    mgr.renameApiKey('old', 'new');
+
+    expect(mgr.getApiKey('new')?.apiKey).toBe('sk-1');
+    const secrets = new SecretStore(secretPath);
+    expect(secrets.get(apiKeySecret('new'))).toBe('sk-1');
+    expect(secrets.get(apiKeySecret('old'))).toBeUndefined();
+  });
+
+  it('drops the secret when an entry is deleted', () => {
+    const mgr = withConfig({ gateway: { port: 3000 }, apiKeys: [{ name: 'gone', apiKey: 'sk-1' }] });
+    mgr.deleteApiKey('gone');
+    expect(new SecretStore(secretPath).get(apiKeySecret('gone'))).toBeUndefined();
+  });
+
+  it('resolves voice config through the store', () => {
+    const mgr = withConfig({
+      gateway: { port: 3000 },
+      apiKeys: [{ name: 'voice-key', apiKey: 'sk-voice', purpose: 'voice' }],
+      voice: {
+        enabled: true, hotkey: 'F5', language: 'en', injection: 'paste',
+        provider: 'api', apiUrl: 'https://x', apiModel: 'whisper-1',
+        localModel: 'l', apiKeyRef: 'voice-key',
+      },
+    });
+    expect(mgr.getResolvedVoiceConfig()?.apiKey).toBe('sk-voice');
+  });
+
+  it('does not invent a secret for an entry that has none', () => {
+    const mgr = withConfig({ gateway: { port: 3000 }, apiKeys: [{ name: 'empty', apiKey: '' }] });
+    expect(mgr.getApiKey('empty')?.apiKey).toBe('');
+  });
+
+  it('stripSecrets blanks values but keeps the entries visible', () => {
+    const stripped = stripSecrets({
+      gateway: { port: 3000 },
+      channels: { telegram: { enabled: true, botToken: 'bot' }, discord: { enabled: false, botToken: 'd' } },
+      agents: {}, models: [], fallback: { enabled: true, order: [] }, dev: { logLevel: 'info' },
+      apiKeys: [{ name: 'a', apiKey: 'sk-1', openaiBaseUrl: 'https://x' }],
+    });
+    expect(stripped.apiKeys[0]).toEqual({ name: 'a', apiKey: '', openaiBaseUrl: 'https://x' });
+    expect(stripped.channels.telegram?.botToken).toBe('');
+    expect(stripped.channels.telegram?.enabled).toBe(true);
+    expect(stripped.channels.discord?.botToken).toBe('');
+  });
+});

--- a/packages/gateway/src/secret-store.ts
+++ b/packages/gateway/src/secret-store.ts
@@ -1,0 +1,121 @@
+import * as path from 'path';
+import { codeyHome, readSecureJson, writeSecureJson } from './secure-file';
+
+/**
+ * The credentials that used to live inline in `gateway.json`: provider API
+ * keys and chat-platform bot tokens.
+ *
+ * `gateway.json` is the wrong home for a secret. It is world-readable by
+ * default, watched, rewritten on every settings change, diffed, copied between
+ * machines, pasted into bug reports, and — until the Router API work — served
+ * over HTTP to anyone who could reach the port. It also has to stay readable,
+ * because everything else in it is ordinary configuration.
+ *
+ * So the split is by sensitivity, not by feature: non-secret metadata (key
+ * name, base URL, purpose; channel enabled/disabled) stays in `gateway.json`,
+ * and only the secret string moves here, to a `0600` file next to
+ * `api-tokens.json`.
+ *
+ * Values are stored in plaintext. This is not a vault — it is the same
+ * trust model as `~/.ssh/id_rsa` or `~/.aws/credentials`: readable by the user
+ * who owns the process, nobody else. Encrypting at rest would need a key,
+ * which would need somewhere to live, which is the problem we started with.
+ */
+
+const STORE_VERSION = 1;
+
+/** Namespaced so a provider key named "telegram" cannot collide with the bot token. */
+export type SecretKey = `apiKey:${string}` | `channel:${string}`;
+
+export function apiKeySecret(name: string): SecretKey { return `apiKey:${name}`; }
+export function channelSecret(channel: string): SecretKey { return `channel:${channel}`; }
+
+interface SecretFile {
+  version: number;
+  secrets: Record<string, string>;
+}
+
+export function defaultSecretFilePath(): string {
+  return path.join(codeyHome(), 'secrets.json');
+}
+
+export class SecretStore {
+  private readonly filePath: string;
+  private file: SecretFile;
+
+  constructor(filePath: string = defaultSecretFilePath()) {
+    this.filePath = filePath;
+    this.file = this.read();
+  }
+
+  private read(): SecretFile {
+    const parsed = readSecureJson<Partial<SecretFile>>(this.filePath, {});
+    const raw = parsed.secrets;
+    const secrets: Record<string, string> = {};
+    if (raw && typeof raw === 'object') {
+      for (const [k, v] of Object.entries(raw)) {
+        if (typeof v === 'string') secrets[k] = v;
+      }
+    }
+    return { version: typeof parsed.version === 'number' ? parsed.version : STORE_VERSION, secrets };
+  }
+
+  get(key: SecretKey): string | undefined {
+    return this.file.secrets[key];
+  }
+
+  /** Setting an empty value deletes the entry — an empty secret is not a secret. */
+  set(key: SecretKey, value: string): void {
+    if (!value) {
+      this.delete(key);
+      return;
+    }
+    if (this.file.secrets[key] === value) return;
+    this.file.secrets[key] = value;
+    this.write();
+  }
+
+  delete(key: SecretKey): boolean {
+    if (!(key in this.file.secrets)) return false;
+    delete this.file.secrets[key];
+    this.write();
+    return true;
+  }
+
+  /** Rename in place, preserving the value. Used when an API key entry is renamed. */
+  rename(from: SecretKey, to: SecretKey): void {
+    const value = this.file.secrets[from];
+    if (value === undefined) return;
+    delete this.file.secrets[from];
+    this.file.secrets[to] = value;
+    this.write();
+  }
+
+  keys(): SecretKey[] {
+    return Object.keys(this.file.secrets) as SecretKey[];
+  }
+
+  /**
+   * Write several secrets in one go. Used by the migration so importing a
+   * config full of inline keys touches the disk once, not once per key.
+   */
+  setMany(entries: Array<[SecretKey, string]>): void {
+    let changed = false;
+    for (const [key, value] of entries) {
+      if (!value) continue;
+      if (this.file.secrets[key] === value) continue;
+      this.file.secrets[key] = value;
+      changed = true;
+    }
+    if (changed) this.write();
+  }
+
+  private write(): void {
+    writeSecureJson(this.filePath, this.file);
+  }
+
+  /** Re-read from disk. Another process (the Mac app, the daemon) may have written. */
+  reload(): void {
+    this.file = this.read();
+  }
+}

--- a/packages/gateway/src/secure-file.ts
+++ b/packages/gateway/src/secure-file.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Read/write primitives for the files that hold credentials.
+ *
+ * Two rules, applied in one place so both the API token store and the secret
+ * store obey them identically:
+ *
+ * 1. Mode `0600`, re-asserted on every read — a file restored from a backup,
+ *    copied between machines or created by an older build must not stay wide.
+ * 2. A corrupt file is not fatal. These files gate access; failing closed
+ *    ("no credentials") is correct, crashing the gateway is not.
+ */
+
+export const SECURE_FILE_MODE = 0o600;
+
+/** Base dir for Codey's own state: CODEY_HOME override, else ~/.codey. */
+export function codeyHome(): string {
+  return process.env.CODEY_HOME ?? path.join(os.homedir(), '.codey');
+}
+
+/**
+ * Tighten permissions if something widened them. Best effort: a filesystem
+ * without POSIX modes is not a failure.
+ */
+export function enforceSecureMode(filePath: string): void {
+  try {
+    const mode = fs.statSync(filePath).mode & 0o777;
+    if (mode !== SECURE_FILE_MODE) {
+      console.warn(`[secure-file] ${filePath} was mode ${mode.toString(8)}; tightening to 600`);
+      fs.chmodSync(filePath, SECURE_FILE_MODE);
+    }
+  } catch { /* best effort */ }
+}
+
+/**
+ * Parse a credential file, or return `fallback` when it is missing, unreadable
+ * or malformed. Never throws.
+ */
+export function readSecureJson<T>(filePath: string, fallback: T): T {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    enforceSecureMode(filePath);
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+  } catch (err) {
+    console.error(`[secure-file] unreadable ${filePath}: ${(err as Error).message}`);
+    return fallback;
+  }
+}
+
+/** Write a credential file, creating its directory, always at mode 0600. */
+export function writeSecureJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  // `mode` applies only when the file is created, so chmod afterwards too:
+  // an existing file would otherwise keep its old, possibly wider, mode.
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), { mode: SECURE_FILE_MODE });
+  enforceSecureMode(filePath);
+}

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.ts'],
     exclude: ['dist/**', 'node_modules/**'],
   },

--- a/packages/gateway/vitest.setup.ts
+++ b/packages/gateway/vitest.setup.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Point CODEY_HOME at a throwaway directory for the whole suite.
+ *
+ * `SecretStore` and `ApiTokenStore` default to `~/.codey/`. A test that builds
+ * one without an explicit path would otherwise read — and write — the
+ * developer's real credentials: a config fixture containing `sk-1` would be
+ * "migrated" straight into their actual secret store.
+ */
+const home = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-test-home-'));
+process.env.CODEY_HOME = home;
+
+process.on('exit', () => {
+  try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+});


### PR DESCRIPTION
## Why

`gateway.json` is the wrong home for a credential. It is world-readable by default, watched, rewritten on every settings change, diffed, copied between machines and pasted into bug reports — and it has to stay readable, because everything else in it is ordinary configuration. Provider API keys and Telegram/Discord bot tokens sat in it in plaintext.

This is the follow-up agreed during the Router API work (§8 of the [spec](docs/superpowers/specs/2026-08-22-router-api-design.md)), now that P1 (#328) and P2 (#329) are in.

## Approach

**Split by sensitivity, not by feature.** Non-secret metadata — key name, base URL, purpose, channel enabled/disabled — stays in `gateway.json`. Only the secret string moves to `~/.codey/secrets.json` at mode `0600`, next to `api-tokens.json` and sharing its read/write primitives (`secure-file.ts`, extracted from `api-tokens.ts` so both stores enforce the same two rules: re-assert `0600` on every read, and treat a corrupt file as "no credentials" rather than crashing).

**Nothing downstream changes.** `ConfigManager` hydrates secrets back into the in-memory config on load, so the channels, the agent adapters and the Mac app's key editor see exactly the shape they always saw. Where a secret is stored is an implementation detail, not an API change.

**Migration is automatic and ordered.** An inline secret is written to the store *first*, then rewritten out of `gateway.json`. A crash between the two steps leaves the value in both places, which the next load reconciles — the sequence can never lose a credential.

**Secret fields are blanked, not deleted.** Someone opening `gateway.json` can see that a credential exists and is stored elsewhere, rather than concluding none was ever configured.

`GET /config` now redacts as well. A bearer token authorizes reading configuration; it does not authorize exfiltrating every provider credential the user has stored.

## Two defects the tests caught

Worth calling out because both would have been silent:

- **`adoptSecrets` called `save()` from inside `loadConfig()`**, before the constructor had assigned `this.config`. The write threw into `save()`'s catch, so the migration failed quietly and left the secret on disk. It now sets a flag and saves after construction.
- **`normalize` dropped any `apiKeys` entry with an empty `apiKey`.** Since stripping leaves every entry's `apiKey` empty, the first restart after a migration would have deleted every saved key. Only a nameless entry is dropped now.

## Test isolation

`packages/gateway/vitest.setup.ts` points `CODEY_HOME` at a temp dir for the whole gateway suite. Without it, a `ConfigManager` built on the default path migrates test fixtures into the developer's real secret store — which happened once while building this, and is why the guard is structural rather than per-test.

## Verification

Verified end to end, not only through mocks: a `gateway.json` holding a real-shaped API key and bot token was loaded through the real `ConfigManager`; both values landed in a `0600` store, neither string remained anywhere in `gateway.json`, and a fresh process resolved both back from the store.

- Full suite: **1613 passed / 0 failed**, including 16 new secret-store and migration tests.
- `tsc` clean for core, gateway and the Electron main process. Lint clean.

## Out of scope

`mcpServers[].env` values stay inline. They are arbitrary user-supplied environment variables with no reliable way to tell which are secret; collecting them would need the user to mark them explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)