### PR TITLE
feat(chat): hand agents a transcript cursor instead of a replay, and cap prompts at the argv limit

### DIFF
--- a/packages/core/src/agents/process-tree.ts
+++ b/packages/core/src/agents/process-tree.ts
@@ -74,7 +74,75 @@ const FOREGROUND_POLICY = [
 ].join('\n');
 
 /** Advisory guard for detach mechanisms that can deliberately escape a
- * process group. The hard lifecycle boundary remains terminateProcessTree. */
+ * process group. The hard lifecycle boundary remains terminateProcessTree.
+ *
+ * Doubles as the single choke point for the argv size cap (see
+ * `capPromptForArgv`): every adapter routes its prompt through here, and the
+ * policy block is appended after the cap so it can never be the part elided. */
 export function withForegroundPolicy(prompt: string): string {
-  return `${prompt}\n\n${FOREGROUND_POLICY}`;
+  const suffix = `\n\n${FOREGROUND_POLICY}`;
+  const capped = capPromptForArgv(prompt, maxPromptBytes() - Buffer.byteLength(suffix, 'utf8'));
+  return `${capped}${suffix}`;
+}
+
+/**
+ * Every adapter hands the prompt to the CLI as a command-line argument, so the
+ * whole prompt has to fit inside the OS argv limit (`ARG_MAX`, 1 MiB on macOS
+ * and Linux, shared with the environment block). Overshooting is not a graceful
+ * degradation: `spawn` fails with `E2BIG` and the agent never starts.
+ *
+ * Callers bound their own prompts (windowed history, transcript pointers), but
+ * a single pasted log or a runaway worker hand-off can still blow past the
+ * limit. This is the last line of defence, applied at the spawn boundary so no
+ * adapter can forget it.
+ */
+export const DEFAULT_MAX_PROMPT_BYTES = 512_000;
+
+/** Bytes reserved for the elision marker itself. */
+const ELISION_RESERVE = 200;
+
+/** Fraction of the surviving budget given to the head; the tail keeps the rest
+ *  because the actual request lives at the end of every prompt we build. */
+const HEAD_SHARE = 0.35;
+
+export function maxPromptBytes(): number {
+  const raw = Number(process.env.CODEY_MAX_PROMPT_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_PROMPT_BYTES;
+}
+
+/** Longest prefix of `text` that fits in `maxBytes`, never splitting a
+ *  multi-byte UTF-8 sequence. */
+function headBytes(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.length <= maxBytes) return text;
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+  return buf.subarray(0, end).toString('utf8');
+}
+
+/** Longest suffix of `text` that fits in `maxBytes`, never splitting a
+ *  multi-byte UTF-8 sequence. */
+function tailBytes(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.length <= maxBytes) return text;
+  let start = buf.length - maxBytes;
+  while (start < buf.length && (buf[start] & 0xc0) === 0x80) start++;
+  return buf.subarray(start).toString('utf8');
+}
+
+/**
+ * Drop the middle of an oversized prompt, keeping a head for the framing and a
+ * larger tail for the actual request. Returns `prompt` untouched when it fits.
+ */
+export function capPromptForArgv(prompt: string, maxBytes = maxPromptBytes()): string {
+  const size = Buffer.byteLength(prompt, 'utf8');
+  if (size <= maxBytes) return prompt;
+
+  const budget = Math.max(0, maxBytes - ELISION_RESERVE);
+  const headBudget = Math.floor(budget * HEAD_SHARE);
+  const head = headBytes(prompt, headBudget);
+  const tail = tailBytes(prompt, budget - Buffer.byteLength(head, 'utf8'));
+  const omitted = size - Buffer.byteLength(head, 'utf8') - Buffer.byteLength(tail, 'utf8');
+
+  return `${head}\n\n[… ${omitted} bytes elided by Codey — the prompt exceeded the ${maxBytes}-byte command-line limit …]\n\n${tail}`;
 }

