### PR TITLE
Speak the OpenAI and Anthropic wire protocols

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -43,6 +43,7 @@ import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
 import { ApiServer } from '@codey/gateway/dist/health'
 import { RouterApi } from '@codey/gateway/dist/router-api'
+import { CompatApi } from '@codey/gateway/dist/compat-api'
 
 let mainWindow: BrowserWindow | null = null
 let captureWindow: BrowserWindow | null = null
@@ -1087,6 +1088,9 @@ async function bootInProcessCore() {
       apiServer.setRouterApi(new RouterApi(inProcessGateway!.asRouterApiHost(), () => ({
         timeoutSec: coreConfigManager!.getApiTimeoutSec(),
         rateLimitPerMin: coreConfigManager!.getApiRateLimitPerMin(),
+      })))
+      apiServer.setCompatApi(new CompatApi(inProcessGateway!.asRouterApiHost(), () => ({
+        timeoutSec: coreConfigManager!.getApiTimeoutSec(),
       })))
       void apiServer.start().then(() => {
         sendToRenderer('gateway-log', `[core] API server listening on ${apiPort}`)

--- a/docs/superpowers/specs/2026-08-22-router-api-design.md
+++ b/docs/superpowers/specs/2026-08-22-router-api-design.md
@@ -245,7 +245,49 @@ npm run api-token -- revoke <id>
    - **匿名流式请求拿不到 sessionId。** 非流式的响应体里有，流式没有信封可放。
      改成走 `X-Codey-Session-Id` 响应头——不然调用方永远不知道自己刚创建的
      session 叫什么，既没法续聊也没法回查历史。
-4. **P4**（另开）— MCP server，内部转调 `/v1/prompt`。
+4. **协议兼容层 — 已实现**（2026-08-22）。`compat-api.ts`：
+   `POST /v1/chat/completions`（OpenAI）、`POST /v1/messages`（Anthropic）、
+   `GET /v1/models`。官方 OpenAI SDK 和官方 Anthropic SDK 都真机验证能直接调通，
+   含流式和错误类型。见下面第 9 节。
+5. **P4**（另开）— MCP server，内部转调 `/v1/prompt`。
+
+## 9. 协议兼容层（2026-08-22）
+
+目标：别的工具**不需要知道 Codey 的存在**就能用它。
+
+```bash
+OPENAI_BASE_URL=http://127.0.0.1:3000/v1   OPENAI_API_KEY=<codey token>
+ANTHROPIC_BASE_URL=http://127.0.0.1:3000   ANTHROPIC_API_KEY=<codey token>
+```
+
+### 关键取舍
+
+- **无状态是默认**，因为两家的 API 本来就是无状态的：客户端自己拿着历史，每次全量重发。
+  Codey 自己的 `/v1/prompt` 是服务端存历史。两者混用会让每条消息重复一遍。
+  所以兼容请求默认把 `messages` 摊平成一个 prompt，跑在一次性 chat 里。
+  想用 Codey 的服务端上下文，加 `X-Codey-Session-Id` 头显式选择，
+  这时**只发最后一条 user 消息**。
+- **摊平时保留角色标签**（`User:` / `Assistant:`）。不加的话多轮历史会糊成一段话，
+  agent 分不清谁说的。单条提问是特例，原样发过去，不套壳。
+- **鉴权同时认两种头**：OpenAI SDK 发 `Authorization: Bearer`，
+  Anthropic SDK 发 `x-api-key` 且完全不发 Authorization。两个都查同一个 token 库。
+- **错误用各自的信封**（OpenAI 是 `{error:{message,type,param,code}}`，
+  Anthropic 是 `{type:"error",error:{...}}`）。SDK 就是靠这个抛出正确的异常类——
+  真机验过两边都抛 `NotFoundError`。
+- **模型名**接受目录里的名字，也接受 `codex/gpt-5` 这种带 agent 前缀的写法。
+  未知模型返回 404 并列出可用的——这条消息客户端会直接显示给人看。
+- **只转发助手文本**。Codey 的 tool_start / checklist / worker 事件在两家的
+  wire format 里没有对应物，硬造一个只会弄坏本来要支持的客户端。
+- **agent 不吐 token 时兜底**：把最终文本作为一个 delta 发出去，
+  否则流式客户端会收到一条空消息。
+- 只对模型有意义的参数（`temperature`、`n`、`logprobs`、`tools`）**收下但忽略**，
+  不做半吊子实现。Codey 是 agent，不是模型服务器。
+
+### 待办
+
+`compat-api.ts` 里有一条 TODO：等 #332（按 token 的 session 保留期）合进来后，
+兼容层建的 chat 也要盖上 `retentionDays`。**无状态调用每次建一个 chat，
+正是保留期要清理的那个堆积的最大来源。**
 
 ## 7. 已决
 

--- a/packages/gateway/src/api-tokens.ts
+++ b/packages/gateway/src/api-tokens.ts
@@ -164,3 +164,21 @@ export function parseBearer(header: string | string[] | undefined): string | nul
   const match = /^Bearer\s+(.+)$/i.exec(raw.trim());
   return match ? match[1].trim() : null;
 }
+
+/**
+ * The token from a request, accepting either convention.
+ *
+ * OpenAI clients send `Authorization: Bearer <key>`; Anthropic clients send
+ * `x-api-key: <key>` and no Authorization header at all. Both are looked up in
+ * the same store — the header a client happens to use says nothing about which
+ * token is valid.
+ */
+export function tokenFromHeaders(headers: {
+  authorization?: string | string[];
+  'x-api-key'?: string | string[];
+}): string | null {
+  const bearer = parseBearer(headers.authorization);
+  if (bearer) return bearer;
+  const apiKey = Array.isArray(headers['x-api-key']) ? headers['x-api-key'][0] : headers['x-api-key'];
+  return apiKey?.trim() || null;
+}

--- a/packages/gateway/src/compat-api.test.ts
+++ b/packages/gateway/src/compat-api.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ApiServer } from './health';
+import { ApiTokenStore } from './api-tokens';
+import { CompatApi } from './compat-api';
+import { RouterApi, RouterApiHost } from './router-api';
+
+/**
+ * The whole point of these endpoints is that a client library recognises the
+ * bytes, so the assertions are about exact wire shape, not just "it worked".
+ */
+describe('Compat API', () => {
+  let dir: string;
+  let store: ApiTokenStore;
+  let server: ApiServer;
+  let port: number;
+  let token: string;
+  let timeoutSec: number;
+
+  let created: Array<Parameters<RouterApiHost['createApiChat']>[0]>;
+  let sent: Array<{ chatId: string; text: string }>;
+  let chats: Set<string>;
+  let respond: (chatId: string, sink: any) => Promise<{
+    response: string; chatId: string; tokens?: number; durationSec?: number;
+  }>;
+
+  const host = (): RouterApiHost => ({
+    getWorkspaceList: () => ['alpha', 'beta'],
+    getTeamNames: () => [],
+    getModelNames: () => ['claude-opus-5', 'gpt-5'],
+    getDefaultAgent: () => 'claude-code',
+    getDefaultModel: () => 'claude-opus-5',
+    createApiChat: (input) => {
+      created.push(input);
+      const id = `chat-${created.length}`;
+      chats.add(id);
+      return { id };
+    },
+    hasChat: (chatId) => chats.has(chatId),
+    getChatMessages: () => [],
+    deleteChat: (chatId) => { chats.delete(chatId); },
+    sendToChat: async (chatId, text, sink) => {
+      sent.push({ chatId, text });
+      return respond(chatId, sink);
+    },
+  });
+
+  const fakeStatus = () => ({
+    status: 'healthy' as const,
+    uptime: 1,
+    timestamp: 'now',
+    channels: { telegram: false, discord: false, imessage: false },
+    stats: { messagesProcessed: 0, activeConversations: 0, errors: 0 },
+  });
+
+  const fakeConfigManager = () => ({
+    get: () => ({ gateway: { port: 0 } }),
+    getApiBindHost: () => '127.0.0.1',
+    getApiAllowedOrigins: () => [],
+    update: () => { /* no-op */ },
+    getResolvedVoiceConfig: () => undefined,
+  }) as any;
+
+  const url = (p: string) => `http://127.0.0.1:${port}${p}`;
+  const json = async (res: Response): Promise<any> => res.json();
+
+  /** OpenAI clients authenticate with a bearer token. */
+  const openai = (body: unknown, headers: Record<string, string> = {}) =>
+    fetch(url('/v1/chat/completions'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+
+  /** Anthropic clients authenticate with x-api-key and send no Authorization. */
+  const anthropic = (body: unknown, headers: Record<string, string> = {}) =>
+    fetch(url('/v1/messages'), {
+      method: 'POST',
+      headers: {
+        'x-api-key': token,
+        'anthropic-version': '2023-06-01',
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    });
+
+  /** Parse an SSE body into [eventName | null, payload] pairs. */
+  const readSse = async (res: Response): Promise<Array<[string | null, any]>> => {
+    const text = await res.text();
+    return text
+      .split('\n\n')
+      .filter(f => f.trim())
+      .map(frame => {
+        const lines = frame.split('\n');
+        const eventLine = lines.find(l => l.startsWith('event: '));
+        const dataLine = lines.find(l => l.startsWith('data: '))!;
+        const raw = dataLine.slice('data: '.length);
+        return [
+          eventLine ? eventLine.slice('event: '.length) : null,
+          raw === '[DONE]' ? '[DONE]' : JSON.parse(raw),
+        ] as [string | null, any];
+      });
+  };
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-compat-'));
+    store = new ApiTokenStore(path.join(dir, 'api-tokens.json'));
+    token = store.create('test').token;
+    created = [];
+    sent = [];
+    chats = new Set();
+    timeoutSec = 5;
+    respond = async (chatId) => ({ response: 'the answer', chatId, tokens: 12 });
+
+    server = new ApiServer(0, fakeStatus, fakeConfigManager(), undefined, undefined, undefined, undefined, store);
+    server.setRouterApi(new RouterApi(host(), () => ({ timeoutSec: 5, rateLimitPerMin: 1000 })));
+    server.setCompatApi(new CompatApi(host(), () => ({ timeoutSec })));
+    await server.start();
+    port = (server as any).server.address().port;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── auth ────────────────────────────────────────────────────────
+
+  it('accepts a token via x-api-key, the way Anthropic clients send it', async () => {
+    const res = await anthropic({ model: 'claude-opus-5', max_tokens: 100, messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects both endpoints without a token', async () => {
+    expect((await fetch(url('/v1/models'))).status).toBe(401);
+    expect((await fetch(url('/v1/chat/completions'), { method: 'POST', body: '{}' })).status).toBe(401);
+    expect((await fetch(url('/v1/messages'), { method: 'POST', body: '{}' })).status).toBe(401);
+  });
+
+  // ── models ──────────────────────────────────────────────────────
+
+  it('lists models in OpenAI shape', async () => {
+    const body = await json(await fetch(url('/v1/models'), { headers: { Authorization: `Bearer ${token}` } }));
+    expect(body.object).toBe('list');
+    expect(body.data.map((m: any) => m.id)).toEqual(['claude-opus-5', 'gpt-5']);
+    expect(body.data[0]).toMatchObject({ object: 'model', owned_by: 'codey' });
+  });
+
+  // ── OpenAI non-streaming ────────────────────────────────────────
+
+  it('answers a chat completion in OpenAI shape', async () => {
+    const res = await openai({ model: 'gpt-5', messages: [{ role: 'user', content: 'hello' }] });
+    expect(res.status).toBe(200);
+
+    const body = await json(res);
+    expect(body.object).toBe('chat.completion');
+    expect(body.id).toMatch(/^chatcmpl-/);
+    expect(body.model).toBe('gpt-5');
+    expect(body.choices).toHaveLength(1);
+    expect(body.choices[0]).toMatchObject({
+      index: 0,
+      message: { role: 'assistant', content: 'the answer' },
+      finish_reason: 'stop',
+    });
+    expect(body.usage.total_tokens).toBe(12);
+    // A single question goes through as itself, with no role scaffolding.
+    expect(sent[0].text).toBe('hello');
+  });
+
+  it('flattens a multi-turn history with role labels', async () => {
+    await openai({
+      model: 'gpt-5',
+      messages: [
+        { role: 'system', content: 'Be terse.' },
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'reply' },
+        { role: 'user', content: 'second' },
+      ],
+    });
+    // Without labels a flattened history reads as one run-on message.
+    expect(sent[0].text).toBe('Be terse.\n\nUser: first\n\nAssistant: reply\n\nUser: second');
+  });
+
+  it('reads OpenAI content blocks as well as plain strings', async () => {
+    await openai({
+      model: 'gpt-5',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'from a block' }] }],
+    });
+    expect(sent[0].text).toBe('from a block');
+  });
+
+  it('routes the agent when the model carries a prefix', async () => {
+    await openai({ model: 'codex/gpt-5', messages: [{ role: 'user', content: 'hi' }] });
+    expect(created[0]).toMatchObject({ agent: 'codex', model: 'gpt-5' });
+  });
+
+  // ── Anthropic non-streaming ─────────────────────────────────────
+
+  it('answers a message in Anthropic shape', async () => {
+    const res = await anthropic({
+      model: 'claude-opus-5',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+    expect(res.status).toBe(200);
+
+    const body = await json(res);
+    expect(body.type).toBe('message');
+    expect(body.id).toMatch(/^msg_/);
+    expect(body.role).toBe('assistant');
+    expect(body.content).toEqual([{ type: 'text', text: 'the answer' }]);
+    expect(body.stop_reason).toBe('end_turn');
+    expect(body.usage.output_tokens).toBe(12);
+  });
+
+  it("honours Anthropic's top-level system field", async () => {
+    await anthropic({
+      model: 'claude-opus-5',
+      max_tokens: 100,
+      system: 'You are terse.',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(sent[0].text).toBe('You are terse.\n\nhi');
+  });
+
+  // ── streaming ───────────────────────────────────────────────────
+
+  it('streams OpenAI chunks and terminates with [DONE]', async () => {
+    respond = async (chatId, sink) => {
+      sink({ type: 'stream', chatId, token: 'par' });
+      sink({ type: 'stream', chatId, token: 'tial' });
+      return { response: 'partial', chatId, tokens: 3 };
+    };
+
+    const res = await openai({ model: 'gpt-5', stream: true, messages: [{ role: 'user', content: 'go' }] });
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const frames = await readSse(res);
+    expect(frames[frames.length - 1][1]).toBe('[DONE]');
+
+    const chunks = frames.slice(0, -1).map(f => f[1]);
+    expect(chunks[0].choices[0].delta.role).toBe('assistant');
+    expect(chunks.map(c => c.choices[0].delta.content ?? '').join('')).toBe('partial');
+    expect(chunks[chunks.length - 1].choices[0].finish_reason).toBe('stop');
+    expect(chunks.every(c => c.object === 'chat.completion.chunk')).toBe(true);
+  });
+
+  it('streams the Anthropic event sequence in order', async () => {
+    respond = async (chatId, sink) => {
+      sink({ type: 'stream', chatId, token: 'hel' });
+      sink({ type: 'stream', chatId, token: 'lo' });
+      return { response: 'hello', chatId, tokens: 2 };
+    };
+
+    const frames = await readSse(await anthropic({
+      model: 'claude-opus-5', max_tokens: 100, stream: true,
+      messages: [{ role: 'user', content: 'go' }],
+    }));
+
+    expect(frames.map(f => f[0])).toEqual([
+      'message_start',
+      'content_block_start',
+      'content_block_delta',
+      'content_block_delta',
+      'content_block_stop',
+      'message_delta',
+      'message_stop',
+    ]);
+    const deltas = frames.filter(f => f[0] === 'content_block_delta');
+    expect(deltas.map(d => d[1].delta.text).join('')).toBe('hello');
+    expect(deltas[0][1].delta.type).toBe('text_delta');
+    expect(frames.find(f => f[0] === 'message_delta')![1].delta.stop_reason).toBe('end_turn');
+  });
+
+  it('still delivers the answer when the agent streams no tokens', async () => {
+    // Not every adapter emits token deltas; a streaming client must not be
+    // left with an empty message just because this one stayed silent.
+    respond = async (chatId) => ({ response: 'all at once', chatId });
+
+    const frames = await readSse(await openai({
+      model: 'gpt-5', stream: true, messages: [{ role: 'user', content: 'go' }],
+    }));
+    const text = frames.slice(0, -1).map(f => f[1].choices[0].delta.content ?? '').join('');
+    expect(text).toBe('all at once');
+  });
+
+  it('reports a mid-stream failure as an event, not a status code', async () => {
+    respond = async () => { throw new Error('agent exploded'); };
+
+    const res = await openai({ model: 'gpt-5', stream: true, messages: [{ role: 'user', content: 'go' }] });
+    expect(res.status).toBe(200);
+
+    const frames = await readSse(res);
+    const errorFrame = frames.find(f => f[1] !== '[DONE]' && f[1].type === 'error');
+    expect(errorFrame![1].error.message).toBe('agent exploded');
+  });
+
+  // ── errors ──────────────────────────────────────────────────────
+
+  it('reports errors in the OpenAI envelope', async () => {
+    const res = await openai({ model: 'nope', messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(404);
+
+    const body = await json(res);
+    expect(body.error.type).toBe('not_found_error');
+    expect(body.error.message).toContain('claude-opus-5');
+  });
+
+  it('reports errors in the Anthropic envelope', async () => {
+    const res = await anthropic({ model: 'nope', max_tokens: 10, messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(404);
+
+    const body = await json(res);
+    expect(body.type).toBe('error');
+    expect(body.error.type).toBe('not_found_error');
+  });
+
+  it('rejects a missing model or empty messages', async () => {
+    expect((await openai({ messages: [{ role: 'user', content: 'hi' }] })).status).toBe(400);
+    expect((await openai({ model: 'gpt-5', messages: [] })).status).toBe(400);
+    expect((await openai({ model: 'gpt-5' })).status).toBe(400);
+  });
+
+  it('never reaches the agent when validation fails', async () => {
+    await openai({ model: 'nope', messages: [{ role: 'user', content: 'hi' }] });
+    expect(sent).toHaveLength(0);
+  });
+
+  it('504s when the agent outruns the timeout', async () => {
+    timeoutSec = 0.05;
+    respond = () => new Promise(resolve => setTimeout(() => resolve({ response: 'late', chatId: 'chat-1' }), 500));
+    expect((await openai({ model: 'gpt-5', messages: [{ role: 'user', content: 'slow' }] })).status).toBe(504);
+  });
+
+  // ── sessions and workspaces ─────────────────────────────────────
+
+  it('is stateless by default: a chat per request', async () => {
+    await openai({ model: 'gpt-5', messages: [{ role: 'user', content: 'a' }] });
+    await openai({ model: 'gpt-5', messages: [{ role: 'user', content: 'b' }] });
+    expect(created).toHaveLength(2);
+  });
+
+  it('reuses a chat and sends only the new message when a session is given', async () => {
+    const headers = { 'X-Codey-Session-Id': 's1' };
+    await openai({ model: 'gpt-5', messages: [{ role: 'user', content: 'first' }] }, headers);
+    await openai({
+      model: 'gpt-5',
+      messages: [
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'reply' },
+        { role: 'user', content: 'second' },
+      ],
+    }, headers);
+
+    expect(created).toHaveLength(1);
+    // Replaying the array into a chat that already holds the history would
+    // duplicate every earlier turn.
+    expect(sent.map(s => s.text)).toEqual(['first', 'second']);
+  });
+
+  it('honours the workspace header and rejects an unknown one', async () => {
+    await openai({ model: 'gpt-5', messages: [{ role: 'user', content: 'hi' }] }, { 'X-Codey-Workspace': 'beta' });
+    expect(created[0].workspaceName).toBe('beta');
+
+    const res = await openai({ model: 'gpt-5', messages: [{ role: 'user', content: 'hi' }] }, { 'X-Codey-Workspace': 'nope' });
+    expect(res.status).toBe(404);
+  });
+
+  // ── coexistence with the native API ─────────────────────────────
+
+  it('leaves Codey\'s own /v1 routes working', async () => {
+    const res = await fetch(url('/v1/prompt'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'native' }),
+    });
+    expect(res.status).toBe(200);
+    expect((await json(res)).response).toBe('the answer');
+  });
+
+  it('404s an unknown /v1 path', async () => {
+    const res = await fetch(url('/v1/nonsense'), { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/gateway/src/compat-api.ts
+++ b/packages/gateway/src/compat-api.ts
@@ -1,0 +1,587 @@
+import * as http from 'http';
+import { CodingAgent } from '@codey/core';
+import { ChatStreamSink } from './chat-runner';
+import { RouterApiHost } from './router-api';
+
+/**
+ * OpenAI- and Anthropic-shaped endpoints, so existing tools can point at Codey
+ * without knowing anything about Codey.
+ *
+ *   OPENAI_BASE_URL=http://127.0.0.1:3000/v1  OPENAI_API_KEY=<codey token>
+ *   ANTHROPIC_BASE_URL=http://127.0.0.1:3000  ANTHROPIC_API_KEY=<codey token>
+ *
+ * What is deliberately NOT claimed: Codey is an agent, not a model server. It
+ * edits files, runs commands and takes tens of seconds. These endpoints speak
+ * the providers' wire format faithfully enough for a client library to work —
+ * request shape, response shape, SSE framing, error shape — but features that
+ * only make sense for a raw model (tool_calls, logprobs, n>1, temperature) are
+ * accepted and ignored rather than half-implemented.
+ *
+ * Statelessness is the important design point. Both provider APIs are
+ * stateless: the client owns the history and resends it every turn. Codey's own
+ * `/v1/prompt` keeps history server-side. Mixing them would double every
+ * message, so by default a compat request flattens the client's `messages` into
+ * one prompt and runs it in a throwaway chat. A client that wants Codey's
+ * server-side context opts in with `X-Codey-Session-Id`, and then only the last
+ * user message is sent.
+ *
+ * TODO: once #332 (per-token session retention) lands on this branch, stamp the
+ * chats created here with the token's `retentionDays` the way `router-api.ts`
+ * does — a stateless compat call creates a chat per request, so it is the
+ * biggest producer of the pile-up that retention exists to clean up.
+ */
+
+export interface CompatOptions {
+  timeoutSec: number;
+  /** Fallback workspace when the request does not name one. */
+  defaultWorkspace?: string;
+}
+
+/** Which provider's dialect a request is speaking. */
+type Dialect = 'openai' | 'anthropic';
+
+const MAX_BODY_BYTES = 1024 * 1024;
+const AGENTS: readonly CodingAgent[] = ['claude-code', 'opencode', 'codex', 'pi'];
+
+class CompatError extends Error {
+  constructor(readonly status: number, message: string, readonly kind = 'invalid_request_error') {
+    super(message);
+  }
+}
+
+/** One message as either provider sends it. Content may be text or blocks. */
+interface WireMessage {
+  role: string;
+  content: unknown;
+}
+
+export class CompatApi {
+  private readonly host: RouterApiHost;
+  private readonly options: () => CompatOptions;
+  /** sessionId → chatId, for callers that opt into server-side context. */
+  private readonly sessions = new Map<string, string>();
+
+  constructor(host: RouterApiHost, options: () => CompatOptions) {
+    this.host = host;
+    this.options = options;
+  }
+
+  /** Returns false when the path is not one of ours. */
+  async handle(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    url: string,
+  ): Promise<boolean> {
+    if (url === '/v1/models' && req.method === 'GET') {
+      this.listModels(res);
+      return true;
+    }
+    if (url === '/v1/chat/completions' && req.method === 'POST') {
+      await this.completion(req, res, 'openai');
+      return true;
+    }
+    if (url === '/v1/messages' && req.method === 'POST') {
+      await this.completion(req, res, 'anthropic');
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * `GET /v1/models` in OpenAI's shape. Many clients call this to populate a
+   * model picker or to validate the model name before the first request.
+   */
+  private listModels(res: http.ServerResponse): void {
+    const created = 0; // Codey's catalog has no creation timestamps.
+    sendJson(res, 200, {
+      object: 'list',
+      data: this.host.getModelNames().map(id => ({
+        id,
+        object: 'model',
+        created,
+        owned_by: 'codey',
+      })),
+    });
+  }
+
+  private async completion(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    dialect: Dialect,
+  ): Promise<void> {
+    let streaming = false;
+    try {
+      const body = await readBody(req);
+      const parsed = this.parse(body, dialect);
+      streaming = parsed.stream;
+
+      const chatId = this.resolveChat(req, parsed);
+
+      if (parsed.stream) {
+        await this.streamTurn(res, dialect, chatId, parsed);
+        return;
+      }
+
+      const result = await this.runWithTimeout(chatId, parsed.prompt);
+      sendJson(res, 200, dialect === 'openai'
+        ? openAiResponse(parsed.model, result.response, result.tokens)
+        : anthropicResponse(parsed.model, result.response, result.tokens));
+    } catch (err) {
+      // Once an SSE body has started the status line is gone; the failure has
+      // to reach the client as a stream event instead of an HTTP code.
+      if (res.headersSent) {
+        writeSse(res, dialect === 'openai' ? null : 'error', {
+          type: 'error',
+          error: { type: 'api_error', message: (err as Error).message },
+        });
+        res.end();
+        return;
+      }
+      const status = err instanceof CompatError ? err.status : 500;
+      const kind = err instanceof CompatError ? err.kind : 'api_error';
+      sendJson(res, status, errorBody(dialect, status, kind, (err as Error).message));
+    }
+    void streaming;
+  }
+
+  // ── request parsing ─────────────────────────────────────────────
+
+  private parse(body: unknown, dialect: Dialect): ParsedRequest {
+    if (!body || typeof body !== 'object') throw new CompatError(400, 'Request body must be a JSON object');
+    const b = body as Record<string, unknown>;
+
+    if (typeof b.model !== 'string' || !b.model.trim()) {
+      throw new CompatError(400, 'model is required');
+    }
+    const { model, agent } = this.resolveModel(b.model.trim());
+
+    const raw = b.messages;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      throw new CompatError(400, 'messages must be a non-empty array');
+    }
+    const messages = raw as WireMessage[];
+
+    // Anthropic carries the system prompt in a top-level field; OpenAI puts it
+    // in the messages array as role:"system".
+    const systemParts: string[] = [];
+    if (dialect === 'anthropic' && b.system !== undefined) {
+      systemParts.push(extractText(b.system));
+    }
+
+    return {
+      model,
+      agent,
+      stream: b.stream === true,
+      messages,
+      system: systemParts.filter(Boolean).join('\n\n'),
+      prompt: '', // filled by resolveChat, which knows whether a session is in play
+    };
+  }
+
+  /**
+   * Map the client's model string onto Codey's catalog.
+   *
+   * Accepts a bare catalog name (`claude-opus-5`) or an explicit agent prefix
+   * (`codex/gpt-5`) for callers that care which CLI runs. An unknown name is a
+   * 404 listing what is available — clients surface that message, so it should
+   * say something useful.
+   */
+  private resolveModel(raw: string): { model: string; agent?: CodingAgent } {
+    let agent: CodingAgent | undefined;
+    let model = raw;
+
+    const slash = raw.indexOf('/');
+    if (slash > 0) {
+      const prefix = raw.slice(0, slash);
+      if (AGENTS.includes(prefix as CodingAgent)) {
+        agent = prefix as CodingAgent;
+        model = raw.slice(slash + 1);
+      }
+    }
+
+    const known = this.host.getModelNames();
+    if (!known.includes(model)) {
+      throw new CompatError(
+        404,
+        `Unknown model: ${model}. Available: ${known.join(', ') || '(none configured)'}`,
+        'not_found_error',
+      );
+    }
+    return { model, agent };
+  }
+
+  /**
+   * Pick the chat this request runs in, and decide what text to send it.
+   *
+   * Without a session header the request is stateless the way both provider
+   * APIs are: a fresh chat, and the client's whole `messages` array flattened
+   * into the prompt. With one, Codey already holds the history, so only the
+   * newest user message is sent — replaying the array too would duplicate
+   * everything the chat has already seen.
+   */
+  private resolveChat(req: http.IncomingMessage, parsed: ParsedRequest): string {
+    const sessionId = headerValue(req, 'x-codey-session-id');
+    const workspace = this.pickWorkspace(headerValue(req, 'x-codey-workspace'));
+
+    if (sessionId) {
+      const existing = this.sessions.get(sessionId);
+      if (existing && this.host.hasChat(existing)) {
+        parsed.prompt = lastUserText(parsed.messages);
+        if (!parsed.prompt) throw new CompatError(400, 'messages must end with a user message');
+        return existing;
+      }
+      const chat = this.host.createApiChat({
+        workspaceName: workspace,
+        title: `API: ${sessionId}`,
+        agent: parsed.agent,
+        model: parsed.model,
+      });
+      this.sessions.set(sessionId, chat.id);
+      parsed.prompt = flatten(parsed.system, parsed.messages);
+      return chat.id;
+    }
+
+    const chat = this.host.createApiChat({
+      workspaceName: workspace,
+      title: 'API: compat',
+      agent: parsed.agent,
+      model: parsed.model,
+    });
+    parsed.prompt = flatten(parsed.system, parsed.messages);
+    return chat.id;
+  }
+
+  private pickWorkspace(requested: string | undefined): string {
+    const workspaces = this.host.getWorkspaceList();
+    if (requested) {
+      if (!workspaces.includes(requested)) {
+        throw new CompatError(404, `Unknown workspace: ${requested}`, 'not_found_error');
+      }
+      return requested;
+    }
+    const fallback = this.options().defaultWorkspace;
+    if (fallback && workspaces.includes(fallback)) return fallback;
+    if (workspaces.length === 0) throw new CompatError(503, 'No workspaces are configured', 'api_error');
+    return workspaces[0];
+  }
+
+  // ── running ─────────────────────────────────────────────────────
+
+  private async runWithTimeout(chatId: string, prompt: string) {
+    const timeoutSec = this.options().timeoutSec;
+    const noop: ChatStreamSink = () => { /* non-streaming callers discard events */ };
+
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () => reject(new CompatError(504, `Agent did not respond within ${timeoutSec}s`, 'api_error')),
+        timeoutSec * 1000,
+      );
+    });
+    try {
+      return await Promise.race([this.host.sendToChat(chatId, prompt, noop), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Stream in the provider's own SSE dialect.
+   *
+   * Only the assistant's text is forwarded. Codey's tool_start/checklist/worker
+   * events have no representation in either wire format, and inventing one
+   * would break the clients this exists to support.
+   */
+  private async streamTurn(
+    res: http.ServerResponse,
+    dialect: Dialect,
+    chatId: string,
+    parsed: ParsedRequest,
+  ): Promise<void> {
+    const id = dialect === 'openai' ? `chatcmpl-${randomId()}` : `msg_${randomId()}`;
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+
+    let aborted = false;
+    const onClose = () => { aborted = true; };
+    res.on('close', onClose);
+
+    if (dialect === 'openai') {
+      // OpenAI clients expect the role to arrive in its own first delta.
+      writeSse(res, null, openAiChunk(id, parsed.model, { role: 'assistant', content: '' }));
+    } else {
+      writeSse(res, 'message_start', {
+        type: 'message_start',
+        message: {
+          id, type: 'message', role: 'assistant', model: parsed.model,
+          content: [], stop_reason: null, stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      });
+      writeSse(res, 'content_block_start', {
+        type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' },
+      });
+    }
+
+    // Codey emits `stream` tokens as the agent talks; anything else is
+    // Codey-specific and has no place in a provider stream.
+    let streamed = '';
+    const sink: ChatStreamSink = (event) => {
+      if (aborted || event.type !== 'stream' || !event.token) return;
+      streamed += event.token;
+      if (dialect === 'openai') {
+        writeSse(res, null, openAiChunk(id, parsed.model, { content: event.token }));
+      } else {
+        writeSse(res, 'content_block_delta', {
+          type: 'content_block_delta', index: 0,
+          delta: { type: 'text_delta', text: event.token },
+        });
+      }
+    };
+
+    const timeoutSec = this.options().timeoutSec;
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () => reject(new CompatError(504, `Agent did not respond within ${timeoutSec}s`, 'api_error')),
+        timeoutSec * 1000,
+      );
+    });
+
+    try {
+      const result = await Promise.race([this.host.sendToChat(chatId, parsed.prompt, sink), timeout]);
+      if (aborted) return;
+
+      // Not every agent streams tokens. When none arrived, deliver the final
+      // text in one delta so a streaming client still receives the answer
+      // rather than an empty message.
+      if (!streamed && result.response) {
+        if (dialect === 'openai') {
+          writeSse(res, null, openAiChunk(id, parsed.model, { content: result.response }));
+        } else {
+          writeSse(res, 'content_block_delta', {
+            type: 'content_block_delta', index: 0,
+            delta: { type: 'text_delta', text: result.response },
+          });
+        }
+      }
+
+      if (dialect === 'openai') {
+        writeSse(res, null, openAiChunk(id, parsed.model, {}, 'stop'));
+        res.write('data: [DONE]\n\n');
+      } else {
+        writeSse(res, 'content_block_stop', { type: 'content_block_stop', index: 0 });
+        writeSse(res, 'message_delta', {
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn', stop_sequence: null },
+          usage: { output_tokens: result.tokens ?? 0 },
+        });
+        writeSse(res, 'message_stop', { type: 'message_stop' });
+      }
+    } catch (err) {
+      if (!aborted) {
+        writeSse(res, dialect === 'openai' ? null : 'error', {
+          type: 'error',
+          error: { type: 'api_error', message: (err as Error).message },
+        });
+        if (dialect === 'openai') res.write('data: [DONE]\n\n');
+      }
+    } finally {
+      if (timer) clearTimeout(timer);
+      res.off('close', onClose);
+      if (!aborted) res.end();
+    }
+  }
+}
+
+interface ParsedRequest {
+  model: string;
+  agent?: CodingAgent;
+  stream: boolean;
+  messages: WireMessage[];
+  system: string;
+  prompt: string;
+}
+
+// ── wire shapes ───────────────────────────────────────────────────
+
+function openAiResponse(model: string, text: string, tokens?: number) {
+  return {
+    id: `chatcmpl-${randomId()}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{
+      index: 0,
+      message: { role: 'assistant', content: text },
+      finish_reason: 'stop',
+    }],
+    // Codey reports one total for the turn; it cannot split input from output.
+    // Reporting the total as completion tokens keeps the sum honest.
+    usage: { prompt_tokens: 0, completion_tokens: tokens ?? 0, total_tokens: tokens ?? 0 },
+  };
+}
+
+function anthropicResponse(model: string, text: string, tokens?: number) {
+  return {
+    id: `msg_${randomId()}`,
+    type: 'message',
+    role: 'assistant',
+    model,
+    content: [{ type: 'text', text }],
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: tokens ?? 0 },
+  };
+}
+
+function openAiChunk(
+  id: string,
+  model: string,
+  delta: Record<string, unknown>,
+  finishReason: string | null = null,
+) {
+  return {
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+/** Each provider reports failures in its own envelope; clients parse for it. */
+function errorBody(dialect: Dialect, status: number, kind: string, message: string) {
+  if (dialect === 'openai') {
+    return { error: { message, type: kind, param: null, code: String(status) } };
+  }
+  return { type: 'error', error: { type: kind, message } };
+}
+
+// ── helpers ───────────────────────────────────────────────────────
+
+/**
+ * Flatten a provider conversation into a single prompt.
+ *
+ * The agent receives one block of text, so the roles have to survive as
+ * labels — without them a multi-turn history reads as one run-on message and
+ * the agent loses track of who said what.
+ */
+function flatten(system: string, messages: WireMessage[]): string {
+  const parts: string[] = [];
+  if (system) parts.push(system);
+
+  const body = messages.filter(m => m.role !== 'system');
+  const systemInline = messages.filter(m => m.role === 'system').map(m => extractText(m.content));
+  for (const s of systemInline) if (s) parts.unshift(s);
+
+  if (body.length === 1 && body[0].role === 'user') {
+    // The common case: one question, no history. Send it as-is rather than
+    // wrapping a bare question in conversation scaffolding.
+    const text = extractText(body[0].content);
+    if (!text) throw new CompatError(400, 'messages must contain text content');
+    parts.push(text);
+    return parts.join('\n\n');
+  }
+
+  for (const m of body) {
+    const text = extractText(m.content);
+    if (!text) continue;
+    parts.push(`${m.role === 'assistant' ? 'Assistant' : 'User'}: ${text}`);
+  }
+  const flat = parts.join('\n\n');
+  if (!flat.trim()) throw new CompatError(400, 'messages must contain text content');
+  return flat;
+}
+
+/** The newest user message, for session-backed requests. */
+function lastUserText(messages: WireMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') return extractText(messages[i].content);
+  }
+  return '';
+}
+
+/**
+ * Pull text out of a content field. Both APIs accept a plain string or an array
+ * of typed blocks; non-text blocks (images, tool results) are skipped rather
+ * than rejected, so a client sending them still gets an answer to its text.
+ */
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map(block => {
+        if (typeof block === 'string') return block;
+        if (block && typeof block === 'object' && (block as any).type === 'text') {
+          return String((block as any).text ?? '');
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+  }
+  return '';
+}
+
+function headerValue(req: http.IncomingMessage, name: string): string | undefined {
+  const raw = req.headers[name];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value?.trim() || undefined;
+}
+
+/** One SSE frame. Anthropic names its events; OpenAI sends bare `data:`. */
+function writeSse(res: http.ServerResponse, event: string | null, payload: unknown): void {
+  if (event) res.write(`event: ${event}\n`);
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function sendJson(res: http.ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+function randomId(): string {
+  return Math.random().toString(36).slice(2, 12) + Math.random().toString(36).slice(2, 12);
+}
+
+function readBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let tooLarge = false;
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        // Drain rather than destroy: killing the socket mid-upload reaches the
+        // client as a reset instead of the 413 that explains what went wrong.
+        tooLarge = true;
+        chunks.length = 0;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (tooLarge) {
+        reject(new CompatError(413, `Request body exceeds ${MAX_BODY_BYTES} bytes`));
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString('utf-8');
+      if (!raw.trim()) {
+        reject(new CompatError(400, 'Request body must be a JSON object'));
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(new CompatError(400, 'Invalid JSON'));
+      }
+    });
+    req.on('error', err => reject(err));
+  });
+}

--- a/packages/gateway/src/health.ts
+++ b/packages/gateway/src/health.ts
@@ -1,7 +1,8 @@
 import * as http from 'http';
 import { ConfigManager, stripSecrets } from './config';
-import { ApiTokenRecord, ApiTokenStore, parseBearer } from './api-tokens';
+import { ApiTokenRecord, ApiTokenStore, tokenFromHeaders } from './api-tokens';
 import { RouterApi } from './router-api';
+import { CompatApi } from './compat-api';
 import { VoiceConverseEvent } from '@codey/core';
 
 /**
@@ -16,6 +17,10 @@ import { VoiceConverseEvent } from '@codey/core';
  * `/voice/*` is not listed because it has its own guard (no-Origin native
  * clients only) and is called by the Swift helper, which has no way to hold a
  * token yet.
+ *
+ * The token may arrive as `Authorization: Bearer` or as `x-api-key` — OpenAI
+ * clients send the first, Anthropic clients the second, and both must reach the
+ * compat endpoints.
  */
 function requiresAuth(url: string | undefined): boolean {
   if (!url) return false;
@@ -61,6 +66,7 @@ export class ApiServer {
   private onOpenSettings?: () => void;
   private tokens: ApiTokenStore;
   private routerApi?: RouterApi;
+  private compatApi?: CompatApi;
 
   constructor(
     port: number,
@@ -100,6 +106,11 @@ export class ApiServer {
     this.routerApi = routerApi;
   }
 
+  /** Attach the OpenAI/Anthropic-compatible endpoints. Same timing rationale. */
+  setCompatApi(compatApi: CompatApi): void {
+    this.compatApi = compatApi;
+  }
+
   /**
    * Authorize a request, writing the error response itself when it fails.
    * Returns the matched token (its id keys per-token rate limiting), or null
@@ -110,12 +121,12 @@ export class ApiServer {
     // process, so a long-lived gateway would otherwise reject tokens minted
     // after it booted until restarted.
     this.tokens.reload();
-    const matched = this.tokens.verify(parseBearer(req.headers.authorization));
+    const matched = this.tokens.verify(tokenFromHeaders(req.headers));
     if (matched) return matched;
     res.writeHead(401, { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer' });
     res.end(JSON.stringify({
       error: 'Unauthorized',
-      hint: 'Send Authorization: Bearer <token>. Create one with: npm run api-token -- create <name>',
+      hint: 'Send Authorization: Bearer <token> (or x-api-key: <token>). Create one with: npm run api-token -- create <name>',
     }));
     return null;
   }
@@ -161,6 +172,13 @@ export class ApiServer {
       // the transport + auth layer rather than growing a second router.
       if (url?.startsWith('/v1/') && this.routerApi) {
         if (await this.routerApi.handle(req, res, url, token!.id)) return;
+      }
+
+      // Provider-shaped endpoints (`/v1/chat/completions`, `/v1/messages`,
+      // `/v1/models`) are checked after Codey's own routes, so the native API
+      // always wins a path collision.
+      if (url?.startsWith('/v1/') && this.compatApi) {
+        if (await this.compatApi.handle(req, res, url)) return;
       }
 
       if (url === '/health' || url === '/') {

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -6,6 +6,7 @@ import { GatewayConfig } from '@codey/core';
 import { Codey } from './gateway';
 import { ApiServer, HealthStatusType } from './health';
 import { RouterApi } from './router-api';
+import { CompatApi } from './compat-api';
 import { assertNoLegacyLayout } from './startup-guard';
 
 dotenv.config();
@@ -78,6 +79,9 @@ function startGateway(): void {
     apiServer.setRouterApi(new RouterApi(gateway.asRouterApiHost(), () => ({
       timeoutSec: configManager.getApiTimeoutSec(),
       rateLimitPerMin: configManager.getApiRateLimitPerMin(),
+    })));
+    apiServer.setCompatApi(new CompatApi(gateway.asRouterApiHost(), () => ({
+      timeoutSec: configManager.getApiTimeoutSec(),
     })));
     await apiServer.start();
 


### PR DESCRIPTION
> Targets `router-api`, not `main` — the Router API lives there until this is finished (see #333).

## Why

`/v1/prompt` is a shape only Codey understands, so using it means writing a Codey client. These endpoints let existing tools point at Codey without knowing it exists:

```bash
OPENAI_BASE_URL=http://127.0.0.1:3000/v1   OPENAI_API_KEY=<codey token>
ANTHROPIC_BASE_URL=http://127.0.0.1:3000   ANTHROPIC_API_KEY=<codey token>
```

## What

`POST /v1/chat/completions` (OpenAI), `POST /v1/messages` (Anthropic), and `GET /v1/models` — the last because many clients call it to populate a model picker or validate a name before the first request. Codey's native routes are matched first, so a path collision always resolves in favour of the real API.

## Decisions worth reviewing

**Stateless by default**, because both provider APIs are: the client owns the history and resends it every turn, while `/v1/prompt` keeps it server-side. Mixing them would duplicate every message. A compat request flattens `messages` into one prompt in a throwaway chat. `X-Codey-Session-Id` opts into Codey's server-side context — and then only the newest user message is sent, since the chat already holds the rest.

**Flattening keeps role labels.** Without `User:` / `Assistant:` a multi-turn history reads as one run-on message and the agent loses track of who said what. A lone question is passed through as itself rather than wrapped in scaffolding.

**Both auth conventions.** OpenAI clients send `Authorization: Bearer`; Anthropic clients send `x-api-key` and no Authorization header at all. Same token store either way — the header a client happens to use says nothing about which token is valid.

**Provider-shaped errors.** `{error:{message,type,param,code}}` vs `{type:"error",error:{...}}`. The SDKs parse these to choose an exception class; both raise `NotFoundError` on an unknown model, verified below.

**Only assistant text is streamed.** Codey's `tool_start` / `checklist` / `worker_start` events have no representation in either wire format, and inventing one would break the clients this exists to serve. When an adapter emits no token deltas at all, the final text goes out as one delta — otherwise a streaming client ends up with an empty message.

**Model-only parameters are accepted and ignored** (`temperature`, `n`, `logprobs`, `tools`) rather than half-implemented. Codey is an agent, not a model server; it edits files and takes tens of seconds. The wire format is faithful, the semantics are honestly different.

## Verification

Verified against a real gateway using the **official SDKs**, not hand-rolled requests — that is the only test that proves compatibility:

| Call | Result |
|---|---|
| `openai.models.list()` | returned the catalog |
| `openai.chat.completions.create()` | `"OPENAI_OK"`, `finish_reason: stop` |
| `openai.chat.completions.create({stream:true})` | `"STREAM_OK"` reassembled from deltas |
| `anthropic.messages.create()` | `"ANTHROPIC_OK"`, `stop_reason: end_turn` |
| `anthropic.messages.stream()` → `finalMessage()` | `"ASTREAM_OK"` |
| unknown model, both SDKs | `NotFoundError` / 404 |

Every response deserialized into the SDK's own types.

- Full suite: **1652 passed / 0 failed**, including 23 new compat tests that assert exact wire shape (SSE frame order, `[DONE]`, `chat.completion.chunk`, the seven-event Anthropic sequence).
- `tsc` clean for core, gateway and the Electron main process. Lint clean.

## Known follow-up

`compat-api.ts` carries a TODO: once #332 (per-token session retention) lands on `router-api`, chats created here need the token's `retentionDays` stamped on them. A stateless compat call creates a chat per request, so it is the biggest producer of exactly the pile-up retention exists to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)