### PR TITLE
fix(mac): keep the transcript pinned to the bottom while composing

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1251,6 +1251,25 @@ export const ChatTab: React.FC<Props> = ({
     return () => cancelAnimationFrame(frame)
   }, [chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length, chat?.contextPanelOpen, updateLatestMessageVisibility])
 
+  // The deps above can't see every way the transcript moves: a tool card
+  // expanding, a status row appearing mid-turn, or the composer growing as the
+  // user types (which shrinks the viewport and pushes the last message out of
+  // sight without any React state changing). Observe the boxes instead, so a
+  // pinned view stays pinned whatever caused the shift.
+  useEffect(() => {
+    const messages = messagesRef.current
+    if (!messages) return
+    const stick = () => {
+      if (stickToBottomRef.current) messages.scrollTop = messages.scrollHeight
+      updateLatestMessageVisibility()
+    }
+    const resize = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(stick) : null
+    resize?.observe(messages)
+    const mutate = typeof MutationObserver !== 'undefined' ? new MutationObserver(stick) : null
+    mutate?.observe(messages, { childList: true, subtree: true, characterData: true })
+    return () => { resize?.disconnect(); mutate?.disconnect() }
+  }, [updateLatestMessageVisibility])
+
   const scrollToLatestMessage = useCallback(() => {
     const messages = messagesRef.current
     if (!messages) return


### PR DESCRIPTION
## What

When you were scrolled to the bottom of a chat and then typed a message, the view stopped following the newest message.

## Why

Typing a multi-line prompt grows the composer textarea, which shrinks the message viewport. The newest message gets pushed out of sight, but no React state changes — so the existing scroll effect (keyed on message count / last message content / tool calls) never fires and the transcript silently unpins.

The same blind spot hides other growth: a tool card expanding, a status row appearing mid-turn.

## How

Observe the boxes instead of guessing at deps, in `ChatTab.tsx`:

- `ResizeObserver` on the scroll container — catches the viewport shrinking or growing.
- `MutationObserver` on its subtree — catches content growth.

Either one re-pins to the bottom, but only if `stickToBottomRef` says the user was already there. Someone who scrolled up keeps their position and still gets the jump-to-latest button.

## Testing

- `npx tsc --noEmit -p codey-mac/tsconfig.json` — clean
- `npm test -w codey-mac` — 757 passed

No unit test for the scroll itself: jsdom has no layout, so `scrollHeight` is always 0 and the behavior can't be observed there. Verified by the reproduction described above; worth a quick manual check in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)