### PR TITLE
Choose a session retention when minting a Router API token

### DIFF
--- a/docs/superpowers/specs/2026-08-22-router-api-design.md
+++ b/docs/superpowers/specs/2026-08-22-router-api-design.md
@@ -1,6 +1,6 @@
 # Spec: Router API — 让别的应用调用 Codey 的 agent
 
-状态：P1、P2 已合并；统一密钥管理、P3 已实现；P4 待做
+状态：P1–P3 + 统一密钥管理已合并；session 保留期已实现；P4 待做
 分支：`router-mode`
 路径：`docs/superpowers/specs/2026-08-22-router-api-design.md`
 
@@ -110,10 +110,28 @@ Linux、容器里；Keychain 只有 macOS，而且需要已解锁的登录会话
 #### CLI
 
 ```bash
-npm run api-token -- create <name>   # 生成，打印一次明文
-npm run api-token -- list            # 只列 id / name / 时间
+npm run api-token -- create <name> [--retention unlimited|15|30|60|90]
+npm run api-token -- list            # 只列 id / name / 时间 / 保留期
 npm run api-token -- revoke <id>
 ```
+
+#### Session 保留期（2026-08-22 加）
+
+每次 API 调用都会在磁盘上留一个隐藏 chat，原本**永不清理**——脚本跑一万次
+就是一万个 json 文件，而且在 UI 里看不见。
+
+所以**在发 token 的时候就让用户选**：无限 / 15 / 30 / 60 / 90 天。
+交互式会列出来让你选；`--retention` 可以直接指定；非交互 shell（CI、脚本）
+拿不到回答，就退回"无限"——也就是原有行为——并提示怎么显式指定。
+
+- 保留期**抄一份到 chat 上**（`Chat.retentionDays`），不是运行时回查 token。
+  这样吊销 token 不会让它产生的 chat 变成没人管的孤儿。
+- 只有**带了 `retentionDays` 的 chat** 会被清理。用户自己的 chat、automation chat、
+  以及"无限" token 建的 chat 一律不碰。
+- 计时从**最后一次活动**（`updatedAt`）算，不是从创建算。还在用的 session 不会被删。
+- 清理由**请求触发**，最多每小时一次，**不开后台定时器**——闲置的 Router API
+  仍然是零开销，而需要清理的堆积本来也只能由请求产生。
+- 清理失败只打日志，不影响触发它的那个请求。
 
 ### 3.2 端点
 

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -141,6 +141,13 @@ export interface Chat {
    * Both are excluded from the chat list the user sees.
    */
   kind?: 'automation' | 'api';
+  /**
+   * Days of inactivity after which this chat is deleted. Set from the Router
+   * API token that created it; absent means keep forever. Copied onto the chat
+   * rather than looked up from the token so revoking the token cannot strand
+   * the transcripts it produced.
+   */
+  retentionDays?: number;
   selection: ChatSelection;
   messages: ChatMessage[];
   createdAt: number;

--- a/packages/gateway/src/api-tokens.test.ts
+++ b/packages/gateway/src/api-tokens.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { ApiTokenStore, TOKEN_PREFIX } from './api-tokens';
+import { ApiTokenStore, TOKEN_PREFIX, describeRetention, parseRetention } from './api-tokens';
 
 describe('ApiTokenStore', () => {
   let dir: string;
@@ -105,5 +105,59 @@ describe('ApiTokenStore', () => {
     const b = store.create('b').token;
     expect(a).not.toBe(b);
     expect(store.list()).toHaveLength(2);
+  });
+
+  it('defaults to unlimited retention', () => {
+    const { record } = store.create('a');
+    expect(record.retentionDays).toBeNull();
+    expect(store.verify(store.create('b').token)?.retentionDays).toBeNull();
+  });
+
+  it('stores the chosen retention and reports it on verify', () => {
+    const { token, record } = store.create('a', 30);
+    expect(record.retentionDays).toBe(30);
+    // The auth layer reads it off the verified token to stamp new chats.
+    expect(store.verify(token)?.retentionDays).toBe(30);
+    expect(new ApiTokenStore(file).list()[0].retentionDays).toBe(30);
+  });
+
+  it('reports unlimited retention for a token minted before the field existed', () => {
+    store.create('a');
+    const raw = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    delete raw.tokens[0].retentionDays;
+    fs.writeFileSync(file, JSON.stringify(raw));
+
+    expect(new ApiTokenStore(file).list()[0].retentionDays).toBeUndefined();
+  });
+});
+
+describe('retention parsing', () => {
+  it('accepts every offered choice', () => {
+    expect(parseRetention('unlimited')).toBeNull();
+    expect(parseRetention('15')).toBe(15);
+    expect(parseRetention('30')).toBe(30);
+    expect(parseRetention('60')).toBe(60);
+    expect(parseRetention('90')).toBe(90);
+  });
+
+  it('accepts the synonyms a user is likely to type', () => {
+    expect(parseRetention('never')).toBeNull();
+    expect(parseRetention('Forever')).toBeNull();
+    expect(parseRetention('0')).toBeNull();
+    expect(parseRetention(' 30 ')).toBe(30);
+  });
+
+  it('rejects a value that is not offered', () => {
+    // 7 is plausible but unoffered — silently accepting it would delete
+    // transcripts on a schedule the user never picked from.
+    expect(() => parseRetention('7')).toThrow(/unlimited/);
+    expect(() => parseRetention('abc')).toThrow();
+    expect(() => parseRetention('-30')).toThrow();
+  });
+
+  it('describes a retention for display', () => {
+    expect(describeRetention(null)).toBe('unlimited');
+    expect(describeRetention(undefined)).toBe('unlimited');
+    expect(describeRetention(30)).toBe('30 days');
   });
 });

--- a/packages/gateway/src/api-tokens.ts
+++ b/packages/gateway/src/api-tokens.ts
@@ -22,6 +22,32 @@ import { codeyHome, readSecureJson, writeSecureJson } from './secure-file';
 export const TOKEN_PREFIX = 'codey_';
 const STORE_VERSION = 1;
 
+/**
+ * Retention choices offered when a token is minted, in days. `null` keeps a
+ * session's chat forever.
+ *
+ * A Router API session is a hidden chat on disk, and nothing ever removed one:
+ * a script calling the API in a loop left a JSON file per call, invisible in
+ * the UI. Retention is recorded per token because the caller who creates the
+ * traffic is the one who knows how long its transcripts are worth keeping.
+ */
+export const RETENTION_CHOICES: ReadonlyArray<number | null> = [null, 15, 30, 60, 90];
+
+/** Parse a user-supplied retention value. Throws on anything not offered. */
+export function parseRetention(input: string): number | null {
+  const raw = input.trim().toLowerCase();
+  if (raw === 'unlimited' || raw === 'never' || raw === 'forever' || raw === '0') return null;
+  const days = Number(raw);
+  if (!RETENTION_CHOICES.includes(days)) {
+    throw new Error(`Retention must be one of: unlimited, ${RETENTION_CHOICES.filter(Boolean).join(', ')}`);
+  }
+  return days;
+}
+
+export function describeRetention(days: number | null | undefined): string {
+  return days == null ? 'unlimited' : `${days} days`;
+}
+
 /** A token as persisted. `hash` never leaves this module. */
 interface StoredToken {
   id: string;
@@ -29,6 +55,12 @@ interface StoredToken {
   hash: string;
   createdAt: number;
   lastUsedAt?: number;
+  /**
+   * Days of inactivity after which a chat created through this token is
+   * deleted. Absent or null = keep forever. Chats carry a copy of this value,
+   * so revoking the token does not strand them.
+   */
+  retentionDays?: number | null;
 }
 
 /** A token as shown to the operator — same fields minus the secret material. */
@@ -86,7 +118,7 @@ export class ApiTokenStore {
    * Mint a token. The returned plaintext is the only copy that will ever
    * exist — the caller must show it to the operator and then drop it.
    */
-  create(name: string): { token: string; record: ApiTokenRecord } {
+  create(name: string, retentionDays: number | null = null): { token: string; record: ApiTokenRecord } {
     const secret = crypto.randomBytes(32).toString('base64url');
     const token = `${TOKEN_PREFIX}${secret}`;
     const hash = sha256(token);
@@ -97,6 +129,7 @@ export class ApiTokenStore {
       name,
       hash,
       createdAt: Date.now(),
+      retentionDays,
     };
     this.file.tokens.push(stored);
     this.write();

--- a/packages/gateway/src/chats.retention.test.ts
+++ b/packages/gateway/src/chats.retention.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+
+/**
+ * Deleting chats is irreversible, so these cover the boundary in both
+ * directions and — more importantly — everything the sweep must NOT touch.
+ */
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function tmpManager(): ChatManager {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chats-'));
+  roots.push(root);
+  fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+  return new ChatManager(root);
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+// Anchored to real time: appendMessage stamps updatedAt with Date.now(), so a
+// fabricated "now" in the future would make a just-written message look stale.
+const NOW = Date.now();
+
+/** Backdate a chat's last activity, the way real elapsed time would. */
+function age(mgr: ChatManager, chatId: string, days: number): void {
+  const chat = mgr.get(chatId)!;
+  chat.updatedAt = NOW - days * DAY;
+  (mgr as any).persist(chat);
+}
+
+describe('ChatManager.deleteExpired', () => {
+  it('deletes a chat past its retention', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 30 });
+    age(mgr, chat.id, 31);
+
+    expect(mgr.deleteExpired(NOW)).toBe(1);
+    expect(mgr.get(chat.id)).toBeUndefined();
+  });
+
+  it('keeps a chat that is still inside its retention', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 30 });
+    age(mgr, chat.id, 29);
+
+    expect(mgr.deleteExpired(NOW)).toBe(0);
+    expect(mgr.get(chat.id)).toBeDefined();
+  });
+
+  it('keeps a chat exactly at the boundary', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 30 });
+    age(mgr, chat.id, 30);
+
+    expect(mgr.deleteExpired(NOW)).toBe(0);
+    expect(mgr.get(chat.id)).toBeDefined();
+  });
+
+  it('never touches a chat without a retention, however old', () => {
+    const mgr = tmpManager();
+    // The user's own chats, and sessions from an 'unlimited' token.
+    const user = mgr.create({ workspaceName: 'ws' });
+    const unlimited = mgr.create({ workspaceName: 'ws', kind: 'api' });
+    const automation = mgr.create({ workspaceName: 'ws', kind: 'automation' });
+    for (const c of [user, unlimited, automation]) age(mgr, c.id, 3650);
+
+    expect(mgr.deleteExpired(NOW)).toBe(0);
+    expect(mgr.get(user.id)).toBeDefined();
+    expect(mgr.get(unlimited.id)).toBeDefined();
+    expect(mgr.get(automation.id)).toBeDefined();
+  });
+
+  it('measures from last activity, not from creation', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 15 });
+    age(mgr, chat.id, 100);
+    // A fresh turn touches updatedAt and buys another full window.
+    mgr.appendMessage(chat.id, { id: 'm1', role: 'user', content: 'still here', timestamp: NOW });
+
+    expect(mgr.deleteExpired(NOW)).toBe(0);
+    expect(mgr.get(chat.id)).toBeDefined();
+  });
+
+  it('deletes only the lapsed chats out of a mixed set', () => {
+    const mgr = tmpManager();
+    const stale = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 15 });
+    const fresh = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 90 });
+    const mine = mgr.create({ workspaceName: 'ws' });
+    age(mgr, stale.id, 20);
+    age(mgr, fresh.id, 20);
+    age(mgr, mine.id, 20);
+
+    expect(mgr.deleteExpired(NOW)).toBe(1);
+    expect(mgr.get(stale.id)).toBeUndefined();
+    expect(mgr.get(fresh.id)).toBeDefined();
+    expect(mgr.get(mine.id)).toBeDefined();
+  });
+
+  it('removes the file from disk, not just the cache', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 15 });
+    age(mgr, chat.id, 20);
+    mgr.deleteExpired(NOW);
+
+    const reopened = new ChatManager((mgr as any).root ?? roots[roots.length - 1]);
+    expect(reopened.get(chat.id)).toBeUndefined();
+  });
+
+  it('is a no-op when there is nothing to sweep', () => {
+    expect(tmpManager().deleteExpired(NOW)).toBe(0);
+  });
+
+  it('persists retentionDays so a restart still knows to sweep', () => {
+    const mgr = tmpManager();
+    const chat = mgr.create({ workspaceName: 'ws', kind: 'api', retentionDays: 60 });
+    expect(mgr.get(chat.id)!.retentionDays).toBe(60);
+
+    const reopened = new ChatManager(roots[roots.length - 1]);
+    expect(reopened.get(chat.id)!.retentionDays).toBe(60);
+  });
+});

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -12,6 +12,8 @@ export interface CreateChatInput {
   title?: string;
   /** Hidden system chat (excluded from list() by default). */
   kind?: 'automation' | 'api';
+  /** Days of inactivity after which the chat is swept. Absent = keep forever. */
+  retentionDays?: number;
   /** Per-chat agent/model overrides, set at creation (used by automations). */
   agent?: Chat['agent'];
   model?: string;
@@ -196,6 +198,7 @@ export class ChatManager {
       createdAt: now,
       updatedAt: now,
       ...(input.kind ? { kind: input.kind } : {}),
+      ...(input.retentionDays ? { retentionDays: input.retentionDays } : {}),
       ...(input.agent ? { agent: input.agent } : {}),
       ...(input.model ? { model: input.model } : {}),
       ...(input.executionMode ? { executionMode: input.executionMode } : {}),
@@ -514,6 +517,28 @@ export class ChatManager {
     else delete chat.pendingSkillSuggestion;
     chat.updatedAt = Date.now();
     this.persist(chat);
+  }
+
+  /**
+   * Delete chats whose retention has lapsed — `retentionDays` past their last
+   * update. Returns how many went.
+   *
+   * Only chats that opted in by carrying `retentionDays` are considered, so a
+   * user's own chats are never touched. Sweeping is caller-driven rather than
+   * on a timer: the Router API costs nothing while idle, and a background
+   * interval purely to delete files would undo that.
+   */
+  deleteExpired(now: number = Date.now()): number {
+    this.ensureLoaded();
+    let deleted = 0;
+    for (const chat of [...this.cache.values()]) {
+      if (!chat.retentionDays) continue;
+      const ageMs = now - chat.updatedAt;
+      if (ageMs <= chat.retentionDays * 24 * 60 * 60 * 1000) continue;
+      this.delete(chat.id);
+      deleted++;
+    }
+    return deleted;
   }
 
   delete(chatId: string): void {

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -1,7 +1,7 @@
 import * as readline from 'readline';
 import { ConfigManager } from './config';
 import { Logger } from './logger';
-import { ApiTokenStore, defaultTokenFilePath } from './api-tokens';
+import { ApiTokenStore, RETENTION_CHOICES, defaultTokenFilePath, describeRetention, parseRetention } from './api-tokens';
 
 export class CLI {
   private config: ConfigManager;
@@ -260,7 +260,7 @@ export async function handleCommand(args: string[], config: ConfigManager, logge
       break;
 
     case 'api-token':
-      handleApiTokenCommand(args.slice(1), logger);
+      await handleApiTokenCommand(args.slice(1), logger);
       break;
 
     case 'set-loglevel':
@@ -327,20 +327,44 @@ function showHelp(): void {
  * `api-token create|list|revoke`. Tokens are stored hashed, so `create` is the
  * one and only moment the plaintext exists — print it loudly and never again.
  */
-function handleApiTokenCommand(args: string[], logger: Logger): void {
+async function handleApiTokenCommand(args: string[], logger: Logger): Promise<void> {
   const store = new ApiTokenStore();
   const sub = args[0];
 
   switch (sub) {
     case 'create': {
-      const name = args.slice(1).join(' ').trim();
+      const rest = args.slice(1);
+      // `--retention <value>` anywhere after the sub-command; the rest is the name.
+      let retentionArg: string | undefined;
+      const flag = rest.indexOf('--retention');
+      if (flag >= 0) {
+        retentionArg = rest[flag + 1];
+        if (retentionArg === undefined) {
+          logger.error('--retention needs a value: unlimited, 15, 30, 60 or 90');
+          return;
+        }
+        rest.splice(flag, 2);
+      }
+      const name = rest.join(' ').trim();
       if (!name) {
-        logger.error('Usage: api-token create <name>');
+        logger.error('Usage: api-token create <name> [--retention unlimited|15|30|60|90]');
         return;
       }
-      const { token, record } = store.create(name);
+
+      let retentionDays: number | null;
+      try {
+        retentionDays = retentionArg !== undefined
+          ? parseRetention(retentionArg)
+          : await promptForRetention();
+      } catch (err) {
+        logger.error((err as Error).message);
+        return;
+      }
+
+      const { token, record } = store.create(name, retentionDays);
       console.log('');
       console.log(`Created ${record.id} (${record.name})`);
+      console.log(`Session retention: ${describeRetention(record.retentionDays)}`);
       console.log('');
       console.log(`  ${token}`);
       console.log('');
@@ -360,7 +384,7 @@ function handleApiTokenCommand(args: string[], logger: Logger): void {
       }
       for (const t of tokens) {
         const used = t.lastUsedAt ? new Date(t.lastUsedAt).toISOString() : 'never';
-        console.log(`${t.id}  ${t.name}  created ${new Date(t.createdAt).toISOString()}  last used ${used}`);
+        console.log(`${t.id}  ${t.name}  created ${new Date(t.createdAt).toISOString()}  last used ${used}  retention ${describeRetention(t.retentionDays)}`);
       }
       return;
     }
@@ -377,6 +401,62 @@ function handleApiTokenCommand(args: string[], logger: Logger): void {
     }
 
     default:
-      logger.error('Usage: api-token <create <name> | list | revoke <id>>');
+      logger.error('Usage: api-token <create <name> [--retention ...] | list | revoke <id>>');
+  }
+}
+
+/**
+ * Ask how long the sessions this token creates should be kept.
+ *
+ * Every Router API call writes a hidden chat to disk and nothing used to
+ * remove it, so the choice is made once, up front, by the person who knows
+ * what the token is for. A non-interactive shell (CI, a script) cannot answer,
+ * so it gets 'unlimited' — the pre-existing behaviour — and is told how to
+ * pick explicitly.
+ */
+async function promptForRetention(): Promise<number | null> {
+  if (!process.stdin.isTTY) {
+    console.log('Non-interactive shell: keeping sessions forever.');
+    console.log('Pass --retention <unlimited|15|30|60|90> to choose.');
+    return null;
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    console.log('');
+    console.log('How long should sessions created with this token be kept?');
+    console.log('(each API call stores a hidden chat; they are deleted after this much inactivity)');
+    console.log('');
+    RETENTION_CHOICES.forEach((choice, i) => {
+      console.log(`  ${i + 1}. ${describeRetention(choice)}`);
+    });
+    console.log('');
+
+    // `closed` distinguishes "user pressed Enter" from "stdin went away"
+    // (Ctrl-D, or a caller that attached a TTY but sent nothing). Without it
+    // the question's callback never fires and the command exits having created
+    // no token, silently.
+    let closed = false;
+    rl.once('close', () => { closed = true; });
+
+    for (;;) {
+      const answer = await new Promise<string | null>(resolve => {
+        rl.once('close', () => resolve(null));
+        rl.question(`Select 1-${RETENTION_CHOICES.length} [1]: `, resolve);
+      });
+      if (answer === null || closed) {
+        console.log('\nNo answer given: keeping sessions forever.');
+        return RETENTION_CHOICES[0];
+      }
+      const raw = answer.trim();
+      if (!raw) return RETENTION_CHOICES[0];
+      const idx = Number(raw);
+      if (Number.isInteger(idx) && idx >= 1 && idx <= RETENTION_CHOICES.length) {
+        return RETENTION_CHOICES[idx - 1];
+      }
+      console.log('Please enter one of the listed numbers.');
+    }
+  } finally {
+    rl.close();
   }
 }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -791,6 +791,7 @@ export class Codey {
       hasChat: (chatId) => !!this.chatManager.get(chatId),
       getChatMessages: (chatId) => this.chatManager.get(chatId)?.messages ?? [],
       deleteChat: (chatId) => this.chatManager.delete(chatId),
+      deleteExpiredChats: () => this.chatManager.deleteExpired(),
       sendToChat: (chatId, text, sink) => this.sendToChat(chatId, text, sink),
     };
   }

--- a/packages/gateway/src/health.ts
+++ b/packages/gateway/src/health.ts
@@ -160,7 +160,7 @@ export class ApiServer {
       // `/v1/*` is the Router API. It is delegated wholesale so this file stays
       // the transport + auth layer rather than growing a second router.
       if (url?.startsWith('/v1/') && this.routerApi) {
-        if (await this.routerApi.handle(req, res, url, token!.id)) return;
+        if (await this.routerApi.handle(req, res, url, token!)) return;
       }
 
       if (url === '/health' || url === '/') {

--- a/packages/gateway/src/router-api.test.ts
+++ b/packages/gateway/src/router-api.test.ts
@@ -19,6 +19,7 @@ describe('Router API /v1', () => {
   let sent: Array<{ chatId: string; text: string }>;
   let chats: Set<string>;
   let messages: Map<string, any[]>;
+  let sweeps: number;
   let respond: (chatId: string, text: string) => Promise<{
     response: string; chatId: string; tokens?: number; durationSec?: number;
   }>;
@@ -38,6 +39,7 @@ describe('Router API /v1', () => {
     hasChat: (chatId) => chats.has(chatId),
     getChatMessages: (chatId) => messages.get(chatId) ?? [],
     deleteChat: (chatId) => { chats.delete(chatId); messages.delete(chatId); },
+    deleteExpiredChats: () => { sweeps++; return 0; },
     sendToChat: async (chatId, text) => {
       sent.push({ chatId, text });
       return respond(chatId, text);
@@ -78,6 +80,7 @@ describe('Router API /v1', () => {
     sent = [];
     chats = new Set();
     messages = new Map();
+    sweeps = 0;
     opts = { timeoutSec: 5, rateLimitPerMin: 60 };
     respond = async (chatId) => ({ response: 'done', chatId, tokens: 42, durationSec: 1.5 });
 
@@ -440,5 +443,51 @@ describe('Router API /v1', () => {
     await post({ prompt: 'hi', sessionId: 's1' });
     const res = await fetch(sessionUrl('s1'), { method: 'PUT', headers: authed() });
     expect(res.status).toBe(404);
+  });
+
+  // ── retention ───────────────────────────────────────────────────
+
+  it("stamps the chat with the token's retention", async () => {
+    // A fresh server whose token carries a retention choice.
+    await server.stop();
+    store = new ApiTokenStore(path.join(dir, 'api-tokens.json'));
+    token = store.create('retained', 30).token;
+    server = new ApiServer(0, fakeStatus, fakeConfigManager(), undefined, undefined, undefined, undefined, store);
+    server.setRouterApi(new RouterApi(host(), () => opts));
+    await server.start();
+    port = (server as any).server.address().port;
+
+    await post({ prompt: 'hi' });
+    expect(created[0].retentionDays).toBe(30);
+  });
+
+  it('leaves the chat unstamped for an unlimited token', async () => {
+    await post({ prompt: 'hi' });
+    expect(created[0].retentionDays).toBeUndefined();
+  });
+
+  it('sweeps expired chats when a request comes in, at most once an hour', async () => {
+    await post({ prompt: 'a' });
+    expect(sweeps).toBe(1);
+
+    // Throttled: a burst of traffic must not rescan every chat each time.
+    await post({ prompt: 'b' });
+    await post({ prompt: 'c' });
+    expect(sweeps).toBe(1);
+  });
+
+  it('still answers the request when the sweep throws', async () => {
+    const failing: RouterApiHost = {
+      ...host(),
+      deleteExpiredChats: () => { throw new Error('disk on fire'); },
+    };
+    await server.stop();
+    server = new ApiServer(0, fakeStatus, fakeConfigManager(), undefined, undefined, undefined, undefined, store);
+    server.setRouterApi(new RouterApi(failing, () => opts));
+    await server.start();
+    port = (server as any).server.address().port;
+
+    // Housekeeping is not the caller's problem.
+    expect((await post({ prompt: 'hi' })).status).toBe(200);
   });
 });

--- a/packages/gateway/src/router-api.ts
+++ b/packages/gateway/src/router-api.ts
@@ -27,11 +27,14 @@ export interface RouterApiHost {
     selection?: { type: 'team'; name: string } | { type: 'none' };
     agent?: CodingAgent;
     model?: string;
+    retentionDays?: number;
   }): { id: string };
   hasChat(chatId: string): boolean;
   /** Recent messages for a session's chat, oldest first. */
   getChatMessages(chatId: string): ChatMessage[];
   deleteChat(chatId: string): void;
+  /** Delete chats whose retention has lapsed. Returns how many went. */
+  deleteExpiredChats(): number;
   sendToChat(
     chatId: string,
     text: string,
@@ -46,6 +49,7 @@ export interface RouterApiOptions {
 
 const AGENTS: readonly CodingAgent[] = ['claude-code', 'opencode', 'codex', 'pi'];
 const MAX_BODY_BYTES = 1024 * 1024;
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
 
 interface PromptRequest {
   prompt: string;
@@ -73,6 +77,8 @@ export class RouterApi {
   private readonly inFlight = new Set<string>();
   /** tokenId → recent request timestamps, trimmed to the last minute. */
   private readonly recentRequests = new Map<string, number[]>();
+  /** When the retention sweep last ran. 0 = never. */
+  private lastSweepAt = 0;
 
   constructor(host: RouterApiHost, options: () => RouterApiOptions) {
     this.host = host;
@@ -87,7 +93,7 @@ export class RouterApi {
     req: http.IncomingMessage,
     res: http.ServerResponse,
     url: string,
-    tokenId: string,
+    token: { id: string; retentionDays?: number | null },
   ): Promise<boolean> {
     if (url === '/v1/capabilities' && req.method === 'GET') {
       send(res, 200, {
@@ -101,7 +107,7 @@ export class RouterApi {
     }
 
     if (url === '/v1/prompt' && req.method === 'POST') {
-      await this.handlePrompt(req, res, tokenId);
+      await this.handlePrompt(req, res, token);
       return true;
     }
 
@@ -118,12 +124,13 @@ export class RouterApi {
   private async handlePrompt(
     req: http.IncomingMessage,
     res: http.ServerResponse,
-    tokenId: string,
+    token: { id: string; retentionDays?: number | null },
   ): Promise<void> {
     let sessionId: string | undefined;
     let claimed = false;
     try {
-      this.enforceRateLimit(tokenId);
+      this.enforceRateLimit(token.id);
+      this.sweepExpiredChats();
       const body = await readBody(req);
       const parsed = this.validate(body);
 
@@ -136,7 +143,7 @@ export class RouterApi {
       this.inFlight.add(sessionId);
       claimed = true;
 
-      const chatId = this.resolveChat(sessionId, parsed);
+      const chatId = this.resolveChat(sessionId, parsed, token.retentionDays ?? undefined);
 
       if (parsed.stream) {
         await this.runStreaming(res, chatId, sessionId, parsed.prompt);
@@ -169,6 +176,26 @@ export class RouterApi {
       });
     } finally {
       if (claimed && sessionId) this.inFlight.delete(sessionId);
+    }
+  }
+
+  /**
+   * Drop chats past their retention, at most once an hour.
+   *
+   * Driven by incoming requests rather than a timer, so an unused Router API
+   * still costs nothing while idle — the pile-up it cleans up can only grow
+   * through requests anyway.
+   */
+  private sweepExpiredChats(): void {
+    const now = Date.now();
+    if (now - this.lastSweepAt < SWEEP_INTERVAL_MS) return;
+    this.lastSweepAt = now;
+    try {
+      const deleted = this.host.deleteExpiredChats();
+      if (deleted > 0) console.log(`[router-api] deleted ${deleted} expired session chat(s)`);
+    } catch (err) {
+      // Housekeeping must never fail the request that triggered it.
+      console.error(`[router-api] retention sweep failed: ${(err as Error).message}`);
     }
   }
 
@@ -253,7 +280,7 @@ export class RouterApi {
    * has since been deleted gets a fresh chat rather than a 404: the caller's
    * session id stays valid, it just loses the old context.
    */
-  private resolveChat(sessionId: string, parsed: PromptRequest): string {
+  private resolveChat(sessionId: string, parsed: PromptRequest, retentionDays?: number): string {
     const existing = this.sessions.get(sessionId);
     if (existing && this.host.hasChat(existing)) return existing;
 
@@ -263,6 +290,7 @@ export class RouterApi {
       selection: parsed.team ? { type: 'team', name: parsed.team } : { type: 'none' },
       agent: parsed.agent,
       model: parsed.model,
+      retentionDays,
     });
     this.sessions.set(sessionId, chat.id);
     return chat.id;


### PR DESCRIPTION
## Why

Every `/v1/prompt` call stores a hidden chat on disk, and nothing ever removed one. A script calling the API in a loop leaves a JSON file per call — invisible in the UI, because `kind: 'api'` chats are filtered out of the chat list. The pile could only ever grow.

Rather than guess a global expiry, the choice happens once, up front, where the person who knows what the token is for can make it.

## What

`api-token create` now asks how long the sessions it creates should be kept:

```
How long should sessions created with this token be kept?
(each API call stores a hidden chat; they are deleted after this much inactivity)

  1. unlimited
  2. 15 days
  3. 30 days
  4. 60 days
  5. 90 days
```

Or non-interactively: `api-token create nightly --retention 30`. A non-interactive shell cannot answer, so it gets `unlimited` — the pre-existing behaviour — and is told how to choose explicitly. `api-token list` shows each token's retention.

## Design points

**The retention is copied onto the chat** (`Chat.retentionDays`), not looked up from the token when sweeping. Revoking a token therefore cannot strand the transcripts it produced.

**Only chats carrying `retentionDays` are ever considered.** The user's own chats, automation chats, and sessions from an `unlimited` token are never touched. Deletion is irreversible, so this has its own test rather than being left implicit.

**Age is measured from last activity, not creation.** A session still in use keeps buying another full window.

**No background timer.** The sweep is driven by incoming requests and throttled to once an hour. An idle Router API stays at zero cost — which was true before this change and needed to stay true — and the pile-up it cleans can only grow through requests anyway. A failing sweep is logged and never fails the request that triggered it.

**Only the offered values parse.** `--retention 7` is refused rather than quietly accepted: transcripts should never be deleted on a schedule the user did not pick from.

## A hang the live run exposed

Driving the prompt through a real pty surfaced a bug the mocked tests could not: when stdin closed at the question (Ctrl-D, or a TTY that sent nothing), readline's callback never fired, the promise never settled, and the command exited having created **no token at all** — silently. It now falls back to `unlimited` and says so.

## Verification

Verified through a real pty, not only mocks: the interactive prompt stored the picked value (chose "4" → 60 days on disk), `--retention 30` stored 30, `--retention 7` was rejected with the list of valid values, a piped non-TTY invocation fell back to unlimited, and the Ctrl-D case created the token instead of vanishing.

- Full suite: **1649 passed / 0 failed**, including 9 new sweep tests and 11 new retention/parsing tests.
- `tsc` clean for core, gateway and the Electron main process. Lint clean.

## Note

Existing tokens have no retention recorded and are treated as `unlimited`, so nothing is deleted on upgrade. Chats created before this change carry no `retentionDays` and are likewise never swept — clearing those out is a manual `rm` if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)