--- a/packages/core/src/agents/prompt-cap.test.ts
+++ b/packages/core/src/agents/prompt-cap.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { capPromptForArgv, withForegroundPolicy, DEFAULT_MAX_PROMPT_BYTES, maxPromptBytes } from './process-tree';
+
+describe('capPromptForArgv', () => {
+  it('leaves a prompt that fits untouched', () => {
+    const prompt = 'hello world';
+    expect(capPromptForArgv(prompt, 1000)).toBe(prompt);
+  });
+
+  it('leaves a prompt exactly at the limit untouched', () => {
+    const prompt = 'x'.repeat(1000);
+    expect(capPromptForArgv(prompt, 1000)).toBe(prompt);
+  });
+
+  it('keeps the result within the byte limit', () => {
+    const prompt = 'x'.repeat(50_000);
+    const capped = capPromptForArgv(prompt, 4_000);
+    expect(Buffer.byteLength(capped, 'utf8')).toBeLessThanOrEqual(4_000);
+  });
+
+  it('keeps the head and the tail, drops the middle', () => {
+    const prompt = `HEAD_MARKER${'x'.repeat(50_000)}TAIL_MARKER`;
+    const capped = capPromptForArgv(prompt, 4_000);
+    expect(capped.startsWith('HEAD_MARKER')).toBe(true);
+    expect(capped.endsWith('TAIL_MARKER')).toBe(true);
+    expect(capped).toContain('elided by Codey');
+  });
+
+  it('gives the tail more room than the head', () => {
+    const prompt = 'x'.repeat(50_000);
+    const capped = capPromptForArgv(prompt, 4_000);
+    const [head, tail] = capped.split(/\n\n\[… .* …\]\n\n/);
+    expect(tail.length).toBeGreaterThan(head.length);
+  });
+
+  it('never splits a multi-byte character', () => {
+    const prompt = '中'.repeat(20_000); // lint-allow-non-english: multi-byte boundary fixture
+    const capped = capPromptForArgv(prompt, 4_000);
+    expect(capped).not.toContain('�');
+    expect(Buffer.byteLength(capped, 'utf8')).toBeLessThanOrEqual(4_000);
+  });
+
+  it('reports how many bytes it dropped', () => {
+    const prompt = 'x'.repeat(50_000);
+    const capped = capPromptForArgv(prompt, 4_000);
+    const omitted = Number(/… (\d+) bytes elided/.exec(capped)![1]);
+    const kept = Buffer.byteLength(capped, 'utf8');
+    expect(omitted).toBeGreaterThan(0);
+    expect(omitted + kept).toBeGreaterThan(50_000);
+  });
+});
+
+describe('maxPromptBytes', () => {
+  it('falls back to the default when the env override is unusable', () => {
+    const prior = process.env.CODEY_MAX_PROMPT_BYTES;
+    try {
+      process.env.CODEY_MAX_PROMPT_BYTES = 'not-a-number';
+      expect(maxPromptBytes()).toBe(DEFAULT_MAX_PROMPT_BYTES);
+      process.env.CODEY_MAX_PROMPT_BYTES = '0';
+      expect(maxPromptBytes()).toBe(DEFAULT_MAX_PROMPT_BYTES);
+      process.env.CODEY_MAX_PROMPT_BYTES = '12345';
+      expect(maxPromptBytes()).toBe(12345);
+    } finally {
+      if (prior === undefined) delete process.env.CODEY_MAX_PROMPT_BYTES;
+      else process.env.CODEY_MAX_PROMPT_BYTES = prior;
+    }
+  });
+});
+
+describe('withForegroundPolicy', () => {
+  it('caps an oversized prompt but never elides the policy block', () => {
+    const prior = process.env.CODEY_MAX_PROMPT_BYTES;
+    try {
+      process.env.CODEY_MAX_PROMPT_BYTES = '4000';
+      const out = withForegroundPolicy('x'.repeat(50_000));
+      expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(4000);
+      expect(out).toContain('<codey-runtime-policy>');
+      expect(out).toContain('</codey-runtime-policy>');
+      expect(out).toContain('elided by Codey');
+    } finally {
+      if (prior === undefined) delete process.env.CODEY_MAX_PROMPT_BYTES;
+      else process.env.CODEY_MAX_PROMPT_BYTES = prior;
+    }
+  });
+
+  it('passes a normal prompt through unchanged', () => {
+    const out = withForegroundPolicy('do the thing');
+    expect(out.startsWith('do the thing\n\n<codey-runtime-policy>')).toBe(true);
+  });
+});

