### PR TITLE
polish(mac): square corners on the selected-turn highlight

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -2441,7 +2441,9 @@ export const ChatTab: React.FC<Props> = ({
                 // The rail is always present, transparent when unselected, so
                 // selecting a turn never shifts the text column sideways.
                 borderLeft: `${TURN_RAIL_WIDTH}px solid ${isSelected ? C.accent : 'transparent'}`,
-                borderRadius: 10,
+                // Square corners: the highlight reads as a marked-up block of a
+                // document, not a chat bubble. Only the user's message is a bubble.
+                borderRadius: 0,
                 background: isSelected ? C.accentDim : 'transparent',
                 // Same treatment the rest of the app gives an active card
                 // (teamStepCardActive, teamRoundTableMemberActive): a tint plus a


### PR DESCRIPTION
## What

The selected assistant turn's highlight used `borderRadius: 10`. Squared it to `0`.

## Why

A rounded highlight reads as a second chat bubble, competing with the user's actual bubble. The bubble shape should mean "what the user said"; an assistant reply is a document, so its selection should read as a marked-up block, not a bubble.

The accent rail on the left and the 1px ring are unchanged, so the selection is still obvious. User messages keep their rounded bubble.

## Test

`npx tsc --noEmit` clean. Visual change only — not yet eyeballed in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)