### PR TITLE
fix(mac): let Stop clear a chat the gateway is no longer running

### DIFF
--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -178,3 +178,19 @@ describe('startSend seeds the turn header', () => {
     })
   })
 })
+
+describe("reducer: clearInFlight (Stop on a turn the gateway isn't running)", () => {
+  it('drops the spinner without touching the transcript', () => {
+    const s = baseState()
+    s.chats.c1 = { ...s.chats.c1, messages: [{ id: 'u1', role: 'user', content: 'x', timestamp: 1, isComplete: true }] }
+    const after = reducer(s, { type: 'clearInFlight', chatId: 'c1' })
+    expect(after.inFlight.c1).toBeUndefined()
+    expect(after.chats.c1.messages.map(m => m.id)).toEqual(['u1'])
+  })
+
+  it('is a no-op when nothing is in flight', () => {
+    const s = baseState()
+    s.inFlight = {}
+    expect(reducer(s, { type: 'clearInFlight', chatId: 'c1' })).toBe(s)
+  })
+})

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -52,6 +52,9 @@ type Action =
   | { type: 'errorSend'; chatId: string; assistantMessageId: string; error: string }
   | { type: 'stoppedSend'; chatId: string; text: string }
   | { type: 'clearRestore'; chatId: string }
+  // Drop the in-flight entry only, leaving messages alone: used when the
+  // gateway reports it has nothing running for this chat.
+  | { type: 'clearInFlight'; chatId: string }
   | { type: 'patchContextPanelOpen'; chatId: string; open: boolean | null }
   | { type: 'patchSoloAdvisor'; chatId: string; enabled: boolean }
   | { type: 'patchTaskBrief'; chatId: string; brief: TaskBrief }
@@ -444,6 +447,12 @@ export function reducer(state: State, action: Action): State {
         inFlight,
         pendingRestores: { ...state.pendingRestores, [action.chatId]: action.text },
       }
+    }
+    case 'clearInFlight': {
+      if (!state.inFlight[action.chatId]) return state
+      const inFlight = { ...state.inFlight }
+      delete inFlight[action.chatId]
+      return { ...state, inFlight }
     }
     case 'clearRestore': {
       if (!(action.chatId in state.pendingRestores)) return state
@@ -845,7 +854,20 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     },
     sendMessage,
     async stopChat(chatId) {
-      try { await apiService.chats.stop(chatId) } catch { /* nothing in flight */ }
+      let stopped = false
+      try { stopped = await apiService.chats.stop(chatId) } catch { /* treated as nothing to stop */ }
+      if (stopped) return
+      // The gateway had no turn to abort, so our in-flight state is stale — a
+      // terminal event for this chat never reached us (channel-started turns
+      // are especially prone to it: their events are the only thing that ever
+      // clears the spinner). Pressing Stop must not leave the chat stuck on
+      // "Thinking..." forever, so drop the local turn and re-sync from disk.
+      delete pendingAssistantId.current[chatId]
+      adopting.current.delete(chatId)
+      dispatch({ type: 'clearInFlight', chatId })
+      try {
+        dispatch({ type: 'upsert', chat: await apiService.chats.get(chatId) })
+      } catch { /* keep whatever we already show */ }
     },
     async resolvePermission(chatId, allow) {
       if (!allow) {


### PR DESCRIPTION
## Symptom

A turn started from Telegram leaves the Mac app stuck on **Thinking…** with the
timer climbing. Pressing Stop does nothing — the chat stays "in progress"
forever.

## Cause

The renderer's in-flight state (the spinner, the timer, the Stop button) is
cleared only by a `done` / `stopped` / `error` event. A channel-started turn has
no local placeholder to fall back on, so if its terminal event never reaches the
renderer, the spinner never stops.

Stop should have been the escape hatch, and it wasn't:

```ts
async stopChat(chatId) {
  try { await apiService.chats.stop(chatId) } catch { /* nothing in flight */ }
}
```

`gateway.stopChat` returns `false` when it finds no abort controller for the
chat — i.e. nothing is running, so nothing is aborted and no `stopped` event is
emitted. The renderer discarded that boolean and left the spinner up.

## Fix

Treat `false` as proof the local turn is stale: clear the in-flight entry (a new
`clearInFlight` action that touches only that entry, not the transcript) and
re-fetch the chat so the view matches what the gateway actually has.

## Tests

`codey-mac/src/hooks/useChats.reducer.test.ts` — 2 tests for `clearInFlight`.
`npm test -w codey-mac` → 675 pass, tsc clean.

## Scope

This is a recovery fix for the reported symptom. It does **not** explain why the
terminal event went missing in the first place — that root cause is still open,
and this only guarantees Stop can always get the chat unstuck. Not smoke-tested
on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)