--- a/packages/gateway/src/chat-runner.bootstrap.test.ts
+++ b/packages/gateway/src/chat-runner.bootstrap.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { Chat, ChatMessage } from '@codey/core';
+import {
+  buildChatBootstrapPrompt,
+  buildQuickQuestionPrompt,
+  BOOTSTRAP_INLINE_LIMIT,
+  BOOTSTRAP_TAIL_INLINE,
+} from './chat-runner';
+
+const PATH = '/tmp/ws/chats/abc.jsonl';
+
+function chatWith(count: number, extra?: Partial<Chat>): Chat {
+  const messages: ChatMessage[] = Array.from({ length: count }, (_, i) => ({
+    id: `m${i + 1}`,
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `body ${i + 1}`,
+    timestamp: i,
+    isComplete: true,
+  }));
+  return {
+    id: 'abc',
+    workspaceName: 'ws',
+    title: 't',
+    createdAt: 0,
+    updatedAt: 0,
+    messages,
+    selection: { type: 'agent' },
+    ...extra,
+  } as Chat;
+}
+
+describe('buildChatBootstrapPrompt — transcript pointer', () => {
+  it('inlines everything when the history is short', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(BOOTSTRAP_INLINE_LIMIT), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).not.toContain(PATH);
+    expect(prompt).toContain('body 1');
+    expect(prompt).toContain(`body ${BOOTSTRAP_INLINE_LIMIT}`);
+  });
+
+  it('inlines everything when no transcript path is available', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40);
+    expect(prompt).not.toContain('not inlined');
+    expect(prompt).toContain('body 100');
+  });
+
+  it('points at the transcript once the history is long', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).toContain(PATH);
+    expect(prompt).toContain(`Lines 1-${100 - BOOTSTRAP_TAIL_INLINE} hold this history.`);
+    expect(prompt).toContain(`sed -n '1,${100 - BOOTSTRAP_TAIL_INLINE}p'`);
+    expect(prompt).toContain('96 messages, not inlined');
+  });
+
+  it('still inlines the recent tail in pointer mode', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    for (let i = 100 - BOOTSTRAP_TAIL_INLINE + 1; i <= 100; i++) {
+      expect(prompt).toContain(`body ${i}`);
+    }
+    expect(prompt).not.toContain(`body ${100 - BOOTSTRAP_TAIL_INLINE}\n`);
+  });
+
+  it('starts the pointer after a compaction summary instead of at line 1', () => {
+    const chat = chatWith(100, {
+      compaction: { summary: 'earlier stuff', summarizedUpTo: 30, model: 'm', updatedAt: 0 },
+    } as Partial<Chat>);
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, { transcriptPath: PATH });
+    expect(prompt).toContain('earlier stuff');
+    expect(prompt).toContain(`Lines 31-${100 - BOOTSTRAP_TAIL_INLINE} hold this history.`);
+  });
+
+  it('reaches back further than the inline window would have', () => {
+    // windowSize 40 would have shown messages 61-100; the pointer offers 1-96.
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).toContain('Lines 1-96');
+  });
+
+  it('keeps the new user message last', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'the ask', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt.trimEnd().endsWith('[Respond to this new user message]\nthe ask')).toBe(true);
+  });
+
+  it('shrinks the prompt substantially versus inlining', () => {
+    const chat = chatWith(100);
+    chat.messages.forEach(m => { m.content = 'y'.repeat(2000); });
+    const inlined = buildChatBootstrapPrompt(chat, 'next', undefined, 40);
+    const pointed = buildChatBootstrapPrompt(chat, 'next', undefined, 40, { transcriptPath: PATH });
+    expect(pointed.length).toBeLessThan(inlined.length / 5);
+  });
+
+  it('does not point when the tail alone covers the history', () => {
+    const chat = chatWith(100, {
+      compaction: { summary: 's', summarizedUpTo: 97, model: 'm', updatedAt: 0 },
+    } as Partial<Chat>);
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, { transcriptPath: PATH });
+    expect(prompt).not.toContain(PATH);
+  });
+});
+
+describe('buildQuickQuestionPrompt — transcript pointer', () => {
+  it('points at the transcript for a long parent chat', () => {
+    const prompt = buildQuickQuestionPrompt(chatWith(100), [], 'q?', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).toContain(PATH);
+    expect(prompt).toContain('read-only reference');
+  });
+});

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -4,6 +4,17 @@ export const MAX_CONCURRENT_AGENTS = 4;
 export const CHAT_CONTEXT_WINDOW = 40;
 
 /**
+ * Above this many windowed messages a bootstrap stops inlining prior history
+ * and points at the transcript sidecar instead. Below it, inlining is cheaper
+ * than making the agent spend a tool call on a handful of short turns.
+ */
+export const BOOTSTRAP_INLINE_LIMIT = 20;
+
+/** Recent messages kept inline even in pointer mode, so a self-contained
+ *  follow-up can be answered without reading the transcript at all. */
+export const BOOTSTRAP_TAIL_INLINE = 4;
+
+/**
  * Appended to the prompt only when a chat has soloAdvisor enabled. Tells the
  * single agent to self-escalate when stuck via the [ASK_ADVISOR] marker.
  */
@@ -73,7 +84,11 @@ function formatAttachmentList(attachments: FileAttachment[]): string {
  * windowed transcript). Shared by buildChatPrompt and buildQuickQuestionPrompt
  * so both window/compact identically.
  */
