### PR TITLE
feat(browser): profile switcher in the toolbar, and fix "Use in chat"

### DIFF
--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -8,6 +8,7 @@ import type {
   BrowserExtensionCandidate,
   BrowserExtensionEntry,
   BrowserLoginWaitEvent,
+  BrowserProfileSummary,
   ChromeBrowserExtensionCandidate,
   BrowserState,
   BrowserTab,
@@ -15,7 +16,7 @@ import type {
 import { C } from '../theme'
 import { UIIcon } from './UIIcons'
 import { BrowserProfiles } from './BrowserProfiles'
-import { getDraft, setDraft } from './chatDrafts'
+import { appendDraftText } from './chatDrafts'
 import { buildBrowserContextPrompt } from './browserContextPrompt'
 
 interface Props {
@@ -74,6 +75,8 @@ export const BrowserPanel: React.FC<Props> = ({
   const hostRef = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
+  const profileMenuRef = useRef<HTMLDivElement>(null)
+  const profileButtonRef = useRef<HTMLButtonElement>(null)
   const shownRef = useRef(false)
   const browserCoveredRef = useRef(false)
   const addressFocusedRef = useRef(false)
@@ -95,9 +98,13 @@ export const BrowserPanel: React.FC<Props> = ({
   const [chromeScanComplete, setChromeScanComplete] = useState(false)
   const [extensionBusy, setExtensionBusy] = useState(false)
   const [browserMenuOpen, setBrowserMenuOpen] = useState(false)
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false)
+  const [profiles, setProfiles] = useState<BrowserProfileSummary[]>([])
+  const [activeProfile, setActiveProfile] = useState<string | null>(null)
+  const [profileBusy, setProfileBusy] = useState(false)
   const [panelWidth, setPanelWidth] = useState(900)
 
-  const browserCovered = browserMenuOpen || activeSettingsSection !== null
+  const browserCovered = browserMenuOpen || profileMenuOpen || activeSettingsSection !== null
   browserCoveredRef.current = browserCovered
 
   useLayoutEffect(() => {
@@ -249,6 +256,51 @@ export const BrowserPanel: React.FC<Props> = ({
     }
   }, [browserMenuOpen])
 
+  useEffect(() => {
+    if (!profileMenuOpen) return
+    const closeMenu = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (!profileMenuRef.current?.contains(target) && !profileButtonRef.current?.contains(target)) setProfileMenuOpen(false)
+    }
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setProfileMenuOpen(false)
+    }
+    document.addEventListener('mousedown', closeMenu)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('mousedown', closeMenu)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [profileMenuOpen])
+
+  // The toolbar's profile chip. There is no profile-changed event, so refresh
+  // on mount and every time the menu opens — the Settings ▸ Profiles page can
+  // have activated a different one behind our back.
+  const refreshProfiles = async () => {
+    if (!window.codey?.browser?.profiles) return
+    const result = await window.codey.browser.profiles.list()
+    if (!result.ok) {
+      setLocalError(result.error)
+      return
+    }
+    setProfiles(result.data.profiles)
+    setActiveProfile(result.data.active)
+  }
+
+  useEffect(() => { void refreshProfiles() }, [])
+
+  const activateProfile = async (name: string) => {
+    setProfileBusy(true)
+    try {
+      const result = await window.codey.browser.profiles.activate(name)
+      if (!result.ok) setLocalError(result.error)
+      await refreshProfiles()
+    } finally {
+      setProfileBusy(false)
+      setProfileMenuOpen(false)
+    }
+  }
+
   const navigate = async () => {
     const next = useResult(await window.codey.browser.navigate(address))
     if (next) setState(next)
@@ -271,12 +323,7 @@ export const BrowserPanel: React.FC<Props> = ({
     if (!chatId) return
     const context = useResult(await window.codey.browser.getPageContext())
     if (!context) return
-    const current = getDraft(chatId)
-    const pagePrompt = buildBrowserContextPrompt(context)
-    setDraft(chatId, {
-      ...current,
-      text: current.text ? `${current.text}\n\n${pagePrompt}` : pagePrompt,
-    })
+    appendDraftText(chatId, buildBrowserContextPrompt(context))
     onClose()
   }
 
@@ -477,6 +524,24 @@ export const BrowserPanel: React.FC<Props> = ({
         </form>
 
         <button
+          ref={profileButtonRef}
+          type="button"
+          style={{ ...styles.profileButton, ...(profileMenuOpen ? styles.profileButtonActive : null) }}
+          title={activeProfile ? `Browser profile: ${activeProfile} — click to switch` : 'No browser profile active — click to pick one'}
+          aria-label="Browser profile"
+          aria-haspopup="menu"
+          aria-expanded={profileMenuOpen}
+          onClick={() => {
+            setProfileMenuOpen(current => {
+              if (!current) void refreshProfiles()
+              return !current
+            })
+          }}
+        >
+          <UIIcon name="users" size={13} color={activeProfile ? C.green : undefined} />
+          {panelWidth >= 640 && <span style={styles.profileButtonLabel}>{activeProfile ?? 'No profile'}</span>}
+        </button>
+        <button
           type="button"
           style={{ ...styles.contextButton, opacity: chatId && state.url && !activeSettingsSection ? 1 : 0.5 }}
           title={chatId ? 'Add this page and its performance timing to the current chat' : 'Select a chat first'}
@@ -500,6 +565,33 @@ export const BrowserPanel: React.FC<Props> = ({
           <UIIcon name="close" size={15} />
         </button>}
       </div>
+
+      {profileMenuOpen && (
+        <div ref={profileMenuRef} style={styles.profileMenu} role="menu" aria-label="Browser profiles">
+          <div style={styles.profileMenuHeading}>Active profile</div>
+          {profiles.length === 0 && (
+            <div style={styles.profileMenuEmpty}>No profiles saved yet.</div>
+          )}
+          {profiles.map(profile => (
+            <button
+              key={profile.name}
+              type="button"
+              role="menuitemradio"
+              aria-checked={profile.active}
+              disabled={profileBusy || profile.active}
+              style={{ ...styles.menuButton, ...(profile.active ? styles.profileMenuItemActive : null) }}
+              onClick={() => void activateProfile(profile.name)}
+            >
+              <span aria-hidden="true" style={styles.profileMenuCheck}>{profile.active ? '✓' : ''}</span>
+              <span style={styles.profileMenuName}>{profile.name}</span>
+            </button>
+          ))}
+          <div style={styles.profileMenuDivider} />
+          <button type="button" style={styles.menuButton} onClick={() => { setProfileMenuOpen(false); openProfiles() }}>
+            <UIIcon name="settings" size={13} /> Manage profiles…
+          </button>
+        </div>
+      )}
 
       {browserMenuOpen && (
         <div ref={menuRef} style={styles.browserMenu} role="menu" aria-label="Browser actions">
@@ -903,6 +995,25 @@ const styles: Record<string, React.CSSProperties> = {
   iconButtonActive: { background: C.accentDim, color: C.accent },
   iconButtonDanger: { background: `${C.red}18`, color: C.red },
   closeButton: { width: 31, height: 31, padding: 0, border: `1px solid ${C.border}`, borderRadius: 7, display: 'grid', placeItems: 'center', background: C.surface2, color: C.fg3, cursor: 'pointer' },
+  profileButton: {
+    height: 31, maxWidth: 150, padding: '0 9px', border: `1px solid ${C.border}`, borderRadius: 7,
+    display: 'flex', alignItems: 'center', gap: 6, background: C.surface2, color: C.fg2,
+    cursor: 'pointer', fontSize: 11, fontWeight: 600, whiteSpace: 'nowrap',
+  },
+  profileButtonActive: { background: C.accentDim, color: C.accent, borderColor: `${C.accent}66` },
+  profileButtonLabel: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  profileMenu: {
+    position: 'absolute', top: 43, right: 8, zIndex: 20, width: 230,
+    display: 'flex', flexDirection: 'column', gap: 2, padding: 6,
+    background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 10,
+    boxShadow: '0 12px 30px rgba(0,0,0,0.32)',
+  },
+  profileMenuHeading: { padding: '4px 9px', color: C.fg3, fontSize: 10, fontWeight: 700, letterSpacing: 0.4, textTransform: 'uppercase' },
+  profileMenuEmpty: { padding: '4px 9px 8px', color: C.fg3, fontSize: 11 },
+  profileMenuItemActive: { color: C.accent },
+  profileMenuCheck: { width: 12, flexShrink: 0, textAlign: 'center' },
+  profileMenuName: { flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  profileMenuDivider: { height: 1, margin: '4px 0', background: C.border },
   contextButton: { height: 31, padding: '0 10px', border: `1px solid ${C.accent}66`, borderRadius: 7, display: 'flex', alignItems: 'center', gap: 6, background: C.accentDim, color: C.accent, cursor: 'pointer', fontSize: 11, fontWeight: 650, whiteSpace: 'nowrap' },
   permissionBadge: { height: 28, padding: '0 8px', borderRadius: 7, display: 'flex', alignItems: 'center', gap: 5, cursor: 'pointer', fontSize: 10, fontWeight: 650, whiteSpace: 'nowrap' },
   permissionApproved: { color: C.warningFg, background: C.warningBg, border: `1px solid ${C.warningFg}88` },

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -28,7 +28,7 @@ import { ACTIVITY_LABEL } from './agentActivity'
 import { ShimmerStatus } from './ShimmerStatus'
 import { statusLine } from './checklistView'
 import { composerPlaceholder } from './coreOfflineView'
-import { getDraft, setDraft } from './chatDrafts'
+import { getDraft, setDraft, subscribeDrafts } from './chatDrafts'
 import { isBottomTerminalOpen, setBottomTerminalOpen as rememberBottomTerminalOpen } from './terminalVisibility'
 import { AGENT_API_TYPE, AGENT_NAMES, ApiType, modelFitsApiType } from './modelApiType'
 import { useInstalledAgents } from './installedAgents'
@@ -1313,6 +1313,21 @@ export const ChatTab: React.FC<Props> = ({
   useEffect(() => {
     setDraft(chatId, { text: input, attachments: pendingAttachments })
   }, [chatId, input, pendingAttachments])
+  // Drafts pushed from outside the composer (browser panel "Use in chat") land
+  // in the store while this ChatTab is already mounted, so the mount-time seed
+  // above would never see them — pull them into the live composer instead.
+  useEffect(() => subscribeDrafts((id, draft) => {
+    if (id !== chatId) return
+    setInput(draft.text)
+    setPendingAttachments(draft.attachments)
+    requestAnimationFrame(() => {
+      const ta = taRef.current
+      if (!ta) return
+      ta.focus()
+      const len = ta.value.length
+      try { ta.setSelectionRange(len, len) } catch { /* not supported */ }
+    })
+  }), [chatId])
   useEffect(() => { setInputHistoryIndex(null) }, [chatId, chat?.messages.length])
   // When a turn is interrupted, lift the original prompt back into the input
   // and focus the textarea so the user can edit/resend without retyping.

--- a/codey-mac/src/components/chatDrafts.test.ts
+++ b/codey-mac/src/components/chatDrafts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { getDraft, setDraft, __resetDrafts } from './chatDrafts'
+import { getDraft, setDraft, appendDraftText, subscribeDrafts, __resetDrafts } from './chatDrafts'
 import type { FileAttachment } from '../types'
 
 const att = (id: string): FileAttachment => ({
@@ -34,5 +34,39 @@ describe('chatDrafts', () => {
     setDraft('a', { text: 'hi', attachments: [] })
     setDraft('a', { text: '', attachments: [] })
     expect(getDraft('a')).toEqual({ text: '', attachments: [] })
+  })
+})
+
+describe('appendDraftText', () => {
+  beforeEach(() => __resetDrafts())
+
+  it('appends to an empty draft and notifies subscribers', () => {
+    const seen: Array<[string, string]> = []
+    subscribeDrafts((chatId, draft) => seen.push([chatId, draft.text]))
+    appendDraftText('a', 'page context')
+    expect(getDraft('a').text).toBe('page context')
+    expect(seen).toEqual([['a', 'page context']])
+  })
+
+  it('keeps existing text and attachments, separated by a blank line', () => {
+    setDraft('a', { text: 'typed', attachments: [att('x')] })
+    appendDraftText('a', 'page context')
+    expect(getDraft('a')).toEqual({ text: 'typed\n\npage context', attachments: [att('x')] })
+  })
+
+  it('stops notifying after unsubscribe', () => {
+    let calls = 0
+    const off = subscribeDrafts(() => { calls += 1 })
+    appendDraftText('a', 'one')
+    off()
+    appendDraftText('a', 'two')
+    expect(calls).toBe(1)
+  })
+
+  it('does not notify on a plain setDraft write', () => {
+    let calls = 0
+    subscribeDrafts(() => { calls += 1 })
+    setDraft('a', { text: 'typing', attachments: [] })
+    expect(calls).toBe(0)
   })
 })

--- a/codey-mac/src/components/chatDrafts.ts
+++ b/codey-mac/src/components/chatDrafts.ts
@@ -27,7 +27,33 @@ export function setDraft(chatId: string, draft: ChatDraft): void {
   drafts.set(chatId, draft)
 }
 
+// Drafts written from outside the composer (e.g. the browser panel's "Use in
+// chat") have to reach an already-mounted ChatTab, which only seeds itself from
+// the store on mount. Subscribers get notified for those writes only —
+// ChatTab's own keystroke sync goes through setDraft and stays silent, so there
+// is no write-back loop.
+type DraftListener = (chatId: string, draft: ChatDraft) => void
+
+const listeners = new Set<DraftListener>()
+
+export function subscribeDrafts(listener: DraftListener): () => void {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+/** Append text to a chat's draft (blank-line separated) and notify the composer. */
+export function appendDraftText(chatId: string, text: string): void {
+  const current = getDraft(chatId)
+  const next: ChatDraft = {
+    ...current,
+    text: current.text ? `${current.text}\n\n${text}` : text,
+  }
+  setDraft(chatId, next)
+  for (const listener of listeners) listener(chatId, next)
+}
+
 // Test-only: reset the store between cases.
 export function __resetDrafts(): void {
   drafts.clear()
+  listeners.clear()
 }


### PR DESCRIPTION
Two browser-panel fixes.

**Profile switcher in the toolbar.** Switching browser profiles meant opening Settings ▸ Profiles. The toolbar now carries a chip (left of "Use in chat") showing the active profile — green icon when one is active, `No profile` when none, icon-only on a narrow panel. Clicking it opens a menu listing every profile with the active one checked; picking another activates it. `Manage profiles…` opens the existing full manager. The menu hides the native web view while open, like the ⋯ menu, otherwise the view paints over it. There is no profile-changed event, so the list refreshes on mount and each time the menu opens, keeping it in step with changes made in Settings.

**"Use in chat" did nothing.** The button wrote the page context into the per-chat draft store, but `ChatTab` only seeds itself from that store on mount — and the browser is a side panel, so the composer was already mounted and never saw the write. The text landed in the store and was invisible. `chatDrafts` now notifies subscribers on external writes (`appendDraftText`), and `ChatTab` pulls those into the live composer and focuses it with the caret at the end. The composer's own keystroke sync still goes through the silent `setDraft`, so there is no write-back loop.

## Testing

- `npm test -w codey-mac` — 76 files, 774 tests pass (4 new for `appendDraftText`/`subscribeDrafts`)
- `npx tsc --noEmit` clean, `npm run lint` clean
- Not yet exercised in the packaged app

🤖 Generated with [Claude Code](https://claude.com/claude-code)