### PR TITLE
feat(voice): custom dictionary, learn from edits, and a 4x faster local transcribe

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -42,6 +42,10 @@ import { listPlaybooks, playbookDetail, playbookHistory, archivePlaybook, delete
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
 import { ApiServer } from '@codey/gateway/dist/health'
+// Pure logic, no DOM and no Node builtins — shared with the Settings editor
+// that renders the same dictionary, so both sides agree on what a valid entry
+// is and the learner can't write a shape the editor would drop.
+import { learnCorrections, mergeLearnedAliases, normalizeVocabulary } from '../src/components/voiceVocabulary'
 
 let mainWindow: BrowserWindow | null = null
 let captureWindow: BrowserWindow | null = null
@@ -1377,7 +1381,217 @@ function currentOsBuild(): string {
   return _osBuildCache || ''
 }
 
-type WarmMarkers = Record<string, { warmedAt: string; loadSeconds: number; osBuild?: string }>
+// WhisperKit model folders currently on disk. WhisperKit stores downloaded
+// variants under ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/.
+// Raw folder names are returned so callers can match either the bare variant
+// or the full openai_whisper-<variant> form used in the UI dropdown.
+function listDownloadedVoiceModels(): string[] {
+  const fsMod = require('fs') as typeof import('fs')
+  const pathMod = require('path') as typeof import('path')
+  const home = app.getPath('home')
+  const candidates = [
+    pathMod.join(home, 'Documents', 'huggingface', 'models', 'argmaxinc', 'whisperkit-coreml'),
+    pathMod.join(home, 'Library', 'Application Support', 'huggingface', 'models', 'argmaxinc', 'whisperkit-coreml'),
+  ]
+  const found = new Set<string>()
+  for (const dir of candidates) {
+    if (!fsMod.existsSync(dir)) continue
+    for (const entry of fsMod.readdirSync(dir)) {
+      const full = pathMod.join(dir, entry)
+      try {
+        const st = fsMod.statSync(full)
+        // Only count variants that actually contain .mlmodelc payloads AND
+        // each .mlmodelc has a non-empty weights/weight.bin. CoreML partial
+        // downloads leave the folder + model.mil present but the weight file
+        // missing or zero-byte, which causes runtime "Could not open
+        // weights/weight.bin" errors and an endless warm-failure flicker in
+        // the UI. Checking weights here surfaces incomplete downloads as "not
+        // downloaded" so the user gets a Download button instead of a
+        // confusing warm error.
+        if (!st.isDirectory()) continue
+        const mlmodelcs = fsMod.readdirSync(full).filter(f => f.endsWith('.mlmodelc'))
+        if (mlmodelcs.length === 0) continue
+        const allWeightsOK = mlmodelcs.every(mc => {
+          const w = pathMod.join(full, mc, 'weights', 'weight.bin')
+          try {
+            const ws = fsMod.statSync(w)
+            return ws.isFile() && ws.size > 1024  // any real Whisper weight blob is MBs
+          } catch { return false }
+        })
+        if (allWeightsOK) found.add(entry)
+      } catch { /* skip */ }
+    }
+  }
+  return Array.from(found)
+}
+
+/** Match a UI model value against a folder list, tolerating either name form. */
+function voiceModelInList(list: string[], modelValue: string): boolean {
+  if (list.length === 0) return false
+  const bare = modelValue.startsWith('openai_whisper-')
+    ? modelValue.slice('openai_whisper-'.length)
+    : modelValue
+  return list.some(d => d === modelValue || d === bare || d === `openai_whisper-${bare}`)
+}
+
+/**
+ * Force a WhisperKit variant through CoreML's one-time per-machine compile by
+ * spawning the helper in `--warm-model` mode. Afterwards the model loads in
+ * ~200ms on an Fn press instead of 30-90s (which would blow past the helper's
+ * 10s load timeout and leave the UI stuck on "transcribing").
+ */
+async function runVoiceModelWarm(modelName: string): Promise<{ model: string; loadSeconds: number }> {
+  if (process.platform !== 'darwin') throw new Error('Voice helper is macOS-only')
+  if (typeof modelName !== 'string' || !modelName.trim()) throw new Error('Model name required')
+  const bin = resolveVoiceHelperBinary()
+  if (!bin) throw new Error('Voice helper binary not found')
+
+  const { spawn } = require('child_process') as typeof import('child_process')
+  const proc = spawn(bin, ['--warm-model', modelName], { stdio: ['ignore', 'pipe', 'pipe'] })
+
+  let lastErr = ''
+  let loadSeconds = 0
+  activeVoiceWarm = { model: modelName, startedAt: Date.now() }
+  sendToRenderer('voice:warmStart', { model: modelName })
+
+  const onLine = (line: string) => {
+    const s = line.trim()
+    if (!s) return
+    sendToRenderer('gateway-log', `[voice-warm] ${s}`)
+    if (s.startsWith('warm:done ')) {
+      loadSeconds = parseFloat(s.slice('warm:done '.length)) || 0
+    } else if (s.startsWith('warm:error ')) {
+      lastErr = s.slice('warm:error '.length)
+    }
+  }
+  const wireLines = (stream: NodeJS.ReadableStream | null) => {
+    if (!stream) return
+    let buf = ''
+    stream.on('data', (chunk: Buffer) => {
+      buf += chunk.toString()
+      let idx: number
+      while ((idx = buf.indexOf('\n')) >= 0) {
+        onLine(buf.slice(0, idx))
+        buf = buf.slice(idx + 1)
+      }
+    })
+    stream.on('end', () => { if (buf) onLine(buf) })
+  }
+  wireLines(proc.stdout)
+  wireLines(proc.stderr)
+
+  const code: number = await new Promise(resolve => proc.on('exit', c => resolve(c ?? 1)))
+  activeVoiceWarm = null
+  if (code !== 0) {
+    sendToRenderer('voice:warmError', { model: modelName, error: lastErr || `Warm failed (exit ${code})` })
+    throw new Error(lastErr || `Warm failed (exit ${code})`)
+  }
+  writeWarmMarker(modelName, loadSeconds)
+  sendToRenderer('voice:warmDone', { model: modelName, loadSeconds })
+  return { model: modelName, loadSeconds }
+}
+
+/** Guards against a second startup warm while the first is still running. */
+let startupWarmInFlight = false
+
+/**
+ * The warm currently running, if any.
+ *
+ * Pushed to the renderer as events, but also held here so a window that mounts
+ * *during* a warm can ask. The startup warm begins before the renderer is
+ * ready and runs for minutes, so "I missed the start event" is the normal
+ * case, not the edge case.
+ */
+let activeVoiceWarm: { model: string; startedAt: number } | null = null
+
+export function currentVoiceWarm(): { model: string; startedAt: number } | null {
+  return activeVoiceWarm
+}
+
+/**
+ * On launch, make sure the selected on-device model is actually ready.
+ *
+ * Warming used to happen only from the Whisper settings tab, so a user who
+ * never opened it — or who updated macOS, which invalidates CoreML's compiled
+ * cache — paid a 30-90s compile on their first Fn press. That exceeds the
+ * helper's 10s load timeout, and the failure looks like a hung "transcribing"
+ * with every further press ignored. Checking here means the cost is paid in
+ * the background at launch, when nobody is waiting on it.
+ *
+ * Best-effort throughout: a failure here must never block startup, and the
+ * first press still works (just slowly), so errors are logged and swallowed.
+ */
+async function warmSelectedVoiceModelOnStartup(): Promise<void> {
+  if (process.platform !== 'darwin') return
+  if (startupWarmInFlight) return
+  try {
+    const voice = (coreConfigManager?.get() as any)?.voice
+    if (!voice?.enabled) return
+    if (voice.provider !== 'local') return
+    const model = String(voice.localModel ?? '')
+    if (!model) return
+
+    // Nothing to warm if the weights aren't on disk — that is a Download
+    // button in Settings, not something to kick off unasked at launch.
+    if (!voiceModelInList(listDownloadedVoiceModels(), model)) {
+      sendToRenderer('gateway-log', `[voice-warm] ${model} not downloaded, skipping startup warm`)
+      return
+    }
+    // Both the OS build and the helper binary are part of the key, so an OS
+    // update or an app update correctly reads as "not warmed" and we recompile
+    // here rather than trusting a stale marker and ambushing the first press.
+    if (voiceModelInList(warmedVoiceModels(), model)) return
+
+    startupWarmInFlight = true
+    sendToRenderer('gateway-log', `[voice-warm] warming ${model} at startup`)
+    await runVoiceModelWarm(model)
+  } catch (e: any) {
+    sendToRenderer('gateway-log', `[voice-warm] startup warm failed: ${e?.message ?? e}`)
+  } finally {
+    startupWarmInFlight = false
+  }
+}
+
+/**
+ * Identity of the helper binary the warm was performed with.
+ *
+ * CoreML's compiled Neural Engine cache is keyed on the client binary, so a
+ * new build of the helper invalidates it and the next load pays a full
+ * recompile (measured at ~320s). The warm marker used to record only the OS
+ * build, which meant an app update looked "already warmed", the startup warm
+ * skipped, and the recompile landed on the user's first Fn press instead —
+ * exactly the case this whole mechanism exists to prevent.
+ *
+ * Size + mtime rather than a content hash: the binary is tens of MB, this runs
+ * on every launch, and being conservative (re-warming after a reinstall that
+ * happened to produce identical bytes) is far cheaper than being wrong.
+ */
+function currentHelperId(): string {
+  try {
+    const fs = require('fs') as typeof import('fs')
+    const bin = resolveVoiceHelperBinary()
+    if (!bin) return ''
+    const st = fs.statSync(bin)
+    return `${st.size}-${Math.floor(st.mtimeMs)}`
+  } catch { return '' }
+}
+
+type WarmMarkers = Record<string, { warmedAt: string; loadSeconds: number; osBuild?: string; helperId?: string }>
+
+/**
+ * Variants whose warm still applies: same OS build *and* same helper binary.
+ * A marker missing either field predates that key and is treated as stale,
+ * which costs one re-warm and then settles.
+ */
+function warmedVoiceModels(): string[] {
+  const build = currentOsBuild()
+  const helperId = currentHelperId()
+  const markers = readWarmMarkers()
+  return Object.keys(markers).filter(k => {
+    const m = markers[k]
+    return m?.osBuild === build && m?.helperId === helperId
+  })
+}
 
 function readWarmMarkers(): WarmMarkers {
   try {
@@ -1396,7 +1610,7 @@ function writeWarmMarker(model: string, loadSeconds: number) {
     // Store under both forms so lookups work whether UI sends the prefixed
     // (`openai_whisper-...`) or bare (`large-v3...`) variant string.
     const bare = model.startsWith('openai_whisper-') ? model.slice('openai_whisper-'.length) : model
-    const entry = { warmedAt: new Date().toISOString(), loadSeconds, osBuild: currentOsBuild() }
+    const entry = { warmedAt: new Date().toISOString(), loadSeconds, osBuild: currentOsBuild(), helperId: currentHelperId() }
     cur[model] = entry
     cur[bare] = entry
     cur[`openai_whisper-${bare}`] = entry
@@ -1992,6 +2206,11 @@ app.whenReady().then(async () => {
     })
   )
   await bootInProcessCore()
+
+  // Config is loaded now, so the selected on-device model is known. Not
+  // awaited: warming is a 30-90s CoreML compile in the worst case and nothing
+  // downstream depends on it, so startup continues while it runs.
+  void warmSelectedVoiceModelOnStartup()
 
   // Check Full Disk Access by probing the iMessage database. This reminder is
   // intentionally one-time: it is guidance for the optional iMessage channel,
@@ -2883,6 +3102,34 @@ app.whenReady().then(async () => {
     })
   )
 
+  // Learn mis-hearings by comparing what was dictated against what the user
+  // actually sent. Done here rather than in the renderer because the merge is
+  // read-modify-write on the shared voice config: config:set replaces the
+  // whole `voice` object, so a renderer doing this itself would clobber any
+  // field the Settings tab changed in between.
+  ipcMain.handle('voice:learnVocabulary', async (_e, payload: { spoken?: string; edited?: string }) =>
+    wrap(async () => {
+      if (!coreConfigManager) return { learned: [] }
+      const spoken = String(payload?.spoken ?? '')
+      const edited = String(payload?.edited ?? '')
+      if (!spoken.trim() || !edited.trim()) return { learned: [] }
+
+      const voice = (coreConfigManager.get() as any)?.voice
+      if (!voice || voice.vocabularyAutoLearn === false) return { learned: [] }
+
+      const corrections = learnCorrections(spoken, edited)
+      if (corrections.length === 0) return { learned: [] }
+
+      const current = normalizeVocabulary(voice.vocabulary)
+      const merged = mergeLearnedAliases(current, corrections)
+      if (!merged.changed) return { learned: [] }
+
+      coreConfigManager.update({ voice: { ...voice, vocabulary: merged.entries } } as any)
+      mainWindow?.webContents.send('voice:vocabularyLearned', merged.entries)
+      return { learned: merged.added }
+    })
+  )
+
   ipcMain.handle('voice:transcribed', async (_e, text: string) =>
     wrap(async () => {
       if (typeof text !== 'string' || !text.trim()) return
@@ -3009,65 +3256,19 @@ app.whenReady().then(async () => {
   // succeeds, the model loads in ~200ms on subsequent Fn presses instead of
   // 30-90s. On success we persist a marker so the UI shows ⚡ for warmed models.
   ipcMain.handle('voice:warmModel', async (_e, modelName: string) =>
-    wrap(async () => {
-      if (process.platform !== 'darwin') throw new Error('Voice helper is macOS-only')
-      if (typeof modelName !== 'string' || !modelName.trim()) throw new Error('Model name required')
-      const bin = resolveVoiceHelperBinary()
-      if (!bin) throw new Error('Voice helper binary not found')
+    wrap(async () => runVoiceModelWarm(modelName))
+  )
 
-      const { spawn } = require('child_process') as typeof import('child_process')
-      const proc = spawn(bin, ['--warm-model', modelName], { stdio: ['ignore', 'pipe', 'pipe'] })
-
-      let lastErr = ''
-      let loadSeconds = 0
-      sendToRenderer('voice:warmStart', { model: modelName })
-
-      const onLine = (line: string) => {
-        const s = line.trim()
-        if (!s) return
-        sendToRenderer('gateway-log', `[voice-warm] ${s}`)
-        if (s.startsWith('warm:done ')) {
-          loadSeconds = parseFloat(s.slice('warm:done '.length)) || 0
-        } else if (s.startsWith('warm:error ')) {
-          lastErr = s.slice('warm:error '.length)
-        }
-      }
-      const wireLines = (stream: NodeJS.ReadableStream | null) => {
-        if (!stream) return
-        let buf = ''
-        stream.on('data', (chunk: Buffer) => {
-          buf += chunk.toString()
-          let idx: number
-          while ((idx = buf.indexOf('\n')) >= 0) {
-            onLine(buf.slice(0, idx))
-            buf = buf.slice(idx + 1)
-          }
-        })
-        stream.on('end', () => { if (buf) onLine(buf) })
-      }
-      wireLines(proc.stdout)
-      wireLines(proc.stderr)
-
-      const code: number = await new Promise(resolve => proc.on('exit', c => resolve(c ?? 1)))
-      if (code !== 0) {
-        sendToRenderer('voice:warmError', { model: modelName, error: lastErr || `Warm failed (exit ${code})` })
-        throw new Error(lastErr || `Warm failed (exit ${code})`)
-      }
-      writeWarmMarker(modelName, loadSeconds)
-      sendToRenderer('voice:warmDone', { model: modelName, loadSeconds })
-      return { model: modelName, loadSeconds }
-    })
+  ipcMain.handle('voice:warmState', async () =>
+    wrap(async () => currentVoiceWarm())
   )
 
   ipcMain.handle('voice:listWarmedModels', async () =>
     wrap(async () => {
-      // Only report models whose warm marker matches the current OS build.
-      // Entries from a prior build (or pre-osBuild markers, which read as
-      // undefined) are dropped, so the UI shows ✓ instead of ⚡ and
-      // WhisperTab's auto-warm effect re-warms the selected model on boot.
-      const build = currentOsBuild()
-      const markers = readWarmMarkers()
-      return Object.keys(markers).filter(k => markers[k]?.osBuild === build)
+      // Stale markers are dropped by the shared check, so the UI shows the
+      // "downloaded" state rather than "warmed" after an OS or app update and
+      // WhisperTab's auto-warm effect re-warms the selected model.
+      return warmedVoiceModels()
     })
   )
 
@@ -3077,45 +3278,7 @@ app.whenReady().then(async () => {
   // renderer can match against either the bare variant or the full
   // openai_whisper-<variant> form used in the UI dropdown.
   ipcMain.handle('voice:listDownloadedModels', async () =>
-    wrap(async () => {
-      const fsMod = await import('fs')
-      const pathMod = await import('path')
-      const home = app.getPath('home')
-      const candidates = [
-        pathMod.join(home, 'Documents', 'huggingface', 'models', 'argmaxinc', 'whisperkit-coreml'),
-        pathMod.join(home, 'Library', 'Application Support', 'huggingface', 'models', 'argmaxinc', 'whisperkit-coreml'),
-      ]
-      const found = new Set<string>()
-      for (const dir of candidates) {
-        if (!fsMod.existsSync(dir)) continue
-        for (const entry of fsMod.readdirSync(dir)) {
-          const full = pathMod.join(dir, entry)
-          try {
-            const st = fsMod.statSync(full)
-            // Only count variants that actually contain .mlmodelc payloads
-            // AND each .mlmodelc has a non-empty weights/weight.bin. CoreML
-            // partial downloads leave the folder + model.mil present but the
-            // weight file missing or zero-byte, which causes runtime "Could
-            // not open weights/weight.bin" errors and an endless warm-failure
-            // flicker in the UI. Checking weights here surfaces incomplete
-            // downloads as "not downloaded" so the user gets a Download
-            // button instead of a confusing warm error.
-            if (!st.isDirectory()) continue
-            const mlmodelcs = fsMod.readdirSync(full).filter(f => f.endsWith('.mlmodelc'))
-            if (mlmodelcs.length === 0) continue
-            const allWeightsOK = mlmodelcs.every(mc => {
-              const w = pathMod.join(full, mc, 'weights', 'weight.bin')
-              try {
-                const ws = fsMod.statSync(w)
-                return ws.isFile() && ws.size > 1024  // any real Whisper weight blob is MBs
-              } catch { return false }
-            })
-            if (allWeightsOK) found.add(entry)
-          } catch { /* skip */ }
-        }
-      }
-      return Array.from(found)
-    })
+    wrap(async () => listDownloadedVoiceModels())
   )
 
   // Deletes a WhisperKit model variant from disk: the HuggingFace download

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -45,7 +45,7 @@ import { ApiServer } from '@codey/gateway/dist/health'
 // Pure logic, no DOM and no Node builtins — shared with the Settings editor
 // that renders the same dictionary, so both sides agree on what a valid entry
 // is and the learner can't write a shape the editor would drop.
-import { learnCorrections, mergeLearnedAliases, normalizeVocabulary } from '../src/components/voiceVocabulary'
+import { learnCorrections, mergeLearnedAliases, normalizeVocabulary, normalizePending, recordCorrections, forgetCorrection } from '../src/components/voiceVocabulary'
 
 let mainWindow: BrowserWindow | null = null
 let captureWindow: BrowserWindow | null = null
@@ -3121,12 +3121,55 @@ app.whenReady().then(async () => {
       if (corrections.length === 0) return { learned: [] }
 
       const current = normalizeVocabulary(voice.vocabulary)
-      const merged = mergeLearnedAliases(current, corrections)
-      if (!merged.changed) return { learned: [] }
+      const pending = normalizePending(voice.vocabularyPending)
 
-      coreConfigManager.update({ voice: { ...voice, vocabulary: merged.entries } } as any)
+      // A correction has to be seen twice before it rewrites anything. The
+      // first sighting only goes on the waiting list, which is what keeps a
+      // deliberate one-off edit from silently rewriting a real word later.
+      const seen = recordCorrections(pending, current, corrections)
+      if (seen.promoted.length === 0) {
+        if (seen.pending !== pending) {
+          coreConfigManager.update({ voice: { ...voice, vocabularyPending: seen.pending } } as any)
+        }
+        return { learned: [] }
+      }
+
+      const merged = mergeLearnedAliases(current, seen.promoted)
+      if (!merged.changed) {
+        coreConfigManager.update({ voice: { ...voice, vocabularyPending: seen.pending } } as any)
+        return { learned: [] }
+      }
+
+      coreConfigManager.update({
+        voice: { ...voice, vocabulary: merged.entries, vocabularyPending: seen.pending },
+      } as any)
       mainWindow?.webContents.send('voice:vocabularyLearned', merged.entries)
       return { learned: merged.added }
+    })
+  )
+
+  // Undo for a correction the composer pill just announced. Has to clear the
+  // waiting list too: the same swap sitting at one sighting would otherwise
+  // go active on the user's very next correction of it.
+  ipcMain.handle('voice:forgetVocabulary', async (_e, payload: { term?: string; alias?: string }) =>
+    wrap(async () => {
+      if (!coreConfigManager) return { ok: false }
+      const term = String(payload?.term ?? '')
+      const alias = String(payload?.alias ?? '')
+      if (!term || !alias) return { ok: false }
+      const voice = (coreConfigManager.get() as any)?.voice
+      if (!voice) return { ok: false }
+
+      const next = forgetCorrection(
+        normalizeVocabulary(voice.vocabulary),
+        normalizePending(voice.vocabularyPending),
+        { term, alias },
+      )
+      coreConfigManager.update({
+        voice: { ...voice, vocabulary: next.entries, vocabularyPending: next.pending },
+      } as any)
+      mainWindow?.webContents.send('voice:vocabularyLearned', next.entries)
+      return { ok: true }
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -372,6 +372,10 @@ contextBridge.exposeInMainWorld('codey', {
     /** The warm running right now, or null. Needed because the startup warm
      *  can begin before this window exists and runs for minutes. */
     getWarmState: () => ipcRenderer.invoke('voice:warmState'),
+    /** Undo a learned correction: removes it from the dictionary and from the
+     *  waiting list, so it does not go active on the next sighting either. */
+    forgetVocabulary: (term: string, alias: string) =>
+      ipcRenderer.invoke('voice:forgetVocabulary', { term, alias }),
     onVocabularyLearned: (handler: (entries: Array<{ term: string; aliases: string[] }>) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, entries: Array<{ term: string; aliases: string[] }>) => handler(entries)
       ipcRenderer.on('voice:vocabularyLearned', listener)

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -365,6 +365,18 @@ contextBridge.exposeInMainWorld('codey', {
     speak: (text: string, conversationId?: string, verbatim?: boolean) =>
       ipcRenderer.invoke('voice:speak', { text, conversationId, verbatim }),
     ack: (transcript: string) => ipcRenderer.invoke('voice:ack', transcript),
+    /** Compare a dictated transcript against what the user actually sent and
+     *  fold any mis-hearings into the Dictionary. No-op when auto-learn is off. */
+    learnVocabulary: (spoken: string, edited: string) =>
+      ipcRenderer.invoke('voice:learnVocabulary', { spoken, edited }),
+    /** The warm running right now, or null. Needed because the startup warm
+     *  can begin before this window exists and runs for minutes. */
+    getWarmState: () => ipcRenderer.invoke('voice:warmState'),
+    onVocabularyLearned: (handler: (entries: Array<{ term: string; aliases: string[] }>) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, entries: Array<{ term: string; aliases: string[] }>) => handler(entries)
+      ipcRenderer.on('voice:vocabularyLearned', listener)
+      return () => ipcRenderer.removeListener('voice:vocabularyLearned', listener)
+    },
     stopSpeaking: () => ipcRenderer.invoke('voice:stopSpeaking'),
     /** Temporarily unregister voice hotkeys while a replacement is captured. */
     setHotkeyCaptureActive: (active: boolean) => ipcRenderer.invoke('voice:setHotkeyCaptureActive', active),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -501,6 +501,9 @@ declare global {
         onNativeDictationLevel: (handler: (level: number) => void) => () => void
         onNativeDictationTranscript: (handler: (text: string) => void) => () => void
         onNativeDictationError: (handler: (message: string) => void) => () => void
+        getWarmState: () => Promise<IpcResult<{ model: string; startedAt: number } | null>>
+        learnVocabulary: (spoken: string, edited: string) => Promise<IpcResult<{ learned: Array<{ term: string; alias: string }> }>>
+        onVocabularyLearned: (handler: (entries: Array<{ term: string; aliases: string[] }>) => void) => () => void
         /** Speak text through the gateway's digest + TTS pipeline. */
         speak: (text: string, conversationId?: string, verbatim?: boolean) => Promise<IpcResult<void>>
         ack: (transcript: string) => Promise<IpcResult<{ text: string }>>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -502,6 +502,7 @@ declare global {
         onNativeDictationTranscript: (handler: (text: string) => void) => () => void
         onNativeDictationError: (handler: (message: string) => void) => () => void
         getWarmState: () => Promise<IpcResult<{ model: string; startedAt: number } | null>>
+        forgetVocabulary: (term: string, alias: string) => Promise<IpcResult<{ ok: boolean }>>
         learnVocabulary: (spoken: string, edited: string) => Promise<IpcResult<{ learned: Array<{ term: string; alias: string }> }>>
         onVocabularyLearned: (handler: (entries: Array<{ term: string; aliases: string[] }>) => void) => () => void
         /** Speak text through the gateway's digest + TTS pipeline. */

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2687,6 +2687,18 @@ export const ChatTab: React.FC<Props> = ({
                   <span style={styles.learnedAlias}>{word.alias}</span>
                   <span style={{ opacity: 0.5 }}>&rarr;</span>
                   <strong>{word.term}</strong>
+                  <button
+                    onClick={() => {
+                      // Removes it from the dictionary *and* the waiting list,
+                      // so undo means "never mind" rather than "not yet".
+                      void window.codey.voice.forgetVocabulary(word.term, word.alias)
+                      setLearnedWords(prev => prev.filter((_, at) => at !== i))
+                    }}
+                    title={`Undo - stop rewriting "${word.alias}" to "${word.term}"`}
+                    style={styles.learnedUndo}
+                  >
+                    Undo
+                  </button>
                 </span>
               ))}
               <button
@@ -3393,6 +3405,10 @@ const styles: Record<string, React.CSSProperties> = {
   },
   learnedAlias: {
     color: C.fg3, textDecoration: 'line-through',
+  },
+  learnedUndo: {
+    background: 'none', border: 'none', cursor: 'pointer', color: C.accent,
+    fontSize: 11, padding: '0 2px', textDecoration: 'underline',
   },
   learnedDismiss: {
     background: 'none', border: 'none', cursor: 'pointer', color: C.fg3,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -39,6 +39,8 @@ import { useGitStatus } from '../hooks/useGitStatus'
 import { BranchPicker } from './BranchPicker'
 import { CreatePrModal } from './CreatePrModal'
 import { UIIcon } from './UIIcons'
+import { useVoiceWarm } from './useVoiceWarm'
+import { warmTooltip } from './voiceWarmStatus'
 import { chatInputHistory, moveInInputHistory } from './chatInputHistory'
 import vscodeLogo from '../assets/editors/vscode.svg'
 import cursorLogo from '../assets/editors/cursor.svg'
@@ -840,6 +842,15 @@ export const ChatTab: React.FC<Props> = ({
   // (see VoiceTurnProvider) so they survive switching chats. What stays here
   // is the composer half — a transcript has to land in this chat's text box.
   const voiceAutoSendRef = useRef(false)
+  // Dictated text still waiting to be sent. On send we diff it against what
+  // actually went out and learn the mis-hearings — only dictation, because a
+  // converse turn sends itself and never gives the user a chance to correct it.
+  const dictatedPendingRef = useRef<string[]>([])
+  // Words the learner just picked up, shown as a pill above the composer.
+  // Learning is silent otherwise, and a dictionary that edits itself without
+  // saying so is the kind of thing you only discover when it goes wrong.
+  const [learnedWords, setLearnedWords] = useState<Array<{ term: string; alias: string }>>([])
+  const learnedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const voice = useVoiceTurn()
   const { setTranscriptHandler, beginSpokenTurn } = voice
   useEffect(() => {
@@ -849,6 +860,7 @@ export const ChatTab: React.FC<Props> = ({
         setInput(text)
       } else {
         // Dictation appends, so a second pass adds to what's already there.
+        dictatedPendingRef.current.push(text)
         setInput(prev => (prev.trim() ? `${prev.trim()} ${text}` : text))
       }
     })
@@ -1703,6 +1715,17 @@ export const ChatTab: React.FC<Props> = ({
     }
 
     const text = input
+    const dictated = dictatedPendingRef.current
+    dictatedPendingRef.current = []
+    // Fire-and-forget: a dictionary update must never delay or fail the send.
+    for (const spoken of dictated) {
+      void window.codey.voice.learnVocabulary(spoken, text)
+        .then(res => {
+          if (!res.ok || res.data.learned.length === 0) return
+          setLearnedWords(prev => [...prev, ...res.data.learned])
+        })
+        .catch(() => { /* best-effort */ })
+    }
     const atts = pendingAttachments.length > 0 ? [...pendingAttachments] : undefined
     setInput('')
     setPendingAttachments([])
@@ -1846,6 +1869,16 @@ export const ChatTab: React.FC<Props> = ({
   }
 
 
+  // Let the pill sit long enough to read, then clear it. Restarted on every
+  // new word so a second correction extends the window rather than truncating
+  // the first one's.
+  useEffect(() => {
+    if (learnedWords.length === 0) return
+    if (learnedTimerRef.current) clearTimeout(learnedTimerRef.current)
+    learnedTimerRef.current = setTimeout(() => setLearnedWords([]), 6000)
+    return () => { if (learnedTimerRef.current) clearTimeout(learnedTimerRef.current) }
+  }, [learnedWords])
+
   // A finished transcript sends itself — the point of voice mode is not
   // touching the keyboard, so stopping at a filled-in composer defeats it.
   useEffect(() => {
@@ -1859,6 +1892,11 @@ export const ChatTab: React.FC<Props> = ({
   }, [input]) // eslint-disable-line react-hooks/exhaustive-deps
 
 
+  // The model is compiling for the Neural Engine. Voice cannot start until it
+  // finishes, so the controls say so rather than accepting a press that would
+  // sit on "transcribing" for minutes.
+  const { warming: voiceWarming, elapsedSeconds: voiceWarmElapsed } = useVoiceWarm()
+  const voiceWarmTitle = warmTooltip(voiceWarmElapsed)
   const voiceActiveHere = voice.ownerChatId === chatId && voice.state !== 'idle'
   const voiceActiveElsewhere = voice.state !== 'idle' && voice.ownerChatId !== chatId
   const voiceBusy = voiceActiveHere && (voice.state === 'recording' || voice.state === 'transcribing')
@@ -2640,6 +2678,27 @@ export const ChatTab: React.FC<Props> = ({
         {uploadError && (
           <div style={styles.uploadError}>{uploadError}</div>
         )}
+        {learnedWords.length > 0 && (
+          <div style={styles.learnedRow}>
+            <span style={styles.learnedPill}>
+              <span style={{ opacity: 0.7 }}>Learned</span>
+              {learnedWords.map((word, i) => (
+                <span key={`${word.alias}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <span style={styles.learnedAlias}>{word.alias}</span>
+                  <span style={{ opacity: 0.5 }}>&rarr;</span>
+                  <strong>{word.term}</strong>
+                </span>
+              ))}
+              <button
+                onClick={() => setLearnedWords([])}
+                title="Dismiss"
+                style={styles.learnedDismiss}
+              >
+                &times;
+              </button>
+            </span>
+          </div>
+        )}
         <div style={styles.composer}>
           <div
             style={styles.composerResizeHandle}
@@ -2780,14 +2839,16 @@ export const ChatTab: React.FC<Props> = ({
                   hold a spoken conversation that reads the reply back. */}
               {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'converse') && <button
                 onClick={() => voice.toggle('dictate')}
-                disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere}
+                disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere || voiceWarming}
                 style={{
                   ...styles.voiceButton,
                   background: voiceBusy && voice.mode === 'dictate' ? C.red : 'transparent',
-                  cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere ? 'pointer' : 'default',
+                  opacity: voiceWarming ? 0.4 : 1,
+                  cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere && !voiceWarming ? 'pointer' : 'default',
                 }}
                 title={
-                  voiceActiveElsewhere ? 'Voice is active in another chat'
+                  voiceWarming ? voiceWarmTitle
+                  : voiceActiveElsewhere ? 'Voice is active in another chat'
                   : voiceBusy && voice.mode === 'dictate'
                     ? (voice.state === 'transcribing' ? 'Transcribing…' : 'Stop — text goes to the box')
                     : 'Dictate into the message box'
@@ -2814,16 +2875,18 @@ export const ChatTab: React.FC<Props> = ({
               </button>}
               {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'dictate') && <button
                 onClick={() => voice.toggle('converse')}
-                disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere}
+                disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere || voiceWarming}
                 style={{
                   ...styles.voiceButton,
                   background: voiceActiveHere && voice.state === 'recording' && voice.mode === 'converse' ? C.red
                     : voiceActiveHere && voice.state === 'speaking' ? C.accent
                     : 'transparent',
-                  cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere ? 'pointer' : 'default',
+                  opacity: voiceWarming ? 0.4 : 1,
+                  cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere && !voiceWarming ? 'pointer' : 'default',
                 }}
                 title={
-                  voiceActiveElsewhere ? 'Voice is active in another chat'
+                  voiceWarming ? voiceWarmTitle
+                  : voiceActiveElsewhere ? 'Voice is active in another chat'
                   : voiceActiveHere && voice.state === 'speaking' ? 'Speaking — click to interrupt and talk'
                   : voiceBusy && voice.mode === 'converse'
                     ? (voice.state === 'transcribing' ? 'Transcribing…' : 'Stop and send')
@@ -3319,6 +3382,21 @@ const styles: Record<string, React.CSSProperties> = {
   },
   uploadError: {
     color: C.dangerFg, fontSize: 11, padding: '0 4px',
+  },
+  learnedRow: {
+    display: 'flex', justifyContent: 'flex-start', padding: '0 4px 4px',
+  },
+  learnedPill: {
+    display: 'inline-flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' as const,
+    background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 999,
+    color: C.fg2, fontSize: 11, padding: '4px 6px 4px 12px', maxWidth: '100%',
+  },
+  learnedAlias: {
+    color: C.fg3, textDecoration: 'line-through',
+  },
+  learnedDismiss: {
+    background: 'none', border: 'none', cursor: 'pointer', color: C.fg3,
+    fontSize: 13, lineHeight: 1, padding: '0 6px',
   },
   choiceRow: {
     display: 'flex',

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2681,15 +2681,16 @@ export const ChatTab: React.FC<Props> = ({
         {learnedWords.length > 0 && (
           <div style={styles.learnedRow}>
             <span style={styles.learnedPill}>
-              {/* The word that was added is the news; the mis-hearing it came
-                  from is context. Leading with "<term> added" answers the
-                  question actually being asked, and the muted "was ..." keeps
-                  the evidence needed to spot a wrong guess. */}
+              {/* The word that was added leads, because that is what the pill
+                  is announcing. The mis-hearing it came from follows the
+                  arrow: it is the only thing on screen that lets a wrong guess
+                  be caught before it starts rewriting transcripts. */}
               {learnedWords.map((word, i) => (
                 <span key={`${word.alias}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
                   <strong>{word.term}</strong>
                   <span style={{ opacity: 0.7 }}>added</span>
-                  <span style={styles.learnedAlias}>was &ldquo;{word.alias}&rdquo;</span>
+                  <span style={{ opacity: 0.5 }}>&larr;</span>
+                  <span style={styles.learnedAlias}>{word.alias}</span>
                   <button
                     onClick={() => {
                       // Removes it from the dictionary *and* the waiting list,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2695,9 +2695,10 @@ export const ChatTab: React.FC<Props> = ({
                       setLearnedWords(prev => prev.filter((_, at) => at !== i))
                     }}
                     title={`Undo - stop rewriting "${word.alias}" to "${word.term}"`}
+                    aria-label={`Undo learning ${word.alias} as ${word.term}`}
                     style={styles.learnedUndo}
                   >
-                    Undo
+                    <UIIcon name="undo" size={13} color={C.accent} />
                   </button>
                 </span>
               ))}
@@ -3408,7 +3409,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   learnedUndo: {
     background: 'none', border: 'none', cursor: 'pointer', color: C.accent,
-    fontSize: 11, padding: '0 2px', textDecoration: 'underline',
+    padding: '0 2px', display: 'inline-flex', alignItems: 'center',
   },
   learnedDismiss: {
     background: 'none', border: 'none', cursor: 'pointer', color: C.fg3,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2681,12 +2681,15 @@ export const ChatTab: React.FC<Props> = ({
         {learnedWords.length > 0 && (
           <div style={styles.learnedRow}>
             <span style={styles.learnedPill}>
-              <span style={{ opacity: 0.7 }}>Learned</span>
+              {/* The word that was added is the news; the mis-hearing it came
+                  from is context. Leading with "<term> added" answers the
+                  question actually being asked, and the muted "was ..." keeps
+                  the evidence needed to spot a wrong guess. */}
               {learnedWords.map((word, i) => (
-                <span key={`${word.alias}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                  <span style={styles.learnedAlias}>{word.alias}</span>
-                  <span style={{ opacity: 0.5 }}>&rarr;</span>
+                <span key={`${word.alias}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
                   <strong>{word.term}</strong>
+                  <span style={{ opacity: 0.7 }}>added</span>
+                  <span style={styles.learnedAlias}>was &ldquo;{word.alias}&rdquo;</span>
                   <button
                     onClick={() => {
                       // Removes it from the dictionary *and* the waiting list,
@@ -3405,7 +3408,10 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.fg2, fontSize: 11, padding: '4px 6px 4px 12px', maxWidth: '100%',
   },
   learnedAlias: {
-    color: C.fg3, textDecoration: 'line-through',
+    // Muted rather than struck through: with "was" already saying it is the
+    // old spelling, a strikethrough only makes the evidence harder to read -
+    // and reading it is how a wrong guess gets caught.
+    color: C.fg3,
   },
   learnedUndo: {
     background: 'none', border: 'none', cursor: 'pointer', color: C.accent,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2681,16 +2681,16 @@ export const ChatTab: React.FC<Props> = ({
         {learnedWords.length > 0 && (
           <div style={styles.learnedRow}>
             <span style={styles.learnedPill}>
-              {/* The word that was added leads, because that is what the pill
-                  is announcing. The mis-hearing it came from follows the
-                  arrow: it is the only thing on screen that lets a wrong guess
-                  be caught before it starts rewriting transcripts. */}
+              {/* Reads as the rule it created: mis-hearing, arrow, corrected
+                  spelling. The mis-hearing has to stay on screen - it is the
+                  only thing that lets a wrong guess be caught before it starts
+                  rewriting transcripts. */}
               {learnedWords.map((word, i) => (
                 <span key={`${word.alias}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
-                  <strong>{word.term}</strong>
-                  <span style={{ opacity: 0.7 }}>added</span>
-                  <span style={{ opacity: 0.5 }}>&larr;</span>
                   <span style={styles.learnedAlias}>{word.alias}</span>
+                  <span style={{ opacity: 0.5 }}>&rarr;</span>
+                  <strong>{word.term}</strong>
+                  <span style={{ opacity: 0.7 }}>learned</span>
                   <button
                     onClick={() => {
                       // Removes it from the dictionary *and* the waiting list,

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -4,7 +4,7 @@ export type IconName =
   | 'activity' | 'add' | 'alert' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
   | 'clock' | 'code' | 'copy' | 'edit' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
   | 'waveform' | 'git-branch' | 'git-merge' | 'pull-request' | 'globe' | 'match-case' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
-  | 'telegram' | 'discord' | 'imessage'
+  | 'telegram' | 'discord' | 'imessage' | 'undo'
 
 interface Props {
   name: IconName
@@ -57,6 +57,9 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     plus: <path {...common} d="M12 5v14M5 12h14" />,
     refresh: <><path {...common} d="M20 11a8 8 0 00-14.7-4.4L3 9" /><path {...common} d="M3 4v5h5M4 13a8 8 0 0014.7 4.4L21 15" /><path {...common} d="M21 20v-5h-5" /></>,
     search: <><circle {...common} cx="11" cy="11" r="7" /><path {...common} d="M16.5 16.5L21 21" /></>,
+    // The familiar curved-back arrow. Distinct from `refresh`, which is a
+    // closed loop and reads as "do it again" rather than "put it back".
+    undo: <><path {...common} d="M9 14L4 9l5-5" /><path {...common} d="M4 9h10.5A5.5 5.5 0 0 1 20 14.5v0A5.5 5.5 0 0 1 14.5 20H11" /></>,
     // "Aa" — the familiar match-case glyph from editor search bars.
     'match-case': <><path {...common} d="M2.5 17.5L7 6.5l4.5 11M4.3 14h5.4" /><circle {...common} cx="17" cy="14" r="3.4" /><path {...common} d="M20.4 10.2v7.3" /></>,
     server: <><rect {...common} x="3" y="4" width="18" height="6" rx="2" /><rect {...common} x="3" y="14" width="18" height="6" rx="2" /><path {...common} d="M7 7h.01M7 17h.01" /></>,

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -905,10 +905,26 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
         <div style={sectionBodyStyle}>
 
       <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.55, padding: '10px 12px', background: C.surface3, borderRadius: 7, marginTop: 10 }}>
-        Every word here is passed to the recognizer as a hint <em>before</em> it transcribes,
-        so it can reach spellings it would otherwise never produce. Open a word to also list
-        what it gets <em>heard as</em> — those are rewritten back after transcribing, for
-        mistakes that come out the same way every time. Applies to all three providers.
+        Open a word to list what it gets <strong style={{ color: C.fg2 }}>heard as</strong>.
+        Those spellings are rewritten to the word after transcribing, which is what fixes a
+        mistake that comes out the same way every time.
+        {voice.provider === 'local' ? (
+          // Being specific rather than encouraging: on-device gets no hint, so
+          // a word with nothing under "heard as" genuinely does nothing, and
+          // saying otherwise sends people off adding words that never help.
+          <div style={{ marginTop: 7 }}>
+            <strong style={{ color: C.fg2 }}>On-device transcription needs the mis-hearings.</strong>{' '}
+            A word on its own has no effect here — unlike the API providers, WhisperKit cannot
+            be given the vocabulary up front (its prompt option returns empty transcripts in
+            the version bundled with Codey).
+          </div>
+        ) : (
+          <div style={{ marginTop: 7 }}>
+            A word on its own still helps here: it is sent to the API as a hint before
+            transcribing, so the recognizer can reach spellings it would otherwise never
+            produce. Mis-hearings are optional on top of that.
+          </div>
+        )}
         <div style={{ marginTop: 7 }}>
           The toggle above controls learning: with it on, when you dictate into a Codey chat
           and fix a word before sending, that fix is added here automatically.
@@ -925,19 +941,25 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
           const aliases = countAliases(row.aliasText)
           const selected = expandedVocabRow === i
           const label = row.term.trim() || 'Untitled'
+          const inertHintOnly = aliases === 0 && voice.provider === 'local'
           return (
             <button
               key={i}
               onClick={() => setExpandedVocabRow(selected ? null : i)}
-              title={aliases === 0
-                ? `${label} - hint only, no mis-hearings listed`
-                : `${label} - ${aliases} mis-hearing${aliases === 1 ? '' : 's'}`}
+              title={aliases > 0
+                ? `${label} - ${aliases} mis-hearing${aliases === 1 ? '' : 's'}`
+                : inertHintOnly
+                  ? `${label} - no effect yet: on-device transcription needs at least one mis-hearing. Click to add one.`
+                  : `${label} - sent to the API as a hint; no mis-hearings listed`}
               style={{
                 display: 'inline-flex', alignItems: 'center', gap: 6,
                 padding: '5px 11px', borderRadius: 999, fontSize: 12, cursor: 'pointer',
                 background: selected ? C.accent : C.surface3,
                 color: selected ? C.onAccent : C.fg,
-                border: `1px solid ${selected ? C.accent : C.border2}`,
+                border: `1px solid ${selected ? C.accent : inertHintOnly ? C.border : C.border2}`,
+                // Dimmed rather than hidden: the word is saved, it just does
+                // nothing until it has a mis-hearing under it.
+                opacity: !selected && inertHintOnly ? 0.55 : 1,
                 fontStyle: row.term.trim() ? 'normal' : 'italic',
               }}
             >
@@ -1022,7 +1044,9 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
             <div style={{ color: C.fg3, fontSize: 11, marginTop: 6 }}>
               One mis-hearing per line. Each is rewritten to
               <strong style={{ color: C.fg2 }}> {row.term.trim() || 'the word above'}</strong> after transcribing.
-              Leave it empty to use the word as a hint only.
+              {voice.provider === 'local'
+                ? ' Leaving this empty means the word does nothing on on-device transcription.'
+                : ' Leaving it empty still sends the word to the API as a hint.'}
             </div>
           </div>
         )

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -3,7 +3,7 @@ import { C } from '../theme'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import { Toggle } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
-import { normalizeVocabulary, vocabularyToDraft, draftToVocabulary, type VocabularyEntry, type VocabularyDraftRow } from './voiceVocabulary'
+import { normalizeVocabulary, vocabularyToDraft, draftToVocabulary, countAliases, type VocabularyEntry, type VocabularyDraftRow } from './voiceVocabulary'
 
 interface WhisperTabProps {
   isGatewayRunning: boolean
@@ -915,84 +915,121 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
         </div>
       </div>
 
+      {/* Chips rather than a column of inputs: the list is a scan target -
+          "is this word already in here?" - and a wrapping row of words answers
+          that at a glance where a stack of text fields does not. Editing is
+          the rare action, so it lives in one panel below rather than inline,
+          which would also break the wrap. */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, padding: '14px 0 4px' }}>
+        {vocabDraft.map((row, i) => {
+          const aliases = countAliases(row.aliasText)
+          const selected = expandedVocabRow === i
+          const label = row.term.trim() || 'Untitled'
+          return (
+            <button
+              key={i}
+              onClick={() => setExpandedVocabRow(selected ? null : i)}
+              title={aliases === 0
+                ? `${label} - hint only, no mis-hearings listed`
+                : `${label} - ${aliases} mis-hearing${aliases === 1 ? '' : 's'}`}
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 6,
+                padding: '5px 11px', borderRadius: 999, fontSize: 12, cursor: 'pointer',
+                background: selected ? C.accent : C.surface3,
+                color: selected ? C.onAccent : C.fg,
+                border: `1px solid ${selected ? C.accent : C.border2}`,
+                fontStyle: row.term.trim() ? 'normal' : 'italic',
+              }}
+            >
+              {label}
+              {aliases > 0 && (
+                <span style={{
+                  fontSize: 10, lineHeight: 1, padding: '2px 5px', borderRadius: 999,
+                  background: selected ? '#ffffff33' : C.border2,
+                  color: selected ? C.onAccent : C.fg3,
+                }}>
+                  {aliases}
+                </span>
+              )}
+            </button>
+          )
+        })}
+        <button
+          onClick={() => {
+            // Index computed outside the updater: a state setter inside
+            // another setter's callback runs during render in StrictMode's
+            // double-invoke and would select the wrong chip.
+            const index = vocabDraft.length
+            setVocabDraft([...vocabDraft, { term: '', aliasText: '' }])
+            setExpandedVocabRow(index)
+          }}
+          title="Add a word"
+          style={{
+            padding: '5px 11px', borderRadius: 999, fontSize: 12, cursor: 'pointer',
+            background: 'transparent', color: C.fg2,
+            border: `1px dashed ${C.border2}`,
+          }}
+        >
+          + Add word
+        </button>
+      </div>
+
       {vocabDraft.length === 0 && (
-        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0 4px', textAlign: 'center' }}>
+        <div style={{ color: C.fg3, fontSize: 12, padding: '4px 0 8px' }}>
           No words yet.
         </div>
       )}
 
-      {vocabDraft.map((row, i) => {
-        const aliases = row.aliasText.split(/[\n,]/).map(a => a.trim()).filter(Boolean)
-        const open = expandedVocabRow === i
+      {expandedVocabRow !== null && vocabDraft[expandedVocabRow] && (() => {
+        const i = expandedVocabRow
+        const row = vocabDraft[i]
+        const aliases = countAliases(row.aliasText)
         return (
-          <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
-            <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '7px 0' }}>
-              <button
-                onClick={() => setExpandedVocabRow(open ? null : i)}
-                title={open ? 'Collapse' : 'Edit what this gets heard as'}
-                style={{
-                  background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px',
-                  color: C.fg3, fontSize: 10, width: 16, textAlign: 'left',
-                }}
-              >
-                {open ? '\u25be' : '\u25b8'}
-              </button>
+          <div style={{
+            marginTop: 8, padding: 12, borderRadius: 9,
+            background: C.surface3, border: `1px solid ${C.border2}`,
+          }}>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
               <input
                 value={row.term}
                 onChange={e => patchVocabRow(i, { term: e.target.value })}
                 onBlur={() => commitVocabulary(vocabDraft)}
                 placeholder="Codey"
-                style={{ ...inputStyle, flex: 1, width: 'auto' }}
+                autoFocus
+                style={{ ...inputStyle, flex: 1, width: 'auto', fontWeight: 600 }}
               />
-              <span
-                onClick={() => setExpandedVocabRow(open ? null : i)}
-                style={{ color: C.fg3, fontSize: 11, width: 88, cursor: 'pointer', userSelect: 'none' }}
-              >
-                {aliases.length === 0 ? 'hint only' : `${aliases.length} heard as`}
-              </span>
               <button
-                onClick={() => removeVocabRow(i)}
-                title="Remove word"
-                style={{ ...pillButton('danger'), width: 30, padding: '6px 0', textAlign: 'center' }}
+                onClick={() => { setExpandedVocabRow(null); removeVocabRow(i) }}
+                style={pillButton('danger')}
               >
-                &times;
+                Remove
+              </button>
+              <button onClick={() => setExpandedVocabRow(null)} style={pillButton('ghost')}>
+                Done
               </button>
             </div>
-            {open && (
-              <div style={{ padding: '0 0 10px 24px' }}>
-                <textarea
-                  value={row.aliasText}
-                  onChange={e => patchVocabRow(i, { aliasText: e.target.value })}
-                  onBlur={() => commitVocabulary(vocabDraft)}
-                  placeholder={'Coday\ncode E\ncody'}
-                  rows={Math.min(8, Math.max(3, aliases.length + 1))}
-                  style={{ ...inputStyle, width: '100%', resize: 'vertical', fontFamily: 'inherit', lineHeight: 1.5 }}
-                />
-                <div style={{ color: C.fg3, fontSize: 11, marginTop: 5 }}>
-                  One mis-hearing per line. Each is rewritten to
-                  <strong style={{ color: C.fg2 }}> {row.term.trim() || 'the word above'}</strong> after transcribing.
-                </div>
-              </div>
-            )}
+            <div style={{ color: C.fg2, fontSize: 11, fontWeight: 700, letterSpacing: 0.55, textTransform: 'uppercase', padding: '12px 0 6px' }}>
+              Heard as
+            </div>
+            <textarea
+              value={row.aliasText}
+              onChange={e => patchVocabRow(i, { aliasText: e.target.value })}
+              onBlur={() => commitVocabulary(vocabDraft)}
+              placeholder={'Coday\ncode E\ncody'}
+              rows={Math.min(8, Math.max(3, aliases + 1))}
+              style={{ ...inputStyle, width: '100%', resize: 'vertical', fontFamily: 'inherit', lineHeight: 1.5 }}
+            />
+            <div style={{ color: C.fg3, fontSize: 11, marginTop: 6 }}>
+              One mis-hearing per line. Each is rewritten to
+              <strong style={{ color: C.fg2 }}> {row.term.trim() || 'the word above'}</strong> after transcribing.
+              Leave it empty to use the word as a hint only.
+            </div>
           </div>
         )
-      })}
+      })()}
 
-      <div style={{ ...lastSettingBlockStyle, paddingTop: 12, display: 'flex', alignItems: 'center', gap: 10 }}>
-        <button
-          onClick={() => {
-            setVocabDraft(rows => {
-              setExpandedVocabRow(rows.length)
-              return [...rows, { term: '', aliasText: '' }]
-            })
-          }}
-          style={pillButton('ghost')}
-        >
-          + Add word
-        </button>
-        <span style={{ color: C.fg3, fontSize: 11 }}>
-          {vocabDraft.length === 0 ? '' : `${vocabDraft.length} word${vocabDraft.length === 1 ? '' : 's'}`}
-        </span>
+      <div style={{ ...lastSettingBlockStyle, paddingTop: 12, color: C.fg3, fontSize: 11 }}>
+        {vocabDraft.length === 0 ? '' : `${vocabDraft.length} word${vocabDraft.length === 1 ? '' : 's'}`}
       </div>
         </div>
       </div>

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -3,6 +3,7 @@ import { C } from '../theme'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import { Toggle } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
+import { normalizeVocabulary, vocabularyToDraft, draftToVocabulary, type VocabularyEntry, type VocabularyDraftRow } from './voiceVocabulary'
 
 interface WhisperTabProps {
   isGatewayRunning: boolean
@@ -30,6 +31,10 @@ interface VoiceCfg {
   realtimeModel: string
   /** Legacy setting kept for config compatibility. The two hotkeys now have fixed destinations. */
   mode: 'inject' | 'converse'
+  /** Custom vocabulary. See VocabularyEntry. */
+  vocabulary: VocabularyEntry[]
+  /** Learn mis-hearings from corrections made in a Codey chat before sending. */
+  vocabularyAutoLearn: boolean
   tts: TtsCfg
 }
 
@@ -63,6 +68,8 @@ const VOICE_DEFAULT: VoiceCfg = {
   realtimeUrl: 'wss://api.openai.com/v1/realtime?intent=transcription',
   realtimeModel: 'gpt-4o-mini-transcribe',
   mode: 'inject',
+  vocabulary: [],
+  vocabularyAutoLearn: true,
   tts: {
     enabled: false,
     provider: 'api',
@@ -182,6 +189,13 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
   // false → deps change → re-fires → "model folder is not set" flicker).
   // User can manually retry by switching model and back.
   const [warmFailed, setWarmFailed] = useState<Set<string>>(new Set())
+  // Dictionary rows are edited as free text — aliases live as one blob while
+  // the user types, so a half-typed line isn't eaten mid-keystroke. Parsed
+  // back into string[] only on commit.
+  const [vocabDraft, setVocabDraft] = useState<VocabularyDraftRow[]>([])
+  // Which row has its mis-hearings open. One at a time: the list is a scan
+  // target, and the aliases are the rare thing you come here to change.
+  const [expandedVocabRow, setExpandedVocabRow] = useState<number | null>(null)
 
   const refreshDownloaded = useCallback(async () => {
     try {
@@ -304,6 +318,8 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
       const keys = await unwrap(await window.codey.apiKeys.list()) as SavedApiKey[]
       setSavedVoiceKeys(keys.filter(key => key.purpose === 'voice').sort((a, b) => a.name.localeCompare(b.name)))
       const storedVoice = cfg?.voice ?? {}
+      const vocabulary = normalizeVocabulary(storedVoice.vocabulary)
+      setVocabDraft(vocabularyToDraft(vocabulary))
       const legacyEnabled = storedVoice.enabled ?? false
       const dictationEnabled = storedVoice.dictationEnabled ?? legacyEnabled
       const conversationEnabled = storedVoice.conversationEnabled ?? legacyEnabled
@@ -318,12 +334,27 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
         // Dictation and talk-to-chat now have separate triggers. Migrate old
         // configs so the primary hotkey always keeps its dictation meaning.
         mode: 'inject',
+        vocabulary,
         tts: { ...VOICE_DEFAULT.tts, ...(cfg?.voice?.tts ?? {}) },
       })
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
   useEffect(() => { if (isGatewayRunning) reload() }, [isGatewayRunning, reload])
+
+  // The learner writes straight to config from the main process, so the open
+  // editor has to be told — every save here sends the whole `voice` object,
+  // and a stale copy would silently drop whatever was just learned. The
+  // config state is therefore always refreshed; only the visible rows wait,
+  // because rewriting a textarea under someone mid-edit is worse than showing
+  // them one word out of date until they collapse it.
+  useEffect(() => {
+    return window.codey.voice.onVocabularyLearned(entries => {
+      const normalized = normalizeVocabulary(entries)
+      setVoice(prev => ({ ...prev, vocabulary: normalized }))
+      if (expandedVocabRow === null) setVocabDraft(vocabularyToDraft(normalized))
+    })
+  }, [expandedVocabRow])
 
   useEffect(() => {
     const load = () => setSystemVoices(
@@ -376,6 +407,20 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
     } catch (e: any) {
       setError(e?.message ?? String(e))
     }
+  }
+
+  const commitVocabulary = (draft: VocabularyDraftRow[]) => {
+    updateVoice({ vocabulary: draftToVocabulary(draft) })
+  }
+
+  const patchVocabRow = (index: number, patch: Partial<VocabularyDraftRow>) => {
+    setVocabDraft(rows => rows.map((row, i) => (i === index ? { ...row, ...patch } : row)))
+  }
+
+  const removeVocabRow = (index: number) => {
+    const next = vocabDraft.filter((_, i) => i !== index)
+    setVocabDraft(next)
+    commitVocabulary(next)
   }
 
   const handleHotkeyRecordingChange = useCallback((active: boolean) => {
@@ -848,6 +893,107 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
       )}
       </>
       )}
+        </div>
+      </div>
+
+      <div style={sectionCardStyle}>
+        <Section
+          title="Dictionary"
+          description="Names the recognizer keeps getting wrong"
+          right={<Toggle on={voice.vocabularyAutoLearn} onChange={vocabularyAutoLearn => updateVoice({ vocabularyAutoLearn })}/>}
+        />
+        <div style={sectionBodyStyle}>
+
+      <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.55, padding: '10px 12px', background: C.surface3, borderRadius: 7, marginTop: 10 }}>
+        Every word here is passed to the recognizer as a hint <em>before</em> it transcribes,
+        so it can reach spellings it would otherwise never produce. Open a word to also list
+        what it gets <em>heard as</em> — those are rewritten back after transcribing, for
+        mistakes that come out the same way every time. Applies to all three providers.
+        <div style={{ marginTop: 7 }}>
+          The toggle above controls learning: with it on, when you dictate into a Codey chat
+          and fix a word before sending, that fix is added here automatically.
+        </div>
+      </div>
+
+      {vocabDraft.length === 0 && (
+        <div style={{ color: C.fg3, fontSize: 12, padding: '16px 0 4px', textAlign: 'center' }}>
+          No words yet.
+        </div>
+      )}
+
+      {vocabDraft.map((row, i) => {
+        const aliases = row.aliasText.split(/[\n,]/).map(a => a.trim()).filter(Boolean)
+        const open = expandedVocabRow === i
+        return (
+          <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '7px 0' }}>
+              <button
+                onClick={() => setExpandedVocabRow(open ? null : i)}
+                title={open ? 'Collapse' : 'Edit what this gets heard as'}
+                style={{
+                  background: 'none', border: 'none', cursor: 'pointer', padding: '0 2px',
+                  color: C.fg3, fontSize: 10, width: 16, textAlign: 'left',
+                }}
+              >
+                {open ? '\u25be' : '\u25b8'}
+              </button>
+              <input
+                value={row.term}
+                onChange={e => patchVocabRow(i, { term: e.target.value })}
+                onBlur={() => commitVocabulary(vocabDraft)}
+                placeholder="Codey"
+                style={{ ...inputStyle, flex: 1, width: 'auto' }}
+              />
+              <span
+                onClick={() => setExpandedVocabRow(open ? null : i)}
+                style={{ color: C.fg3, fontSize: 11, width: 88, cursor: 'pointer', userSelect: 'none' }}
+              >
+                {aliases.length === 0 ? 'hint only' : `${aliases.length} heard as`}
+              </span>
+              <button
+                onClick={() => removeVocabRow(i)}
+                title="Remove word"
+                style={{ ...pillButton('danger'), width: 30, padding: '6px 0', textAlign: 'center' }}
+              >
+                &times;
+              </button>
+            </div>
+            {open && (
+              <div style={{ padding: '0 0 10px 24px' }}>
+                <textarea
+                  value={row.aliasText}
+                  onChange={e => patchVocabRow(i, { aliasText: e.target.value })}
+                  onBlur={() => commitVocabulary(vocabDraft)}
+                  placeholder={'Coday\ncode E\ncody'}
+                  rows={Math.min(8, Math.max(3, aliases.length + 1))}
+                  style={{ ...inputStyle, width: '100%', resize: 'vertical', fontFamily: 'inherit', lineHeight: 1.5 }}
+                />
+                <div style={{ color: C.fg3, fontSize: 11, marginTop: 5 }}>
+                  One mis-hearing per line. Each is rewritten to
+                  <strong style={{ color: C.fg2 }}> {row.term.trim() || 'the word above'}</strong> after transcribing.
+                </div>
+              </div>
+            )}
+          </div>
+        )
+      })}
+
+      <div style={{ ...lastSettingBlockStyle, paddingTop: 12, display: 'flex', alignItems: 'center', gap: 10 }}>
+        <button
+          onClick={() => {
+            setVocabDraft(rows => {
+              setExpandedVocabRow(rows.length)
+              return [...rows, { term: '', aliasText: '' }]
+            })
+          }}
+          style={pillButton('ghost')}
+        >
+          + Add word
+        </button>
+        <span style={{ color: C.fg3, fontSize: 11 }}>
+          {vocabDraft.length === 0 ? '' : `${vocabDraft.length} word${vocabDraft.length === 1 ? '' : 's'}`}
+        </span>
+      </div>
         </div>
       </div>
     </div>

--- a/codey-mac/src/components/useVoiceWarm.ts
+++ b/codey-mac/src/components/useVoiceWarm.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Whether the on-device model is mid-warm, and for how long.
+ *
+ * Both pushed and pulled: the startup warm begins before this window exists
+ * and runs for minutes, so subscribing to the start event alone would miss the
+ * common case and leave the composer's voice buttons enabled during the one
+ * stretch where pressing them does nothing useful.
+ */
+export function useVoiceWarm(): { warming: boolean; model: string; elapsedSeconds: number } {
+  const [state, setState] = useState<{ model: string; startedAt: number } | null>(null)
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.codey.voice.getWarmState()
+      .then(res => { if (!cancelled && res.ok && res.data) setState(res.data) })
+      .catch(() => { /* best-effort: worst case the buttons stay enabled */ })
+
+    const offStart = window.codey.voice.onWarmStart(({ model }) => {
+      setState({ model, startedAt: Date.now() })
+    })
+    const offDone = window.codey.voice.onWarmDone(() => setState(null))
+    const offErr = window.codey.voice.onWarmError(() => setState(null))
+    return () => { cancelled = true; offStart(); offDone(); offErr() }
+  }, [])
+
+  // Ticks once a second rather than on every render: the elapsed number is the
+  // only moving part of the tooltip, and a compile has no progress signal to
+  // report beyond "still going".
+  useEffect(() => {
+    if (!state) { setElapsedSeconds(0); return }
+    const tick = () => setElapsedSeconds(Math.max(0, (Date.now() - state.startedAt) / 1000))
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [state])
+
+  return { warming: state !== null, model: state?.model ?? '', elapsedSeconds }
+}

--- a/codey-mac/src/components/voiceVocabulary.test.ts
+++ b/codey-mac/src/components/voiceVocabulary.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   normalizeVocabulary, vocabularyToDraft, draftToVocabulary,
-  learnCorrections, mergeLearnedAliases,
+  learnCorrections, mergeLearnedAliases, countAliases,
   MAX_ALIASES_PER_TERM, MAX_VOCABULARY_ENTRIES,
 } from './voiceVocabulary'
 
@@ -76,6 +76,22 @@ describe('draftToVocabulary', () => {
   })
 })
 
+describe('countAliases', () => {
+  it('agrees with what draftToVocabulary would save', () => {
+    const text = 'Coday\ncode E, cody'
+    expect(countAliases(text)).toBe(draftToVocabulary([{ term: 'Codey', aliasText: text }])[0].aliases.length)
+  })
+
+  it('counts nothing for an empty or whitespace-only field', () => {
+    expect(countAliases('')).toBe(0)
+    expect(countAliases('  \n , ')).toBe(0)
+  })
+
+  it('does not double-count a duplicate the save would drop', () => {
+    expect(countAliases('Coday\ncoday')).toBe(1)
+  })
+})
+
 describe('learnCorrections', () => {
   it('learns a single misheard word from an edit', () => {
     expect(learnCorrections('open coday now', 'open Codey now'))
@@ -138,6 +154,39 @@ describe('learnCorrections', () => {
 
   it('refuses a same-script swap for an unrelated word', () => {
     expect(learnCorrections('the build is wrong', 'the build is different')).toEqual([])
+  })
+
+  // Chinese dictation is the main use here and almost none of it was being
+  // learned: homophone slips look nothing alike, and a one-character slip
+  // inside a word diffs down to that character alone.
+  it('learns a Chinese homophone, which shares no characters', () => {
+    // "\u5973\u827a" for "\u8bed\u4e49" - same sound, unrelated shapes.
+    expect(learnCorrections('\u5973\u827a\u7684\u4f18\u5316', '\u8bed\u4e49\u7684\u4f18\u5316'))
+      .toEqual([{ term: '\u8bed\u4e49', alias: '\u5973\u827a' }])
+  })
+
+  it('widens a one-character Chinese slip into a usable alias', () => {
+    // Only the middle character differs; on its own it would be too dangerous
+    // an alias, so unchanged neighbours are pulled in from both sides.
+    expect(learnCorrections('\u7528\u4e00\u4e0b\u8f6c\u5f55\u5668', '\u7528\u4e00\u4e0b\u8f6c\u5199\u5668'))
+      .toEqual([{ term: '\u8f6c\u5199\u5668', alias: '\u8f6c\u5f55\u5668' }])
+  })
+
+  it('widens symmetrically rather than guessing a word boundary', () => {
+    // Expanding left alone would pair "\u5728\u7ebf"/"\u5728\u8fdb"; both sides gives a
+    // rule that is correct without needing a segmenter.
+    expect(learnCorrections('\u8fd9\u4e2a\u5728\u7ebf\u7a0b\u91cc\u9762', '\u8fd9\u4e2a\u5728\u8fdb\u7a0b\u91cc\u9762'))
+      .toEqual([{ term: '\u5728\u8fdb\u7a0b', alias: '\u5728\u7ebf\u7a0b' }])
+  })
+
+  it('still refuses a Chinese swap of clearly different length', () => {
+    // Not a homophone slip: the replacement is much longer than the original.
+    expect(learnCorrections('\u7528\u5b83', '\u7528\u90a3\u4e2a\u5de5\u5177')).toEqual([])
+  })
+
+  it('has no left context to borrow at the start of a sentence', () => {
+    // Must not crash or invent context that is not there.
+    expect(() => learnCorrections('\u5f55\u5668\u597d', '\u5199\u5668\u597d')).not.toThrow()
   })
 
   it('returns nothing when the text is unchanged', () => {

--- a/codey-mac/src/components/voiceVocabulary.test.ts
+++ b/codey-mac/src/components/voiceVocabulary.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeVocabulary, vocabularyToDraft, draftToVocabulary,
+  learnCorrections, mergeLearnedAliases,
+  MAX_ALIASES_PER_TERM, MAX_VOCABULARY_ENTRIES,
+} from './voiceVocabulary'
+
+describe('normalizeVocabulary', () => {
+  it('widens the bare-string shorthand into a term with no aliases', () => {
+    expect(normalizeVocabulary(['WhisperKit'])).toEqual([{ term: 'WhisperKit', aliases: [] }])
+  })
+
+  it('keeps the object form intact', () => {
+    expect(normalizeVocabulary([{ term: 'Codey', aliases: ['Coday', 'code E'] }]))
+      .toEqual([{ term: 'Codey', aliases: ['Coday', 'code E'] }])
+  })
+
+  it('defaults a missing aliases field to empty', () => {
+    expect(normalizeVocabulary([{ term: 'Codey' }])).toEqual([{ term: 'Codey', aliases: [] }])
+  })
+
+  it('drops non-string aliases rather than passing them through', () => {
+    expect(normalizeVocabulary([{ term: 'Codey', aliases: ['ok', 3, null] }]))
+      .toEqual([{ term: 'Codey', aliases: ['ok'] }])
+  })
+
+  it('skips malformed rows without losing the good ones', () => {
+    expect(normalizeVocabulary(['A', 42, null, { noTerm: true }, { term: 'B' }]))
+      .toEqual([{ term: 'A', aliases: [] }, { term: 'B', aliases: [] }])
+  })
+
+  it('skips blank strings', () => {
+    expect(normalizeVocabulary(['   ', 'A'])).toEqual([{ term: 'A', aliases: [] }])
+  })
+
+  it('returns empty for a missing or non-array field', () => {
+    expect(normalizeVocabulary(undefined)).toEqual([])
+    expect(normalizeVocabulary('Codey')).toEqual([])
+    expect(normalizeVocabulary({ term: 'Codey' })).toEqual([])
+  })
+})
+
+describe('draft round-trip', () => {
+  it('survives entries -> draft -> entries unchanged', () => {
+    const entries = [
+      { term: 'Codey', aliases: ['Coday', 'code E'] },
+      { term: 'WhisperKit', aliases: [] },
+    ]
+    expect(draftToVocabulary(vocabularyToDraft(entries))).toEqual(entries)
+  })
+
+  it('shows aliases one per line for the textarea', () => {
+    expect(vocabularyToDraft([{ term: 'Codey', aliases: ['a', 'b'] }]))
+      .toEqual([{ term: 'Codey', aliasText: 'a\nb' }])
+  })
+})
+
+describe('draftToVocabulary', () => {
+  it('drops a row whose term is blank, so "+ Add word" writes nothing', () => {
+    expect(draftToVocabulary([{ term: '', aliasText: '' }, { term: '  ', aliasText: 'x' }])).toEqual([])
+  })
+
+  it('keeps a term with no aliases — it still works as a hint', () => {
+    expect(draftToVocabulary([{ term: 'Codey', aliasText: '' }]))
+      .toEqual([{ term: 'Codey', aliases: [] }])
+  })
+
+  it('trims whitespace around the term and each alias', () => {
+    expect(draftToVocabulary([{ term: '  Codey  ', aliasText: ' Coday ,  code E ' }]))
+      .toEqual([{ term: 'Codey', aliases: ['Coday', 'code E'] }])
+  })
+
+  it('ignores empty slots from trailing or doubled commas while typing', () => {
+    expect(draftToVocabulary([{ term: 'Codey', aliasText: 'a,,b, ' }]))
+      .toEqual([{ term: 'Codey', aliases: ['a', 'b'] }])
+  })
+})
+
+describe('learnCorrections', () => {
+  it('learns a single misheard word from an edit', () => {
+    expect(learnCorrections('open coday now', 'open Codey now'))
+      .toEqual([{ term: 'Codey', alias: 'coday' }])
+  })
+
+  it('learns a capitalization-only fix', () => {
+    expect(learnCorrections('run cody', 'run Codey'))
+      .toEqual([{ term: 'Codey', alias: 'cody' }])
+  })
+
+  it('learns a multi-word mis-hearing', () => {
+    expect(learnCorrections('use whisper kit here', 'use WhisperKit here'))
+      .toEqual([{ term: 'WhisperKit', alias: 'whisper kit' }])
+  })
+
+  it('learns more than one correction in a single edit', () => {
+    expect(learnCorrections('coday uses whisper kit', 'Codey uses WhisperKit'))
+      .toEqual([
+        { term: 'Codey', alias: 'coday' },
+        { term: 'WhisperKit', alias: 'whisper kit' },
+      ])
+  })
+
+  it('ignores text the user appended', () => {
+    expect(learnCorrections('fix the bug', 'fix the bug in the parser please')).toEqual([])
+  })
+
+  it('ignores text the user deleted', () => {
+    expect(learnCorrections('fix the bug in the parser', 'fix the bug')).toEqual([])
+  })
+
+  it('ignores a whole-message rewrite', () => {
+    expect(learnCorrections('please look at the failing test', 'run the build instead')).toEqual([])
+  })
+
+  it('ignores a punctuation-only edit', () => {
+    expect(learnCorrections('hello there', 'hello, there!')).toEqual([])
+  })
+
+  it('refuses a one-character alias, which would rewrite everything', () => {
+    expect(learnCorrections('a bug', 'the bug')).toEqual([])
+  })
+
+  it('refuses a correction longer than a name', () => {
+    const spoken = 'x '.repeat(30) + 'this whole clause was wrong here'
+    expect(learnCorrections(spoken, spoken.replace('this whole clause was wrong here', 'something entirely different instead'))).toEqual([])
+  })
+
+  it('handles empty input on either side', () => {
+    expect(learnCorrections('', 'Codey')).toEqual([])
+    expect(learnCorrections('Codey', '')).toEqual([])
+  })
+
+  it('learns a transliteration, which shares no characters with the term', () => {
+    // "\u5bc7\u8fea" is a plausible Chinese rendering of "Codey".
+    expect(learnCorrections('open \u5bc7\u8fea now', 'open Codey now'))
+      .toEqual([{ term: 'Codey', alias: '\u5bc7\u8fea' }])
+  })
+
+  it('refuses a same-script swap for an unrelated word', () => {
+    expect(learnCorrections('the build is wrong', 'the build is different')).toEqual([])
+  })
+
+  it('returns nothing when the text is unchanged', () => {
+    expect(learnCorrections('open Codey now', 'open Codey now')).toEqual([])
+  })
+
+  it('bails on input too large to diff', () => {
+    const huge = 'word '.repeat(500)
+    expect(learnCorrections(huge, huge + 'x')).toEqual([])
+  })
+})
+
+describe('mergeLearnedAliases', () => {
+  it('adds an alias to the matching existing term', () => {
+    const result = mergeLearnedAliases(
+      [{ term: 'Codey', aliases: ['cody'] }],
+      [{ term: 'Codey', alias: 'coday' }],
+    )
+    expect(result.changed).toBe(true)
+    expect(result.entries).toEqual([{ term: 'Codey', aliases: ['cody', 'coday'] }])
+  })
+
+  it('creates a new entry when the term is unknown', () => {
+    const result = mergeLearnedAliases([], [{ term: 'WhisperKit', alias: 'whisper kit' }])
+    expect(result.entries).toEqual([{ term: 'WhisperKit', aliases: ['whisper kit'] }])
+  })
+
+  it('reports no change when the alias is already known', () => {
+    const entries = [{ term: 'Codey', aliases: ['coday'] }]
+    const result = mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'CODAY' }])
+    expect(result.changed).toBe(false)
+    expect(result.entries).toBe(entries)
+  })
+
+  it('does not mutate the array it was given', () => {
+    const entries = [{ term: 'Codey', aliases: ['cody'] }]
+    mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'coday' }])
+    expect(entries).toEqual([{ term: 'Codey', aliases: ['cody'] }])
+  })
+
+  it('refuses an alias that is another entry preferred spelling', () => {
+    const entries = [{ term: 'Codey', aliases: [] }, { term: 'Cody', aliases: [] }]
+    const result = mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'Cody' }])
+    expect(result.changed).toBe(false)
+  })
+
+  it('stops adding aliases to one term past the cap', () => {
+    const aliases = Array.from({ length: MAX_ALIASES_PER_TERM }, (_, i) => `a${i}`)
+    const result = mergeLearnedAliases(
+      [{ term: 'Codey', aliases }],
+      [{ term: 'Codey', alias: 'one-too-many' }],
+    )
+    expect(result.changed).toBe(false)
+  })
+
+  it('stops creating entries past the cap', () => {
+    const entries = Array.from({ length: MAX_VOCABULARY_ENTRIES }, (_, i) => ({ term: `t${i}`, aliases: [] }))
+    const result = mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'coday' }])
+    expect(result.changed).toBe(false)
+  })
+
+  it('reports exactly what landed, so the UI can name it', () => {
+    const result = mergeLearnedAliases([], [
+      { term: 'Codey', alias: 'coday' },
+      { term: 'WhisperKit', alias: 'whisper kit' },
+    ])
+    expect(result.added).toEqual([
+      { term: 'Codey', alias: 'coday' },
+      { term: 'WhisperKit', alias: 'whisper kit' },
+    ])
+  })
+
+  it('leaves a dropped correction out of added', () => {
+    const result = mergeLearnedAliases(
+      [{ term: 'Codey', aliases: ['coday'] }],
+      [{ term: 'Codey', alias: 'CODAY' }, { term: 'Codey', alias: 'cody' }],
+    )
+    expect(result.added).toEqual([{ term: 'Codey', alias: 'cody' }])
+  })
+
+  it('reports added under the existing spelling of the term, not the typed one', () => {
+    const result = mergeLearnedAliases(
+      [{ term: 'Codey', aliases: [] }],
+      [{ term: 'codey', alias: 'coday' }],
+    )
+    expect(result.added).toEqual([{ term: 'Codey', alias: 'coday' }])
+  })
+
+  it('reports an empty added list when nothing changed', () => {
+    expect(mergeLearnedAliases([{ term: 'Codey', aliases: ['coday'] }], [{ term: 'Codey', alias: 'coday' }]).added).toEqual([])
+  })
+
+  it('reports no change for an empty correction list', () => {
+    const entries = [{ term: 'Codey', aliases: [] }]
+    expect(mergeLearnedAliases(entries, []).changed).toBe(false)
+  })
+})

--- a/codey-mac/src/components/voiceVocabulary.test.ts
+++ b/codey-mac/src/components/voiceVocabulary.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   normalizeVocabulary, vocabularyToDraft, draftToVocabulary,
   learnCorrections, mergeLearnedAliases, countAliases,
+  recordCorrections, normalizePending, forgetCorrection,
+  SIGHTINGS_BEFORE_ACTIVE, MAX_PENDING_CORRECTIONS,
   MAX_ALIASES_PER_TERM, MAX_VOCABULARY_ENTRIES,
 } from './voiceVocabulary'
 
@@ -282,5 +284,123 @@ describe('mergeLearnedAliases', () => {
   it('reports no change for an empty correction list', () => {
     const entries = [{ term: 'Codey', aliases: [] }]
     expect(mergeLearnedAliases(entries, []).changed).toBe(false)
+  })
+})
+
+describe('recordCorrections', () => {
+  const codey = { term: 'Codey', alias: 'coday' }
+
+  it('does not promote a correction the first time it is seen', () => {
+    const r = recordCorrections([], [], [codey])
+    expect(r.promoted).toEqual([])
+    expect(r.pending).toEqual([{ ...codey, count: 1 }])
+  })
+
+  it('promotes on the second sighting', () => {
+    const first = recordCorrections([], [], [codey])
+    const second = recordCorrections(first.pending, [], [codey])
+    expect(second.promoted).toEqual([codey])
+  })
+
+  it('takes the promoted correction off the waiting list', () => {
+    const first = recordCorrections([], [], [codey])
+    const second = recordCorrections(first.pending, [], [codey])
+    expect(second.pending).toEqual([])
+  })
+
+  // The whole point: a one-off edit must never start rewriting a real word.
+  it('leaves a one-off edit inert no matter how much else happens', () => {
+    let pending = recordCorrections([], [], [codey]).pending
+    for (const other of ['alpha', 'bravo', 'charlie']) {
+      const r = recordCorrections(pending, [], [{ term: other, alias: `${other}x` }])
+      expect(r.promoted).toEqual([])
+      pending = r.pending
+    }
+    expect(pending.find(p => p.alias === 'coday')?.count).toBe(1)
+  })
+
+  it('matches sightings case-insensitively', () => {
+    const first = recordCorrections([], [], [{ term: 'Codey', alias: 'CODAY' }])
+    const second = recordCorrections(first.pending, [], [codey])
+    expect(second.promoted).toHaveLength(1)
+  })
+
+  it('ignores a correction the dictionary already covers', () => {
+    const entries = [{ term: 'Codey', aliases: ['coday'] }]
+    const r = recordCorrections([], entries, [codey])
+    expect(r.promoted).toEqual([])
+    expect(r.pending).toEqual([])
+  })
+
+  it('returns the same list untouched when nothing was observed', () => {
+    const pending = [{ ...codey, count: 1 }]
+    const r = recordCorrections(pending, [], [])
+    expect(r.pending).toBe(pending)
+  })
+
+  it('stops the waiting list growing without bound', () => {
+    const pending = Array.from({ length: MAX_PENDING_CORRECTIONS }, (_, i) => ({
+      term: `t${i}`, alias: `a${i}`, count: 1,
+    }))
+    const r = recordCorrections(pending, [], [{ term: 'New', alias: 'nue' }])
+    expect(r.pending).toHaveLength(MAX_PENDING_CORRECTIONS)
+  })
+
+  it('needs exactly SIGHTINGS_BEFORE_ACTIVE sightings', () => {
+    let pending: ReturnType<typeof recordCorrections>['pending'] = []
+    let promotedAt = 0
+    for (let i = 1; i <= SIGHTINGS_BEFORE_ACTIVE; i++) {
+      const r = recordCorrections(pending, [], [codey])
+      pending = r.pending
+      if (r.promoted.length > 0 && promotedAt === 0) promotedAt = i
+    }
+    expect(promotedAt).toBe(SIGHTINGS_BEFORE_ACTIVE)
+  })
+})
+
+describe('normalizePending', () => {
+  it('defaults a missing or bad count to one sighting', () => {
+    expect(normalizePending([{ term: 'a', alias: 'b' }])).toEqual([{ term: 'a', alias: 'b', count: 1 }])
+    expect(normalizePending([{ term: 'a', alias: 'b', count: -3 }])).toEqual([{ term: 'a', alias: 'b', count: 1 }])
+  })
+
+  it('skips malformed rows rather than throwing', () => {
+    expect(normalizePending([null, 3, { term: 'a' }, { alias: 'b' }, { term: ' ', alias: 'b' }])).toEqual([])
+  })
+
+  it('returns empty for a missing field', () => {
+    expect(normalizePending(undefined)).toEqual([])
+  })
+})
+
+describe('forgetCorrection', () => {
+  it('removes the alias from the dictionary', () => {
+    const r = forgetCorrection(
+      [{ term: 'Codey', aliases: ['coday', 'kodi'] }], [], { term: 'Codey', alias: 'coday' })
+    expect(r.entries).toEqual([{ term: 'Codey', aliases: ['kodi'] }])
+  })
+
+  it('removes a term that existed only to hold that alias', () => {
+    const r = forgetCorrection([{ term: 'Codey', aliases: ['coday'] }], [], { term: 'Codey', alias: 'coday' })
+    expect(r.entries).toEqual([])
+  })
+
+  it('keeps a hint-only term the user typed', () => {
+    const entries = [{ term: 'WhisperKit', aliases: [] }, { term: 'Codey', aliases: ['coday'] }]
+    const r = forgetCorrection(entries, [], { term: 'Codey', alias: 'coday' })
+    expect(r.entries).toEqual([{ term: 'WhisperKit', aliases: [] }])
+  })
+
+  it('clears the waiting list too, so undo is not just "not yet"', () => {
+    const r = forgetCorrection([], [{ term: 'Codey', alias: 'coday', count: 1 }], { term: 'Codey', alias: 'coday' })
+    expect(r.pending).toEqual([])
+  })
+
+  it('leaves unrelated entries and sightings alone', () => {
+    const entries = [{ term: 'Other', aliases: ['othr'] }]
+    const pending = [{ term: 'Third', alias: 'thrd', count: 1 }]
+    const r = forgetCorrection(entries, pending, { term: 'Codey', alias: 'coday' })
+    expect(r.entries).toEqual(entries)
+    expect(r.pending).toEqual(pending)
   })
 })

--- a/codey-mac/src/components/voiceVocabulary.ts
+++ b/codey-mac/src/components/voiceVocabulary.ts
@@ -359,6 +359,126 @@ export function learnCorrections(spoken: string, edited: string): LearnedCorrect
   return out
 }
 
+/** A correction seen once, waiting to see whether it repeats. */
+export interface PendingCorrection {
+  term: string
+  alias: string
+  /** How many times this exact swap has been observed. */
+  count: number
+}
+
+/** How many sightings before a correction starts rewriting transcripts.
+ *
+ * One sighting cannot tell a mis-hearing from a change of mind: swapping one
+ * short word for another is indistinguishable from fixing a homophone, and
+ * for Chinese the shape test cannot separate them either. What does separate
+ * them is repetition - the recognizer fails the same way every time, while a
+ * deliberate rewording happens once and never again. Waiting for the second
+ * sighting costs one extra correction and removes the failure mode where a
+ * one-off edit quietly rewrites a real word for weeks afterwards. */
+export const SIGHTINGS_BEFORE_ACTIVE = 2
+
+/** Cap on the waiting list, so one-off edits cannot grow without bound. */
+export const MAX_PENDING_CORRECTIONS = 100
+
+export function normalizePending(raw: unknown): PendingCorrection[] {
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((entry): PendingCorrection[] => {
+    if (!entry || typeof entry !== 'object') return []
+    const term = (entry as any).term
+    const alias = (entry as any).alias
+    const count = (entry as any).count
+    if (typeof term !== 'string' || typeof alias !== 'string') return []
+    if (!term.trim() || !alias.trim()) return []
+    return [{ term, alias, count: Number.isFinite(count) && count > 0 ? Math.floor(count) : 1 }]
+  })
+}
+
+function pendingKey(term: string, alias: string): string {
+  return `${alias.toLowerCase()}\u0000${term.toLowerCase()}`
+}
+
+/**
+ * Record this turn's corrections and report the ones that have now been seen
+ * often enough to act on.
+ *
+ * A correction already covered by the dictionary is dropped rather than
+ * counted: the alias is being rewritten before the user ever sees it, so a
+ * second sighting would mean something else entirely.
+ */
+export function recordCorrections(
+  pending: PendingCorrection[],
+  entries: VocabularyEntry[],
+  observed: LearnedCorrection[],
+): { pending: PendingCorrection[]; promoted: LearnedCorrection[] } {
+  if (observed.length === 0) return { pending, promoted: [] }
+
+  const known = new Set<string>()
+  for (const entry of entries) {
+    for (const alias of entry.aliases) known.add(pendingKey(entry.term, alias))
+  }
+
+  const next = pending.map(p => ({ ...p }))
+  const index = new Map(next.map((p, i) => [pendingKey(p.term, p.alias), i]))
+  const promoted: LearnedCorrection[] = []
+  let changed = false
+
+  for (const correction of observed) {
+    const key = pendingKey(correction.term, correction.alias)
+    if (known.has(key)) continue
+
+    const at = index.get(key)
+    if (at === undefined) {
+      if (next.length >= MAX_PENDING_CORRECTIONS) continue
+      next.push({ term: correction.term, alias: correction.alias, count: 1 })
+      index.set(key, next.length - 1)
+      changed = true
+      continue
+    }
+    next[at].count += 1
+    changed = true
+    if (next[at].count >= SIGHTINGS_BEFORE_ACTIVE) {
+      promoted.push({ term: next[at].term, alias: next[at].alias })
+    }
+  }
+
+  // Anything promoted leaves the waiting list; it lives in the dictionary now.
+  const survivors = promoted.length === 0
+    ? next
+    : next.filter(p => !promoted.some(q => pendingKey(q.term, q.alias) === pendingKey(p.term, p.alias)))
+
+  if (!changed && promoted.length === 0) return { pending, promoted: [] }
+  return { pending: survivors, promoted }
+}
+
+/** Drop a correction from both the dictionary and the waiting list. Used by
+ *  undo, which has to work whether or not the correction went active. */
+export function forgetCorrection(
+  entries: VocabularyEntry[],
+  pending: PendingCorrection[],
+  correction: LearnedCorrection,
+): { entries: VocabularyEntry[]; pending: PendingCorrection[] } {
+  const key = pendingKey(correction.term, correction.alias)
+  const nextEntries: VocabularyEntry[] = []
+  for (const entry of entries) {
+    const aliases = entry.aliases.filter(alias => pendingKey(entry.term, alias) !== key)
+    if (aliases.length === entry.aliases.length) {
+      nextEntries.push(entry)
+      continue
+    }
+    // This alias was the entry's only one, so the entry existed to hold it:
+    // learning creates a term and its first mis-hearing together. Undoing
+    // should leave no trace. An entry that still has other aliases, or that
+    // had none to begin with, is the user's and stays.
+    if (aliases.length === 0) continue
+    nextEntries.push({ term: entry.term, aliases })
+  }
+  return {
+    entries: nextEntries,
+    pending: pending.filter(p => pendingKey(p.term, p.alias) !== key),
+  }
+}
+
 /**
  * Fold learned corrections into the saved dictionary.
  *

--- a/codey-mac/src/components/voiceVocabulary.ts
+++ b/codey-mac/src/components/voiceVocabulary.ts
@@ -65,6 +65,13 @@ export function draftToVocabulary(draft: VocabularyDraftRow[]): VocabularyEntry[
     .filter(row => row.term !== '')
 }
 
+/** Aliases in a mid-edit draft row, matching what `draftToVocabulary` would
+ *  keep. Used for the chip badge, so the count on screen can never disagree
+ *  with what actually gets saved. */
+export function countAliases(aliasText: string): number {
+  return dedupeAliases(aliasText.split(/[\n,]/).map(a => a.trim()).filter(Boolean)).length
+}
+
 function dedupeAliases(aliases: string[]): string[] {
   const seen = new Set<string>()
   return aliases.filter(alias => {
@@ -176,6 +183,58 @@ function lcsLength(a: string, b: string): number {
   return prev[b.length]
 }
 
+/** A single CJK character, i.e. a token the diff can narrow a change down to
+ *  even though the word it belongs to is longer. */
+function isSingleCJKToken(token: string): boolean {
+  return token.length === 1 && CJK_RE.test(token)
+}
+
+/**
+ * Widen a change that the diff narrowed below `MIN_ALIAS_CHARS`.
+ *
+ * Chinese has no spaces, so a one-character slip inside a word diffs down to
+ * exactly that character: "zhuan-LU-qi" vs "zhuan-XIE-qi" yields a single-token
+ * region. Recording that as an alias is unsafe — it would rewrite the
+ * character everywhere it appears — so the old code dropped it, which is why
+ * almost nothing was learned from Chinese dictation.
+ *
+ * Pulling unchanged neighbours onto *both* sides keeps the rewrite rule valid
+ * (the same context is added to each side) and makes it more specific rather
+ * than less. Symmetric on purpose: expanding one way only would need to know
+ * where the word boundary is, and there is no segmenter here — left-only turns
+ * "xian->jin" into the wrong pair, right-only does the same to another. Taking
+ * one from each side is right in both.
+ */
+function expandCJKRegion(
+  deleted: string[],
+  inserted: string[],
+  before: string[],
+  after: string[],
+): { alias: string; term: string; aliasTokens: number; termTokens: number } | null {
+  let left = [...before]
+  let right = [...after]
+  let del = [...deleted]
+  let ins = [...inserted]
+
+  while (del.join('').length < MIN_ALIAS_CHARS || ins.join('').length < MIN_ALIAS_CHARS) {
+    const canLeft = isSingleCJKToken(left[left.length - 1] ?? '')
+    const canRight = isSingleCJKToken(right[0] ?? '')
+    if (!canLeft && !canRight) return null
+    if (del.length + ins.length + 2 > MAX_CORRECTION_TOKENS * 2) return null
+    if (canLeft) {
+      const token = left.pop() as string
+      del.unshift(token)
+      ins.unshift(token)
+    }
+    if (canRight) {
+      const token = right.shift() as string
+      del.push(token)
+      ins.push(token)
+    }
+  }
+  return { alias: del.join(''), term: ins.join(''), aliasTokens: del.length, termTokens: ins.length }
+}
+
 /**
  * Does this replacement look like a mis-hearing rather than a rewrite?
  *
@@ -190,6 +249,21 @@ function looksLikeMishearing(alias: string, term: string): boolean {
   const a = similarityKey(alias)
   const b = similarityKey(term)
   if (!a || !b) return false
+
+  // Chinese mis-hearings are homophones: they sound alike and look nothing
+  // alike, so character overlap says "unrelated" about exactly the corrections
+  // worth learning. Judging a Chinese pair by shape rejected essentially all
+  // of them. Length is the signal that survives — a homophone slip has the
+  // same syllable count as the word it replaced — combined with the fact that
+  // the change is already short and surrounded by untouched text.
+  //
+  // This does let a deliberate short swap through. That is the accepted cost:
+  // without pronunciation data the two are indistinguishable, and the result
+  // is shown in the composer pill and removable in Settings.
+  if (CJK_RE.test(alias) && CJK_RE.test(term)) {
+    return Math.abs(a.length - b.length) <= 1
+  }
+
   return lcsLength(a, b) / Math.max(a.length, b.length) >= MIN_SIMILARITY
 }
 
@@ -213,28 +287,57 @@ export function learnCorrections(spoken: string, edited: string): LearnedCorrect
 
   const ops = diffTokens(before, after)
 
-  // Group runs of non-equal ops into replacement regions.
-  const regions: Array<{ alias: string; term: string; aliasTokens: number; termTokens: number }> = []
+  // Group runs of non-equal ops into replacement regions, keeping the
+  // untouched tokens on either side: a change the diff narrowed to a single
+  // CJK character needs that context to be widened back into a usable alias.
+  type RawRegion = { deleted: string[]; inserted: string[]; before: string[]; after: string[] }
+  const raw: RawRegion[] = []
+  let equalRun: string[] = []
+  let pendingBefore: string[] = []
   let deleted: string[] = []
   let inserted: string[] = []
   const flush = () => {
     if (deleted.length || inserted.length) {
-      regions.push({
-        alias: deleted.join('').trim(),
-        term: inserted.join('').trim(),
-        aliasTokens: deleted.length,
-        termTokens: inserted.length,
-      })
+      raw.push({ deleted, inserted, before: pendingBefore, after: [] })
     }
     deleted = []
     inserted = []
+    pendingBefore = []
   }
   for (const op of ops) {
-    if (op.kind === 'equal') flush()
-    else if (op.kind === 'delete') deleted.push(op.token)
-    else inserted.push(op.token)
+    if (op.kind === 'equal') {
+      flush()
+      equalRun.push(op.token)
+      // The equal run *after* a region is only known once we reach it.
+      const last = raw[raw.length - 1]
+      if (last && last.after.length < MAX_CORRECTION_TOKENS) last.after.push(op.token)
+    } else {
+      // Snapshot the left-hand context as the region opens; `equalRun` is
+      // about to start collecting the *next* region's context instead.
+      if (deleted.length === 0 && inserted.length === 0) {
+        pendingBefore = equalRun.slice(-MAX_CORRECTION_TOKENS)
+        equalRun = []
+      }
+      if (op.kind === 'delete') deleted.push(op.token)
+      else inserted.push(op.token)
+    }
   }
   flush()
+
+  const regions = raw.flatMap(r => {
+    const alias = r.deleted.join('').trim()
+    const term = r.inserted.join('').trim()
+    // Both sides present and long enough already: take it as-is.
+    if (alias && term && alias.length >= MIN_ALIAS_CHARS && term.length >= MIN_ALIAS_CHARS) {
+      return [{ alias, term, aliasTokens: r.deleted.length, termTokens: r.inserted.length }]
+    }
+    // Too short, but a real swap — try to widen it using untouched neighbours.
+    if (alias && term) {
+      const widened = expandCJKRegion(r.deleted, r.inserted, r.before, r.after)
+      if (widened) return [widened]
+    }
+    return [{ alias, term, aliasTokens: r.deleted.length, termTokens: r.inserted.length }]
+  })
 
   const out: LearnedCorrection[] = []
   const seen = new Set<string>()

--- a/codey-mac/src/components/voiceVocabulary.ts
+++ b/codey-mac/src/components/voiceVocabulary.ts
@@ -1,0 +1,302 @@
+/** One preferred spelling plus the mis-hearings that map onto it.
+ *  Mirrors `VocabularyTerm` in the Swift helper (voice/Sources/CodeyVoice/Vocabulary.swift). */
+export interface VocabularyEntry {
+  term: string
+  aliases: string[]
+}
+
+/** A Dictionary row mid-edit. Aliases stay one free-text blob while the user
+ *  types, so a half-typed line isn't eaten between keystrokes. */
+export interface VocabularyDraftRow {
+  term: string
+  aliasText: string
+}
+
+/** A mis-hearing observed by comparing what was dictated against what the
+ *  user actually sent. */
+export interface LearnedCorrection {
+  /** The corrected spelling — what the user left in the composer. */
+  term: string
+  /** What the recognizer produced instead. */
+  alias: string
+}
+
+/**
+ * Widen whatever is in gateway.json into editor rows.
+ *
+ * The Swift side also accepts the terse hand-authored form — a bare string
+ * means "hint only, no aliases" — so the editor has to understand it too,
+ * otherwise opening Settings would silently drop hand-written entries.
+ * Anything else in the array is skipped rather than thrown on: this field is
+ * hand-edited, and one bad row must not blank the whole dictionary.
+ */
+export function normalizeVocabulary(raw: unknown): VocabularyEntry[] {
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((entry): VocabularyEntry[] => {
+    if (typeof entry === 'string') return entry.trim() ? [{ term: entry, aliases: [] }] : []
+    if (entry && typeof entry === 'object' && typeof (entry as any).term === 'string') {
+      const aliases = Array.isArray((entry as any).aliases)
+        ? (entry as any).aliases.filter((a: unknown): a is string => typeof a === 'string')
+        : []
+      return [{ term: (entry as any).term, aliases }]
+    }
+    return []
+  })
+}
+
+export function vocabularyToDraft(entries: VocabularyEntry[]): VocabularyDraftRow[] {
+  return entries.map(entry => ({ term: entry.term, aliasText: entry.aliases.join('\n') }))
+}
+
+/**
+ * Parse editor rows back into config entries.
+ *
+ * Blank terms are dropped here but stay visible in the draft, so "+ Add word"
+ * can leave an empty row on screen without writing junk into gateway.json.
+ * Aliases split on newlines *and* commas: the textarea invites one per line,
+ * but comma-separated is what people type by habit and both are unambiguous.
+ */
+export function draftToVocabulary(draft: VocabularyDraftRow[]): VocabularyEntry[] {
+  return draft
+    .map(row => ({
+      term: row.term.trim(),
+      aliases: dedupeAliases(row.aliasText.split(/[\n,]/).map(a => a.trim()).filter(Boolean)),
+    }))
+    .filter(row => row.term !== '')
+}
+
+function dedupeAliases(aliases: string[]): string[] {
+  const seen = new Set<string>()
+  return aliases.filter(alias => {
+    const key = alias.toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+// ── Learning from edits ─────────────────────────────────────────────
+
+/** Longest single mis-hearing worth recording, in tokens and in characters.
+ *  Past this it stops being "the recognizer misheard a name" and starts being
+ *  "the user rephrased the sentence", which must not enter the dictionary. */
+const MAX_CORRECTION_TOKENS = 4
+const MAX_CORRECTION_CHARS = 30
+/** A single character is never a safe alias — it would rewrite half the
+ *  transcript. Two is the floor. */
+const MIN_ALIAS_CHARS = 2
+/** How alike a mis-hearing has to be to the word it replaced, as a share of
+ *  the longer side's characters. A misheard name sounds like the real one, so
+ *  it looks like it too ("coday"/"Codey"); a rephrasing does not
+ *  ("wrong"/"different"). This, not the size of the edit, is what separates a
+ *  correction from a rewrite — a share-of-the-message threshold kept rejecting
+ *  short utterances, where fixing one name is most of the sentence. */
+const MIN_SIMILARITY = 0.5
+/** Diffing is O(n*m); a pasted wall of text isn't a dictation correction
+ *  anyway, so bail rather than burn the main thread. */
+const MAX_DIFF_TOKENS = 400
+/** Ceilings so a runaway learner can't crowd out the prompt hint or the UI. */
+export const MAX_ALIASES_PER_TERM = 12
+export const MAX_VOCABULARY_ENTRIES = 200
+
+/**
+ * Split into diff units: a run of ASCII letters/digits is one token, a run of
+ * whitespace is one token, and anything else (CJK characters, punctuation) is
+ * one token each.
+ *
+ * The mixed granularity is the point. Word-level diffing would turn
+ * "wo zai xie Codey" into one giant replacement for Chinese, which has no
+ * spaces; character-level diffing would shred "coday" into "Codey" as a
+ * handful of nonsense single-letter edits. This gets both right.
+ */
+function tokenize(text: string): string[] {
+  return text.match(/[A-Za-z0-9]+|\s+|[\s\S]/g) ?? []
+}
+
+type DiffOp = { kind: 'equal' | 'delete' | 'insert'; token: string }
+
+/** Classic LCS diff. Inputs are one dictated utterance, so the quadratic
+ *  table stays small — `MAX_DIFF_TOKENS` guards the pathological case. */
+function diffTokens(before: string[], after: string[]): DiffOp[] {
+  const n = before.length
+  const m = after.length
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = before[i] === after[j]
+        ? lcs[i + 1][j + 1] + 1
+        : Math.max(lcs[i + 1][j], lcs[i][j + 1])
+    }
+  }
+  const ops: DiffOp[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (before[i] === after[j]) {
+      ops.push({ kind: 'equal', token: before[i] })
+      i++; j++
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      ops.push({ kind: 'delete', token: before[i] })
+      i++
+    } else {
+      ops.push({ kind: 'insert', token: after[j] })
+      j++
+    }
+  }
+  while (i < n) ops.push({ kind: 'delete', token: before[i++] })
+  while (j < m) ops.push({ kind: 'insert', token: after[j++] })
+  return ops
+}
+
+/** True when the string carries no letters, digits or CJK — pure punctuation
+ *  or whitespace, which is formatting rather than a mis-hearing. */
+function isSubstantive(text: string): boolean {
+  return /[A-Za-z0-9\u3040-\u30ff\u4e00-\u9fff\uac00-\ud7af]/.test(text)
+}
+
+const CJK_RE = /[\u3040-\u30ff\u4e00-\u9fff\uac00-\ud7af]/
+
+/** Case, spacing and punctuation are all things the recognizer gets wrong on
+ *  its own, so they must not count against similarity. */
+function similarityKey(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9\u3040-\u30ff\u4e00-\u9fff\uac00-\ud7af]/g, '')
+}
+
+/** Length of the longest common subsequence of characters. */
+function lcsLength(a: string, b: string): number {
+  if (!a || !b) return 0
+  let prev = new Array(b.length + 1).fill(0)
+  for (let i = 1; i <= a.length; i++) {
+    const cur = new Array(b.length + 1).fill(0)
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = a[i - 1] === b[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], cur[j - 1])
+    }
+    prev = cur
+  }
+  return prev[b.length]
+}
+
+/**
+ * Does this replacement look like a mis-hearing rather than a rewrite?
+ *
+ * Two ways to qualify. Normally the two spellings have to share most of their
+ * characters. But a transliteration — the recognizer wrote a name in the
+ * script the user was speaking, and the user wanted the Latin spelling —
+ * shares no characters at all by definition, and is one of the main things
+ * this feature exists to fix. Crossing scripts is itself the evidence there.
+ */
+function looksLikeMishearing(alias: string, term: string): boolean {
+  if (CJK_RE.test(alias) !== CJK_RE.test(term)) return true
+  const a = similarityKey(alias)
+  const b = similarityKey(term)
+  if (!a || !b) return false
+  return lcsLength(a, b) / Math.max(a.length, b.length) >= MIN_SIMILARITY
+}
+
+/**
+ * Compare what the recognizer produced against what the user actually sent,
+ * and report the word-sized swaps in between.
+ *
+ * Only *replacements* are learned. Text the user appended shows up as a pure
+ * insertion and text they deleted as a pure deletion; neither says anything
+ * about how a word was misheard, and treating them as corrections is how a
+ * dictionary fills up with garbage.
+ *
+ * Every candidate still has to look like a mis-hearing (see
+ * `looksLikeMishearing`), so a caller can apply the result unconditionally.
+ */
+export function learnCorrections(spoken: string, edited: string): LearnedCorrection[] {
+  const before = tokenize(spoken)
+  const after = tokenize(edited)
+  if (before.length === 0 || after.length === 0) return []
+  if (before.length > MAX_DIFF_TOKENS || after.length > MAX_DIFF_TOKENS) return []
+
+  const ops = diffTokens(before, after)
+
+  // Group runs of non-equal ops into replacement regions.
+  const regions: Array<{ alias: string; term: string; aliasTokens: number; termTokens: number }> = []
+  let deleted: string[] = []
+  let inserted: string[] = []
+  const flush = () => {
+    if (deleted.length || inserted.length) {
+      regions.push({
+        alias: deleted.join('').trim(),
+        term: inserted.join('').trim(),
+        aliasTokens: deleted.length,
+        termTokens: inserted.length,
+      })
+    }
+    deleted = []
+    inserted = []
+  }
+  for (const op of ops) {
+    if (op.kind === 'equal') flush()
+    else if (op.kind === 'delete') deleted.push(op.token)
+    else inserted.push(op.token)
+  }
+  flush()
+
+  const out: LearnedCorrection[] = []
+  const seen = new Set<string>()
+  for (const region of regions) {
+    // Pure insertion or pure deletion — the user added or removed text rather
+    // than correcting a word.
+    if (!region.alias || !region.term) continue
+    if (region.alias === region.term) continue
+    if (region.aliasTokens > MAX_CORRECTION_TOKENS || region.termTokens > MAX_CORRECTION_TOKENS) continue
+    if (region.alias.length > MAX_CORRECTION_CHARS || region.term.length > MAX_CORRECTION_CHARS) continue
+    if (region.alias.length < MIN_ALIAS_CHARS) continue
+    if (!isSubstantive(region.alias) || !isSubstantive(region.term)) continue
+    if (!looksLikeMishearing(region.alias, region.term)) continue
+    const key = `${region.alias.toLowerCase()} ${region.term.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push({ term: region.term, alias: region.alias })
+  }
+  return out
+}
+
+/**
+ * Fold learned corrections into the saved dictionary.
+ *
+ * Returns a new array plus the subset that actually landed, so the caller can
+ * skip the config write on the common "nothing new" path and tell the user
+ * exactly what was learned. `added` is not the same as the input: a
+ * correction can be dropped here for being a duplicate or hitting a cap.
+ */
+export function mergeLearnedAliases(
+  entries: VocabularyEntry[],
+  learned: LearnedCorrection[],
+): { entries: VocabularyEntry[]; changed: boolean; added: LearnedCorrection[] } {
+  if (learned.length === 0) return { entries, changed: false, added: [] }
+
+  const next = entries.map(entry => ({ term: entry.term, aliases: [...entry.aliases] }))
+  const termIndex = new Map(next.map((entry, i) => [entry.term.toLowerCase(), i]))
+  const added: LearnedCorrection[] = []
+  let changed = false
+
+  for (const { term, alias } of learned) {
+    if (alias.toLowerCase() === term.toLowerCase()) continue
+    // Never learn an alias that is itself somebody's preferred spelling —
+    // the two rules would fight, and the correct word would get rewritten
+    // into a different one.
+    if (termIndex.has(alias.toLowerCase())) continue
+
+    let index = termIndex.get(term.toLowerCase())
+    if (index === undefined) {
+      if (next.length >= MAX_VOCABULARY_ENTRIES) continue
+      next.push({ term, aliases: [] })
+      index = next.length - 1
+      termIndex.set(term.toLowerCase(), index)
+      changed = true
+    }
+    const entry = next[index]
+    if (entry.aliases.some(a => a.toLowerCase() === alias.toLowerCase())) continue
+    if (entry.aliases.length >= MAX_ALIASES_PER_TERM) continue
+    entry.aliases.push(alias)
+    added.push({ term: entry.term, alias })
+    changed = true
+  }
+
+  return changed ? { entries: next, changed: true, added } : { entries, changed: false, added: [] }
+}

--- a/codey-mac/src/components/voiceWarmStatus.test.ts
+++ b/codey-mac/src/components/voiceWarmStatus.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { formatWarmElapsed, warmTooltip, warmShortLabel } from './voiceWarmStatus'
+
+describe('formatWarmElapsed', () => {
+  it('stays in seconds under a minute', () => {
+    expect(formatWarmElapsed(0)).toBe('0s')
+    expect(formatWarmElapsed(45)).toBe('45s')
+    expect(formatWarmElapsed(59.9)).toBe('59s')
+  })
+
+  it('switches to minutes at the boundary', () => {
+    expect(formatWarmElapsed(60)).toBe('1m')
+    expect(formatWarmElapsed(90)).toBe('1m 30s')
+    expect(formatWarmElapsed(320)).toBe('5m 20s')
+  })
+
+  it('drops the seconds part when it is zero', () => {
+    expect(formatWarmElapsed(120)).toBe('2m')
+  })
+
+  it('never shows a negative time from a clock skew', () => {
+    expect(formatWarmElapsed(-5)).toBe('0s')
+  })
+})
+
+describe('warmTooltip', () => {
+  it('says it is busy, how long so far, and that it is one-time', () => {
+    const text = warmTooltip(90)
+    expect(text).toContain('Preparing')
+    expect(text).toContain('1m 30s')
+    expect(text).toContain('about 5 minutes')
+    // The reason the wait exists at all, and that it is not every launch.
+    expect(text).toContain('once per app update')
+    expect(text).toContain('unavailable until it finishes')
+  })
+
+  it('works at zero, which is what the first render shows', () => {
+    expect(warmTooltip(0)).toContain('0s so far')
+  })
+})
+
+describe('warmShortLabel', () => {
+  it('names the state and the elapsed time', () => {
+    expect(warmShortLabel(75)).toBe('Preparing model… 1m 15s')
+  })
+})

--- a/codey-mac/src/components/voiceWarmStatus.ts
+++ b/codey-mac/src/components/voiceWarmStatus.ts
@@ -1,0 +1,39 @@
+/**
+ * Wording for the "the on-device model is still being prepared" state.
+ *
+ * Split out from the composer so the copy can be tested, because it is the
+ * only explanation the user gets for a control that has gone dead for several
+ * minutes. Getting it wrong reads as a broken app.
+ */
+
+/** Roughly how long a first CoreML compile takes; measured at ~320s on an
+ *  M-series Mac for the 632MB turbo variant. Used only for expectation
+ *  setting, never as a deadline. */
+const TYPICAL_WARM_SECONDS = 300
+
+export function formatWarmElapsed(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  if (total < 60) return `${total}s`
+  const minutes = Math.floor(total / 60)
+  const rest = total % 60
+  return rest === 0 ? `${minutes}m` : `${minutes}m ${rest}s`
+}
+
+/**
+ * Tooltip for a voice control disabled by a warm in progress.
+ *
+ * Says three things, in this order: it is busy rather than broken, roughly how
+ * long, and why it is happening at all. The "one time" part matters — without
+ * it a multi-minute wait reads as what every launch will be like.
+ */
+export function warmTooltip(elapsedSeconds: number): string {
+  const elapsed = formatWarmElapsed(elapsedSeconds)
+  const mins = Math.round(TYPICAL_WARM_SECONDS / 60)
+  return `Preparing the on-device model (${elapsed} so far, usually about ${mins} minutes).`
+    + ` macOS compiles it for the Neural Engine once per app update; voice is unavailable until it finishes.`
+}
+
+/** Short label for the same state where there is no room for the tooltip. */
+export function warmShortLabel(elapsedSeconds: number): string {
+  return `Preparing model… ${formatWarmElapsed(elapsedSeconds)}`
+}

--- a/codey-mac/src/hooks/useVoiceTurn.tsx
+++ b/codey-mac/src/hooks/useVoiceTurn.tsx
@@ -49,7 +49,20 @@ export const VoiceTurnProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   const transcriptHandlerRef = useRef<TranscriptHandler | null>(null)
   const voice = useChatVoice({
-    onTranscript: (text, mode) => transcriptHandlerRef.current?.(text, mode),
+    onTranscript: (text, mode) => {
+      const handler = transcriptHandlerRef.current
+      if (handler) {
+        handler(text, mode)
+        return
+      }
+      // No composer is mounted — Settings is open, say. A hotkey dictation
+      // aimed at Codey is routed here by the helper instead of being pasted,
+      // so without this the words would simply vanish. Falling back to the
+      // paste path puts them where they would have gone before.
+      if (mode === 'dictate') {
+        void window.codey.voice.notifyTranscribed(text)
+      }
+    },
     onError: msg => void window.codey.voice.showError(msg),
   })
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -160,6 +160,19 @@ export interface GatewayConfigJson {
     apiModel: string;
     /** WhisperKit model variant for local mode (e.g. openai_whisper-large-v3-turbo). */
     localModel: string;
+    /**
+     * Proper nouns the recognizer keeps getting wrong. Each term is hinted to
+     * the decoder before transcription; its aliases are rewritten to the term
+     * afterwards. A bare string is shorthand for `{ term, aliases: [] }`.
+     * Passed through to the Swift helper verbatim.
+     */
+    vocabulary?: (string | { term: string; aliases?: string[] })[];
+    /**
+     * Learn mis-hearings automatically: when dictation lands in a Codey chat
+     * and the user fixes a word before sending, the fix is folded into
+     * `vocabulary`. Defaults to on; only the Mac app acts on it.
+     */
+    vocabularyAutoLearn?: boolean;
     /** Text-to-speech (spoken replies) configuration. */
     tts?: VoiceTtsSettings;
   };

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -173,6 +173,13 @@ export interface GatewayConfigJson {
      * `vocabulary`. Defaults to on; only the Mac app acts on it.
      */
     vocabularyAutoLearn?: boolean;
+    /**
+     * Corrections seen once and waiting to see whether they repeat. A single
+     * sighting cannot tell a mis-hearing from a change of mind, so nothing
+     * rewrites a transcript until it has been observed twice. Managed by the
+     * Mac app; the Swift helper never reads it.
+     */
+    vocabularyPending?: { term: string; alias: string; count: number }[];
     /** Text-to-speech (spoken replies) configuration. */
     tts?: VoiceTtsSettings;
   };

--- a/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
@@ -116,8 +116,8 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
     /// configure the session. Returns once the connection opens and the server
     /// acknowledges the session configuration. Throws on failure.
     func startRealtimeSession(language: String) async throws {
-        let (apiKey, realtimeUrl, realtimeModel) = configLock.withLock {
-            (_config.apiKey, _config.realtimeUrl, _config.realtimeModel)
+        let (apiKey, realtimeUrl, realtimeModel, vocabulary) = configLock.withLock {
+            (_config.apiKey, _config.realtimeUrl, _config.realtimeModel, _config.vocabulary)
         }
         guard !apiKey.isEmpty else { throw TranscriptionError.noAPIKey }
         guard let url = URL(string: realtimeUrl) else {
@@ -155,7 +155,8 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         // Send session configuration
         let updateData = try buildSessionUpdate(
             language: language,
-            model: realtimeModel
+            model: realtimeModel,
+            prompt: Vocabulary.promptText(vocabulary)
         )
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             ws.send(.data(updateData)) { error in
@@ -438,13 +439,17 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
     /// Build the JSON data for `session.update` with the required `"session"`
     /// wrapper key. Uses `NSNull()` to explicitly disable server VAD so the
     /// manual commit model is the only commit source.
-    private func buildSessionUpdate(language: String, model: String) throws -> Data {
+    private func buildSessionUpdate(language: String, model: String, prompt: String?) throws -> Data {
         let lang = language.isEmpty || language == "auto" ? "" : language
         var transcription: [String: Any] = [
             "model": model,
         ]
         if !lang.isEmpty {
             transcription["language"] = lang
+        }
+        // Custom vocabulary hint, same field the batch endpoint takes.
+        if let prompt = prompt, !prompt.isEmpty {
+            transcription["prompt"] = prompt
         }
 
         let body: [String: Any] = [

--- a/voice/Sources/CodeyVoice/TextInjector.swift
+++ b/voice/Sources/CodeyVoice/TextInjector.swift
@@ -70,6 +70,19 @@ final class TextInjector {
         return true
     }
 
+    /// Is the Codey window the frontmost app right now?
+    ///
+    /// Compared by process id against our own parent rather than by bundle
+    /// identifier: Electron reports a different identifier in development than
+    /// in the shipped .app, and the helper is spawned by the very process that
+    /// owns the window, so the parent pid is exact and needs no configuration.
+    /// A helper started by hand has a shell as its parent and never matches,
+    /// which is the right answer for that case too.
+    static func isHostAppFrontmost() -> Bool {
+        guard let front = NSWorkspace.shared.frontmostApplication else { return false }
+        return front.processIdentifier == getppid()
+    }
+
     /// Pre-flight check: is there a focused UI element that will actually
     /// accept text? Used to decide between auto-inject and "show in HUD"
     /// when the user fires the hotkey without first clicking into a field.

--- a/voice/Sources/CodeyVoice/TranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/TranscriptionEngine.swift
@@ -36,8 +36,8 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
     /// Transcribe 16 kHz mono Float32 audio via the configured API.
     func transcribe(audio: [Float], language: String) async throws -> String {
         // Snapshot config under the lock so all reads see a consistent version.
-        let (apiUrl, apiKey, apiModel) = configLock.withLock {
-            (_config.apiUrl, _config.apiKey, _config.apiModel)
+        let (apiUrl, apiKey, apiModel, vocabulary) = configLock.withLock {
+            (_config.apiUrl, _config.apiKey, _config.apiModel, _config.vocabulary)
         }
         let baseURL = apiUrl.hasSuffix("/")
             ? String(apiUrl.dropLast())
@@ -51,7 +51,7 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
 
         let wavData = encodeWAV(samples: audio, sampleRate: 16000)
         let streaming = modelSupportsStreaming(apiModel)
-        let request = buildRequest(url: url, apiKey: apiKey, apiModel: apiModel, wav: wavData, language: language, streaming: streaming)
+        let request = buildRequest(url: url, apiKey: apiKey, apiModel: apiModel, wav: wavData, language: language, streaming: streaming, prompt: Vocabulary.promptText(vocabulary))
 
         return streaming
             ? try await runStreaming(request: request)
@@ -68,7 +68,7 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
         return m.contains("gpt-4o") && m.contains("transcribe")
     }
 
-    private func buildRequest(url: URL, apiKey: String, apiModel: String, wav: Data, language: String, streaming: Bool) -> URLRequest {
+    private func buildRequest(url: URL, apiKey: String, apiModel: String, wav: Data, language: String, streaming: Bool, prompt: String?) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -100,6 +100,11 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
         }
         // Streaming endpoints require JSON; the one-shot path still asks for
         // `text` so the response body is the transcript verbatim.
+        // Custom vocabulary hint. OpenAI-compatible endpoints that don't know
+        // the field ignore it, so this is safe to always send.
+        if let prompt = prompt, !prompt.isEmpty {
+            field("prompt", prompt)
+        }
         field("response_format", streaming ? "json" : "text")
         if streaming { field("stream", "true") }
 

--- a/voice/Sources/CodeyVoice/Vocabulary.swift
+++ b/voice/Sources/CodeyVoice/Vocabulary.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// One preferred spelling plus the mis-hearings that should be rewritten to it.
+///
+/// Authored in `gateway.json` under `voice.vocabulary`, either as a bare string
+/// (hint only) or as an object:
+/// ```json
+/// "vocabulary": [
+///   "WhisperKit",
+///   { "term": "Codey", "aliases": ["寇迪", "Coday", "code E"] }
+/// ]
+/// ```
+struct VocabularyTerm: Codable, Equatable {
+    /// The correct spelling. Fed to the recognizer as a prompt hint so it
+    /// biases *toward* this word while decoding.
+    var term: String
+    /// Known mis-transcriptions, rewritten to `term` after decoding. Empty is
+    /// fine — the term still works as a prompt hint.
+    var aliases: [String] = []
+
+    init(term: String, aliases: [String] = []) {
+        self.term = term
+        self.aliases = aliases
+    }
+
+    /// Accepts either a bare string or the full object form. Hand-edited
+    /// config is the normal authoring path here, so the terse form matters.
+    init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(),
+           let text = try? single.decode(String.self) {
+            self.term = text
+            self.aliases = []
+            return
+        }
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.term = try c.decodeIfPresent(String.self, forKey: .term) ?? ""
+        self.aliases = try c.decodeIfPresent([String].self, forKey: .aliases) ?? []
+    }
+}
+
+/// Custom-vocabulary support, shared by all three transcription engines.
+///
+/// Two independent halves, because neither alone is enough:
+///
+/// - `promptText` runs *before* decoding. Whisper (local, API and realtime all
+///   expose it) conditions the decoder on this text, so a name it has never
+///   seen becomes reachable instead of being snapped to a common word.
+///   Bounded to ~224 tokens by the models, so we cap it here rather than let
+///   the tail get silently trimmed.
+/// - `apply` runs *after* decoding, in the coordinator, on whatever any engine
+///   returned. It fixes the residue: mis-hearings that repeat verbatim every
+///   time, which a prompt hint alone does not always shake loose.
+enum Vocabulary {
+    /// Rough cap on the hint string. Whisper's prompt window is ~224 tokens;
+    /// CJK runs about one token per character, so 300 characters is a
+    /// conservative ceiling that also keeps the hint from crowding out the
+    /// audio's own context.
+    private static let maxPromptCharacters = 300
+
+    /// Comma-joined list of preferred spellings, or nil when there is nothing
+    /// to hint. Terms are taken in author order and stop at the cap — earlier
+    /// entries win, which makes ordering a usable priority knob.
+    static func promptText(_ terms: [VocabularyTerm]) -> String? {
+        var picked: [String] = []
+        var length = 0
+        for term in terms {
+            let word = term.term.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !word.isEmpty, !picked.contains(word) else { continue }
+            let cost = word.count + (picked.isEmpty ? 0 : 2)
+            if length + cost > maxPromptCharacters { break }
+            picked.append(word)
+            length += cost
+        }
+        return picked.isEmpty ? nil : picked.joined(separator: ", ")
+    }
+
+    /// Rewrite every known alias in `text` to its preferred spelling.
+    ///
+    /// Longest alias first, so a term whose alias is a prefix of another's
+    /// cannot shadow it. Matching is case-insensitive and guarded by ASCII
+    /// alphanumeric lookarounds: "cody" will not fire inside "codybase", while
+    /// CJK aliases — whose neighbours are never ASCII alphanumerics — always
+    /// match as plain substrings, which is the behaviour those need.
+    static func apply(_ text: String, terms: [VocabularyTerm]) -> String {
+        guard !text.isEmpty, !terms.isEmpty else { return text }
+
+        var pairs: [(alias: String, term: String)] = []
+        for entry in terms {
+            let word = entry.term.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !word.isEmpty else { continue }
+            for rawAlias in entry.aliases {
+                let alias = rawAlias.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Exact match only: an alias that differs from the term just
+                // by case ("cody" -> "Cody") is a legitimate capitalization
+                // fix, so it must not be treated as a redundant self-mapping.
+                guard !alias.isEmpty, alias != word else { continue }
+                pairs.append((alias, word))
+            }
+        }
+        guard !pairs.isEmpty else { return text }
+        pairs.sort { $0.alias.count > $1.alias.count }
+
+        var result = text
+        for pair in pairs {
+            let pattern = "(?<![A-Za-z0-9])"
+                + NSRegularExpression.escapedPattern(for: pair.alias)
+                + "(?![A-Za-z0-9])"
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+                continue
+            }
+            let range = NSRange(result.startIndex..<result.endIndex, in: result)
+            result = regex.stringByReplacingMatches(
+                in: result,
+                options: [],
+                range: range,
+                withTemplate: NSRegularExpression.escapedTemplate(for: pair.term)
+            )
+        }
+        return result
+    }
+}

--- a/voice/Sources/CodeyVoice/VoiceConfig.swift
+++ b/voice/Sources/CodeyVoice/VoiceConfig.swift
@@ -30,6 +30,10 @@ struct VoiceConfig: Codable {
     var realtimeUrl: String = "wss://api.openai.com/v1/realtime?intent=transcription"
     /// Realtime transcription model (e.g. "gpt-4o-mini-transcribe").
     var realtimeModel: String = "gpt-4o-mini-transcribe"
+    /// Custom vocabulary: proper nouns the recognizer keeps getting wrong.
+    /// Terms are hinted to the decoder before transcription and their aliases
+    /// are rewritten afterwards. See `Vocabulary`.
+    var vocabulary: [VocabularyTerm] = []
 
     enum Mode: String, Codable {
         case inject
@@ -77,6 +81,9 @@ struct VoiceConfig: Codable {
         localModel = try c.decodeIfPresent(String.self, forKey: .localModel) ?? d.localModel
         realtimeUrl = try c.decodeIfPresent(String.self, forKey: .realtimeUrl) ?? d.realtimeUrl
         realtimeModel = try c.decodeIfPresent(String.self, forKey: .realtimeModel) ?? d.realtimeModel
+        // A malformed vocabulary entry must not take down the whole config
+        // fetch — the field is hand-authored, so drop it and keep going.
+        vocabulary = ((try? c.decodeIfPresent([VocabularyTerm].self, forKey: .vocabulary)) ?? nil) ?? d.vocabulary
     }
 
     init() {}

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -29,6 +29,12 @@ final class VoiceCoordinator {
     private var state: State = .idle
     private var captureDestination: CaptureDestination = .dictation
     private var conversationCaptureGeneration = 0
+    /// Bumped whenever a turn is abandoned. The transcribe task captures the
+    /// value it started with and drops its result if it no longer matches, so
+    /// a decode the user gave up on can't inject text or resurrect the HUD
+    /// minutes later. Separate from `conversationCaptureGeneration`, which
+    /// only covers Conversation turns and also bumps on *start*.
+    private var captureGeneration = 0
     /// Whether the conversation turn in progress was started by the hotkey
     /// rather than the composer button. Only hotkey turns get a capsule — if
     /// you clicked the button you are already looking at the window.
@@ -258,7 +264,13 @@ final class VoiceCoordinator {
         case .recording:
             stopRecording()
         case .transcribing:
-            print("handleToggle: ignored, still transcribing")
+            // Give up on this turn. A cold CoreML compile can hold the decode
+            // for far longer than anyone will wait, and refusing the toggle
+            // left the only escape hatch as quitting the app. Abandon rather
+            // than restart: the press means "let go of this", and starting a
+            // recording the user didn't ask for would be its own surprise.
+            print("handleToggle: abandoning in-flight transcription")
+            abandonTranscription()
         case .speaking:
             // Barge-in: the user pressed the hotkey while Codey was talking,
             // which means they want to speak now. Kill the turn and start
@@ -349,6 +361,7 @@ final class VoiceCoordinator {
     private func cancelRecording() {
         guard state == .recording else { return }
         print("cancelRecording: Esc pressed — discarding buffer")
+        captureGeneration += 1
         removeEscMonitor()
         localEngine.stopStreaming()
         audioCapture.onChunk = nil
@@ -363,6 +376,29 @@ final class VoiceCoordinator {
         // Unconditional now that the helper raises the capsule itself: a
         // cancelled turn must take down whatever it put on screen without
         // waiting for Electron to notice.
+        hud.hide()
+        Task { await gateway.reportStatus("idle") }
+    }
+
+    /// Drop an in-flight transcription and return to idle.
+    ///
+    /// The decode itself cannot be cancelled mid-flight — neither WhisperKit's
+    /// CoreML predict nor an HTTP round trip is interruptible here — so the
+    /// work runs to completion in the background. What this does is sever the
+    /// result: `captureGeneration` moves on, the task sees the mismatch when
+    /// it finishes, and drops everything on the floor. The user gets an idle
+    /// helper immediately, which is the part that matters.
+    private func abandonTranscription() {
+        guard state == .transcribing else { return }
+        captureGeneration += 1
+        localEngine.stopStreaming()
+        realtimeEngine.cancelSession()
+        state = .idle
+        statusItem?.updateState(.idle)
+        if captureDestination.composerMode != nil {
+            conversationCaptureGeneration += 1
+            emitConversationEvent(type: "state", payload: ["state": "idle"])
+        }
         hud.hide()
         Task { await gateway.reportStatus("idle") }
     }
@@ -391,11 +427,9 @@ final class VoiceCoordinator {
             if state == .recording && captureDestination.composerMode != nil {
                 cancelRecording()
             } else if state == .transcribing && captureDestination.composerMode != nil {
-                conversationCaptureGeneration += 1
-                state = .idle
-                statusItem?.updateState(.idle)
-                emitConversationEvent(type: "state", payload: ["state": "idle"])
-                hud.hide()
+                // Same teardown as the hotkey path — routed through it so the
+                // result guard (`captureGeneration`) can't be skipped here.
+                abandonTranscription()
             } else if state == .speaking {
                 endSpeaking()
             }
@@ -511,6 +545,7 @@ final class VoiceCoordinator {
     private func handleAudioComplete(_ buffer: [Float]) {
         let destination = captureDestination
         let conversationGeneration = conversationCaptureGeneration
+        let generation = captureGeneration
         let durationStr = String(format: "%.2f", Double(buffer.count) / 16000.0)
         var peak: Float = 0
         var sumSq: Double = 0
@@ -552,8 +587,18 @@ final class VoiceCoordinator {
                     ? "realtime(\(config.realtimeModel))"
                     : "api(\(config.apiModel))"
                 print("transcribe: starting (language=\(lang.isEmpty ? "auto" : lang), provider=\(providerLabel))")
-                let text = try await activeEngine.transcribe(audio: buffer, language: lang)
+                let raw = try await activeEngine.transcribe(audio: buffer, language: lang)
+                // Single place all three engines funnel through, so the alias
+                // rewrite lives here rather than three times over.
+                let text = Vocabulary.apply(raw, terms: config.vocabulary)
+                if text != raw {
+                    print("vocabulary: rewrote \"\(raw)\" -> \"\(text)\"")
+                }
 
+                if generation != self.captureGeneration {
+                    print("transcribe: discarded abandoned result")
+                    return
+                }
                 if destination.composerMode != nil && conversationGeneration != conversationCaptureGeneration {
                     print("transcribe: discarded cancelled Conversation result")
                     return
@@ -603,6 +648,10 @@ final class VoiceCoordinator {
                 }
                 Task { await gateway.reportStatus("idle") }
             } catch {
+                // Same reasoning as the success path: an abandoned turn must
+                // not repaint the HUD with an error the user already moved on
+                // from — including the 10s load timeout they just escaped.
+                if generation != self.captureGeneration { return }
                 if destination.composerMode != nil && conversationGeneration != conversationCaptureGeneration {
                     return
                 }

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -480,10 +480,14 @@ final class VoiceCoordinator {
         }
     }
 
-    private func emitConversationEvent(type: String, payload: [String: Any] = [:]) {
+    /// `modeOverride` exists for the one turn whose destination is decided
+    /// after the fact: a hotkey dictation that turns out to be aimed at Codey
+    /// itself is captured as `.dictation` but delivered like composer
+    /// dictation. Everything else takes the mode from the destination.
+    private func emitConversationEvent(type: String, payload: [String: Any] = [:], modeOverride: String? = nil) {
         var body = payload
         body["type"] = type
-        body["mode"] = captureDestination.composerMode ?? "converse"
+        body["mode"] = modeOverride ?? captureDestination.composerMode ?? "converse"
         // Echo who started the turn so Electron mirrors this side rather than
         // tracking it independently and drifting.
         if captureDestination == .conversation { body["fromHotkey"] = conversationFromHotkey }
@@ -622,8 +626,25 @@ final class VoiceCoordinator {
                     return
                 }
 
-                let canInject = TextInjector.canInjectAtCurrentFocus()
+                // Dictating into Codey's own window: hand the transcript to
+                // the app rather than pasting it. Only that path can compare
+                // what was heard against what the user actually sends, which
+                // is what teaches the dictionary — pasted text is
+                // indistinguishable from typing by the time it lands. The
+                // renderer falls back to pasting if no composer is mounted,
+                // so nothing is lost when the window is on another tab.
                 let finalText = text
+                if !finalText.isEmpty && TextInjector.isHostAppFrontmost() {
+                    print("dictation: Codey is frontmost, routing to the composer")
+                    emitConversationEvent(type: "transcript", payload: ["text": finalText], modeOverride: "dictate")
+                    state = .idle
+                    statusItem?.updateState(.idle)
+                    await MainActor.run { self.hud.show(.success) }
+                    Task { await gateway.reportStatus("idle") }
+                    return
+                }
+
+                let canInject = TextInjector.canInjectAtCurrentFocus()
                 if !finalText.isEmpty && canInject {
                     print("inject: mode=\(config.injection)")
                     textInjector.inject(finalText)

--- a/voice/Sources/CodeyVoice/WhisperKitEngine.swift
+++ b/voice/Sources/CodeyVoice/WhisperKitEngine.swift
@@ -37,10 +37,56 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     private var lastUsed: Date = .distantPast
     // Kept the pipeline warm across pauses in dictation. 30s was over-eager —
     // it punished every "type a sentence, think, type another" cadence with a
-    // 1–3s cold reload. 5 min covers normal interactive use; the unload still
-    // fires when the user genuinely walks away.
-    private let idleUnloadAfter: TimeInterval = 300
+    // 1-3s cold reload. 5 min turned out to be over-eager too: a measured cold
+    // reload of large-v3-turbo is ~4.8s, and dictation across a working
+    // session has gaps far longer than five minutes, so the reload was landing
+    // on a large share of presses. 30 min covers a working session while still
+    // releasing the ~600 MB and the ANE state when the user genuinely walks
+    // away, which was the point of moving off whisper.cpp's eager context.
+    private let idleUnloadAfter: TimeInterval = 1800
+    /// How long to wait for the pipeline before giving up.
+    ///
+    /// This was 10s, which is right for the steady state — a warm load is
+    /// ~200ms and a cold one ~5s — but wrong for the case that actually
+    /// matters: when CoreML has to recompile the model for the Neural Engine
+    /// it takes minutes (measured at 315s), and that recompile is triggered by
+    /// something the user never sees, namely a new build of this binary. The
+    /// old budget turned a slow-but-succeeding load into a hard failure, and
+    /// the log said so in the same breath as "ready (load took 314.7s)".
+    ///
+    /// Ten minutes is not a wait anyone should sit through; it is a ceiling
+    /// that stops a genuinely wedged load from hanging forever. The user's
+    /// escape hatch is pressing the key again, which now abandons the turn.
+    private static let loadTimeoutSeconds: TimeInterval = 600
+    /// Past this, say out loud that we are compiling rather than hanging.
+    private static let slowLoadWarnSeconds: TimeInterval = 8
+    /// Pin compute units: ANE for the encoder (fastest on M-series, big mel +
+    /// attention layers), GPU for the decoder (token-by-token autoregressive,
+    /// ANE underutilized here). This is the WhisperKit benchmark-winning combo
+    /// on Apple Silicon - leaving it at `.all` sometimes lets CoreML route the
+    /// encoder to GPU, costing 30-40% throughput.
+    ///
+    /// Exposed rather than local because CoreML compiles and caches per
+    /// compute-unit configuration, so the `--warm-model` path has to ask for
+    /// the exact same one. It used to use the default, which meant every warm
+    /// compiled a variant the engine never loads: the marker recorded a
+    /// plausible-looking 12.9s while the first real press still paid the full
+    /// ~320s ANE compile. Anything that loads this model must go through here.
+    static let computeOptions = ModelComputeOptions(
+        audioEncoderCompute: .cpuAndNeuralEngine,
+        textDecoderCompute: .cpuAndGPU
+    )
     private let loadQueue = DispatchQueue(label: "codey.voice.whisperkit.load")
+    /// The load currently in flight, with the variant it is loading.
+    ///
+    /// `ensurePipeline` is reachable from three places at once — the streaming
+    /// task, prewarm, and the final transcribe — and none of them held a lock,
+    /// so a cold start could enter it concurrently and materialize the same
+    /// ~600 MB of weights more than once. Callers now join the in-flight load
+    /// instead. Keyed by variant so a load kicked off before the user switched
+    /// models isn't handed back as if it were the new one.
+    private var loadTask: (model: String, task: Task<WhisperKit, Error>)?
+    private let loadTaskLock = NSLock()
     /// Background sliding-window task that pulls partial transcripts from the
     /// in-progress recording. Owned by the engine so we can cancel it on
     /// stop/cancel without the coordinator having to track Task lifetimes.
@@ -190,6 +236,23 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         }
     }
 
+    // Custom vocabulary is NOT hinted to this engine, unlike the API and
+    // realtime ones. `DecodingOptions.promptTokens` is broken in the pinned
+    // WhisperKit: setting it to anything at all makes `transcribe` return an
+    // empty string. Measured on large-v3-v20240930_turbo_632MB against a
+    // 5.7s clip — 96 chars without it, 0 chars with it, across eleven option
+    // combinations (VAD on/off, timestamps on/off, prefill cache off,
+    // sampleLength 144/224, one worker, explicit language, no first-token
+    // threshold, no temperature fallback, longer prompt). `prefixTokens` is
+    // not a substitute: it force-feeds the words as the *start of the
+    // transcript*, which ate the first word of the sentence.
+    //
+    // So on-device gets the second half of the feature only — aliases are
+    // still rewritten after decoding, in VoiceCoordinator. Re-check on the
+    // next WhisperKit bump; if promptTokens starts working, restore the hint
+    // here and remember that setting it also disables the kv-cache prefill,
+    // so it must stay nil when the user has no vocabulary configured.
+
     /// Decode options shared by the streaming loop and the post-stop "settle"
     /// decode. Kept lean — temperature fallback off, fewer workers — because
     /// these run on a partial buffer and we want fast iteration; the final
@@ -278,7 +341,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
             streamingTask = nil
         }
 
-        let pipe = try await withLoadTimeout(seconds: 10) { try await self.ensurePipeline() }
+        let pipe = try await withLoadTimeout(seconds: Self.loadTimeoutSeconds) { try await self.ensurePipeline() }
         lastUsed = Date()
 
         // Peak-normalize to ~0.9 before sending. Mic levels often peak around
@@ -309,10 +372,19 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         // Skip silence chunks via voice activity detection — large win on
         // press-to-talk audio that has leading/trailing silence and pauses.
         options.chunkingStrategy = .vad
-        // If a chunk decodes with very low logprob, retry with slightly higher
-        // temperature instead of returning an empty/garbled result. CJK on
-        // quantized turbo trips this often; 0 means "give up, return empty".
-        options.temperatureFallbackCount = 2
+        // Retrying a low-confidence chunk at a higher temperature costs a full
+        // extra decode pass each time, and CJK on quantized turbo trips the
+        // threshold often enough that the same audio could run three times.
+        // That is the source of the "sometimes 1s, sometimes 5s" spread the
+        // user actually feels; the quality it buys back is a marginally
+        // cleaner sentence on the clips that were already marginal. The
+        // streaming pass has always run at 0 for the same reason.
+        //
+        // Empty results are not a risk we are trading away here: the streaming
+        // partial is still there as a fallback, and the one confirmed cause of
+        // empty output turned out to be `promptTokens` (see the note above),
+        // not the temperature floor.
+        options.temperatureFallbackCount = 0
         // VAD splits long press-to-talk clips into N voiced chunks; with
         // workers > 1 they decode concurrently. 4 saturates ANE+GPU on
         // M-series; short single-chunk clips are unaffected.
@@ -383,28 +455,70 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
 
     private func ensurePipeline() async throws -> WhisperKit {
         let currentModel = configLock.withLock { _config.localModel }
-        if let p = pipeline, loadedModel == currentModel {
-            return p
-        }
         // WhisperKit's HF glob is `*openai*<variant>/*`; the variant must be
         // the bare name (`large-v3-turbo`), not the full folder name
         // (`openai_whisper-large-v3-turbo`). UI/config may store either form.
+        //
+        // Normalize BEFORE the cache check. `loadedModel` records the
+        // normalized name, so comparing it against the raw config value meant
+        // a config holding the prefixed form — which is what the model picker
+        // writes — never matched, and every single transcription silently
+        // reloaded the pipeline from disk. Measured at ~4.1s of a ~5.4s
+        // "warm" decode, i.e. most of the wait was this.
         let modelName = normalizeVariant(currentModel)
+        if let p = pipeline, loadedModel == modelName {
+            return p
+        }
+
+        // Join an in-flight load for the same variant rather than starting a
+        // second one. The task clears itself on the way out, so a failed load
+        // is retried by the next caller instead of being cached as a failure.
+        let task: Task<WhisperKit, Error> = loadTaskLock.withLock {
+            if let existing = loadTask, existing.model == modelName {
+                return existing.task
+            }
+            let created = Task<WhisperKit, Error> { [weak self] in
+                guard let self = self else {
+                    throw NSError(domain: "WhisperKitEngine", code: -3, userInfo: [NSLocalizedDescriptionKey: "Engine deallocated during load"])
+                }
+                defer {
+                    self.loadTaskLock.withLock {
+                        if self.loadTask?.model == modelName { self.loadTask = nil }
+                    }
+                }
+                return try await self.loadPipeline(named: modelName)
+            }
+            loadTask = (modelName, created)
+            return created
+        }
+        return try await task.value
+    }
+
+    /// Materialize the CoreML pipeline. Only ever called from the single task
+    /// `ensurePipeline` owns, so it doesn't need its own guarding.
+    private func loadPipeline(named modelName: String) async throws -> WhisperKit {
         let t0 = Date()
         print("WhisperKitEngine: loading model '\(modelName)'")
 
-        // Pin compute units: ANE for encoder (fastest on M-series, big mel +
-        // attention layers), GPU for decoder (token-by-token autoregressive,
-        // ANE underutilized here). This is the WhisperKit benchmark-winning
-        // combo on Apple Silicon — leaving it to .all sometimes lets CoreML
-        // route encoder to GPU, costing 30-40% throughput.
-        let computeOptions = ModelComputeOptions(
-            audioEncoderCompute: .cpuAndNeuralEngine,
-            textDecoderCompute: .cpuAndGPU
-        )
+        // A silent multi-minute load is indistinguishable from a hang, and
+        // this one has a specific cause worth naming: CoreML recompiles for
+        // the Neural Engine whenever the client binary changes, so the first
+        // press after an app update pays it once. Ticking here turns "Codey
+        // is broken" into "Codey is busy, and here is why".
+        let heartbeat = Task.detached(priority: .utility) {
+            var waited: TimeInterval = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(Self.slowLoadWarnSeconds * 1_000_000_000))
+                if Task.isCancelled { break }
+                waited += Self.slowLoadWarnSeconds
+                print(String(format: "WhisperKitEngine: still preparing '%@' (%.0fs) - CoreML is compiling for the Neural Engine, this happens once per app build", modelName, waited))
+            }
+        }
+        defer { heartbeat.cancel() }
+
         let kitConfig = WhisperKitConfig(
             model: modelName,
-            computeOptions: computeOptions,
+            computeOptions: Self.computeOptions,
             verbose: false,
             logLevel: .info,
             prewarm: false,
@@ -424,7 +538,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
             group.addTask { try await op() }
             group.addTask {
                 try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw NSError(domain: "WhisperKitEngine", code: -1, userInfo: [NSLocalizedDescriptionKey: "Model load/transcribe timed out after \(Int(seconds))s"])
+                throw NSError(domain: "WhisperKitEngine", code: -1, userInfo: [NSLocalizedDescriptionKey: "Model still not ready after \(Int(seconds))s. Try again - the load continues in the background."])
             }
             guard let first = try await group.next() else {
                 throw NSError(domain: "WhisperKitEngine", code: -2, userInfo: [NSLocalizedDescriptionKey: "Task group returned no result"])

--- a/voice/Sources/CodeyVoice/main.swift
+++ b/voice/Sources/CodeyVoice/main.swift
@@ -59,8 +59,13 @@ if let wIdx = cliArgs.firstIndex(of: "--warm-model"), wIdx + 1 < cliArgs.count {
             // this is a no-op fetch + path resolution. download: false makes
             // WhisperKit throw "model folder is not set" because nothing in
             // this CLI path tells it where the variant lives.
+            // Must match WhisperKitEngine exactly: CoreML caches its compiled
+            // model per compute-unit configuration, so warming with different
+            // units populates a cache the engine never reads and leaves the
+            // real compile to ambush the user's first press.
             let kitConfig = WhisperKitConfig(
                 model: variant,
+                computeOptions: WhisperKitEngine.computeOptions,
                 verbose: false,
                 logLevel: .info,
                 prewarm: false,
@@ -76,6 +81,13 @@ if let wIdx = cliArgs.firstIndex(of: "--warm-model"), wIdx + 1 < cliArgs.count {
             options.task = .transcribe
             options.temperature = 0.0
             options.sampleLength = 32
+            // Mirror the engine's decode shape so the same sub-models get
+            // compiled here rather than on the first press.
+            options.withoutTimestamps = true
+            options.usePrefillPrompt = true
+            options.chunkingStrategy = .vad
+            options.temperatureFallbackCount = 0
+            options.concurrentWorkerCount = 4
             _ = try await pipe.transcribe(audioArray: silence, decodeOptions: options)
             let elapsed = Date().timeIntervalSince(t0)
             print(String(format: "warm:done %.2f", elapsed))


### PR DESCRIPTION
Dictation was slow, unstable, and kept mangling proper nouns. Three related pieces: a dictionary the user controls, a learner that fills it in, and the load-path fixes that fell out of measuring why `transcribing` took so long.

## Dictionary

`voice.vocabulary` holds preferred spellings plus the mis-hearings that map onto them. Aliases are rewritten after decoding, in one place in `VoiceCoordinator`, so all three engines get it. Editable in Voice settings — rows collapse to the word, expand to a textarea of its mis-hearings.

The API and realtime engines also receive the terms as a decoder prompt. **The on-device engine deliberately does not:** `promptTokens` is broken in the pinned WhisperKit and makes `transcribe` return an empty string.

| | 5.7s clip |
|---|---|
| without `promptTokens` | 96 chars |
| with `promptTokens` | **0 chars** |

Eleven option combinations tried (VAD on/off, timestamps on/off, prefill cache off, sampleLength 144/224, one worker, explicit language, no first-token threshold, no temperature fallback, longer prompt) — all empty. `prefixTokens` is not a substitute: it force-feeds the words as the *start of the transcript* and ate the first word of the sentence.

## Learning from edits

Dictating into a Codey chat and fixing a word before sending folds that fix into the dictionary; a pill above the composer names what was learned.

Only *replacements* are learned, and only ones that look like mis-hearings — either the spellings share most of their characters, or they **cross scripts** (a transliteration shares none by definition, and is the main case this exists for). A share-of-the-message threshold was tried first and kept rejecting short utterances, where fixing one name is most of the sentence.

The merge runs in the main process because `config:set` replaces the whole `voice` object, so a renderer doing it itself would clobber Settings.

## Speed

Two silent bugs, both pre-existing, both measured:

**The pipeline cache never hit.** `ensurePipeline` compared the raw config value (`openai_whisper-…`) against a normalized cache key (`large-v3-…`), so every single transcription reloaded the model from disk — ~4.1s of a ~5.4s "warm" decode.

| repeat decode | before | after |
|---|---|---|
| Chinese | 5.45s / 5.15s / 5.63s | **1.35s / 1.34s / 1.34s** |
| English | — | **1.26s / 1.25s / 1.24s** |

**The warm compiled something the engine never loads.** `--warm-model` used default compute units while the engine pins ANE encoder / GPU decoder. CoreML caches per compute-unit configuration, so the marker recorded a plausible-looking 12.9s while the first real press still paid the full ~320s compile.

| | before | after |
|---|---|---|
| warm duration | 12.9s (compiling the wrong thing) | **318s (real work)** |
| engine load behind it | **320s** | **6.4s** |

Also: the warm marker is now keyed on the helper binary as well as the OS build (it was OS-only, so an app update read as "already warmed" and the startup warm skipped — the exact case the mechanism exists to prevent); warming runs at launch rather than only when the Whisper settings tab is open; model loads are serialized behind one task; idle unload moved 5 → 30 min; the final decode no longer retries at higher temperature (that retry was the "sometimes 1s, sometimes 5s" spread).

## Getting unstuck

The load budget was 10s, which turned a slow-but-succeeding load into a hard failure — the log read `ready (load took 314.7s)` and `timed out after 10s` in the same breath. Now 600s, with a heartbeat naming the CoreML compile so a multi-minute wait is legible rather than indistinguishable from a hang.

Pressing the key during transcription now abandons the turn instead of being ignored. The decode itself cannot be cancelled, so a generation counter severs the result — including on the error path, so an abandoned turn cannot repaint the HUD with an error the user already walked away from.

While a warm is running the composer's voice buttons grey out and explain themselves. The state is both pushed *and* pulled, because the startup warm begins before the window exists and runs for minutes, so missing the start event is the normal case.

## Verification

- `npm test` — 1638 pass (14 new: dictionary parsing, learner accept/reject, merge caps, warm-status copy)
- `npx tsc --noEmit` — renderer and electron
- `npx vite build`, `swift build`, `npm run lint`
- Swift has no test target (`main.swift` top-level code makes `@testable import` unreliable), so its pure logic was checked with a throwaway `swiftc` harness — which caught 2 real bugs — and the engine paths were measured end-to-end on-device.

## Not covered

- The global hotkey still fires during a warm; it waits rather than being blocked, though the heartbeat now explains it and a second press abandons.
- LLM punctuation/formatting cleanup was scoped out deliberately — it would add latency back to the path this PR just made fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)