### PR TITLE
fix(mac): show the warming tooltip over the disabled voice buttons

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2900,6 +2900,11 @@ export const ChatTab: React.FC<Props> = ({
                   background: voiceBusy && voice.mode === 'dictate' ? C.red : 'transparent',
                   opacity: voiceWarming ? 0.4 : 1,
                   cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere && !voiceWarming ? 'pointer' : 'default',
+                  // A disabled button still hit-tests, so it swallows the hover
+                  // and the wrapper's title never fires - which is precisely the
+                  // state the explanation exists for. Hand the hover to the
+                  // wrapper instead.
+                  pointerEvents: !isGatewayRunning || !!coreFailed || voiceActiveElsewhere || voiceWarming ? 'none' : 'auto',
                 }}
               >
                 {voice.state === 'recording' && voice.mode === 'dictate'
@@ -2944,6 +2949,11 @@ export const ChatTab: React.FC<Props> = ({
                     : 'transparent',
                   opacity: voiceWarming ? 0.4 : 1,
                   cursor: isGatewayRunning && !coreFailed && !voiceActiveElsewhere && !voiceWarming ? 'pointer' : 'default',
+                  // A disabled button still hit-tests, so it swallows the hover
+                  // and the wrapper's title never fires - which is precisely the
+                  // state the explanation exists for. Hand the hover to the
+                  // wrapper instead.
+                  pointerEvents: !isGatewayRunning || !!coreFailed || voiceActiveElsewhere || voiceWarming ? 'none' : 'auto',
                 }}
               >
                 {voice.state === 'recording' && voice.mode === 'converse'


### PR DESCRIPTION
Hovering the mic / converse buttons while the on-device model is warming showed no tooltip.

The explanation was already written and already placed on a wrapper `<span>` — a disabled button's own `title` never renders. But the disabled button still hit-tests, so it swallowed the hover and the wrapper's title never fired either. Net effect: the one state that most needs an explanation (model warming, gateway down, voice busy elsewhere) had no tooltip at all.

Fix: `pointerEvents: 'none'` on the button while it is disabled, so the hover lands on the wrapper. Both voice buttons.

`codey-mac/src/components/ChatTab.tsx`

**Verification:** `tsc --noEmit` clean, `npm test -w codey-mac` 739/739 pass. Not hover-tested on a real warm — that needs a live app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)