### PR TITLE
feat(browser+mac): agent-facing browser profiles, Settings ▸ Memory tab

### DIFF
--- a/codey-mac/electron/browser-agent-bridge.test.ts
+++ b/codey-mac/electron/browser-agent-bridge.test.ts
@@ -89,6 +89,15 @@ describe('BrowserAgentBridge', () => {
       switchTab: vi.fn(() => state),
       closeTab: vi.fn(() => state),
       submit: vi.fn(async ref => ({ ok: true as const, url: state.url, message: `Submitted ${ref}` })),
+      listProfiles: vi.fn(() => []),
+      activeProfileName: vi.fn(() => null),
+      saveProfile: vi.fn(async name => ({ name, cookies: [], origins: [], createdAt: 1, updatedAt: 1, sourceUrl: null })),
+      importProfile: vi.fn(async name => ({ name, cookies: [], origins: [], createdAt: 1, updatedAt: 1, sourceUrl: null })),
+      activateProfile: vi.fn(async name => ({
+        name, active: true, cookieCount: 0, originCount: 0, createdAt: 1, updatedAt: 1, sourceUrl: null,
+      })),
+      deleteProfile: vi.fn(async () => ({ deleted: true })),
+      exportProfile: vi.fn(async () => ({ path: '/tmp/exported.json' })),
     }
     const onOpen = vi.fn()
     const requestControl = vi.fn(async () => true)
@@ -146,6 +155,33 @@ describe('BrowserAgentBridge', () => {
       expect(loginEvents.map(event => event.status)).toEqual(['watching', 'changed'])
       expect(loginEvents[1]).toMatchObject({ chatId: 'chat-123', reason: 'signed-in', url: 'https://example.com/home' })
 
+      const profiles = await call(info, 'GET', '/profiles')
+      expect(profiles).toEqual({ status: 200, body: { active: null, profiles: [] } })
+
+      const saved = await call(info, 'POST', '/profile/save', { name: 'work' })
+      expect(saved.status).toBe(200)
+      expect(saved.body).toMatchObject({ name: 'work' })
+      expect(controller.saveProfile).toHaveBeenCalledWith('work')
+
+      const imported = await call(info, 'POST', '/profile/import', {
+        name: 'gh',
+        source: { json: '{"cookies":[]}' },
+      })
+      expect(imported.status).toBe(200)
+      expect(controller.importProfile).toHaveBeenCalledWith('gh', { json: '{"cookies":[]}' }, true)
+      // Import activates by default, so it goes through the user approval gate.
+      expect(requestControl).toHaveBeenCalledWith({ command: 'activate-profile', url: state.url })
+
+      const activated = await call(info, 'POST', '/profile/activate', { name: 'work' })
+      expect(activated.status).toBe(200)
+      expect(controller.activateProfile).toHaveBeenCalledWith('work')
+
+      const exported = await call(info, 'POST', '/profile/export', { name: 'work', path: '/tmp/work.json' })
+      expect(exported.body).toEqual({ path: '/tmp/exported.json' })
+      expect(controller.exportProfile).toHaveBeenCalledWith('work', '/tmp/work.json')
+
+      const deleted = await call(info, 'POST', '/profile/delete', { name: 'work' })
+      expect(deleted.body).toEqual({ deleted: true })
       const tabs = await call(info, 'GET', '/tabs')
       expect(tabs.body[0]).toMatchObject({ id: 't1', active: true })
       const newTab = await call(info, 'POST', '/tab/new', { url: 'https://example.com/auth' })
@@ -185,6 +221,28 @@ describe('BrowserAgentBridge', () => {
       })
       expect(JSON.parse(cliResult.stdout).text).toBe('Hello from the page')
 
+      // `--profile <name>` forwards the profile to the bridge, which
+      // activates it before the command runs.
+      const profileCli = await execFileAsync(process.execPath, [cli, '--profile', 'cli', 'view'], {
+        env: {
+          ...process.env,
+          CODEY_BROWSER_SOCKET: info.socketPath,
+          CODEY_BROWSER_TOKEN: info.token,
+        },
+      })
+      expect(JSON.parse(profileCli.stdout).text).toBe('Hello from the page')
+      expect(controller.activateProfile).toHaveBeenLastCalledWith('cli')
+      // Switching identity mid-command needs the same approval as an explicit activate.
+      expect(requestControl).toHaveBeenLastCalledWith({ command: 'activate-profile', url: state.url })
+
+      const profileListCli = await execFileAsync(process.execPath, [cli, 'profile', 'list'], {
+        env: {
+          ...process.env,
+          CODEY_BROWSER_SOCKET: info.socketPath,
+          CODEY_BROWSER_TOKEN: info.token,
+        },
+      })
+      expect(JSON.parse(profileListCli.stdout)).toEqual({ active: null, profiles: [] })
       const screenshotPath = path.join(os.tmpdir(), `codey-browser-test-${process.pid}.png`)
       try {
         const screenshotResult = await execFileAsync(process.execPath, [cli, 'screenshot', screenshotPath], {

--- a/codey-mac/electron/browser-agent-bridge.ts
+++ b/codey-mac/electron/browser-agent-bridge.ts
@@ -13,6 +13,7 @@ type BridgeController = Pick<
   | 'waitFor' | 'upload' | 'listDownloads' | 'waitForDownload' | 'submit'
   | 'getLoginStatus'
   | 'getState' | 'back' | 'forward' | 'reload' | 'listTabs' | 'newTab' | 'switchTab' | 'closeTab'
+  | 'listProfiles' | 'activeProfileName' | 'saveProfile' | 'importProfile' | 'activateProfile' | 'deleteProfile' | 'exportProfile'
 >
 
 export interface BrowserAgentBridgeInfo {
@@ -129,6 +130,21 @@ export class BrowserAgentBridge {
 
     const route = (req.url || '/').split('?')[0]
     try {
+      // An agent can target a specific browser profile by passing
+      // `--profile <name>` to the CLI, which forwards it here. The profile is
+      // activated first, so the command below operates under that identity —
+      // and because that is the same identity switch as `/profile/activate`,
+      // it goes through the same user approval gate.
+      const requestedProfile = typeof req.headers['x-codey-profile'] === 'string'
+        ? (req.headers['x-codey-profile'] as string).trim()
+        : ''
+      const isProfileRoute = route === '/profiles' || route.startsWith('/profile/')
+      if (requestedProfile && !isProfileRoute) {
+        const active = this.controller.activeProfileName()
+        if (active !== requestedProfile) {
+          await this.controlled('activate-profile', () => this.controller.activateProfile(requestedProfile))
+        }
+      }
       if (req.method === 'POST' && route === '/open') {
         const body = await readJson(req)
         const url = typeof body.url === 'string' ? body.url : ''
@@ -179,7 +195,7 @@ export class BrowserAgentBridge {
         return
       }
       if (req.method === 'GET' && route === '/state') {
-        json(res, 200, this.controller.getState())
+        json(res, 200, { ...this.controller.getState(), profile: this.controller.activeProfileName() })
         return
       }
       if (req.method === 'POST' && route === '/wait-login') {
@@ -317,6 +333,55 @@ export class BrowserAgentBridge {
       if (req.method === 'POST' && route === '/submit') {
         const body = await readJson(req)
         json(res, 200, await this.controlled('submit', () => this.controller.submit(String(body.ref || ''))))
+        return
+      }
+      // ── Profiles ──────────────────────────────────────────────────────
+      if (req.method === 'GET' && route === '/profiles') {
+        json(res, 200, { active: this.controller.activeProfileName(), profiles: this.controller.listProfiles() })
+        return
+      }
+      if (req.method === 'POST' && route === '/profile/save') {
+        const body = await readJson(req)
+        json(res, 200, await this.exclusive(() => this.controller.saveProfile(String(body.name || ''))))
+        return
+      }
+      if (req.method === 'POST' && route === '/profile/import') {
+        const body = await readJson(req)
+        const source = body.source
+        const name = String(body.name || '')
+        const activate = body.activate !== false
+        const operation = async () => {
+          if (typeof source === 'object' && source !== null && 'path' in source) {
+            const filePath = String((source as Record<string, unknown>).path || '')
+            if (!filePath) throw new Error('A profile source path is required')
+            const derived = name || path.basename(filePath).replace(/\.json$/i, '')
+            return await this.controller.importProfile(derived, { path: filePath }, activate)
+          }
+          if (typeof source === 'object' && source !== null && 'json' in source) {
+            if (!name) throw new Error('A profile name is required when importing JSON text')
+            return await this.controller.importProfile(name, { json: String((source as Record<string, unknown>).json || '') }, activate)
+          }
+          throw new Error('profile import needs a source: { path } or { json }')
+        }
+        // Importing activates by default, which replaces the session's cookies
+        // — that identity switch goes through the same user approval gate as
+        // any other mutating browser command.
+        json(res, 200, activate ? await this.controlled('activate-profile', operation) : await this.exclusive(operation))
+        return
+      }
+      if (req.method === 'POST' && route === '/profile/activate') {
+        const body = await readJson(req)
+        json(res, 200, await this.controlled('activate-profile', () => this.controller.activateProfile(String(body.name || ''))))
+        return
+      }
+      if (req.method === 'POST' && route === '/profile/delete') {
+        const body = await readJson(req)
+        json(res, 200, await this.controlled('delete-profile', () => this.controller.deleteProfile(String(body.name || ''))))
+        return
+      }
+      if (req.method === 'POST' && route === '/profile/export') {
+        const body = await readJson(req)
+        json(res, 200, await this.exclusive(() => this.controller.exportProfile(String(body.name || ''), String(body.path || ''))))
         return
       }
       json(res, 404, { error: 'Unknown browser command' })

--- a/codey-mac/electron/browser-agent-cli.cjs
+++ b/codey-mac/electron/browser-agent-cli.cjs
@@ -9,11 +9,24 @@ const path = require('path')
 const socketPath = process.env.CODEY_BROWSER_SOCKET
 const token = process.env.CODEY_BROWSER_TOKEN
 const chatId = process.env.CODEY_BROWSER_CHAT_ID
-const command = process.argv[2]
+
+// `--profile <name>` (or `-p <name>`) before the command selects the browser
+// profile this command operates under. It is forwarded to the bridge as a
+// header, and the bridge activates that profile before running the command —
+// so every subsequent action happens under that profile's session.
+let args = process.argv.slice(2)
+let profile = ''
+if ((args[0] === '--profile' || args[0] === '-p') && args.length > 1) {
+  profile = args[1]
+  args = args.slice(2)
+}
+const command = args[0]
+const rest = args.slice(1)
 
 function usage() {
   return [
     'Codey Browser agent tool',
+    '  --profile <name>     Operate under a saved browser profile (activates it first)',
     '  open <url or search>  Open a page and show the in-app browser',
     '  open-view <url>       Open a page and return its content atomically',
     '  view                  Read visible page text and performance timing',
@@ -40,10 +53,23 @@ function usage() {
     '  switch-tab <id>       Switch the visible tab',
     '  close-tab <id>        Close a tab',
     '  submit <ref>           Submit the element\'s form',
-    '  state                 Read URL and navigation state',
+    '  state                 Read URL, navigation state and the active profile',
     '  back | forward        Navigate browser history',
     '  reload                Reload the current page',
+    '  profile list               List saved profiles and the active one',
+    '  profile save <name>        Snapshot the current session into a profile',
+    '  profile import <path> [name]  Import a session file and activate it',
+    '  profile activate <name>    Switch the live session to a profile',
+    '  profile export <name> <path>  Write a profile to a shareable JSON file',
+    '  profile delete <name>      Remove a profile',
   ].join('\n')
+}
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${token}`,
+    ...(profile ? { 'X-Codey-Profile': profile } : {}),
+  }
 }
 
 function requestBinary(method, route) {
@@ -52,7 +78,7 @@ function requestBinary(method, route) {
       socketPath,
       path: route,
       method,
-      headers: { Authorization: `Bearer ${token}` },
+      headers: authHeaders(),
       timeout: 300000,
     }, res => {
       const chunks = []
@@ -80,7 +106,7 @@ function request(method, route, body) {
       path: route,
       method,
       headers: {
-        Authorization: `Bearer ${token}`,
+        ...authHeaders(),
         ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}),
       },
       // A first control command can wait here while the user reviews the
@@ -110,13 +136,13 @@ async function main() {
   let value
   switch (command) {
     case 'open': {
-      const url = process.argv.slice(3).join(' ').trim()
+      const url = rest.join(' ').trim()
       if (!url) throw new Error(`Missing URL\n${usage()}`)
       value = await request('POST', '/open', { url })
       break
     }
     case 'open-view': {
-      const url = process.argv.slice(3).join(' ').trim()
+      const url = rest.join(' ').trim()
       if (!url) throw new Error(`Missing URL\n${usage()}`)
       value = await request('POST', '/open-view', { url })
       break
@@ -127,8 +153,8 @@ async function main() {
     case 'screenshot': {
       const screenshot = await requestBinary('GET', '/screenshot')
       const png = screenshot.data
-      const output = process.argv[3]
-        ? path.resolve(process.argv[3])
+      const output = rest[0]
+        ? path.resolve(rest[0])
         : path.join(os.tmpdir(), `codey-browser-${Date.now()}.png`)
       fs.writeFileSync(output, png, { mode: 0o600 })
       value = {
@@ -144,60 +170,87 @@ async function main() {
     }
     case 'state': value = await request('GET', '/state'); break
     case 'downloads': value = await request('GET', '/downloads'); break
-    case 'wait-download': value = await request('POST', '/wait-download', { timeoutMs: Number(process.argv[3] || 60000) }); break
+    case 'wait-download': value = await request('POST', '/wait-download', { timeoutMs: Number(rest[0] || 60000) }); break
     case 'tabs': value = await request('GET', '/tabs'); break
-    case 'new-tab': value = await request('POST', '/tab/new', { url: process.argv.slice(3).join(' ') || 'about:blank' }); break
-    case 'switch-tab': value = await request('POST', '/tab/switch', { id: process.argv[3] }); break
-    case 'close-tab': value = await request('POST', '/tab/close', { id: process.argv[3] }); break
+    case 'new-tab': value = await request('POST', '/tab/new', { url: rest.join(' ') || 'about:blank' }); break
+    case 'switch-tab': value = await request('POST', '/tab/switch', { id: rest[0] }); break
+    case 'close-tab': value = await request('POST', '/tab/close', { id: rest[0] }); break
     case 'back': value = await request('POST', '/back'); break
     case 'forward': value = await request('POST', '/forward'); break
     case 'reload': value = await request('POST', '/reload'); break
-    case 'click': value = await request('POST', '/click', { ref: process.argv[3] }); break
+    case 'click': value = await request('POST', '/click', { ref: rest[0] }); break
     case 'click-at': value = await request('POST', '/click-at', {
-      x: Number(process.argv[3]), y: Number(process.argv[4]), clickCount: Number(process.argv[5] || 1),
+      x: Number(rest[0]), y: Number(rest[1]), clickCount: Number(rest[2] || 1),
     }); break
     case 'drag': value = await request('POST', '/drag', {
-      fromX: Number(process.argv[3]), fromY: Number(process.argv[4]),
-      toX: Number(process.argv[5]), toY: Number(process.argv[6]), steps: Number(process.argv[7] || 12),
+      fromX: Number(rest[0]), fromY: Number(rest[1]),
+      toX: Number(rest[2]), toY: Number(rest[3]), steps: Number(rest[4] || 12),
     }); break
-    case 'fill': value = await request('POST', '/fill', { ref: process.argv[3], value: process.argv.slice(4).join(' ') }); break
-    case 'upload': value = await request('POST', '/upload', { ref: process.argv[3], files: process.argv.slice(4) }); break
-    case 'select': value = await request('POST', '/select', { ref: process.argv[3], value: process.argv.slice(4).join(' ') }); break
-    case 'check': value = await request('POST', '/check', { ref: process.argv[3], checked: true }); break
-    case 'uncheck': value = await request('POST', '/check', { ref: process.argv[3], checked: false }); break
-    case 'press': value = await request('POST', '/press', { key: process.argv[3], ref: process.argv[4] }); break
-    case 'hover': value = await request('POST', '/hover', { ref: process.argv[3] }); break
-    case 'scroll': value = await request('POST', '/scroll', { deltaY: Number(process.argv[3]), deltaX: Number(process.argv[4] || 0) }); break
+    case 'fill': value = await request('POST', '/fill', { ref: rest[0], value: rest.slice(1).join(' ') }); break
+    case 'upload': value = await request('POST', '/upload', { ref: rest[0], files: rest.slice(1) }); break
+    case 'select': value = await request('POST', '/select', { ref: rest[0], value: rest.slice(1).join(' ') }); break
+    case 'check': value = await request('POST', '/check', { ref: rest[0], checked: true }); break
+    case 'uncheck': value = await request('POST', '/check', { ref: rest[0], checked: false }); break
+    case 'press': value = await request('POST', '/press', { key: rest[0], ref: rest[1] }); break
+    case 'hover': value = await request('POST', '/hover', { ref: rest[0] }); break
+    case 'scroll': value = await request('POST', '/scroll', { deltaY: Number(rest[0]), deltaX: Number(rest[1] || 0) }); break
     case 'scroll-at': value = await request('POST', '/scroll-at', {
-      x: Number(process.argv[3]), y: Number(process.argv[4]),
-      deltaY: Number(process.argv[5]), deltaX: Number(process.argv[6] || 0),
+      x: Number(rest[0]), y: Number(rest[1]),
+      deltaY: Number(rest[2]), deltaX: Number(rest[3] || 0),
     }); break
     case 'wait': {
-      const kind = process.argv[3]
-      const args = process.argv.slice(4)
+      const kind = rest[0]
+      const waitArgs = rest.slice(1)
       let timeoutMs
       let state
-      const timeoutIndex = args.indexOf('--timeout')
+      const timeoutIndex = waitArgs.indexOf('--timeout')
       if (timeoutIndex >= 0) {
-        timeoutMs = Number(args[timeoutIndex + 1])
-        args.splice(timeoutIndex, 2)
+        timeoutMs = Number(waitArgs[timeoutIndex + 1])
+        waitArgs.splice(timeoutIndex, 2)
       }
-      const stateIndex = args.indexOf('--state')
+      const stateIndex = waitArgs.indexOf('--state')
       if (stateIndex >= 0) {
-        state = args[stateIndex + 1]
-        args.splice(stateIndex, 2)
+        state = waitArgs[stateIndex + 1]
+        waitArgs.splice(stateIndex, 2)
       }
-      value = await request('POST', '/wait', { kind, value: args.join(' '), state, timeoutMs })
+      value = await request('POST', '/wait', { kind, value: waitArgs.join(' '), state, timeoutMs })
       break
     }
     case 'wait-login': {
       if (!chatId) throw new Error('Login waiting is only available from a Codey chat')
-      const seconds = process.argv[3] === undefined ? 300 : Number(process.argv[3])
+      const seconds = rest[0] === undefined ? 300 : Number(rest[0])
       if (!Number.isFinite(seconds) || seconds <= 0) throw new Error('wait-login timeout must be a positive number of seconds')
       value = await request('POST', '/wait-login', { chatId, timeoutMs: Math.round(seconds * 1000) })
       break
     }
-    case 'submit': value = await request('POST', '/submit', { ref: process.argv[3] }); break
+    case 'submit': value = await request('POST', '/submit', { ref: rest[0] }); break
+    case 'profile': {
+      const sub = rest[0]
+      if (sub === 'list') {
+        value = await request('GET', '/profiles')
+      } else if (sub === 'save') {
+        if (!rest[1]) throw new Error(`Missing profile name\n${usage()}`)
+        value = await request('POST', '/profile/save', { name: rest[1] })
+      } else if (sub === 'activate') {
+        if (!rest[1]) throw new Error(`Missing profile name\n${usage()}`)
+        value = await request('POST', '/profile/activate', { name: rest[1] })
+      } else if (sub === 'delete') {
+        if (!rest[1]) throw new Error(`Missing profile name\n${usage()}`)
+        value = await request('POST', '/profile/delete', { name: rest[1] })
+      } else if (sub === 'import') {
+        if (!rest[1]) throw new Error(`Missing profile file path\n${usage()}`)
+        value = await request('POST', '/profile/import', {
+          ...(rest[2] ? { name: rest[2] } : {}),
+          source: { path: rest[1] },
+        })
+      } else if (sub === 'export') {
+        if (!rest[1] || !rest[2]) throw new Error(`profile export needs a profile name and an output path\n${usage()}`)
+        value = await request('POST', '/profile/export', { name: rest[1], path: rest[2] })
+      } else {
+        throw new Error(`Unknown profile command: ${sub || ''}\n${usage()}`)
+      }
+      break
+    }
     case 'help':
     case '--help':
     case '-h':
@@ -213,3 +266,4 @@ main().catch(error => {
   process.stderr.write(`codey-browser: ${error.message || error}\n`)
   process.exitCode = 1
 })
+

--- a/codey-mac/src/components/AgentMemorySection.tsx
+++ b/codey-mac/src/components/AgentMemorySection.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
-import { Section, Toggle, fieldStyle, pillButton, unwrap } from './settingsAtoms'
+import { selectStyle, Toggle, fieldStyle, unwrap } from './settingsAtoms'
+import { OpenInEditorButton } from './OpenInEditorButton'
 import { MemoryPanel } from './CodeyMemorySection'
 import { formatBytes, memoryPreview, summarizeMemory } from './agentMemoryView'
 import type { AgentMemoryGroup, MemoryEntry } from '../codey-api'
@@ -10,10 +11,10 @@ import type { AgentMemoryGroup, MemoryEntry } from '../codey-api'
  * loads on its own before any prompt. Memory splits by who it is about:
  *
  *   user     what the agent knows about the user everywhere (~/.claude/CLAUDE.md,
- *            ~/.codex/AGENTS.md, …) — shown in Settings ▸ Agents.
+ *            ~/.codex/AGENTS.md, …) — shown in Settings ▸ Memory, under "Your memory".
  *   project  what it knows about one repository (CLAUDE.md, AGENTS.md, Claude
- *            Code's per-project memory and subagent memory) — shown on the
- *            workspace that owns that repository.
+ *            Code's per-project memory and subagent memory) — shown in
+ *            Settings ▸ Memory, under "Workspace memory".
  */
 
 const MemoryRow: React.FC<{ entry: MemoryEntry }> = ({ entry }) => {
@@ -31,11 +32,7 @@ const MemoryRow: React.FC<{ entry: MemoryEntry }> = ({ entry }) => {
           {entry.label}
         </button>
         <span style={{ color: C.fg3, fontSize: 11 }}>{formatBytes(entry.bytes)}</span>
-        <button
-          onClick={() => void window.codey.skills.reveal(entry.path)}
-          style={{ ...pillButton('ghost'), padding: '3px 8px', fontSize: 11 }}
-          title="Show this file in Finder"
-        >Reveal</button>
+        <OpenInEditorButton path={entry.path} />
       </div>
       {!open && preview && (
         <div style={{ color: C.fg3, fontSize: 11, marginTop: 3, marginLeft: 16, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{preview}</div>
@@ -94,60 +91,105 @@ const ErrorBox: React.FC<{ message: string }> = ({ message }) => (
   <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{message}</div>
 )
 
-/** Settings ▸ Agents: what each agent knows about the user, in every project. */
-export const UserMemorySection: React.FC<{ isGatewayRunning: boolean }> = ({ isGatewayRunning }) => {
-  const load = useCallback(async () => unwrap(await window.codey.memory.user()).agents, [])
-  const { groups, loading, error, reload } = useMemory(load, isGatewayRunning)
+/** A read-only card showing one agent's instruction files, chosen by a
+ *  dropdown that defaults to the gateway's default agent. */
+const AgentMemoryFilesCard: React.FC<{
+  description: string
+  emptyText: string
+  groups: AgentMemoryGroup[]
+  loading: boolean
+  error: string | null
+  reload: () => void
+}> = ({ description, emptyText, groups, loading, error, reload }) => {
+  const [selected, setSelected] = useState<string>('')
 
-  return (
-    <>
-      <Section
-        title="Memory"
-        description="What each agent has been told about you — the global instruction file it loads in every project. Project memory lives on the workspace."
-        right={
-          <button onClick={() => void reload()} style={pillButton('ghost')} disabled={loading} title="Re-read the memory files from disk">
-            {loading ? 'Reading…' : '↻ Refresh'}
-          </button>
-        }
-      />
-      {error && <ErrorBox message={error} />}
-      <MemoryGroups groups={groups} />
-    </>
-  )
-}
+  useEffect(() => {
+    if (groups.length === 0) { setSelected(''); return }
+    void (async () => {
+      let defaultAgent = 'claude-code'
+      try {
+        const fb = unwrap(await window.codey.fallback.get())
+        defaultAgent = fb.order?.[0]?.agent ?? 'claude-code'
+      } catch { /* keep fallback */ }
+      setSelected(prev => {
+        if (groups.some(g => g.agent === prev)) return prev
+        return groups.some(g => g.agent === defaultAgent) ? defaultAgent : groups[0].agent
+      })
+    })()
+  }, [groups])
 
-/** Workspaces tab: what each agent knows about this workspace's repository. */
-export const ProjectMemorySection: React.FC<{ workspace: string }> = ({ workspace }) => {
-  const load = useCallback(async () => unwrap(await window.codey.memory.project(workspace)).agents, [workspace])
-  const { groups, loading, error, reload } = useMemory(load, true)
-  const withFiles = groups.filter(g => g.entries.length > 0)
+  const selectedGroup = groups.find(g => g.agent === selected)
 
   return (
     <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 8 }}>
         <div>
-          <div style={{ fontSize: 14, fontWeight: 600 }}>Agent memory</div>
-          <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>
-            Instruction files the agents read from this project. Read-only.
-          </div>
+          <div style={{ fontSize: 14, fontWeight: 600 }}>Agent memory files</div>
+          <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>{description}</div>
         </div>
-        <button
-          onClick={() => void reload()}
-          disabled={loading}
-          style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, cursor: 'pointer' }}
-        >{loading ? 'Reading…' : '↻ Refresh'}</button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {groups.length > 1 && (
+            <select
+              value={selected}
+              onChange={e => setSelected(e.target.value)}
+              style={{ ...selectStyle, width: 132 }}
+              title="Choose which agent's memory to view"
+            >
+              {groups.map(g => <option key={g.agent} value={g.agent}>{g.agent}</option>)}
+            </select>
+          )}
+          <button
+            onClick={() => void reload()}
+            disabled={loading}
+            style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, cursor: 'pointer' }}
+          >{loading ? 'Reading…' : '↻ Refresh'}</button>
+        </div>
       </div>
       {error && <ErrorBox message={error} />}
-      {!loading && withFiles.length === 0 && !error && (
-        <div style={{ fontSize: 12, color: C.fg3 }}>No agent memory in this project yet.</div>
+      {!loading && groups.length === 0 && !error && (
+        <div style={{ fontSize: 12, color: C.fg3 }}>{emptyText}</div>
       )}
-      <MemoryGroups groups={withFiles} />
+      {selectedGroup && <MemoryGroups groups={[selectedGroup]} />}
     </div>
   )
 }
 
+/** Your memory: the global instruction file each agent loads in every project. */
+export const UserMemorySection: React.FC = () => {
+  const load = useCallback(async () => unwrap(await window.codey.memory.user()).agents, [])
+  const { groups, loading, error, reload } = useMemory(load, true)
+
+  return (
+    <AgentMemoryFilesCard
+      description="The global instruction file each agent loads in every project. Read-only."
+      emptyText="No agent memory files yet."
+      groups={groups}
+      loading={loading}
+      error={error}
+      reload={reload}
+    />
+  )
+}
+
+/** Workspace memory: the instruction files each agent reads from one project. */
+export const ProjectMemorySection: React.FC<{ workspace: string }> = ({ workspace }) => {
+  const load = useCallback(async () => unwrap(await window.codey.memory.project(workspace)).agents, [workspace])
+  const { groups, loading, error, reload } = useMemory(load, true)
+
+  return (
+    <AgentMemoryFilesCard
+      description="Instruction files the agents read from this project. Read-only."
+      emptyText="No agent memory in this project yet."
+      groups={groups}
+      loading={loading}
+      error={error}
+      reload={reload}
+    />
+  )
+}
+
 /**
- * Settings ▸ Agents: the one knowledge base about the user.
+ * Your global memory: the one knowledge base about the user.
  *
  * The entries live in Codey's user-global memory store — the same ones it
  * injects into its own prompts. Turning sharing on also renders them into
@@ -156,7 +198,7 @@ export const ProjectMemorySection: React.FC<{ workspace: string }> = ({ workspac
  * deliver; Codey drops its own injection while sharing is on so no fact
  * reaches the model twice.
  */
-export const SharedMemorySection: React.FC<{ isGatewayRunning: boolean }> = ({ isGatewayRunning }) => {
+export const GlobalMemoryPanel: React.FC = () => {
   const [enabled, setEnabled] = useState(false)
   const [targets, setTargets] = useState<Array<{ agent: string; path: string }>>([])
   const [error, setError] = useState<string | null>(null)
@@ -170,10 +212,7 @@ export const SharedMemorySection: React.FC<{ isGatewayRunning: boolean }> = ({ i
     } catch (e: any) { setError(e?.message ?? String(e)) }
   }, [])
 
-  useEffect(() => {
-    if (!isGatewayRunning) return
-    void reload()
-  }, [isGatewayRunning, reload])
+  useEffect(() => { void reload() }, [reload])
 
   const toggle = async (next: boolean) => {
     setEnabled(next)
@@ -182,27 +221,20 @@ export const SharedMemorySection: React.FC<{ isGatewayRunning: boolean }> = ({ i
     catch (e: any) { setEnabled(!next); setError(e?.message ?? String(e)) }
   }
 
-  if (!isGatewayRunning) return null
-
   return (
     <>
-      <Section
-        title="Shared memory"
-        description="What Codey knows about you in every workspace. Codey always uses it; sharing also writes it into the agents' own memory files."
-      />
       {error && <ErrorBox message={error} />}
       <MemoryPanel
         scope="global"
-        title="About you"
-        description="Standing facts and preferences that hold in every project."
+        description="Standing facts and preferences about you, used in every project."
         banner={
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '10px 0', borderTop: `1px solid ${C.border}` }}>
             <div>
               <div style={{ color: C.fg, fontSize: 13 }}>Share with every agent</div>
               <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>
                 {enabled
-                  ? `Written into ${targets.length} agent memory file${targets.length === 1 ? '' : 's'}, inside a Codey-managed block.`
-                  : 'Off — only Codey itself uses these memories. The block is removed from the agent files.'}
+                  ? `Written into ${targets.length} agent memory file${targets.length === 1 ? '' : 's'} below, inside a Codey-managed block.`
+                  : 'Off — only Codey itself uses these memories. The block is removed from the agent files below.'}
               </div>
             </div>
             <Toggle on={enabled} onChange={v => void toggle(v)} label="Share memory with every agent" />

--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -8,7 +8,6 @@ import {
   EnvEditor,
 } from './SettingsTab'
 import { refreshInstalledAgents, useInstalledAgents } from './installedAgents'
-import { SharedMemorySection, UserMemorySection } from './AgentMemorySection'
 import {
   AGENT_TEAMS_AGENT,
   envWithoutAgentTeams,
@@ -122,10 +121,6 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
           </div>
         )
       })}
-
-      <UserMemorySection isGatewayRunning={isGatewayRunning} />
-
-      <SharedMemorySection isGatewayRunning={isGatewayRunning} />
     </div>
   )
 }

--- a/codey-mac/src/components/CodeyMemorySection.tsx
+++ b/codey-mac/src/components/CodeyMemorySection.tsx
@@ -96,7 +96,8 @@ interface PanelProps {
   scope: MemoryStoreScope
   /** Required for the workspace scope; ignored for the global one. */
   workspace?: string
-  title: string
+  /** Optional header title; omit it when an outer section already names the panel. */
+  title?: string
   description: string
   /** Rendered between the header and the composer, e.g. a sharing switch. */
   banner?: React.ReactNode
@@ -137,8 +138,8 @@ export const MemoryPanel: React.FC<PanelProps> = ({ scope, workspace, title, des
     <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
         <div>
-          <div style={{ fontSize: 14, fontWeight: 600 }}>{title}</div>
-          <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>{description}</div>
+          {title && <div style={{ fontSize: 14, fontWeight: 600 }}>{title}</div>}
+          <div style={{ color: C.fg3, fontSize: 11, marginTop: title ? 2 : 0 }}>{description}</div>
         </div>
         <button onClick={() => void reload()} disabled={loading} style={smallButton()}>
           {loading ? 'Reading…' : '↻ Refresh'}
@@ -169,13 +170,11 @@ export const MemoryPanel: React.FC<PanelProps> = ({ scope, workspace, title, des
             onClick={() => void add()}
             disabled={adding || !draft.trim()}
             style={{ ...smallButton(), color: C.accent, borderColor: C.accent, opacity: (adding || !draft.trim()) ? 0.5 : 1 }}
-          >{adding ? 'Saving…' : 'Remember'}</button>
+          >{adding ? 'Saving…' : 'Save'}</button>
         </div>
       </div>
 
-      {entries.length === 0 && !loading ? (
-        <div style={{ color: C.fg3, fontSize: 12, marginTop: 8 }}>Nothing remembered yet.</div>
-      ) : (
+      {entries.length > 0 && (
         <div style={{ marginTop: 4 }}>
           {entries.map(entry => (
             <EntryRow
@@ -196,7 +195,7 @@ export const CodeyMemorySection: React.FC<{ workspace: string }> = ({ workspace 
   <MemoryPanel
     scope="workspace"
     workspace={workspace}
-    title="Memory"
+    title="Shared memory"
     description="What Codey remembers about this workspace and adds to its prompts."
   />
 )
@@ -240,7 +239,7 @@ export const CodeyMemorySettings: React.FC = () => {
     onChange: (v: boolean) => void,
     disabled?: boolean,
   ) => (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginTop: 10, opacity: disabled ? 0.5 : 1 }}>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '5px 0', opacity: disabled ? 0.5 : 1 }}>
       <div>
         <div style={{ color: C.fg, fontSize: 13 }}>{title}</div>
         <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>{hint}</div>
@@ -250,10 +249,9 @@ export const CodeyMemorySettings: React.FC = () => {
   )
 
   return (
-    <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8, marginBottom: 12 }}>
-      <div style={{ fontSize: 14, fontWeight: 600 }}>Codey memory</div>
+    <div style={{ padding: '12px 16px', background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8, marginBottom: 12 }}>
       {error && (
-        <div style={{ background: C.red + '22', color: C.red, padding: 8, borderRadius: 6, fontSize: 12, marginTop: 8 }}>{error}</div>
+        <div style={{ background: C.red + '22', color: C.red, padding: 8, borderRadius: 6, fontSize: 12, marginBottom: 8 }}>{error}</div>
       )}
       {row('Use memory in prompts', 'Off means nothing remembered is sent to the agents.', enabled, v => void patch({ enabled: v }))}
       {row('Record memories automatically', 'Off means only what you add by hand is kept.', autoExtract, v => void patch({ autoExtract: v }), !enabled)}

--- a/codey-mac/src/components/MemoryTab.tsx
+++ b/codey-mac/src/components/MemoryTab.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { C } from '../theme'
+import { pageStyle, Section } from './settingsAtoms'
+import { CodeyMemorySettings } from './CodeyMemorySection'
+import { GlobalMemoryPanel, UserMemorySection } from './AgentMemorySection'
+
+/**
+ * Settings ▸ Memory — the user's global memory in one place.
+ *
+ *   Your memory  what Codey remembers about you everywhere (plus the global
+ *                instruction file each agent loads on its own).
+ *
+ * Workspace-scoped memory lives on the Workspaces tab, next to the folders it
+ * belongs to.
+ */
+
+interface Props {
+  isGatewayRunning: boolean
+}
+
+export const MemoryTab: React.FC<Props> = ({ isGatewayRunning }) => {
+  if (!isGatewayRunning) {
+    return (
+      <div style={pageStyle}>
+        <div style={{ marginTop: 40, textAlign: 'center', color: C.fg3, fontSize: 13 }}>Gateway not available</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={pageStyle}>
+      <Section
+        first
+        title="Your memory"
+        description="What Codey remembers about you everywhere, and what each agent already knows about you."
+      />
+      <CodeyMemorySettings />
+      <GlobalMemoryPanel />
+      <div style={{ marginTop: 12 }}>
+        <UserMemorySection />
+      </div>
+    </div>
+  )
+}

--- a/codey-mac/src/components/OpenInEditorButton.tsx
+++ b/codey-mac/src/components/OpenInEditorButton.tsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { C } from '../theme'
+import { UIIcon } from './UIIcons'
+
+interface EditorInfo { id: string; name: string; installed: boolean }
+
+const PREFERRED_KEY = 'codey.preferredEditor'
+
+const primaryStyle: React.CSSProperties = {
+  padding: '3px 8px', fontSize: 11, borderRadius: 6, cursor: 'pointer',
+  background: C.surface3, color: C.fg2, border: `1px solid ${C.border2}`,
+  borderTopRightRadius: 0, borderBottomRightRadius: 0, borderRight: 'none',
+  whiteSpace: 'nowrap',
+}
+const dropdownStyle: React.CSSProperties = {
+  padding: '3px 6px', fontSize: 11, borderRadius: 6, cursor: 'pointer',
+  background: C.surface3, color: C.fg2, border: `1px solid ${C.border2}`,
+  borderTopLeftRadius: 0, borderBottomLeftRadius: 0, display: 'inline-flex', alignItems: 'center',
+}
+const menuStyle: React.CSSProperties = {
+  position: 'absolute', top: 'calc(100% + 4px)', right: 0, zIndex: 1000,
+  background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8,
+  boxShadow: '0 6px 20px rgba(0,0,0,0.25)', minWidth: 170, padding: 4,
+  display: 'flex', flexDirection: 'column',
+}
+const menuItemStyle: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 8, padding: '6px 9px', borderRadius: 6,
+  background: 'transparent', border: 'none', color: C.fg, fontSize: 12, cursor: 'pointer',
+  textAlign: 'left', width: '100%',
+}
+
+/**
+ * Compact "Open in" split button: opens a file (or directory) in the user's
+ * preferred editor, with a chevron to pick another installed editor. Shares
+ * the `codey.preferredEditor` preference with the chat toolbar's Open-in.
+ */
+export const OpenInEditorButton: React.FC<{ path: string }> = ({ path }) => {
+  const [editors, setEditors] = useState<EditorInfo[]>([])
+  const [loaded, setLoaded] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [opening, setOpening] = useState<string | null>(null)
+  const [preferredId, setPreferredId] = useState(() => localStorage.getItem(PREFERRED_KEY) ?? '')
+
+  const loadEditors = useCallback(async (): Promise<EditorInfo[]> => {
+    if (loaded) return editors
+    const res = await window.codey.editors.list()
+    const next = res.ok ? res.data : []
+    if (res.ok) setEditors(next)
+    setLoaded(true)
+    return next
+  }, [loaded, editors])
+
+  useEffect(() => { void loadEditors() }, [])
+
+  const open = useCallback(async (editor: EditorInfo) => {
+    setOpening(editor.id)
+    setMenuOpen(false)
+    const res = await window.codey.editors.open(editor.id, path)
+    setOpening(null)
+    if (!res.ok) { alert(`Couldn't open ${editor.name}: ${res.error}`); return }
+    setPreferredId(editor.id)
+    localStorage.setItem(PREFERRED_KEY, editor.id)
+  }, [path])
+
+  const openPreferred = useCallback(async () => {
+    const available = (loaded ? editors : await loadEditors()).filter(e => e.installed)
+    const target = available.find(e => e.id === preferredId) ?? available[0]
+    if (target) await open(target)
+  }, [loaded, editors, loadEditors, preferredId, open])
+
+  const installed = editors.filter(e => e.installed)
+  const preferred = installed.find(e => e.id === preferredId)
+  const disabled = opening !== null || (loaded && installed.length === 0)
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'stretch', flexShrink: 0 }}>
+      <button
+        onClick={() => void openPreferred()}
+        disabled={disabled}
+        title={preferred ? `Open in ${preferred.name}` : 'Open in editor'}
+        style={primaryStyle}
+      >
+        {opening ? 'Opening…' : 'Open in'}
+      </button>
+      <button
+        onClick={async () => { if (!loaded) await loadEditors(); setMenuOpen(o => !o) }}
+        disabled={opening !== null}
+        title="Choose another editor"
+        aria-label="Choose another editor"
+        style={dropdownStyle}
+      >
+        <UIIcon name="chevron" size={11} />
+      </button>
+      {menuOpen && (
+        <>
+          <div onClick={() => setMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 999 }} />
+          <div style={menuStyle} onClick={e => e.stopPropagation()}>
+            {!loaded ? (
+              <div style={{ color: C.fg3, fontSize: 11, padding: '6px 9px' }}>Checking editors…</div>
+            ) : installed.length > 0 ? (
+              installed.map(editor => (
+                <button key={editor.id} style={menuItemStyle} onClick={() => void open(editor)}>
+                  <span style={{ flex: 1 }}>{opening === editor.id ? `Opening ${editor.name}…` : editor.name}</span>
+                  {editor.id === preferredId && <UIIcon name="check" size={13} />}
+                </button>
+              ))
+            ) : (
+              <div style={{ color: C.fg3, fontSize: 11, padding: '6px 9px' }}>No supported editor found.</div>
+            )}
+          </div>
+        </>
+      )}
+    </span>
+  )
+}

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -3,11 +3,22 @@ import { C } from '../theme'
 import { pillButton, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { matchesToolSearch } from './tools-search'
+import { BrowserProfiles } from './BrowserProfiles'
 import type { PluginInfo, PluginInstallResult, PluginUpdateCheck } from '../codey-api'
 
 /** Codey refused to touch a skill of this name it did not write. The user
  *  decides; nothing is replaced or deleted until they say so. */
 type Pending = { action: 'install' | 'uninstall'; dir: string }
+
+/** Plugins whose card carries a settings page. The browser plugin's settings
+ *  are the session profiles: save, import, activate, export and delete. */
+const SETTINGS_PLUGINS = new Set<string>(['browser'])
+
+/** Toggle which plugin's settings page is open: clicking the same plugin again
+ *  closes it, clicking another opens it. */
+export function toggleSettingsId(current: string | null, id: string): string | null {
+  return current === id ? null : id
+}
 
 export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '' }) => {
   const [plugins, setPlugins] = useState<PluginInfo[]>([])
@@ -20,6 +31,8 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
   // Whether the published skill moved since this copy was installed. `null`
   // means nothing could be checked — the repo was unreachable, so no claim.
   const [update, setUpdate] = useState<Record<string, PluginUpdateCheck>>({})
+  // Which plugin's settings page is open (only plugins in SETTINGS_PLUGINS).
+  const [settingsFor, setSettingsFor] = useState<string | null>(null)
   const filteredPlugins = useMemo(
     () => plugins.filter(plugin => matchesToolSearch(searchQuery, plugin.name, plugin.description)),
     [plugins, searchQuery],
@@ -108,96 +121,130 @@ export const PluginsTab: React.FC<{ searchQuery?: string }> = ({ searchQuery = '
         const working = busy === plugin.id
         const last = outcome[plugin.id]
         const ask = pending[plugin.id]
+        const hasSettings = SETTINGS_PLUGINS.has(plugin.id) && installed
+        const settingsOpen = settingsFor === plugin.id
         return (
-          <div key={plugin.id} style={styles.card}>
-            <div style={styles.cardIcon}><UIIcon name="tools" size={18} /></div>
-            <div style={styles.cardBody}>
-              <div style={styles.cardName}>
-                {plugin.name}
-                {installed && (
-                  <span style={plugin.state === 'disabled' ? styles.badgeMuted : styles.badge}>
-                    {plugin.state === 'disabled' ? 'Off in Skills' : 'Installed'}
-                    {plugin.hash ? ` ${plugin.hash.slice(0, 7)}` : ''}
-                  </span>
+          <div key={plugin.id} style={styles.pluginWrap}>
+            <div style={{ ...styles.card, ...(settingsOpen ? styles.cardWithSettings : null) }}>
+              <div style={styles.cardIcon}><UIIcon name="tools" size={18} /></div>
+              <div style={styles.cardBody}>
+                <div style={styles.cardName}>
+                  {plugin.name}
+                  {installed && (
+                    <span style={plugin.state === 'disabled' ? styles.badgeMuted : styles.badge}>
+                      {plugin.state === 'disabled' ? 'Off in Skills' : 'Installed'}
+                    </span>
+                  )}
+                </div>
+                <div style={styles.cardDesc}>{plugin.description}</div>
+                {installed ? (
+                  <div style={styles.cardHint}>
+                    {plugin.state === 'disabled'
+                      ? 'Switched off in Skills, so no agent loads it. Turn it back on there.'
+                      : 'Listed in Skills as "codey:browser".'}
+                    {update[plugin.id]?.needsUpdate === true && (
+                      <div style={styles.updateHint}>
+                        {update[plugin.id]?.recorded === 'bundled'
+                          ? 'This copy came with the app, installed while the repository was '
+                            + 'unreachable — Update to pull the published one.'
+                          : 'The published skill has moved since this copy was installed — '
+                            + 'Update to get it.'}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div style={styles.cardHint}>
+                    Downloads from <span style={styles.path}>{plugin.sourceUrl}</span>
+                  </div>
+                )}
+                {last?.installed && last.source === 'bundled' && (
+                  <div style={styles.cardWarn}>
+                    Could not reach the skills repository, so Codey installed the copy it
+                    ships with. {last.reason}
+                  </div>
+                )}
+                {ask && (
+                  <div style={styles.cardWarn}>
+                    A skill named "browser" is already at <span style={styles.path}>{ask.dir}</span>,
+                    and Codey did not write it.{' '}
+                    {ask.action === 'install'
+                      ? 'Installing replaces it.'
+                      : 'Uninstalling deletes it.'} There is no undo.
+                  </div>
                 )}
               </div>
-              <div style={styles.cardDesc}>{plugin.description}</div>
-              {installed ? (
-                <div style={styles.cardHint}>
-                  {plugin.state === 'disabled'
-                    ? 'Switched off in Skills, so no agent loads it. Turn it back on there.'
-                    : 'Listed in Skills as "codey:browser".'}
-                  {update[plugin.id]?.needsUpdate === true && (
-                    <div style={styles.updateHint}>
-                      {update[plugin.id]?.recorded === 'bundled'
-                        ? 'This copy came with the app, installed while the repository was '
-                          + 'unreachable — Update to pull the published one.'
-                        : 'The published skill has moved since this copy was installed — '
-                          + 'Update to get it.'}
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div style={styles.cardHint}>
-                  Downloads from <span style={styles.path}>{plugin.sourceUrl}</span>
-                </div>
-              )}
-              {last?.installed && last.source === 'bundled' && (
-                <div style={styles.cardWarn}>
-                  Could not reach the skills repository, so Codey installed the copy it
-                  ships with. {last.reason}
-                </div>
-              )}
-              {ask && (
-                <div style={styles.cardWarn}>
-                  A skill named "browser" is already at <span style={styles.path}>{ask.dir}</span>,
-                  and Codey did not write it.{' '}
-                  {ask.action === 'install'
-                    ? 'Installing replaces it.'
-                    : 'Uninstalling deletes it.'} There is no undo.
-                </div>
-              )}
-            </div>
-            <div style={styles.cardActions}>
-              {ask ? (
-                <>
+              <div style={styles.cardActions}>
+                {hasSettings && (
                   <button
-                    onClick={() => setPending(prev => forget(plugin.id, prev))}
+                    onClick={() => setSettingsFor(current => toggleSettingsId(current, plugin.id))}
                     disabled={working}
-                    style={pillButton('ghost')}
+                    style={pluginActionButton(settingsOpen ? 'active' : 'neutral')}
+                    title="Browser settings — session profiles"
                   >
-                    Keep mine
+                    <UIIcon name="settings" size={13} /> Settings
                   </button>
-                  <button
-                    onClick={() => { if (!working) void act(plugin, ask.action, true) }}
-                    disabled={working}
-                    style={pillButton('danger')}
-                  >
-                    {ask.action === 'install' ? 'Replace it' : 'Delete it'}
-                  </button>
-                </>
-              ) : (
-                <>
-                  {installed && update[plugin.id]?.needsUpdate === true && (
+                )}
+                {ask ? (
+                  <>
                     <button
-                      onClick={() => { if (!working) void act(plugin, 'install') }}
+                      onClick={() => setPending(prev => forget(plugin.id, prev))}
                       disabled={working}
-                      style={pillButton('primary')}
-                      title="A newer published version is available — update now"
+                      style={pillButton('ghost')}
                     >
-                      Update
+                      Keep mine
                     </button>
-                  )}
-                  <button
-                    onClick={() => { if (!working) void act(plugin, installed ? 'uninstall' : 'install') }}
-                    disabled={working}
-                    style={pillButton(installed ? 'danger' : 'primary')}
-                  >
-                    {working ? (installed ? 'Working…' : 'Installing…') : installed ? 'Uninstall' : 'Install'}
-                  </button>
-                </>
-              )}
+                    <button
+                      onClick={() => { if (!working) void act(plugin, ask.action, true) }}
+                      disabled={working}
+                      style={pillButton('danger')}
+                    >
+                      {ask.action === 'install' ? 'Replace it' : 'Delete it'}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    {installed && update[plugin.id]?.needsUpdate === true && (
+                      <button
+                        onClick={() => { if (!working) void act(plugin, 'install') }}
+                        disabled={working}
+                        style={pillButton('primary')}
+                        title="A newer published version is available — update now"
+                      >
+                        Update
+                      </button>
+                    )}
+                    <button
+                      onClick={() => { if (!working) void act(plugin, installed ? 'uninstall' : 'install') }}
+                      disabled={working}
+                      style={installed ? pluginActionButton('danger') : pillButton('primary')}
+                    >
+                      {installed && <UIIcon name="trash" size={13} />}
+                      {working ? (installed ? 'Working…' : 'Installing…') : installed ? 'Uninstall' : 'Install'}
+                    </button>
+                  </>
+                )}
+              </div>
             </div>
+            {settingsOpen && (
+              <div style={styles.settingsPanel}>
+                <div style={styles.settingsHeader}>
+                  <div style={styles.settingsHeading}>
+                    <div style={styles.settingsIcon}><UIIcon name="users" size={15} /></div>
+                    <div>
+                      <div style={styles.settingsTitle}>Session profiles</div>
+                      <div style={styles.settingsCopy}>
+                        Save your current browser session, import a Codey or Playwright profile, and switch identities
+                        without signing in again.
+                      </div>
+                    </div>
+                  </div>
+                  <button type="button" onClick={() => setSettingsFor(null)} style={pillButton('ghost')}>
+                    Done
+                  </button>
+                </div>
+                <BrowserProfiles />
+              </div>
+            )}
           </div>
         )
       })}
@@ -215,10 +262,28 @@ const styles: Record<string, React.CSSProperties> = {
     background: C.dangerBg, color: C.dangerFg, border: `1px solid ${C.dangerBorder}`,
     padding: '9px 11px', borderRadius: 9, marginBottom: 14, fontSize: 12,
   },
-  card: {
-    display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px',
-    border: `1px solid ${C.border}`, borderRadius: 12, background: C.surface2, marginBottom: 10,
+  pluginWrap: {
+    marginBottom: 10, border: `1px solid ${C.border}`, borderRadius: 12,
+    background: C.surface2, overflow: 'hidden',
   },
+  card: {
+    display: 'flex', alignItems: 'center', gap: 12, padding: '15px 16px',
+    background: C.surface2,
+  },
+  cardWithSettings: { paddingBottom: 14 },
+  settingsPanel: {
+    padding: '16px', borderTop: `1px solid ${C.border}`, background: C.surface,
+  },
+  settingsHeader: {
+    display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 12,
+  },
+  settingsHeading: { display: 'flex', alignItems: 'flex-start', gap: 10, minWidth: 0 },
+  settingsIcon: {
+    width: 30, height: 30, display: 'grid', placeItems: 'center', flexShrink: 0,
+    borderRadius: 8, background: C.accentDim, color: C.accent,
+  },
+  settingsTitle: { color: C.fg, fontSize: 13, fontWeight: 750 },
+  settingsCopy: { color: C.fg3, fontSize: 11, lineHeight: 1.45, marginTop: 3, maxWidth: 650 },
   cardIcon: { color: C.accent, flexShrink: 0 },
   cardBody: { flex: 1, minWidth: 0 },
   cardName: { color: C.fg, fontSize: 13, fontWeight: 700, marginBottom: 3 },
@@ -237,4 +302,13 @@ const styles: Record<string, React.CSSProperties> = {
   },
   cardActions: { display: 'flex', gap: 8, alignItems: 'center', flexShrink: 0 },
   emptySearch: { color: C.fg3, fontSize: 12, textAlign: 'center', padding: '30px 16px' },
+}
+
+function pluginActionButton(variant: 'neutral' | 'active' | 'danger'): React.CSSProperties {
+  return {
+    ...pillButton('ghost'), display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+    minWidth: 94, background: variant === 'active' ? C.accentDim : C.surface,
+    border: `1px solid ${variant === 'danger' ? C.dangerBorder : variant === 'active' ? C.accent : C.border2}`,
+    color: variant === 'danger' ? C.dangerFg : variant === 'active' ? C.accent : C.fg2,
+  }
 }

--- a/codey-mac/src/components/SettingsOverlay.tsx
+++ b/codey-mac/src/components/SettingsOverlay.tsx
@@ -3,6 +3,7 @@ import { OverlayWindow } from './OverlayWindow'
 import { StatusTab } from './StatusTab'
 import { SettingsTab } from './SettingsTab'
 import { AgentsTab } from './AgentsTab'
+import { MemoryTab } from './MemoryTab'
 import { WorkspacesTab } from './WorkspacesTab'
 import WorkersTab from './WorkersTab'
 import { TeamsTab } from './TeamsTab'
@@ -12,12 +13,13 @@ import { AppearanceTab } from './AppearanceTab'
 import { WhisperTab } from './WhisperTab'
 import { ApiKeysTab } from './ApiKeysTab'
 import { UIIcon, type IconName } from './UIIcons'
-type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'agents' | 'whisper' | 'apiKeys'
+type Tab = 'general' | 'workers' | 'teams' | 'workspaces' | 'status' | 'settings' | 'agents' | 'memory' | 'whisper' | 'apiKeys'
 const TABS: { key: Tab; label: string; icon: IconName; description: string }[] = [
   { key: 'general',    label: 'General',    icon: 'settings', description: 'Appearance & behavior' },
   { key: 'apiKeys',    label: 'API Keys',   icon: 'key', description: 'Shared credentials' },
   { key: 'settings',   label: 'AI Models',  icon: 'sparkle', description: 'Models & fallbacks' },
   { key: 'agents',     label: 'Agents',     icon: 'bot', description: 'CLI install & environment' },
+  { key: 'memory',     label: 'Memory',     icon: 'book', description: 'Global & workspace memory' },
   { key: 'whisper',    label: 'Voice',      icon: 'mic', description: 'Voice input & hotkeys' },
   { key: 'workspaces', label: 'Workspaces', icon: 'workspace', description: 'Project directories' },
   { key: 'workers',    label: 'Workers',    icon: 'users', description: 'Personalities' },
@@ -81,6 +83,7 @@ export const SettingsOverlay: React.FC<Props> = ({ onClose, initialTab }) => {
               {tab === 'teams'      && <TeamsTab />}
               {tab === 'settings'   && <SettingsTab isGatewayRunning={isRunning} />}
               {tab === 'agents'     && <AgentsTab isGatewayRunning={isRunning} />}
+              {tab === 'memory'     && <MemoryTab isGatewayRunning={isRunning} />}
               {tab === 'whisper'    && (
                 <WhisperTab
                   isGatewayRunning={isRunning}

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export type IconName =
-  | 'activity' | 'add' | 'alert' | 'archive' | 'bell' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
+  | 'activity' | 'add' | 'alert' | 'archive' | 'bell' | 'book' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
   | 'clock' | 'code' | 'copy' | 'edit' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
   | 'waveform' | 'git-branch' | 'git-merge' | 'pull-request' | 'globe' | 'match-case' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
   | 'telegram' | 'discord' | 'imessage' | 'undo'
@@ -24,6 +24,7 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     alert: <><path {...common} d="M12 4.5L21 19.5H3L12 4.5z" /><path {...common} d="M12 10v4M12 17h.01" /></>,
     archive: <><path {...common} d="M4 7h16v13H4zM3 4h18v3H3zM9 12h6" /></>,
     bell: <><path {...common} d="M18 9a6 6 0 00-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9" /><path {...common} d="M10 21h4" /></>,
+    book: <><path {...common} d="M4 19.5A2.5 2.5 0 016.5 17H20" /><path {...common} d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" /></>,
     bot: <><rect {...common} x="4" y="7" width="16" height="13" rx="3" /><path {...common} d="M12 3v4M9 13h.01M15 13h.01M8 17h8" /><circle fill="currentColor" cx="9" cy="13" r="1" /><circle fill="currentColor" cx="15" cy="13" r="1" /></>,
     chat: <><path {...common} d="M20 11.5a7.5 7.5 0 01-8 7.5 8.7 8.7 0 01-3.3-.65L4 20l1.55-3.9A7.3 7.3 0 014 11.5 7.5 7.5 0 0112 4a7.5 7.5 0 018 7.5z" /></>,
     check: <path {...common} d="M5 12.5l4.2 4.2L19 7" />,

--- a/codey-mac/src/components/WorkspacesTab.tsx
+++ b/codey-mac/src/components/WorkspacesTab.tsx
@@ -3,7 +3,7 @@ import { apiService } from '../services/api'
 import { C } from '../theme'
 import { emitWorkspacesChanged } from './workspacesChanged'
 import { ProjectMemorySection } from './AgentMemorySection'
-import { CodeyMemorySection, CodeyMemorySettings } from './CodeyMemorySection'
+import { CodeyMemorySection } from './CodeyMemorySection'
 
 interface WorkspacesTabProps {
   isGatewayRunning: boolean
@@ -157,8 +157,6 @@ export const WorkspacesTab: React.FC<WorkspacesTabProps> = ({ isGatewayRunning }
       </div>
 
       {error && <div style={styles.error}>{error}</div>}
-
-      <CodeyMemorySettings />
 
       {workspaces.length === 0 ? (
         <div style={{ color: C.fg3, padding: '20px 0' }}>No workspaces yet — click "Add folder" to pick one.</div>

--- a/codey-mac/src/components/pluginsSettings.test.ts
+++ b/codey-mac/src/components/pluginsSettings.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { toggleSettingsId } from './PluginsTab'
+
+describe('toggleSettingsId', () => {
+  it('opens a plugin settings page when none is open', () => {
+    expect(toggleSettingsId(null, 'browser')).toBe('browser')
+  })
+
+  it('closes the same plugin when it is already open', () => {
+    expect(toggleSettingsId('browser', 'browser')).toBeNull()
+  })
+
+  it('switches to a different plugin', () => {
+    expect(toggleSettingsId('mcp', 'browser')).toBe('browser')
+  })
+})
+

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -35,6 +35,34 @@ size and display scale - open that path with your image-reading tool. Screenshot
 pixels are not CSS pixels: scale by the returned viewport before using any
 coordinate command.
 
+## Profiles
+
+The browser can save and restore named sessions ("profiles") - the cookies and
+per-site storage that keep a site signed in - so you can switch identity for a
+task or carry a session to another machine.
+
+- `profile list` - names of saved profiles plus which one is active
+- `profile save <name>` - snapshot the current session into a named profile
+- `profile import <path> [name]` - import a session file (a Codey profile or
+  a Playwright storageState JSON) and activate it in one step
+- `profile activate <name>` - switch the live session to a saved profile
+- `profile export <name> <path>` - write a saved profile to a shareable file
+- `profile delete <name>` - remove a saved profile
+
+To run a command under a specific profile, put `--profile <name>` before the
+command - the profile is activated first if it is not already (an identity
+switch, so the user is asked to approve it):
+
+```
+ELECTRON_RUN_AS_NODE=1 "$CODEY_BROWSER_RUNTIME" "$CODEY_BROWSER_CLI" --profile work open-view "https://github.com"
+```
+
+`state` reports the active profile. Activating a profile replaces the
+session's cookies with the profile's (an identity switch, so the previous
+session's cookies are removed); its site storage is applied best-effort for the
+origins it knows, and a page may need to reload before its stored state is
+visible.
+
 ## Rules
 
 - Browsing is view-only by default. Opening, navigating, tabs, back/forward,


### PR DESCRIPTION
Two independent pieces of polish that were sitting uncommitted.

## Browser profiles for the agent

The browser controller already knew how to save/restore named sessions; this exposes that to agents.

- New CLI commands: `profile list | save | import | activate | export | delete`
- `--profile <name>` before any command runs that command under a saved session (the bridge activates it first if it isn't already)
- `state` now reports the active profile
- `SKILL.md` documents both, including that activating replaces the session's cookies

Activating a profile is an identity switch, so it goes through the same user approval gate as any other mutating browser command — both the explicit `/profile/activate` route and the `--profile` header path.

## Mac app: Settings ▸ Memory

- Global memory moved out of Agents and Workspaces into its own **Memory** tab; workspace-scoped memory stays on Workspaces
- Agent memory files collapse behind an agent picker instead of listing every agent
- New shared `OpenInEditorButton` split button (reveal → open in preferred editor, chevron to pick another)
- Plugins settings pages open/close through one `toggleSettingsId` helper, now unit-tested

## Testing

- `npm test` — 43 + 73 files, 1132 tests, all pass
- `npx tsc --noEmit` in `codey-mac` — clean
- `npm run lint` — clean
- Not smoke-tested in the real Mac app yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)