-function renderChatContextSections(chat: Chat, windowSize: number): string[] {
+function renderChatContextSections(
+  chat: Chat,
+  windowSize: number,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
+): string[] {
   const sections: string[] = [];
 
   const summarizedUpTo = chat.compaction?.summarizedUpTo ?? 0;
@@ -83,7 +98,32 @@ function renderChatContextSections(chat: Chat, windowSize: number): string[] {
     );
   }
 
-  const start = Math.max(summarizedUpTo, chat.messages.length - windowSize);
+  let start = Math.max(summarizedUpTo, chat.messages.length - windowSize);
+  const inlineLimit = opts?.inlineLimit ?? BOOTSTRAP_INLINE_LIMIT;
+
+  // Past the inline limit, hand over a transcript cursor instead of the
+  // replay. Sidecar line N holds messages[N-1]. The pointer deliberately
+  // reaches back further than `windowSize` — reading more costs the agent a
+  // longer `sed` range, not a longer prompt — while a short tail stays inlined
+  // so a self-contained follow-up needs no tool round-trip at all.
+  if (opts?.transcriptPath && chat.messages.length - start > inlineLimit) {
+    const pointerFirst = summarizedUpTo + 1;
+    const pointerLast = chat.messages.length - BOOTSTRAP_TAIL_INLINE;
+    if (pointerLast >= pointerFirst) {
+      sections.push(
+        [
+          `[Earlier conversation — ${pointerLast - pointerFirst + 1} messages, not inlined]`,
+          `Transcript: ${opts.transcriptPath}`,
+          'One JSON object per line, one line per message, oldest first.',
+          `Lines ${pointerFirst}-${pointerLast} hold this history.`,
+          `Read them before answering (e.g. \`sed -n '${pointerFirst},${pointerLast}p'\`) unless the new request below is fully self-contained.`,
+          'Context only — do not repeat or fabricate turns.',
+        ].join('\n'),
+      );
+      start = pointerLast;
+    }
+  }
+
   const tail = chat.messages.slice(start);
   if (tail.length > 0) {
     const transcript = tail.map(m => {
@@ -103,6 +143,7 @@ export function buildChatPrompt(
   userText: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
   const sections: string[] = [];
 
@@ -110,7 +151,7 @@ export function buildChatPrompt(
     sections.push(formatAttachmentList(attachments));
   }
 
-  sections.push(...renderChatContextSections(chat, windowSize));
+  sections.push(...renderChatContextSections(chat, windowSize, opts));
 
   sections.push(`[Respond to this new user message]\n${userText}`);
   return sections.join('\n\n');
@@ -126,8 +167,9 @@ export function buildChatBootstrapPrompt(
   userText: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
-  return buildChatPrompt(chat, userText, attachments, windowSize);
+  return buildChatPrompt(chat, userText, attachments, windowSize, opts);
 }
 
 const RESUME_CONTEXT_MAX_CHARS = 8_000;
@@ -294,6 +336,7 @@ export function buildQuickQuestionPrompt(
   question: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
   const sections: string[] = [];
 
@@ -301,7 +344,7 @@ export function buildQuickQuestionPrompt(
     sections.push(formatAttachmentList(attachments));
   }
 
-  const ctx = renderChatContextSections(chat, windowSize);
+  const ctx = renderChatContextSections(chat, windowSize, opts);
   if (ctx.length > 0) {
     sections.push(
       '[Main chat — read-only reference. Do not continue or modify this conversation.]',

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -178,11 +178,20 @@ export function buildChatResumePrompt(
  * agent receives the gap exactly once instead of being polluted by the full
  * transcript every time the user switches back.
  */
+/**
+ * Above this many missed messages a catch-up stops inlining the replay and
+ * points at the transcript sidecar instead. Inlining is cheaper for a short
+ * gap (no extra tool round-trip); past the threshold the replay is what
+ * actually blows up the argv the CLI is spawned with.
+ */
+export const CATCHUP_INLINE_LIMIT = 20;
+
 export function buildChatCatchupPrompt(
   chat: Chat,
   syncedThroughMessageId: string,
   userText: string,
   attachments?: FileAttachment[],
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
   const cursor = chat.messages.findIndex(message => message.id === syncedThroughMessageId);
   if (cursor < 0 || cursor === chat.messages.length - 1) {
@@ -192,16 +201,37 @@ export function buildChatCatchupPrompt(
   const parts: string[] = [];
   if (attachments && attachments.length > 0) parts.push(formatAttachmentList(attachments));
 
-  const updates = chat.messages.slice(cursor + 1).map(message => {
-    if (message.role === 'user') return `[user]\n${message.content}`;
-    const identity = [message.agent, message.model].filter(Boolean).join(' / ');
-    return `[assistant${identity ? ` via ${identity}` : ''}]\n${message.content}`;
-  }).join('\n\n');
+  const missed = chat.messages.slice(cursor + 1);
+  const inlineLimit = opts?.inlineLimit ?? CATCHUP_INLINE_LIMIT;
 
-  parts.push(
-    `[Codey conversation updates since this agent was last active — context only; do not repeat or fabricate turns]\n${updates}`,
-    `[Respond to this new user message]\n${userText}`,
-  );
+  if (opts?.transcriptPath && missed.length > inlineLimit) {
+    // Sidecar line N holds messages[N-1], so the first unseen message sits on
+    // line cursor + 2. Codey owns this cursor — the agent is a fresh process
+    // every turn and cannot be asked to remember where it left off.
+    const firstUnseenLine = cursor + 2;
+    const lastLine = chat.messages.length;
+    parts.push(
+      [
+        `[Codey conversation updates since this agent was last active — ${missed.length} messages, not inlined]`,
+        `Transcript: ${opts.transcriptPath}`,
+        'One JSON object per line, one line per message, oldest first.',
+        `You last saw line ${cursor + 1}. Lines ${firstUnseenLine}-${lastLine} are new.`,
+        `Read them if you need the detail (e.g. \`sed -n '${firstUnseenLine},${lastLine}p'\`); skip it if the new request stands on its own.`,
+        'Context only — do not repeat or fabricate turns.',
+      ].join('\n'),
+    );
+  } else {
+    const updates = missed.map(message => {
+      if (message.role === 'user') return `[user]\n${message.content}`;
+      const identity = [message.agent, message.model].filter(Boolean).join(' / ');
+      return `[assistant${identity ? ` via ${identity}` : ''}]\n${message.content}`;
+    }).join('\n\n');
+    parts.push(
+      `[Codey conversation updates since this agent was last active — context only; do not repeat or fabricate turns]\n${updates}`,
+    );
+  }
+
+  parts.push(`[Respond to this new user message]\n${userText}`);
   return parts.join('\n\n');
 }
 

--- a/packages/gateway/src/chats.transcript.test.ts
+++ b/packages/gateway/src/chats.transcript.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+import { buildChatCatchupPrompt, CATCHUP_INLINE_LIMIT } from './chat-runner';
+
+function lines(file: string): string[] {
+  return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+}
+
+describe('ChatManager transcript sidecar', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-transcript-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('writes one line per message, in order', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'first', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'a1', role: 'assistant', content: 'second', timestamp: 2, isComplete: true, agent: 'codex', model: 'm' });
+
+    const file = mgr.transcriptPath(chat.id)!;
+    const rows = lines(file).map(l => JSON.parse(l));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ id: 'u1', role: 'user', content: 'first' });
+    expect(rows[1]).toMatchObject({ id: 'a1', role: 'assistant', content: 'second', agent: 'codex', model: 'm' });
+  });
+
+  it('keeps line N aligned with messages[N-1] as the chat grows', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    for (let i = 0; i < 25; i++) {
+      mgr.appendMessage(chat.id, { id: `m${i}`, role: i % 2 ? 'assistant' : 'user', content: `body ${i}`, timestamp: i, isComplete: true });
+    }
+    const rows = lines(mgr.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    const messages = mgr.get(chat.id)!.messages;
+    expect(rows).toHaveLength(messages.length);
+    rows.forEach((row, idx) => expect(row.id).toBe(messages[idx].id));
+  });
+
+  it('embeds newlines rather than emitting extra lines', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'line one\nline two\nline three', timestamp: 1, isComplete: true });
+    const rows = lines(mgr.transcriptPath(chat.id)!);
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]).content).toBe('line one\nline two\nline three');
+  });
+
+  it('omits bulky tool calls and thinking', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, {
+      id: 'a1', role: 'assistant', content: 'answer', timestamp: 1, isComplete: true,
+      thinking: 'SECRET_REASONING',
+      toolCalls: [{ type: 'tool_end', tool: 'Bash', message: 'BULKY_TOOL_OUTPUT' } as never],
+    });
+    const raw = fs.readFileSync(mgr.transcriptPath(chat.id)!, 'utf8');
+    expect(raw).toContain('answer');
+    expect(raw).not.toContain('SECRET_REASONING');
+    expect(raw).not.toContain('BULKY_TOOL_OUTPUT');
+  });
+
+  it('refreshes the line when a stub message is filled in later', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'a1', role: 'assistant', content: '', timestamp: 1, isComplete: false });
+    mgr.updateMessage(chat.id, 'a1', { content: 'filled in by the worker', isComplete: true });
+
+    const rows = lines(mgr.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe('filled in by the worker');
+  });
+
+  it('rebuilds after a mid-list removal', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'keep me', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'u2', role: 'user', content: 'drop me', timestamp: 2, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'u3', role: 'user', content: 'keep me too', timestamp: 3, isComplete: true });
+
+    mgr.removeMessage(chat.id, 'u2');
+
+    const rows = lines(mgr.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    expect(rows.map(r => r.id)).toEqual(['u1', 'u3']);
+  });
+
+  it('backfills a chat that predates the sidecar', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'old one', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'u2', role: 'user', content: 'old two', timestamp: 2, isComplete: true });
+
+    // Simulate a chat written before the sidecar existed.
+    fs.unlinkSync(mgr.transcriptPath(chat.id)!);
+    const reloaded = new ChatManager(root);
+    reloaded.appendMessage(chat.id, { id: 'u3', role: 'user', content: 'new one', timestamp: 3, isComplete: true });
+
+    const rows = lines(reloaded.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    expect(rows.map(r => r.id)).toEqual(['u1', 'u2', 'u3']);
+  });
+
+  it('deletes the sidecar with the chat', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'hi', timestamp: 1, isComplete: true });
+    const file = mgr.transcriptPath(chat.id)!;
+    expect(fs.existsSync(file)).toBe(true);
+
+    mgr.delete(chat.id);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it('returns an absolute path even for a relative workspaces root', () => {
+    // Relative to cwd but still inside the temp dir, so nothing lands in the repo.
+    const relativeRoot = path.relative(process.cwd(), root);
+    expect(path.isAbsolute(relativeRoot)).toBe(false);
+
+    const relative = new ChatManager(relativeRoot);
+    const chat = relative.create({ workspaceName: 'ws' });
+    const file = relative.transcriptPath(chat.id)!;
+    expect(path.isAbsolute(file)).toBe(true);
+    expect(file.startsWith(path.resolve(root))).toBe(true);
+  });
+});
+
+describe('buildChatCatchupPrompt gap handling', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-transcript-gap-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  function seed(count: number) {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    for (let i = 0; i < count; i++) {
+      mgr.appendMessage(chat.id, { id: `m${i}`, role: i % 2 ? 'assistant' : 'user', content: `body ${i}`, timestamp: i, isComplete: true });
+    }
+    return chat.id;
+  }
+
+  it('still inlines a small gap', () => {
+    const chatId = seed(6);
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm1', 'now what', undefined, {
+      transcriptPath: mgr.transcriptPath(chatId),
+    });
+    expect(prompt).toContain('body 2');
+    expect(prompt).toContain('body 5');
+    expect(prompt).not.toContain('.jsonl');
+  });
+
+  it('points at the transcript instead of replaying a large gap', () => {
+    const total = CATCHUP_INLINE_LIMIT + 30;
+    const chatId = seed(total);
+    const file = mgr.transcriptPath(chatId)!;
+
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm0', 'now what', undefined, {
+      transcriptPath: file,
+    });
+
+    expect(prompt).toContain(file);
+    expect(prompt).toContain(`${total - 1} messages`);
+    // m0 is messages[0] -> line 1; the first unseen message is line 2.
+    expect(prompt).toContain(`Lines 2-${total} are new`);
+    expect(prompt).toContain('You last saw line 1.');
+    expect(prompt).toContain('now what');
+    // The bodies themselves must not be inlined — that is the whole point.
+    expect(prompt).not.toContain('body 5');
+  });
+
+  it('names a cursor that maps back to the right sidecar line', () => {
+    const total = CATCHUP_INLINE_LIMIT + 10;
+    const chatId = seed(total);
+    const file = mgr.transcriptPath(chatId)!;
+
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm3', 'go on', undefined, { transcriptPath: file });
+    expect(prompt).toContain('You last saw line 4.');
+
+    const rows = lines(file).map(l => JSON.parse(l));
+    expect(rows[3].id).toBe('m3');
+    expect(rows[4].id).toBe('m4');
+  });
+
+  it('falls back to inlining when no transcript path is supplied', () => {
+    const chatId = seed(CATCHUP_INLINE_LIMIT + 30);
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm0', 'now what');
+    expect(prompt).toContain('body 5');
+    expect(prompt).not.toContain('.jsonl');
+  });
+});

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -34,6 +34,8 @@ export class ChatManager {
   private loaded = false;
   private compactionRunner?: CompactionRunner;
   private compactingChats = new Set<string>();
+  /** chatId -> lines currently in that chat's transcript sidecar. */
+  private transcriptLines = new Map<string, number>();
 
   constructor(private readonly workspacesRoot: string) {}
 
@@ -52,6 +54,79 @@ export class ChatManager {
 
   private chatFile(workspaceName: string, chatId: string): string {
     return path.join(this.chatsDir(workspaceName), `${chatId}.json`);
+  }
+
+  /**
+   * Append-only transcript sidecar: one JSON object per line, one line per
+   * message, line N == messages[N-1]. Written next to the chat's `.json` so a
+   * catch-up prompt can hand an agent a stable `path:line` cursor instead of
+   * inlining a large replay. The `.json` is rewritten wholesale on every
+   * persist, so its line offsets are not stable; this file's are.
+   */
+  private transcriptFile(workspaceName: string, chatId: string): string {
+    return path.join(this.chatsDir(workspaceName), `${chatId}.jsonl`);
+  }
+
+  /** Absolute transcript path for a chat, or undefined if the chat is gone.
+   *  Resolved: `workspacesRoot` defaults to a relative './workspaces', and the
+   *  agent runs with the workspace as cwd, not the gateway's. */
+  transcriptPath(chatId: string): string | undefined {
+    this.ensureLoaded();
+    const chat = this.cache.get(chatId);
+    if (!chat) return undefined;
+    return path.resolve(this.transcriptFile(chat.workspaceName, chat.id));
+  }
+
+  /** Lean projection — the fields a catching-up agent needs, nothing else.
+   *  Tool calls and thinking are deliberately omitted: they dominate the byte
+   *  count and add nothing to "what did I miss". */
+  private transcriptLine(message: ChatMessage): string {
+    return JSON.stringify({
+      id: message.id,
+      role: message.role,
+      timestamp: message.timestamp,
+      ...(message.agent ? { agent: message.agent } : {}),
+      ...(message.model ? { model: message.model } : {}),
+      ...(message.worker ? { worker: message.worker } : {}),
+      content: message.content,
+    });
+  }
+
+  /** Rewrite the whole sidecar from the in-memory messages. Used to backfill
+   *  chats that predate the sidecar and to repair it after a mid-list delete. */
+  private rewriteTranscript(chat: Chat): void {
+    const file = this.transcriptFile(chat.workspaceName, chat.id);
+    try {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      const body = chat.messages.map(m => this.transcriptLine(m)).join('\n');
+      const tmp = `${file}.tmp`;
+      fs.writeFileSync(tmp, body ? `${body}\n` : '', 'utf8');
+      fs.renameSync(tmp, file);
+      this.transcriptLines.set(chat.id, chat.messages.length);
+    } catch (err) {
+      log.warn(`ChatManager: transcript rewrite failed for ${chat.id}: ${(err as Error).message}`);
+      this.transcriptLines.delete(chat.id);
+    }
+  }
+
+  /** Append the last message to the sidecar. Falls back to a full rewrite when
+   *  our line count is unknown or has drifted (fresh process, missing file). */
+  private appendTranscript(chat: Chat): void {
+    const known = this.transcriptLines.get(chat.id);
+    const file = this.transcriptFile(chat.workspaceName, chat.id);
+    if (known !== chat.messages.length - 1 || !fs.existsSync(file)) {
+      this.rewriteTranscript(chat);
+      return;
+    }
+    const last = chat.messages[chat.messages.length - 1];
+    if (!last) return;
+    try {
+      fs.appendFileSync(file, `${this.transcriptLine(last)}\n`, 'utf8');
+      this.transcriptLines.set(chat.id, chat.messages.length);
+    } catch (err) {
+      log.warn(`ChatManager: transcript append failed for ${chat.id}: ${(err as Error).message}`);
+      this.transcriptLines.delete(chat.id);
+    }
   }
 
   private ensureLoaded(): void {
@@ -519,6 +594,9 @@ export class ChatManager {
     if (!chat) return;
     const file = this.chatFile(chat.workspaceName, chat.id);
     if (fs.existsSync(file)) fs.unlinkSync(file);
+    const transcript = this.transcriptFile(chat.workspaceName, chat.id);
+    if (fs.existsSync(transcript)) fs.unlinkSync(transcript);
+    this.transcriptLines.delete(chatId);
     const chatDir = path.join(this.workspacesRoot, chat.workspaceName, 'chats', chatId);
     if (fs.existsSync(chatDir)) {
       fs.rmSync(chatDir, { recursive: true, force: true });
@@ -538,6 +616,8 @@ export class ChatManager {
     chat.messages.splice(idx, 1);
     chat.updatedAt = Date.now();
     this.persist(chat);
+    // A mid-list removal breaks the append-only invariant — rebuild the sidecar.
+    this.rewriteTranscript(chat);
     return chat;
   }
 
@@ -551,6 +631,7 @@ export class ChatManager {
       chat.title = deriveTitle(message.content);
     }
     this.persist(chat);
+    this.appendTranscript(chat);
     this.maybeScheduleCompaction(chat);
     return chat;
   }
@@ -565,6 +646,11 @@ export class ChatManager {
     chat.messages[idx] = { ...chat.messages[idx], ...patch };
     chat.updatedAt = Date.now();
     this.persist(chat);
+    // Team stubs are appended empty and filled here, so the sidecar's copy of
+    // this line is stale whenever the patch carries new content or identity.
+    if (patch.content !== undefined || patch.agent !== undefined || patch.model !== undefined) {
+      this.rewriteTranscript(chat);
+    }
     return chat;
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -29,7 +29,7 @@ import { resolveEffort } from './effort-resolve';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
-import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildChatCatchupPrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
+import { CHAT_CONTEXT_WINDOW, buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildChatCatchupPrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
 import { resolveChoiceDigit } from './digit-mapping';
@@ -5820,7 +5820,8 @@ Example: /model gpt-4.1 write a Python script`;
     this.qqAborts.set(chatId, abortController);
 
     const started = Date.now();
-    const prompt = buildQuickQuestionPrompt(chat, qqHistory, question, attachments);
+    const prompt = buildQuickQuestionPrompt(chat, qqHistory, question, attachments, CHAT_CONTEXT_WINDOW,
+      { transcriptPath: this.chatManager.transcriptPath(chatId) });
 
     let streamedText = '';
     const onStream = (text: string) => {
@@ -6165,7 +6166,8 @@ Example: /model gpt-4.1 write a Python script`;
     } else {
       // Bootstrap turn: include prior history once. For claude-code, pre-allocate
       // a session id so we can resume on the next turn without parsing CLI output.
-      prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments);
+      prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments, CHAT_CONTEXT_WINDOW,
+        { transcriptPath: this.chatManager.transcriptPath(chatId) });
       if (canResume && agent === 'claude-code') {
         newSessionId = randomUUID();
       }
@@ -6358,7 +6360,8 @@ Example: /model gpt-4.1 write a Python script`;
           streamedText = '';
           resumeSessionId = undefined;
           newSessionId = canResume && agent === 'claude-code' ? randomUUID() : undefined;
-          prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments) + chatWorkspaceInstruction;
+          prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments, CHAT_CONTEXT_WINDOW,
+            { transcriptPath: this.chatManager.transcriptPath(chatId) }) + chatWorkspaceInstruction;
           // Re-apply the skill banner: the rebuilt bootstrap prompt replaced
           // the one that carried it (still exactly once per prompt build).
           if (appliedChatSkill) prompt = applySkill(prompt, appliedChatSkill);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -6158,7 +6158,8 @@ Example: /model gpt-4.1 write a Python script`;
       // Resume the agent's own session. If other agents produced messages
       // while it was inactive, replay only that unseen gap before the new turn.
       prompt = selPrefix + (warmAnchor.syncedThroughMessageId
-        ? buildChatCatchupPrompt(chat, warmAnchor.syncedThroughMessageId, userText, attachments)
+        ? buildChatCatchupPrompt(chat, warmAnchor.syncedThroughMessageId, userText, attachments,
+            { transcriptPath: this.chatManager.transcriptPath(chatId) })
         : buildChatResumePrompt(chat, userText, attachments));
       resumeSessionId = warmAnchor.sessionId;
     } else {


### PR DESCRIPTION
## Why

Every adapter hands the prompt to the CLI as a command-line argument (`claude-code.ts:233`, `codex.ts:148`, `opencode.ts:105`, `pi.ts:101`), so the whole prompt has to fit inside `ARG_MAX` — 1 MiB here, shared with the environment block. Overshooting is not a degraded turn: `spawn` fails with `E2BIG` and the agent never starts. Nothing in the codebase measured prompt bytes.

Two paths could grow without bound:

- **Catch-up** — when you switch agents and switch back, the returning agent was replayed *every* message it missed, sliced straight to the end with no window and no summary. `CHAT_CONTEXT_WINDOW` does not reach this path.
- **Bootstrap** — a cold start (new chat, agent switch, `/clear`, failed resume) inlined the last 40 messages. Every team turn takes this path too, because team dispatch never resumes a session.

The warm path — same agent, same model, next turn — sends one message and is untouched. The CLI owns its own memory there.

## What

**Transcript sidecar.** `<chatId>.jsonl` sits next to `<chatId>.json`, append-only, one line per message, line N == `messages[N-1]`. The `.json` is rewritten wholesale on every persist so its line offsets are not stable; this file's are. It carries a lean projection — no tool calls, no thinking, which dominate the byte count and add nothing to "what did I miss". `updateMessage` and `removeMessage` rewrite it; older chats backfill on their first append.

**Both cold paths now hand over a cursor.** Past a threshold the prompt carries a path and a line range instead of the replay. Codey owns the cursor, not the agent — a fresh process every turn cannot be asked to remember where it left off. Short gaps stay inlined, where a tool round-trip costs more than the text it saves. Bootstrap keeps a short tail inline so a self-contained follow-up still needs no round-trip, and its pointer deliberately reaches back further than the inline window did: reading further costs the agent a longer `sed` range, not a longer prompt.

**An argv cap underneath.** A pointer cannot bound what lives nowhere on disk — a pasted log in the user's own message, a worker hand-off carrying the previous worker's full output, injected memory, a worker personality block. `capPromptForArgv` drops the middle of an oversized prompt, keeping a larger tail because the actual request sits at the end, and never splitting a multi-byte character. It hangs off `withForegroundPolicy`, the one function every adapter already routes through, so no adapter can forget it; the policy block is appended after the cap so it is never the part elided. Default 512 KB, overridable via `CODEY_MAX_PROMPT_BYTES`.

The two layers solve different problems: the cursor handles a long history (100 messages x 2 KB), the cap handles a single large payload (1 message x 300 KB). Neither subsumes the other.

## Verification

```
npm test -w @codey/core       -> 594 passed (42 files)
npm test -w @codey/gateway    -> 426 passed (46 files)
npx tsc --noEmit (both)       -> 0 errors
npm run lint                  -> pass
```

33 new tests across three files: sidecar line alignment under append/update/remove/delete and backfill, catch-up and bootstrap threshold behaviour, and the byte cap (limit respected, head and tail preserved, tail favoured, multi-byte boundaries intact, policy block never elided).

Not smoke-tested against a real long chat on the Mac app yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)