### PR TITLE
fix(voice): carry the vocabulary hint in punctuated sentences

### DIFF
--- a/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/RealtimeTranscriptionEngine.swift
@@ -156,7 +156,7 @@ final class RealtimeTranscriptionEngine: NSObject, TranscriptionEngineProtocol, 
         let updateData = try buildSessionUpdate(
             language: language,
             model: realtimeModel,
-            prompt: Vocabulary.promptText(vocabulary)
+            prompt: Vocabulary.promptText(vocabulary, language: language)
         )
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             ws.send(.data(updateData)) { error in

--- a/voice/Sources/CodeyVoice/TranscriptionEngine.swift
+++ b/voice/Sources/CodeyVoice/TranscriptionEngine.swift
@@ -51,7 +51,7 @@ final class TranscriptionEngine: TranscriptionEngineProtocol, @unchecked Sendabl
 
         let wavData = encodeWAV(samples: audio, sampleRate: 16000)
         let streaming = modelSupportsStreaming(apiModel)
-        let request = buildRequest(url: url, apiKey: apiKey, apiModel: apiModel, wav: wavData, language: language, streaming: streaming, prompt: Vocabulary.promptText(vocabulary))
+        let request = buildRequest(url: url, apiKey: apiKey, apiModel: apiModel, wav: wavData, language: language, streaming: streaming, prompt: Vocabulary.promptText(vocabulary, language: language))
 
         return streaming
             ? try await runStreaming(request: request)

--- a/voice/Sources/CodeyVoice/Vocabulary.swift
+++ b/voice/Sources/CodeyVoice/Vocabulary.swift
@@ -46,6 +46,13 @@ struct VocabularyTerm: Codable, Equatable {
 /// to ~224 tokens by the models, so we cap it here rather than let the tail
 /// get silently trimmed.
 ///
+/// The hint carries a second job: Whisper imitates the *style* of whatever it
+/// is conditioned on, punctuation included. A bare comma-joined term list —
+/// which is what this emitted before — reads as unpunctuated running text and
+/// pulled periods and question marks out of the transcript along with it. So
+/// the terms now ride inside ordinary punctuated sentences, and those
+/// sentences are emitted even when the user has no vocabulary at all.
+///
 /// There used to be a second half that rewrote known mis-hearings after
 /// decoding. It existed because WhisperKit 0.18 ignored the hint outright; 1.1
 /// does not, and a blind find-and-replace over a transcript is worse than
@@ -54,21 +61,57 @@ enum Vocabulary {
     /// Rough cap on the hint string. Whisper's prompt window is ~224 tokens;
     /// CJK runs about one token per character, so 300 characters is a
     /// conservative ceiling that also keeps the hint from crowding out the
-    /// audio's own context.
+    /// audio's own context. Covers the style sentence too, not just the terms.
     private static let maxPromptCharacters = 300
 
-    /// Comma-joined list of preferred spellings, or nil when there is nothing
-    /// to hint. Terms are taken in author order and stop at the cap — earlier
-    /// entries win, which makes ordering a usable priority knob.
+    /// Longest wrapper a term sentence can add around the list itself.
+    /// Reserved up front so a long carrier can't starve the terms to zero.
+    private static let termSentenceOverhead = 20
+
+    /// Which carrier language to write the hint in.
+    private enum Style {
+        case english
+        case chinese
+        /// `language: "auto"` — the user may speak either, and a hint written
+        /// wholly in one language nudges Whisper's language detection toward
+        /// it. Emitting both keeps detection where it was.
+        case bilingual
+    }
+
+    /// The prompt Whisper is conditioned on, or nil when there is nothing
+    /// useful to say.
     ///
-    /// `repeats` emits the whole list more than once. A single mention of a
-    /// name is a weak signal: measured on `large-v3-v20240930_turbo_632MB`,
-    /// a bare "Codey" left the transcript as "Cody" on English audio and
-    /// "Code" on Chinese, while the same list twice got both right. The cap
-    /// covers the finished string, so more repeats means fewer terms fit.
-    static func promptText(_ terms: [VocabularyTerm], repeats: Int = 1) -> String? {
+    /// Returns a punctuation-carrying sentence even with an empty vocabulary —
+    /// that sentence is the whole point for users who never authored terms.
+    ///
+    /// Terms are taken in author order and stop at the cap — earlier entries
+    /// win, which makes ordering a usable priority knob.
+    ///
+    /// `repeats` emits the term list in more than one sentence. A single
+    /// mention of a name is a weak signal: measured on
+    /// `large-v3-v20240930_turbo_632MB`, a bare "Codey" left the transcript as
+    /// "Cody" on English audio and "Code" on Chinese, while the same list
+    /// twice got both right. The cap covers the finished string, so more
+    /// repeats means fewer terms fit.
+    static func promptText(_ terms: [VocabularyTerm], repeats: Int = 1, language: String = "auto") -> String? {
+        let style = resolveStyle(language)
+        let opener = styleSentence(style)
         let copies = max(1, repeats)
-        let budget = maxPromptCharacters / copies
+
+        let budget = (maxPromptCharacters - opener.count) / copies - termSentenceOverhead
+        let picked = pickTerms(terms, budget: budget)
+        guard !picked.isEmpty else { return opener }
+
+        var sentences = [opener]
+        for index in 0..<copies {
+            sentences.append(termSentence(style, index: index, terms: picked))
+        }
+        return sentences.joined(separator: " ")
+    }
+
+    /// Terms that fit, in author order, deduplicated.
+    private static func pickTerms(_ terms: [VocabularyTerm], budget: Int) -> [String] {
+        guard budget > 0 else { return [] }
         var picked: [String] = []
         var length = 0
         for term in terms {
@@ -79,8 +122,48 @@ enum Vocabulary {
             picked.append(word)
             length += cost
         }
-        guard !picked.isEmpty else { return nil }
-        let list = picked.joined(separator: ", ")
-        return Array(repeating: list, count: copies).joined(separator: ", ")
+        return picked
+    }
+
+    /// `language` arrives as the raw config value: a BCP-47-ish tag, "auto",
+    /// or empty.
+    private static func resolveStyle(_ language: String) -> Style {
+        let tag = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split(separator: "-").first.map(String.init) ?? ""
+        switch tag {
+        case "", "auto": return .bilingual
+        case "zh", "yue": return .chinese
+        default: return .english
+        }
+    }
+
+    /// The sentence that exists purely to demonstrate punctuation.
+    private static func styleSentence(_ style: Style) -> String {
+        switch style {
+        case .english: return englishOpener
+        case .chinese: return chineseOpener
+        case .bilingual: return englishOpener + " " + chineseOpener
+        }
+    }
+
+    private static let englishOpener =
+        "Transcribed with full punctuation: commas, periods, and question marks."
+    private static let chineseOpener =
+        "以下内容使用完整标点，包含逗号、句号和问号。"
+
+    /// One sentence naming the vocabulary. For `.bilingual` the sentences
+    /// alternate so repeated copies reinforce both languages rather than one.
+    private static func termSentence(_ style: Style, index: Int, terms: [String]) -> String {
+        let useChinese: Bool
+        switch style {
+        case .english: useChinese = false
+        case .chinese: useChinese = true
+        case .bilingual: useChinese = index % 2 == 1
+        }
+        return useChinese
+            ? "其中可能提到：" + terms.joined(separator: "、") + "。"
+            : "It may mention: " + terms.joined(separator: ", ") + "."
     }
 }

--- a/voice/Sources/CodeyVoice/WhisperKitEngine.swift
+++ b/voice/Sources/CodeyVoice/WhisperKitEngine.swift
@@ -252,9 +252,9 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     /// the whole prefix. Returns nil rather than an empty array so the option
     /// stays unset when there is nothing to say — WhisperKit takes a different
     /// (slower) decode path whenever `promptTokens` is non-nil.
-    private func vocabularyPromptTokens(_ pipe: WhisperKit) -> [Int]? {
+    private func vocabularyPromptTokens(_ pipe: WhisperKit, language: String) -> [Int]? {
         let terms = configLock.withLock { _config.vocabulary }
-        guard let text = Vocabulary.promptText(terms, repeats: 2),
+        guard let text = Vocabulary.promptText(terms, repeats: 2, language: language),
               let tokenizer = pipe.tokenizer else { return nil }
         let specialBegin = tokenizer.specialTokens.specialTokenBegin
         // Leading space: Whisper's BPE encodes a word differently at the start
@@ -270,7 +270,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     /// non-streaming `transcribe()` path keeps the more conservative options.
     private func streamingOptions(language: String, pipe: WhisperKit) -> DecodingOptions {
         var options = DecodingOptions()
-        options.promptTokens = vocabularyPromptTokens(pipe)
+        options.promptTokens = vocabularyPromptTokens(pipe, language: language)
         options.task = .transcribe
         if !language.isEmpty && language != "auto" { options.language = language }
         options.temperature = 0.0
@@ -364,7 +364,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         let normalized = peakNormalize(audio, target: 0.9)
 
         var options = DecodingOptions()
-        options.promptTokens = vocabularyPromptTokens(pipe)
+        options.promptTokens = vocabularyPromptTokens(pipe, language: language)
         options.task = .transcribe
         if !language.isEmpty && language != "auto" {
             options.language = language


### PR DESCRIPTION
## Why

Whisper imitates the style of whatever it is conditioned on, punctuation included.

Since #345 the vocabulary hint has been a bare comma-joined term list:

```
Codey, WhisperKit, Codey, WhisperKit
```

That reads as unpunctuated running text, and it pulled periods and question marks out of the transcript along with it. Dictation has been coming back as one long comma-free run.

## What

The terms now ride inside ordinary punctuated sentences, preceded by one sentence that exists only to demonstrate punctuation:

```
Transcribed with full punctuation: commas, periods, and question marks. 以下内容使用完整标点，包含逗号、句号和问号。 It may mention: Codey, WhisperKit. 其中可能提到：Codey、WhisperKit。
```

- **The opener is emitted even with an empty vocabulary.** Previously an empty list meant no prompt at all, so users who never authored terms got nothing. They are the ones who most need this.
- **The carrier is language-aware**, threaded from each engine's `language` (API, local WhisperKit, realtime). `auto` emits both English and Chinese — a hint written wholly in one language nudges Whisper's language detection toward it, and emitting both leaves detection where it was. Repeated copies alternate for the same reason. `zh` or `en` emits that language alone.
- **Term selection is unchanged** — author order, dedup, earlier entries win, so ordering stays a usable priority knob.
- **The 300-character cap now covers the opener too**, with the term-sentence wrapper reserved up front so a long carrier can't starve the terms to zero.

## Verification

- `swift build` and `swift build -c release` clean (only the pre-existing WhisperKit `Sendable` warnings)
- `npm run lint` passes
- Compiled `Vocabulary.swift` standalone and printed all six cases — `auto`/`zh`/`en` × with-terms/no-terms — plus a 40-long-term stress case at `repeats: 2`, which lands at 263 characters, under the cap

Not yet verified on a real dictation run; that is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)