### PR TITLE
Polish the agent memory file list

### DIFF
--- a/codey-mac/src/components/AgentMemorySection.tsx
+++ b/codey-mac/src/components/AgentMemorySection.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
-import { selectStyle, Toggle, fieldStyle, unwrap } from './settingsAtoms'
+import { selectStyle, Toggle, unwrap } from './settingsAtoms'
 import { OpenInEditorButton } from './OpenInEditorButton'
 import { MemoryPanel } from './CodeyMemorySection'
 import { formatBytes, memoryPreview, summarizeMemory } from './agentMemoryView'
+import { UIIcon } from './UIIcons'
 import type { AgentMemoryGroup, MemoryEntry } from '../codey-api'
 
 /**
@@ -17,30 +18,48 @@ import type { AgentMemoryGroup, MemoryEntry } from '../codey-api'
  *            Settings ▸ Memory, under "Workspace memory".
  */
 
-const MemoryRow: React.FC<{ entry: MemoryEntry }> = ({ entry }) => {
+const MemoryRow: React.FC<{ entry: MemoryEntry; first: boolean }> = ({ entry, first }) => {
   const [open, setOpen] = useState(false)
   const preview = memoryPreview(entry.content)
   return (
-    <div style={{ borderTop: `1px solid ${C.border}`, padding: '8px 0' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+    <div style={{ borderTop: first ? 'none' : `1px solid ${C.border}`, padding: '11px 12px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
         <button
           onClick={() => setOpen(o => !o)}
-          style={{ background: 'none', border: 'none', color: C.fg, fontSize: 12, cursor: 'pointer', padding: 0, textAlign: 'left', flex: 1 }}
+          aria-expanded={open}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flex: 1,
+            background: 'none', border: 'none', color: C.fg, fontSize: 12,
+            cursor: 'pointer', padding: 0, textAlign: 'left',
+          }}
           title={entry.path}
         >
-          <span style={{ color: C.fg3, marginRight: 6 }}>{open ? '▾' : '▸'}</span>
-          {entry.label}
+          <span style={{
+            width: 20, height: 20, borderRadius: 5, flexShrink: 0,
+            display: 'grid', placeItems: 'center', color: C.fg3, background: C.surface3,
+            transform: open ? 'rotate(90deg)' : undefined, transition: 'transform 120ms ease',
+          }}>
+            <UIIcon name="disclosure" size={11} />
+          </span>
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 550 }}>
+            {entry.label}
+          </span>
         </button>
-        <span style={{ color: C.fg3, fontSize: 11 }}>{formatBytes(entry.bytes)}</span>
+        <span style={{ color: C.fg3, fontSize: 11, whiteSpace: 'nowrap' }}>{formatBytes(entry.bytes)}</span>
         <OpenInEditorButton path={entry.path} />
       </div>
       {!open && preview && (
-        <div style={{ color: C.fg3, fontSize: 11, marginTop: 3, marginLeft: 16, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{preview}</div>
+        <div style={{
+          color: C.fg3, fontSize: 11, lineHeight: 1.45, marginTop: 4, marginLeft: 28,
+          marginRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>{preview}</div>
       )}
       {open && (
         <pre style={{
-          margin: '6px 0 0 16px', padding: 10, background: C.surface3, borderRadius: 8,
-          color: C.fg2, fontSize: 11, lineHeight: 1.5, maxHeight: 280, overflow: 'auto', whiteSpace: 'pre-wrap',
+          margin: '9px 0 1px 28px', padding: 12, background: C.surface3,
+          border: `1px solid ${C.border}`, borderRadius: 8,
+          color: C.fg2, fontSize: 11, lineHeight: 1.55, maxHeight: 280,
+          overflow: 'auto', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere',
         }}>
           {entry.content}
           {entry.truncated && <span style={{ color: C.fg3 }}>{'\n\n… truncated — open the file to read the rest.'}</span>}
@@ -50,20 +69,16 @@ const MemoryRow: React.FC<{ entry: MemoryEntry }> = ({ entry }) => {
   )
 }
 
-/** One card per agent, with its files below. Agents with nothing are still
- *  listed so the absence of memory is visible rather than ambiguous. */
-const MemoryGroups: React.FC<{ groups: AgentMemoryGroup[] }> = ({ groups }) => (
-  <>
-    {groups.map(({ agent, entries }) => (
-      <div key={agent} style={{ ...fieldStyle, display: 'block' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
-          <span style={{ color: C.fg, fontSize: 13 }}>{agent}</span>
-          <span style={{ color: C.fg3, fontSize: 11 }}>{summarizeMemory(entries)}</span>
-        </div>
-        {entries.map(entry => <MemoryRow key={entry.path} entry={entry} />)}
-      </div>
-    ))}
-  </>
+/** The selected agent is already identified by the picker, so the file list
+ *  intentionally contains no second agent heading. */
+const MemoryFileList: React.FC<{ entries: MemoryEntry[]; emptyText: string }> = ({ entries, emptyText }) => (
+  <div style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10, overflow: 'hidden' }}>
+    {entries.length > 0 ? entries.map((entry, index) => (
+      <MemoryRow key={entry.path} entry={entry} first={index === 0} />
+    )) : (
+      <div style={{ color: C.fg3, fontSize: 12, padding: '18px 14px', textAlign: 'center' }}>{emptyText}</div>
+    )}
+  </div>
 )
 
 function useMemory(load: () => Promise<AgentMemoryGroup[]>, enabled: boolean) {
@@ -121,35 +136,58 @@ const AgentMemoryFilesCard: React.FC<{
   const selectedGroup = groups.find(g => g.agent === selected)
 
   return (
-    <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 8 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 8 }}>
-        <div>
+    <div style={{ padding: 16, background: C.surface2, border: `1px solid ${C.border}`, borderRadius: 10 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        flexWrap: 'wrap', gap: 12, marginBottom: 12,
+      }}>
+        <div style={{ minWidth: 220, flex: '1 1 280px' }}>
           <div style={{ fontSize: 14, fontWeight: 600 }}>Agent memory files</div>
-          <div style={{ color: C.fg3, fontSize: 11, marginTop: 2 }}>{description}</div>
+          <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.45, marginTop: 3 }}>{description}</div>
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8,
+          width: 376, maxWidth: '100%', marginLeft: 'auto',
+        }}>
           {groups.length > 1 && (
             <select
               value={selected}
               onChange={e => setSelected(e.target.value)}
-              style={{ ...selectStyle, width: 132 }}
+              style={{ ...selectStyle, width: 148, paddingTop: 6, paddingBottom: 6 }}
               title="Choose which agent's memory to view"
+              aria-label="Agent"
             >
               {groups.map(g => <option key={g.agent} value={g.agent}>{g.agent}</option>)}
             </select>
           )}
+          {selectedGroup && (
+            <span style={{
+              color: C.fg3, fontSize: 11, lineHeight: 1, whiteSpace: 'nowrap',
+              width: 112, boxSizing: 'border-box', textAlign: 'center',
+              padding: '6px 8px', background: C.surface3, borderRadius: 6,
+            }}>
+              {summarizeMemory(selectedGroup.entries)}
+            </span>
+          )}
           <button
             onClick={() => void reload()}
             disabled={loading}
-            style={{ padding: '4px 10px', fontSize: 12, background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`, borderRadius: 6, cursor: 'pointer' }}
-          >{loading ? 'Reading…' : '↻ Refresh'}</button>
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 9px', fontSize: 12,
+              background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`,
+              borderRadius: 7, cursor: loading ? 'default' : 'pointer', opacity: loading ? 0.65 : 1,
+            }}
+          >
+            <UIIcon name="refresh" size={13} />
+            {loading ? 'Reading…' : 'Refresh'}
+          </button>
         </div>
       </div>
       {error && <ErrorBox message={error} />}
       {!loading && groups.length === 0 && !error && (
-        <div style={{ fontSize: 12, color: C.fg3 }}>{emptyText}</div>
+        <MemoryFileList entries={[]} emptyText={emptyText} />
       )}
-      {selectedGroup && <MemoryGroups groups={[selectedGroup]} />}
+      {selectedGroup && <MemoryFileList entries={selectedGroup.entries} emptyText={emptyText} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- remove the duplicate agent heading from the selected agent's file list
- keep the agent picker controls stable when switching between agents with and without memory files
- improve file rows, previews, disclosure controls, empty states, and refresh styling

## Verification

- `npm run test -w codey-mac -- --run src/components/agentMemoryView.test.ts` (9 tests)
- `npx tsc --noEmit -p codey-mac/tsconfig.json`
- `npm run lint`
- `npx vite build` from `codey-mac/`