### PR TITLE
feat(context): extract missing history into a slice file instead of naming a line range

### DIFF
--- a/gateway.json.example
+++ b/gateway.json.example
@@ -57,8 +57,6 @@
   ],
   "activeProfile": "default",
   "context": {
-    "maxTokenBudget": 12000,
-    "maxTurns": 30,
     "ttlMinutes": 60
   },
   "memory": {

--- a/packages/core/src/agents/process-tree.ts
+++ b/packages/core/src/agents/process-tree.ts
@@ -74,7 +74,75 @@ const FOREGROUND_POLICY = [
 ].join('\n');
 
 /** Advisory guard for detach mechanisms that can deliberately escape a
- * process group. The hard lifecycle boundary remains terminateProcessTree. */
+ * process group. The hard lifecycle boundary remains terminateProcessTree.
+ *
+ * Doubles as the single choke point for the argv size cap (see
+ * `capPromptForArgv`): every adapter routes its prompt through here, and the
+ * policy block is appended after the cap so it can never be the part elided. */
 export function withForegroundPolicy(prompt: string): string {
-  return `${prompt}\n\n${FOREGROUND_POLICY}`;
+  const suffix = `\n\n${FOREGROUND_POLICY}`;
+  const capped = capPromptForArgv(prompt, maxPromptBytes() - Buffer.byteLength(suffix, 'utf8'));
+  return `${capped}${suffix}`;
+}
+
+/**
+ * Every adapter hands the prompt to the CLI as a command-line argument, so the
+ * whole prompt has to fit inside the OS argv limit (`ARG_MAX`, 1 MiB on macOS
+ * and Linux, shared with the environment block). Overshooting is not a graceful
+ * degradation: `spawn` fails with `E2BIG` and the agent never starts.
+ *
+ * Callers bound their own prompts (windowed history, transcript pointers), but
+ * a single pasted log or a runaway worker hand-off can still blow past the
+ * limit. This is the last line of defence, applied at the spawn boundary so no
+ * adapter can forget it.
+ */
+export const DEFAULT_MAX_PROMPT_BYTES = 512_000;
+
+/** Bytes reserved for the elision marker itself. */
+const ELISION_RESERVE = 200;
+
+/** Fraction of the surviving budget given to the head; the tail keeps the rest
+ *  because the actual request lives at the end of every prompt we build. */
+const HEAD_SHARE = 0.35;
+
+export function maxPromptBytes(): number {
+  const raw = Number(process.env.CODEY_MAX_PROMPT_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_PROMPT_BYTES;
+}
+
+/** Longest prefix of `text` that fits in `maxBytes`, never splitting a
+ *  multi-byte UTF-8 sequence. */
+function headBytes(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.length <= maxBytes) return text;
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+  return buf.subarray(0, end).toString('utf8');
+}
+
+/** Longest suffix of `text` that fits in `maxBytes`, never splitting a
+ *  multi-byte UTF-8 sequence. */
+function tailBytes(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.length <= maxBytes) return text;
+  let start = buf.length - maxBytes;
+  while (start < buf.length && (buf[start] & 0xc0) === 0x80) start++;
+  return buf.subarray(start).toString('utf8');
+}
+
+/**
+ * Drop the middle of an oversized prompt, keeping a head for the framing and a
+ * larger tail for the actual request. Returns `prompt` untouched when it fits.
+ */
+export function capPromptForArgv(prompt: string, maxBytes = maxPromptBytes()): string {
+  const size = Buffer.byteLength(prompt, 'utf8');
+  if (size <= maxBytes) return prompt;
+
+  const budget = Math.max(0, maxBytes - ELISION_RESERVE);
+  const headBudget = Math.floor(budget * HEAD_SHARE);
+  const head = headBytes(prompt, headBudget);
+  const tail = tailBytes(prompt, budget - Buffer.byteLength(head, 'utf8'));
+  const omitted = size - Buffer.byteLength(head, 'utf8') - Buffer.byteLength(tail, 'utf8');
+
+  return `${head}\n\n[… ${omitted} bytes elided by Codey — the prompt exceeded the ${maxBytes}-byte command-line limit …]\n\n${tail}`;
 }

