### PR TITLE
fix(mac): keep browser dock inside chat area

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -48,6 +48,7 @@ import cursorLogo from '../assets/editors/cursor.svg'
 import xcodeLogo from '../assets/editors/xcode.svg'
 import type { BrowserLoginWaitEvent } from '../codey-api'
 import { WorkspaceDock, type WorkspaceDockTool } from './WorkspaceDock'
+import { resolveWorkspaceDockLayout } from './workspaceDockLayout'
 import { TerminalPanel } from './TerminalPanel'
 import { splitWhiteboardMarkers, type WhiteboardMarker } from './teamWhiteboardFormat'
 import { groupTeamMessagesByMember, type TeamMemberMessageGroup } from './teamRunModel'
@@ -901,6 +902,7 @@ export const ChatTab: React.FC<Props> = ({
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
 }) => {
+  const outerRef = useRef<HTMLDivElement>(null)
   const { state, createChat, sendMessage, removeQueuedMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
@@ -1417,10 +1419,23 @@ export const ChatTab: React.FC<Props> = ({
   // the user resizes Codey down — at small widths the middle column was
   // collapsing to ~200px and wrapping CJK characters one per line.
   const [windowWidth, setWindowWidth] = useState<number>(() => window.innerWidth)
+  // Start closed rather than borrowing the full window width for one frame.
+  // A native BrowserView can otherwise flash across the sidebar before the
+  // first ResizeObserver measurement arrives.
+  const [containerWidth, setContainerWidth] = useState(0)
   useEffect(() => {
     const onResize = () => setWindowWidth(window.innerWidth)
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
+  }, [])
+  useLayoutEffect(() => {
+    const outer = outerRef.current
+    if (!outer) return
+    const updateWidth = () => setContainerWidth(Math.round(outer.getBoundingClientRect().width))
+    const observer = new ResizeObserver(updateWidth)
+    observer.observe(outer)
+    updateWidth()
+    return () => observer.disconnect()
   }, [])
   useEffect(() => {
     setFollowLatest(true)
@@ -2082,7 +2097,7 @@ export const ChatTab: React.FC<Props> = ({
   }, [panelTeamName])
 
   return (
-    <div style={styles.outer}>
+    <div ref={outerRef} style={styles.outer}>
       <div
         style={styles.container}
         onDragEnter={handleDragEnter}
@@ -3118,18 +3133,11 @@ export const ChatTab: React.FC<Props> = ({
       )}
       </div>
       {/* Overview, Terminal, and Browser share this single right panel. On a
-          narrow window it overlays the chat so the conversation remains usable. */}
+          narrow chat area it overlays the conversation, but remains bounded by
+          this component so the native BrowserView cannot cover the app sidebar. */}
       {(() => {
-        const CHAT_LIST_W = windowWidth < 600 ? 180 : 240
-        const MIN_MIDDLE = 360
-
         if (panelOpen && resolvedRightPanelMode) {
-          const MIN_PANEL = 320
-          const available = windowWidth - CHAT_LIST_W - MIN_MIDDLE
-          const overlay = available < MIN_PANEL
-          const effectiveWidth = overlay
-            ? Math.min(rightPanelWidth, Math.max(MIN_PANEL, windowWidth - 72))
-            : Math.min(rightPanelWidth, available)
+          const { overlay, width: effectiveWidth } = resolveWorkspaceDockLayout(containerWidth, rightPanelWidth)
           const overview = (
             <ChatContextPanel
               chat={chat}

--- a/codey-mac/src/components/WorkspaceDock.tsx
+++ b/codey-mac/src/components/WorkspaceDock.tsx
@@ -114,7 +114,7 @@ const ToolButton: React.FC<{
 
 const styles: Record<string, React.CSSProperties> = {
   root: {
-    position: 'relative', height: '100%', minWidth: 320, flexShrink: 0,
+    position: 'relative', height: '100%', minWidth: 0, flexShrink: 0,
     display: 'flex', flexDirection: 'column', overflow: 'hidden',
     background: C.surface, borderLeft: `1px solid ${C.border2}`,
   },

--- a/codey-mac/src/components/workspaceDockLayout.test.ts
+++ b/codey-mac/src/components/workspaceDockLayout.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorkspaceDockLayout } from './workspaceDockLayout'
+
+describe('resolveWorkspaceDockLayout', () => {
+  it('uses the width beside the chat when both columns fit', () => {
+    expect(resolveWorkspaceDockLayout(729, 620)).toEqual({ overlay: false, width: 369 })
+  })
+
+  it('keeps an overlay inside its actual chat container', () => {
+    expect(resolveWorkspaceDockLayout(600, 620)).toEqual({ overlay: true, width: 528 })
+  })
+
+  it('can shrink below the normal dock minimum without crossing the sidebar', () => {
+    expect(resolveWorkspaceDockLayout(300, 620)).toEqual({ overlay: true, width: 228 })
+  })
+
+  it('never returns a negative width', () => {
+    expect(resolveWorkspaceDockLayout(50, 620)).toEqual({ overlay: true, width: 0 })
+  })
+})

--- a/codey-mac/src/components/workspaceDockLayout.ts
+++ b/codey-mac/src/components/workspaceDockLayout.ts
@@ -1,0 +1,32 @@
+export interface WorkspaceDockLayout {
+  overlay: boolean
+  width: number
+}
+
+const MIN_MIDDLE_WIDTH = 360
+const MIN_DOCK_WIDTH = 320
+const OVERLAY_REVEAL_WIDTH = 72
+
+/**
+ * Size the workspace dock against the space it actually lives in. Using the
+ * Electron window width here lets an overlay extend behind the app sidebar;
+ * that is especially visible for the native BrowserView, which is composited
+ * above normal DOM content and cannot be clipped with z-index.
+ */
+export function resolveWorkspaceDockLayout(
+  containerWidth: number,
+  preferredWidth: number,
+): WorkspaceDockLayout {
+  const safeContainerWidth = Math.max(0, containerWidth)
+  const safePreferredWidth = Math.max(0, preferredWidth)
+  const availableBesideChat = safeContainerWidth - MIN_MIDDLE_WIDTH
+  const overlay = availableBesideChat < MIN_DOCK_WIDTH
+  const widthLimit = overlay
+    ? Math.max(0, safeContainerWidth - OVERLAY_REVEAL_WIDTH)
+    : availableBesideChat
+
+  return {
+    overlay,
+    width: Math.min(safePreferredWidth, widthLimit),
+  }
+}


### PR DESCRIPTION
## Summary

- size the workspace dock from the actual chat container instead of the full Electron window
- keep the native BrowserView from covering the app sidebar at narrow widths
- allow the dock to shrink below its previous 320px minimum and add focused layout tests

## Verification

- `npm test -- --run src/components/workspaceDockLayout.test.ts`
- `npx tsc --noEmit`