### PR TITLE
fix(gateway): give every channel turn a Codey chat so the Mac app sees it

### DIFF
--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -178,3 +178,52 @@ describe('startSend seeds the turn header', () => {
     })
   })
 })
+
+
+describe('reducer: a wholesale reload landing mid-turn', () => {
+  // linkChannel re-pulls every chat, and pairing auto-link fires it while an
+  // agent is running. The reply used to vanish: the placeholder was wiped and
+  // completeSend's lookup matched nothing.
+  const inFlight = (): State => {
+    const s = baseState()
+    s.chats.c1 = {
+      ...s.chats.c1,
+      messages: [
+        { id: 'u1', role: 'user', content: 'do the thing', timestamp: 1, isComplete: true },
+        { id: 'asst-x', role: 'assistant', content: 'partial', timestamp: 2, isComplete: false },
+      ],
+    }
+    return s
+  }
+
+  // The server copy at that moment: user message persisted, no assistant yet.
+  const serverChat = (): Chat => ({
+    ...baseState().chats.c1,
+    messages: [{ id: 'u1', role: 'user', content: 'do the thing', timestamp: 1, isComplete: true }],
+  })
+
+  it('keeps the assistant placeholder the server does not know about yet', () => {
+    const s = reducer(inFlight(), { type: 'loaded', chats: [serverChat()] })
+    expect(s.chats.c1.messages.map(m => m.id)).toEqual(['u1', 'asst-x'])
+  })
+
+  it('does not resurrect local messages once the turn is over', () => {
+    const s = baseState()
+    s.inFlight = {}
+    s.chats.c1 = { ...s.chats.c1, messages: [{ id: 'gone', role: 'user', content: 'x', timestamp: 1, isComplete: true }] }
+    const after = reducer(s, { type: 'loaded', chats: [serverChat()] })
+    expect(after.chats.c1.messages.map(m => m.id)).toEqual(['u1'])
+  })
+
+  it('still shows the reply when the placeholder was already lost', () => {
+    const s = baseState()
+    s.chats.c1 = { ...s.chats.c1, messages: [{ id: 'u1', role: 'user', content: 'x', timestamp: 1, isComplete: true }] }
+    const after = reducer(s, {
+      type: 'completeSend',
+      chatId: 'c1',
+      assistantMessageId: 'asst-x',
+      content: 'the answer',
+    })
+    expect(after.chats.c1.messages.at(-1)).toMatchObject({ id: 'asst-x', content: 'the answer', isComplete: true })
+  })
+})

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -96,7 +96,21 @@ export function reducer(state: State, action: Action): State {
     case 'loaded': {
       const chats: Record<string, Chat> = {}
       const sorted = [...action.chats].sort((a, b) => b.updatedAt - a.updatedAt)
-      for (const c of sorted) chats[c.id] = c
+      for (const c of sorted) {
+        // A wholesale reload can land MID-TURN — linkChannel re-pulls every
+        // chat, and pairing auto-link fires it while an agent is running. The
+        // server's copy has no in-flight messages (they aren't persisted until
+        // the turn ends), so a blind overwrite drops the assistant placeholder
+        // that `completeSend` later looks up by id: the map matches nothing and
+        // the finished reply is silently thrown away. Carry local-only messages
+        // over for any chat with a turn in flight, same as `upsert` does.
+        const fl = state.inFlight[c.id]
+        const prev = fl ? state.chats[c.id] : undefined
+        if (!prev) { chats[c.id] = c; continue }
+        const serverIds = new Set(c.messages.map(m => m.id))
+        const localOnly = prev.messages.filter(m => !serverIds.has(m.id))
+        chats[c.id] = localOnly.length > 0 ? { ...c, messages: [...c.messages, ...localOnly] } : c
+      }
       return { ...state, chats, order: sorted.map(c => c.id) }
     }
     case 'setWorkspaces':
@@ -401,7 +415,7 @@ export function reducer(state: State, action: Action): State {
             teamMode: firstWorker?.teamMode,
           }]
         }
