### PR TITLE
feat(voice): dictionary as prompt hints, drop heard-as aliases

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -27,6 +27,7 @@ import { scanSkillUsage } from './skill-usage'
 import type { SkillUsageMap, UsageCacheEntry } from './skill-usage'
 import { BROWSER_PARTITION, BrowserController, type BrowserBounds } from './browser-controller'
 import { BrowserAgentBridge, type BrowserLoginWaitEvent } from './browser-agent-bridge'
+import { deriveProfileNameFromFile } from './browser-profiles'
 import { BrowserControlPermissionGate } from './browser-control-permission'
 import { BrowserSitePermissionManager } from './browser-site-permissions'
 import { canConfigureBrowserWebAuthn, configureBrowserWebAuthn, passkeyAccountLabel, type BrowserPasskeyPickerRequest } from './browser-webauthn'
@@ -45,7 +46,7 @@ import { ApiServer } from '@codey/gateway/dist/health'
 // Pure logic, no DOM and no Node builtins — shared with the Settings editor
 // that renders the same dictionary, so both sides agree on what a valid entry
 // is and the learner can't write a shape the editor would drop.
-import { learnCorrections, mergeLearnedAliases, normalizeVocabulary, normalizePending, recordCorrections, forgetCorrection } from '../src/components/voiceVocabulary'
+import { learnCorrections, mergeLearnedTerms, normalizeVocabulary, normalizePending, recordCorrections, forgetCorrection } from '../src/components/voiceVocabulary'
 
 let mainWindow: BrowserWindow | null = null
 let captureWindow: BrowserWindow | null = null
@@ -70,6 +71,10 @@ const browserController = new BrowserController(
   state => sendToRenderer('browser:state', state),
   download => sendToRenderer('browser:download', download),
   () => join(app.getPath('downloads'), 'Codey'),
+  undefined,
+  // Named browser profiles (saved/imported sessions) live in the app's own
+  // data directory, next to the browser-control permission store.
+  { getProfilesDir: () => join(app.getPath('userData'), 'browser-profiles') },
 )
 let browserAgentBridge: BrowserAgentBridge | null = null
 let browserControlPermission: BrowserControlPermissionGate | null = null
@@ -1244,7 +1249,42 @@ function sendVoiceHelperCommand(command: string): boolean {
   return true
 }
 
