### PR TITLE
fix(mac): label the Advisor row ADVISOR, not ROUTER

### DIFF
--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -549,7 +549,7 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
         <span style={{
           color: C.fg3, fontSize: 11, fontWeight: 400,
           width: 56, letterSpacing: 0.3,
-        }}>ROUTER</span>
+        }}>ADVISOR</span>
         <select
           value={advisor.agent}
           onChange={e => {


### PR DESCRIPTION
Settings ▸ Advisor had a hardcoded `ROUTER` tag on the agent/model row. It didn't match the section title ("Advisor") or the name used anywhere else in the app. One-word label change, no logic touched.

`codey-mac/src/components/SettingsTab.tsx:552`

🤖 Generated with [Claude Code](https://claude.com/claude-code)