-      } else {
+      } else if (chat.messages.some(m => m.id === action.assistantMessageId)) {
         messages = chat.messages.map(m =>
           m.id === action.assistantMessageId
             // `?? m.thinking` rather than a plain assignment: thinking that
@@ -410,6 +424,25 @@ export function reducer(state: State, action: Action): State {
             ? { ...m, content: action.content, thinking: action.thinking ?? m.thinking, tokens: action.tokens, durationSec: action.durationSec, agent: action.agent, model: action.model, isComplete: true, choices: action.choices, userQuestion: action.userQuestion, fallback: action.fallback }
             : m
         )
+      } else {
+        // The placeholder is gone (a mid-turn reload replaced this chat). Show
+        // the reply anyway rather than dropping the whole turn on the floor.
+        messages = [...chat.messages, {
+          id: action.assistantMessageId,
+          role: 'assistant',
+          content: action.content,
+          thinking: action.thinking,
+          timestamp: Date.now(),
+          toolCalls: [],
+          isComplete: true,
+          tokens: action.tokens,
+          durationSec: action.durationSec,
+          agent: action.agent,
+          model: action.model,
+          choices: action.choices,
+          userQuestion: action.userQuestion,
+          fallback: action.fallback,
+        }]
       }
       const updatedChat: Chat = { ...chat, messages, updatedAt: Date.now() }
       if (action.title) updatedChat.title = action.title

--- a/packages/gateway/src/gateway.channel-chat.test.ts
+++ b/packages/gateway/src/gateway.channel-chat.test.ts
@@ -1,0 +1,80 @@
+// A channel turn must always land in a Codey chat, otherwise the Mac app has
+// nothing to show and the reply exists only on the chat platform.
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+import { PairingStore } from './pairings';
+import { Codey } from './gateway';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function tmpRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chanchat-'));
+  roots.push(root);
+  fs.mkdirSync(path.join(root, 'main'), { recursive: true });
+  return root;
+}
+
+/** Minimal `this` for the method under test — it only touches these five. */
+function harness() {
+  const root = tmpRoot();
+  const chatManager = new ChatManager(root);
+  const pairingStore = new PairingStore(path.join(root, 'pairings.json'));
+  const ctx = {
+    chatManager,
+    pairingStore,
+    workspaceManager: { getCurrentWorkspace: () => 'main' },
+    logger: { info: () => {}, error: () => {} },
+    createChat: (input: any) => Promise.resolve(chatManager.create({ ...input, executionMode: 'shared-checkout' })),
+  };
+  const ensure = (Codey.prototype as any).ensureChannelChat.bind(ctx);
+  const resolve = (Codey.prototype as any).resolveChatId.bind({
+    ...ctx,
+    isPairableChannel: (c: string) => c === 'telegram',
+  });
+  return { ctx, chatManager, pairingStore, ensure, resolve };
+}
+
+describe('ensureChannelChat', () => {
+  it('creates a routed chat for an unpaired channel user', async () => {
+    const { chatManager, ensure, resolve } = harness();
+    expect(resolve('telegram', 'u1')).toBeUndefined();
+
+    const chatId = await ensure('telegram', 'u1', 'c1');
+
+    expect(chatId).toBeTruthy();
+    expect(chatManager.get(chatId!)?.routes).toEqual([
+      expect.objectContaining({ channel: 'telegram', channelUserId: 'u1', channelChatId: 'c1' }),
+    ]);
+    // The route is what makes the NEXT turn reuse this chat instead of piling
+    // up a new one per message.
+    expect(resolve('telegram', 'u1')).toBe(chatId);
+  });
+
+  it('adopts a paired user\'s workspace and marks the chat current', async () => {
+    const { pairingStore, chatManager, ensure } = harness();
+    const code = pairingStore.startPairing({ channel: 'telegram' });
+    pairingStore.completePairing(code, { channel: 'telegram', channelUserId: 'u1', channelChatId: 'tg-1' });
+    pairingStore.updatePrefs('telegram', 'u1', { workspace: 'main' });
+
+    const chatId = await ensure('telegram', 'u1', 'ignored');
+
+    expect(chatManager.get(chatId!)?.workspaceName).toBe('main');
+    expect(chatManager.get(chatId!)?.routes?.[0].channelChatId).toBe('tg-1');
+    expect(pairingStore.findByChannelUser('telegram', 'u1')?.currentChatId).toBe(chatId);
+  });
+
+  it('returns undefined instead of throwing when chat creation fails', async () => {
+    const { ctx } = harness();
+    const ensure = (Codey.prototype as any).ensureChannelChat.bind({
+      ...ctx,
+      createChat: () => Promise.reject(new Error('disk full')),
+    });
+    await expect(ensure('telegram', 'u1', 'c1')).resolves.toBeUndefined();
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2270,6 +2270,47 @@ export class Codey {
     return undefined;
   }
 
+  /**
+   * A channel turn with no Codey chat behind it is INVISIBLE in the Mac app:
+   * it runs on the plain-conversation path, persists no chat record, and emits
+   * no chat events, so the reply exists only in the chat platform. That is the
+   * default state right after a bot token is configured — pairing (`/pair`) or
+   * a Mac-side link is what normally creates the chat, and until then the two
+   * surfaces silently disagree about what happened.
+   *
+   * So: give every pairable-channel user a chat on their first prompt. The
+   * route makes `resolveChatId` find it from then on (no second chat is ever
+   * created), and it becomes the binding's current chat when a pairing exists.
+   */
+  private async ensureChannelChat(
+    channel: 'telegram' | 'discord' | 'imessage',
+    userId: string,
+    channelChatId: string,
+  ): Promise<string | undefined> {
+    try {
+      const binding = this.pairingStore.findByChannelUser(channel, userId);
+      const workspaceName = binding?.prefs?.workspace ?? this.workspaceManager.getCurrentWorkspace();
+      const chat = await this.createChat({ workspaceName });
+      if (binding?.prefs?.agent || binding?.prefs?.model) {
+        this.chatManager.updateAgentModel(chat.id, binding.prefs.agent, binding.prefs.model);
+      }
+      this.chatManager.addRoute(chat.id, {
+        channel,
+        channelUserId: userId,
+        channelChatId: binding?.channelChatId ?? channelChatId,
+        attachedAt: Date.now(),
+      });
+      if (binding) this.pairingStore.setCurrentChat(channel, userId, chat.id);
+      this.logger.info(`[chat] auto-created ${chat.id} for ${channel}:${userId} so the Mac app mirrors this turn`);
+      return chat.id;
+    } catch (err) {
+      // Never block the turn on this — worst case we fall back to the old
+      // channel-only path.
+      this.logger.error(`ensureChannelChat failed for ${channel}:${userId}: ${(err as Error).message}`);
+      return undefined;
+    }
+  }
+
   private async processPrompt(
     message: UserMessage,
     parsed: ParsedCommand,
@@ -2300,7 +2341,13 @@ export class Codey {
   ): Promise<void> {
     const { userId, chatId, channel, id: messageId } = message;
 
-    const codeyChatId = this.resolveChatId(channel as ChannelType, userId);
+    let codeyChatId = this.resolveChatId(channel as ChannelType, userId);
+
+    // No chat yet (channel connected but never paired/linked) → make one, so
+    // this turn is mirrored into the Mac app like every other channel turn.
+    if (!codeyChatId && parsed.prompt.trim() && this.isPairableChannel(channel)) {
+      codeyChatId = await this.ensureChannelChat(channel, userId, chatId);
+    }
 
     // Channel-side with a linked Codey chat → route through sendToChat so the
     // Codey Chat record is updated and the Mac app sees the events.


### PR DESCRIPTION
Two independent gaps that both end with a turn showing up in Telegram but not
in the Mac app.

## 1. A mid-turn chat reload ate the reply (the reported bug)

Linking a channel to a chat re-pulls every chat and dispatches `loaded`, which
replaced each chat wholesale with the server's copy. An in-flight assistant
message is not persisted until the turn ends, so linking while an agent was
running deleted the placeholder. `completeSend` then mapped over the messages
looking for it by id, matched nothing, and dropped the finished reply — which
still reached the channel via the route fan-out.

Repro from the reporter's data: turn started from the Mac app at 15:04, pairing
auto-linked the chat at 15:18, the agent finished at 15:30. Telegram got the
answer; the Mac app showed nothing.

`loaded` now carries over local-only messages for any chat with a turn in
flight, mirroring what `upsert` already did. `completeSend` appends the reply
instead of discarding it when the placeholder has gone missing.

## 2. A channel turn with no chat behind it is invisible

`runOneTurn` routes a channel message through `sendToChat` only when
`resolveChatId` finds a chat, which happens after `/pair` or a Mac-side link.
Otherwise it falls to the plain-conversation path: no chat record persisted, no
chat events emitted, so the Mac app has nothing to render.

`ensureChannelChat()` creates a routed chat on a pairable-channel user's first
prompt when there is none. The route makes `resolveChatId` reuse it afterwards,
so no second chat is created. Creation failure falls back to the old
channel-only path rather than dropping the turn.

## Tests

- `codey-mac/src/hooks/useChats.reducer.test.ts` — 3 tests for #1. Verified as a
  real regression test: reverting the `loaded` change turns the first one red.
- `packages/gateway/src/gateway.channel-chat.test.ts` — 3 tests for #2.
- `npm test -w codey-mac` → 676 pass. `npm test -w @codey/gateway` → 382 pass.
  Both tsconfigs typecheck clean.

## Not verified

Neither change has been smoke-tested on a device — that needs a Mac app rebuild.
#2 in particular changes routing behaviour (it auto-creates a chat and attaches
a route), and has only been exercised by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)