+/**
+ * The resident helper's own model load, if one is running.
+ *
+ * Separate from `activeVoiceWarm` (the one-shot `--warm-model` process) but
+ * indistinguishable to the user: both are "the model isn't usable yet", and
+ * they routinely overlap. The UI reads them merged, through
+ * `currentVoiceWarm()` and the `voice:prepareChange` push below, so the
+ * indicator stays up until *both* are done rather than disappearing when the
+ * first one finishes.
+ */
+let helperModelLoad: { model: string; startedAt: number } | null = null
+
+/** Last value pushed to the renderer, so we only emit on real transitions —
+ *  re-sending "started" would restart the elapsed counter every time. */
+let voicePreparingPushed = false
+
+function syncVoicePreparing() {
+  const active = activeVoiceWarm ?? helperModelLoad
+  if (active && !voicePreparingPushed) {
+    voicePreparingPushed = true
+    sendToRenderer('voice:prepareChange', { model: active.model, startedAt: active.startedAt })
+  } else if (!active && voicePreparingPushed) {
+    voicePreparingPushed = false
+    sendToRenderer('voice:prepareChange', null)
+  }
+}
+
 function handleVoiceHelperLine(line: string) {
+  // Machine-readable load markers from WhisperKitEngine.loadPipeline.
+  if (line.startsWith('model:loading ')) {
+    helperModelLoad = { model: line.slice('model:loading '.length).trim(), startedAt: Date.now() }
+    syncVoicePreparing()
+  } else if (line.startsWith('model:ready ') || line.startsWith('model:failed ')) {
+    helperModelLoad = null
+    syncVoicePreparing()
+  }
   const marker = 'CODEY_CONVERSATION_EVENT '
   if (!line.startsWith(marker)) {
     if (line) sendToRenderer('gateway-log', `[voice-helper] ${line}`)
@@ -1452,6 +1492,7 @@ async function runVoiceModelWarm(modelName: string): Promise<{ model: string; lo
   let lastErr = ''
   let loadSeconds = 0
   activeVoiceWarm = { model: modelName, startedAt: Date.now() }
+  syncVoicePreparing()
   sendToRenderer('voice:warmStart', { model: modelName })
 
   const onLine = (line: string) => {
@@ -1482,6 +1523,7 @@ async function runVoiceModelWarm(modelName: string): Promise<{ model: string; lo
 
   const code: number = await new Promise(resolve => proc.on('exit', c => resolve(c ?? 1)))
   activeVoiceWarm = null
+  syncVoicePreparing()
   if (code !== 0) {
     sendToRenderer('voice:warmError', { model: modelName, error: lastErr || `Warm failed (exit ${code})` })
     throw new Error(lastErr || `Warm failed (exit ${code})`)
@@ -1505,7 +1547,12 @@ let startupWarmInFlight = false
 let activeVoiceWarm: { model: string; startedAt: number } | null = null
 
 export function currentVoiceWarm(): { model: string; startedAt: number } | null {
-  return activeVoiceWarm
+  // Whichever started first is the one the elapsed counter should reflect: it
+  // is the wait the user has actually been sitting through.
+  if (activeVoiceWarm && helperModelLoad) {
+    return activeVoiceWarm.startedAt <= helperModelLoad.startedAt ? activeVoiceWarm : helperModelLoad
+  }
+  return activeVoiceWarm ?? helperModelLoad
 }
 
 /**
@@ -1731,6 +1778,8 @@ async function applyVoiceHelper(rawCfg: any) {
     voiceHelperProc.stderr?.on('data', d => sendToRenderer('gateway-log', `[voice-helper] ${d.toString().trimEnd()}`))
     voiceHelperProc.on('exit', code => {
       sendToRenderer('gateway-log', `[voice-helper] exited (code ${code})`)
+      helperModelLoad = null
+      syncVoicePreparing()
       voiceHelperProc = null
       voiceHelperStarted = false
       nativeConverseActive = false
@@ -1973,6 +2022,48 @@ app.whenReady().then(async () => {
     browserSitePermissions?.clear()
     browserControlPermission?.revoke()
     return state
+  }))
+  // Browser profiles: saved/imported sessions the renderer (browser toolbar
+  // and Settings) manages through the same controller the agents use.
+  ipcMain.handle('browser:profiles:list', event => browserCall(event, () => ({
+    active: browserController.activeProfileName(),
+    profiles: browserController.listProfiles(),
+  })))
+  ipcMain.handle('browser:profiles:save', (event, name: string) =>
+    browserCall(event, () => browserController.saveProfile(String(name || ''))))
+  ipcMain.handle('browser:profiles:activate', (event, name: string) =>
+    browserCall(event, () => browserController.activateProfile(String(name || ''))))
+  ipcMain.handle('browser:profiles:delete', (event, name: string) =>
+    browserCall(event, () => browserController.deleteProfile(String(name || ''))))
+  ipcMain.handle('browser:profiles:import', event => browserCall(event, async () => {
+    const result = await dialog.showOpenDialog(mainWindow ?? (undefined as any), {
+      title: 'Import browser profile',
+      buttonLabel: 'Import',
+      properties: ['openFile'],
+      filters: [
+        { name: 'Browser profile (JSON)', extensions: ['json'] },
+        { name: 'All files', extensions: ['*'] },
+      ],
+    })
+    if (result.canceled || result.filePaths.length === 0) return { imported: false, profile: null }
+    const filePath = result.filePaths[0]
+    const name = deriveProfileNameFromFile(filePath)
+    // Importing activates by default — "import then enable" in one step — and
+    // the identity switch prompts the user like any mutating browser command.
+    const profile = await browserController.importProfile(name, { path: filePath })
+    return { imported: true, profile }
+  }))
+  ipcMain.handle('browser:profiles:export', (event, name: string) => browserCall(event, async () => {
+    const requested = String(name || '')
+    const result = await dialog.showSaveDialog(mainWindow ?? (undefined as any), {
+      title: 'Export browser profile',
+      buttonLabel: 'Export',
+      defaultPath: requested ? `${requested}.json` : 'profile.json',
+      filters: [{ name: 'Browser profile (JSON)', extensions: ['json'] }],
+    })
+    if (result.canceled || !result.filePath) return { exported: false, path: null }
+    const out = await browserController.exportProfile(requested, result.filePath)
+    return { exported: true, path: out.path }
   }))
   ipcMain.handle('browser:extensions:list', event => browserCall(event, () => {
     if (!browserExtensionManager) throw new Error('Browser extensions are unavailable')
@@ -2807,20 +2898,18 @@ app.whenReady().then(async () => {
     }))))
   )
 
-  ipcMain.handle('editors:open', async (_e, editorId: string, workingDir: string) =>
+  ipcMain.handle('editors:open', async (_e, editorId: string, target: string) =>
     wrap(async () => {
       const editor = supportedEditors.find(candidate => candidate.id === editorId)
       if (!editor) throw new Error('Unsupported editor')
-      if (!workingDir || typeof workingDir !== 'string') throw new Error('A project directory is required')
+      if (!target || typeof target !== 'string') throw new Error('A file or directory path is required')
       const fsMod = await import('fs')
-      if (!fsMod.existsSync(workingDir) || !fsMod.statSync(workingDir).isDirectory()) {
-        throw new Error('Project directory is unavailable')
-      }
+      if (!fsMod.existsSync(target)) throw new Error('Path is unavailable')
       const appPath = await findEditorApp(editor)
       if (!appPath) throw new Error(`${editor.name} is not installed`)
       const { execFile } = await import('child_process')
       await new Promise<void>((resolve, reject) => {
-        execFile('open', ['-a', appPath, workingDir], (error) => error ? reject(error) : resolve())
+        execFile('open', ['-a', appPath, target], (error) => error ? reject(error) : resolve())
       })
     })
   )
@@ -3102,7 +3191,7 @@ app.whenReady().then(async () => {
     })
   )
 
-  // Learn mis-hearings by comparing what was dictated against what the user
+  // Learn new dictionary words by comparing what was dictated against what the user
   // actually sent. Done here rather than in the renderer because the merge is
   // read-modify-write on the shared voice config: config:set replaces the
   // whole `voice` object, so a renderer doing this itself would clobber any
@@ -3123,9 +3212,9 @@ app.whenReady().then(async () => {
       const current = normalizeVocabulary(voice.vocabulary)
       const pending = normalizePending(voice.vocabularyPending)
 
-      // A correction has to be seen twice before it rewrites anything. The
-      // first sighting only goes on the waiting list, which is what keeps a
-      // deliberate one-off edit from silently rewriting a real word later.
+      // A correction has to be seen twice before it enters the dictionary.
+      // The first sighting only goes on the waiting list, which keeps a
+      // deliberate one-off edit from becoming a permanent hint.
       const seen = recordCorrections(pending, current, corrections)
       if (seen.promoted.length === 0) {
         if (seen.pending !== pending) {
@@ -3134,17 +3223,21 @@ app.whenReady().then(async () => {
         return { learned: [] }
       }
 
-      const merged = mergeLearnedAliases(current, seen.promoted)
+      const merged = mergeLearnedTerms(current, seen.promoted)
       if (!merged.changed) {
         coreConfigManager.update({ voice: { ...voice, vocabularyPending: seen.pending } } as any)
         return { learned: [] }
       }
 
       coreConfigManager.update({
-        voice: { ...voice, vocabulary: merged.entries, vocabularyPending: seen.pending },
+        voice: { ...voice, vocabulary: merged.terms, vocabularyPending: seen.pending },
       } as any)
-      mainWindow?.webContents.send('voice:vocabularyLearned', merged.entries)
-      return { learned: merged.added }
+      mainWindow?.webContents.send('voice:vocabularyLearned', merged.terms)
+      // The alias goes back with each word purely so undo can find its waiting
+      // list entry; it is not stored anywhere and the pill does not show it.
+      const promotedFor = (term: string) =>
+        seen.promoted.find(p => p.term.toLowerCase() === term.toLowerCase())?.alias ?? ''
+      return { learned: merged.added.map(term => ({ term, alias: promotedFor(term) })) }
     })
   )
 
@@ -3166,9 +3259,9 @@ app.whenReady().then(async () => {
         { term, alias },
       )
       coreConfigManager.update({
-        voice: { ...voice, vocabulary: next.entries, vocabularyPending: next.pending },
+        voice: { ...voice, vocabulary: next.terms, vocabularyPending: next.pending },
       } as any)
-      mainWindow?.webContents.send('voice:vocabularyLearned', next.entries)
+      mainWindow?.webContents.send('voice:vocabularyLearned', next.terms)
       return { ok: true }
     })
   )

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -25,7 +25,7 @@ contextBridge.exposeInMainWorld('codey', {
   },
   editors: {
     list: () => ipcRenderer.invoke('editors:list'),
-    open: (editorId: string, workingDir: string) => ipcRenderer.invoke('editors:open', editorId, workingDir),
+    open: (editorId: string, path: string) => ipcRenderer.invoke('editors:open', editorId, path),
   },
   globalTeams: {
     get: () => ipcRenderer.invoke('globalTeams:get'),
@@ -419,6 +419,13 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.on('voice:warmError', listener)
       return () => ipcRenderer.removeListener('voice:warmError', listener)
     },
+    // "The on-device model is not usable yet", merging the one-shot warm
+    // process and the resident helper's own load. `null` means ready.
+    onPrepareChange: (handler: (msg: { model: string; startedAt: number } | null) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, msg: any) => handler(msg)
+      ipcRenderer.on('voice:prepareChange', listener)
+      return () => ipcRenderer.removeListener('voice:prepareChange', listener)
+    },
   },
   app: {
     version: () => ipcRenderer.invoke('app:version'),
@@ -467,6 +474,14 @@ contextBridge.exposeInMainWorld('codey', {
     switchTab: (id: string) => ipcRenderer.invoke('browser:switchTab', id),
     closeTab: (id: string) => ipcRenderer.invoke('browser:closeTab', id),
     resetSession: () => ipcRenderer.invoke('browser:resetSession'),
+    profiles: {
+      list: () => ipcRenderer.invoke('browser:profiles:list'),
+      save: (name: string) => ipcRenderer.invoke('browser:profiles:save', name),
+      activate: (name: string) => ipcRenderer.invoke('browser:profiles:activate', name),
+      delete: (name: string) => ipcRenderer.invoke('browser:profiles:delete', name),
+      import: () => ipcRenderer.invoke('browser:profiles:import'),
+      export: (name: string) => ipcRenderer.invoke('browser:profiles:export', name),
+    },
     extensions: {
       list: () => ipcRenderer.invoke('browser:extensions:list'),
       discoverChrome: () => ipcRenderer.invoke('browser:extensions:discoverChrome'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -188,6 +188,17 @@ export interface BrowserTab {
   active: boolean
 }
 
+/** A saved browser session ("profile") as listed by the profiles manager. */
+export interface BrowserProfileSummary {
+  name: string
+  createdAt: number
+  updatedAt: number
+  cookieCount: number
+  originCount: number
+  active: boolean
+  sourceUrl: string | null
+}
+
 export interface BrowserLoginWaitEvent {
   id: string
   chatId: string
@@ -248,7 +259,8 @@ declare global {
       }
       editors: {
         list: () => Promise<IpcResult<Array<{ id: string; name: string; installed: boolean }>>>
-        open: (editorId: string, workingDir: string) => Promise<IpcResult<void>>
+        /** Open a file or directory in the given editor. */
+        open: (editorId: string, path: string) => Promise<IpcResult<void>>
       }
       globalTeams: {
         get: () => Promise<IpcResult<Record<string, TeamConfigRaw>>>
@@ -504,7 +516,7 @@ declare global {
         getWarmState: () => Promise<IpcResult<{ model: string; startedAt: number } | null>>
         forgetVocabulary: (term: string, alias: string) => Promise<IpcResult<{ ok: boolean }>>
         learnVocabulary: (spoken: string, edited: string) => Promise<IpcResult<{ learned: Array<{ term: string; alias: string }> }>>
-        onVocabularyLearned: (handler: (entries: Array<{ term: string; aliases: string[] }>) => void) => () => void
+        onVocabularyLearned: (handler: (terms: string[]) => void) => () => void
         /** Speak text through the gateway's digest + TTS pipeline. */
         speak: (text: string, conversationId?: string, verbatim?: boolean) => Promise<IpcResult<void>>
         ack: (transcript: string) => Promise<IpcResult<{ text: string }>>
@@ -523,6 +535,7 @@ declare global {
         onWarmStart: (handler: (msg: { model: string }) => void) => () => void
         onWarmDone: (handler: (msg: { model: string; loadSeconds: number }) => void) => () => void
         onWarmError: (handler: (msg: { model: string; error: string }) => void) => () => void
+        onPrepareChange: (handler: (msg: { model: string; startedAt: number } | null) => void) => () => void
       }
       app: {
         version: () => Promise<string>
@@ -556,6 +569,14 @@ declare global {
         switchTab: (id: string) => Promise<IpcResult<BrowserState>>
         closeTab: (id: string) => Promise<IpcResult<BrowserState>>
         resetSession: () => Promise<IpcResult<BrowserState>>
+        profiles: {
+          list: () => Promise<IpcResult<{ active: string | null; profiles: BrowserProfileSummary[] }>>
+          save: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
+          activate: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
+          delete: (name: string) => Promise<IpcResult<{ deleted: boolean }>>
+          import: () => Promise<IpcResult<{ imported: boolean; profile: BrowserProfileSummary | null }>>
+          export: (name: string) => Promise<IpcResult<{ exported: boolean; path: string | null }>>
+        }
         extensions: {
           list: () => Promise<IpcResult<BrowserExtensionEntry[]>>
           discoverChrome: () => Promise<IpcResult<ChromeBrowserExtensionCandidate[]>>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -844,8 +844,9 @@ export const ChatTab: React.FC<Props> = ({
   // is the composer half — a transcript has to land in this chat's text box.
   const voiceAutoSendRef = useRef(false)
   // Dictated text still waiting to be sent. On send we diff it against what
-  // actually went out and learn the mis-hearings — only dictation, because a
-  // converse turn sends itself and never gives the user a chance to correct it.
+  // actually went out and take the words the user fixed — only dictation,
+  // because a converse turn sends itself and never gives the user a chance to
+  // correct it.
   const dictatedPendingRef = useRef<string[]>([])
   // Words the learner just picked up, shown as a pill above the composer.
   // Learning is silent otherwise, and a dictionary that edits itself without
@@ -1250,6 +1251,25 @@ export const ChatTab: React.FC<Props> = ({
     })
     return () => cancelAnimationFrame(frame)
   }, [chat?.messages?.length, lastMsg?.content, lastMsg?.toolCalls?.length, chat?.contextPanelOpen, updateLatestMessageVisibility])
+
+  // The deps above can't see every way the transcript moves: a tool card
+  // expanding, a status row appearing mid-turn, or the composer growing as the
+  // user types (which shrinks the viewport and pushes the last message out of
+  // sight without any React state changing). Observe the boxes instead, so a
+  // pinned view stays pinned whatever caused the shift.
+  useEffect(() => {
+    const messages = messagesRef.current
+    if (!messages) return
+    const stick = () => {
+      if (stickToBottomRef.current) messages.scrollTop = messages.scrollHeight
+      updateLatestMessageVisibility()
+    }
+    const resize = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(stick) : null
+    resize?.observe(messages)
+    const mutate = typeof MutationObserver !== 'undefined' ? new MutationObserver(stick) : null
+    mutate?.observe(messages, { childList: true, subtree: true, characterData: true })
+    return () => { resize?.disconnect(); mutate?.disconnect() }
+  }, [updateLatestMessageVisibility])
 
   const scrollToLatestMessage = useCallback(() => {
     const messages = messagesRef.current
@@ -1906,6 +1926,7 @@ export const ChatTab: React.FC<Props> = ({
   const voiceBusy = voiceActiveHere && (voice.state === 'recording' || voice.state === 'transcribing')
   const isSending = !!flight
   const orphaned = state.workspaces.length > 0 && !state.workspaces.includes(chat.workspaceName)
+  const canSend = isGatewayRunning && !coreFailed && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
   // Retry and edit-and-resend both re-run a past user message. They append a
   // new turn rather than rewriting history: the agent keeps the whole
   // conversation as context, and the transcript stays an honest record.
@@ -1934,7 +1955,6 @@ export const ChatTab: React.FC<Props> = ({
     setEditingMsgId(null)
     await resendMessage(text, msg.attachments)
   }
-  const canSend = isGatewayRunning && !coreFailed && (!!input.trim() || pendingAttachments.length > 0) && !orphaned
   // Three layers when the agent gave us its task list: what it is on, the tool
   // it is running right now, and how far through it is — a bare "Editing…"
   // withholds information we already have in hand.
@@ -2685,16 +2705,14 @@ export const ChatTab: React.FC<Props> = ({
         {learnedWords.length > 0 && (
           <div style={styles.learnedRow}>
             <span style={styles.learnedPill}>
-              {/* Reads as the rule it created: mis-hearing, arrow, corrected
-                  spelling. The mis-hearing has to stay on screen - it is the
-                  only thing that lets a wrong guess be caught before it starts
-                  rewriting transcripts. */}
+              {/* Just the word that went in. The mis-hearing that triggered it
+                  is not shown: nothing gets rewritten any more, so there is no
+                  rule to double-check - only a word the recognizer will now be
+                  told about. */}
               {learnedWords.map((word, i) => (
-                <span key={`${word.alias}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
-                  <span style={styles.learnedAlias}>{word.alias}</span>
-                  <span style={{ opacity: 0.5 }}>&rarr;</span>
+                <span key={`${word.term}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
                   <strong>{word.term}</strong>
-                  <span style={{ opacity: 0.7 }}>learned</span>
+                  <span style={{ opacity: 0.7 }}>is added</span>
                   <button
                     onClick={() => {
                       // Removes it from the dictionary *and* the waiting list,
@@ -2702,8 +2720,8 @@ export const ChatTab: React.FC<Props> = ({
                       void window.codey.voice.forgetVocabulary(word.term, word.alias)
                       setLearnedWords(prev => prev.filter((_, at) => at !== i))
                     }}
-                    title={`Undo - stop rewriting "${word.alias}" to "${word.term}"`}
-                    aria-label={`Undo learning ${word.alias} as ${word.term}`}
+                    title={`Undo - remove "${word.term}" from the dictionary`}
+                    aria-label={`Undo adding ${word.term}`}
                     style={styles.learnedUndo}
                   >
                     <UIIcon name="undo" size={13} color={C.accent} />
@@ -2858,8 +2876,24 @@ export const ChatTab: React.FC<Props> = ({
             <div style={styles.composerActions}>
               {/* Two ways to use your voice: dictate into the composer, or
                   hold a spoken conversation that reads the reply back. */}
-              {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'converse') && <button
+              {/* The tooltip lives on the wrapper, not the button: a disabled
+                  button takes no mouse events in Chromium, so its own `title`
+                  never appears - and disabled is exactly when the explanation
+                  is needed (gateway down, model still warming). */}
+              {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'converse') && <span
+                style={styles.voiceButtonWrap}
+                title={
+                  voiceWarming ? voiceWarmTitle
+                  : !isGatewayRunning ? 'Start the gateway to use voice'
+                  : coreFailed ? 'Voice is unavailable while the gateway is failing'
+                  : voiceActiveElsewhere ? 'Voice is active in another chat'
+                  : voiceBusy && voice.mode === 'dictate'
+                    ? (voice.state === 'transcribing' ? 'Transcribing… (Esc to cancel)' : 'Stop — text goes to the box')
+                    : 'Dictate into the message box'
+                }
+              ><button
                 onClick={() => voice.toggle('dictate')}
+                aria-label="Dictate into the message box"
                 disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere || voiceWarming}
                 style={{
                   ...styles.voiceButton,
@@ -2867,13 +2901,6 @@ export const ChatTab: React.FC<Props> = ({
                   opacity: voiceWarming ? 0.4 : 1,
                   cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere && !voiceWarming ? 'pointer' : 'default',
                 }}
-                title={
-                  voiceWarming ? voiceWarmTitle
-                  : voiceActiveElsewhere ? 'Voice is active in another chat'
-                  : voiceBusy && voice.mode === 'dictate'
-                    ? (voice.state === 'transcribing' ? 'Transcribing…' : 'Stop — text goes to the box')
-                    : 'Dictate into the message box'
-                }
               >
                 {voice.state === 'recording' && voice.mode === 'dictate'
                   ? <StopIcon color="#fff" />
@@ -2882,7 +2909,7 @@ export const ChatTab: React.FC<Props> = ({
                       size={19}
                       color={voiceBusy && voice.mode === 'dictate' ? '#fff' : C.fg2}
                     />}
-              </button>}
+              </button></span>}
               {/* While dictating, the mic slot is the stop button, so the way
                   out of the recording needs a control of its own — same thing
                   Esc does: drop the audio instead of transcribing it. */}
@@ -2894,8 +2921,21 @@ export const ChatTab: React.FC<Props> = ({
               >
                 <UIIcon name="close" size={15} color={C.fg3} />
               </button>}
-              {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'dictate') && <button
+              {!(voiceActiveHere && voice.state === 'recording' && voice.mode === 'dictate') && <span
+                style={styles.voiceButtonWrap}
+                title={
+                  voiceWarming ? voiceWarmTitle
+                  : !isGatewayRunning ? 'Start the gateway to use voice'
+                  : coreFailed ? 'Voice is unavailable while the gateway is failing'
+                  : voiceActiveElsewhere ? 'Voice is active in another chat'
+                  : voiceActiveHere && voice.state === 'speaking' ? 'Speaking — click to interrupt and talk'
+                  : voiceBusy && voice.mode === 'converse'
+                    ? (voice.state === 'transcribing' ? 'Transcribing… (Esc to cancel)' : 'Stop and send')
+                    : 'Talk to this chat — the reply is read back'
+                }
+              ><button
                 onClick={() => voice.toggle('converse')}
+                aria-label="Talk to this chat"
                 disabled={!isGatewayRunning || !!coreFailed || voiceActiveElsewhere || voiceWarming}
                 style={{
                   ...styles.voiceButton,
@@ -2905,14 +2945,6 @@ export const ChatTab: React.FC<Props> = ({
                   opacity: voiceWarming ? 0.4 : 1,
                   cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere && !voiceWarming ? 'pointer' : 'default',
                 }}
-                title={
-                  voiceWarming ? voiceWarmTitle
-                  : voiceActiveElsewhere ? 'Voice is active in another chat'
-                  : voiceActiveHere && voice.state === 'speaking' ? 'Speaking — click to interrupt and talk'
-                  : voiceBusy && voice.mode === 'converse'
-                    ? (voice.state === 'transcribing' ? 'Transcribing…' : 'Stop and send')
-                    : 'Talk to this chat — the reply is read back'
-                }
               >
                 {voice.state === 'recording' && voice.mode === 'converse'
                   ? <StopIcon color="#fff" />
@@ -2921,8 +2953,11 @@ export const ChatTab: React.FC<Props> = ({
                       size={19}
                       color={voiceActiveHere && voice.state === 'speaking' ? C.onAccent : C.fg2}
                     />}
-              </button>}
-              {isSending && (
+              </button></span>}
+              {/* One slot, two jobs: Stop while a turn runs, Send otherwise.
+                  Keeps the action row at three buttons either way. Queuing the
+                  next message has no button - that is what ↵ is for. */}
+              {isSending ? (
                 <button
                   onClick={() => stopChat(chatId)}
                   style={{ ...styles.sendButton, background: C.red, cursor: 'pointer' }}
@@ -2930,12 +2965,11 @@ export const ChatTab: React.FC<Props> = ({
                 >
                   <StopIcon color="#fff" />
                 </button>
-              )}
-              {(
+              ) : (
                 <button
                   onClick={send}
                   disabled={!canSend}
-                  title={isSending ? 'Queue this message (↵)' : 'Send (↵)'}
+                  title="Send (↵)"
                   style={{ ...styles.sendButton, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
                 >
                   <SendIcon color={canSend ? C.onAccent : C.fg3} />
@@ -3290,6 +3324,9 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     flexShrink: 0, transition: 'background 0.15s',
   },
+  voiceButtonWrap: {
+    display: 'inline-flex', flexShrink: 0,
+  },
   voiceButton: {
     width: 36, height: 36, borderRadius: 9, border: 'none',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -3411,12 +3448,6 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'inline-flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' as const,
     background: C.surface3, border: `1px solid ${C.border2}`, borderRadius: 999,
     color: C.fg2, fontSize: 11, padding: '4px 6px 4px 12px', maxWidth: '100%',
-  },
-  learnedAlias: {
-    // Muted rather than struck through: with "was" already saying it is the
-    // old spelling, a strikethrough only makes the evidence harder to read -
-    // and reading it is how a wrong guess gets caught.
-    color: C.fg3,
   },
   learnedUndo: {
     background: 'none', border: 'none', cursor: 'pointer', color: C.accent,

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -3,7 +3,7 @@ import { C } from '../theme'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import { Toggle } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
-import { normalizeVocabulary, vocabularyToDraft, draftToVocabulary, countAliases, type VocabularyEntry, type VocabularyDraftRow } from './voiceVocabulary'
+import { normalizeVocabulary } from './voiceVocabulary'
 
 interface WhisperTabProps {
   isGatewayRunning: boolean
@@ -31,9 +31,9 @@ interface VoiceCfg {
   realtimeModel: string
   /** Legacy setting kept for config compatibility. The two hotkeys now have fixed destinations. */
   mode: 'inject' | 'converse'
-  /** Custom vocabulary. See VocabularyEntry. */
-  vocabulary: VocabularyEntry[]
-  /** Learn mis-hearings from corrections made in a Codey chat before sending. */
+  /** Preferred spellings, handed to the recognizer as a prompt hint. */
+  vocabulary: string[]
+  /** Add words to the dictionary from corrections made in a Codey chat before sending. */
   vocabularyAutoLearn: boolean
   tts: TtsCfg
 }
@@ -189,12 +189,11 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
   // false → deps change → re-fires → "model folder is not set" flicker).
   // User can manually retry by switching model and back.
   const [warmFailed, setWarmFailed] = useState<Set<string>>(new Set())
-  // Dictionary rows are edited as free text — aliases live as one blob while
-  // the user types, so a half-typed line isn't eaten mid-keystroke. Parsed
-  // back into string[] only on commit.
-  const [vocabDraft, setVocabDraft] = useState<VocabularyDraftRow[]>([])
-  // Which row has its mis-hearings open. One at a time: the list is a scan
-  // target, and the aliases are the rare thing you come here to change.
+  // Words are held as a draft so a half-typed one isn't written to config on
+  // every keystroke; committed on blur.
+  const [vocabDraft, setVocabDraft] = useState<string[]>([])
+  // Which word is being edited. One at a time: the list is a scan target, and
+  // editing is the rare thing you come here to do.
   const [expandedVocabRow, setExpandedVocabRow] = useState<number | null>(null)
 
   const refreshDownloaded = useCallback(async () => {
@@ -319,7 +318,7 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
       setSavedVoiceKeys(keys.filter(key => key.purpose === 'voice').sort((a, b) => a.name.localeCompare(b.name)))
       const storedVoice = cfg?.voice ?? {}
       const vocabulary = normalizeVocabulary(storedVoice.vocabulary)
-      setVocabDraft(vocabularyToDraft(vocabulary))
+      setVocabDraft(vocabulary)
       const legacyEnabled = storedVoice.enabled ?? false
       const dictationEnabled = storedVoice.dictationEnabled ?? legacyEnabled
       const conversationEnabled = storedVoice.conversationEnabled ?? legacyEnabled
@@ -352,7 +351,7 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
     return window.codey.voice.onVocabularyLearned(entries => {
       const normalized = normalizeVocabulary(entries)
       setVoice(prev => ({ ...prev, vocabulary: normalized }))
-      if (expandedVocabRow === null) setVocabDraft(vocabularyToDraft(normalized))
+      if (expandedVocabRow === null) setVocabDraft(normalized)
     })
   }, [expandedVocabRow])
 
@@ -409,12 +408,14 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
     }
   }
 
-  const commitVocabulary = (draft: VocabularyDraftRow[]) => {
-    updateVoice({ vocabulary: draftToVocabulary(draft) })
+  const commitVocabulary = (draft: string[]) => {
+    // Blank rows stay visible in the draft so "+ Add word" can leave an empty
+    // chip on screen, but they must never reach gateway.json.
+    updateVoice({ vocabulary: normalizeVocabulary(draft) })
   }
 
-  const patchVocabRow = (index: number, patch: Partial<VocabularyDraftRow>) => {
-    setVocabDraft(rows => rows.map((row, i) => (i === index ? { ...row, ...patch } : row)))
+  const patchVocabRow = (index: number, word: string) => {
+    setVocabDraft(rows => rows.map((row, i) => (i === index ? word : row)))
   }
 
   const removeVocabRow = (index: number) => {
@@ -899,37 +900,10 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
       <div style={sectionCardStyle}>
         <Section
           title="Dictionary"
-          description="Names the recognizer keeps getting wrong"
+          description="Words the recognizer should know about"
           right={<Toggle on={voice.vocabularyAutoLearn} onChange={vocabularyAutoLearn => updateVoice({ vocabularyAutoLearn })}/>}
         />
         <div style={sectionBodyStyle}>
-
-      <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.55, padding: '10px 12px', background: C.surface3, borderRadius: 7, marginTop: 10 }}>
-        Open a word to list what it gets <strong style={{ color: C.fg2 }}>heard as</strong>.
-        Those spellings are rewritten to the word after transcribing, which is what fixes a
-        mistake that comes out the same way every time.
-        {voice.provider === 'local' ? (
-          // Being specific rather than encouraging: on-device gets no hint, so
-          // a word with nothing under "heard as" genuinely does nothing, and
-          // saying otherwise sends people off adding words that never help.
-          <div style={{ marginTop: 7 }}>
-            <strong style={{ color: C.fg2 }}>On-device transcription needs the mis-hearings.</strong>{' '}
-            A word on its own has no effect here — unlike the API providers, WhisperKit cannot
-            be given the vocabulary up front (its prompt option returns empty transcripts in
-            the version bundled with Codey).
-          </div>
-        ) : (
-          <div style={{ marginTop: 7 }}>
-            A word on its own still helps here: it is sent to the API as a hint before
-            transcribing, so the recognizer can reach spellings it would otherwise never
-            produce. Mis-hearings are optional on top of that.
-          </div>
-        )}
-        <div style={{ marginTop: 7 }}>
-          The toggle above controls learning: with it on, when you dictate into a Codey chat
-          and fix a word before sending, that fix is added here automatically.
-        </div>
-      </div>
 
       {/* Chips rather than a column of inputs: the list is a scan target -
           "is this word already in here?" - and a wrapping row of words answers
@@ -937,42 +911,24 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
           the rare action, so it lives in one panel below rather than inline,
           which would also break the wrap. */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, padding: '14px 0 4px' }}>
-        {vocabDraft.map((row, i) => {
-          const aliases = countAliases(row.aliasText)
+        {vocabDraft.map((word, i) => {
           const selected = expandedVocabRow === i
-          const label = row.term.trim() || 'Untitled'
-          const inertHintOnly = aliases === 0 && voice.provider === 'local'
+          const label = word.trim() || 'Untitled'
           return (
             <button
               key={i}
               onClick={() => setExpandedVocabRow(selected ? null : i)}
-              title={aliases > 0
-                ? `${label} - ${aliases} mis-hearing${aliases === 1 ? '' : 's'}`
-                : inertHintOnly
-                  ? `${label} - no effect yet: on-device transcription needs at least one mis-hearing. Click to add one.`
-                  : `${label} - sent to the API as a hint; no mis-hearings listed`}
+              title={`${label} - click to edit or remove`}
               style={{
                 display: 'inline-flex', alignItems: 'center', gap: 6,
                 padding: '5px 11px', borderRadius: 999, fontSize: 12, cursor: 'pointer',
                 background: selected ? C.accent : C.surface3,
                 color: selected ? C.onAccent : C.fg,
-                border: `1px solid ${selected ? C.accent : inertHintOnly ? C.border : C.border2}`,
-                // Dimmed rather than hidden: the word is saved, it just does
-                // nothing until it has a mis-hearing under it.
-                opacity: !selected && inertHintOnly ? 0.55 : 1,
-                fontStyle: row.term.trim() ? 'normal' : 'italic',
+                border: `1px solid ${selected ? C.accent : C.border2}`,
+                fontStyle: word.trim() ? 'normal' : 'italic',
               }}
             >
               {label}
-              {aliases > 0 && (
-                <span style={{
-                  fontSize: 10, lineHeight: 1, padding: '2px 5px', borderRadius: 999,
-                  background: selected ? '#ffffff33' : C.border2,
-                  color: selected ? C.onAccent : C.fg3,
-                }}>
-                  {aliases}
-                </span>
-              )}
             </button>
           )
         })}
@@ -982,7 +938,7 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
             // another setter's callback runs during render in StrictMode's
             // double-invoke and would select the wrong chip.
             const index = vocabDraft.length
-            setVocabDraft([...vocabDraft, { term: '', aliasText: '' }])
+            setVocabDraft([...vocabDraft, ''])
             setExpandedVocabRow(index)
           }}
           title="Add a word"
@@ -1002,10 +958,8 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
         </div>
       )}
 
-      {expandedVocabRow !== null && vocabDraft[expandedVocabRow] && (() => {
+      {expandedVocabRow !== null && vocabDraft[expandedVocabRow] !== undefined && (() => {
         const i = expandedVocabRow
-        const row = vocabDraft[i]
-        const aliases = countAliases(row.aliasText)
         return (
           <div style={{
             marginTop: 8, padding: 12, borderRadius: 9,
@@ -1013,8 +967,8 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
           }}>
             <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
               <input
-                value={row.term}
-                onChange={e => patchVocabRow(i, { term: e.target.value })}
+                value={vocabDraft[i]}
+                onChange={e => patchVocabRow(i, e.target.value)}
                 onBlur={() => commitVocabulary(vocabDraft)}
                 placeholder="Codey"
                 autoFocus
@@ -1029,24 +983,6 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
               <button onClick={() => setExpandedVocabRow(null)} style={pillButton('ghost')}>
                 Done
               </button>
-            </div>
-            <div style={{ color: C.fg2, fontSize: 11, fontWeight: 700, letterSpacing: 0.55, textTransform: 'uppercase', padding: '12px 0 6px' }}>
-              Heard as
-            </div>
-            <textarea
-              value={row.aliasText}
-              onChange={e => patchVocabRow(i, { aliasText: e.target.value })}
-              onBlur={() => commitVocabulary(vocabDraft)}
-              placeholder={'Coday\ncode E\ncody'}
-              rows={Math.min(8, Math.max(3, aliases + 1))}
-              style={{ ...inputStyle, width: '100%', resize: 'vertical', fontFamily: 'inherit', lineHeight: 1.5 }}
-            />
-            <div style={{ color: C.fg3, fontSize: 11, marginTop: 6 }}>
-              One mis-hearing per line. Each is rewritten to
-              <strong style={{ color: C.fg2 }}> {row.term.trim() || 'the word above'}</strong> after transcribing.
-              {voice.provider === 'local'
-                ? ' Leaving this empty means the word does nothing on on-device transcription.'
-                : ' Leaving it empty still sends the word to the API as a hint.'}
             </div>
           </div>
         )

--- a/codey-mac/src/components/useChatVoice.ts
+++ b/codey-mac/src/components/useChatVoice.ts
@@ -84,6 +84,11 @@ export function useChatVoice({ onTranscript, onError }: Options) {
   const recorderRef = useRef<MediaRecorder | null>(null)
   /** Set by cancel() so the recorder's onstop discards instead of transcribing. */
   const cancelledRef = useRef(false)
+  /** Bumped by cancel() and by each new recording. The transcribe call keeps
+   *  the value it started with and drops its result on a mismatch: the HTTP
+   *  round trip can't be interrupted, so Esc during `transcribing` has to work
+   *  by severing the result rather than by stopping the work. */
+  const captureGenRef = useRef(0)
   const chunksRef = useRef<Blob[]>([])
   const streamRef = useRef<MediaStream | null>(null)
   const stateRef = useRef<ChatVoiceState>('idle')
@@ -372,9 +377,11 @@ export function useChatVoice({ onTranscript, onError }: Options) {
   // ── Recording ─────────────────────────────────────────────────────
 
   const transcribe = useCallback(async (blob: Blob, mime: string) => {
+    const generation = captureGenRef.current
     updateState('transcribing')
     try {
       const result = await window.codey.voice.transcribe(await blob.arrayBuffer(), mime)
+      if (generation !== captureGenRef.current) return // Esc: the turn is gone
       if (!result.ok) throw new Error(result.error)
       const text = result.data.text.trim()
       if (!text) throw new Error('No speech detected.')
@@ -384,6 +391,7 @@ export function useChatVoice({ onTranscript, onError }: Options) {
       // starts speaking; hiding here made a successful stop look like failure.
       if (capturedMode === 'dictate') updateState('idle')
     } catch (err: any) {
+      if (generation !== captureGenRef.current) return
       fail(err?.message ?? String(err))
       updateState('idle')
     }
@@ -402,6 +410,7 @@ export function useChatVoice({ onTranscript, onError }: Options) {
       const rec = new MediaRecorder(stream, { mimeType: mime })
       chunksRef.current = []
       cancelledRef.current = false
+      captureGenRef.current += 1
       rec.ondataavailable = e => { if (e.data.size > 0) chunksRef.current.push(e.data) }
       rec.onstop = () => {
         stopMeter()
@@ -473,6 +482,7 @@ export function useChatVoice({ onTranscript, onError }: Options) {
       return
     }
     cancelledRef.current = true
+    captureGenRef.current += 1
     try { recorderRef.current?.stop() } catch { /* already stopped */ }
     streamRef.current?.getTracks().forEach(t => t.stop())
     streamRef.current = null

--- a/codey-mac/src/components/useVoiceWarm.ts
+++ b/codey-mac/src/components/useVoiceWarm.ts
@@ -1,12 +1,18 @@
 import { useEffect, useState } from 'react'
 
 /**
- * Whether the on-device model is mid-warm, and for how long.
+ * Whether the on-device model is being prepared, and for how long.
  *
  * Both pushed and pulled: the startup warm begins before this window exists
  * and runs for minutes, so subscribing to the start event alone would miss the
  * common case and leave the composer's voice buttons enabled during the one
  * stretch where pressing them does nothing useful.
+ *
+ * Listens to `onPrepareChange` rather than the three warm events, because two
+ * separate things can be preparing the same model at once — the `--warm-model`
+ * process and the resident helper's own load — and either finishing while the
+ * other runs must not read as "ready". The main process merges them; this hook
+ * takes the merged answer.
  */
 export function useVoiceWarm(): { warming: boolean; model: string; elapsedSeconds: number } {
   const [state, setState] = useState<{ model: string; startedAt: number } | null>(null)
@@ -18,12 +24,10 @@ export function useVoiceWarm(): { warming: boolean; model: string; elapsedSecond
       .then(res => { if (!cancelled && res.ok && res.data) setState(res.data) })
       .catch(() => { /* best-effort: worst case the buttons stay enabled */ })
 
-    const offStart = window.codey.voice.onWarmStart(({ model }) => {
-      setState({ model, startedAt: Date.now() })
+    const off = window.codey.voice.onPrepareChange(next => {
+      setState(next ? { model: next.model, startedAt: next.startedAt } : null)
     })
-    const offDone = window.codey.voice.onWarmDone(() => setState(null))
-    const offErr = window.codey.voice.onWarmError(() => setState(null))
-    return () => { cancelled = true; offStart(); offDone(); offErr() }
+    return () => { cancelled = true; off() }
   }, [])
 
   // Ticks once a second rather than on every render: the elapsed number is the

--- a/codey-mac/src/components/voiceVocabulary.test.ts
+++ b/codey-mac/src/components/voiceVocabulary.test.ts
@@ -1,96 +1,37 @@
 import { describe, it, expect } from 'vitest'
 import {
-  normalizeVocabulary, vocabularyToDraft, draftToVocabulary,
-  learnCorrections, mergeLearnedAliases, countAliases,
+  normalizeVocabulary,
+  learnCorrections, mergeLearnedTerms,
   recordCorrections, normalizePending, forgetCorrection,
   SIGHTINGS_BEFORE_ACTIVE, MAX_PENDING_CORRECTIONS,
-  MAX_ALIASES_PER_TERM, MAX_VOCABULARY_ENTRIES,
+  MAX_VOCABULARY_ENTRIES,
 } from './voiceVocabulary'
 
 describe('normalizeVocabulary', () => {
-  it('widens the bare-string shorthand into a term with no aliases', () => {
-    expect(normalizeVocabulary(['WhisperKit'])).toEqual([{ term: 'WhisperKit', aliases: [] }])
+  it('takes the bare-string shorthand as-is', () => {
+    expect(normalizeVocabulary(['WhisperKit'])).toEqual(['WhisperKit'])
   })
 
-  it('keeps the object form intact', () => {
-    expect(normalizeVocabulary([{ term: 'Codey', aliases: ['Coday', 'code E'] }]))
-      .toEqual([{ term: 'Codey', aliases: ['Coday', 'code E'] }])
-  })
-
-  it('defaults a missing aliases field to empty', () => {
-    expect(normalizeVocabulary([{ term: 'Codey' }])).toEqual([{ term: 'Codey', aliases: [] }])
-  })
-
-  it('drops non-string aliases rather than passing them through', () => {
-    expect(normalizeVocabulary([{ term: 'Codey', aliases: ['ok', 3, null] }]))
-      .toEqual([{ term: 'Codey', aliases: ['ok'] }])
+  it('migrates the old { term, aliases } shape by keeping only the term', () => {
+    expect(normalizeVocabulary([{ term: 'Codey', aliases: ['Coday', 'code E'] }])).toEqual(['Codey'])
   })
 
   it('skips malformed rows without losing the good ones', () => {
-    expect(normalizeVocabulary(['A', 42, null, { noTerm: true }, { term: 'B' }]))
-      .toEqual([{ term: 'A', aliases: [] }, { term: 'B', aliases: [] }])
+    expect(normalizeVocabulary(['A', 42, null, { noTerm: true }, { term: 'B' }])).toEqual(['A', 'B'])
   })
 
-  it('skips blank strings', () => {
-    expect(normalizeVocabulary(['   ', 'A'])).toEqual([{ term: 'A', aliases: [] }])
+  it('drops blanks, so "+ Add word" can leave an empty chip on screen', () => {
+    expect(normalizeVocabulary(['   ', 'A'])).toEqual(['A'])
+  })
+
+  it('trims and de-duplicates case-insensitively', () => {
+    expect(normalizeVocabulary(['  Codey  ', 'codey', 'Codey'])).toEqual(['Codey'])
   })
 
   it('returns empty for a missing or non-array field', () => {
     expect(normalizeVocabulary(undefined)).toEqual([])
     expect(normalizeVocabulary('Codey')).toEqual([])
     expect(normalizeVocabulary({ term: 'Codey' })).toEqual([])
-  })
-})
-
-describe('draft round-trip', () => {
-  it('survives entries -> draft -> entries unchanged', () => {
-    const entries = [
-      { term: 'Codey', aliases: ['Coday', 'code E'] },
-      { term: 'WhisperKit', aliases: [] },
-    ]
-    expect(draftToVocabulary(vocabularyToDraft(entries))).toEqual(entries)
-  })
-
-  it('shows aliases one per line for the textarea', () => {
-    expect(vocabularyToDraft([{ term: 'Codey', aliases: ['a', 'b'] }]))
-      .toEqual([{ term: 'Codey', aliasText: 'a\nb' }])
-  })
-})
-
-describe('draftToVocabulary', () => {
-  it('drops a row whose term is blank, so "+ Add word" writes nothing', () => {
-    expect(draftToVocabulary([{ term: '', aliasText: '' }, { term: '  ', aliasText: 'x' }])).toEqual([])
-  })
-
-  it('keeps a term with no aliases — it still works as a hint', () => {
-    expect(draftToVocabulary([{ term: 'Codey', aliasText: '' }]))
-      .toEqual([{ term: 'Codey', aliases: [] }])
-  })
-
-  it('trims whitespace around the term and each alias', () => {
-    expect(draftToVocabulary([{ term: '  Codey  ', aliasText: ' Coday ,  code E ' }]))
-      .toEqual([{ term: 'Codey', aliases: ['Coday', 'code E'] }])
-  })
-
-  it('ignores empty slots from trailing or doubled commas while typing', () => {
-    expect(draftToVocabulary([{ term: 'Codey', aliasText: 'a,,b, ' }]))
-      .toEqual([{ term: 'Codey', aliases: ['a', 'b'] }])
-  })
-})
-
-describe('countAliases', () => {
-  it('agrees with what draftToVocabulary would save', () => {
-    const text = 'Coday\ncode E, cody'
-    expect(countAliases(text)).toBe(draftToVocabulary([{ term: 'Codey', aliasText: text }])[0].aliases.length)
-  })
-
-  it('counts nothing for an empty or whitespace-only field', () => {
-    expect(countAliases('')).toBe(0)
-    expect(countAliases('  \n , ')).toBe(0)
-  })
-
-  it('does not double-count a duplicate the save would drop', () => {
-    expect(countAliases('Coday\ncoday')).toBe(1)
   })
 })
 
@@ -201,92 +142,6 @@ describe('learnCorrections', () => {
   })
 })
 
-describe('mergeLearnedAliases', () => {
-  it('adds an alias to the matching existing term', () => {
-    const result = mergeLearnedAliases(
-      [{ term: 'Codey', aliases: ['cody'] }],
-      [{ term: 'Codey', alias: 'coday' }],
-    )
-    expect(result.changed).toBe(true)
-    expect(result.entries).toEqual([{ term: 'Codey', aliases: ['cody', 'coday'] }])
-  })
-
-  it('creates a new entry when the term is unknown', () => {
-    const result = mergeLearnedAliases([], [{ term: 'WhisperKit', alias: 'whisper kit' }])
-    expect(result.entries).toEqual([{ term: 'WhisperKit', aliases: ['whisper kit'] }])
-  })
-
-  it('reports no change when the alias is already known', () => {
-    const entries = [{ term: 'Codey', aliases: ['coday'] }]
-    const result = mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'CODAY' }])
-    expect(result.changed).toBe(false)
-    expect(result.entries).toBe(entries)
-  })
-
-  it('does not mutate the array it was given', () => {
-    const entries = [{ term: 'Codey', aliases: ['cody'] }]
-    mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'coday' }])
-    expect(entries).toEqual([{ term: 'Codey', aliases: ['cody'] }])
-  })
-
-  it('refuses an alias that is another entry preferred spelling', () => {
-    const entries = [{ term: 'Codey', aliases: [] }, { term: 'Cody', aliases: [] }]
-    const result = mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'Cody' }])
-    expect(result.changed).toBe(false)
-  })
-
-  it('stops adding aliases to one term past the cap', () => {
-    const aliases = Array.from({ length: MAX_ALIASES_PER_TERM }, (_, i) => `a${i}`)
-    const result = mergeLearnedAliases(
-      [{ term: 'Codey', aliases }],
-      [{ term: 'Codey', alias: 'one-too-many' }],
-    )
-    expect(result.changed).toBe(false)
-  })
-
-  it('stops creating entries past the cap', () => {
-    const entries = Array.from({ length: MAX_VOCABULARY_ENTRIES }, (_, i) => ({ term: `t${i}`, aliases: [] }))
-    const result = mergeLearnedAliases(entries, [{ term: 'Codey', alias: 'coday' }])
-    expect(result.changed).toBe(false)
-  })
-
-  it('reports exactly what landed, so the UI can name it', () => {
-    const result = mergeLearnedAliases([], [
-      { term: 'Codey', alias: 'coday' },
-      { term: 'WhisperKit', alias: 'whisper kit' },
-    ])
-    expect(result.added).toEqual([
-      { term: 'Codey', alias: 'coday' },
-      { term: 'WhisperKit', alias: 'whisper kit' },
-    ])
-  })
-
-  it('leaves a dropped correction out of added', () => {
-    const result = mergeLearnedAliases(
-      [{ term: 'Codey', aliases: ['coday'] }],
-      [{ term: 'Codey', alias: 'CODAY' }, { term: 'Codey', alias: 'cody' }],
-    )
-    expect(result.added).toEqual([{ term: 'Codey', alias: 'cody' }])
-  })
-
-  it('reports added under the existing spelling of the term, not the typed one', () => {
-    const result = mergeLearnedAliases(
-      [{ term: 'Codey', aliases: [] }],
-      [{ term: 'codey', alias: 'coday' }],
-    )
-    expect(result.added).toEqual([{ term: 'Codey', alias: 'coday' }])
-  })
-
-  it('reports an empty added list when nothing changed', () => {
-    expect(mergeLearnedAliases([{ term: 'Codey', aliases: ['coday'] }], [{ term: 'Codey', alias: 'coday' }]).added).toEqual([])
-  })
-
-  it('reports no change for an empty correction list', () => {
-    const entries = [{ term: 'Codey', aliases: [] }]
-    expect(mergeLearnedAliases(entries, []).changed).toBe(false)
-  })
-})
-
 describe('recordCorrections', () => {
   const codey = { term: 'Codey', alias: 'coday' }
 
@@ -325,9 +180,8 @@ describe('recordCorrections', () => {
     expect(second.promoted).toHaveLength(1)
   })
 
-  it('ignores a correction the dictionary already covers', () => {
-    const entries = [{ term: 'Codey', aliases: ['coday'] }]
-    const r = recordCorrections([], entries, [codey])
+  it('ignores a correction whose word is already in the dictionary', () => {
+    const r = recordCorrections([], ['Codey'], [codey])
     expect(r.promoted).toEqual([])
     expect(r.pending).toEqual([])
   })
@@ -374,21 +228,14 @@ describe('normalizePending', () => {
 })
 
 describe('forgetCorrection', () => {
-  it('removes the alias from the dictionary', () => {
-    const r = forgetCorrection(
-      [{ term: 'Codey', aliases: ['coday', 'kodi'] }], [], { term: 'Codey', alias: 'coday' })
-    expect(r.entries).toEqual([{ term: 'Codey', aliases: ['kodi'] }])
+  it('removes the learned word from the dictionary', () => {
+    const r = forgetCorrection(['WhisperKit', 'Codey'], [], { term: 'Codey', alias: 'coday' })
+    expect(r.terms).toEqual(['WhisperKit'])
   })
 
-  it('removes a term that existed only to hold that alias', () => {
-    const r = forgetCorrection([{ term: 'Codey', aliases: ['coday'] }], [], { term: 'Codey', alias: 'coday' })
-    expect(r.entries).toEqual([])
-  })
-
-  it('keeps a hint-only term the user typed', () => {
-    const entries = [{ term: 'WhisperKit', aliases: [] }, { term: 'Codey', aliases: ['coday'] }]
-    const r = forgetCorrection(entries, [], { term: 'Codey', alias: 'coday' })
-    expect(r.entries).toEqual([{ term: 'WhisperKit', aliases: [] }])
+  it('matches the word case-insensitively', () => {
+    const r = forgetCorrection(['codey'], [], { term: 'Codey', alias: 'coday' })
+    expect(r.terms).toEqual([])
   })
 
   it('clears the waiting list too, so undo is not just "not yet"', () => {
@@ -396,11 +243,47 @@ describe('forgetCorrection', () => {
     expect(r.pending).toEqual([])
   })
 
-  it('leaves unrelated entries and sightings alone', () => {
-    const entries = [{ term: 'Other', aliases: ['othr'] }]
+  it('leaves unrelated words and sightings alone', () => {
+    const terms = ['Other']
     const pending = [{ term: 'Third', alias: 'thrd', count: 1 }]
-    const r = forgetCorrection(entries, pending, { term: 'Codey', alias: 'coday' })
-    expect(r.entries).toEqual(entries)
+    const r = forgetCorrection(terms, pending, { term: 'Codey', alias: 'coday' })
+    expect(r.terms).toEqual(terms)
     expect(r.pending).toEqual(pending)
+  })
+})
+
+describe('mergeLearnedTerms', () => {
+  it('appends the corrected spelling as a new word', () => {
+    const r = mergeLearnedTerms(['WhisperKit'], [{ term: 'Codey', alias: 'coday' }])
+    expect(r.terms).toEqual(['WhisperKit', 'Codey'])
+    expect(r.added).toEqual(['Codey'])
+    expect(r.changed).toBe(true)
+  })
+
+  it('reports no change when the word is already there', () => {
+    const terms = ['Codey']
+    const r = mergeLearnedTerms(terms, [{ term: 'codey', alias: 'coday' }])
+    expect(r.changed).toBe(false)
+    expect(r.terms).toBe(terms)
+    expect(r.added).toEqual([])
+  })
+
+  it('adds a word only once even if it was corrected twice in one turn', () => {
+    const r = mergeLearnedTerms([], [
+      { term: 'Codey', alias: 'coday' },
+      { term: 'Codey', alias: 'cody' },
+    ])
+    expect(r.terms).toEqual(['Codey'])
+  })
+
+  it('stops at the dictionary cap rather than crowding out the prompt hint', () => {
+    const terms = Array.from({ length: MAX_VOCABULARY_ENTRIES }, (_, i) => `w${i}`)
+    const r = mergeLearnedTerms(terms, [{ term: 'New', alias: 'nue' }])
+    expect(r.changed).toBe(false)
+  })
+
+  it('does nothing when nothing was learned', () => {
+    const terms = ['Codey']
+    expect(mergeLearnedTerms(terms, []).terms).toBe(terms)
   })
 })

--- a/codey-mac/src/components/voiceVocabulary.ts
+++ b/codey-mac/src/components/voiceVocabulary.ts
@@ -1,19 +1,16 @@
-/** One preferred spelling plus the mis-hearings that map onto it.
- *  Mirrors `VocabularyTerm` in the Swift helper (voice/Sources/CodeyVoice/Vocabulary.swift). */
-export interface VocabularyEntry {
-  term: string
-  aliases: string[]
-}
+/**
+ * The dictionary is a plain list of preferred spellings.
+ *
+ * Each one is handed to the recognizer *before* it decodes, as a prompt hint,
+ * so a name it would otherwise snap to a common word becomes reachable. There
+ * is no after-the-fact rewrite table any more: that existed because
+ * WhisperKit 0.18 ignored the hint entirely, and 1.1 does not.
+ */
 
-/** A Dictionary row mid-edit. Aliases stay one free-text blob while the user
- *  types, so a half-typed line isn't eaten between keystrokes. */
-export interface VocabularyDraftRow {
-  term: string
-  aliasText: string
-}
-
-/** A mis-hearing observed by comparing what was dictated against what the
- *  user actually sent. */
+/** A word swap observed by comparing what was dictated against what the user
+ *  actually sent. `alias` never reaches the dictionary — it is the evidence
+ *  that `term` is a word the recognizer cannot spell, and the key the waiting
+ *  list counts sightings under. */
 export interface LearnedCorrection {
   /** The corrected spelling — what the user left in the composer. */
   term: string
@@ -22,64 +19,32 @@ export interface LearnedCorrection {
 }
 
 /**
- * Widen whatever is in gateway.json into editor rows.
+ * Widen whatever is in gateway.json into a clean word list.
  *
- * The Swift side also accepts the terse hand-authored form — a bare string
- * means "hint only, no aliases" — so the editor has to understand it too,
- * otherwise opening Settings would silently drop hand-written entries.
- * Anything else in the array is skipped rather than thrown on: this field is
+ * Accepts three shapes because all three exist on disk: a bare string (the
+ * terse hand-authored form the Swift helper has always taken), the old
+ * `{ term, aliases }` object (aliases are dropped — this is the migration),
+ * and anything else, which is skipped rather than thrown on. This field is
  * hand-edited, and one bad row must not blank the whole dictionary.
  */
-export function normalizeVocabulary(raw: unknown): VocabularyEntry[] {
+export function normalizeVocabulary(raw: unknown): string[] {
   if (!Array.isArray(raw)) return []
-  return raw.flatMap((entry): VocabularyEntry[] => {
-    if (typeof entry === 'string') return entry.trim() ? [{ term: entry, aliases: [] }] : []
-    if (entry && typeof entry === 'object' && typeof (entry as any).term === 'string') {
-      const aliases = Array.isArray((entry as any).aliases)
-        ? (entry as any).aliases.filter((a: unknown): a is string => typeof a === 'string')
-        : []
-      return [{ term: (entry as any).term, aliases }]
-    }
-    return []
-  })
-}
-
-export function vocabularyToDraft(entries: VocabularyEntry[]): VocabularyDraftRow[] {
-  return entries.map(entry => ({ term: entry.term, aliasText: entry.aliases.join('\n') }))
-}
-
-/**
- * Parse editor rows back into config entries.
- *
- * Blank terms are dropped here but stay visible in the draft, so "+ Add word"
- * can leave an empty row on screen without writing junk into gateway.json.
- * Aliases split on newlines *and* commas: the textarea invites one per line,
- * but comma-separated is what people type by habit and both are unambiguous.
- */
-export function draftToVocabulary(draft: VocabularyDraftRow[]): VocabularyEntry[] {
-  return draft
-    .map(row => ({
-      term: row.term.trim(),
-      aliases: dedupeAliases(row.aliasText.split(/[\n,]/).map(a => a.trim()).filter(Boolean)),
-    }))
-    .filter(row => row.term !== '')
-}
-
-/** Aliases in a mid-edit draft row, matching what `draftToVocabulary` would
- *  keep. Used for the chip badge, so the count on screen can never disagree
- *  with what actually gets saved. */
-export function countAliases(aliasText: string): number {
-  return dedupeAliases(aliasText.split(/[\n,]/).map(a => a.trim()).filter(Boolean)).length
-}
-
-function dedupeAliases(aliases: string[]): string[] {
   const seen = new Set<string>()
-  return aliases.filter(alias => {
-    const key = alias.toLowerCase()
-    if (seen.has(key)) return false
+  const out: string[] = []
+  for (const entry of raw) {
+    const word = typeof entry === 'string'
+      ? entry
+      : entry && typeof entry === 'object' && typeof (entry as any).term === 'string'
+        ? (entry as any).term
+        : ''
+    const trimmed = word.trim()
+    if (!trimmed) continue
+    const key = trimmed.toLowerCase()
+    if (seen.has(key)) continue
     seen.add(key)
-    return true
-  })
+    out.push(trimmed)
+  }
+  return out
 }
 
 // ── Learning from edits ─────────────────────────────────────────────
@@ -102,8 +67,7 @@ const MIN_SIMILARITY = 0.5
 /** Diffing is O(n*m); a pasted wall of text isn't a dictation correction
  *  anyway, so bail rather than burn the main thread. */
 const MAX_DIFF_TOKENS = 400
-/** Ceilings so a runaway learner can't crowd out the prompt hint or the UI. */
-export const MAX_ALIASES_PER_TERM = 12
+/** Ceiling so a runaway learner can't crowd out the prompt hint or the UI. */
 export const MAX_VOCABULARY_ENTRIES = 200
 
 /**
@@ -402,21 +366,18 @@ function pendingKey(term: string, alias: string): string {
  * Record this turn's corrections and report the ones that have now been seen
  * often enough to act on.
  *
- * A correction already covered by the dictionary is dropped rather than
- * counted: the alias is being rewritten before the user ever sees it, so a
- * second sighting would mean something else entirely.
+ * A correction whose term is already in the dictionary is dropped rather than
+ * counted: the hint was in play and did not take, so counting to two would
+ * only add the word a second time.
  */
 export function recordCorrections(
   pending: PendingCorrection[],
-  entries: VocabularyEntry[],
+  terms: string[],
   observed: LearnedCorrection[],
 ): { pending: PendingCorrection[]; promoted: LearnedCorrection[] } {
   if (observed.length === 0) return { pending, promoted: [] }
 
-  const known = new Set<string>()
-  for (const entry of entries) {
-    for (const alias of entry.aliases) known.add(pendingKey(entry.term, alias))
-  }
+  const known = new Set(terms.map(t => t.toLowerCase()))
 
   const next = pending.map(p => ({ ...p }))
   const index = new Map(next.map((p, i) => [pendingKey(p.term, p.alias), i]))
@@ -424,8 +385,10 @@ export function recordCorrections(
   let changed = false
 
   for (const correction of observed) {
+    // Already a dictionary word: the recognizer had the hint and still got it
+    // wrong, which a second sighting would not change. Nothing to learn.
+    if (known.has(correction.term.toLowerCase())) continue
     const key = pendingKey(correction.term, correction.alias)
-    if (known.has(key)) continue
 
     const at = index.get(key)
     if (at === undefined) {
@@ -451,75 +414,48 @@ export function recordCorrections(
   return { pending: survivors, promoted }
 }
 
-/** Drop a correction from both the dictionary and the waiting list. Used by
+/** Drop a learned word from both the dictionary and the waiting list. Used by
  *  undo, which has to work whether or not the correction went active. */
 export function forgetCorrection(
-  entries: VocabularyEntry[],
+  terms: string[],
   pending: PendingCorrection[],
   correction: LearnedCorrection,
-): { entries: VocabularyEntry[]; pending: PendingCorrection[] } {
+): { terms: string[]; pending: PendingCorrection[] } {
   const key = pendingKey(correction.term, correction.alias)
-  const nextEntries: VocabularyEntry[] = []
-  for (const entry of entries) {
-    const aliases = entry.aliases.filter(alias => pendingKey(entry.term, alias) !== key)
-    if (aliases.length === entry.aliases.length) {
-      nextEntries.push(entry)
-      continue
-    }
-    // This alias was the entry's only one, so the entry existed to hold it:
-    // learning creates a term and its first mis-hearing together. Undoing
-    // should leave no trace. An entry that still has other aliases, or that
-    // had none to begin with, is the user's and stays.
-    if (aliases.length === 0) continue
-    nextEntries.push({ term: entry.term, aliases })
-  }
   return {
-    entries: nextEntries,
+    terms: terms.filter(t => t.toLowerCase() !== correction.term.toLowerCase()),
     pending: pending.filter(p => pendingKey(p.term, p.alias) !== key),
   }
 }
 
 /**
- * Fold learned corrections into the saved dictionary.
+ * Fold learned words into the saved dictionary.
  *
  * Returns a new array plus the subset that actually landed, so the caller can
  * skip the config write on the common "nothing new" path and tell the user
- * exactly what was learned. `added` is not the same as the input: a
- * correction can be dropped here for being a duplicate or hitting a cap.
+ * exactly what was added. `added` is not the same as the input: a word can be
+ * dropped here for already being present or for hitting the cap.
  */
-export function mergeLearnedAliases(
-  entries: VocabularyEntry[],
+export function mergeLearnedTerms(
+  terms: string[],
   learned: LearnedCorrection[],
-): { entries: VocabularyEntry[]; changed: boolean; added: LearnedCorrection[] } {
-  if (learned.length === 0) return { entries, changed: false, added: [] }
+): { terms: string[]; changed: boolean; added: string[] } {
+  if (learned.length === 0) return { terms, changed: false, added: [] }
 
-  const next = entries.map(entry => ({ term: entry.term, aliases: [...entry.aliases] }))
-  const termIndex = new Map(next.map((entry, i) => [entry.term.toLowerCase(), i]))
-  const added: LearnedCorrection[] = []
-  let changed = false
+  const next = [...terms]
+  const known = new Set(next.map(t => t.toLowerCase()))
+  const added: string[] = []
 
-  for (const { term, alias } of learned) {
-    if (alias.toLowerCase() === term.toLowerCase()) continue
-    // Never learn an alias that is itself somebody's preferred spelling —
-    // the two rules would fight, and the correct word would get rewritten
-    // into a different one.
-    if (termIndex.has(alias.toLowerCase())) continue
-
-    let index = termIndex.get(term.toLowerCase())
-    if (index === undefined) {
-      if (next.length >= MAX_VOCABULARY_ENTRIES) continue
-      next.push({ term, aliases: [] })
-      index = next.length - 1
-      termIndex.set(term.toLowerCase(), index)
-      changed = true
-    }
-    const entry = next[index]
-    if (entry.aliases.some(a => a.toLowerCase() === alias.toLowerCase())) continue
-    if (entry.aliases.length >= MAX_ALIASES_PER_TERM) continue
-    entry.aliases.push(alias)
-    added.push({ term: entry.term, alias })
-    changed = true
+  for (const { term } of learned) {
+    const word = term.trim()
+    if (!word) continue
+    const key = word.toLowerCase()
+    if (known.has(key)) continue
+    if (next.length >= MAX_VOCABULARY_ENTRIES) continue
+    next.push(word)
+    known.add(key)
+    added.push(word)
   }
 
-  return changed ? { entries: next, changed: true, added } : { entries, changed: false, added: [] }
+  return added.length > 0 ? { terms: next, changed: true, added } : { terms, changed: false, added: [] }
 }

--- a/codey-mac/src/components/voiceWarmStatus.test.ts
+++ b/codey-mac/src/components/voiceWarmStatus.test.ts
@@ -24,14 +24,12 @@ describe('formatWarmElapsed', () => {
 })
 
 describe('warmTooltip', () => {
-  it('says it is busy, how long so far, and that it is one-time', () => {
+  it('says it is busy, how long so far, and how long it usually takes', () => {
     const text = warmTooltip(90)
     expect(text).toContain('Preparing')
     expect(text).toContain('1m 30s')
+    // Without the typical duration a multi-minute wait reads as a hang.
     expect(text).toContain('about 5 minutes')
-    // The reason the wait exists at all, and that it is not every launch.
-    expect(text).toContain('once per app update')
-    expect(text).toContain('unavailable until it finishes')
   })
 
   it('works at zero, which is what the first render shows', () => {

--- a/codey-mac/src/components/voiceWarmStatus.ts
+++ b/codey-mac/src/components/voiceWarmStatus.ts
@@ -22,15 +22,13 @@ export function formatWarmElapsed(seconds: number): string {
 /**
  * Tooltip for a voice control disabled by a warm in progress.
  *
- * Says three things, in this order: it is busy rather than broken, roughly how
- * long, and why it is happening at all. The "one time" part matters — without
- * it a multi-minute wait reads as what every launch will be like.
+ * Busy rather than broken, and roughly how long. The typical duration is the
+ * part that matters — without it a multi-minute wait reads as a hang.
  */
 export function warmTooltip(elapsedSeconds: number): string {
   const elapsed = formatWarmElapsed(elapsedSeconds)
   const mins = Math.round(TYPICAL_WARM_SECONDS / 60)
   return `Preparing the on-device model (${elapsed} so far, usually about ${mins} minutes).`
-    + ` macOS compiles it for the Neural Engine once per app update; voice is unavailable until it finishes.`
 }
 
 /** Short label for the same state where there is no room for the tooltip. */

--- a/voice/Package.resolved
+++ b/voice/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a0fb7d9247915a65b07c6e2dddb37a71f728ad9d25262d6a9cd0cff4c2bf505b",
+  "originHash" : "d58e3b5ddf0bd37f7b5ac967386fc5f019f1f97f03bb93d276b50f4a10bf6bfa",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -11,66 +11,12 @@
       }
     },
     {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
-        "version" : "2.3.6"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers.git",
-      "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
-      }
-    },
-    {
       "identity" : "whisperkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/WhisperKit",
       "state" : {
-        "revision" : "e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef",
-        "version" : "0.18.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
+        "revision" : "1e2a163736dfa5a198e637ae44c114e1c6d5cc2d",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/voice/Package.swift
+++ b/voice/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "CodeyVoice",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: "https://github.com/argmaxinc/WhisperKit", from: "0.9.0"),
+        .package(url: "https://github.com/argmaxinc/WhisperKit", from: "1.1.0"),
     ],
     targets: [
         .executableTarget(

--- a/voice/Sources/CodeyVoice/HudOverlay.swift
+++ b/voice/Sources/CodeyVoice/HudOverlay.swift
@@ -17,6 +17,10 @@ final class HudOverlay {
         /// user sees progress before injection happens at the end.
         case partial(String)
         case success
+        /// A press that was refused because the on-device model is not loaded
+        /// yet. Spinner rather than a cross: nothing failed, the answer is
+        /// "not yet".
+        case notice(String)
         case error(String)
         case dictation(String)
         /// The conversation capsule. Distinct from the dictation pill on
@@ -144,6 +148,16 @@ final class HudOverlay {
             applyPillLayout()
             panel.ignoresMouseEvents = true
             scheduleHide(after: 1.0)
+        case .notice(let msg):
+            setCapsuleMode(false)
+            label.stringValue = msg
+            label.textColor = NSColor.secondaryLabelColor
+            setMeterVisible(false)
+            spinner.isHidden = false
+            spinner.startAnimation(nil)
+            applyPillLayout()
+            panel.ignoresMouseEvents = true
+            scheduleHide(after: 2.5)
         case .error(let msg):
             setCapsuleMode(false)
             label.stringValue = "✕ \(msg)"

--- a/voice/Sources/CodeyVoice/Vocabulary.swift
+++ b/voice/Sources/CodeyVoice/Vocabulary.swift
@@ -1,55 +1,55 @@
 import Foundation
 
-/// One preferred spelling plus the mis-hearings that should be rewritten to it.
+/// One preferred spelling the recognizer should be biased toward.
 ///
-/// Authored in `gateway.json` under `voice.vocabulary`, either as a bare string
-/// (hint only) or as an object:
+/// Authored in `gateway.json` under `voice.vocabulary`, normally as a bare
+/// string:
 /// ```json
-/// "vocabulary": [
-///   "WhisperKit",
-///   { "term": "Codey", "aliases": ["寇迪", "Coday", "code E"] }
-/// ]
+/// "vocabulary": ["WhisperKit", "Codey"]
 /// ```
 struct VocabularyTerm: Codable, Equatable {
-    /// The correct spelling. Fed to the recognizer as a prompt hint so it
-    /// biases *toward* this word while decoding.
     var term: String
-    /// Known mis-transcriptions, rewritten to `term` after decoding. Empty is
-    /// fine — the term still works as a prompt hint.
-    var aliases: [String] = []
 
-    init(term: String, aliases: [String] = []) {
+    init(term: String) {
         self.term = term
-        self.aliases = aliases
     }
 
-    /// Accepts either a bare string or the full object form. Hand-edited
-    /// config is the normal authoring path here, so the terse form matters.
+    /// Accepts a bare string or an object with a `term` field. The object form
+    /// is what older configs hold — together with an `aliases` array that this
+    /// build no longer reads, since the recognizer is now given the word up
+    /// front instead of having its output rewritten afterwards.
     init(from decoder: Decoder) throws {
         if let single = try? decoder.singleValueContainer(),
            let text = try? single.decode(String.self) {
             self.term = text
-            self.aliases = []
             return
         }
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.term = try c.decodeIfPresent(String.self, forKey: .term) ?? ""
-        self.aliases = try c.decodeIfPresent([String].self, forKey: .aliases) ?? []
     }
+
+    /// Written back as a bare string, which is also the shape the Mac app now
+    /// saves.
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        try c.encode(term)
+    }
+
+    private enum CodingKeys: String, CodingKey { case term }
 }
 
 /// Custom-vocabulary support, shared by all three transcription engines.
 ///
-/// Two independent halves, because neither alone is enough:
+/// One mechanism, applied *before* decoding: Whisper — local, API and realtime
+/// all expose it — conditions the decoder on this text, so a name it has never
+/// seen becomes reachable instead of being snapped to a common word. Bounded
+/// to ~224 tokens by the models, so we cap it here rather than let the tail
+/// get silently trimmed.
 ///
-/// - `promptText` runs *before* decoding. Whisper (local, API and realtime all
-///   expose it) conditions the decoder on this text, so a name it has never
-///   seen becomes reachable instead of being snapped to a common word.
-///   Bounded to ~224 tokens by the models, so we cap it here rather than let
-///   the tail get silently trimmed.
-/// - `apply` runs *after* decoding, in the coordinator, on whatever any engine
-///   returned. It fixes the residue: mis-hearings that repeat verbatim every
-///   time, which a prompt hint alone does not always shake loose.
+/// There used to be a second half that rewrote known mis-hearings after
+/// decoding. It existed because WhisperKit 0.18 ignored the hint outright; 1.1
+/// does not, and a blind find-and-replace over a transcript is worse than
+/// letting the model spell the word itself.
 enum Vocabulary {
     /// Rough cap on the hint string. Whisper's prompt window is ~224 tokens;
     /// CJK runs about one token per character, so 300 characters is a
@@ -60,62 +60,27 @@ enum Vocabulary {
     /// Comma-joined list of preferred spellings, or nil when there is nothing
     /// to hint. Terms are taken in author order and stop at the cap — earlier
     /// entries win, which makes ordering a usable priority knob.
-    static func promptText(_ terms: [VocabularyTerm]) -> String? {
+    ///
+    /// `repeats` emits the whole list more than once. A single mention of a
+    /// name is a weak signal: measured on `large-v3-v20240930_turbo_632MB`,
+    /// a bare "Codey" left the transcript as "Cody" on English audio and
+    /// "Code" on Chinese, while the same list twice got both right. The cap
+    /// covers the finished string, so more repeats means fewer terms fit.
+    static func promptText(_ terms: [VocabularyTerm], repeats: Int = 1) -> String? {
+        let copies = max(1, repeats)
+        let budget = maxPromptCharacters / copies
         var picked: [String] = []
         var length = 0
         for term in terms {
             let word = term.term.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !word.isEmpty, !picked.contains(word) else { continue }
             let cost = word.count + (picked.isEmpty ? 0 : 2)
-            if length + cost > maxPromptCharacters { break }
+            if length + cost > budget { break }
             picked.append(word)
             length += cost
         }
-        return picked.isEmpty ? nil : picked.joined(separator: ", ")
-    }
-
-    /// Rewrite every known alias in `text` to its preferred spelling.
-    ///
-    /// Longest alias first, so a term whose alias is a prefix of another's
-    /// cannot shadow it. Matching is case-insensitive and guarded by ASCII
-    /// alphanumeric lookarounds: "cody" will not fire inside "codybase", while
-    /// CJK aliases — whose neighbours are never ASCII alphanumerics — always
-    /// match as plain substrings, which is the behaviour those need.
-    static func apply(_ text: String, terms: [VocabularyTerm]) -> String {
-        guard !text.isEmpty, !terms.isEmpty else { return text }
-
-        var pairs: [(alias: String, term: String)] = []
-        for entry in terms {
-            let word = entry.term.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !word.isEmpty else { continue }
-            for rawAlias in entry.aliases {
-                let alias = rawAlias.trimmingCharacters(in: .whitespacesAndNewlines)
-                // Exact match only: an alias that differs from the term just
-                // by case ("cody" -> "Cody") is a legitimate capitalization
-                // fix, so it must not be treated as a redundant self-mapping.
-                guard !alias.isEmpty, alias != word else { continue }
-                pairs.append((alias, word))
-            }
-        }
-        guard !pairs.isEmpty else { return text }
-        pairs.sort { $0.alias.count > $1.alias.count }
-
-        var result = text
-        for pair in pairs {
-            let pattern = "(?<![A-Za-z0-9])"
-                + NSRegularExpression.escapedPattern(for: pair.alias)
-                + "(?![A-Za-z0-9])"
-            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
-                continue
-            }
-            let range = NSRange(result.startIndex..<result.endIndex, in: result)
-            result = regex.stringByReplacingMatches(
-                in: result,
-                options: [],
-                range: range,
-                withTemplate: NSRegularExpression.escapedTemplate(for: pair.term)
-            )
-        }
-        return result
+        guard !picked.isEmpty else { return nil }
+        let list = picked.joined(separator: ", ")
+        return Array(repeating: list, count: copies).joined(separator: ", ")
     }
 }

--- a/voice/Sources/CodeyVoice/VoiceConfig.swift
+++ b/voice/Sources/CodeyVoice/VoiceConfig.swift
@@ -30,9 +30,8 @@ struct VoiceConfig: Codable {
     var realtimeUrl: String = "wss://api.openai.com/v1/realtime?intent=transcription"
     /// Realtime transcription model (e.g. "gpt-4o-mini-transcribe").
     var realtimeModel: String = "gpt-4o-mini-transcribe"
-    /// Custom vocabulary: proper nouns the recognizer keeps getting wrong.
-    /// Terms are hinted to the decoder before transcription and their aliases
-    /// are rewritten afterwards. See `Vocabulary`.
+    /// Custom vocabulary: proper nouns the recognizer would not otherwise
+    /// reach. Hinted to the decoder before transcription. See `Vocabulary`.
     var vocabulary: [VocabularyTerm] = []
 
     enum Mode: String, Codable {

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -260,6 +260,7 @@ final class VoiceCoordinator {
         print("handleToggle: current state=\(state)")
         switch state {
         case .idle:
+            guard localModelReady(for: destination) else { return }
             startRecording(destination: destination)
         case .recording:
             stopRecording()
@@ -281,6 +282,30 @@ final class VoiceCoordinator {
             endSpeaking()
             startRecording(destination: destination)
         }
+    }
+
+    /// Refuse a press the on-device pipeline can't serve yet, and say so.
+    ///
+    /// The load is lazy: a few seconds cold, minutes on the first press after
+    /// an app update while CoreML recompiles for the Neural Engine. Recording
+    /// anyway looked like it worked and then stalled *after* the user had
+    /// finished talking, which is the worst moment to discover the wait. Say
+    /// "not yet" up front, kick the load, and let them press again.
+    private func localModelReady(for destination: CaptureDestination) -> Bool {
+        guard config.provider == .local, !localEngine.isReady else { return true }
+        print("handleToggle: refused — the on-device model is not loaded yet")
+        localEngine.prewarm()
+        let message = "Preparing the speech model"
+        if destination.composerMode != nil {
+            emitConversationEvent(type: "error", payload: ["message": message])
+            emitConversationEvent(type: "state", payload: ["state": "idle"])
+        }
+        // The composer button reports through the event above; only turns the
+        // user started away from the window need the pill.
+        if destination == .dictation || (destination == .conversation && conversationFromHotkey) {
+            hud.show(.notice(message))
+        }
+        return false
     }
 
     private func startRecording(destination: CaptureDestination = .dictation) {
@@ -343,7 +368,9 @@ final class VoiceCoordinator {
 
     private func stopRecording() {
         print("stopRecording: requesting stop")
-        removeEscMonitor()
+        // The monitor deliberately stays up through the decode: a cold CoreML
+        // compile can hold `.transcribing` for minutes, which is exactly when
+        // someone reaches for Esc. Torn down on the way back to idle instead.
         if captureDestination.composerMode != nil {
             setConversationCapsule(.thinking)
             emitConversationEvent(type: "state", payload: ["state": "transcribing"])
@@ -391,6 +418,7 @@ final class VoiceCoordinator {
     private func abandonTranscription() {
         guard state == .transcribing else { return }
         captureGeneration += 1
+        removeEscMonitor()
         localEngine.stopStreaming()
         realtimeEngine.cancelSession()
         state = .idle
@@ -511,7 +539,11 @@ final class VoiceCoordinator {
                 // state: discard the recording, or shut Codey up mid-reply.
                 switch self.state {
                 case .speaking: self.endSpeaking()
-                case .recording, .transcribing: self.cancelRecording()
+                case .recording: self.cancelRecording()
+                // Not cancelRecording: that one guards on `.recording` and so
+                // was a silent no-op here, which is why Esc did nothing while
+                // "Transcribing" was on screen.
+                case .transcribing: self.abandonTranscription()
                 default: self.cancelElectronTurn()
                 }
             }
@@ -562,6 +594,7 @@ final class VoiceCoordinator {
         print("handleAudioComplete: \(buffer.count) samples (\(durationStr)s) peak=\(String(format: "%.4f", peak)) rms=\(String(format: "%.4f", rms))")
         guard !buffer.isEmpty else {
             print("handleAudioComplete: EMPTY buffer — nothing to transcribe")
+            removeEscMonitor()
             state = .idle
             statusItem?.updateState(.idle)
             if destination.composerMode != nil {
@@ -591,13 +624,7 @@ final class VoiceCoordinator {
                     ? "realtime(\(config.realtimeModel))"
                     : "api(\(config.apiModel))"
                 print("transcribe: starting (language=\(lang.isEmpty ? "auto" : lang), provider=\(providerLabel))")
-                let raw = try await activeEngine.transcribe(audio: buffer, language: lang)
-                // Single place all three engines funnel through, so the alias
-                // rewrite lives here rather than three times over.
-                let text = Vocabulary.apply(raw, terms: config.vocabulary)
-                if text != raw {
-                    print("vocabulary: rewrote \"\(raw)\" -> \"\(text)\"")
-                }
+                let text = try await activeEngine.transcribe(audio: buffer, language: lang)
 
                 if generation != self.captureGeneration {
                     print("transcribe: discarded abandoned result")
@@ -611,6 +638,10 @@ final class VoiceCoordinator {
                 print("transcribe: result = \"\(text)\" (\(text.count) chars)")
 
                 if destination.composerMode != nil {
+                    // Capture is over, so this helper's Esc monitor comes down.
+                    // Electron reinstalls it via `hud-state thinking` for the
+                    // rest of the turn.
+                    await MainActor.run { self.removeEscMonitor() }
                     state = .idle
                     statusItem?.updateState(.idle)
                     if text.isEmpty {
@@ -639,7 +670,7 @@ final class VoiceCoordinator {
                     emitConversationEvent(type: "transcript", payload: ["text": finalText], modeOverride: "dictate")
                     state = .idle
                     statusItem?.updateState(.idle)
-                    await MainActor.run { self.hud.show(.success) }
+                    await MainActor.run { self.removeEscMonitor(); self.hud.show(.success) }
                     Task { await gateway.reportStatus("idle") }
                     return
                 }
@@ -657,6 +688,7 @@ final class VoiceCoordinator {
                 state = .idle
                 statusItem?.updateState(.idle)
                 await MainActor.run {
+                    self.removeEscMonitor()
                     if finalText.isEmpty {
                         self.hud.hide()
                     } else if canInject {
@@ -681,6 +713,7 @@ final class VoiceCoordinator {
                 statusItem?.updateState(.error(error.localizedDescription))
                 let msg = error.localizedDescription
                 await MainActor.run {
+                    self.removeEscMonitor()
                     if destination.composerMode != nil {
                         self.emitConversationEvent(type: "error", payload: ["message": msg])
                         self.emitConversationEvent(type: "state", payload: ["state": "idle"])

--- a/voice/Sources/CodeyVoice/WhisperKitEngine.swift
+++ b/voice/Sources/CodeyVoice/WhisperKitEngine.swift
@@ -183,7 +183,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
                     (self.streamingState.confirmedEndSeconds, self.streamingState.confirmedText)
                 }
 
-                var options = self.streamingOptions(language: lang)
+                var options = self.streamingOptions(language: lang, pipe: pipe)
                 if clipStart > 0 { options.clipTimestamps = [clipStart] }
 
                 self.lastUsed = Date()
@@ -236,29 +236,41 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         }
     }
 
-    // Custom vocabulary is NOT hinted to this engine, unlike the API and
-    // realtime ones. `DecodingOptions.promptTokens` is broken in the pinned
-    // WhisperKit: setting it to anything at all makes `transcribe` return an
-    // empty string. Measured on large-v3-v20240930_turbo_632MB against a
-    // 5.7s clip — 96 chars without it, 0 chars with it, across eleven option
-    // combinations (VAD on/off, timestamps on/off, prefill cache off,
-    // sampleLength 144/224, one worker, explicit language, no first-token
-    // threshold, no temperature fallback, longer prompt). `prefixTokens` is
-    // not a substitute: it force-feeds the words as the *start of the
-    // transcript*, which ate the first word of the sentence.
-    //
-    // So on-device gets the second half of the feature only — aliases are
-    // still rewritten after decoding, in VoiceCoordinator. Re-check on the
-    // next WhisperKit bump; if promptTokens starts working, restore the hint
-    // here and remember that setting it also disables the kv-cache prefill,
-    // so it must stay nil when the user has no vocabulary configured.
+    /// Tokenized vocabulary hint for `DecodingOptions.promptTokens`, or nil
+    /// when the user has no terms.
+    ///
+    /// Whisper conditions the decoder on this as if it were the text just
+    /// before the audio, so a name the model would otherwise snap to a common
+    /// word becomes reachable. This was dead on WhisperKit 0.18, where setting
+    /// `promptTokens` to anything at all returned an empty transcript; 1.1
+    /// fixed it. Verified against `large-v3-v20240930_turbo_632MB`:
+    /// "Whisper Kid" -> "WhisperKit", "Cody" -> "Codey", and 用Code -> 用Codey
+    /// on Chinese audio, with no change to a clip containing none of the terms.
+    ///
+    /// Special tokens are filtered out: the values are spliced in ahead of the
+    /// SOT/language/task prefill, and a stray `<|...|>` there desynchronizes
+    /// the whole prefix. Returns nil rather than an empty array so the option
+    /// stays unset when there is nothing to say — WhisperKit takes a different
+    /// (slower) decode path whenever `promptTokens` is non-nil.
+    private func vocabularyPromptTokens(_ pipe: WhisperKit) -> [Int]? {
+        let terms = configLock.withLock { _config.vocabulary }
+        guard let text = Vocabulary.promptText(terms, repeats: 2),
+              let tokenizer = pipe.tokenizer else { return nil }
+        let specialBegin = tokenizer.specialTokens.specialTokenBegin
+        // Leading space: Whisper's BPE encodes a word differently at the start
+        // of a segment than mid-sentence, and mid-sentence is what the model
+        // will actually be decoding.
+        let tokens = tokenizer.encode(text: " " + text).filter { $0 < specialBegin }
+        return tokens.isEmpty ? nil : tokens
+    }
 
     /// Decode options shared by the streaming loop and the post-stop "settle"
     /// decode. Kept lean — temperature fallback off, fewer workers — because
     /// these run on a partial buffer and we want fast iteration; the final
     /// non-streaming `transcribe()` path keeps the more conservative options.
-    private func streamingOptions(language: String) -> DecodingOptions {
+    private func streamingOptions(language: String, pipe: WhisperKit) -> DecodingOptions {
         var options = DecodingOptions()
+        options.promptTokens = vocabularyPromptTokens(pipe)
         options.task = .transcribe
         if !language.isEmpty && language != "auto" { options.language = language }
         options.temperature = 0.0
@@ -352,6 +364,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         let normalized = peakNormalize(audio, target: 0.9)
 
         var options = DecodingOptions()
+        options.promptTokens = vocabularyPromptTokens(pipe)
         options.task = .transcribe
         if !language.isEmpty && language != "auto" {
             options.language = language
@@ -381,9 +394,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         // streaming pass has always run at 0 for the same reason.
         //
         // Empty results are not a risk we are trading away here: the streaming
-        // partial is still there as a fallback, and the one confirmed cause of
-        // empty output turned out to be `promptTokens` (see the note above),
-        // not the temperature floor.
+        // partial is still there as a fallback.
         options.temperatureFallbackCount = 0
         // VAD splits long press-to-talk clips into N voiced chunks; with
         // workers > 1 they decode concurrently. 4 saturates ANE+GPU on
@@ -433,6 +444,17 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         guard peak > 0.0001, peak < target else { return samples }
         let gain = target / peak
         return samples.map { $0 * gain }
+    }
+
+    /// Whether the pipeline for the *currently selected* variant is already in
+    /// memory, i.e. a press right now would decode rather than first sit
+    /// through a load. Compares against the normalized name for the same
+    /// reason `ensurePipeline` does: `loadedModel` is normalized, the config
+    /// may hold the prefixed folder name, and a raw comparison would report
+    /// "not ready" forever.
+    var isReady: Bool {
+        let modelName = normalizeVariant(configLock.withLock { _config.localModel })
+        return loadQueue.sync { pipeline != nil && loadedModel == modelName }
     }
 
     func unloadIfIdle() {
@@ -499,6 +521,11 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     private func loadPipeline(named modelName: String) async throws -> WhisperKit {
         let t0 = Date()
         print("WhisperKitEngine: loading model '\(modelName)'")
+        // Machine-readable twin of the log line above. Electron turns these
+        // into the "preparing" state the composer shows: the prose line is for
+        // humans reading the log, and parsing it would break the first time
+        // someone reworded it.
+        print("model:loading \(modelName)")
 
         // A silent multi-minute load is indistinguishable from a hang, and
         // this one has a specific cause worth naming: CoreML recompiles for
@@ -525,11 +552,21 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
             load: true,
             download: true
         )
-        let pipe = try await WhisperKit(kitConfig)
+        let pipe: WhisperKit
+        do {
+            pipe = try await WhisperKit(kitConfig)
+        } catch {
+            // Electron is holding a "preparing" indicator up on the strength of
+            // `model:loading`. Without a terminal marker it would stay there
+            // forever on a failed load.
+            print("model:failed \(modelName)")
+            throw error
+        }
         let elapsed = Date().timeIntervalSince(t0)
         self.pipeline = pipe
         self.loadedModel = modelName
         print(String(format: "WhisperKitEngine: model '%@' ready (load took %.1fs)", modelName, elapsed))
+        print(String(format: "model:ready %@ %.1f", modelName, elapsed))
         return pipe
     }
 


### PR DESCRIPTION
The dictionary is now a plain word list. The heard-as/alias rewrite (`Vocabulary.apply`) is gone — no more post-decode string matching. Instead the terms are fed to the on-device WhisperKit engine as decoder conditioning so the recognizer references them directly.

## What changed

**Dictionary → prompt hints**
- WhisperKit `0.9.0` → `1.1.0`. `promptTokens` was broken in the pinned 0.18 (returned empty transcripts, measured across 11 option combinations); it works in 1.1.0 and was verified against real audio (`Cody and Whisper Kid` → `Codey and WhisperKit`, `用Code` → `用Codey`, unrelated audio unchanged).
- The API and realtime engines already sent the terms as a prompt; the on-device engine now does too, via `DecodingOptions.promptTokens` (decoder conditioning, not instruction injection — special tokens filtered).
- Prompt hint uses `repeats: 2` (a single mention was measured too weak).

**Heard-as removed**
- `VocabularyTerm` is down to `{ term }`. Old `{ term, aliases }` config objects still read correctly and migrate automatically; aliases are dropped on next save.
- The alias rewrite (`Vocabulary.apply`) and every alias test are deleted.

**Learning from edits**
- Fixing a dictated word now adds the corrected word to the dictionary, behind the same mishearing gate and twice-seen rule. The pill reads "`word` is added" with an undo that removes the word and clears the waiting list.
- Words already in the dictionary stop counting as sightings.

**Status / cancel**
- Esc cancels during transcription (previously only during recording).
- The voice button tooltip and the hotkey capsule now surface model warm/preparing state; a hotkey press before the model is ready shows a "Preparing the speech model" notice instead of silently firing.

## Notes
- The on-device engine takes the (slower) prompt-set decode path, so the next real device run triggers a one-time CoreML recompile (new helper binary, ~5 min) and prompt-set decodes are a bit slower than the prefill-cache path.
- Not yet run on a real device; unit tests (73 files / 739 tests), `tsc --noEmit`, and `swift build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)