--- a/packages/core/src/agents/prompt-cap.test.ts
+++ b/packages/core/src/agents/prompt-cap.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { capPromptForArgv, withForegroundPolicy, DEFAULT_MAX_PROMPT_BYTES, maxPromptBytes } from './process-tree';
+
+describe('capPromptForArgv', () => {
+  it('leaves a prompt that fits untouched', () => {
+    const prompt = 'hello world';
+    expect(capPromptForArgv(prompt, 1000)).toBe(prompt);
+  });
+
+  it('leaves a prompt exactly at the limit untouched', () => {
+    const prompt = 'x'.repeat(1000);
+    expect(capPromptForArgv(prompt, 1000)).toBe(prompt);
+  });
+
+  it('keeps the result within the byte limit', () => {
+    const prompt = 'x'.repeat(50_000);
+    const capped = capPromptForArgv(prompt, 4_000);
+    expect(Buffer.byteLength(capped, 'utf8')).toBeLessThanOrEqual(4_000);
+  });
+
+  it('keeps the head and the tail, drops the middle', () => {
+    const prompt = `HEAD_MARKER${'x'.repeat(50_000)}TAIL_MARKER`;
+    const capped = capPromptForArgv(prompt, 4_000);
+    expect(capped.startsWith('HEAD_MARKER')).toBe(true);
+    expect(capped.endsWith('TAIL_MARKER')).toBe(true);
+    expect(capped).toContain('elided by Codey');
+  });
+
+  it('gives the tail more room than the head', () => {
+    const prompt = 'x'.repeat(50_000);
+    const capped = capPromptForArgv(prompt, 4_000);
+    const [head, tail] = capped.split(/\n\n\[… .* …\]\n\n/);
+    expect(tail.length).toBeGreaterThan(head.length);
+  });
+
+  it('never splits a multi-byte character', () => {
+    const prompt = '中'.repeat(20_000); // lint-allow-non-english: multi-byte boundary fixture
+    const capped = capPromptForArgv(prompt, 4_000);
+    expect(capped).not.toContain('�');
+    expect(Buffer.byteLength(capped, 'utf8')).toBeLessThanOrEqual(4_000);
+  });
+
+  it('reports how many bytes it dropped', () => {
+    const prompt = 'x'.repeat(50_000);
+    const capped = capPromptForArgv(prompt, 4_000);
+    const omitted = Number(/… (\d+) bytes elided/.exec(capped)![1]);
+    const kept = Buffer.byteLength(capped, 'utf8');
+    expect(omitted).toBeGreaterThan(0);
+    expect(omitted + kept).toBeGreaterThan(50_000);
+  });
+});
+
+describe('maxPromptBytes', () => {
+  it('falls back to the default when the env override is unusable', () => {
+    const prior = process.env.CODEY_MAX_PROMPT_BYTES;
+    try {
+      process.env.CODEY_MAX_PROMPT_BYTES = 'not-a-number';
+      expect(maxPromptBytes()).toBe(DEFAULT_MAX_PROMPT_BYTES);
+      process.env.CODEY_MAX_PROMPT_BYTES = '0';
+      expect(maxPromptBytes()).toBe(DEFAULT_MAX_PROMPT_BYTES);
+      process.env.CODEY_MAX_PROMPT_BYTES = '12345';
+      expect(maxPromptBytes()).toBe(12345);
+    } finally {
+      if (prior === undefined) delete process.env.CODEY_MAX_PROMPT_BYTES;
+      else process.env.CODEY_MAX_PROMPT_BYTES = prior;
+    }
+  });
+});
+
+describe('withForegroundPolicy', () => {
+  it('caps an oversized prompt but never elides the policy block', () => {
+    const prior = process.env.CODEY_MAX_PROMPT_BYTES;
+    try {
+      process.env.CODEY_MAX_PROMPT_BYTES = '4000';
+      const out = withForegroundPolicy('x'.repeat(50_000));
+      expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(4000);
+      expect(out).toContain('<codey-runtime-policy>');
+      expect(out).toContain('</codey-runtime-policy>');
+      expect(out).toContain('elided by Codey');
+    } finally {
+      if (prior === undefined) delete process.env.CODEY_MAX_PROMPT_BYTES;
+      else process.env.CODEY_MAX_PROMPT_BYTES = prior;
+    }
+  });
+
+  it('passes a normal prompt through unchanged', () => {
+    const out = withForegroundPolicy('do the thing');
+    expect(out.startsWith('do the thing\n\n<codey-runtime-policy>')).toBe(true);
+  });
+});

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { ContextManager } from './context';
 
 function manager(): ContextManager {
-  return new ContextManager({ maxTokenBudget: 50000, maxTurns: 10, ttlMs: 60000 });
+  return new ContextManager({ ttlMs: 60000 });
 }
 
 describe('ContextManager conversation keying', () => {

--- a/packages/core/src/context.transcript.test.ts
+++ b/packages/core/src/context.transcript.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  ContextManager,
+  CONTEXT_INLINE_LIMIT,
+  CONTEXT_TAIL_INLINE,
+  CONTEXT_RETAINED_TURNS,
+} from './context';
+
+describe('ContextManager transcript sidecar', () => {
+  let dir: string;
+  let mgr: ContextManager;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctx-'));
+    mgr = new ContextManager({ ttlMs: 60_000, persistDir: dir });
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  function file(id: string): string {
+    return path.join(dir, 'context-archive', `${id}.jsonl`);
+  }
+
+  function rows(id: string): any[] {
+    return fs.readFileSync(file(id), 'utf-8').split('\n').filter(Boolean).map(l => JSON.parse(l));
+  }
+
+  async function seed(id: string, turns: number): Promise<void> {
+    await mgr.getOrCreate(id);
+    for (let i = 1; i <= turns; i++) {
+      if (i % 2) await mgr.addUserTurn(id, `user ${i}`);
+      else await mgr.addAssistantTurn(id, `assistant ${i}`);
+    }
+  }
+
+  it('writes one line per turn, in order', async () => {
+    await seed('c1', 4);
+    const out = rows('c1');
+    expect(out).toHaveLength(4);
+    expect(out[0]).toMatchObject({ role: 'user', text: 'user 1' });
+    expect(out[3]).toMatchObject({ role: 'assistant', text: 'assistant 4' });
+  });
+
+  it('records tool and file metadata without their payloads', async () => {
+    await mgr.getOrCreate('c2');
+    await mgr.addUserTurn('c2', 'go');
+    await mgr.addAssistantTurn('c2', 'done', {
+      agent: 'codex',
+      toolCalls: [{ tool: 'Read', status: 'success', output: 'x'.repeat(5000) }],
+      filesChanged: [{ path: 'a.ts', action: 'edit' }],
+    });
+    const line = rows('c2')[1];
+    expect(line).toMatchObject({ agent: 'codex', tools: ['Read'], files: ['edit:a.ts'] });
+    expect(JSON.stringify(line).length).toBeLessThan(300);
+  });
+
+  it('keeps line N aligned with the Nth turn even after eviction', async () => {
+    await seed('c3', CONTEXT_RETAINED_TURNS + 30);
+    const win = mgr.getWindow('c3')!;
+    expect(win.turns.length).toBe(CONTEXT_RETAINED_TURNS);
+    expect(win.transcriptLines).toBe(CONTEXT_RETAINED_TURNS + 30);
+    const out = rows('c3');
+    expect(out).toHaveLength(CONTEXT_RETAINED_TURNS + 30);
+    expect(out[0].text).toBe('user 1');
+    // The evicted head is still on disk, which is what makes eviction lossless.
+    expect(win.turns[0].text).not.toBe('user 1');
+  });
+
+  it('truncates the sidecar when an expired conversation restarts', async () => {
+    const shortLived = new ContextManager({ ttlMs: 1, persistDir: dir });
+    await shortLived.getOrCreate('c5');
+    await shortLived.addUserTurn('c5', 'old turn');
+    await new Promise(r => setTimeout(r, 5));
+    // Expiry archives the old window and starts a fresh one under the same id;
+    // stale lines would make line N stop meaning turn N.
+    await shortLived.getOrCreate('c5');
+    await shortLived.addUserTurn('c5', 'new turn');
+    const out = rows('c5');
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe('new turn');
+    expect(shortLived.getWindow('c5')!.transcriptLines).toBe(1);
+  });
+
+  it('survives an archive and reload with its cursor intact', async () => {
+    await seed('c4', 30);
+    mgr.shutdown();
+    const revived = new ContextManager({ ttlMs: 60_000, persistDir: dir });
+    expect(revived.load()).toBe(1);
+    expect(revived.getWindow('c4')!.transcriptLines).toBe(30);
+  });
+});
+
+describe('ContextManager.buildPrompt', () => {
+  let dir: string;
+  let mgr: ContextManager;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctx-'));
+    mgr = new ContextManager({ ttlMs: 60_000, persistDir: dir });
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  async function seed(id: string, turns: number): Promise<void> {
+    await mgr.getOrCreate(id);
+    for (let i = 1; i <= turns; i++) {
+      if (i % 2) await mgr.addUserTurn(id, `user ${i}`);
+      else await mgr.addAssistantTurn(id, `assistant ${i}`);
+    }
+  }
+
+  it('inlines everything when the history is short', async () => {
+    await seed('s1', CONTEXT_INLINE_LIMIT);
+    const prompt = mgr.buildPrompt('s1', 'now what');
+    expect(prompt).not.toContain('not inlined');
+    expect(prompt).toContain('user 1');
+    expect(prompt).toContain('now what');
+  });
+
+  it('inlines everything when no persist dir is configured', async () => {
+    const memOnly = new ContextManager({ ttlMs: 60_000 });
+    await memOnly.getOrCreate('s2');
+    for (let i = 1; i <= 100; i++) await memOnly.addUserTurn('s2', `user ${i}`);
+    const prompt = memOnly.buildPrompt('s2', 'now what');
+    expect(prompt).not.toContain('not inlined');
+    expect(prompt).toContain('user 1');
+  });
+
+  it('points at the transcript once the history is long', async () => {
+    await seed('s3', 100);
+    const prompt = mgr.buildPrompt('s3', 'now what');
+    expect(prompt).toContain(path.join(dir, 'context-archive', 's3.jsonl'));
+    expect(prompt).toContain(`Lines 1-${100 - CONTEXT_TAIL_INLINE} hold this history.`);
+    expect(prompt).toContain(`sed -n '1,${100 - CONTEXT_TAIL_INLINE}p'`);
+  });
+
+  it('still inlines the recent tail in pointer mode', async () => {
+    await seed('s4', 100);
+    const prompt = mgr.buildPrompt('s4', 'now what');
+    for (let i = 100 - CONTEXT_TAIL_INLINE + 1; i <= 100; i++) {
+      expect(prompt).toContain(`${i}`);
+    }
+    expect(prompt).not.toContain('user 1\n');
+    expect(prompt.trimEnd().endsWith('## Current Request\nnow what')).toBe(true);
+  });
+
+  it('starts the pointer after evicted turns rather than claiming line 1', async () => {
+    await seed('s5', CONTEXT_RETAINED_TURNS + 50);
+    const prompt = mgr.buildPrompt('s5', 'now what');
+    const first = CONTEXT_RETAINED_TURNS + 50 - CONTEXT_RETAINED_TURNS + 1;
+    expect(prompt).toContain(`Lines ${first}-${CONTEXT_RETAINED_TURNS + 50 - CONTEXT_TAIL_INLINE}`);
+  });
+
+  it('shrinks the prompt substantially versus inlining', async () => {
+    await mgr.getOrCreate('s6');
+    for (let i = 1; i <= 100; i++) await mgr.addUserTurn('s6', 'y'.repeat(2000));
+    const pointed = mgr.buildPrompt('s6', 'now what');
+    expect(pointed.length).toBeLessThan(100 * 2000 / 5);
+  });
+
+  it('keeps workspace memory at the top', async () => {
+    await seed('s7', 100);
+    const prompt = mgr.buildPrompt('s7', 'now what', '## Memory\nremember this');
+    expect(prompt.startsWith('## Memory\nremember this')).toBe(true);
+  });
+});

--- a/packages/core/src/context.transcript.test.ts
+++ b/packages/core/src/context.transcript.test.ts
@@ -133,8 +133,8 @@ describe('ContextManager.buildPrompt', () => {
     const win = mgr.getWindow('s1b')!;
     expect(win.turns.length).toBeLessThan(20);
     const prompt = mgr.buildPrompt('s1b', 'now what');
-    expect(prompt).toContain('not inlined');
-    expect(prompt).toContain('Lines 1-2 hold this history.');
+    expect(prompt).toContain('extracted into a file for you');
+    expect(prompt).toContain('2 messages');
   });
 
   it('keeps inlining many small turns that a turn cap would have cut off', async () => {
@@ -159,9 +159,23 @@ describe('ContextManager.buildPrompt', () => {
     await seed('s3', 100);
     // 100 turns of real text clears the byte budget.
     const prompt = mgr.buildPrompt('s3', 'now what');
-    expect(prompt).toContain(path.join(dir, 'context-archive', 's3.jsonl'));
-    expect(prompt).toContain(`Lines 1-${100 - CONTEXT_TAIL_INLINE} hold this history.`);
-    expect(prompt).toContain(`sed -n '1,${100 - CONTEXT_TAIL_INLINE}p'`);
+    const slice = path.join(dir, 'context-archive', '.slices', 's3.slice.jsonl');
+    expect(prompt).toContain(slice);
+    expect(prompt).toContain(`${100 - CONTEXT_TAIL_INLINE} messages`);
+    // The file holds exactly the un-inlined range, so there is no range left
+    // for the agent to work out.
+    expect(fs.readFileSync(slice, 'utf-8').split('\n').filter(Boolean)).toHaveLength(
+      100 - CONTEXT_TAIL_INLINE,
+    );
+  });
+
+  it('inlines a skeleton so a skipped file is not a blind turn', async () => {
+    await seed('s3b', 100);
+    const prompt = mgr.buildPrompt('s3b', 'now what');
+    expect(prompt).toContain('Skeleton of the same messages');
+    // Recognisable, but nothing like the full replay.
+    expect(prompt).toContain('turn-1');
+    expect(prompt.length).toBeLessThan(100 * 400 / 4);
   });
 
   it('still inlines the recent tail in pointer mode', async () => {
@@ -170,8 +184,9 @@ describe('ContextManager.buildPrompt', () => {
     for (let i = 100 - CONTEXT_TAIL_INLINE + 1; i <= 100; i++) {
       expect(prompt).toContain(`turn-${i} `);
     }
-    expect(prompt).not.toContain('turn-1 ');
-    expect(prompt).not.toContain(`turn-${100 - CONTEXT_TAIL_INLINE} `);
+    // The skeleton may name an early turn; its body must not be inlined.
+    expect(prompt).not.toContain(`turn-1 ${'.'.repeat(400)}`);
+    expect(prompt).not.toContain(`turn-${100 - CONTEXT_TAIL_INLINE} ${'.'.repeat(400)}`);
     expect(prompt.trimEnd().endsWith('## Current Request\nnow what')).toBe(true);
   });
 
@@ -182,7 +197,10 @@ describe('ContextManager.buildPrompt', () => {
     // so the cursor must still offer line 1.
     expect(mgr.getWindow('s5')!.turns.length).toBe(CONTEXT_RETAINED_TURNS);
     const prompt = mgr.buildPrompt('s5', 'now what');
-    expect(prompt).toContain(`Lines 1-${total - CONTEXT_TAIL_INLINE} hold this history.`);
+    const slice = path.join(dir, 'context-archive', '.slices', 's5.slice.jsonl');
+    expect(fs.readFileSync(slice, 'utf-8').split('\n').filter(Boolean)).toHaveLength(
+      total - CONTEXT_TAIL_INLINE,
+    );
   });
 
   it('shrinks the prompt substantially versus inlining', async () => {

--- a/packages/core/src/context.transcript.test.ts
+++ b/packages/core/src/context.transcript.test.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   ContextManager,
-  CONTEXT_INLINE_LIMIT,
+  CONTEXT_INLINE_MAX_BYTES,
   CONTEXT_TAIL_INLINE,
   CONTEXT_RETAINED_TURNS,
 } from './context';
@@ -104,20 +104,46 @@ describe('ContextManager.buildPrompt', () => {
 
   afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
 
+  /** Turns of a realistic size: 100 of these clear the byte budget, which is
+   *  what pushes the prompt into pointer mode. */
   async function seed(id: string, turns: number): Promise<void> {
     await mgr.getOrCreate(id);
     for (let i = 1; i <= turns; i++) {
-      if (i % 2) await mgr.addUserTurn(id, `user ${i}`);
-      else await mgr.addAssistantTurn(id, `assistant ${i}`);
+      const body = `turn-${i} ${'.'.repeat(400)}`;
+      if (i % 2) await mgr.addUserTurn(id, body);
+      else await mgr.addAssistantTurn(id, body);
     }
   }
 
-  it('inlines everything when the history is short', async () => {
-    await seed('s1', CONTEXT_INLINE_LIMIT);
+  it('inlines everything while the replay stays under the byte budget', async () => {
+    await seed('s1', 40);
     const prompt = mgr.buildPrompt('s1', 'now what');
     expect(prompt).not.toContain('not inlined');
-    expect(prompt).toContain('user 1');
+    expect(prompt).toContain('turn-1 ');
     expect(prompt).toContain('now what');
+  });
+
+  it('switches to a pointer on bytes, not on turn count', async () => {
+    await mgr.getOrCreate('s1b');
+    // Six turns, but well past the byte budget: turn count would have inlined
+    // these, and inlining them is exactly what the budget exists to prevent.
+    for (let i = 0; i < 6; i++) {
+      await mgr.addUserTurn('s1b', 'z'.repeat(CONTEXT_INLINE_MAX_BYTES / 4));
+    }
+    const win = mgr.getWindow('s1b')!;
+    expect(win.turns.length).toBeLessThan(20);
+    const prompt = mgr.buildPrompt('s1b', 'now what');
+    expect(prompt).toContain('not inlined');
+    expect(prompt).toContain('Lines 1-2 hold this history.');
+  });
+
+  it('keeps inlining many small turns that a turn cap would have cut off', async () => {
+    await mgr.getOrCreate('s1c');
+    for (let i = 1; i <= 60; i++) await mgr.addUserTurn('s1c', `tiny ${i}`);
+    const prompt = mgr.buildPrompt('s1c', 'now what');
+    expect(prompt).not.toContain('not inlined');
+    expect(prompt).toContain('tiny 1');
+    expect(prompt).toContain('tiny 60');
   });
 
   it('inlines everything when no persist dir is configured', async () => {
@@ -131,6 +157,7 @@ describe('ContextManager.buildPrompt', () => {
 
   it('points at the transcript once the history is long', async () => {
     await seed('s3', 100);
+    // 100 turns of real text clears the byte budget.
     const prompt = mgr.buildPrompt('s3', 'now what');
     expect(prompt).toContain(path.join(dir, 'context-archive', 's3.jsonl'));
     expect(prompt).toContain(`Lines 1-${100 - CONTEXT_TAIL_INLINE} hold this history.`);
@@ -141,9 +168,10 @@ describe('ContextManager.buildPrompt', () => {
     await seed('s4', 100);
     const prompt = mgr.buildPrompt('s4', 'now what');
     for (let i = 100 - CONTEXT_TAIL_INLINE + 1; i <= 100; i++) {
-      expect(prompt).toContain(`${i}`);
+      expect(prompt).toContain(`turn-${i} `);
     }
-    expect(prompt).not.toContain('user 1\n');
+    expect(prompt).not.toContain('turn-1 ');
+    expect(prompt).not.toContain(`turn-${100 - CONTEXT_TAIL_INLINE} `);
     expect(prompt.trimEnd().endsWith('## Current Request\nnow what')).toBe(true);
   });
 

--- a/packages/core/src/context.transcript.test.ts
+++ b/packages/core/src/context.transcript.test.ts
@@ -147,11 +147,14 @@ describe('ContextManager.buildPrompt', () => {
     expect(prompt.trimEnd().endsWith('## Current Request\nnow what')).toBe(true);
   });
 
-  it('starts the pointer after evicted turns rather than claiming line 1', async () => {
-    await seed('s5', CONTEXT_RETAINED_TURNS + 50);
+  it('reaches back past evicted turns, not just what memory retained', async () => {
+    const total = CONTEXT_RETAINED_TURNS + 50;
+    await seed('s5', total);
+    // Only CONTEXT_RETAINED_TURNS are still in RAM, but every turn is on disk,
+    // so the cursor must still offer line 1.
+    expect(mgr.getWindow('s5')!.turns.length).toBe(CONTEXT_RETAINED_TURNS);
     const prompt = mgr.buildPrompt('s5', 'now what');
-    const first = CONTEXT_RETAINED_TURNS + 50 - CONTEXT_RETAINED_TURNS + 1;
-    expect(prompt).toContain(`Lines ${first}-${CONTEXT_RETAINED_TURNS + 50 - CONTEXT_TAIL_INLINE}`);
+    expect(prompt).toContain(`Lines 1-${total - CONTEXT_TAIL_INLINE} hold this history.`);
   });
 
   it('shrinks the prompt substantially versus inlining', async () => {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -116,11 +116,16 @@ export const CONTEXT_INLINE_LIMIT = 20;
 export const CONTEXT_TAIL_INLINE = 4;
 
 /**
- * Turns retained in memory per window. The sidecar holds every turn, so
- * evicting the head is lossless — it bounds RAM for a long-running
- * conversation without bounding what the agent can reach.
+ * Turns retained in memory per window — derived, not chosen. Nothing outside
+ * this module reads `turns`, and the only reader here inlines at most
+ * CONTEXT_INLINE_LIMIT of them, so retaining more buys nothing; the margin
+ * just keeps pointer mode reachable once eviction starts.
+ *
+ * Eviction is lossless for the prompt but not for the snapshot: retained turns
+ * carry tool status, an output preview and errors, which the sidecar
+ * deliberately omits. That is what this working set exists to hold.
  */
-export const CONTEXT_RETAINED_TURNS = 200;
+export const CONTEXT_RETAINED_TURNS = CONTEXT_INLINE_LIMIT + 4;
 
 // ── Context Manager ────────────────────────────────────────────────
 
@@ -361,8 +366,11 @@ export class ContextManager {
     let inline = window.turns;
     if (transcript && window.turns.length > CONTEXT_INLINE_LIMIT) {
       const pointerLast = window.transcriptLines - CONTEXT_TAIL_INLINE;
-      // The window only holds the retained tail; earlier lines exist on disk.
-      const pointerFirst = window.transcriptLines - window.turns.length + 1;
+      // Always line 1: the sidecar is truncated whenever a window restarts, so
+      // its first line is this conversation's first turn. How many turns are
+      // still retained in memory must not bound how far back the agent can
+      // read — everything evicted is on disk precisely so it stays reachable.
+      const pointerFirst = 1;
       if (pointerLast >= pointerFirst) {
         sections.push([
           `## Earlier Conversation (${pointerLast - pointerFirst + 1} turns, not inlined)`,

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -105,27 +105,35 @@ const DEFAULT_CONFIG: ContextConfig = {
 };
 
 /**
- * Above this many turns a prompt stops inlining history and hands over a
- * transcript cursor instead. Below it, inlining beats making the agent spend
- * a tool call on a handful of short turns.
+ * Above this much inlined history a prompt hands over a transcript cursor
+ * instead of the replay. Below it, inlining wins: reading the sidecar costs
+ * the agent a tool round-trip, which is a bad trade for a few short turns.
+ *
+ * Measured in bytes rather than turns because bytes are the thing that
+ * actually hurts — the prompt is passed as a command-line argument, and twenty
+ * turns of chat and twenty turns of pasted logs differ by orders of magnitude.
+ * The threshold itself is a judgement call, not a measurement: roughly 6k
+ * tokens, small beside any current model's window but well past the point
+ * where one extra tool call is the cheaper option.
  */
-export const CONTEXT_INLINE_LIMIT = 20;
+export const CONTEXT_INLINE_MAX_BYTES = 24_000;
 
 /** Recent turns kept inline even in pointer mode, so a self-contained
  *  follow-up can be answered without reading the transcript at all. */
 export const CONTEXT_TAIL_INLINE = 4;
 
 /**
- * Turns retained in memory per window — derived, not chosen. Nothing outside
- * this module reads `turns`, and the only reader here inlines at most
- * CONTEXT_INLINE_LIMIT of them, so retaining more buys nothing; the margin
- * just keeps pointer mode reachable once eviction starts.
+ * Turns retained in memory per window. Purely a RAM ceiling: what the prompt
+ * inlines is decided by CONTEXT_INLINE_MAX_BYTES, and how far the cursor
+ * reaches is decided by the sidecar, so this number does not shape the prompt.
+ * It is set high enough that the byte budget, not eviction, is normally what
+ * ends inlining.
  *
  * Eviction is lossless for the prompt but not for the snapshot: retained turns
  * carry tool status, an output preview and errors, which the sidecar
  * deliberately omits. That is what this working set exists to hold.
  */
-export const CONTEXT_RETAINED_TURNS = CONTEXT_INLINE_LIMIT + 4;
+export const CONTEXT_RETAINED_TURNS = 200;
 
 // ── Context Manager ────────────────────────────────────────────────
 
@@ -358,13 +366,23 @@ export class ContextManager {
       sections.push(workspaceMemory);
     }
 
-    // Past the inline limit, hand over a cursor instead of the replay. Codey
-    // owns the cursor — the CLI is a fresh process every turn and cannot be
-    // asked to remember where it left off. A short tail stays inline so a
-    // self-contained follow-up needs no tool round-trip at all.
+    // Hand over a cursor instead of the replay once inlining stops paying for
+    // itself. Codey owns the cursor — the CLI is a fresh process every turn and
+    // cannot be asked to remember where it left off. A short tail stays inline
+    // so a self-contained follow-up needs no tool round-trip at all.
+    //
+    // Two independent reasons to switch: the replay has grown past the byte
+    // budget, or part of the history was evicted from memory and simply is not
+    // there to inline. Neither consults the retention cap — how much Codey
+    // keeps in RAM must not decide how the prompt is shaped.
     const transcript = this.transcriptFile(window.id);
     let inline = window.turns;
-    if (transcript && window.turns.length > CONTEXT_INLINE_LIMIT) {
+    const evicted = window.transcriptLines - window.turns.length;
+    const inlineBytes = window.turns.reduce(
+      (sum, turn) => sum + Buffer.byteLength(turn.summary || turn.text, 'utf8'),
+      0,
+    );
+    if (transcript && (evicted > 0 || inlineBytes > CONTEXT_INLINE_MAX_BYTES)) {
       const pointerLast = window.transcriptLines - CONTEXT_TAIL_INLINE;
       // Always line 1: the sidecar is truncated whenever a window restarts, so
       // its first line is this conversation's first turn. How many turns are

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -86,15 +86,14 @@ export interface ContextWindow {
   sessionAnchor?: SessionAnchor;
   /** Warm CLI sessions for workers running in this conversation, by name. */
   workerAnchors?: Record<string, WorkerAnchor>;
+  /** Lines written to the transcript sidecar so far. Line N holds the Nth turn
+   *  this window ever saw — including turns already evicted from `turns`. */
+  transcriptLines: number;
 }
 
 // ── Configuration ──────────────────────────────────────────────────
 
 export interface ContextConfig {
-  /** Max estimated tokens before compaction kicks in (default 12000) */
-  maxTokenBudget: number;
-  /** Max number of turns to keep (default 30) */
-  maxTurns: number;
   /** TTL in ms (default 60 minutes) */
   ttlMs: number;
   /** Directory for persisting context snapshots (optional) */
@@ -102,10 +101,26 @@ export interface ContextConfig {
 }
 
 const DEFAULT_CONFIG: ContextConfig = {
-  maxTokenBudget: 12000,
-  maxTurns: 30,
   ttlMs: 60 * 60 * 1000,
 };
+
+/**
+ * Above this many turns a prompt stops inlining history and hands over a
+ * transcript cursor instead. Below it, inlining beats making the agent spend
+ * a tool call on a handful of short turns.
+ */
+export const CONTEXT_INLINE_LIMIT = 20;
+
+/** Recent turns kept inline even in pointer mode, so a self-contained
+ *  follow-up can be answered without reading the transcript at all. */
+export const CONTEXT_TAIL_INLINE = 4;
+
+/**
+ * Turns retained in memory per window. The sidecar holds every turn, so
+ * evicting the head is lossless — it bounds RAM for a long-running
+ * conversation without bounding what the agent can reach.
+ */
+export const CONTEXT_RETAINED_TURNS = 200;
 
 // ── Context Manager ────────────────────────────────────────────────
 
@@ -142,6 +157,21 @@ export class ContextManager {
     }
   }
 
+  /**
+   * Start a window from zero. The sidecar is truncated with it: a window is
+   * only ever recreated after the previous one expired or was cleared, and
+   * leaving the old lines in place would silently desynchronise the cursor —
+   * line N would no longer be turn N. The archived JSON snapshot keeps the
+   * history that is being dropped here.
+   */
+  private createWindow(id: string): ContextWindow {
+    const file = this.transcriptFile(id);
+    if (file) {
+      try { fs.rmSync(file, { force: true }); } catch { /* best-effort */ }
+    }
+    return { id, turns: [], lastActive: Date.now(), totalTokens: 0, transcriptLines: 0 };
+  }
+
   // ── CRUD ───────────────────────────────────────────────────────
 
   async getOrCreate(conversationId: string): Promise<ContextWindow> {
@@ -157,12 +187,7 @@ export class ContextManager {
         this.windows.delete(conversationId);
       }
 
-      const window: ContextWindow = {
-        id: conversationId,
-        turns: [],
-        lastActive: Date.now(),
-        totalTokens: 0,
-      };
+      const window = this.createWindow(conversationId);
       this.windows.set(conversationId, window);
       return window;
     });
@@ -225,7 +250,7 @@ export class ContextManager {
     return this.withLock(windowId, () => {
       let window = this.windows.get(windowId);
       if (!window) {
-        window = { id: windowId, turns: [], lastActive: Date.now(), totalTokens: 0 };
+        window = this.createWindow(windowId);
         this.windows.set(windowId, window);
       }
       if (!window.workerAnchors) window.workerAnchors = {};
@@ -264,22 +289,23 @@ export class ContextManager {
     return this.withLock(windowId, () => {
       let window = this.windows.get(windowId);
       if (!window) {
-        window = { id: windowId, turns: [], lastActive: Date.now(), totalTokens: 0 };
+        window = this.createWindow(windowId);
         this.windows.set(windowId, window);
       }
 
       const tokenEstimate = estimateTokens(text);
-      window.turns.push({
+      const turn: ContextTurn = {
         id: `turn-${++this.turnCounter}`,
         role: 'user',
         timestamp: Date.now(),
         text,
         tokenEstimate,
-      });
+      };
+      window.turns.push(turn);
       window.totalTokens += tokenEstimate;
       window.lastActive = Date.now();
 
-      this.compact(window);
+      this.recordTurn(window, turn);
     });
   }
 
@@ -289,18 +315,19 @@ export class ContextManager {
       if (!window) return;
 
       const tokenEstimate = estimateTokens(text);
-      window.turns.push({
+      const turn: ContextTurn = {
         id: `turn-${++this.turnCounter}`,
         role: 'assistant',
         timestamp: Date.now(),
         text,
         meta,
         tokenEstimate,
-      });
+      };
+      window.turns.push(turn);
       window.totalTokens += tokenEstimate;
       window.lastActive = Date.now();
 
-      this.compact(window);
+      this.recordTurn(window, turn);
     });
   }
 
@@ -326,10 +353,33 @@ export class ContextManager {
       sections.push(workspaceMemory);
     }
 
+    // Past the inline limit, hand over a cursor instead of the replay. Codey
+    // owns the cursor — the CLI is a fresh process every turn and cannot be
+    // asked to remember where it left off. A short tail stays inline so a
+    // self-contained follow-up needs no tool round-trip at all.
+    const transcript = this.transcriptFile(window.id);
+    let inline = window.turns;
+    if (transcript && window.turns.length > CONTEXT_INLINE_LIMIT) {
+      const pointerLast = window.transcriptLines - CONTEXT_TAIL_INLINE;
+      // The window only holds the retained tail; earlier lines exist on disk.
+      const pointerFirst = window.transcriptLines - window.turns.length + 1;
+      if (pointerLast >= pointerFirst) {
+        sections.push([
+          `## Earlier Conversation (${pointerLast - pointerFirst + 1} turns, not inlined)`,
+          `Transcript: ${transcript}`,
+          'One JSON object per line, one line per turn, oldest first.',
+          `Lines ${pointerFirst}-${pointerLast} hold this history.`,
+          `Read them before answering (e.g. \`sed -n '${pointerFirst},${pointerLast}p'\`) unless the current request below is fully self-contained.`,
+          'Context only — do not repeat or fabricate turns.',
+        ].join('\n'));
+        inline = window.turns.slice(-CONTEXT_TAIL_INLINE);
+      }
+    }
+
     // Build conversation context
     sections.push('## Conversation History');
 
-    for (const turn of window.turns) {
+    for (const turn of inline) {
       const displayText = turn.summary || turn.text;
 
       if (turn.role === 'user') {
@@ -364,86 +414,68 @@ export class ContextManager {
     return sections.join('\n\n');
   }
 
-  // ── Compaction ─────────────────────────────────────────────────
+  // ── Transcript sidecar ─────────────────────────────────────────
 
   /**
-   * Compress older turns when the context window exceeds budget.
-   * Strategy: summarize the oldest half of turns into a single summary turn.
+   * Append-only transcript for a conversation: one JSON object per line, one
+   * line per turn, line N == the Nth turn the window ever saw. `archive()`
+   * rewrites its JSON snapshot wholesale, so that file's line offsets are not
+   * stable; this file's are, which is what lets a prompt hand an agent a
+   * `path:line` cursor instead of inlining the history.
    */
-  private compact(window: ContextWindow): void {
-    // Enforce turn limit
-    while (window.turns.length > this.config.maxTurns) {
-      const removed = window.turns.shift();
-      if (removed) window.totalTokens -= removed.tokenEstimate;
-    }
+  private transcriptFile(windowId: string): string | undefined {
+    if (!this.config.persistDir) return undefined;
+    return path.resolve(
+      path.join(this.config.persistDir, 'context-archive', `${windowId}.jsonl`),
+    );
+  }
 
-    // Token budget compaction
-    if (window.totalTokens > this.config.maxTokenBudget && window.turns.length > 4) {
-      const halfIdx = Math.floor(window.turns.length / 2);
-      const oldTurns = window.turns.slice(0, halfIdx);
-      const newTurns = window.turns.slice(halfIdx);
+  /** Absolute transcript path for a conversation, or undefined when the
+   *  manager was built without a persist dir (tests, embedded use). */
+  transcriptPath(windowId: string): string | undefined {
+    return this.transcriptFile(windowId);
+  }
 
-      // Create a summary of the old turns
-      const summary = this.summarizeTurns(oldTurns);
-      const summaryTokens = estimateTokens(summary);
-
-      // Replace old turns with a single summary turn
-      const summaryTurn: ContextTurn = {
-        id: `summary-${Date.now()}`,
-        role: 'assistant',
-        timestamp: oldTurns[0].timestamp,
-        text: '',
-        summary,
-        tokenEstimate: summaryTokens,
-      };
-
-      const removedTokens = oldTurns.reduce((sum, t) => sum + t.tokenEstimate, 0);
-      window.turns = [summaryTurn, ...newTurns];
-      window.totalTokens = window.totalTokens - removedTokens + summaryTokens;
-    }
+  /** Lean projection — what a catching-up agent needs. Tool call payloads and
+   *  token accounting are omitted: they dominate the byte count and add
+   *  nothing to "what was said". */
+  private transcriptLine(turn: ContextTurn): string {
+    return JSON.stringify({
+      id: turn.id,
+      role: turn.role,
+      timestamp: turn.timestamp,
+      ...(turn.meta?.agent ? { agent: turn.meta.agent } : {}),
+      ...(turn.meta?.toolCalls?.length
+        ? { tools: turn.meta.toolCalls.map(tc => tc.tool) }
+        : {}),
+      ...(turn.meta?.filesChanged?.length
+        ? { files: turn.meta.filesChanged.map(fc => `${fc.action}:${fc.path}`) }
+        : {}),
+      text: turn.summary || turn.text,
+    });
   }
 
   /**
-   * Create a compact summary of turns. This is a local heuristic —
-   * not an LLM call — to keep it fast and free.
+   * Persist a turn to the sidecar and evict the head of the in-memory window
+   * once it outgrows the retention cap. Eviction is lossless: everything
+   * evicted is still on disk and still reachable through the cursor.
    */
-  private summarizeTurns(turns: ContextTurn[]): string {
-    const parts: string[] = ['[Earlier conversation summary]'];
-
-    // Extract key topics discussed
-    const userMessages = turns.filter(t => t.role === 'user').map(t => t.summary || t.text);
-    if (userMessages.length > 0) {
-      parts.push(`User asked about: ${userMessages.map(m => m.substring(0, 80)).join('; ')}`);
-    }
-
-    // Extract all tools used
-    const allTools = new Set<string>();
-    const allFiles = new Set<string>();
-    const allErrors: string[] = [];
-
-    for (const turn of turns) {
-      if (turn.meta?.toolCalls) {
-        for (const tc of turn.meta.toolCalls) allTools.add(tc.tool);
-      }
-      if (turn.meta?.filesChanged) {
-        for (const fc of turn.meta.filesChanged) allFiles.add(`${fc.action}:${fc.path}`);
-      }
-      if (turn.meta?.errors) {
-        allErrors.push(...turn.meta.errors);
+  private recordTurn(window: ContextWindow, turn: ContextTurn): void {
+    const file = this.transcriptFile(window.id);
+    if (file) {
+      try {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.appendFileSync(file, this.transcriptLine(turn) + '\n');
+      } catch {
+        // Best-effort: a failed append costs the cursor a line, never the turn.
       }
     }
+    window.transcriptLines += 1;
 
-    if (allTools.size > 0) {
-      parts.push(`Tools used: ${Array.from(allTools).join(', ')}`);
+    while (window.turns.length > CONTEXT_RETAINED_TURNS) {
+      const evicted = window.turns.shift();
+      if (evicted) window.totalTokens -= evicted.tokenEstimate;
     }
-    if (allFiles.size > 0) {
-      parts.push(`Files touched: ${Array.from(allFiles).join(', ')}`);
-    }
-    if (allErrors.length > 0) {
-      parts.push(`Errors encountered: ${allErrors.slice(0, 3).join('; ')}`);
-    }
-
-    return parts.join('\n');
   }
 
   // ── Persistence ────────────────────────────────────────────────
@@ -461,6 +493,7 @@ export class ContextManager {
       const data = {
         id: window.id,
         turns: window.turns,
+        transcriptLines: window.transcriptLines,
         archivedAt: Date.now(),
       };
       fs.writeFileSync(path.join(archiveDir, filename), JSON.stringify(data, null, 2));
@@ -488,6 +521,7 @@ export class ContextManager {
           const data = JSON.parse(raw) as {
             id: string;
             turns: ContextTurn[];
+            transcriptLines?: number;
             archivedAt: number;
           };
 
@@ -502,6 +536,9 @@ export class ContextManager {
             turns: data.turns || [],
             lastActive: data.archivedAt,
             totalTokens: (data.turns || []).reduce((sum, t) => sum + (t.tokenEstimate || 0), 0),
+            // Snapshots written before the sidecar existed have no count; the
+            // retained turns are all we can vouch for, so start the cursor there.
+            transcriptLines: data.transcriptLines ?? (data.turns || []).length,
           };
           this.windows.set(window.id, window);
           fs.unlinkSync(path.join(archiveDir, file));

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { estimateTokens } from './utils/tokens';
 import { toolPhaseOf } from './agents/tool-events';
+import { writeTranscriptSlice, renderSliceSection } from './transcript-slice';
 
 // ── Structured turn types ──────────────────────────────────────────
 
@@ -390,14 +391,24 @@ export class ContextManager {
       // read — everything evicted is on disk precisely so it stays reachable.
       const pointerFirst = 1;
       if (pointerLast >= pointerFirst) {
-        sections.push([
-          `## Earlier Conversation (${pointerLast - pointerFirst + 1} turns, not inlined)`,
-          `Transcript: ${transcript}`,
-          'One JSON object per line, one line per turn, oldest first.',
-          `Lines ${pointerFirst}-${pointerLast} hold this history.`,
-          `Read them before answering (e.g. \`sed -n '${pointerFirst},${pointerLast}p'\`) unless the current request below is fully self-contained.`,
-          'Context only — do not repeat or fabricate turns.',
-        ].join('\n'));
+        // Cut the range out into its own file rather than naming it. The agent
+        // then has nothing to get wrong: the file is the range.
+        const slice = writeTranscriptSlice(transcript, pointerFirst, pointerLast);
+        sections.push(slice
+          ? renderSliceSection(slice, {
+              heading: 'Earlier conversation',
+              closing: 'Context only — do not repeat or fabricate turns.',
+            })
+          : [
+              // Unreadable sidecar: name the range in place instead of
+              // dropping the history.
+              `## Earlier Conversation (${pointerLast - pointerFirst + 1} turns, not inlined)`,
+              `Transcript: ${transcript}`,
+              'One JSON object per line, one line per turn, oldest first.',
+              `Lines ${pointerFirst}-${pointerLast} hold this history.`,
+              `Read them before answering (e.g. \`sed -n '${pointerFirst},${pointerLast}p'\`) unless the current request below is fully self-contained.`,
+              'Context only — do not repeat or fabricate turns.',
+            ].join('\n'));
         inline = window.turns.slice(-CONTEXT_TAIL_INLINE);
       }
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './memory';
 export * from './agents';
 export * from './errors';
 export * from './context';
+export * from './transcript-slice';
 export * from './advisor';
 export * from './advisor-personality';
 export * from './solo-advisor';

--- a/packages/core/src/transcript-slice.test.ts
+++ b/packages/core/src/transcript-slice.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  writeTranscriptSlice,
+  buildSliceDigest,
+  renderSliceSection,
+  sweepTranscriptSlices,
+} from './transcript-slice';
+
+describe('writeTranscriptSlice', () => {
+  let dir: string;
+  let source: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-slice-'));
+    source = path.join(dir, 'chat.jsonl');
+    const rows = Array.from({ length: 50 }, (_, i) =>
+      JSON.stringify({ id: `m${i + 1}`, role: i % 2 ? 'assistant' : 'user', text: `body ${i + 1}` }));
+    fs.writeFileSync(source, rows.join('\n') + '\n');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  function sliceLines(file: string): any[] {
+    return fs.readFileSync(file, 'utf-8').split('\n').filter(Boolean).map(l => JSON.parse(l));
+  }
+
+  it('extracts exactly the requested inclusive range', () => {
+    const slice = writeTranscriptSlice(source, 10, 20)!;
+    const rows = sliceLines(slice.path);
+    expect(slice.lines).toBe(11);
+    expect(rows).toHaveLength(11);
+    expect(rows[0].text).toBe('body 10');
+    expect(rows[10].text).toBe('body 20');
+  });
+
+  it('writes beside the source, not over it', () => {
+    const slice = writeTranscriptSlice(source, 1, 5)!;
+    expect(slice.path).toBe(path.join(dir, '.slices', 'chat.slice.jsonl'));
+    expect(sliceLines(source)).toHaveLength(50);
+  });
+
+  it('supersedes the previous slice instead of accumulating files', () => {
+    writeTranscriptSlice(source, 1, 5);
+    const second = writeTranscriptSlice(source, 40, 50)!;
+    expect(fs.readdirSync(path.join(dir, '.slices'))).toHaveLength(1);
+    expect(sliceLines(second.path)[0].text).toBe('body 40');
+  });
+
+  it('returns undefined for an empty or inverted range', () => {
+    expect(writeTranscriptSlice(source, 20, 10)).toBeUndefined();
+    expect(writeTranscriptSlice(source, 0, 5)).toBeUndefined();
+    expect(writeTranscriptSlice(source, 90, 99)).toBeUndefined();
+  });
+
+  it('returns undefined when the source is unreadable', () => {
+    expect(writeTranscriptSlice(path.join(dir, 'missing.jsonl'), 1, 5)).toBeUndefined();
+  });
+
+  it('clamps a range that runs past the end of the source', () => {
+    const slice = writeTranscriptSlice(source, 45, 200)!;
+    expect(slice.lines).toBe(6);
+  });
+});
+
+describe('buildSliceDigest', () => {
+  function rows(count: number, body = 'hello'): string[] {
+    return Array.from({ length: count }, (_, i) =>
+      JSON.stringify({ role: i % 2 ? 'assistant' : 'user', text: `${body} ${i + 1}` }));
+  }
+
+  it('numbers entries from the slice start line, not from one', () => {
+    const digest = buildSliceDigest(rows(3), 48);
+    expect(digest.split('\n')[0].startsWith('48 [user]')).toBe(true);
+  });
+
+  it('drops the middle once there are too many entries', () => {
+    const digest = buildSliceDigest(rows(40), 1);
+    expect(digest).toContain('more turns omitted from this skeleton');
+    expect(digest.split('\n').length).toBeLessThan(15);
+  });
+
+  it('truncates long bodies instead of reproducing them', () => {
+    const digest = buildSliceDigest([JSON.stringify({ role: 'user', text: 'x'.repeat(5000) })], 1);
+    expect(digest.length).toBeLessThan(200);
+    expect(digest).toContain('…');
+  });
+
+  it('skips unparseable and empty rows rather than failing', () => {
+    const digest = buildSliceDigest(['not json', JSON.stringify({ role: 'user', text: '' }), rows(1)[0]], 1);
+    expect(digest.split('\n')).toHaveLength(1);
+  });
+
+  it('prefers a worker or agent label over the bare role', () => {
+    const digest = buildSliceDigest([JSON.stringify({ role: 'assistant', agent: 'codex', text: 'hi' })], 1);
+    expect(digest).toContain('[codex]');
+  });
+});
+
+describe('renderSliceSection', () => {
+  it('tells the agent to read the file and warns that it is temporary', () => {
+    const section = renderSliceSection(
+      { path: '/tmp/x.slice.jsonl', lines: 96, digest: '1 [user] hi' },
+      { heading: 'Earlier conversation', closing: 'Context only.' },
+    );
+    expect(section).toContain('/tmp/x.slice.jsonl');
+    expect(section).toContain('96 messages');
+    expect(section).toContain('Read the whole file');
+    expect(section).toContain('temporary');
+    expect(section).toContain('Skeleton');
+    expect(section.trimEnd().endsWith('Context only.')).toBe(true);
+  });
+
+  it('omits the skeleton block when there is no digest', () => {
+    const section = renderSliceSection(
+      { path: '/tmp/x.slice.jsonl', lines: 2, digest: '' },
+      { heading: 'Earlier conversation', closing: 'Context only.' },
+    );
+    expect(section).not.toContain('Skeleton');
+  });
+});
+
+describe('sweepTranscriptSlices', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-sweep-'));
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('removes aged slices and keeps fresh ones', () => {
+    fs.writeFileSync(path.join(dir, 'old.slice.jsonl'), 'x');
+    fs.writeFileSync(path.join(dir, 'new.slice.jsonl'), 'x');
+    const old = path.join(dir, 'old.slice.jsonl');
+    const aged = Date.now() - 3 * 60 * 60 * 1000;
+    fs.utimesSync(old, aged / 1000, aged / 1000);
+
+    expect(sweepTranscriptSlices(dir)).toBe(1);
+    expect(fs.readdirSync(dir)).toEqual(['new.slice.jsonl']);
+  });
+
+  it('is a no-op on a directory that does not exist', () => {
+    expect(sweepTranscriptSlices(path.join(dir, 'nope'))).toBe(0);
+  });
+});

--- a/packages/core/src/transcript-slice.ts
+++ b/packages/core/src/transcript-slice.ts
@@ -1,0 +1,188 @@
+/**
+ * Transcript slices — handing an agent exactly the history it is missing.
+ *
+ * The alternative is a cursor: "read lines 48-260 of this file". That works,
+ * but it leaves the agent three ways to get it wrong — read the whole file,
+ * miscount the range, or interpret the instruction differently per CLI. A
+ * slice removes the choice: Codey cuts the range out itself and hands over a
+ * small file whose entire contents are what the agent should see.
+ *
+ * The prompt cost is identical (one path either way), so this is really the
+ * inline replay again — delivered through the filesystem instead of argv,
+ * where it is not bounded by ARG_MAX.
+ *
+ * A slice is still only useful if the agent reads it. `buildSliceDigest`
+ * covers the case where it does not: a small skeleton that rides inline, so a
+ * cold start that skips the file still knows roughly what happened.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Directory name for slices, created beside the transcript being sliced. */
+const SLICE_DIR = '.slices';
+
+/** Slices older than this are swept. Generous: a slice outliving its turn is
+ *  harmless, while deleting one an agent is still reading is not. */
+const SLICE_TTL_MS = 60 * 60 * 1000;
+
+/** Per-entry text budget in the digest. Enough to recognise a turn, far too
+ *  little to stand in for reading the slice. */
+const DIGEST_ENTRY_CHARS = 100;
+
+/** Entries kept in the digest: a head and a tail, with the middle dropped. */
+const DIGEST_HEAD_ENTRIES = 4;
+const DIGEST_TAIL_ENTRIES = 6;
+
+export interface TranscriptSlice {
+  /** Absolute path of the written slice. */
+  path: string;
+  /** Lines it contains. */
+  lines: number;
+  /** A lossy inline skeleton of the same lines. */
+  digest: string;
+}
+
+/** One line of a transcript sidecar, as far as slicing cares. */
+interface TranscriptRow {
+  role?: string;
+  text?: string;
+  content?: string;
+  worker?: string;
+  agent?: string;
+}
+
+function sliceDir(source: string): string {
+  return path.join(path.dirname(source), SLICE_DIR);
+}
+
+/**
+ * Remove slices left behind by turns that already finished — or by a process
+ * that died mid-turn. Age-based rather than lifecycle-based on purpose: a
+ * cleanup hook wired into the run would have to fire on success, failure,
+ * timeout, abort and crash, and getting it wrong deletes a file the agent is
+ * still reading. Superseding and ageing out cannot fail that way.
+ */
+export function sweepTranscriptSlices(dir: string, now = Date.now()): number {
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const file = path.join(dir, entry);
+    try {
+      if (now - fs.statSync(file).mtimeMs < SLICE_TTL_MS) continue;
+      fs.rmSync(file, { force: true });
+      removed++;
+    } catch {
+      // Another process may have swept it first.
+    }
+  }
+  return removed;
+}
+
+/** Compact one transcript row for the digest. */
+function digestEntry(line: string, lineNumber: number): string | undefined {
+  let row: TranscriptRow;
+  try {
+    row = JSON.parse(line) as TranscriptRow;
+  } catch {
+    return undefined;
+  }
+  const body = (row.text ?? row.content ?? '').replace(/\s+/g, ' ').trim();
+  if (!body) return undefined;
+  const who = row.worker || row.agent || row.role || 'turn';
+  const clipped = body.length > DIGEST_ENTRY_CHARS
+    ? `${body.slice(0, DIGEST_ENTRY_CHARS)}…`
+    : body;
+  return `${lineNumber} [${who}] ${clipped}`;
+}
+
+/**
+ * A deliberately lossy skeleton of the sliced lines: enough to know what the
+ * conversation was about, not enough to answer from. It exists so that an
+ * agent which ignores the slice is merely under-informed rather than blind.
+ */
+export function buildSliceDigest(lines: string[], firstLine: number): string {
+  const entries: string[] = [];
+  lines.forEach((line, index) => {
+    const entry = digestEntry(line, firstLine + index);
+    if (entry) entries.push(entry);
+  });
+  if (entries.length === 0) return '';
+  if (entries.length <= DIGEST_HEAD_ENTRIES + DIGEST_TAIL_ENTRIES) {
+    return entries.join('\n');
+  }
+  return [
+    ...entries.slice(0, DIGEST_HEAD_ENTRIES),
+    `… ${entries.length - DIGEST_HEAD_ENTRIES - DIGEST_TAIL_ENTRIES} more turns omitted from this skeleton …`,
+    ...entries.slice(-DIGEST_TAIL_ENTRIES),
+  ].join('\n');
+}
+
+/**
+ * Cut `firstLine`..`lastLine` (1-based, inclusive) out of a transcript sidecar
+ * and write them to a slice beside it. Returns undefined when the source is
+ * unreadable or the range is empty — callers fall back to inlining.
+ *
+ * The slice is named after the source, so the next turn for the same
+ * conversation overwrites it instead of accumulating a new file.
+ */
+export function writeTranscriptSlice(
+  source: string,
+  firstLine: number,
+  lastLine: number,
+): TranscriptSlice | undefined {
+  if (lastLine < firstLine || firstLine < 1) return undefined;
+
+  let all: string[];
+  try {
+    all = fs.readFileSync(source, 'utf-8').split('\n').filter(Boolean);
+  } catch {
+    return undefined;
+  }
+
+  const lines = all.slice(firstLine - 1, lastLine);
+  if (lines.length === 0) return undefined;
+
+  const dir = sliceDir(source);
+  const target = path.join(dir, `${path.basename(source, path.extname(source))}.slice.jsonl`);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(target, lines.join('\n') + '\n');
+  } catch {
+    return undefined;
+  }
+  sweepTranscriptSlices(dir);
+
+  return {
+    path: path.resolve(target),
+    lines: lines.length,
+    digest: buildSliceDigest(lines, firstLine),
+  };
+}
+
+/**
+ * The prompt block that hands a slice over. Says "read this file" rather than
+ * naming a line range: the file already is the range, so there is nothing left
+ * for the agent to get wrong.
+ */
+export function renderSliceSection(
+  slice: TranscriptSlice,
+  opts: { heading: string; closing: string },
+): string {
+  const parts = [
+    `[${opts.heading} — ${slice.lines} messages, extracted into a file for you]`,
+    `File: ${slice.path}`,
+    'It holds exactly those messages, one JSON object per line, oldest first, and nothing else.',
+    'Read the whole file — it is small, and it is the history you are missing.',
+    'It is temporary: it is rewritten on the next turn, so do not rely on it later.',
+  ];
+  if (slice.digest) {
+    parts.push('', 'Skeleton of the same messages, in case you skip the file:', slice.digest);
+  }
+  parts.push('', opts.closing);
+  return parts.join('\n');
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -370,8 +370,8 @@ export interface AideSettings {
 
 // Context configuration
 export interface ContextSettings {
-  maxTokenBudget?: number;
-  maxTurns?: number;
+  /** Conversation lifetime in minutes. History is no longer bounded by turn
+   *  or token count: the prompt hands the agent a transcript cursor instead. */
   ttlMinutes?: number;
 }
 

--- a/packages/gateway/src/chat-runner.bootstrap.test.ts
+++ b/packages/gateway/src/chat-runner.bootstrap.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { Chat, ChatMessage } from '@codey/core';
+import {
+  buildChatBootstrapPrompt,
+  buildQuickQuestionPrompt,
+  BOOTSTRAP_INLINE_LIMIT,
+  BOOTSTRAP_TAIL_INLINE,
+} from './chat-runner';
+
+const PATH = '/tmp/ws/chats/abc.jsonl';
+
+function chatWith(count: number, extra?: Partial<Chat>): Chat {
+  const messages: ChatMessage[] = Array.from({ length: count }, (_, i) => ({
+    id: `m${i + 1}`,
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `body ${i + 1}`,
+    timestamp: i,
+    isComplete: true,
+  }));
+  return {
+    id: 'abc',
+    workspaceName: 'ws',
+    title: 't',
+    createdAt: 0,
+    updatedAt: 0,
+    messages,
+    selection: { type: 'agent' },
+    ...extra,
+  } as Chat;
+}
+
+describe('buildChatBootstrapPrompt — transcript pointer', () => {
+  it('inlines everything when the history is short', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(BOOTSTRAP_INLINE_LIMIT), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).not.toContain(PATH);
+    expect(prompt).toContain('body 1');
+    expect(prompt).toContain(`body ${BOOTSTRAP_INLINE_LIMIT}`);
+  });
+
+  it('inlines everything when no transcript path is available', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40);
+    expect(prompt).not.toContain('not inlined');
+    expect(prompt).toContain('body 100');
+  });
+
+  it('points at the transcript once the history is long', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).toContain(PATH);
+    expect(prompt).toContain(`Lines 1-${100 - BOOTSTRAP_TAIL_INLINE} hold this history.`);
+    expect(prompt).toContain(`sed -n '1,${100 - BOOTSTRAP_TAIL_INLINE}p'`);
+    expect(prompt).toContain('96 messages, not inlined');
+  });
+
+  it('still inlines the recent tail in pointer mode', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    for (let i = 100 - BOOTSTRAP_TAIL_INLINE + 1; i <= 100; i++) {
+      expect(prompt).toContain(`body ${i}`);
+    }
+    expect(prompt).not.toContain(`body ${100 - BOOTSTRAP_TAIL_INLINE}\n`);
+  });
+
+  it('starts the pointer after a compaction summary instead of at line 1', () => {
+    const chat = chatWith(100, {
+      compaction: { summary: 'earlier stuff', summarizedUpTo: 30, model: 'm', updatedAt: 0 },
+    } as Partial<Chat>);
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, { transcriptPath: PATH });
+    expect(prompt).toContain('earlier stuff');
+    expect(prompt).toContain(`Lines 31-${100 - BOOTSTRAP_TAIL_INLINE} hold this history.`);
+  });
+
+  it('reaches back further than the inline window would have', () => {
+    // windowSize 40 would have shown messages 61-100; the pointer offers 1-96.
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'next', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).toContain('Lines 1-96');
+  });
+
+  it('keeps the new user message last', () => {
+    const prompt = buildChatBootstrapPrompt(chatWith(100), 'the ask', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt.trimEnd().endsWith('[Respond to this new user message]\nthe ask')).toBe(true);
+  });
+
+  it('shrinks the prompt substantially versus inlining', () => {
+    const chat = chatWith(100);
+    chat.messages.forEach(m => { m.content = 'y'.repeat(2000); });
+    const inlined = buildChatBootstrapPrompt(chat, 'next', undefined, 40);
+    const pointed = buildChatBootstrapPrompt(chat, 'next', undefined, 40, { transcriptPath: PATH });
+    expect(pointed.length).toBeLessThan(inlined.length / 5);
+  });
+
+  it('does not point when the tail alone covers the history', () => {
+    const chat = chatWith(100, {
+      compaction: { summary: 's', summarizedUpTo: 97, model: 'm', updatedAt: 0 },
+    } as Partial<Chat>);
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, { transcriptPath: PATH });
+    expect(prompt).not.toContain(PATH);
+  });
+});
+
+describe('buildQuickQuestionPrompt — transcript pointer', () => {
+  it('points at the transcript for a long parent chat', () => {
+    const prompt = buildQuickQuestionPrompt(chatWith(100), [], 'q?', undefined, 40,
+      { transcriptPath: PATH });
+    expect(prompt).toContain(PATH);
+    expect(prompt).toContain('read-only reference');
+  });
+});

--- a/packages/gateway/src/chat-runner.slice.test.ts
+++ b/packages/gateway/src/chat-runner.slice.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Chat, ChatMessage, writeTranscriptSlice } from '@codey/core';
+import { buildChatBootstrapPrompt, buildChatCatchupPrompt } from './chat-runner';
+
+function chatWith(count: number): Chat {
+  const messages: ChatMessage[] = Array.from({ length: count }, (_, i) => ({
+    id: `m${i + 1}`,
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `body ${i + 1}`,
+    timestamp: i,
+    isComplete: true,
+  }));
+  return {
+    id: 'abc', workspaceName: 'ws', title: 't', createdAt: 0, updatedAt: 0,
+    messages, selection: { type: 'none' },
+  } as Chat;
+}
+
+describe('chat prompts with a slice writer', () => {
+  let dir: string;
+  let source: string;
+  let chat: Chat;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-chat-slice-'));
+    source = path.join(dir, 'abc.jsonl');
+    chat = chatWith(100);
+    fs.writeFileSync(
+      source,
+      chat.messages.map(m => JSON.stringify({ id: m.id, role: m.role, content: m.content })).join('\n') + '\n',
+    );
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const delivery = () => ({
+    transcriptPath: source,
+    writeSlice: (first: number, last: number) => writeTranscriptSlice(source, first, last),
+  });
+
+  function sliceRows(): any[] {
+    const file = path.join(dir, '.slices', 'abc.slice.jsonl');
+    return fs.readFileSync(file, 'utf-8').split('\n').filter(Boolean).map(l => JSON.parse(l));
+  }
+
+  it('bootstrap hands over a file holding exactly the un-inlined messages', () => {
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, delivery());
+    expect(prompt).toContain(path.join(dir, '.slices', 'abc.slice.jsonl'));
+    expect(prompt).toContain('Read the whole file');
+    expect(prompt).not.toContain('sed -n');
+    const rows = sliceRows();
+    expect(rows).toHaveLength(96);
+    expect(rows[0].id).toBe('m1');
+    expect(rows[95].id).toBe('m96');
+  });
+
+  it('bootstrap keeps the recent tail inline and out of the slice', () => {
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, delivery());
+    expect(prompt).toContain('body 100');
+    expect(sliceRows().some(r => r.id === 'm97')).toBe(false);
+  });
+
+  it('catch-up slices only what the returning agent missed', () => {
+    const prompt = buildChatCatchupPrompt(chat, 'm40', 'next', undefined, delivery());
+    expect(prompt).toContain('since this agent was last active');
+    const rows = sliceRows();
+    expect(rows).toHaveLength(60);
+    expect(rows[0].id).toBe('m41');
+    expect(rows[59].id).toBe('m100');
+  });
+
+  it('carries an inline skeleton alongside the file', () => {
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, delivery());
+    expect(prompt).toContain('Skeleton of the same messages');
+    expect(prompt).toContain('1 [user] body 1');
+  });
+
+  it('falls back to naming the line range when the sidecar is unreadable', () => {
+    const prompt = buildChatBootstrapPrompt(chat, 'next', undefined, 40, {
+      transcriptPath: source,
+      writeSlice: () => writeTranscriptSlice(path.join(dir, 'gone.jsonl'), 1, 96),
+    });
+    expect(prompt).toContain('sed -n');
+    expect(prompt).toContain('Lines 1-96 hold this history.');
+  });
+
+  it('keeps the new user message last in both shapes', () => {
+    for (const prompt of [
+      buildChatBootstrapPrompt(chat, 'the ask', undefined, 40, delivery()),
+      buildChatCatchupPrompt(chat, 'm40', 'the ask', undefined, delivery()),
+    ]) {
+      expect(prompt.trimEnd().endsWith('[Respond to this new user message]\nthe ask')).toBe(true);
+    }
+  });
+
+  it('costs far fewer prompt bytes than inlining the same history', () => {
+    const big = chatWith(100);
+    big.messages.forEach(m => { m.content = 'y'.repeat(2000); });
+    fs.writeFileSync(
+      source,
+      big.messages.map(m => JSON.stringify({ id: m.id, role: m.role, content: m.content })).join('\n') + '\n',
+    );
+    const inlined = buildChatBootstrapPrompt(big, 'next', undefined, 40);
+    const sliced = buildChatBootstrapPrompt(big, 'next', undefined, 40, delivery());
+    expect(sliced.length).toBeLessThan(inlined.length / 5);
+  });
+});

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -1,14 +1,30 @@
-import { Chat, ChatMessage, ChecklistItem, CodingAgent, FileAttachment, TaskBrief, TeamRunSummary, ToolCallEntry } from '@codey/core';
+import { Chat, ChatMessage, ChecklistItem, CodingAgent, FileAttachment, TaskBrief, TeamRunSummary, ToolCallEntry, TranscriptSlice, renderSliceSection } from '@codey/core';
 
 export const MAX_CONCURRENT_AGENTS = 4;
 export const CHAT_CONTEXT_WINDOW = 40;
 
 /**
  * Above this many windowed messages a bootstrap stops inlining prior history
- * and points at the transcript sidecar instead. Below it, inlining is cheaper
+ * and hands over a transcript slice instead. Below it, inlining is cheaper
  * than making the agent spend a tool call on a handful of short turns.
  */
 export const BOOTSTRAP_INLINE_LIMIT = 20;
+
+/**
+ * Materialises lines `first`..`last` (1-based, inclusive) of the chat's
+ * transcript sidecar as a standalone file. Injected rather than called
+ * directly so the prompt builders stay free of filesystem access; the gateway
+ * supplies the real writer.
+ */
+export type SliceWriter = (first: number, last: number) => TranscriptSlice | undefined;
+
+export interface HistoryDeliveryOptions {
+  /** Absolute path of the transcript sidecar, when one exists. */
+  transcriptPath?: string;
+  /** Writer used to cut the un-inlined range out into its own file. */
+  writeSlice?: SliceWriter;
+  inlineLimit?: number;
+}
 
 /** Recent messages kept inline even in pointer mode, so a self-contained
  *  follow-up can be answered without reading the transcript at all. */
@@ -87,7 +103,7 @@ function formatAttachmentList(attachments: FileAttachment[]): string {
 function renderChatContextSections(
   chat: Chat,
   windowSize: number,
-  opts?: { transcriptPath?: string; inlineLimit?: number },
+  opts?: HistoryDeliveryOptions,
 ): string[] {
   const sections: string[] = [];
 
@@ -110,15 +126,23 @@ function renderChatContextSections(
     const pointerFirst = summarizedUpTo + 1;
     const pointerLast = chat.messages.length - BOOTSTRAP_TAIL_INLINE;
     if (pointerLast >= pointerFirst) {
-      sections.push(
-        [
-          `[Earlier conversation — ${pointerLast - pointerFirst + 1} messages, not inlined]`,
-          `Transcript: ${opts.transcriptPath}`,
-          'One JSON object per line, one line per message, oldest first.',
-          `Lines ${pointerFirst}-${pointerLast} hold this history.`,
-          `Read them before answering (e.g. \`sed -n '${pointerFirst},${pointerLast}p'\`) unless the new request below is fully self-contained.`,
-          'Context only — do not repeat or fabricate turns.',
-        ].join('\n'),
+      const slice = opts.writeSlice?.(pointerFirst, pointerLast);
+      sections.push(slice
+        ? renderSliceSection(slice, {
+            heading: 'Earlier conversation',
+            closing: 'Context only — do not repeat or fabricate turns.',
+          })
+        : [
+            // No slice (unreadable sidecar, or no writer wired): fall back to
+            // naming the range in place. Strictly worse — the agent has to
+            // extract it — but better than dropping the history entirely.
+            `[Earlier conversation — ${pointerLast - pointerFirst + 1} messages, not inlined]`,
+            `Transcript: ${opts.transcriptPath}`,
+            'One JSON object per line, one line per message, oldest first.',
+            `Lines ${pointerFirst}-${pointerLast} hold this history.`,
+            `Read them before answering (e.g. \`sed -n '${pointerFirst},${pointerLast}p'\`) unless the new request below is fully self-contained.`,
+            'Context only — do not repeat or fabricate turns.',
+          ].join('\n'),
       );
       start = pointerLast;
     }
@@ -143,7 +167,7 @@ export function buildChatPrompt(
   userText: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
-  opts?: { transcriptPath?: string; inlineLimit?: number },
+  opts?: HistoryDeliveryOptions,
 ): string {
   const sections: string[] = [];
 
@@ -167,7 +191,7 @@ export function buildChatBootstrapPrompt(
   userText: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
-  opts?: { transcriptPath?: string; inlineLimit?: number },
+  opts?: HistoryDeliveryOptions,
 ): string {
   return buildChatPrompt(chat, userText, attachments, windowSize, opts);
 }
@@ -233,7 +257,7 @@ export function buildChatCatchupPrompt(
   syncedThroughMessageId: string,
   userText: string,
   attachments?: FileAttachment[],
-  opts?: { transcriptPath?: string; inlineLimit?: number },
+  opts?: HistoryDeliveryOptions,
 ): string {
   const cursor = chat.messages.findIndex(message => message.id === syncedThroughMessageId);
   if (cursor < 0 || cursor === chat.messages.length - 1) {
@@ -252,15 +276,20 @@ export function buildChatCatchupPrompt(
     // every turn and cannot be asked to remember where it left off.
     const firstUnseenLine = cursor + 2;
     const lastLine = chat.messages.length;
-    parts.push(
-      [
-        `[Codey conversation updates since this agent was last active — ${missed.length} messages, not inlined]`,
-        `Transcript: ${opts.transcriptPath}`,
-        'One JSON object per line, one line per message, oldest first.',
-        `You last saw line ${cursor + 1}. Lines ${firstUnseenLine}-${lastLine} are new.`,
-        `Read them if you need the detail (e.g. \`sed -n '${firstUnseenLine},${lastLine}p'\`); skip it if the new request stands on its own.`,
-        'Context only — do not repeat or fabricate turns.',
-      ].join('\n'),
+    const slice = opts.writeSlice?.(firstUnseenLine, lastLine);
+    parts.push(slice
+      ? renderSliceSection(slice, {
+          heading: 'Codey conversation updates since this agent was last active',
+          closing: 'Context only — do not repeat or fabricate turns.',
+        })
+      : [
+          `[Codey conversation updates since this agent was last active — ${missed.length} messages, not inlined]`,
+          `Transcript: ${opts.transcriptPath}`,
+          'One JSON object per line, one line per message, oldest first.',
+          `You last saw line ${cursor + 1}. Lines ${firstUnseenLine}-${lastLine} are new.`,
+          `Read them if you need the detail (e.g. \`sed -n '${firstUnseenLine},${lastLine}p'\`); skip it if the new request stands on its own.`,
+          'Context only — do not repeat or fabricate turns.',
+        ].join('\n'),
     );
   } else {
     const updates = missed.map(message => {
@@ -336,7 +365,7 @@ export function buildQuickQuestionPrompt(
   question: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
-  opts?: { transcriptPath?: string; inlineLimit?: number },
+  opts?: HistoryDeliveryOptions,
 ): string {
   const sections: string[] = [];
 

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -4,6 +4,17 @@ export const MAX_CONCURRENT_AGENTS = 4;
 export const CHAT_CONTEXT_WINDOW = 40;
 
 /**
+ * Above this many windowed messages a bootstrap stops inlining prior history
+ * and points at the transcript sidecar instead. Below it, inlining is cheaper
+ * than making the agent spend a tool call on a handful of short turns.
+ */
+export const BOOTSTRAP_INLINE_LIMIT = 20;
+
+/** Recent messages kept inline even in pointer mode, so a self-contained
+ *  follow-up can be answered without reading the transcript at all. */
+export const BOOTSTRAP_TAIL_INLINE = 4;
+
+/**
  * Appended to the prompt only when a chat has soloAdvisor enabled. Tells the
  * single agent to self-escalate when stuck via the [ASK_ADVISOR] marker.
  */
@@ -73,7 +84,11 @@ function formatAttachmentList(attachments: FileAttachment[]): string {
  * windowed transcript). Shared by buildChatPrompt and buildQuickQuestionPrompt
  * so both window/compact identically.
  */
-function renderChatContextSections(chat: Chat, windowSize: number): string[] {
+function renderChatContextSections(
+  chat: Chat,
+  windowSize: number,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
+): string[] {
   const sections: string[] = [];
 
   const summarizedUpTo = chat.compaction?.summarizedUpTo ?? 0;
@@ -83,7 +98,32 @@ function renderChatContextSections(chat: Chat, windowSize: number): string[] {
     );
   }
 
-  const start = Math.max(summarizedUpTo, chat.messages.length - windowSize);
+  let start = Math.max(summarizedUpTo, chat.messages.length - windowSize);
+  const inlineLimit = opts?.inlineLimit ?? BOOTSTRAP_INLINE_LIMIT;
+
+  // Past the inline limit, hand over a transcript cursor instead of the
+  // replay. Sidecar line N holds messages[N-1]. The pointer deliberately
+  // reaches back further than `windowSize` — reading more costs the agent a
+  // longer `sed` range, not a longer prompt — while a short tail stays inlined
+  // so a self-contained follow-up needs no tool round-trip at all.
+  if (opts?.transcriptPath && chat.messages.length - start > inlineLimit) {
+    const pointerFirst = summarizedUpTo + 1;
+    const pointerLast = chat.messages.length - BOOTSTRAP_TAIL_INLINE;
+    if (pointerLast >= pointerFirst) {
+      sections.push(
+        [
+          `[Earlier conversation — ${pointerLast - pointerFirst + 1} messages, not inlined]`,
+          `Transcript: ${opts.transcriptPath}`,
+          'One JSON object per line, one line per message, oldest first.',
+          `Lines ${pointerFirst}-${pointerLast} hold this history.`,
+          `Read them before answering (e.g. \`sed -n '${pointerFirst},${pointerLast}p'\`) unless the new request below is fully self-contained.`,
+          'Context only — do not repeat or fabricate turns.',
+        ].join('\n'),
+      );
+      start = pointerLast;
+    }
+  }
+
   const tail = chat.messages.slice(start);
   if (tail.length > 0) {
     const transcript = tail.map(m => {
@@ -103,6 +143,7 @@ export function buildChatPrompt(
   userText: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
   const sections: string[] = [];
 
@@ -110,7 +151,7 @@ export function buildChatPrompt(
     sections.push(formatAttachmentList(attachments));
   }
 
-  sections.push(...renderChatContextSections(chat, windowSize));
+  sections.push(...renderChatContextSections(chat, windowSize, opts));
 
   sections.push(`[Respond to this new user message]\n${userText}`);
   return sections.join('\n\n');
@@ -126,8 +167,9 @@ export function buildChatBootstrapPrompt(
   userText: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
-  return buildChatPrompt(chat, userText, attachments, windowSize);
+  return buildChatPrompt(chat, userText, attachments, windowSize, opts);
 }
 
 const RESUME_CONTEXT_MAX_CHARS = 8_000;
@@ -294,6 +336,7 @@ export function buildQuickQuestionPrompt(
   question: string,
   attachments?: FileAttachment[],
   windowSize = CHAT_CONTEXT_WINDOW,
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
   const sections: string[] = [];
 
@@ -301,7 +344,7 @@ export function buildQuickQuestionPrompt(
     sections.push(formatAttachmentList(attachments));
   }
 
-  const ctx = renderChatContextSections(chat, windowSize);
+  const ctx = renderChatContextSections(chat, windowSize, opts);
   if (ctx.length > 0) {
     sections.push(
       '[Main chat — read-only reference. Do not continue or modify this conversation.]',

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -178,11 +178,20 @@ export function buildChatResumePrompt(
  * agent receives the gap exactly once instead of being polluted by the full
  * transcript every time the user switches back.
  */
+/**
+ * Above this many missed messages a catch-up stops inlining the replay and
+ * points at the transcript sidecar instead. Inlining is cheaper for a short
+ * gap (no extra tool round-trip); past the threshold the replay is what
+ * actually blows up the argv the CLI is spawned with.
+ */
+export const CATCHUP_INLINE_LIMIT = 20;
+
 export function buildChatCatchupPrompt(
   chat: Chat,
   syncedThroughMessageId: string,
   userText: string,
   attachments?: FileAttachment[],
+  opts?: { transcriptPath?: string; inlineLimit?: number },
 ): string {
   const cursor = chat.messages.findIndex(message => message.id === syncedThroughMessageId);
   if (cursor < 0 || cursor === chat.messages.length - 1) {
@@ -192,16 +201,37 @@ export function buildChatCatchupPrompt(
   const parts: string[] = [];
   if (attachments && attachments.length > 0) parts.push(formatAttachmentList(attachments));
 
-  const updates = chat.messages.slice(cursor + 1).map(message => {
-    if (message.role === 'user') return `[user]\n${message.content}`;
-    const identity = [message.agent, message.model].filter(Boolean).join(' / ');
-    return `[assistant${identity ? ` via ${identity}` : ''}]\n${message.content}`;
-  }).join('\n\n');
+  const missed = chat.messages.slice(cursor + 1);
+  const inlineLimit = opts?.inlineLimit ?? CATCHUP_INLINE_LIMIT;
 
-  parts.push(
-    `[Codey conversation updates since this agent was last active — context only; do not repeat or fabricate turns]\n${updates}`,
-    `[Respond to this new user message]\n${userText}`,
-  );
+  if (opts?.transcriptPath && missed.length > inlineLimit) {
+    // Sidecar line N holds messages[N-1], so the first unseen message sits on
+    // line cursor + 2. Codey owns this cursor — the agent is a fresh process
+    // every turn and cannot be asked to remember where it left off.
+    const firstUnseenLine = cursor + 2;
+    const lastLine = chat.messages.length;
+    parts.push(
+      [
+        `[Codey conversation updates since this agent was last active — ${missed.length} messages, not inlined]`,
+        `Transcript: ${opts.transcriptPath}`,
+        'One JSON object per line, one line per message, oldest first.',
+        `You last saw line ${cursor + 1}. Lines ${firstUnseenLine}-${lastLine} are new.`,
+        `Read them if you need the detail (e.g. \`sed -n '${firstUnseenLine},${lastLine}p'\`); skip it if the new request stands on its own.`,
+        'Context only — do not repeat or fabricate turns.',
+      ].join('\n'),
+    );
+  } else {
+    const updates = missed.map(message => {
+      if (message.role === 'user') return `[user]\n${message.content}`;
+      const identity = [message.agent, message.model].filter(Boolean).join(' / ');
+      return `[assistant${identity ? ` via ${identity}` : ''}]\n${message.content}`;
+    }).join('\n\n');
+    parts.push(
+      `[Codey conversation updates since this agent was last active — context only; do not repeat or fabricate turns]\n${updates}`,
+    );
+  }
+
+  parts.push(`[Respond to this new user message]\n${userText}`);
   return parts.join('\n\n');
 }
 

--- a/packages/gateway/src/chats.transcript.test.ts
+++ b/packages/gateway/src/chats.transcript.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChatManager } from './chats';
+import { buildChatCatchupPrompt, CATCHUP_INLINE_LIMIT } from './chat-runner';
+
+function lines(file: string): string[] {
+  return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+}
+
+describe('ChatManager transcript sidecar', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-transcript-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('writes one line per message, in order', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'first', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'a1', role: 'assistant', content: 'second', timestamp: 2, isComplete: true, agent: 'codex', model: 'm' });
+
+    const file = mgr.transcriptPath(chat.id)!;
+    const rows = lines(file).map(l => JSON.parse(l));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ id: 'u1', role: 'user', content: 'first' });
+    expect(rows[1]).toMatchObject({ id: 'a1', role: 'assistant', content: 'second', agent: 'codex', model: 'm' });
+  });
+
+  it('keeps line N aligned with messages[N-1] as the chat grows', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    for (let i = 0; i < 25; i++) {
+      mgr.appendMessage(chat.id, { id: `m${i}`, role: i % 2 ? 'assistant' : 'user', content: `body ${i}`, timestamp: i, isComplete: true });
+    }
+    const rows = lines(mgr.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    const messages = mgr.get(chat.id)!.messages;
+    expect(rows).toHaveLength(messages.length);
+    rows.forEach((row, idx) => expect(row.id).toBe(messages[idx].id));
+  });
+
+  it('embeds newlines rather than emitting extra lines', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'line one\nline two\nline three', timestamp: 1, isComplete: true });
+    const rows = lines(mgr.transcriptPath(chat.id)!);
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]).content).toBe('line one\nline two\nline three');
+  });
+
+  it('omits bulky tool calls and thinking', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, {
+      id: 'a1', role: 'assistant', content: 'answer', timestamp: 1, isComplete: true,
+      thinking: 'SECRET_REASONING',
+      toolCalls: [{ type: 'tool_end', tool: 'Bash', message: 'BULKY_TOOL_OUTPUT' } as never],
+    });
+    const raw = fs.readFileSync(mgr.transcriptPath(chat.id)!, 'utf8');
+    expect(raw).toContain('answer');
+    expect(raw).not.toContain('SECRET_REASONING');
+    expect(raw).not.toContain('BULKY_TOOL_OUTPUT');
+  });
+
+  it('refreshes the line when a stub message is filled in later', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'a1', role: 'assistant', content: '', timestamp: 1, isComplete: false });
+    mgr.updateMessage(chat.id, 'a1', { content: 'filled in by the worker', isComplete: true });
+
+    const rows = lines(mgr.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe('filled in by the worker');
+  });
+
+  it('rebuilds after a mid-list removal', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'keep me', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'u2', role: 'user', content: 'drop me', timestamp: 2, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'u3', role: 'user', content: 'keep me too', timestamp: 3, isComplete: true });
+
+    mgr.removeMessage(chat.id, 'u2');
+
+    const rows = lines(mgr.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    expect(rows.map(r => r.id)).toEqual(['u1', 'u3']);
+  });
+
+  it('backfills a chat that predates the sidecar', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'old one', timestamp: 1, isComplete: true });
+    mgr.appendMessage(chat.id, { id: 'u2', role: 'user', content: 'old two', timestamp: 2, isComplete: true });
+
+    // Simulate a chat written before the sidecar existed.
+    fs.unlinkSync(mgr.transcriptPath(chat.id)!);
+    const reloaded = new ChatManager(root);
+    reloaded.appendMessage(chat.id, { id: 'u3', role: 'user', content: 'new one', timestamp: 3, isComplete: true });
+
+    const rows = lines(reloaded.transcriptPath(chat.id)!).map(l => JSON.parse(l));
+    expect(rows.map(r => r.id)).toEqual(['u1', 'u2', 'u3']);
+  });
+
+  it('deletes the sidecar with the chat', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.appendMessage(chat.id, { id: 'u1', role: 'user', content: 'hi', timestamp: 1, isComplete: true });
+    const file = mgr.transcriptPath(chat.id)!;
+    expect(fs.existsSync(file)).toBe(true);
+
+    mgr.delete(chat.id);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it('returns an absolute path even for a relative workspaces root', () => {
+    // Relative to cwd but still inside the temp dir, so nothing lands in the repo.
+    const relativeRoot = path.relative(process.cwd(), root);
+    expect(path.isAbsolute(relativeRoot)).toBe(false);
+
+    const relative = new ChatManager(relativeRoot);
+    const chat = relative.create({ workspaceName: 'ws' });
+    const file = relative.transcriptPath(chat.id)!;
+    expect(path.isAbsolute(file)).toBe(true);
+    expect(file.startsWith(path.resolve(root))).toBe(true);
+  });
+});
+
+describe('buildChatCatchupPrompt gap handling', () => {
+  let root: string;
+  let mgr: ChatManager;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-transcript-gap-'));
+    fs.mkdirSync(path.join(root, 'ws'), { recursive: true });
+    mgr = new ChatManager(root);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  function seed(count: number) {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    for (let i = 0; i < count; i++) {
+      mgr.appendMessage(chat.id, { id: `m${i}`, role: i % 2 ? 'assistant' : 'user', content: `body ${i}`, timestamp: i, isComplete: true });
+    }
+    return chat.id;
+  }
+
+  it('still inlines a small gap', () => {
+    const chatId = seed(6);
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm1', 'now what', undefined, {
+      transcriptPath: mgr.transcriptPath(chatId),
+    });
+    expect(prompt).toContain('body 2');
+    expect(prompt).toContain('body 5');
+    expect(prompt).not.toContain('.jsonl');
+  });
+
+  it('points at the transcript instead of replaying a large gap', () => {
+    const total = CATCHUP_INLINE_LIMIT + 30;
+    const chatId = seed(total);
+    const file = mgr.transcriptPath(chatId)!;
+
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm0', 'now what', undefined, {
+      transcriptPath: file,
+    });
+
+    expect(prompt).toContain(file);
+    expect(prompt).toContain(`${total - 1} messages`);
+    // m0 is messages[0] -> line 1; the first unseen message is line 2.
+    expect(prompt).toContain(`Lines 2-${total} are new`);
+    expect(prompt).toContain('You last saw line 1.');
+    expect(prompt).toContain('now what');
+    // The bodies themselves must not be inlined — that is the whole point.
+    expect(prompt).not.toContain('body 5');
+  });
+
+  it('names a cursor that maps back to the right sidecar line', () => {
+    const total = CATCHUP_INLINE_LIMIT + 10;
+    const chatId = seed(total);
+    const file = mgr.transcriptPath(chatId)!;
+
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm3', 'go on', undefined, { transcriptPath: file });
+    expect(prompt).toContain('You last saw line 4.');
+
+    const rows = lines(file).map(l => JSON.parse(l));
+    expect(rows[3].id).toBe('m3');
+    expect(rows[4].id).toBe('m4');
+  });
+
+  it('falls back to inlining when no transcript path is supplied', () => {
+    const chatId = seed(CATCHUP_INLINE_LIMIT + 30);
+    const prompt = buildChatCatchupPrompt(mgr.get(chatId)!, 'm0', 'now what');
+    expect(prompt).toContain('body 5');
+    expect(prompt).not.toContain('.jsonl');
+  });
+});

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -34,6 +34,8 @@ export class ChatManager {
   private loaded = false;
   private compactionRunner?: CompactionRunner;
   private compactingChats = new Set<string>();
+  /** chatId -> lines currently in that chat's transcript sidecar. */
+  private transcriptLines = new Map<string, number>();
 
   constructor(private readonly workspacesRoot: string) {}
 
@@ -52,6 +54,79 @@ export class ChatManager {
 
   private chatFile(workspaceName: string, chatId: string): string {
     return path.join(this.chatsDir(workspaceName), `${chatId}.json`);
+  }
+
+  /**
+   * Append-only transcript sidecar: one JSON object per line, one line per
+   * message, line N == messages[N-1]. Written next to the chat's `.json` so a
+   * catch-up prompt can hand an agent a stable `path:line` cursor instead of
+   * inlining a large replay. The `.json` is rewritten wholesale on every
+   * persist, so its line offsets are not stable; this file's are.
+   */
+  private transcriptFile(workspaceName: string, chatId: string): string {
+    return path.join(this.chatsDir(workspaceName), `${chatId}.jsonl`);
+  }
+
+  /** Absolute transcript path for a chat, or undefined if the chat is gone.
+   *  Resolved: `workspacesRoot` defaults to a relative './workspaces', and the
+   *  agent runs with the workspace as cwd, not the gateway's. */
+  transcriptPath(chatId: string): string | undefined {
+    this.ensureLoaded();
+    const chat = this.cache.get(chatId);
+    if (!chat) return undefined;
+    return path.resolve(this.transcriptFile(chat.workspaceName, chat.id));
+  }
+
+  /** Lean projection — the fields a catching-up agent needs, nothing else.
+   *  Tool calls and thinking are deliberately omitted: they dominate the byte
+   *  count and add nothing to "what did I miss". */
+  private transcriptLine(message: ChatMessage): string {
+    return JSON.stringify({
+      id: message.id,
+      role: message.role,
+      timestamp: message.timestamp,
+      ...(message.agent ? { agent: message.agent } : {}),
+      ...(message.model ? { model: message.model } : {}),
+      ...(message.worker ? { worker: message.worker } : {}),
+      content: message.content,
+    });
+  }
+
+  /** Rewrite the whole sidecar from the in-memory messages. Used to backfill
+   *  chats that predate the sidecar and to repair it after a mid-list delete. */
+  private rewriteTranscript(chat: Chat): void {
+    const file = this.transcriptFile(chat.workspaceName, chat.id);
+    try {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      const body = chat.messages.map(m => this.transcriptLine(m)).join('\n');
+      const tmp = `${file}.tmp`;
+      fs.writeFileSync(tmp, body ? `${body}\n` : '', 'utf8');
+      fs.renameSync(tmp, file);
+      this.transcriptLines.set(chat.id, chat.messages.length);
+    } catch (err) {
+      log.warn(`ChatManager: transcript rewrite failed for ${chat.id}: ${(err as Error).message}`);
+      this.transcriptLines.delete(chat.id);
+    }
+  }
+
+  /** Append the last message to the sidecar. Falls back to a full rewrite when
+   *  our line count is unknown or has drifted (fresh process, missing file). */
+  private appendTranscript(chat: Chat): void {
+    const known = this.transcriptLines.get(chat.id);
+    const file = this.transcriptFile(chat.workspaceName, chat.id);
+    if (known !== chat.messages.length - 1 || !fs.existsSync(file)) {
+      this.rewriteTranscript(chat);
+      return;
+    }
+    const last = chat.messages[chat.messages.length - 1];
+    if (!last) return;
+    try {
+      fs.appendFileSync(file, `${this.transcriptLine(last)}\n`, 'utf8');
+      this.transcriptLines.set(chat.id, chat.messages.length);
+    } catch (err) {
+      log.warn(`ChatManager: transcript append failed for ${chat.id}: ${(err as Error).message}`);
+      this.transcriptLines.delete(chat.id);
+    }
   }
 
   private ensureLoaded(): void {
@@ -519,6 +594,9 @@ export class ChatManager {
     if (!chat) return;
     const file = this.chatFile(chat.workspaceName, chat.id);
     if (fs.existsSync(file)) fs.unlinkSync(file);
+    const transcript = this.transcriptFile(chat.workspaceName, chat.id);
+    if (fs.existsSync(transcript)) fs.unlinkSync(transcript);
+    this.transcriptLines.delete(chatId);
     const chatDir = path.join(this.workspacesRoot, chat.workspaceName, 'chats', chatId);
     if (fs.existsSync(chatDir)) {
       fs.rmSync(chatDir, { recursive: true, force: true });
@@ -538,6 +616,8 @@ export class ChatManager {
     chat.messages.splice(idx, 1);
     chat.updatedAt = Date.now();
     this.persist(chat);
+    // A mid-list removal breaks the append-only invariant — rebuild the sidecar.
+    this.rewriteTranscript(chat);
     return chat;
   }
 
@@ -551,6 +631,7 @@ export class ChatManager {
       chat.title = deriveTitle(message.content);
     }
     this.persist(chat);
+    this.appendTranscript(chat);
     this.maybeScheduleCompaction(chat);
     return chat;
   }
@@ -565,6 +646,11 @@ export class ChatManager {
     chat.messages[idx] = { ...chat.messages[idx], ...patch };
     chat.updatedAt = Date.now();
     this.persist(chat);
+    // Team stubs are appended empty and filled here, so the sidecar's copy of
+    // this line is stale whenever the patch carries new content or identity.
+    if (patch.content !== undefined || patch.agent !== undefined || patch.model !== undefined) {
+      this.rewriteTranscript(chat);
+    }
     return chat;
   }
 

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -29,7 +29,7 @@ import { resolveEffort } from './effort-resolve';
 import { PairingStore, ChannelBinding } from './pairings';
 import { summarizePriorHistory } from './summary';
 import { chatStreamEventForStatus, isPersistableToolCall } from './chat-status-events';
-import { buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildChatCatchupPrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
+import { CHAT_CONTEXT_WINDOW, buildChatPrompt, buildChatBootstrapPrompt, buildChatResumePrompt, buildChatCatchupPrompt, buildQuickQuestionPrompt, assistantPrefixForSelection, RunSemaphore, ChatStreamSink, READ_ONLY_TOOLS, QQStreamEvent, QQHistoryEntry, SOLO_ADVISOR_INSTRUCTION } from './chat-runner';
 import { TurnQueue, QueuedMessage, Surface } from './turn-queue';
 import { renderQuestion, renderCancelNotice, stripAskMarker } from './team-pause';
 import { resolveChoiceDigit } from './digit-mapping';
@@ -5820,7 +5820,8 @@ Example: /model gpt-4.1 write a Python script`;
     this.qqAborts.set(chatId, abortController);
 
     const started = Date.now();
-    const prompt = buildQuickQuestionPrompt(chat, qqHistory, question, attachments);
+    const prompt = buildQuickQuestionPrompt(chat, qqHistory, question, attachments, CHAT_CONTEXT_WINDOW,
+      { transcriptPath: this.chatManager.transcriptPath(chatId) });
 
     let streamedText = '';
     const onStream = (text: string) => {
@@ -6165,7 +6166,8 @@ Example: /model gpt-4.1 write a Python script`;
     } else {
       // Bootstrap turn: include prior history once. For claude-code, pre-allocate
       // a session id so we can resume on the next turn without parsing CLI output.
-      prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments);
+      prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments, CHAT_CONTEXT_WINDOW,
+        { transcriptPath: this.chatManager.transcriptPath(chatId) });
       if (canResume && agent === 'claude-code') {
         newSessionId = randomUUID();
       }
@@ -6358,7 +6360,8 @@ Example: /model gpt-4.1 write a Python script`;
           streamedText = '';
           resumeSessionId = undefined;
           newSessionId = canResume && agent === 'claude-code' ? randomUUID() : undefined;
-          prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments) + chatWorkspaceInstruction;
+          prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments, CHAT_CONTEXT_WINDOW,
+            { transcriptPath: this.chatManager.transcriptPath(chatId) }) + chatWorkspaceInstruction;
           // Re-apply the skill banner: the rebuilt bootstrap prompt replaced
           // the one that carried it (still exactly once per prompt build).
           if (appliedChatSkill) prompt = applySkill(prompt, appliedChatSkill);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -685,8 +685,6 @@ export class Codey {
     );
     this.logger = logger || Logger.getInstance();
     this.contextManager = new ContextManager({
-      maxTokenBudget: config.context?.maxTokenBudget ?? 12000,
-      maxTurns: config.context?.maxTurns ?? 30,
       ttlMs: (config.context?.ttlMinutes ?? 60) * 60 * 1000,
       persistDir: './workspaces',
     });

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, needsPolish, buildVoicePolishPrompt, sanitizePolished, DEFAULT_POLISH_TIMEOUT_MS, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType, unwiredAllProtocols } from '@codey/core';
+import { writeTranscriptSlice, TranscriptSlice, AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, needsPolish, buildVoicePolishPrompt, sanitizePolished, DEFAULT_POLISH_TIMEOUT_MS, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType, unwiredAllProtocols } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -607,6 +607,21 @@ export class Codey {
    * summary via the Aide, leaving a recent tail untouched so the next turn
    * still has fresh transcript to anchor on.
    */
+  /**
+   * History delivery for a chat turn: the sidecar path, plus a writer that
+   * cuts a line range out of it into a standalone file. Handing the agent a
+   * file that contains exactly the missing messages removes the two ways a
+   * line range goes wrong — reading too much, or miscounting the range.
+   */
+  private historyDelivery(chatId: string): { transcriptPath?: string; writeSlice?: (first: number, last: number) => TranscriptSlice | undefined } {
+    const transcriptPath = this.chatManager.transcriptPath(chatId);
+    if (!transcriptPath) return {};
+    return {
+      transcriptPath,
+      writeSlice: (first, last) => writeTranscriptSlice(transcriptPath, first, last),
+    };
+  }
+
   private async runChatCompaction(chat: Chat): Promise<ChatCompaction | null> {
     const KEEP_TAIL = 40;
     const already = chat.compaction?.summarizedUpTo ?? 0;
@@ -5819,7 +5834,7 @@ Example: /model gpt-4.1 write a Python script`;
 
     const started = Date.now();
     const prompt = buildQuickQuestionPrompt(chat, qqHistory, question, attachments, CHAT_CONTEXT_WINDOW,
-      { transcriptPath: this.chatManager.transcriptPath(chatId) });
+      this.historyDelivery(chatId));
 
     let streamedText = '';
     const onStream = (text: string) => {
@@ -6158,14 +6173,14 @@ Example: /model gpt-4.1 write a Python script`;
       // while it was inactive, replay only that unseen gap before the new turn.
       prompt = selPrefix + (warmAnchor.syncedThroughMessageId
         ? buildChatCatchupPrompt(chat, warmAnchor.syncedThroughMessageId, userText, attachments,
-            { transcriptPath: this.chatManager.transcriptPath(chatId) })
+            this.historyDelivery(chatId))
         : buildChatResumePrompt(chat, userText, attachments));
       resumeSessionId = warmAnchor.sessionId;
     } else {
       // Bootstrap turn: include prior history once. For claude-code, pre-allocate
       // a session id so we can resume on the next turn without parsing CLI output.
       prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments, CHAT_CONTEXT_WINDOW,
-        { transcriptPath: this.chatManager.transcriptPath(chatId) });
+        this.historyDelivery(chatId));
       if (canResume && agent === 'claude-code') {
         newSessionId = randomUUID();
       }
@@ -6359,7 +6374,7 @@ Example: /model gpt-4.1 write a Python script`;
           resumeSessionId = undefined;
           newSessionId = canResume && agent === 'claude-code' ? randomUUID() : undefined;
           prompt = selPrefix + buildChatBootstrapPrompt(chat, userText, attachments, CHAT_CONTEXT_WINDOW,
-            { transcriptPath: this.chatManager.transcriptPath(chatId) }) + chatWorkspaceInstruction;
+            this.historyDelivery(chatId)) + chatWorkspaceInstruction;
           // Re-apply the skill banner: the rebuilt bootstrap prompt replaced
           // the one that carried it (still exactly once per prompt build).
           if (appliedChatSkill) prompt = applySkill(prompt, appliedChatSkill);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -6158,7 +6158,8 @@ Example: /model gpt-4.1 write a Python script`;
       // Resume the agent's own session. If other agents produced messages
       // while it was inactive, replay only that unseen gap before the new turn.
       prompt = selPrefix + (warmAnchor.syncedThroughMessageId
-        ? buildChatCatchupPrompt(chat, warmAnchor.syncedThroughMessageId, userText, attachments)
+        ? buildChatCatchupPrompt(chat, warmAnchor.syncedThroughMessageId, userText, attachments,
+            { transcriptPath: this.chatManager.transcriptPath(chatId) })
         : buildChatResumePrompt(chat, userText, attachments));
       resumeSessionId = warmAnchor.sessionId;
     } else {

--- a/scripts/verify-gateway.ts
+++ b/scripts/verify-gateway.ts
@@ -37,8 +37,6 @@ async function run() {
     planner: { enabled: false },  // disable planner to skip LLM call
     memory: { enabled: false, autoExtract: false },
     context: {
-      maxTokenBudget: 12000,
-      maxTurns: 30,
       ttlMinutes: 60,
     },
   };


### PR DESCRIPTION
Stacked on #358 and #359 — it contains both, because the mechanism has to be one mechanism and splitting it across two open PRs would guarantee the two surfaces drift. If those land first, this PR shrinks to its own final commit on its own.

## Why

#358 and #359 replaced a bounded replay with a cursor: "read lines 48-260 of this file". That removes the prompt-size problem, but it leaves the agent three ways to get it wrong, all silent — read the whole file, miscount the range, or interpret the instruction differently across `claude` / `codex` / `opencode` / `pi`.

Codey already knows the exact range. So it now cuts that range out itself and hands over a small file whose entire contents are what the agent should see. Nothing is left to get wrong: the file *is* the range. Prompt cost is unchanged — one path either way — which means this is the inline replay again, delivered through the filesystem rather than argv, where `ARG_MAX` does not apply.

## What

**`transcript-slice.ts`** — one module both surfaces share. `writeTranscriptSlice(source, first, last)` reads the append-only sidecar, writes the range to `.slices/<name>.slice.jsonl` beside it, and returns the path plus a digest.

**An inline skeleton, for the case the file is ignored.** The slice only helps if the agent opens it, and whether it does is exactly what neither PR has verified on a real conversation. `buildSliceDigest` emits a bounded, deliberately lossy outline of the same messages — head and tail entries, each clipped to ~100 characters — which rides inline. A cold start that skips the file is then under-informed rather than blind. The two are complementary: the file removes "read the wrong amount", the skeleton removes "read nothing".

**Lifecycle by superseding and ageing, not by a cleanup hook.** A hook would have to fire on success, failure, timeout, abort and crash alike, and firing it early deletes a file the agent is still reading. Instead the slice is named after its source, so the next turn for that conversation overwrites it, and anything older than an hour is swept on the next write. A slice outliving its turn is harmless; deleting one mid-read is not.

**Graceful degradation.** When a slice cannot be written — unreadable sidecar, no writer injected — the previous line-range wording is still emitted. An unreadable sidecar costs precision, not the history.

The chat path injects the writer as a callback so the prompt builders keep no filesystem access; `ContextManager` calls the module directly.

## Verification

```
npm test -w @codey/core       -> 624 passed (44 files)
npm test -w @codey/gateway    -> 433 passed (44 files)
npx tsc --noEmit (both)       -> 0 errors
npm run lint                  -> pass
```

22 new tests: range extraction including clamping and inverted/empty ranges, superseding rather than accumulating, unreadable sources, digest numbering from the slice start line, middle-dropping, body truncation, malformed rows, the rendered section, the age sweep, and both chat surfaces end to end (bootstrap, catch-up, tail-stays-inline, fallback wording, byte saving).

Still not smoke-tested against a real long conversation — that remains the open question for all three PRs, and is exactly what the skeleton is insurance against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)