### PR TITLE
feat(mac): add responsive browser settings page

### DIFF
--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -448,3 +448,217 @@ describe('sanitizeBounds', () => {
       .toEqual({ x: 10, y: 10, width: 100, height: 100 })
   })
 })
+
+describe('BrowserController profiles', () => {
+  function makeFixture(dir: string, overrides: {
+    tabs?: Array<{ id: string; view: { webContents: any } }>
+    session?: any
+    options?: any
+  } = {}) {
+    const cookiesGet = vi.fn(async () => [
+      { name: 'sid', value: 'abc', domain: 'example.com', path: '/', secure: true, httpOnly: true, sameSite: 'lax', hostOnly: false },
+    ])
+    const cookiesSet = vi.fn(async () => {})
+    const cookiesRemove = vi.fn(async () => {})
+    const session = overrides.session ?? { cookies: { get: cookiesGet, set: cookiesSet, remove: cookiesRemove } }
+    const contents = {
+      isDestroyed: vi.fn(() => false),
+      getURL: vi.fn(() => 'https://example.com/dashboard'),
+      getTitle: vi.fn(() => 'Dashboard'),
+      executeJavaScript: vi.fn(async (_script: string) => ({
+        origin: 'https://example.com',
+        entries: [{ name: 'token', value: 't0k3n' }],
+      })),
+      close: vi.fn(),
+      once: vi.fn(),
+      loadURL: vi.fn(async () => {}),
+    }
+    const tabs = overrides.tabs ?? [{ id: 't1', view: { webContents: contents } }]
+    const controller = new BrowserController(
+      () => null,
+      vi.fn(),
+      vi.fn(),
+      undefined,
+      () => session as any,
+      { getProfilesDir: () => dir, ...(overrides.options ?? {}) },
+    )
+    ;(controller as any).tabs = tabs
+    ;(controller as any).view = tabs[0]?.view ?? null
+    return { controller, session, contents, cookiesGet, cookiesSet, cookiesRemove }
+  }
+
+  it('saves the live session into a named profile file', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller, contents } = makeFixture(dir)
+      const profile = await controller.saveProfile('work')
+      expect(profile.name).toBe('work')
+      expect(profile.sourceUrl).toBe('https://example.com/dashboard')
+      expect(profile.cookies).toEqual([expect.objectContaining({ name: 'sid', value: 'abc', domain: 'example.com', expires: -1 })])
+      expect(profile.origins).toEqual([{ origin: 'https://example.com', localStorage: [{ name: 'token', value: 't0k3n' }] }])
+      // The capture script only reads localStorage — never page text or fields.
+      const script = contents.executeJavaScript.mock.calls[0][0]
+      expect(script).toContain('localStorage')
+      expect(script).not.toContain('innerText')
+      const stored = JSON.parse(fs.readFileSync(path.join(dir, 'work.json'), 'utf8'))
+      expect(stored.name).toBe('work')
+      expect(controller.listProfiles()[0]).toMatchObject({ name: 'work', cookieCount: 1, originCount: 1, active: false })
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects unsafe profile names', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller } = makeFixture(dir)
+      await expect(controller.saveProfile('../evil')).rejects.toThrow(/Profile names/)
+      await expect(controller.activateProfile('.hidden')).rejects.toThrow(/Profile names/)
+      await expect(controller.deleteProfile('a/b')).rejects.toThrow(/Profile names/)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('imports Playwright storageState JSON and activates it by default', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      // The profile's only origin (github.com) is not open in any tab, so a
+      // hidden view applies its localStorage — stub it because the test
+      // environment has no real Electron views.
+      const hidden = {
+        webContents: {
+          isDestroyed: vi.fn(() => false),
+          getURL: vi.fn(() => 'about:blank'),
+          executeJavaScript: vi.fn(async (_script: string) => true),
+          once: vi.fn((event: string, cb: () => void) => { if (event === 'did-finish-load') cb() }),
+          loadURL: vi.fn(async () => {}),
+          close: vi.fn(),
+        },
+      }
+      const { controller, cookiesSet, cookiesRemove } = makeFixture(dir, {
+        options: { createHiddenView: () => hidden },
+      })
+      const json = JSON.stringify({
+        cookies: [
+          { name: 'gh', value: 'tok', domain: 'github.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'Lax' },
+        ],
+        origins: [{ origin: 'https://github.com', localStorage: [{ name: 'gh-token', value: 'xyz' }] }],
+      })
+      const profile = await controller.importProfile('gh', { json }, true)
+      expect(profile.name).toBe('gh')
+      // Activating removed the live cookies and applied the profile's.
+      expect(cookiesRemove).toHaveBeenCalledWith('https://example.com/', 'sid')
+      expect(cookiesSet).toHaveBeenCalledWith(expect.objectContaining({
+        url: 'https://github.com/',
+        name: 'gh',
+        domain: 'github.com',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'lax',
+      }))
+      expect(controller.activeProfileName()).toBe('gh')
+      expect(controller.listProfiles().find(profile => profile.name === 'gh')?.active).toBe(true)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('import with activate:false stores without switching identity', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller, cookiesSet } = makeFixture(dir)
+      await controller.importProfile('work', { json: '{"cookies":[]}' }, false)
+      expect(controller.activeProfileName()).toBeNull()
+      expect(cookiesSet).not.toHaveBeenCalled()
+      expect(controller.listProfiles()).toHaveLength(1)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('applies localStorage through an already-open tab when available', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      // The fixture's tab is already on https://example.com, so applying that
+      // origin's storage goes through the open tab, never a hidden view.
+      const createHiddenView = vi.fn()
+      const { controller, contents } = makeFixture(dir, { options: { createHiddenView } })
+      await controller.importProfile('work', { json: JSON.stringify({
+        cookies: [],
+        origins: [{ origin: 'https://example.com', localStorage: [{ name: 'token', value: 'new' }] }],
+      }) }, true)
+      const setCalls = contents.executeJavaScript.mock.calls.map(call => call[0])
+      const applyScript = setCalls.find(script => script.includes('localStorage.setItem'))
+      expect(applyScript).toContain('"name":"token"')
+      // No hidden view was needed because the tab was already on the origin.
+      expect(createHiddenView).not.toHaveBeenCalled()
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses a hidden view to apply localStorage of origins that are not open', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const hidden = {
+        webContents: {
+          isDestroyed: vi.fn(() => false),
+          getURL: vi.fn(() => 'about:blank'),
+          executeJavaScript: vi.fn(async (_script: string) => true),
+          once: vi.fn((event: string, cb: () => void) => { if (event === 'did-finish-load') cb() }),
+          loadURL: vi.fn(async () => {}),
+          close: vi.fn(),
+        },
+      }
+      const { controller } = makeFixture(dir, {
+        tabs: [{ id: 't1', view: { webContents: { ...hidden.webContents } } }],
+        options: { createHiddenView: () => hidden },
+      })
+      await controller.importProfile('work', { json: JSON.stringify({
+        cookies: [],
+        origins: [{ origin: 'https://github.com', localStorage: [{ name: 'gh', value: 'tok' }] }],
+      }) }, true)
+      expect(hidden.webContents.loadURL).toHaveBeenCalledWith('https://github.com/')
+      expect(hidden.webContents.close).toHaveBeenCalled()
+      const applyScript = hidden.webContents.executeJavaScript.mock.calls[0][0]
+      expect(applyScript).toContain('localStorage.setItem')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('activate is a no-op when the profile is already active, and delete clears it', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller, cookiesSet, cookiesRemove } = makeFixture(dir)
+      await controller.importProfile('work', { json: '{"cookies":[]}' }, true)
+      expect(controller.activeProfileName()).toBe('work')
+      cookiesRemove.mockClear()
+      cookiesSet.mockClear()
+      const summary = await controller.activateProfile('work')
+      expect(summary.active).toBe(true)
+      expect(cookiesRemove).not.toHaveBeenCalled()
+      await controller.deleteProfile('work')
+      expect(controller.activeProfileName()).toBeNull()
+      expect(controller.listProfiles()).toEqual([])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('exportProfile writes the profile to an arbitrary path', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller } = makeFixture(dir)
+      await controller.importProfile('work', { json: '{"cookies":[]}' }, false)
+      const out = path.join(dir, '..', 'exported-work.json')
+      const result = await controller.exportProfile('work', out)
+      expect(result.path).toBe(path.resolve(out))
+      expect(JSON.parse(fs.readFileSync(out, 'utf8')).name).toBe('work')
+      fs.rmSync(out, { force: true })
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -9,6 +9,17 @@ import {
   type WebContents,
 } from 'electron'
 import type { BrowserSitePermissionDetails, BrowserSitePermissionManager } from './browser-site-permissions'
+import {
+  assertProfileName,
+  BrowserProfileStore,
+  parseProfileJsonText,
+  readProfileJson,
+  type BrowserProfile,
+  type BrowserProfileCookie,
+  type BrowserProfileData,
+  type BrowserProfileStorageOrigin,
+  type BrowserProfileSummary,
+} from './browser-profiles'
 
 export const BROWSER_PARTITION = 'persist:codey-browser'
 
@@ -74,6 +85,15 @@ export interface BrowserActionResult {
 export interface HumanInputOptions {
   random?: () => number
   sleep?: (ms: number) => Promise<void>
+}
+
+/** Constructor seams for the browser profile feature: where profile files live
+ *  (defaults to a temp dir so the controller works without the app), and a
+ *  factory for the hidden page used to apply localStorage of origins that are
+ *  not currently open (injectable so tests need no real Electron). */
+export interface BrowserControllerOptions extends HumanInputOptions {
+  getProfilesDir?: () => string
+  createHiddenView?: () => WebContentsView
 }
 
 export interface BrowserWaitRequest {
@@ -220,6 +240,10 @@ export class BrowserController {
   private pointer: { x: number; y: number } | null = null
   private readonly random: () => number
   private readonly sleep: (ms: number) => Promise<void>
+  private readonly getProfilesDir: () => string
+  private readonly createHiddenView?: () => WebContentsView
+  private profileStore: BrowserProfileStore | null = null
+  private profileStoreDir: string | null = null
 
   constructor(
     private readonly getWindow: () => BrowserWindow | null,
@@ -227,10 +251,33 @@ export class BrowserController {
     private readonly onDownload: (download: BrowserDownload) => void = () => {},
     private readonly getDownloadDirectory: () => string = () => path.join(os.tmpdir(), 'codey-downloads'),
     private readonly getBrowserSession: () => Session = () => session.fromPartition(BROWSER_PARTITION, { cache: true }),
-    options: HumanInputOptions = {},
+    options: BrowserControllerOptions = {},
   ) {
     this.random = options.random ?? Math.random
     this.sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
+    this.getProfilesDir = options.getProfilesDir ?? (() => path.join(os.tmpdir(), 'codey-browser-profiles'))
+    // Hidden page used to apply a profile's localStorage for origins that are
+    // not currently open in a tab. Shares the browser's persistent partition,
+    // so it reads and writes the same storage the visible tabs use.
+    this.createHiddenView = options.createHiddenView ?? (() => new WebContentsView({
+      webPreferences: {
+        partition: BROWSER_PARTITION,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        webSecurity: true,
+        backgroundThrottling: false,
+      },
+    }))
+  }
+
+  private profiles(): BrowserProfileStore {
+    const dir = this.getProfilesDir()
+    if (!this.profileStore || this.profileStoreDir !== dir) {
+      this.profileStore = new BrowserProfileStore(dir)
+      this.profileStoreDir = dir
+    }
+    return this.profileStore
   }
 
   setSitePermissionManager(manager: BrowserSitePermissionManager): void {
@@ -880,6 +927,255 @@ export class BrowserController {
     await browserSession.clearCache()
     await browserSession.clearAuthCache()
     return this.patchState({ ...EMPTY_STATE })
+  }
+
+  // ── Profiles ─────────────────────────────────────────────────────────
+  // A profile is a named snapshot of the browser's session state — cookies
+  // plus per-origin localStorage — that can be saved from the live session,
+  // imported from a file, and activated to switch the browser's identity.
+  // See browser-profiles.ts for the model and store.
+
+  /** All saved profiles, with the enabled one flagged. */
+  listProfiles(): BrowserProfileSummary[] {
+    return this.profiles().list()
+  }
+
+  /** Name of the enabled profile, or null when none is enabled. */
+  activeProfileName(): string | null {
+    return this.profiles().active()
+  }
+
+  /** Snapshot the live session (cookies + reachable per-site storage) into a
+   *  named profile. Saving does not activate the profile — call activateProfile
+   *  (or import with activate) to switch the browser to it. */
+  async saveProfile(name: string): Promise<BrowserProfile> {
+    assertProfileName(name)
+    const data = await this.captureProfileData()
+    const sourceUrl = this.view?.webContents.getURL() || null
+    return this.profiles().write(name, data, sourceUrl)
+  }
+
+  /** Import a session snapshot from a file path or raw JSON (our profile
+   *  format or a Playwright storageState) into a named profile. Activating is
+   *  the default — "import then enable" in one step. */
+  async importProfile(
+    name: string,
+    source: { path: string } | { json: string },
+    activate = true,
+  ): Promise<BrowserProfile> {
+    assertProfileName(name)
+    const data = 'path' in source
+      ? readProfileJson(source.path)
+      : parseProfileJsonText(source.json)
+    const profile = this.profiles().write(name, data, null)
+    if (activate) {
+      await this.applyProfileData(profile)
+      this.profiles().setActive(name)
+    }
+    return profile
+  }
+
+  /** Switch the live session to a saved profile: the session's cookies are
+   *  replaced with the profile's and its site storage is applied best-effort.
+   *  Activating a profile that is already enabled is a no-op — the live
+   *  session already carries that snapshot. */
+  async activateProfile(name: string): Promise<BrowserProfileSummary> {
+    assertProfileName(name)
+    if (this.profiles().active() === name) {
+      const current = this.profiles().list().find(profile => profile.name === name)
+      if (current) return current
+      throw new Error(`Profile ${name} is enabled but missing on disk`)
+    }
+    const profile = this.profiles().read(name)
+    await this.applyProfileData(profile)
+    this.profiles().setActive(name)
+    return this.profiles().list().find(summary => summary.name === name) ?? {
+      name,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
+      cookieCount: profile.cookies.length,
+      originCount: profile.origins.length,
+      active: true,
+      sourceUrl: profile.sourceUrl,
+    }
+  }
+
+  /** Remove a saved profile. Deleting the enabled profile disables it. */
+  async deleteProfile(name: string): Promise<{ deleted: boolean }> {
+    assertProfileName(name)
+    this.profiles().remove(name)
+    if (this.profiles().active() === name) this.profiles().setActive(null)
+    return { deleted: true }
+  }
+
+  /** Write a saved profile to an arbitrary path, so a session can be handed to
+   *  another machine (or another profile-enabled tool). */
+  async exportProfile(name: string, targetPath: string): Promise<{ path: string }> {
+    const profile = this.profiles().read(name)
+    const file = path.resolve(String(targetPath))
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(profile, null, 2), { encoding: 'utf8', mode: 0o600 })
+    try { fs.chmodSync(file, 0o600) } catch { /* best-effort */ }
+    return { path: file }
+  }
+
+  /** Collect the live session's cookies and the localStorage of every open
+   *  http(s) tab (unique origins). Page text and fields are never read — only
+   *  the storage that holds login state. */
+  private async captureProfileData(): Promise<BrowserProfileData> {
+    let cookies: BrowserProfileCookie[] = []
+    try {
+      const found = await this.getBrowserSession().cookies.get({})
+      cookies = found.map(cookie => ({
+        name: cookie.name,
+        value: cookie.value,
+        domain: cookie.domain || '',
+        path: cookie.path || '/',
+        expires: cookie.expirationDate !== undefined && Number.isFinite(cookie.expirationDate)
+          ? cookie.expirationDate
+          : -1,
+        httpOnly: cookie.httpOnly === true,
+        secure: cookie.secure === true,
+        sameSite: cookie.sameSite || 'unspecified',
+        ...(cookie.hostOnly ? { hostOnly: true } : {}),
+      })).filter(cookie => cookie.domain)
+    } catch {
+      // Cookies unavailable (session torn down) — save what is reachable.
+    }
+
+    const origins = new Map<string, BrowserProfileStorageOrigin>()
+    for (const tab of this.tabs) {
+      const contents = tab.view.webContents
+      if (contents.isDestroyed()) continue
+      const url = contents.getURL()
+      if (!url || url === 'about:blank') continue
+      let origin: string
+      try {
+        const parsed = new URL(url)
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue
+        origin = parsed.origin
+      } catch {
+        continue
+      }
+      if (origins.has(origin)) continue
+      try {
+        const result = await contents.executeJavaScript(`(() => {
+          const entries = []
+          for (let i = 0; i < localStorage.length; i += 1) {
+            const key = localStorage.key(i)
+            if (key === null) continue
+            try { entries.push({ name: key, value: localStorage.getItem(key) || '' }) } catch { /* skip */ }
+          }
+          return { origin: location.origin, entries }
+        })()`, true) as { origin?: unknown; entries?: unknown }
+        const originName = typeof result?.origin === 'string' && result.origin ? result.origin : origin
+        const entries = Array.isArray(result?.entries)
+          ? result.entries
+            .map(entry => {
+              if (typeof entry !== 'object' || entry === null) return null
+              const record = entry as Record<string, unknown>
+              return {
+                name: typeof record.name === 'string' ? record.name : '',
+                value: typeof record.value === 'string' ? record.value : String(record.value ?? ''),
+              }
+            })
+            .filter((entry): entry is { name: string; value: string } => !!entry && !!entry.name)
+          : []
+        if (entries.length > 0) origins.set(originName, { origin: originName, localStorage: entries })
+      } catch {
+        // Page context unavailable — skip this tab's storage.
+      }
+    }
+    return { cookies, origins: Array.from(origins.values()) }
+  }
+
+  /** Replace the live session's cookies with the profile's, then apply its
+   *  per-origin localStorage. Replacing rather than merging is what makes
+   *  activating a profile an identity switch: leftovers from the previous
+   *  profile cannot leak into the new one. */
+  private async applyProfileData(profile: BrowserProfile): Promise<void> {
+    const browserSession = this.getBrowserSession()
+    let existing: Electron.Cookie[] = []
+    try {
+      existing = await browserSession.cookies.get({})
+    } catch {
+      // Session unavailable — nothing to replace.
+    }
+    for (const cookie of existing) {
+      const domain = cookie.domain || ''
+      if (!domain) continue
+      const url = `https://${domain.replace(/^\./, '')}${cookie.path || '/'}`
+      try { await browserSession.cookies.remove(url, cookie.name) } catch { /* best-effort */ }
+    }
+    for (const cookie of profile.cookies) {
+      try {
+        const url = `https://${cookie.domain}${cookie.path || '/'}`
+        await browserSession.cookies.set({
+          url,
+          name: cookie.name,
+          value: cookie.value,
+          domain: cookie.domain,
+          path: cookie.path || '/',
+          secure: cookie.secure,
+          httpOnly: cookie.httpOnly,
+          ...(cookie.expires > 0 ? { expirationDate: cookie.expires } : {}),
+          ...(cookie.sameSite !== 'unspecified' ? { sameSite: cookie.sameSite } : {}),
+        })
+      } catch {
+        // One cookie failing must not abort the whole activation.
+      }
+    }
+    for (const origin of profile.origins) {
+      await this.applyLocalStorage(origin.origin, origin.localStorage)
+    }
+  }
+
+  /** Write localStorage entries for one origin: through a tab that is already
+   *  on it when possible, otherwise through a hidden page loaded for that
+   *  origin. Best-effort — a site that refuses to load just keeps its storage
+   *  untouched (cookies, the part that matters most for logins, are applied
+   *  unconditionally). */
+  private async applyLocalStorage(origin: string, items: Array<{ name: string; value: string }>): Promise<void> {
+    if (items.length === 0) return
+    const open = this.tabs.find(tab => {
+      try { return new URL(tab.view.webContents.getURL()).origin === origin } catch { return false }
+    })
+    if (open && !open.view.webContents.isDestroyed()) {
+      try {
+        await open.view.webContents.executeJavaScript(this.localStorageApplyScript(items), true)
+        return
+      } catch {
+        // Fall through to a hidden page.
+      }
+    }
+    const view = this.createHiddenView?.()
+    if (!view) return
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('timeout')), 10000)
+        view.webContents.once('did-finish-load', () => { clearTimeout(timer); resolve() })
+        view.webContents.once('did-fail-load', (_event, errorCode, errorDescription) => {
+          clearTimeout(timer)
+          reject(new Error(errorDescription || String(errorCode)))
+        })
+        void view.webContents.loadURL(origin + '/').catch(() => {})
+      })
+      await view.webContents.executeJavaScript(this.localStorageApplyScript(items), true)
+    } catch {
+      // Best-effort per origin.
+    } finally {
+      if (!view.webContents.isDestroyed()) view.webContents.close({ waitForBeforeUnload: false })
+    }
+  }
+
+  private localStorageApplyScript(items: Array<{ name: string; value: string }>): string {
+    return `(() => {
+      const items = ${JSON.stringify(items)}
+      for (const item of items) {
+        try { localStorage.setItem(item.name, item.value) } catch { /* quota or private mode */ }
+      }
+      return true
+    })()`
   }
 
   destroy(options: { closeContents?: boolean } = {}): void {

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -1,0 +1,192 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { describe, expect, it } from 'vitest'
+import {
+  ACTIVE_PROFILE_FILE,
+  assertProfileName,
+  BrowserProfileStore,
+  deriveProfileNameFromFile,
+  parseProfileData,
+  parseProfileJsonText,
+  profileFileName,
+  readProfileJson,
+} from './browser-profiles'
+
+describe('assertProfileName / profileFileName', () => {
+  it('accepts ordinary profile names', () => {
+    for (const name of ['work', 'Work-1', 'personal.bak', 'a_b', 'x'.repeat(64)]) {
+      expect(() => assertProfileName(name)).not.toThrow()
+      expect(profileFileName(name)).toBe(`${name}.json`)
+    }
+  })
+
+  it('rejects names that are not safe file names', () => {
+    for (const name of ['', '../evil', 'a/b', 'a\\b', '.hidden', '.', '..', 'a b', 'a:b', 'x'.repeat(65)]) {
+      expect(() => assertProfileName(name), name).toThrow(/Profile names/)
+    }
+  })
+})
+
+describe('deriveProfileNameFromFile', () => {
+  it('turns a file name into a safe profile name', () => {
+    expect(deriveProfileNameFromFile('/tmp/work.json')).toBe('work')
+    expect(deriveProfileNameFromFile('C:\\Users\\me\\My Session.json')).toBe('My-Session')
+    expect(deriveProfileNameFromFile('~/Downloads/gh-account (2).JSON')).toBe('gh-account-2')
+  })
+
+  it('falls back to imported for unusable names', () => {
+    expect(deriveProfileNameFromFile('/tmp/.json')).toBe('imported')
+    expect(deriveProfileNameFromFile('')).toBe('imported')
+    expect(deriveProfileNameFromFile('/tmp/...')).toBe('imported')
+  })
+})
+
+describe('parseProfileData', () => {
+  it('parses a full saved profile with metadata', () => {
+    const data = parseProfileData({
+      name: 'work',
+      createdAt: 1,
+      updatedAt: 2,
+      sourceUrl: 'https://example.com/',
+      cookies: [
+        { name: 'sid', value: 'abc', domain: 'example.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'lax', hostOnly: true },
+      ],
+      origins: [{ origin: 'https://example.com', localStorage: [{ name: 'token', value: 't' }] }],
+    })
+    expect(data.cookies).toEqual([expect.objectContaining({ name: 'sid', domain: 'example.com', expires: -1, httpOnly: true, hostOnly: true })])
+    expect(data.origins).toEqual([{ origin: 'https://example.com', localStorage: [{ name: 'token', value: 't' }] }])
+  })
+
+  it('parses a bare Playwright storageState and normalizes its vocabulary', () => {
+    const data = parseProfileData({
+      cookies: [
+        { name: 'a', value: '1', domain: '.github.com', path: '/', expires: 1234, httpOnly: false, secure: false, sameSite: 'Strict' },
+        { name: 'b', value: '2', domain: 'example.com', sameSite: 'None' },
+      ],
+      origins: [{ origin: 'https://github.com', localStorage: [{ name: 'gh', value: 'tok' }] }],
+    })
+    expect(data.cookies[0]).toMatchObject({ domain: 'github.com', path: '/', expires: 1234, sameSite: 'strict' })
+    expect(data.cookies[1]).toMatchObject({ domain: 'example.com', path: '/', expires: -1, sameSite: 'no_restriction' })
+    expect(data.origins[0]).toEqual({ origin: 'https://github.com', localStorage: [{ name: 'gh', value: 'tok' }] })
+  })
+
+  it('accepts missing cookies or origins as empty lists', () => {
+    expect(parseProfileData({})).toEqual({ cookies: [], origins: [] })
+  })
+
+  it('rejects malformed input', () => {
+    expect(() => parseProfileData(null)).toThrow()
+    expect(() => parseProfileData('nope')).toThrow()
+    expect(() => parseProfileData([])).toThrow()
+    expect(() => parseProfileData({ cookies: [{ name: 'x', value: 'y' }] })).toThrow(/domain/)
+    expect(() => parseProfileData({ origins: [{ origin: 'ftp://nope', localStorage: [] }] })).toThrow(/origin/)
+  })
+
+  it('parseProfileJsonText surfaces JSON errors', () => {
+    expect(parseProfileJsonText('{"cookies":[]}')).toEqual({ cookies: [], origins: [] })
+    expect(() => parseProfileJsonText('not json')).toThrow(/Invalid profile JSON/)
+  })
+
+  it('readProfileJson reads a file and rejects bad files', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-profile-read-'))
+    try {
+      const file = path.join(dir, 'p.json')
+      fs.writeFileSync(file, JSON.stringify({ cookies: [{ name: 'a', value: '1', domain: 'example.com' }] }))
+      expect(readProfileJson(file).cookies[0].name).toBe('a')
+      expect(() => readProfileJson(path.join(dir, 'missing.json'))).toThrow(/Cannot read profile file/)
+      fs.writeFileSync(file, '{broken')
+      expect(() => readProfileJson(file)).toThrow(/Invalid profile file/)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('BrowserProfileStore', () => {
+  function makeStore(): { dir: string; store: BrowserProfileStore } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-profiles-store-'))
+    return { dir, store: new BrowserProfileStore(dir) }
+  }
+
+  it('writes, reads, lists and removes profiles', () => {
+    const { dir, store } = makeStore()
+    try {
+      expect(store.list()).toEqual([])
+      const before = Date.now()
+      const written = store.write('work', {
+        cookies: [{ name: 'sid', value: 'abc', domain: 'example.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'lax' }],
+        origins: [],
+      }, 'https://example.com/')
+      expect(written.name).toBe('work')
+      expect(written.createdAt).toBeGreaterThanOrEqual(before)
+      expect(written.sourceUrl).toBe('https://example.com/')
+
+      const read = store.read('work')
+      expect(read.cookies).toHaveLength(1)
+      expect(read.cookies[0].value).toBe('abc')
+
+      // Re-writing keeps the original createdAt and refreshes updatedAt.
+      const again = store.write('work', { cookies: [], origins: [] }, null)
+      expect(again.createdAt).toBe(written.createdAt)
+      expect(again.updatedAt).toBeGreaterThanOrEqual(written.updatedAt)
+      expect(again.sourceUrl).toBe('https://example.com/')
+
+      store.write('zebra', { cookies: [], origins: [] }, null)
+      const summaries = store.list()
+      expect(summaries.map(profile => profile.name)).toEqual(['work', 'zebra'])
+      expect(summaries[0]).toMatchObject({ name: 'work', cookieCount: 0, originCount: 0, active: false })
+
+      store.remove('work')
+      expect(store.list().map(profile => profile.name)).toEqual(['zebra'])
+      expect(() => store.remove('work')).toThrow(/does not exist/)
+      expect(fs.existsSync(dir)).toBe(true)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('tracks the active profile in a dot-file', () => {
+    const { dir, store } = makeStore()
+    try {
+      expect(store.active()).toBeNull()
+      store.setActive('work')
+      expect(store.active()).toBe('work')
+      expect(fs.readFileSync(path.join(dir, ACTIVE_PROFILE_FILE), 'utf8')).toBe('work')
+      store.setActive(null)
+      expect(store.active()).toBeNull()
+      expect(fs.existsSync(path.join(dir, ACTIVE_PROFILE_FILE))).toBe(false)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('flags the active profile in list()', () => {
+    const { store } = makeStore()
+    try {
+      store.write('a', { cookies: [], origins: [] }, null)
+      store.write('b', { cookies: [], origins: [] }, null)
+      store.setActive('b')
+      const summaries = store.list()
+      expect(summaries.find(profile => profile.name === 'b')?.active).toBe(true)
+      expect(summaries.find(profile => profile.name === 'a')?.active).toBe(false)
+    } finally {
+      // store() dir cleanup handled by each test's own dir; nothing to do.
+    }
+  })
+
+  it('treats a missing or corrupt profile as absent rather than crashing', () => {
+    const { dir, store } = makeStore()
+    try {
+      expect(() => store.read('ghost')).toThrow(/missing or unreadable/)
+      store.write('bad', { cookies: [], origins: [] }, null)
+      fs.writeFileSync(path.join(dir, 'bad.json'), '{corrupt')
+      expect(() => store.read('bad')).toThrow(/missing or unreadable|corrupt/)
+      // list() still returns a zeroed summary for the corrupt file.
+      const summary = store.list().find(profile => profile.name === 'bad')
+      expect(summary).toMatchObject({ cookieCount: 0, originCount: 0 })
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -1,0 +1,311 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Browser profiles: named, portable snapshots of the Codey Browser's session
+ * state. A profile holds the cookies plus the per-origin localStorage of the
+ * partition the browser uses, so it captures everything that keeps a site
+ * signed in — and activating one switches the live session to that identity.
+ *
+ * The on-disk shape is deliberately compatible with Playwright's
+ * `storageState` (\`{ cookies, origins: [{ origin, localStorage }] }\`), so a
+ * session exported from Playwright (or from another Codey install) imports
+ * as-is. Profile files live one-per-name under a store directory and the
+ * active profile is recorded in a dot-file next to them.
+ */
+
+/** A cookie as stored in a profile: Playwright's storageState cookie shape,
+ *  plus Electron's sameSite vocabulary and a hostOnly flag for fidelity. */
+export interface BrowserProfileCookie {
+  name: string
+  value: string
+  /** Host without a leading dot; host-only vs domain cookies are told apart
+   *  by `hostOnly`. */
+  domain: string
+  path: string
+  /** Seconds since the epoch; -1 means a session cookie (Playwright's
+   *  convention for "expires with the session"). */
+  expires: number
+  httpOnly: boolean
+  secure: boolean
+  sameSite: 'unspecified' | 'no_restriction' | 'lax' | 'strict'
+  hostOnly?: boolean
+}
+
+export interface BrowserProfileStorageOrigin {
+  origin: string
+  localStorage: Array<{ name: string; value: string }>
+}
+
+export interface BrowserProfileData {
+  cookies: BrowserProfileCookie[]
+  origins: BrowserProfileStorageOrigin[]
+}
+
+export interface BrowserProfile extends BrowserProfileData {
+  name: string
+  createdAt: number
+  updatedAt: number
+  /** The page that was showing when the profile was saved; null for imports. */
+  sourceUrl: string | null
+}
+
+export interface BrowserProfileSummary {
+  name: string
+  createdAt: number
+  updatedAt: number
+  cookieCount: number
+  originCount: number
+  active: boolean
+  sourceUrl: string | null
+}
+
+/** The dot-file that records which profile is enabled. */
+export const ACTIVE_PROFILE_FILE = '.active'
+
+/** Profile names are file names inside the store directory, so they must be
+ *  safe on every platform: no separators, no leading dot (hidden files), and
+ *  a sane length. */
+export function assertProfileName(name: unknown): asserts name is string {
+  if (
+    typeof name !== 'string'
+    || !/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)
+    || name === '.'
+    || name === '..'
+  ) {
+    throw new Error('Profile names must be 1-64 characters of letters, digits, dots, dashes or underscores, and must not start with a dot')
+  }
+}
+
+/** Derive a safe profile name from an import file's name, so importing
+ *  "my session backup.json" just works without asking for a name. Falls back
+ *  to `imported` when nothing usable remains. */
+export function deriveProfileNameFromFile(filePath: string): string {
+  const base = String(filePath || '').replace(/\\/g, '/').split('/').pop() || ''
+  const name = base
+    .replace(/\.json$/i, '')
+    .replace(/[^a-zA-Z0-9._-]/g, '-')
+    .replace(/^[.\-]+|[.\-]+$/g, '')
+    .replace(/-+/g, '-')
+    .slice(0, 64)
+  if (!name) return 'imported'
+  try {
+    assertProfileName(name)
+    return name
+  } catch {
+    return 'imported'
+  }
+}
+
+export function profileFileName(name: string): string {
+  assertProfileName(name)
+  return `${name}.json`
+}
+
+const SAMESITE_ALIASES: Record<string, BrowserProfileCookie['sameSite']> = {
+  strict: 'strict',
+  lax: 'lax',
+  none: 'no_restriction',
+  no_restriction: 'no_restriction',
+  unspecified: 'unspecified',
+}
+
+function normalizeCookie(value: unknown): BrowserProfileCookie {
+  if (typeof value !== 'object' || value === null) throw new Error('profile cookies must be objects')
+  const cookie = value as Record<string, unknown>
+  const name = typeof cookie.name === 'string' && cookie.name ? cookie.name : null
+  const domain = typeof cookie.domain === 'string' && cookie.domain.trim() ? cookie.domain.trim().replace(/^\./, '') : null
+  if (!name || !domain) throw new Error('each profile cookie needs a name and a domain')
+  const rawPath = typeof cookie.path === 'string' && cookie.path ? cookie.path : '/'
+  const sameSiteRaw = typeof cookie.sameSite === 'string' ? cookie.sameSite.toLowerCase() : 'lax'
+  return {
+    name,
+    value: typeof cookie.value === 'string' ? cookie.value : String(cookie.value ?? ''),
+    domain,
+    path: rawPath.startsWith('/') ? rawPath : `/${rawPath}`,
+    expires: typeof cookie.expires === 'number' && Number.isFinite(cookie.expires) ? cookie.expires : -1,
+    httpOnly: cookie.httpOnly === true,
+    secure: cookie.secure === true,
+    sameSite: SAMESITE_ALIASES[sameSiteRaw] ?? 'lax',
+    ...(cookie.hostOnly === true ? { hostOnly: true } : {}),
+  }
+}
+
+function normalizeOrigin(value: unknown): BrowserProfileStorageOrigin {
+  if (typeof value !== 'object' || value === null) throw new Error('profile origins must be objects')
+  const record = value as Record<string, unknown>
+  const rawOrigin = typeof record.origin === 'string' && record.origin.trim() ? record.origin.trim() : null
+  let origin: string
+  try {
+    const parsed = new URL(rawOrigin ?? '')
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') throw new Error('not http(s)')
+    origin = parsed.origin
+  } catch {
+    throw new Error(`invalid profile origin: ${rawOrigin ?? ''}`)
+  }
+  const items = Array.isArray(record.localStorage) ? record.localStorage : []
+  const localStorage = items.map(item => {
+    if (typeof item !== 'object' || item === null) throw new Error('localStorage entries must be objects')
+    const entry = item as Record<string, unknown>
+    const name = typeof entry.name === 'string' && entry.name ? entry.name : null
+    if (!name) throw new Error('localStorage entries need a name')
+    return { name, value: typeof entry.value === 'string' ? entry.value : String(entry.value ?? '') }
+  })
+  return { origin, localStorage }
+}
+
+/** Parse a profile file's JSON payload: a full profile (with metadata) or bare
+ *  data (a Playwright storageState). Throws on malformed input. */
+export function parseProfileData(input: unknown): BrowserProfileData {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error('profile must be a JSON object')
+  }
+  const value = input as Record<string, unknown>
+  const cookies = Array.isArray(value.cookies) ? value.cookies.map(normalizeCookie) : []
+  const origins = Array.isArray(value.origins) ? value.origins.map(normalizeOrigin) : []
+  return { cookies, origins }
+}
+
+/** Parse a profile's JSON text (an inline import source). */
+export function parseProfileJsonText(text: string): BrowserProfileData {
+  try {
+    return parseProfileData(JSON.parse(text))
+  } catch (error) {
+    throw new Error(`Invalid profile JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+/** Read and parse a profile file from disk (an import source). */
+export function readProfileJson(filePath: string): BrowserProfileData {
+  let text: string
+  try {
+    text = fs.readFileSync(path.resolve(String(filePath)), 'utf8')
+  } catch (error) {
+    throw new Error(`Cannot read profile file: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  try {
+    return parseProfileData(JSON.parse(text))
+  } catch (error) {
+    throw new Error(`Invalid profile file ${filePath}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+/** File store for profiles. One \`.json\` per profile plus a dot-file that
+ *  records which profile is enabled. */
+export class BrowserProfileStore {
+  constructor(private readonly dir: string) {}
+
+  private file(name: string): string {
+    return path.join(this.dir, profileFileName(name))
+  }
+
+  private activeFile(): string {
+    return path.join(this.dir, ACTIVE_PROFILE_FILE)
+  }
+
+  /** All profiles in the store, sorted by name, with the active one flagged. */
+  list(): BrowserProfileSummary[] {
+    const active = this.active()
+    let names: string[] = []
+    try {
+      names = fs.readdirSync(this.dir)
+        .filter(file => file.endsWith('.json'))
+        .map(file => file.slice(0, -'.json'.length))
+    } catch {
+      return []
+    }
+    return names.sort().map(name => this.summary(name, active))
+  }
+
+  private summary(name: string, activeName: string | null): BrowserProfileSummary {
+    let profile: BrowserProfile | null = null
+    try {
+      profile = this.read(name)
+    } catch {
+      // A half-written file still shows up; counts read as zero.
+    }
+    return {
+      name,
+      createdAt: profile?.createdAt ?? 0,
+      updatedAt: profile?.updatedAt ?? 0,
+      cookieCount: profile?.cookies.length ?? 0,
+      originCount: profile?.origins.length ?? 0,
+      active: activeName === name,
+      sourceUrl: profile?.sourceUrl ?? null,
+    }
+  }
+
+  read(name: string): BrowserProfile {
+    assertProfileName(name)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(fs.readFileSync(this.file(name), 'utf8'))
+    } catch (error) {
+      throw new Error(`Profile ${name} is missing or unreadable: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    if (typeof parsed !== 'object' || parsed === null) throw new Error(`Profile ${name} is corrupt`)
+    const record = parsed as Record<string, unknown>
+    const data = parseProfileData(record)
+    return {
+      ...data,
+      name,
+      createdAt: typeof record.createdAt === 'number' ? record.createdAt : 0,
+      updatedAt: typeof record.updatedAt === 'number' ? record.updatedAt : 0,
+      sourceUrl: typeof record.sourceUrl === 'string' ? record.sourceUrl : null,
+    }
+  }
+
+  /** Write (or overwrite) a profile. Keeps the original createdAt so re-saving
+   *  a profile updates its snapshot without pretending it is new. */
+  write(name: string, data: BrowserProfileData, sourceUrl: string | null, now = Date.now()): BrowserProfile {
+    assertProfileName(name)
+    let existing: BrowserProfile | null = null
+    try {
+      existing = this.read(name)
+    } catch {
+      // New profile.
+    }
+    const profile: BrowserProfile = {
+      ...data,
+      name,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      sourceUrl: sourceUrl ?? existing?.sourceUrl ?? null,
+    }
+    fs.mkdirSync(this.dir, { recursive: true })
+    const file = this.file(name)
+    fs.writeFileSync(file, JSON.stringify(profile, null, 2), { encoding: 'utf8', mode: 0o600 })
+    try { fs.chmodSync(file, 0o600) } catch { /* best-effort */ }
+    return profile
+  }
+
+  remove(name: string): void {
+    assertProfileName(name)
+    try {
+      fs.unlinkSync(this.file(name))
+    } catch {
+      throw new Error(`Profile ${name} does not exist`)
+    }
+  }
+
+  /** Name of the enabled profile, or null when none is enabled. */
+  active(): string | null {
+    try {
+      const name = fs.readFileSync(this.activeFile(), 'utf8').trim()
+      assertProfileName(name)
+      return name
+    } catch {
+      return null
+    }
+  }
+
+  setActive(name: string | null): void {
+    if (name === null) {
+      try { fs.unlinkSync(this.activeFile()) } catch { /* already absent */ }
+      return
+    }
+    assertProfileName(name)
+    fs.mkdirSync(this.dir, { recursive: true })
+    fs.writeFileSync(this.activeFile(), name, { encoding: 'utf8', mode: 0o600 })
+  }
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -27,6 +27,7 @@ import { scanSkillUsage } from './skill-usage'
 import type { SkillUsageMap, UsageCacheEntry } from './skill-usage'
 import { BROWSER_PARTITION, BrowserController, type BrowserBounds } from './browser-controller'
 import { BrowserAgentBridge, type BrowserLoginWaitEvent } from './browser-agent-bridge'
+import { deriveProfileNameFromFile } from './browser-profiles'
 import { BrowserControlPermissionGate } from './browser-control-permission'
 import { BrowserSitePermissionManager } from './browser-site-permissions'
 import { canConfigureBrowserWebAuthn, configureBrowserWebAuthn, passkeyAccountLabel, type BrowserPasskeyPickerRequest } from './browser-webauthn'
@@ -70,6 +71,10 @@ const browserController = new BrowserController(
   state => sendToRenderer('browser:state', state),
   download => sendToRenderer('browser:download', download),
   () => join(app.getPath('downloads'), 'Codey'),
+  undefined,
+  // Named browser profiles (saved/imported sessions) live in the app's own
+  // data directory, next to the browser-control permission store.
+  { getProfilesDir: () => join(app.getPath('userData'), 'browser-profiles') },
 )
 let browserAgentBridge: BrowserAgentBridge | null = null
 let browserControlPermission: BrowserControlPermissionGate | null = null
@@ -1973,6 +1978,48 @@ app.whenReady().then(async () => {
     browserSitePermissions?.clear()
     browserControlPermission?.revoke()
     return state
+  }))
+  // Browser profiles: saved/imported sessions the renderer (browser toolbar
+  // and Settings) manages through the same controller the agents use.
+  ipcMain.handle('browser:profiles:list', event => browserCall(event, () => ({
+    active: browserController.activeProfileName(),
+    profiles: browserController.listProfiles(),
+  })))
+  ipcMain.handle('browser:profiles:save', (event, name: string) =>
+    browserCall(event, () => browserController.saveProfile(String(name || ''))))
+  ipcMain.handle('browser:profiles:activate', (event, name: string) =>
+    browserCall(event, () => browserController.activateProfile(String(name || ''))))
+  ipcMain.handle('browser:profiles:delete', (event, name: string) =>
+    browserCall(event, () => browserController.deleteProfile(String(name || ''))))
+  ipcMain.handle('browser:profiles:import', event => browserCall(event, async () => {
+    const result = await dialog.showOpenDialog(mainWindow ?? (undefined as any), {
+      title: 'Import browser profile',
+      buttonLabel: 'Import',
+      properties: ['openFile'],
+      filters: [
+        { name: 'Browser profile (JSON)', extensions: ['json'] },
+        { name: 'All files', extensions: ['*'] },
+      ],
+    })
+    if (result.canceled || result.filePaths.length === 0) return { imported: false, profile: null }
+    const filePath = result.filePaths[0]
+    const name = deriveProfileNameFromFile(filePath)
+    // Importing activates by default — "import then enable" in one step — and
+    // the identity switch prompts the user like any mutating browser command.
+    const profile = await browserController.importProfile(name, { path: filePath })
+    return { imported: true, profile }
+  }))
+  ipcMain.handle('browser:profiles:export', (event, name: string) => browserCall(event, async () => {
+    const requested = String(name || '')
+    const result = await dialog.showSaveDialog(mainWindow ?? (undefined as any), {
+      title: 'Export browser profile',
+      buttonLabel: 'Export',
+      defaultPath: requested ? `${requested}.json` : 'profile.json',
+      filters: [{ name: 'Browser profile (JSON)', extensions: ['json'] }],
+    })
+    if (result.canceled || !result.filePath) return { exported: false, path: null }
+    const out = await browserController.exportProfile(requested, result.filePath)
+    return { exported: true, path: out.path }
   }))
   ipcMain.handle('browser:extensions:list', event => browserCall(event, () => {
     if (!browserExtensionManager) throw new Error('Browser extensions are unavailable')

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -467,6 +467,14 @@ contextBridge.exposeInMainWorld('codey', {
     switchTab: (id: string) => ipcRenderer.invoke('browser:switchTab', id),
     closeTab: (id: string) => ipcRenderer.invoke('browser:closeTab', id),
     resetSession: () => ipcRenderer.invoke('browser:resetSession'),
+    profiles: {
+      list: () => ipcRenderer.invoke('browser:profiles:list'),
+      save: (name: string) => ipcRenderer.invoke('browser:profiles:save', name),
+      activate: (name: string) => ipcRenderer.invoke('browser:profiles:activate', name),
+      delete: (name: string) => ipcRenderer.invoke('browser:profiles:delete', name),
+      import: () => ipcRenderer.invoke('browser:profiles:import'),
+      export: (name: string) => ipcRenderer.invoke('browser:profiles:export', name),
+    },
     extensions: {
       list: () => ipcRenderer.invoke('browser:extensions:list'),
       discoverChrome: () => ipcRenderer.invoke('browser:extensions:discoverChrome'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -188,6 +188,17 @@ export interface BrowserTab {
   active: boolean
 }
 
+/** A saved browser session ("profile") as listed by the profiles manager. */
+export interface BrowserProfileSummary {
+  name: string
+  createdAt: number
+  updatedAt: number
+  cookieCount: number
+  originCount: number
+  active: boolean
+  sourceUrl: string | null
+}
+
 export interface BrowserLoginWaitEvent {
   id: string
   chatId: string
@@ -556,6 +567,14 @@ declare global {
         switchTab: (id: string) => Promise<IpcResult<BrowserState>>
         closeTab: (id: string) => Promise<IpcResult<BrowserState>>
         resetSession: () => Promise<IpcResult<BrowserState>>
+        profiles: {
+          list: () => Promise<IpcResult<{ active: string | null; profiles: BrowserProfileSummary[] }>>
+          save: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
+          activate: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
+          delete: (name: string) => Promise<IpcResult<{ deleted: boolean }>>
+          import: () => Promise<IpcResult<{ imported: boolean; profile: BrowserProfileSummary | null }>>
+          export: (name: string) => Promise<IpcResult<{ exported: boolean; path: string | null }>>
+        }
         extensions: {
           list: () => Promise<IpcResult<BrowserExtensionEntry[]>>
           discoverChrome: () => Promise<IpcResult<ChromeBrowserExtensionCandidate[]>>

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -14,6 +14,7 @@ import type {
 } from '../codey-api'
 import { C } from '../theme'
 import { UIIcon } from './UIIcons'
+import { BrowserProfiles } from './BrowserProfiles'
 import { getDraft, setDraft } from './chatDrafts'
 import { buildBrowserContextPrompt } from './browserContextPrompt'
 
@@ -37,6 +38,13 @@ const EMPTY_STATE: BrowserState = {
 
 const VIEW_ONLY: BrowserControlPermissionState = { approved: false, pending: null }
 const NO_SITE_PERMISSION: BrowserSitePermissionState = { pending: null, savedSiteCount: 0 }
+
+type BrowserSettingsSection = 'extensions' | 'profiles'
+
+const SETTINGS_SECTIONS: Record<BrowserSettingsSection, { title: string; url: string }> = {
+  extensions: { title: 'Extensions', url: 'codey://settings/extensions' },
+  profiles: { title: 'Profiles', url: 'codey://settings/profiles' },
+}
 
 const SITE_PERMISSION_LABELS: Record<BrowserSitePermission, string> = {
   camera: 'camera',
@@ -62,8 +70,12 @@ export const BrowserPanel: React.FC<Props> = ({
   onClose,
   embedded = false,
 }) => {
+  const rootRef = useRef<HTMLElement>(null)
   const hostRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
   const shownRef = useRef(false)
+  const browserCoveredRef = useRef(false)
   const addressFocusedRef = useRef(false)
   const [state, setState] = useState<BrowserState>(EMPTY_STATE)
   const [address, setAddress] = useState('')
@@ -74,13 +86,29 @@ export const BrowserPanel: React.FC<Props> = ({
   const [resetBusy, setResetBusy] = useState(false)
   const [tabs, setTabs] = useState<BrowserTab[]>([])
   const [latestDownload, setLatestDownload] = useState<BrowserDownload | null>(null)
-  const [extensionsOpen, setExtensionsOpen] = useState(false)
+  const [settingsTabOpen, setSettingsTabOpen] = useState(false)
+  const [activeSettingsSection, setActiveSettingsSection] = useState<BrowserSettingsSection | null>(null)
+  const [lastSettingsSection, setLastSettingsSection] = useState<BrowserSettingsSection>('extensions')
   const [extensions, setExtensions] = useState<BrowserExtensionEntry[]>([])
   const [extensionCandidate, setExtensionCandidate] = useState<BrowserExtensionCandidate | null>(null)
   const [chromeExtensions, setChromeExtensions] = useState<ChromeBrowserExtensionCandidate[]>([])
   const [chromeScanComplete, setChromeScanComplete] = useState(false)
   const [extensionBusy, setExtensionBusy] = useState(false)
   const [browserMenuOpen, setBrowserMenuOpen] = useState(false)
+  const [panelWidth, setPanelWidth] = useState(900)
+
+  const browserCovered = browserMenuOpen || activeSettingsSection !== null
+  browserCoveredRef.current = browserCovered
+
+  useLayoutEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    const updateWidth = () => setPanelWidth(Math.round(root.getBoundingClientRect().width))
+    const observer = new ResizeObserver(updateWidth)
+    observer.observe(root)
+    updateWidth()
+    return () => observer.disconnect()
+  }, [])
 
   const useResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | undefined => {
     if (!result.ok) {
@@ -163,7 +191,7 @@ export const BrowserPanel: React.FC<Props> = ({
       cancelAnimationFrame(frame)
       frame = requestAnimationFrame(() => {
         const bounds = rectToBounds(host.getBoundingClientRect())
-        if (bounds.width === 0 || bounds.height === 0) return
+        if (bounds.width === 0 || bounds.height === 0 || browserCoveredRef.current) return
         if (!shownRef.current) {
           shownRef.current = true
           void window.codey.browser.show(bounds).then(result => {
@@ -186,6 +214,40 @@ export const BrowserPanel: React.FC<Props> = ({
       window.removeEventListener('resize', placeBrowser)
     }
   }, [])
+
+  useLayoutEffect(() => {
+    if (browserCovered) {
+      shownRef.current = false
+      void window.codey.browser.hide()
+      return
+    }
+    const host = hostRef.current
+    if (!host) return
+    const bounds = rectToBounds(host.getBoundingClientRect())
+    if (bounds.width === 0 || bounds.height === 0) return
+    shownRef.current = true
+    void window.codey.browser.show(bounds).then(result => {
+      const next = useResult(result)
+      if (next) setState(next)
+    })
+  }, [browserCovered])
+
+  useEffect(() => {
+    if (!browserMenuOpen) return
+    const closeMenu = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (!menuRef.current?.contains(target) && !menuButtonRef.current?.contains(target)) setBrowserMenuOpen(false)
+    }
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setBrowserMenuOpen(false)
+    }
+    document.addEventListener('mousedown', closeMenu)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('mousedown', closeMenu)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [browserMenuOpen])
 
   const navigate = async () => {
     const next = useResult(await window.codey.browser.navigate(address))
@@ -253,13 +315,32 @@ export const BrowserPanel: React.FC<Props> = ({
     }
   }
 
+  const openSettingsSection = (section: BrowserSettingsSection) => {
+    setSettingsTabOpen(true)
+    setLastSettingsSection(section)
+    setActiveSettingsSection(section)
+    setBrowserMenuOpen(false)
+  }
+
   const openExtensions = async () => {
-    const nextOpen = !extensionsOpen
-    setExtensionsOpen(nextOpen)
+    openSettingsSection('extensions')
     setExtensionCandidate(null)
-    if (!nextOpen) return
     const next = useResult(await window.codey.browser.extensions.list())
     if (next) setExtensions(next)
+  }
+
+  const openProfiles = () => {
+    openSettingsSection('profiles')
+  }
+
+  const showWebTab = async (operation: () => Promise<{ ok: true; data: BrowserState } | { ok: false; error: string }>) => {
+    setActiveSettingsSection(null)
+    await run(operation)
+  }
+
+  const closeSettingsTab = () => {
+    setSettingsTabOpen(false)
+    setActiveSettingsSection(null)
   }
 
   const pickExtension = async () => {
@@ -331,8 +412,19 @@ export const BrowserPanel: React.FC<Props> = ({
     catch { return controlPermission.pending?.url || '' }
   })()
 
+  const compactSettings = panelWidth < 700
+  const narrowSettings = panelWidth < 480
+  const settingsContentTop = compactSettings ? 138 : 82
+  const settingsSidebarStyle: React.CSSProperties = compactSettings
+    ? { ...styles.settingsSidebar, inset: '82px 0 auto 0', width: 'auto', height: 56, padding: '9px 12px', flexDirection: 'row', alignItems: 'center', gap: 6, borderRight: 'none', borderBottom: `1px solid ${C.border}` }
+    : styles.settingsSidebar
+  const settingsPanelStyle: React.CSSProperties = {
+    inset: `${settingsContentTop}px 0 0 ${compactSettings ? 0 : 216}px`,
+    padding: narrowSettings ? '18px 14px 28px' : '28px clamp(22px, 5vw, 56px) 40px',
+  }
+
   return (
-    <section style={styles.root} aria-label="Codey Browser">
+    <section ref={rootRef} style={styles.root} aria-label="Codey Browser">
       <div style={{ ...styles.toolbar, ...(embedded ? styles.compactToolbar : null) }}>
         <div style={styles.navGroup}>
           <button
@@ -366,14 +458,15 @@ export const BrowserPanel: React.FC<Props> = ({
           style={{ ...styles.addressForm, ...(displayedError ? styles.addressError : null) }}
           onSubmit={event => { event.preventDefault(); void navigate() }}
         >
-          <span style={{ ...styles.security, color: secure ? C.green : C.fg3 }} title={secure ? 'Secure connection' : 'Connection information'}>
-            {secure ? '●' : '○'}
+          <span style={{ ...styles.security, color: activeSettingsSection ? C.accent : secure ? C.green : C.fg3 }} title={activeSettingsSection ? 'Codey browser page' : secure ? 'Secure connection' : 'Connection information'}>
+            {activeSettingsSection ? '◆' : secure ? '●' : '○'}
           </span>
           <input
-            value={address}
+            value={activeSettingsSection ? SETTINGS_SECTIONS[activeSettingsSection].url : address}
             onChange={event => setAddress(event.target.value)}
             onFocus={event => { addressFocusedRef.current = true; event.currentTarget.select() }}
             onBlur={() => { addressFocusedRef.current = false }}
+            readOnly={activeSettingsSection !== null}
             placeholder="Search or enter an address"
             aria-label="Browser address"
             spellCheck={false}
@@ -385,73 +478,38 @@ export const BrowserPanel: React.FC<Props> = ({
 
         <button
           type="button"
-          style={{ ...styles.contextButton, opacity: chatId && state.url ? 1 : 0.5 }}
+          style={{ ...styles.contextButton, opacity: chatId && state.url && !activeSettingsSection ? 1 : 0.5 }}
           title={chatId ? 'Add this page and its performance timing to the current chat' : 'Select a chat first'}
-          disabled={!chatId || !state.url}
+          disabled={!chatId || !state.url || activeSettingsSection !== null}
           onClick={() => void usePageInChat()}
         >
           <UIIcon name="sparkle" size={14} />
           {!embedded && <span>Use in chat</span>}
         </button>
-        {!embedded && <button
+        <button
+          ref={menuButtonRef}
           type="button"
-          style={{ ...styles.iconButton, ...(extensionsOpen ? styles.iconButtonActive : null) }}
-          title="Browser extensions"
-          aria-label="Browser extensions"
-          aria-expanded={extensionsOpen}
-          onClick={() => void openExtensions()}
-        >⊞</button>}
-        {!embedded && <button
-          type="button"
-          style={styles.iconButton}
-          title="Open in default browser"
-          aria-label="Open in default browser"
-          disabled={!state.url}
-          onClick={() => { if (state.url) void window.codey.openExternal(state.url) }}
-        >↗</button>}
-        {!embedded && <button
-          type="button"
-          style={{
-            ...styles.permissionBadge,
-            ...(controlPermission.approved ? styles.permissionApproved : styles.permissionViewOnly),
-          }}
-          title={controlPermission.approved ? 'Revoke agent browser control' : 'Agents can only view until you approve control'}
-          onClick={() => {
-            if (controlPermission.approved) void updateControlPermission(window.codey.browser.controlPermission.revoke)
-          }}
-        >
-          <span style={styles.permissionDot} />
-          {controlPermission.approved ? 'Full Control' : 'View Only'}
-        </button>}
-        {!embedded && <button
-          type="button"
-          style={{ ...styles.iconButton, ...(resetConfirmation ? styles.iconButtonDanger : null) }}
-          title="Clear browser data and sign out"
-          aria-label="Clear browser data and sign out"
-          aria-expanded={resetConfirmation}
-          onClick={() => setResetConfirmation(current => !current)}
-        ><UIIcon name="trash" size={14} /></button>}
-        {embedded && (
-          <button
-            type="button"
-            style={{ ...styles.iconButton, ...(browserMenuOpen ? styles.iconButtonActive : null) }}
-            title="More browser actions"
-            aria-label="More browser actions"
-            aria-expanded={browserMenuOpen}
-            onClick={() => setBrowserMenuOpen(current => !current)}
-          ><UIIcon name="more" size={15} /></button>
-        )}
+          style={{ ...styles.iconButton, ...(browserMenuOpen ? styles.iconButtonActive : null) }}
+          title="More browser actions"
+          aria-label="More browser actions"
+          aria-haspopup="menu"
+          aria-expanded={browserMenuOpen}
+          onClick={() => setBrowserMenuOpen(current => !current)}
+        ><UIIcon name="more" size={15} /></button>
         {!embedded && <button type="button" style={styles.closeButton} onClick={onClose} title="Close browser" aria-label="Close browser">
           <UIIcon name="close" size={15} />
         </button>}
       </div>
 
-      {embedded && browserMenuOpen && (
-        <div style={styles.browserMenu} aria-label="Browser actions">
+      {browserMenuOpen && (
+        <div ref={menuRef} style={styles.browserMenu} role="menu" aria-label="Browser actions">
           <button type="button" style={styles.menuButton} onClick={() => { setBrowserMenuOpen(false); void openExtensions() }}>
             <span aria-hidden="true">⊞</span> Extensions
           </button>
-          <button type="button" style={styles.menuButton} disabled={!state.url} onClick={() => { setBrowserMenuOpen(false); if (state.url) void window.codey.openExternal(state.url) }}>
+          <button type="button" style={styles.menuButton} onClick={() => { setBrowserMenuOpen(false); openProfiles() }}>
+            <UIIcon name="users" size={13} /> Profiles
+          </button>
+          <button type="button" style={styles.menuButton} disabled={!state.url || activeSettingsSection !== null} onClick={() => { setBrowserMenuOpen(false); if (state.url && !activeSettingsSection) void window.codey.openExternal(state.url) }}>
             <span aria-hidden="true">↗</span> Open externally
           </button>
           <button
@@ -477,12 +535,12 @@ export const BrowserPanel: React.FC<Props> = ({
             key={tab.id}
             role="tab"
             tabIndex={0}
-            aria-selected={tab.active}
+            aria-selected={tab.active && activeSettingsSection === null}
             title={tab.title || tab.url || 'New tab'}
-            style={{ ...styles.tab, ...(tab.active ? styles.activeTab : null) }}
-            onClick={() => void run(() => window.codey.browser.switchTab(tab.id))}
+            style={{ ...styles.tab, ...(tab.active && activeSettingsSection === null ? styles.activeTab : null) }}
+            onClick={() => void showWebTab(() => window.codey.browser.switchTab(tab.id))}
             onKeyDown={event => {
-              if (event.key === 'Enter' || event.key === ' ') void run(() => window.codey.browser.switchTab(tab.id))
+              if (event.key === 'Enter' || event.key === ' ') void showWebTab(() => window.codey.browser.switchTab(tab.id))
             }}
           >
             <span style={styles.tabTitle}>{tab.title || 'New tab'}</span>
@@ -497,36 +555,81 @@ export const BrowserPanel: React.FC<Props> = ({
             >×</button>
           </div>
         ))}
+        {settingsTabOpen && (
+          <div
+            role="tab"
+            tabIndex={0}
+            aria-selected={activeSettingsSection !== null}
+            title="Browser settings"
+            style={{ ...styles.tab, ...(activeSettingsSection !== null ? styles.activeTab : null) }}
+            onClick={() => setActiveSettingsSection(lastSettingsSection)}
+            onKeyDown={event => {
+              if (event.key === 'Enter' || event.key === ' ') setActiveSettingsSection(lastSettingsSection)
+            }}
+          >
+            <span style={styles.tabTitle}>Browser settings</span>
+            <button
+              type="button"
+              aria-label="Close browser settings"
+              style={styles.tabClose}
+              onClick={event => { event.stopPropagation(); closeSettingsTab() }}
+            >×</button>
+          </div>
+        )}
         <button
           type="button"
           style={styles.newTabButton}
           title="New tab"
           aria-label="New tab"
-          onClick={() => void run(() => window.codey.browser.newTab())}
+          onClick={() => void showWebTab(() => window.codey.browser.newTab())}
         >+</button>
       </div>
 
-      {extensionsOpen && (
-        <div style={styles.extensionsPanel} aria-label="Browser extensions">
-          <div style={styles.extensionsHeader}>
+      {activeSettingsSection !== null && (
+        <aside style={settingsSidebarStyle} aria-label="Browser settings sections">
+          {!compactSettings && <div style={styles.settingsSidebarTitle}>Browser settings</div>}
+          <button
+            type="button"
+            style={{ ...styles.settingsNavButton, ...(compactSettings ? styles.settingsNavButtonCompact : null), ...(activeSettingsSection === 'extensions' ? styles.settingsNavButtonActive : null) }}
+            aria-current={activeSettingsSection === 'extensions' ? 'page' : undefined}
+            onClick={() => void openExtensions()}
+          >
+            <span aria-hidden="true">⊞</span> Extensions
+          </button>
+          <button
+            type="button"
+            style={{ ...styles.settingsNavButton, ...(compactSettings ? styles.settingsNavButtonCompact : null), ...(activeSettingsSection === 'profiles' ? styles.settingsNavButtonActive : null) }}
+            aria-current={activeSettingsSection === 'profiles' ? 'page' : undefined}
+            onClick={openProfiles}
+          >
+            <UIIcon name="users" size={14} /> Profiles
+          </button>
+        </aside>
+      )}
+
+      {activeSettingsSection === 'extensions' && (
+        <div style={{ ...styles.settingsPanel, ...settingsPanelStyle }} aria-label="Browser extensions">
+          <div style={styles.settingsContent}>
+          <div style={styles.settingsPageHeader}>
+            <div style={styles.settingsPageIcon}><UIIcon name="tools" size={20} /></div>
             <div>
-              <div style={styles.extensionsTitle}>Extensions</div>
+              <div style={styles.settingsPageTitle}>Extensions</div>
               <div style={styles.extensionsCopy}>Install in Chrome first, then import a compatible copy into Codey. Chrome Web Store buttons cannot install directly into Electron.</div>
             </div>
-            <div style={styles.extensionsActions}>
+          </div>
+            <div style={{ ...styles.extensionsActions, ...(narrowSettings ? styles.extensionsActionsNarrow : null) }}>
               <button
                 type="button"
-                style={styles.secondaryButton}
+                style={{ ...styles.secondaryButton, ...(narrowSettings ? styles.responsiveActionButton : null) }}
                 onClick={() => void window.codey.openExternal('https://chromewebstore.google.com/category/extensions')}
               >View Web Store ↗</button>
-              <button type="button" style={styles.primaryButton} disabled={extensionBusy} onClick={() => void discoverChromeExtensions()}>
+              <button type="button" style={{ ...styles.primaryButton, ...(narrowSettings ? styles.responsiveActionButton : null) }} disabled={extensionBusy} onClick={() => void discoverChromeExtensions()}>
                 {chromeScanComplete ? 'Scan Chrome again' : 'Import from Chrome'}
               </button>
-              <button type="button" style={styles.secondaryButton} disabled={extensionBusy} onClick={() => void pickExtension()}>
+              <button type="button" style={{ ...styles.secondaryButton, ...(narrowSettings ? styles.responsiveActionButton : null) }} disabled={extensionBusy} onClick={() => void pickExtension()}>
                 Load unpacked
               </button>
             </div>
-          </div>
 
           {extensionCandidate && (
             <div style={styles.extensionReview} role="dialog" aria-label="Review unpacked extension">
@@ -549,7 +652,7 @@ export const BrowserPanel: React.FC<Props> = ({
           )}
 
           {!extensionCandidate && chromeExtensions.map(candidate => (
-            <div key={`${candidate.profile}:${candidate.extensionId}`} style={styles.extensionRow}>
+            <div key={`${candidate.profile}:${candidate.extensionId}`} style={{ ...styles.extensionRow, ...(narrowSettings ? styles.extensionRowNarrow : null) }}>
               <div style={{ ...styles.extensionStatusIcon, color: candidate.compatible ? C.green : C.warningFg }}>
                 {candidate.compatible ? '●' : '⚠'}
               </div>
@@ -589,7 +692,7 @@ export const BrowserPanel: React.FC<Props> = ({
           )}
 
           {!extensionCandidate && extensions.map(extension => (
-            <div key={extension.key} style={styles.extensionRow}>
+            <div key={extension.key} style={{ ...styles.extensionRow, ...(narrowSettings ? styles.extensionRowNarrow : null) }}>
               <div style={styles.extensionStatusIcon}>{extension.enabled && !extension.error ? '●' : '○'}</div>
               <div style={styles.extensionInfo}>
                 <div style={styles.extensionName}>
@@ -619,6 +722,22 @@ export const BrowserPanel: React.FC<Props> = ({
               >Remove</button>
             </div>
           ))}
+          </div>
+        </div>
+      )}
+
+      {activeSettingsSection === 'profiles' && (
+        <div style={{ ...styles.settingsPanel, ...settingsPanelStyle }} aria-label="Browser profiles">
+          <div style={styles.settingsContent}>
+          <div style={styles.settingsPageHeader}>
+            <div style={styles.settingsPageIcon}><UIIcon name="users" size={20} /></div>
+            <div>
+              <div style={styles.settingsPageTitle}>Profiles</div>
+              <div style={styles.extensionsCopy}>Manage saved browser sessions, cookies, and site storage.</div>
+            </div>
+          </div>
+          <BrowserProfiles compact={narrowSettings} />
+          </div>
         </div>
       )}
 
@@ -758,12 +877,21 @@ export const BrowserPanel: React.FC<Props> = ({
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  root: { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: C.bg },
+  root: { position: 'relative', flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: C.bg },
   toolbar: { height: 48, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 7, padding: '7px 10px', background: C.surface, borderBottom: `1px solid ${C.border}` },
   compactToolbar: { gap: 4, padding: '7px 6px' },
-  browserMenu: { minHeight: 38, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 4, padding: '5px 7px', overflowX: 'auto', background: C.surface2, borderBottom: `1px solid ${C.border}` },
-  menuButton: { height: 28, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 5, padding: '0 8px', border: `1px solid ${C.border}`, borderRadius: 6, background: C.surface, color: C.fg2, cursor: 'pointer', fontSize: 10, whiteSpace: 'nowrap' },
-  menuButtonWarning: { color: C.warningFg, borderColor: `${C.warningFg}88`, background: C.warningBg },
+  browserMenu: {
+    position: 'absolute', top: 43, right: 8, zIndex: 20, width: 230,
+    display: 'flex', flexDirection: 'column', gap: 2, padding: 6,
+    background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 10,
+    boxShadow: '0 12px 30px rgba(0,0,0,0.32)',
+  },
+  menuButton: {
+    width: '100%', minHeight: 32, display: 'flex', alignItems: 'center', gap: 8,
+    padding: '0 9px', border: 'none', borderRadius: 6, background: 'transparent',
+    color: C.fg2, cursor: 'pointer', fontSize: 11, textAlign: 'left', whiteSpace: 'nowrap',
+  },
+  menuButtonWarning: { color: C.warningFg, background: C.warningBg },
   tabStrip: { height: 34, flexShrink: 0, display: 'flex', alignItems: 'flex-end', gap: 3, padding: '4px 8px 0', overflowX: 'auto', background: C.surface, borderBottom: `1px solid ${C.border}` },
   tab: { maxWidth: 180, minWidth: 90, height: 29, padding: '0 6px 0 9px', display: 'flex', alignItems: 'center', gap: 7, border: `1px solid transparent`, borderBottom: 'none', borderRadius: '7px 7px 0 0', background: 'transparent', color: C.fg3, cursor: 'pointer', fontSize: 10.5 },
   activeTab: { background: C.bg, color: C.fg, borderColor: C.border },
@@ -804,19 +932,29 @@ const styles: Record<string, React.CSSProperties> = {
   security: { fontSize: 9, flexShrink: 0 },
   address: { flex: 1, minWidth: 0, height: '100%', padding: 0, border: 'none', outline: 'none', background: 'transparent', color: C.fg, fontSize: 12.5 },
   loadingDot: { width: 7, height: 7, borderRadius: '50%', background: C.accent, animation: 'codey-pulse 1s ease-in-out infinite', flexShrink: 0 },
-  extensionsPanel: { maxHeight: 360, flexShrink: 0, overflowY: 'auto', padding: '10px 12px', background: C.surface, borderBottom: `1px solid ${C.border}` },
-  extensionsHeader: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 10 },
-  extensionsTitle: { color: C.fg, fontSize: 12.5, fontWeight: 750 },
-  extensionsCopy: { color: C.fg3, fontSize: 10.5, lineHeight: 1.4, marginTop: 2 },
-  extensionsActions: { display: 'flex', alignItems: 'center', gap: 7, flexShrink: 0 },
+  settingsSidebar: { position: 'absolute', inset: '82px auto 0 0', zIndex: 4, width: 216, padding: '24px 14px', display: 'flex', flexDirection: 'column', background: C.surface, borderRight: `1px solid ${C.border}` },
+  settingsSidebarTitle: { padding: '0 10px 14px', color: C.fg3, fontSize: 10, fontWeight: 750, textTransform: 'uppercase', letterSpacing: 0.8 },
+  settingsNavButton: { width: '100%', minHeight: 38, display: 'flex', alignItems: 'center', gap: 10, padding: '0 11px', border: '1px solid transparent', borderRadius: 9, background: 'transparent', color: C.fg2, cursor: 'pointer', fontSize: 12, textAlign: 'left' },
+  settingsNavButtonCompact: { width: 'auto', flex: 1, justifyContent: 'center', minHeight: 36, padding: '0 12px' },
+  settingsNavButtonActive: { color: C.accent, background: C.accentDim, fontWeight: 700 },
+  settingsPanel: { position: 'absolute', zIndex: 3, overflowY: 'auto', background: C.bg },
+  settingsContent: { width: '100%', maxWidth: 900, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 20 },
+  settingsPageHeader: { display: 'flex', alignItems: 'center', gap: 14 },
+  settingsPageIcon: { width: 42, height: 42, flexShrink: 0, display: 'grid', placeItems: 'center', borderRadius: 12, color: C.accent, background: C.accentDim, border: `1px solid ${C.accent}44` },
+  settingsPageTitle: { color: C.fg, fontSize: 20, lineHeight: 1.2, fontWeight: 750 },
+  extensionsCopy: { maxWidth: 620, color: C.fg3, fontSize: 11.5, lineHeight: 1.5, marginTop: 3 },
+  extensionsActions: { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8, padding: 12, borderRadius: 11, background: C.surface, border: `1px solid ${C.border}` },
+  extensionsActionsNarrow: { alignItems: 'stretch' },
+  responsiveActionButton: { flex: '1 1 140px' },
   primaryButton: { minHeight: 29, padding: '0 10px', border: `1px solid ${C.accent}`, borderRadius: 7, background: C.accent, color: C.onAccent, cursor: 'pointer', fontSize: 10.5, fontWeight: 700, whiteSpace: 'nowrap' },
   secondaryButton: { minHeight: 29, padding: '0 10px', border: `1px solid ${C.border2}`, borderRadius: 7, background: C.surface2, color: C.fg2, cursor: 'pointer', fontSize: 10.5, whiteSpace: 'nowrap' },
   smallButton: { minHeight: 25, padding: '0 8px', border: `1px solid ${C.border}`, borderRadius: 6, background: C.surface2, color: C.fg2, cursor: 'pointer', fontSize: 10 },
-  extensionsEmpty: { marginTop: 10, padding: '10px 12px', color: C.fg3, background: C.surface2, border: `1px dashed ${C.border2}`, borderRadius: 8, fontSize: 10.5 },
-  extensionReview: { display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, padding: 10, background: C.surface2, border: `1px solid ${C.accent}66`, borderRadius: 9 },
+  extensionsEmpty: { padding: '18px 20px', color: C.fg3, background: C.surface, border: `1px dashed ${C.border2}`, borderRadius: 11, fontSize: 11.5, lineHeight: 1.5 },
+  extensionReview: { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8, padding: 12, background: C.surface, border: `1px solid ${C.accent}66`, borderRadius: 11 },
   extensionReviewBody: { flex: 1, minWidth: 0 },
   extensionSectionLabel: { marginTop: 11, color: C.fg2, fontSize: 10, fontWeight: 750, textTransform: 'uppercase', letterSpacing: 0.5 },
-  extensionRow: { display: 'flex', alignItems: 'center', gap: 8, marginTop: 8, padding: '8px 9px', background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 },
+  extensionRow: { display: 'flex', alignItems: 'center', gap: 8, padding: '11px 12px', background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10 },
+  extensionRowNarrow: { flexWrap: 'wrap', alignItems: 'center' },
   extensionStatusIcon: { width: 15, flexShrink: 0, color: C.green, fontSize: 9, textAlign: 'center' },
   extensionInfo: { flex: 1, minWidth: 0 },
   extensionName: { color: C.fg, fontSize: 11.5, fontWeight: 700 },

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { C } from '../theme'
+import { UIIcon } from './UIIcons'
+import type { BrowserProfileSummary } from '../codey-api'
+
+type IpcLike = { ok: boolean; error?: string }
+
+function formatWhen(timestamp: number): string {
+  if (!timestamp) return ''
+  const minutes = Math.max(1, Math.round((Date.now() - timestamp) / 60000))
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}
+
+/** The browser-profiles manager, shared by the browser toolbar (compact) and
+ *  the Settings tab (full width). List, save the current session, import a
+ *  session file, activate, export and delete profiles through the main
+ *  process's `window.codey.browser.profiles` bridge. */
+export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
+  const [active, setActive] = useState<string | null>(null)
+  const [profiles, setProfiles] = useState<BrowserProfileSummary[]>([])
+  const [name, setName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    // A stale preload (app not restarted since the profiles bridge was added)
+    // would otherwise fail silently — surface it instead.
+    if (!window.codey?.browser?.profiles) {
+      setError('Browser profiles are unavailable — quit and relaunch Codey to load the latest build')
+      return
+    }
+    try {
+      const result = await window.codey.browser.profiles.list()
+      if (result.ok) {
+        setActive(result.data.active)
+        setProfiles(result.data.profiles)
+        setError(null)
+      } else {
+        setError(result.error)
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught))
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  const run = async (action: () => Promise<IpcLike>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await action()
+      if (!result.ok) setError(result.error ?? 'Something went wrong')
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught))
+    } finally {
+      setBusy(false)
+      void refresh()
+    }
+  }
+
+  const saveCurrent = () => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    setName('')
+    void run(() => window.codey.browser.profiles.save(trimmed))
+  }
+
+  const importFile = () => {
+    void run(() => window.codey.browser.profiles.import())
+  }
+
+  const meta = (profile: BrowserProfileSummary): string => {
+    const bits: string[] = []
+    if (profile.cookieCount > 0) bits.push(`${profile.cookieCount} cookie${profile.cookieCount === 1 ? '' : 's'}`)
+    if (profile.originCount > 0) bits.push(`${profile.originCount} site${profile.originCount === 1 ? '' : 's'}`)
+    const when = formatWhen(profile.updatedAt)
+    if (when) bits.push(`updated ${when}`)
+    return bits.join(' · ')
+  }
+
+  const title = (profile: BrowserProfileSummary): string => {
+    const parts = [`Profile ${profile.name}`]
+    if (profile.sourceUrl) parts.push(`saved from ${profile.sourceUrl}`)
+    const detail = meta(profile)
+    if (detail) parts.push(detail)
+    return parts.join(' — ')
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: compact ? 6 : 10 }}>
+      {error && (
+        <div style={{
+          background: C.red + '22', color: C.red, padding: '8px 10px', borderRadius: 8, fontSize: compact ? 11 : 12,
+        }}>{error}</div>
+      )}
+
+      <div style={compact ? styles.compactComposer : styles.composer}>
+        <input
+          value={name}
+          onChange={event => setName(event.target.value)}
+          onKeyDown={event => { if (event.key === 'Enter') saveCurrent() }}
+          placeholder="Profile name"
+          aria-label="New profile name"
+          spellCheck={false}
+          style={{
+            flex: '1 1 260px', minWidth: 0, background: C.surface2, border: `1px solid ${C.border2}`, color: C.fg,
+            borderRadius: 8, padding: '7px 10px', fontSize: compact ? 12 : 13, outline: 'none',
+          }}
+        />
+        <button
+          type="button"
+          disabled={busy || !name.trim()}
+          onClick={saveCurrent}
+          style={buttonStyle(compact)}
+          title="Snapshot the current session into a profile"
+        >
+          <UIIcon name="add" size={13} /> {compact ? 'Save' : 'Save current session'}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={importFile}
+          style={buttonStyle(compact)}
+          title="Import a profile or Playwright storageState JSON and activate it"
+        >
+          <UIIcon name="folder-open" size={13} /> {compact ? 'Import' : 'Import…'}
+        </button>
+      </div>
+
+      {profiles.length === 0 && !busy && (
+        <div style={compact ? styles.compactEmpty : styles.empty}>
+          {!compact && <div style={styles.emptyIcon}><UIIcon name="users" size={16} /></div>}
+          <span>No profiles yet — save this session or import a session file to get started.</span>
+        </div>
+      )}
+
+      {profiles.map(profile => (
+        <div key={profile.name} style={{
+          display: 'flex', alignItems: 'center', flexWrap: compact ? 'wrap' : 'nowrap', gap: 8,
+          background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10, padding: compact ? '10px' : '9px 11px',
+        }}>
+          <UIIcon name="users" size={14} color={profile.active ? C.green : C.fg3} />
+          <div style={{ flex: 1, minWidth: compact ? 180 : 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ color: C.fg, fontSize: compact ? 12 : 13, fontWeight: 600 }}>{profile.name}</span>
+              {profile.active && (
+                <span style={{
+                  background: C.green + '22', color: C.green, borderRadius: 999, padding: '1px 7px',
+                  fontSize: compact ? 10 : 11, fontWeight: 600,
+                }}>ACTIVE</span>
+              )}
+            </div>
+            <div style={{ color: C.fg3, fontSize: compact ? 10 : 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={title(profile)}>
+              {meta(profile) || (profile.sourceUrl ? 'saved session' : 'empty profile')}
+            </div>
+          </div>
+          <button
+            type="button"
+            disabled={busy || profile.active}
+            onClick={() => void run(() => window.codey.browser.profiles.activate(profile.name))}
+            style={profile.active ? activeBadgeStyle(compact) : buttonStyle(compact)}
+            title={profile.active ? 'This profile is active' : 'Switch the live session to this profile'}
+          >
+            {profile.active ? 'Active' : 'Activate'}
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void run(() => window.codey.browser.profiles.export(profile.name))}
+            style={buttonStyle(compact)}
+            title="Write this profile to a shareable JSON file"
+          ><UIIcon name="copy" size={12} /></button>
+          {confirmDelete === profile.name ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => { setConfirmDelete(null); void run(() => window.codey.browser.profiles.delete(profile.name)) }}
+              style={{ ...buttonStyle(compact), background: C.red, borderColor: C.red, color: '#fff' }}
+              title="Click again to confirm"
+            >Confirm</button>
+          ) : (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => {
+                setConfirmDelete(profile.name)
+                setTimeout(() => setConfirmDelete(current => current === profile.name ? null : current), 3000)
+              }}
+              style={buttonStyle(compact)}
+              title="Delete this profile"
+            ><UIIcon name="trash" size={12} /></button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function buttonStyle(compact: boolean): React.CSSProperties {
+  return {
+    display: 'inline-flex', alignItems: 'center', gap: 5, whiteSpace: 'nowrap',
+    background: C.surface, border: `1px solid ${C.border}`, color: C.fg,
+    borderRadius: 8, padding: compact ? '4px 8px' : '7px 12px',
+    fontSize: compact ? 11 : 12, cursor: 'pointer',
+  }
+}
+
+function activeBadgeStyle(compact: boolean): React.CSSProperties {
+  return {
+    whiteSpace: 'nowrap', background: 'transparent', border: 'none',
+    color: C.green, fontSize: compact ? 11 : 12, fontWeight: 600, padding: '4px 8px', cursor: 'default',
+  }
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  composer: {
+    display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8,
+    padding: 12, borderRadius: 11, background: C.surface, border: `1px solid ${C.border}`,
+  },
+  compactComposer: {
+    display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8,
+    padding: 10, borderRadius: 10, background: C.surface, border: `1px solid ${C.border}`,
+  },
+  empty: {
+    display: 'flex', alignItems: 'center', gap: 10, color: C.fg3, fontSize: 12,
+    padding: '18px 16px', borderRadius: 11, background: C.surface, border: `1px dashed ${C.border2}`,
+  },
+  compactEmpty: { color: C.fg3, fontSize: 11, lineHeight: 1.5, padding: '15px', borderRadius: 10, background: C.surface, border: `1px dashed ${C.border2}` },
+  emptyIcon: {
+    width: 28, height: 28, display: 'grid', placeItems: 'center', flexShrink: 0,
+    borderRadius: 8, background: C.surface2, color: C.fg3,
+  },
+}


### PR DESCRIPTION
## Summary

- move browser actions into a compact overflow dropdown
- combine Extensions and Profiles in a Chrome-style Browser settings tab
- add responsive sidebar/top navigation and adaptive controls for narrow panels
- add browser profile persistence, import/export, activation, and tests

## Validation

- TypeScript type check
- renderer, Electron main, and preload production builds
- `git diff --check`