### PR TITLE
feat(mac): queue messages typed while a turn is running

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -831,9 +831,10 @@ export const ChatTab: React.FC<Props> = ({
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
 }) => {
-  const { state, createChat, sendMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, createChat, sendMessage, removeQueuedMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
+  const queuedMessages = state.queuedMessages[chatId] ?? []
 
   // Voice: capture, playback and the turn itself live above this component
   // (see VoiceTurnProvider) so they survive switching chats. What stays here
@@ -1681,7 +1682,9 @@ export const ChatTab: React.FC<Props> = ({
   }
 
   const send = async () => {
-    if ((!input.trim() && pendingAttachments.length === 0) || !isGatewayRunning || !!flight) return
+    // No `flight` guard: sendMessage queues the prompt when a turn is running
+    // and delivers it once the chat goes idle.
+    if ((!input.trim() && pendingAttachments.length === 0) || !isGatewayRunning) return
 
     // Quick Question triggers — these never go to the main chat.
     const trimmed = input.trim()
@@ -1889,7 +1892,7 @@ export const ChatTab: React.FC<Props> = ({
     setEditingMsgId(null)
     await resendMessage(text, msg.attachments)
   }
-  const canSend = isGatewayRunning && !coreFailed && !isSending && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
+  const canSend = isGatewayRunning && !coreFailed && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
   // Three layers when the agent gave us its task list: what it is on, the tool
   // it is running right now, and how far through it is — a bare "Editing…"
   // withholds information we already have in hand.
@@ -2651,6 +2654,21 @@ export const ChatTab: React.FC<Props> = ({
               opacity: composerHandleHover || composerResizing ? 1 : 0,
             }} />
           </div>
+          {queuedMessages.length > 0 && (
+            <div style={styles.queuedRow}>
+              {queuedMessages.map((queued, i) => (
+                <div key={queued.id} style={styles.queuedChip} title={queued.text}>
+                  <span style={styles.queuedIndex}>{i + 1}</span>
+                  <span style={styles.queuedText}>{queued.text.trim() || `${queued.attachments?.length ?? 0} attachment(s)`}</span>
+                  <button
+                    onClick={() => removeQueuedMessage(chatId, queued.id)}
+                    style={styles.queuedRemoveBtn}
+                    aria-label="Remove queued message"
+                  >×</button>
+                </div>
+              ))}
+            </div>
+          )}
           {pendingAttachments.length > 0 && (
             <div style={styles.pendingRow}>
               {pendingAttachments.map(att => {
@@ -2730,11 +2748,11 @@ export const ChatTab: React.FC<Props> = ({
             <div style={styles.composerTools}>
               <button
                 onClick={() => fileInputRef.current?.click()}
-                disabled={!isGatewayRunning || !!coreFailed || isSending}
+                disabled={!isGatewayRunning || !!coreFailed}
                 style={styles.attachButton}
                 title="Attach file"
               >
-                <PaperclipIcon color={isGatewayRunning && !isSending ? C.fg2 : C.fg3} />
+                <PaperclipIcon color={isGatewayRunning ? C.fg2 : C.fg3} />
               </button>
             </div>
             <div style={styles.voiceIndicatorSlot}>
@@ -2820,7 +2838,7 @@ export const ChatTab: React.FC<Props> = ({
                       color={voiceActiveHere && voice.state === 'speaking' ? C.onAccent : C.fg2}
                     />}
               </button>}
-              {isSending ? (
+              {isSending && (
                 <button
                   onClick={() => stopChat(chatId)}
                   style={{ ...styles.sendButton, background: C.red, cursor: 'pointer' }}
@@ -2828,10 +2846,12 @@ export const ChatTab: React.FC<Props> = ({
                 >
                   <StopIcon color="#fff" />
                 </button>
-              ) : (
+              )}
+              {(
                 <button
                   onClick={send}
                   disabled={!canSend}
+                  title={isSending ? 'Queue this message (↵)' : 'Send (↵)'}
                   style={{ ...styles.sendButton, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
                 >
                   <SendIcon color={canSend ? C.onAccent : C.fg3} />
@@ -3234,6 +3254,30 @@ const styles: Record<string, React.CSSProperties> = {
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const, maxWidth: 160,
   },
   attachmentFileSize: { color: `${C.onAccent}b8`, fontSize: 10, fontVariantNumeric: 'tabular-nums' as const },
+  // Queued prompts sit directly above the composer, oldest first, so the order
+  // they will run in is the order you read them.
+  queuedRow: {
+    display: 'flex', flexDirection: 'column' as const, gap: 4,
+    padding: '8px 8px 0',
+  },
+  queuedChip: {
+    display: 'flex', alignItems: 'center', gap: 8,
+    padding: '5px 8px', borderRadius: 8,
+    background: C.surface2, border: `1px dashed ${C.border2}`,
+  },
+  queuedIndex: {
+    flexShrink: 0, minWidth: 16, height: 16, borderRadius: 8,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    fontSize: 10, color: C.fg3, background: C.surface3,
+  },
+  queuedText: {
+    flex: 1, fontSize: 12, color: C.fg2,
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+  },
+  queuedRemoveBtn: {
+    flexShrink: 0, border: 'none', background: 'transparent',
+    color: C.fg3, cursor: 'pointer', fontSize: 14, lineHeight: 1, padding: 2,
+  },
   pendingRow: {
     display: 'flex', flexWrap: 'wrap' as const, gap: 8,
     padding: '8px 8px 4px',

--- a/codey-mac/src/components/coreOfflineView.test.ts
+++ b/codey-mac/src/components/coreOfflineView.test.ts
@@ -30,7 +30,7 @@ describe('composerPlaceholder', () => {
     expect(composerPlaceholder({ coreFailed: false, isGatewayRunning: false, isSending: false }))
       .toBe('Start gateway to chat')
     expect(composerPlaceholder({ coreFailed: false, isGatewayRunning: true, isSending: true }))
-      .toBe('Sending…')
+      .toBe('Queue the next message… (↵ to queue)')
     expect(composerPlaceholder({ coreFailed: false, isGatewayRunning: true, isSending: false }))
       .toBe('Message Codey… (↵ to send)')
   })

--- a/codey-mac/src/components/coreOfflineView.ts
+++ b/codey-mac/src/components/coreOfflineView.ts
@@ -18,5 +18,7 @@ export function composerPlaceholder(opts: {
 }): string {
   if (opts.coreFailed) return 'Core offline — relaunch to continue'
   if (!opts.isGatewayRunning) return 'Start gateway to chat'
-  return opts.isSending ? 'Sending…' : 'Message Codey… (↵ to send)'
+  // While a turn runs the composer stays live: what you type is queued and
+  // sent as soon as the agent finishes, so say so instead of "Sending…".
+  return opts.isSending ? 'Queue the next message… (↵ to queue)' : 'Message Codey… (↵ to send)'
 }

--- a/codey-mac/src/hooks/messageQueue.test.ts
+++ b/codey-mac/src/hooks/messageQueue.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { readyDeliveries } from './messageQueue'
+
+const msg = (id: string, text: string) => ({ id, text })
+
+describe('readyDeliveries', () => {
+  it('releases only the head of an idle chat', () => {
+    const ready = readyDeliveries({ c1: [msg('q1', 'one'), msg('q2', 'two')] }, {}, new Set())
+    expect(ready).toEqual([{ chatId: 'c1', message: msg('q1', 'one') }])
+  })
+
+  it('holds a chat whose turn is still running', () => {
+    expect(readyDeliveries({ c1: [msg('q1', 'one')] }, { c1: {} }, new Set())).toEqual([])
+  })
+
+  it('holds a chat already mid-delivery so the head cannot fire twice', () => {
+    expect(readyDeliveries({ c1: [msg('q1', 'one')] }, {}, new Set(['c1']))).toEqual([])
+  })
+
+  it('drains independent chats in the same pass', () => {
+    const ready = readyDeliveries(
+      { c1: [msg('q1', 'one')], c2: [msg('q2', 'two')] },
+      { c1: {} },
+      new Set(),
+    )
+    expect(ready).toEqual([{ chatId: 'c2', message: msg('q2', 'two') }])
+  })
+})

--- a/codey-mac/src/hooks/messageQueue.ts
+++ b/codey-mac/src/hooks/messageQueue.ts
@@ -1,0 +1,18 @@
+import type { QueuedMessage } from './useChats'
+
+/** Which queued prompts are ready to go out right now: the head of every
+ *  chat's queue whose turn has finished and that is not already being
+ *  delivered. Pure so the drain rule can be tested without a DOM. */
+export function readyDeliveries(
+  queuedMessages: Record<string, QueuedMessage[]>,
+  inFlight: Record<string, unknown>,
+  draining: ReadonlySet<string>,
+): Array<{ chatId: string; message: QueuedMessage }> {
+  const ready: Array<{ chatId: string; message: QueuedMessage }> = []
+  for (const [chatId, queue] of Object.entries(queuedMessages)) {
+    const head = queue[0]
+    if (!head || inFlight[chatId] || draining.has(chatId)) continue
+    ready.push({ chatId, message: head })
+  }
+  return ready
+}

--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -5,7 +5,7 @@ import type { Chat } from '../types'
 const emptyState = (): State => ({
   chats: {}, order: [], selectedChatId: null, inFlight: {},
   collapsedWorkspaces: {}, workspaces: [], pendingRestores: {},
-  unreadChats: {}, pendingPermissions: {},
+  unreadChats: {}, pendingPermissions: {}, queuedMessages: {},
 })
 
 // A chat as it exists server-side at turn start: the user message is already
@@ -22,7 +22,7 @@ function baseState(): State {
     chats: { c1: { id: 'c1', title: 't', workspaceName: 'ws', selection: { type: 'team', name: 'team' }, messages: [], createdAt: 0, updatedAt: 0 } },
     order: ['c1'], selectedChatId: 'c1',
     inFlight: { c1: { assistantMessageId: 'asst-x', userMessageId: 'u1', agentStatus: 'thinking' } },
-    collapsedWorkspaces: {}, workspaces: ['ws'], pendingRestores: {}, unreadChats: {}, pendingPermissions: {},
+    collapsedWorkspaces: {}, workspaces: ['ws'], pendingRestores: {}, unreadChats: {}, pendingPermissions: {}, queuedMessages: {},
   };
 }
 
@@ -176,5 +176,52 @@ describe('startSend seeds the turn header', () => {
     expect(s.chats.c1.messages.find(m => m.id === 'a1')).toMatchObject({
       agent: 'codex', model: 'gpt-5', tokens: 2100, durationSec: 60, isComplete: true,
     })
+  })
+})
+
+describe('message queue', () => {
+  const q = (text: string, id: string) => ({ type: 'enqueueMessage' as const, chatId: 'c1', message: { id, text } })
+
+  it('enqueue appends in order', () => {
+    let s = baseState()
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, q('two', 'q2'))
+    expect(s.queuedMessages.c1.map(m => m.text)).toEqual(['one', 'two'])
+  })
+
+  it('dequeue removes the head', () => {
+    let s = baseState()
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, q('two', 'q2'))
+    s = reducer(s, { type: 'dequeueMessage', chatId: 'c1' })
+    expect(s.queuedMessages.c1.map(m => m.text)).toEqual(['two'])
+    s = reducer(s, { type: 'dequeueMessage', chatId: 'c1' })
+    expect(s.queuedMessages.c1).toBeUndefined()
+  })
+
+  it('removeQueuedMessage drops one by id', () => {
+    let s = baseState()
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, q('two', 'q2'))
+    s = reducer(s, { type: 'removeQueuedMessage', chatId: 'c1', id: 'q1' })
+    expect(s.queuedMessages.c1.map(m => m.text)).toEqual(['two'])
+  })
+
+  it('stopping a turn drops the queue so nothing fires after an interrupt', () => {
+    let s = baseState()
+    s.chats.c1.messages = [
+      { id: 'u1', role: 'user', content: 'go', timestamp: 1, isComplete: true },
+      { id: 'asst-x', role: 'assistant', content: '', timestamp: 1, isComplete: false },
+    ]
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, { type: 'stoppedSend', chatId: 'c1', text: 'go' })
+    expect(s.queuedMessages.c1).toBeUndefined()
+  })
+
+  it('deleting a chat drops its queue', () => {
+    let s = baseState()
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, { type: 'remove', chatId: 'c1' })
+    expect(s.queuedMessages.c1).toBeUndefined()
   })
 })

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -4,6 +4,7 @@ import type { Chat, ChatSelection, ChatMessage, ChecklistItem, ToolCallEntry, Fi
 import type { ChatStreamEvent } from '../../../packages/gateway/src/chat-runner'
 import { activityForTool, type AgentActivity } from '../components/agentActivity'
 import type { UnreadKind } from '../components/notificationLogic'
+import { readyDeliveries } from './messageQueue'
 
 interface InFlight {
   assistantMessageId: string
@@ -12,6 +13,15 @@ interface InFlight {
   queuedPosition?: number
   thinking?: string
   thinkingByStep?: Record<number, string>
+}
+
+/** A prompt typed while a turn was still running. It waits its turn and is
+ *  sent verbatim once the chat goes idle. */
+export interface QueuedMessage {
+  id: string
+  text: string
+  attachments?: FileAttachment[]
+  identity?: { agent?: ChatMessage['agent']; model?: string }
 }
 
 export interface State {
@@ -28,6 +38,9 @@ export interface State {
   // failures and use a neutral marker for a plain completion.
   unreadChats: Record<string, UnreadKind>
   pendingPermissions: Record<string, string[]>
+  // Prompts typed while a turn was in flight, per chat, oldest first. Drained
+  // one at a time by the provider as soon as the chat has no inFlight turn.
+  queuedMessages: Record<string, QueuedMessage[]>
 }
 
 type Action =
@@ -58,6 +71,9 @@ type Action =
   | { type: 'patchPullRequest'; chatId: string; pullRequest: NonNullable<Chat['pullRequest']> }
   | { type: 'permissionRequest'; chatId: string; toolNames: string[] }
   | { type: 'dismissPermission'; chatId: string }
+  | { type: 'enqueueMessage'; chatId: string; message: QueuedMessage }
+  | { type: 'dequeueMessage'; chatId: string }
+  | { type: 'removeQueuedMessage'; chatId: string; id: string }
   | { type: 'teamStart'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'parallel'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string }> }
   | { type: 'workerStart'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string; reason?: string }
   | { type: 'workerEnd'; chatId: string; messageId: string; step: number; status: 'running' | 'done' | 'failed' | 'askedUser' }
@@ -89,6 +105,23 @@ export function shouldAdoptExternalTurn(
 
 function mkWorkerStub(teamTurnId: string, teamName: string, mode: ChatMessage['teamMode'], id: string, step: number, worker: string, reason?: string, agent?: ChatMessage['agent'], model?: string): ChatMessage {
   return { id, role: 'assistant', content: '', timestamp: Date.now(), toolCalls: [], isComplete: false, teamTurnId, teamName, teamMode: mode, step, worker, workerStatus: 'running', advisorReason: reason, agent, model }
+}
+
+/** Keep the map free of empty arrays — an absent key and an empty queue mean
+ *  the same thing, and callers test for the key. */
+function setQueue(
+  map: Record<string, QueuedMessage[]>,
+  chatId: string,
+  queue: QueuedMessage[],
+): Record<string, QueuedMessage[]> {
+  const next = { ...map }
+  if (queue.length === 0) delete next[chatId]
+  else next[chatId] = queue
+  return next
+}
+
+function dropQueue(map: Record<string, QueuedMessage[]>, chatId: string): Record<string, QueuedMessage[]> {
+  return setQueue(map, chatId, [])
 }
 
 export function reducer(state: State, action: Action): State {
@@ -197,6 +230,20 @@ export function reducer(state: State, action: Action): State {
       delete pp[action.chatId]
       return { ...state, pendingPermissions: pp }
     }
+    case 'enqueueMessage': {
+      const queue = state.queuedMessages[action.chatId] ?? []
+      return { ...state, queuedMessages: { ...state.queuedMessages, [action.chatId]: [...queue, action.message] } }
+    }
+    case 'dequeueMessage': {
+      const queue = state.queuedMessages[action.chatId]
+      if (!queue || queue.length === 0) return state
+      return { ...state, queuedMessages: setQueue(state.queuedMessages, action.chatId, queue.slice(1)) }
+    }
+    case 'removeQueuedMessage': {
+      const queue = state.queuedMessages[action.chatId]
+      if (!queue) return state
+      return { ...state, queuedMessages: setQueue(state.queuedMessages, action.chatId, queue.filter(m => m.id !== action.id)) }
+    }
     case 'remove': {
       const chats = { ...state.chats }
       delete chats[action.chatId]
@@ -204,7 +251,9 @@ export function reducer(state: State, action: Action): State {
       const selectedChatId = state.selectedChatId === action.chatId ? (order[0] ?? null) : state.selectedChatId
       const inFlight = { ...state.inFlight }
       delete inFlight[action.chatId]
-      return { ...state, chats, order, selectedChatId, inFlight }
+      const queuedMessages = { ...state.queuedMessages }
+      delete queuedMessages[action.chatId]
+      return { ...state, chats, order, selectedChatId, inFlight, queuedMessages }
     }
     case 'select': {
       const unreadChats = { ...state.unreadChats }
@@ -442,6 +491,9 @@ export function reducer(state: State, action: Action): State {
         ...state,
         chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } },
         inFlight,
+        // An interrupt means "stop", so anything queued behind this turn is
+        // dropped rather than fired the instant the turn clears.
+        queuedMessages: dropQueue(state.queuedMessages, action.chatId),
         pendingRestores: { ...state.pendingRestores, [action.chatId]: action.text },
       }
     }
@@ -501,6 +553,8 @@ interface ChatsContextValue {
    *  overrides are used instead. */
   sendMessage: (chatId: string, text: string, attachments?: FileAttachment[], identity?: { agent?: ChatMessage['agent']; model?: string }) => Promise<void>
   stopChat: (chatId: string) => Promise<void>
+  /** Drop a prompt that is still waiting behind the running turn. */
+  removeQueuedMessage: (chatId: string, id: string) => void
   resolvePermission: (chatId: string, allow: boolean) => Promise<void>
   clearRestore: (chatId: string) => void
   toggleWorkspace: (workspaceName: string) => void
@@ -526,6 +580,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     pendingRestores: {},
     unreadChats: {},
     pendingPermissions: {},
+    queuedMessages: {},
   })
 
   const pendingAssistantId = useRef<Record<string, string>>({})
@@ -724,7 +779,12 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     return off
   }, [])
 
-  const sendMessage = useCallback(async (
+  // The reducer state as of the last render, for callbacks that must not take
+  // `state` as a dependency (sendMessage is handed to children and would churn).
+  const stateRef = useRef(state)
+  stateRef.current = state
+
+  const deliverMessage = useCallback(async (
     chatId: string,
     text: string,
     attachments?: FileAttachment[],
@@ -748,6 +808,38 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       delete pendingAssistantId.current[chatId]
     }
   }, [])
+
+  // Typing while the agent works does not block and does not interrupt: the
+  // prompt joins a per-chat queue and is delivered when the turn finishes.
+  const sendMessage = useCallback(async (
+    chatId: string,
+    text: string,
+    attachments?: FileAttachment[],
+    identity?: { agent?: ChatMessage['agent']; model?: string },
+  ) => {
+    const busy = !!stateRef.current.inFlight[chatId] || (stateRef.current.queuedMessages[chatId]?.length ?? 0) > 0
+    if (busy) {
+      dispatch({
+        type: 'enqueueMessage',
+        chatId,
+        message: { id: `q-${Date.now()}-${Math.random()}`, text, attachments, identity },
+      })
+      return
+    }
+    await deliverMessage(chatId, text, attachments, identity)
+  }, [deliverMessage])
+
+  // Drain: one queued prompt per idle chat, per pass. `draining` guards against
+  // a second pass firing the same head before `startSend` lands in state.
+  const draining = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    for (const { chatId, message } of readyDeliveries(state.queuedMessages, state.inFlight, draining.current)) {
+      draining.current.add(chatId)
+      dispatch({ type: 'dequeueMessage', chatId })
+      void deliverMessage(chatId, message.text, message.attachments, message.identity)
+        .finally(() => { draining.current.delete(chatId) })
+    }
+  }, [state.queuedMessages, state.inFlight, deliverMessage])
 
   const value = useMemo<ChatsContextValue>(() => ({
     state,
@@ -844,6 +936,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       dispatch({ type: 'upsert', chat })
     },
     sendMessage,
+    removeQueuedMessage(chatId, id) { dispatch({ type: 'removeQueuedMessage', chatId, id }) },
     async stopChat(chatId) {
       try { await apiService.chats.stop(chatId) } catch { /* nothing in flight */ }
     },


### PR DESCRIPTION
## What

The chat composer used to lock for the whole turn. Now you can keep typing while the agent works — the prompt joins a per-chat queue and is sent, verbatim, as soon as the turn finishes. One at a time, in order.

## Behaviour

- Send button and paperclip stay live during a turn; ↵ queues instead of sending.
- Queued prompts (with attachments) are listed above the composer, oldest first, numbered, each removable with `×`.
- Placeholder while busy: `Queue the next message… (↵ to queue)`.
- **Stop clears the queue.** An interrupt means stop — not "fire the backlog the instant the turn clears". Deleting a chat drops its queue too.

## How

- `queuedMessages: Record<chatId, QueuedMessage[]>` in `useChats`, with `enqueueMessage` / `dequeueMessage` / `removeQueuedMessage`.
- `sendMessage` queues when the chat is busy; `deliverMessage` does the real send; a drain effect releases one head per idle chat.
- `readyDeliveries` (new `hooks/messageQueue.ts`) holds the drain rule as a pure function — codey-mac has no React testing setup, so the decision logic is tested standalone.
- A `draining` ref guards the window between dequeue and `startSend` landing in state, so a head can't fire twice.

## Testing

- `npm test -w codey-mac` — 682 passed, all green.
- `npx tsc --noEmit -p codey-mac/tsconfig.json` — clean.
- New unit tests cover queue ordering, dequeue, removal by id, clear-on-stop, clear-on-delete, and the four drain cases.
- Not yet exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)