### PR TITLE
fix(voice): auto-dismiss the dictation card after 5s

### DIFF
--- a/voice/Sources/CodeyVoice/HudOverlay.swift
+++ b/voice/Sources/CodeyVoice/HudOverlay.swift
@@ -6,8 +6,9 @@ import Cocoa
 /// is minimized or hidden behind another app.
 ///
 /// `.dictation` is the special "nowhere to paste" mode: we display the full
-/// transcript in a wider card, copy it to the clipboard, and wait for the
-/// user to click-to-dismiss (mouse events are enabled only in that mode).
+/// transcript in a wider card, copy it to the clipboard, and auto-dismiss
+/// after a few seconds (a click dismisses it sooner; mouse events are enabled
+/// only in that mode).
 final class HudOverlay {
     enum Mode {
         case recording
@@ -189,11 +190,15 @@ final class HudOverlay {
             spinner.stopAnimation(nil)
             spinner.isHidden = true
             label.textColor = NSColor.labelColor
-            label.stringValue = "\(text)\n\n✓ Copied — click to dismiss"
+            label.stringValue = "\(text)\n\n✓ Copied"
             setMeterVisible(false)
             applyDictationLayout()
+            // Mouse events stay on so a click can dismiss it early, but the
+            // card no longer waits for one: the text is already on the
+            // clipboard, so making the user confirm buys nothing and leaves a
+            // panel floating over whatever they do next.
             panel.ignoresMouseEvents = false
-            // No scheduled hide — user dismisses by clicking.
+            scheduleHide(after: 5.0)
         case .conversation(let phase):
             label.stringValue = phase.label
             label.textColor = NSColor.white

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -716,8 +716,8 @@ final class VoiceCoordinator {
                     } else if canInject {
                         self.hud.show(.success)
                     } else {
-                        // Nowhere to paste: show full text + auto-copy, wait
-                        // for click to dismiss.
+                        // Nowhere to paste: show full text + auto-copy, then
+                        // auto-dismiss after a few seconds.
                         self.hud.show(.dictation(finalText))
                     }
                 }


### PR DESCRIPTION
When voice dictation has nowhere to inject the transcript (no focused text
field, no place for ⌘V), the HUD showed the full text plus
"✓ Copied — click to dismiss" and waited forever for a click.

The text is already on the clipboard at that point, so the confirmation
click buys nothing — it just leaves a panel floating over whatever the
user does next.

Now the card hides itself after 5 seconds. Mouse events stay enabled, so
clicking still dismisses it sooner.

Verified with `swift build` in `voice/`. Not yet run on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)