### PR TITLE
chore: bump version to 0.12.12

### DIFF
--- a/codey-mac/package-lock.json
+++ b/codey-mac/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-mac",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-mac",
-      "version": "0.12.11",
+      "version": "0.12.12",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.12.11",
+      "version": "0.12.12",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -23,7 +23,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.12.11",
+      "version": "0.12.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11743,7 +11743,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.12.11",
+      "version": "0.12.12",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -11755,7 +11755,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.12.11",
+      "version": "0.12.12",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.12.11",
+  "version": "0.12.12",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codey/core",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codey/core",
-      "version": "0.12.11",
+      "version": "0.12.12",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps all workspaces from 0.12.11 to 0.12.12.

- `package.json` + `package-lock.json`
- `packages/core`, `packages/gateway`
- `codey-mac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)