### PR TITLE
polish(mac): say which required field is missing instead of greying Save

### DIFF
--- a/codey-mac/src/components/ApiKeysTab.tsx
+++ b/codey-mac/src/components/ApiKeysTab.tsx
@@ -30,11 +30,21 @@ const ApiRow: React.FC<{
   const [draft, setDraft] = useState<ApiKeyEntry>(entry)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  // Which required fields the user left blank. Greying the Save button out
+  // hid *which* field was missing, so name them instead and mark them red.
+  const [missing, setMissing] = useState<{ name: boolean; apiKey: boolean }>({ name: false, apiKey: false })
 
   useEffect(() => { if (!editing) setDraft(entry) }, [entry.name, editing])
 
   const save = async () => {
-    if (!draft.name.trim() || !draft.apiKey.trim()) return
+    const blank = { name: !draft.name.trim(), apiKey: !draft.apiKey.trim() }
+    if (blank.name || blank.apiKey) {
+      setMissing(blank)
+      const labels = [blank.name && 'Name', blank.apiKey && 'API Key'].filter(Boolean)
+      setErr(`${labels.join(' and ')} ${labels.length > 1 ? 'are' : 'is'} required.`)
+      return
+    }
+    setMissing({ name: false, apiKey: false })
     setBusy(true); setErr(null)
     try { await onSave(draft, entry.name); setEditing(false) }
     catch (e: any) { setErr(e?.message ?? String(e)) }
@@ -105,11 +115,15 @@ const ApiRow: React.FC<{
     }}>
       <div style={{ display: 'grid', gridTemplateColumns: '140px 1fr', gap: 8, alignItems: 'center' }}>
         <label style={{ color: C.fg3, fontSize: 12 }}>Name</label>
-        <input value={draft.name} onChange={e => setDraft({ ...draft, name: e.target.value })}
-          placeholder="e.g. my-proxy" style={{ ...inputStyle, width: '100%' }} />
+        <input value={draft.name}
+          onChange={e => { setDraft({ ...draft, name: e.target.value }); if (missing.name) { setMissing(m => ({ ...m, name: false })); setErr(null) } }}
+          placeholder="e.g. my-proxy"
+          style={{ ...inputStyle, width: '100%', ...(missing.name ? { border: `1px solid ${C.red}` } : null) }} />
         <label style={{ color: C.fg3, fontSize: 12 }}>API Key</label>
-        <input type="password" value={draft.apiKey} onChange={e => setDraft({ ...draft, apiKey: e.target.value })}
-          placeholder="API key" style={{ ...inputStyle, width: '100%' }} />
+        <input type="password" value={draft.apiKey}
+          onChange={e => { setDraft({ ...draft, apiKey: e.target.value }); if (missing.apiKey) { setMissing(m => ({ ...m, apiKey: false })); setErr(null) } }}
+          placeholder="API key"
+          style={{ ...inputStyle, width: '100%', ...(missing.apiKey ? { border: `1px solid ${C.red}` } : null) }} />
         {draft.purpose !== 'voice' && <>
           <label style={{ color: C.fg3, fontSize: 12 }}>Anthropic Base URL</label>
           <input value={draft.anthropicBaseUrl ?? ''} onChange={e => setDraft({ ...draft, anthropicBaseUrl: e.target.value || undefined })}
@@ -121,8 +135,8 @@ const ApiRow: React.FC<{
       </div>
       {err && <div style={{ color: C.red, fontSize: 12, marginTop: 8 }}>{err}</div>}
       <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'flex-end' }}>
-        <button onClick={() => { setEditing(false); setDraft(entry); setErr(null); onCancel?.() }} style={pillButton('ghost')} disabled={busy}>Cancel</button>
-        <button onClick={save} style={pillButton('primary')} disabled={busy || !draft.name.trim() || !draft.apiKey.trim()}>
+        <button onClick={() => { setEditing(false); setDraft(entry); setErr(null); setMissing({ name: false, apiKey: false }); onCancel?.() }} style={pillButton('ghost')} disabled={busy}>Cancel</button>
+        <button onClick={save} style={pillButton('primary')} disabled={busy}>
           {busy ? 'Saving…' : 'Save'}
         </button>
       </div>

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -26,6 +26,9 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
+  // True once the user tried to save with an empty name. Greying the button
+  // out hid what was missing, so say it and mark the field instead.
+  const [nameMissing, setNameMissing] = useState(false)
 
   const refresh = useCallback(async () => {
     // A stale preload (app not restarted since the profiles bridge was added)
@@ -66,7 +69,12 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
 
   const saveCurrent = () => {
     const trimmed = name.trim()
-    if (!trimmed) return
+    if (!trimmed) {
+      setNameMissing(true)
+      setError('Give the profile a name first — type one in the field on the left.')
+      return
+    }
+    setNameMissing(false)
     setName('')
     void run(() => window.codey.browser.profiles.save(trimmed))
   }
@@ -103,19 +111,20 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
       <div style={compact ? styles.compactComposer : styles.composer}>
         <input
           value={name}
-          onChange={event => setName(event.target.value)}
+          onChange={event => { setName(event.target.value); if (nameMissing) { setNameMissing(false); setError(null) } }}
           onKeyDown={event => { if (event.key === 'Enter') saveCurrent() }}
           placeholder="Profile name"
           aria-label="New profile name"
           spellCheck={false}
           style={{
-            flex: '1 1 260px', minWidth: 0, background: C.surface2, border: `1px solid ${C.border2}`, color: C.fg,
+            flex: '1 1 260px', minWidth: 0, background: C.surface2,
+            border: `1px solid ${nameMissing ? C.red : C.border2}`, color: C.fg,
             borderRadius: 8, padding: '7px 10px', fontSize: compact ? 12 : 13, outline: 'none',
           }}
         />
         <button
           type="button"
-          disabled={busy || !name.trim()}
+          disabled={busy}
           onClick={saveCurrent}
           style={buttonStyle(compact)}
           title="Snapshot the current session into a profile"


### PR DESCRIPTION
## What

Two places in the Mac app disabled their save button while a required field was empty, with no explanation of *which* field was missing:

- **Browser profiles** — "Save current session" greyed out until a profile name was typed.
- **API keys** — "Save" greyed out until both Name and API Key were filled.

The user hits a dead button and has to guess.

## Change

Keep the buttons clickable; validate on click instead.

- Browser profiles: empty name → red strip "Give the profile a name first…" + red border on the name input.
- API keys: names the blank field(s) — "Name is required." / "Name and API Key are required." — and outlines each blank input in red.
- Typing in a flagged field clears its error; Cancel resets the API-key editor's state.

Base URLs stay optional in both.

## Testing

`npm test -w codey-mac` — 792 tests pass. Not smoke-tested in the running app yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)