### PR TITLE
fix(mac): keep the bottom Terminal open across chat switches

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -29,6 +29,7 @@ import { ShimmerStatus } from './ShimmerStatus'
 import { statusLine } from './checklistView'
 import { composerPlaceholder } from './coreOfflineView'
 import { getDraft, setDraft } from './chatDrafts'
+import { isBottomTerminalOpen, setBottomTerminalOpen as rememberBottomTerminalOpen } from './terminalVisibility'
 import { AGENT_API_TYPE, AGENT_NAMES, ApiType, modelFitsApiType } from './modelApiType'
 import { useInstalledAgents } from './installedAgents'
 import { applyMention, filterEntries, findActiveMention, splitMentionSegments } from './mentions'
@@ -963,7 +964,9 @@ export const ChatTab: React.FC<Props> = ({
   )
   // Settings switch. Off hides both status surfaces and suppresses brief generation.
   const statusPanelEnabled = useStatusPanelEnabled()
-  const [bottomTerminalOpen, setBottomTerminalOpen] = useState(false)
+  // Seeded from the module store so a Terminal left open survives the remount
+  // that a chat switch causes (App.tsx keys ChatTab by chat id).
+  const [bottomTerminalOpen, setBottomTerminalOpen] = useState(() => isBottomTerminalOpen(chatId))
   const [bottomTerminalHeight, setBottomTerminalHeight] = useState<number>(() => {
     const value = Number(localStorage.getItem('codey.bottomTerminalHeight'))
     return Number.isFinite(value) ? Math.max(180, Math.min(560, value)) : 280
@@ -1295,6 +1298,7 @@ export const ChatTab: React.FC<Props> = ({
     })
   }, [restoreText, chatId])
   useEffect(() => { localStorage.setItem('codey.bottomTerminalHeight', String(bottomTerminalHeight)) }, [bottomTerminalHeight])
+  useEffect(() => { rememberBottomTerminalOpen(chatId, bottomTerminalOpen) }, [chatId, bottomTerminalOpen])
   // Track window width so the context panel can shrink (or be hidden) when
   // the user resizes Codey down — at small widths the middle column was
   // collapsing to ~200px and wrapping CJK characters one per line.

--- a/codey-mac/src/components/terminalVisibility.test.ts
+++ b/codey-mac/src/components/terminalVisibility.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  isBottomTerminalOpen,
+  setBottomTerminalOpen,
+  __resetBottomTerminalVisibility,
+} from './terminalVisibility'
+
+describe('bottom terminal visibility', () => {
+  beforeEach(() => { __resetBottomTerminalVisibility() })
+
+  it('defaults to closed', () => {
+    expect(isBottomTerminalOpen('chat-1')).toBe(false)
+  })
+
+  it('remembers an open terminal across a chat switch and back', () => {
+    setBottomTerminalOpen('chat-1', true)
+    // Switching to another chat must not surface chat-1's terminal there...
+    expect(isBottomTerminalOpen('chat-2')).toBe(false)
+    // ...and switching back must still show it.
+    expect(isBottomTerminalOpen('chat-1')).toBe(true)
+  })
+
+  it('forgets a closed terminal', () => {
+    setBottomTerminalOpen('chat-1', true)
+    setBottomTerminalOpen('chat-1', false)
+    expect(isBottomTerminalOpen('chat-1')).toBe(false)
+  })
+})

--- a/codey-mac/src/components/terminalVisibility.ts
+++ b/codey-mac/src/components/terminalVisibility.ts
@@ -1,0 +1,21 @@
+// Per-chat bottom-Terminal visibility. ChatTab is remounted on every chat
+// switch (App.tsx keys it by chat id), so its local `bottomTerminalOpen` state
+// reset to false and the Terminal vanished when the user came back — even
+// though the shell sessions themselves live on in the main process. We keep the
+// open/closed flag in a module-level store keyed by chat id so it survives that
+// remount, mirroring chatDrafts.ts.
+const openChats = new Set<string>()
+
+export function isBottomTerminalOpen(chatId: string): boolean {
+  return openChats.has(chatId)
+}
+
+export function setBottomTerminalOpen(chatId: string, open: boolean): void {
+  if (open) openChats.add(chatId)
+  else openChats.delete(chatId)
+}
+
+// Test-only: reset the store between cases.
+export function __resetBottomTerminalVisibility(): void {
+  openChats.clear()
+}


### PR DESCRIPTION
## What

Open the bottom Terminal in a chat, switch to another chat, switch back — the Terminal was gone.

`App.tsx` keys `ChatTab` by chat id, so every chat switch remounts it and `bottomTerminalOpen` fell back to its `useState(false)` default. The shell sessions themselves were fine (they live in the main process, keyed by chat + cwd) — only the visibility flag was lost.

## How

New `terminalVisibility.ts` module-level store keyed by chat id, mirroring the existing `chatDrafts.ts` pattern. `ChatTab` seeds `bottomTerminalOpen` from it on mount and writes back on change.

## Test

- `codey-mac/src/components/terminalVisibility.test.ts` — 3 cases (default closed, survives switch-away-and-back without leaking into other chats, forgets on close). All pass.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)