### PR TITLE
feat(mac): mention skills, plugins and MCP servers with "@"

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -32,9 +32,12 @@ import { getDraft, setDraft, subscribeDrafts } from './chatDrafts'
 import { isBottomTerminalOpen, setBottomTerminalOpen as rememberBottomTerminalOpen } from './terminalVisibility'
 import { AGENT_API_TYPE, AGENT_NAMES, ApiType, modelFitsApiType } from './modelApiType'
 import { useInstalledAgents } from './installedAgents'
-import { applyMention, filterEntries, findActiveMention, splitMentionSegments } from './mentions'
+import {
+  appendMentionContext, applyMention, filterEntries, findActiveMention, findResourceMentions,
+  resourceEntry, splitMentionSegments,
+} from './mentions'
 import { ChatFindBar } from './ChatFindBar'
-import type { ActiveMention, MentionFile } from './mentions'
+import type { ActiveMention, MentionEntry, MentionFile } from './mentions'
 import { clampFloatingLeft, floatingViewportRight } from './floatingLayer'
 import { useGitStatus } from '../hooks/useGitStatus'
 import { BranchPicker } from './BranchPicker'
@@ -944,6 +947,9 @@ export const ChatTab: React.FC<Props> = ({
   // "@" file mentions: the workspace index, the token the caret is inside, and
   // the highlighted row in the menu.
   const [fileIndex, setFileIndex] = useState<MentionFile[]>([])
+  // Installed skills/plugins/MCP servers, offered by the same "@" menu under a
+  // `skill:` / `plugin:` / `mcp:` prefix.
+  const [resourceIndex, setResourceIndex] = useState<MentionEntry[]>([])
   const [mention, setMention] = useState<ActiveMention | null>(null)
   const [mentionIdx, setMentionIdx] = useState(0)
   const [workers, setWorkers] = useState<WorkerDto[]>([])
@@ -1626,6 +1632,55 @@ export const ChatTab: React.FC<Props> = ({
     return () => { stale = true }
   }, [mention !== null, workingDir]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Skills/plugins/MCP servers, loaded on the same lazy trigger as the file
+  // index. All three lists are small and already cached in the main process,
+  // so one fetch per opened mention is cheap.
+  useEffect(() => {
+    if (!mention) return
+    let stale = false
+    void (async () => {
+      const [skills, plugins, mcp, agentMcp] = await Promise.all([
+        window.codey.skills.list(effectiveAgent, workingDir ?? undefined),
+        window.codey.plugins.list(),
+        window.codey.mcp.list(),
+        window.codey.mcp.listAgent(),
+      ])
+      if (stale) return
+      const entries: MentionEntry[] = []
+      if (skills.ok) {
+        for (const skill of skills.data.skills) {
+          if (!skill.enabled) continue
+          entries.push(resourceEntry('skill', skill.qualifiedName || skill.name, skill.description))
+        }
+      }
+      if (plugins.ok) {
+        for (const plugin of plugins.data) {
+          if (plugin.state !== 'installed') continue
+          entries.push(resourceEntry('plugin', plugin.id, plugin.description))
+        }
+      }
+      // A server the user thinks of by name may be configured in Codey or
+      // straight in the agent; both are offered, Codey's wins on a name clash.
+      const seenMcp = new Set<string>()
+      if (mcp.ok) {
+        for (const server of mcp.data) {
+          if (!server.enabled || seenMcp.has(server.name)) continue
+          seenMcp.add(server.name)
+          entries.push(resourceEntry('mcp', server.name, server.url ?? server.command ?? server.transport))
+        }
+      }
+      if (agentMcp.ok) {
+        for (const server of agentMcp.data) {
+          if (!server.enabled || seenMcp.has(server.name)) continue
+          seenMcp.add(server.name)
+          entries.push(resourceEntry('mcp', server.name, `${server.agent} · ${server.url ?? server.command ?? server.transport}`))
+        }
+      }
+      setResourceIndex(entries)
+    })()
+    return () => { stale = true }
+  }, [mention !== null, effectiveAgent, workingDir]) // eslint-disable-line react-hooks/exhaustive-deps
+
   // A chat can be rebound to a different worktree while mounted; the old
   // repo's paths must not linger in the menu.
   useEffect(() => { setFileIndex([]) }, [workingDir])
@@ -1633,8 +1688,8 @@ export const ChatTab: React.FC<Props> = ({
   // Scoring touches every indexed entry, so keep it tied to the query rather
   // than to render count — this component re-renders on every streamed token.
   const mentionMatches = React.useMemo(
-    () => (mention ? filterEntries(fileIndex, mention.query) : []),
-    [mention?.query, fileIndex], // eslint-disable-line react-hooks/exhaustive-deps
+    () => (mention ? filterEntries([...resourceIndex, ...fileIndex], mention.query) : []),
+    [mention?.query, fileIndex, resourceIndex], // eslint-disable-line react-hooks/exhaustive-deps
   )
   const showMentionMenu = mentionMatches.length > 0
   useEffect(() => { setMentionIdx(0) }, [mention?.query, mention?.start])
@@ -1654,13 +1709,17 @@ export const ChatTab: React.FC<Props> = ({
   // caret event, so close the menu whenever the composer empties out.
   useEffect(() => { if (!input) setMention(null) }, [input])
 
-  const knownPaths = React.useMemo(() => new Set(fileIndex.map(e => e.path)), [fileIndex])
+  const mentionByPath = React.useMemo(
+    () => new Map<string, MentionEntry>([...fileIndex, ...resourceIndex].map(e => [e.path, e])),
+    [fileIndex, resourceIndex],
+  )
+  const knownPaths = React.useMemo(() => new Set(mentionByPath.keys()), [mentionByPath])
   const inputSegments = React.useMemo(
     () => splitMentionSegments(input, p => knownPaths.has(p)),
     [input, knownPaths],
   )
 
-  const chooseMention = (entry: MentionFile) => {
+  const chooseMention = (entry: MentionEntry) => {
     if (!mention) return
     const next = applyMention(input, mention, entry.path, entry.isDir)
     setInputHistoryIndex(null)
@@ -1835,12 +1894,16 @@ export const ChatTab: React.FC<Props> = ({
       return
     }
 
-    const text = input
+    // "@skill:x" means nothing to an agent on its own, so the referenced
+    // capabilities are spelled out at the end of the prompt. Nothing is
+    // enabled or configured — it is a hint the agent may ignore.
+    const typed = input
+    const text = appendMentionContext(typed, findResourceMentions(typed, p => mentionByPath.get(p)))
     const dictated = dictatedPendingRef.current
     dictatedPendingRef.current = []
     // Fire-and-forget: a dictionary update must never delay or fail the send.
     for (const spoken of dictated) {
-      void window.codey.voice.learnVocabulary(spoken, text)
+      void window.codey.voice.learnVocabulary(spoken, typed)
         .then(res => {
           if (!res.ok || res.data.learned.length === 0) return
           setLearnedWords(prev => [...prev, ...res.data.learned])
@@ -2784,10 +2847,13 @@ export const ChatTab: React.FC<Props> = ({
                 onMouseEnter={() => setMentionIdx(i)}
               >
                 <span style={styles.mentionIcon}>
-                  {entry.isDir ? <FolderIcon color={C.fg3} size={13} /> : <FileIcon color={C.fg3} size={13} />}
+                  {entry.kind === 'skill' ? <UIIcon name="sparkle" size={13} color={C.fg3} />
+                    : entry.kind === 'plugin' ? <UIIcon name="tools" size={13} color={C.fg3} />
+                    : entry.kind === 'mcp' ? <UIIcon name="server" size={13} color={C.fg3} />
+                    : entry.isDir ? <FolderIcon color={C.fg3} size={13} /> : <FileIcon color={C.fg3} size={13} />}
                 </span>
                 <span style={styles.slashCmdName}>{entry.name}{entry.isDir ? '/' : ''}</span>
-                <span style={styles.slashCmdDesc}>{entry.path}</span>
+                <span style={styles.slashCmdDesc}>{entry.detail || entry.path}</span>
               </div>
             ))}
           </div>

--- a/codey-mac/src/components/mentions.test.ts
+++ b/codey-mac/src/components/mentions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { applyMention, filterEntries, findActiveMention, scoreEntry, splitMentionSegments } from './mentions'
+import {
+  appendMentionContext, applyMention, filterEntries, findActiveMention, findResourceMentions,
+  mentionKindOf, resourceEntry, scoreEntry, splitMentionSegments,
+} from './mentions'
 
 /** Mirror of the main-process index shape: files plus their ancestor dirs. */
 const toEntries = (paths: string[]) => {
@@ -196,5 +199,61 @@ describe('filterEntries', () => {
 
   it('supports a path fragment containing a slash', () => {
     expect(filterEntries(entries, 'components/chatl')[0].path).toBe('src/components/ChatListPanel.tsx')
+  })
+})
+
+describe('resource mentions', () => {
+  const skill = resourceEntry('skill', 'browser', 'Use when a task needs the live web')
+  const plugin = resourceEntry('plugin', 'chrome-companion', 'Drive the real Chrome')
+  const mcp = resourceEntry('mcp', 'figma', 'remote')
+  const resources = [skill, plugin, mcp]
+
+  it('namespaces the token so it cannot collide with a path', () => {
+    expect(skill.path).toBe('skill:browser')
+    expect(mentionKindOf('skill:browser')).toBe('skill')
+    expect(mentionKindOf('src/app.ts')).toBe('file')
+  })
+
+  it('ranks a resource by its bare name', () => {
+    expect(filterEntries(resources, 'browser')[0]).toBe(skill)
+  })
+
+  it('lists every resource of a kind when the prefix is typed', () => {
+    const files = toEntries(['src/skillet.ts'])
+    const matches = filterEntries([...files, ...resources], 'skill:')
+    expect(matches[0]).toBe(skill)
+  })
+
+  it('inserts a resource token with a trailing space', () => {
+    const mention = { start: 0, end: 4, query: 'bro' }
+    expect(applyMention('@bro', mention, skill.path)).toEqual({ text: '@skill:browser ', caret: 15 })
+  })
+
+  it('highlights a resolved resource token', () => {
+    const known = new Set(resources.map(r => r.path))
+    expect(splitMentionSegments('use @skill:browser now', p => known.has(p))).toEqual([
+      { text: 'use ', isMention: false },
+      { text: '@skill:browser', isMention: true },
+      { text: ' now', isMention: false },
+    ])
+  })
+
+  it('collects resource mentions in order, deduped, ignoring files', () => {
+    const byPath = new Map(resources.map(r => [r.path, r]))
+    byPath.set('src/app.ts', { path: 'src/app.ts', name: 'app.ts', isDir: false })
+    const found = findResourceMentions('@skill:browser @src/app.ts @mcp:figma @skill:browser', p => byPath.get(p))
+    expect(found.map(f => f.path)).toEqual(['skill:browser', 'mcp:figma'])
+  })
+
+  it('appends a hint block naming the referenced capabilities', () => {
+    expect(appendMentionContext('do the thing @skill:browser', [skill])).toBe(
+      'do the thing @skill:browser\n\n[Referenced by the user — use these if they fit the task]\n'
+      + '- skill "browser": Use when a task needs the live web',
+    )
+  })
+
+  it('labels an MCP server readably and leaves plain text untouched', () => {
+    expect(appendMentionContext('hi', [mcp])).toContain('- MCP server "figma": remote')
+    expect(appendMentionContext('hi', [])).toBe('hi')
   })
 })

--- a/codey-mac/src/components/mentions.ts
+++ b/codey-mac/src/components/mentions.ts
@@ -7,6 +7,39 @@
 /** One indexed workspace path, as returned by the `workspace:files` IPC. */
 export type MentionFile = { path: string; name: string; isDir: boolean }
 
+/**
+ * What a menu row refers to. Files are paths in the workspace; the other three
+ * are capabilities the user already has installed, referenced by a namespaced
+ * token (`skill:browser`) so one flat matcher can rank them all.
+ */
+export type MentionKind = 'file' | 'skill' | 'plugin' | 'mcp'
+
+/**
+ * A row in the "@" menu. `path` is the match key and the text inserted after
+ * the "@" — for resources it is `<kind>:<name>`, which never collides with a
+ * workspace-relative path because those never start with a bare `kind:`.
+ */
+export type MentionEntry = MentionFile & {
+  /** Absent means 'file', so the existing file index needs no rewriting. */
+  kind?: MentionKind
+  /** One-line detail shown on the right of the row (a skill description...). */
+  detail?: string
+}
+
+/** The namespace prefixes, in the order the menu groups them. */
+export const RESOURCE_KINDS: Exclude<MentionKind, 'file'>[] = ['skill', 'plugin', 'mcp']
+
+/** Build a menu row for an installed capability. */
+export function resourceEntry(kind: Exclude<MentionKind, 'file'>, name: string, detail = ''): MentionEntry {
+  return { path: `${kind}:${name}`, name, isDir: false, kind, detail }
+}
+
+/** The kind a resolved token belongs to, or 'file'. */
+export function mentionKindOf(path: string): MentionKind {
+  for (const kind of RESOURCE_KINDS) if (path.startsWith(`${kind}:`)) return kind
+  return 'file'
+}
+
 export type ActiveMention = {
   /** Index of the "@" in the input. */
   start: number
@@ -81,7 +114,7 @@ function subsequenceIndex(haystack: string, needle: string): number {
  * Ordering intent: exact name > name prefix > name substring > path substring >
  * scattered subsequence, with shallower and shorter paths breaking ties.
  */
-export function scoreEntry(entry: MentionFile, query: string): number | null {
+export function scoreEntry(entry: MentionEntry, query: string): number | null {
   if (!query) return 0
   const q = query.toLowerCase()
   const name = entry.name.toLowerCase()
@@ -101,8 +134,8 @@ export function scoreEntry(entry: MentionFile, query: string): number | null {
 }
 
 /** Best `limit` entries for `query`, already ordered for display. */
-export function filterEntries(entries: MentionFile[], query: string, limit = 12): MentionFile[] {
-  const scored: Array<{ entry: MentionFile; score: number }> = []
+export function filterEntries(entries: MentionEntry[], query: string, limit = 12): MentionEntry[] {
+  const scored: Array<{ entry: MentionEntry; score: number }> = []
   for (const entry of entries) {
     const score = scoreEntry(entry, query)
     if (score === null) continue
@@ -139,4 +172,47 @@ export function splitMentionSegments(text: string, isKnownPath: (path: string) =
 
   if (plainFrom < text.length) segments.push({ text: text.slice(plainFrom), isMention: false })
   return segments
+}
+
+/** Every resolved token in `text` that names a capability, in order, deduped. */
+export function findResourceMentions(
+  text: string,
+  resolve: (path: string) => MentionEntry | undefined,
+): MentionEntry[] {
+  const found: MentionEntry[] = []
+  const seen = new Set<string>()
+
+  MENTION_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = MENTION_RE.exec(text)) !== null) {
+    const raw = match[2].startsWith('"') ? match[2].slice(1, -1) : match[2]
+    const path = raw.endsWith('/') ? raw.slice(0, -1) : raw
+    if (!path || seen.has(path)) continue
+    const entry = resolve(path)
+    if (!entry || !entry.kind || entry.kind === 'file') continue
+    seen.add(path)
+    found.push(entry)
+  }
+  return found
+}
+
+const KIND_LABEL: Record<Exclude<MentionKind, 'file'>, string> = {
+  skill: 'skill',
+  plugin: 'plugin',
+  mcp: 'MCP server',
+}
+
+/**
+ * Append a short block naming the referenced capabilities. Agents do not know
+ * what `@skill:foo` means on its own, so the message carries the name and the
+ * one-line description with it. Nothing is enabled or configured — this is a
+ * hint in the prompt, and an agent is free to ignore it.
+ */
+export function appendMentionContext(text: string, entries: MentionEntry[]): string {
+  if (entries.length === 0) return text
+  const lines = entries.map(e => {
+    const label = KIND_LABEL[(e.kind ?? 'skill') as Exclude<MentionKind, 'file'>]
+    return `- ${label} "${e.name}"${e.detail ? `: ${e.detail}` : ''}`
+  })
+  return `${text.trimEnd()}\n\n[Referenced by the user — use these if they fit the task]\n${lines.join('\n')}`
 }


### PR DESCRIPTION
## What

The `@` menu in the composer only knew workspace paths. Skills, plugins and MCP servers are the other things a user points an agent at, and reaching for one meant leaving the composer to go remember its exact name.

They now share the same menu under a namespaced token:

- `@skill:browser`
- `@plugin:chrome-companion`
- `@mcp:figma`

One matcher ranks all four kinds, so typing `@skill` lists the skills and typing a bare name still finds it. The existing highlight pill and the quoting/caret rules work on the new tokens unchanged, because the token *is* the match key.

MCP servers configured inside a coding agent's own config are offered next to Codey's own (Codey wins a name clash) — the user thinks of "the figma MCP" by name, not by where it happens to be configured.

## What it does on send

`@skill:browser` means nothing to an agent on its own, so the send path appends the referenced names and their one-line descriptions:

```
[Referenced by the user — use these if they fit the task]
- skill "browser": Use when a task needs the live web
```

Nothing is enabled, installed, or written to config. This is deliberate: MCP/plugin enablement is global state, and flipping it for one message means owning "when does it flip back". A prompt hint costs nothing when the user mis-types a mention.

## Testing

- `npx vitest run` in `codey-mac` — 80 files / 814 tests pass, 8 of them new (`mentions.test.ts`)
- `npx tsc --noEmit` clean
- `npm run lint` clean

Not yet exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)