### PR TITLE
refactor(tmp): one scratch directory for Codey, swept, at ~/.codey/tmp

### DIFF
--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,11 +1,11 @@
 import { spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { AgentRequest, AgentResponse, AgentStateEntry } from '../types';
 import { BaseAgentAdapter } from './base';
 import { AgentSpawnError } from '../errors';
+import { codeyTmpFile } from '../codey-paths';
 import { ToolCallCollector } from './tool-events';
 import { ChecklistTracker, checklistFromCodexItem } from './checklist';
 import { codexMcpArgs } from './mcp-config';
@@ -120,8 +120,9 @@ export class CodexAdapter extends BaseAgentAdapter {
 
   async run(request: AgentRequest): Promise<AgentResponse> {
     return new Promise((resolve) => {
-      // Tempfile for `--output-last-message`. Cleaned up after the run.
-      const outFile = path.join(os.tmpdir(), `codex-out-${randomUUID()}.txt`);
+      // Tempfile for `--output-last-message`. Cleaned up after the run; the
+      // age sweep in `codeyTmpDir` covers the runs that are killed before that.
+      const outFile = codeyTmpFile(`codex-out-${randomUUID()}.txt`);
 
       const args = ['exec'];
       if (request.resumeSessionId) {

--- a/packages/core/src/agents/mcp-config.ts
+++ b/packages/core/src/agents/mcp-config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { McpServerSpec } from '../types';
+import { codeyTmpDir } from '../codey-paths';
 
 /**
  * Write a Claude Code MCP config file and return the CLI args referencing it.
@@ -12,7 +12,7 @@ import { McpServerSpec } from '../types';
 export function writeClaudeMcpConfig(
   servers: Record<string, McpServerSpec>,
 ): { args: string[]; cleanup: () => void } {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-mcp-'));
+  const dir = fs.mkdtempSync(path.join(codeyTmpDir(), 'mcp-'));
   const file = path.join(dir, 'mcp.json');
   const mcpServers: Record<string, unknown> = {};
   for (const [name, spec] of Object.entries(servers)) {
@@ -76,7 +76,7 @@ export function codexMcpArgs(servers: Record<string, McpServerSpec>): string[] {
 export function writeOpenCodeMcpConfig(
   servers: Record<string, McpServerSpec>,
 ): { env: Record<string, string>; cleanup: () => void } {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-mcp-'));
+  const dir = fs.mkdtempSync(path.join(codeyTmpDir(), 'mcp-'));
   const file = path.join(dir, 'opencode.json');
   const mcp: Record<string, unknown> = {};
   for (const [name, spec] of Object.entries(servers)) {

--- a/packages/core/src/codey-paths.test.ts
+++ b/packages/core/src/codey-paths.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { codeyHome, codeyTmpDir, codeyTmpFile, pruneCodeyTmp } from './codey-paths';
+
+describe('codey-paths', () => {
+  let home: string;
+  let previous: string | undefined;
+
+  beforeEach(() => {
+    previous = process.env.CODEY_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-paths-'));
+    process.env.CODEY_HOME = home;
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.CODEY_HOME;
+    else process.env.CODEY_HOME = previous;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('honours CODEY_HOME', () => {
+    expect(codeyHome()).toBe(home);
+  });
+
+  it('falls back to ~/.codey without the override', () => {
+    delete process.env.CODEY_HOME;
+    expect(codeyHome()).toBe(path.join(os.homedir(), '.codey'));
+  });
+
+  it('creates tmp/ on first use', () => {
+    const dir = codeyTmpDir();
+    expect(dir).toBe(path.join(home, 'tmp'));
+    expect(fs.statSync(dir).isDirectory()).toBe(true);
+  });
+
+  it('builds a file path inside tmp/', () => {
+    expect(codeyTmpFile('capture.wav')).toBe(path.join(home, 'tmp', 'capture.wav'));
+  });
+
+  it('sweeps files older than the cutoff and keeps fresh ones', () => {
+    const dir = codeyTmpDir();
+    const stale = path.join(dir, 'stale.txt');
+    const fresh = path.join(dir, 'fresh.txt');
+    fs.writeFileSync(stale, 'old');
+    fs.writeFileSync(fresh, 'new');
+    const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    fs.utimesSync(stale, twoDaysAgo, twoDaysAgo);
+
+    pruneCodeyTmp();
+
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  it('sweeps stale directories too — a killed spawn leaves its config dir behind', () => {
+    const dir = codeyTmpDir();
+    const stale = path.join(dir, 'mcp-abc123');
+    fs.mkdirSync(stale);
+    fs.writeFileSync(path.join(stale, 'mcp.json'), '{}');
+    const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    fs.utimesSync(stale, twoDaysAgo, twoDaysAgo);
+
+    pruneCodeyTmp();
+
+    expect(fs.existsSync(stale)).toBe(false);
+  });
+
+  it('keeps a directory that is still fresh', () => {
+    const dir = codeyTmpDir();
+    const fresh = path.join(dir, 'mcp-live');
+    fs.mkdirSync(fresh);
+
+    pruneCodeyTmp();
+
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  it('does not throw when tmp/ does not exist yet', () => {
+    expect(() => pruneCodeyTmp()).not.toThrow();
+  });
+});

--- a/packages/core/src/codey-paths.ts
+++ b/packages/core/src/codey-paths.ts
@@ -1,0 +1,82 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Where Codey keeps its own state on disk.
+ *
+ * `CODEY_HOME` overrides the location — the gateway honours the same variable,
+ * and the test setup points it at a temp dir so a suite can never write into a
+ * real `~/.codey`.
+ */
+export function codeyHome(): string {
+  return process.env.CODEY_HOME ?? path.join(os.homedir(), '.codey');
+}
+
+/** Files under `tmp/` older than this are deleted the next time it is opened. */
+export const CODEY_TMP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * `~/.codey/tmp` — scratch space for files that only matter until someone
+ * looks at them: an agent's `--output-last-message` handoff, a diagnostic
+ * capture, a generated config a CLI is about to read.
+ *
+ * Kept here rather than in `os.tmpdir()` so the files are findable when
+ * something goes wrong (the system temp dir is a haystack, and macOS puts it
+ * behind a per-boot random path). The trade is that nothing reaps it for us,
+ * hence the age sweep below.
+ *
+ * Creates the directory and sweeps entries older than
+ * `CODEY_TMP_MAX_AGE_MS`. Both are best effort: a full disk or a read-only
+ * home should not take down the caller, which is always in the middle of doing
+ * something more important than housekeeping.
+ *
+ * The sweep riding along here only runs when something asks for scratch space,
+ * so the gateway also calls `pruneCodeyTmp` once on startup — otherwise a user
+ * who stops using the agent that writes temp files keeps whatever was left.
+ */
+export function codeyTmpDir(): string {
+  const dir = path.join(codeyHome(), 'tmp');
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    pruneCodeyTmp();
+  } catch { /* best effort */ }
+  return dir;
+}
+
+/** Absolute path for a scratch file, with `tmp/` created and swept. */
+export function codeyTmpFile(name: string): string {
+  return path.join(codeyTmpDir(), name);
+}
+
+/**
+ * Delete stale entries in `~/.codey/tmp` — both files and directories.
+ *
+ * Directories count because the per-spawn MCP config dirs are directories, and
+ * a CLI killed before its `cleanup()` runs leaves one behind. Under
+ * `os.tmpdir()` the OS eventually reaped those; inside `~/.codey` nothing does,
+ * so the sweep has to. A directory here is a day-old scratch dir by
+ * construction — this path is only ever handed out by `codeyTmpDir`.
+ */
+export function pruneCodeyTmp(maxAgeMs: number = CODEY_TMP_MAX_AGE_MS): void {
+  const dir = path.join(codeyHome(), 'tmp');
+  const cutoff = Date.now() - maxAgeMs;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    try {
+      // A directory's own mtime only moves when its listing changes, which is
+      // exactly what "still in use" looks like for these — a spawn writes its
+      // config once and reads it for the life of the process. Long-running
+      // agents are the reason the cutoff is a day and not an hour.
+      if (fs.statSync(full).mtimeMs >= cutoff) continue;
+      if (entry.isDirectory()) fs.rmSync(full, { recursive: true, force: true });
+      else fs.unlinkSync(full);
+    } catch { /* raced with another process, or not ours to delete */ }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 // @codey/core — barrel export
 export * from './types';
+export * from './codey-paths';
 export * from './utils/format';
 export * from './utils/fs';
 export * from './utils/json';

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -18,6 +18,7 @@ import { TelegramHandler, DiscordHandler, IMessageHandler, TuiHandler, VoiceChan
 import { synthesizeSpeech } from './voice-tts';
 import { runTextCompletion, streamTextCompletion, canRunDirectly } from './text-completion';
 import { AgentFactory, isThinkingEffort } from '@codey/core';
+import { pruneCodeyTmp } from '@codey/core';
 import { Logger } from './logger';
 import { ContextManager, ContextWindow } from '@codey/core';
 import { MemoryStore } from '@codey/core';
@@ -1563,6 +1564,12 @@ export class Codey {
   async start(): Promise<void> {
     this.startTime = Date.now();
     this.logger.info('Starting Codey...');
+
+    // Sweep ~/.codey/tmp of day-old scratch files. The same sweep rides along
+    // with every temp-file write, but that only fires while something is
+    // actively writing — a leftover from a crashed run would otherwise sit
+    // there until the next one.
+    pruneCodeyTmp();
 
     // Load workspace and workers
     await this.workspaceManager.load();

--- a/voice/Sources/CodeyVoice/AudioCapture.swift
+++ b/voice/Sources/CodeyVoice/AudioCapture.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 import Foundation
 import QuartzCore  // CACurrentMediaTime
 
@@ -55,6 +56,11 @@ final class AudioCapture {
 
         let inputNode = engine.inputNode
         let inputFormat = inputNode.inputFormat(forBus: 0)
+        // Log which device we actually got. A dictation session that comes back
+        // empty is almost always the input having silently moved to another
+        // device (headset disconnect, a call app grabbing it), and the format
+        // line is the only place that shows up.
+        print("AudioCapture: input '\(Self.currentInputDeviceName())' \(inputFormat.sampleRate)Hz x\(inputFormat.channelCount)")
 
         // Install tap at device sample rate, we'll resample to 16 kHz
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
@@ -173,5 +179,31 @@ final class AudioCapture {
                 self?.stopRecording()
             }
         }
+    }
+
+    /// Human-readable name of the current default input device, for logs.
+    /// Falls back to "unknown" rather than throwing — this is diagnostics only.
+    static func currentInputDeviceName() -> String {
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID) == noErr else {
+            return "unknown"
+        }
+        var name: CFString = "" as CFString
+        var nameSize = UInt32(MemoryLayout<CFString>.size)
+        var nameAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        guard AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &name) == noErr else {
+            return "unknown"
+        }
+        return name as String
     }
 }


### PR DESCRIPTION
## Why

Codey's temp files were going to `os.tmpdir()` — on macOS a per-boot random path under `/var/folders` that nothing can find when a run goes wrong. This gives Codey one scratch directory it owns, next to the rest of its state.

## What

`packages/core/src/codey-paths.ts` — `codeyHome()`, `codeyTmpDir()`, `codeyTmpFile()`, `pruneCodeyTmp()`. `~/.codey/tmp` is created on demand and swept of entries older than a day; `CODEY_HOME` overrides the base, as everywhere else. Both temp-file writers in core move onto it: codex's `--output-last-message` handoff file, and the per-spawn MCP config dirs.

Moving in means owning the cleanup `os.tmpdir()` used to provide for free:

- **The sweep covers directories, not just files.** The MCP config dirs are directories, and an agent killed before its `cleanup()` runs leaves one behind. Under `/var/folders` the OS eventually reaped those; inside `~/.codey` nothing would. A directory's mtime only moves when its listing changes, which is exactly what "still in use" looks like for these (one config, written once and read for the life of the process) — so the cutoff is a day, not an hour.
- **The gateway sweeps once on startup.** The sweep otherwise only rides along with a temp-file write, so a user who stops using the agent that writes them would keep the leftovers indefinitely.

Also: `AudioCapture.startRecording` now logs the resolved input device and format (`AudioCapture: input 'MacBook Pro Microphone' 48000.0Hz x1`). A dictation turn that comes back empty is usually the input having silently moved to another device — a headset disconnecting, a call app taking the mic — and that never showed up anywhere. One line, no audio retained.

## Scope left out

The `os.tmpdir()` callers in `codey-mac/electron` (screenshots, browser download/profile dirs, the agent bridge socket) are untouched. The socket path in particular is length-sensitive and deserves its own look; happy to do them in a follow-up.

## Verification

- `npm test` green — 802 tests, including 8 new ones for `codey-paths`: stale file swept, fresh file kept, stale dir swept, fresh dir kept, missing dir does not throw, `CODEY_HOME` honoured and defaulted.
- `swift build -c release` clean.
- The device log line has not been seen on a live hotkey press yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)