### PR TITLE
fix(mac): keep composer at three buttons - stop while a turn runs, send otherwise

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2922,7 +2922,10 @@ export const ChatTab: React.FC<Props> = ({
                       color={voiceActiveHere && voice.state === 'speaking' ? C.onAccent : C.fg2}
                     />}
               </button>}
-              {isSending && (
+              {/* One slot, two jobs: Stop while a turn runs, Send otherwise.
+                  Keeps the action row at three buttons either way. Queuing the
+                  next message has no button - that is what ↵ is for. */}
+              {isSending ? (
                 <button
                   onClick={() => stopChat(chatId)}
                   style={{ ...styles.sendButton, background: C.red, cursor: 'pointer' }}
@@ -2930,12 +2933,11 @@ export const ChatTab: React.FC<Props> = ({
                 >
                   <StopIcon color="#fff" />
                 </button>
-              )}
-              {(
+              ) : (
                 <button
                   onClick={send}
                   disabled={!canSend}
-                  title={isSending ? 'Queue this message (↵)' : 'Send (↵)'}
+                  title="Send (↵)"
                   style={{ ...styles.sendButton, background: canSend ? C.accent : C.surface3, cursor: canSend ? 'pointer' : 'default' }}
                 >
                   <SendIcon color={canSend ? C.onAccent : C.fg3} />


### PR DESCRIPTION
## What

The composer action row in the Mac app always keeps **three buttons** (mic · voice · send). While a turn is running, the third slot swaps from a Send button to a red **Stop** button — no extra button appears, and the layout never jumps.

## Why

The send button is redundant while a turn is running: pressing it only queues the message, and Enter already does exactly that. Showing a live Send button next to a running turn just invites a click that does nothing visible. Reusing the slot for Stop keeps the row stable and gives pause a clear, always-visible home.

## Behavior

| State | Third button |
|---|---|
| Idle | Send (↵ sends) |
| Turn running | Stop (red); Enter queues the next message |

## Notes

- `canSend` moved next to `isSending` (both derived from the same flight/gateway state).
- No test changes needed — this is layout-only; all 757 mac-workspace tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)