### PR TITLE
feat(chrome): make the Codey-controlled tab obvious

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 3,
   "name": "Codey",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1+DxZ4LtqCNXKrmvuwl2d6perIWziIQWgkBVn5RbieIAF7g8knl39m3UOq/BZuSHp2VS1CQtk1EfwTzK0pnjdzikr00O+7iee4lVf8oduovxxi83CzRsZxzEreb3Jht3qfZcw3P94FwYk4wZM3YoRGJF99fWJQy/ybMvmIFSeFAHn9/3m56Xe5j0vCPSkmST1zLVuypW2DB23KojXxx4cKd9i+qcKnvfCEFwydjHRDpL4eUqk1nTU/NDlu3p0Fy5XQhvC6s98JBXXBEtD31l6oUq+wE1ap3yi1l3aK4I07bgWSdJSokwMZOJz22owdzaYra/c8loiVnx4efajwNbWwIDAQAB",
   "description": "Securely connects your existing Chrome tabs and signed-in sites to Codey.",
-  "permissions": ["alarms", "cookies", "offscreen", "scripting", "sidePanel", "storage", "tabs"],
+  "permissions": ["alarms", "cookies", "offscreen", "scripting", "sidePanel", "storage", "tabGroups", "tabs"],
   "host_permissions": ["http://127.0.0.1/*", "http://*/*", "https://*/*"],
   "background": {
     "service_worker": "service-worker.js"

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -5,8 +5,31 @@ const POLL_ALARM = 'codey-companion-poll'
 const CONTROLLED_TAB_KEY = 'controlledTabId'
 const CONTROLLED_TITLE_PREFIX = '● Codey · '
 const OFFSCREEN_DOCUMENT = 'offscreen.html'
+const CONTROLLED_GROUP_TITLE = 'Codey'
+const ACCENT_KEY = 'accent'
+// Toolbar badge: a green chip with a white check, independent of the accent so
+// "Codey is driving this tab" always reads as an OK signal.
+const BADGE_TEXT = '\u2713'
+const BADGE_BG = '#1e8e3e'
+const BADGE_FG = '#ffffff'
+const DEFAULT_ACCENT = '#3377d5'
+// Chrome only accepts these nine names for a tab group, so the Mac app's accent
+// hex is snapped to whichever one sits closest in RGB space.
+const GROUP_COLORS = {
+  grey: [95, 99, 104],
+  blue: [26, 115, 232],
+  red: [217, 48, 37],
+  yellow: [249, 171, 0],
+  green: [30, 142, 62],
+  pink: [208, 24, 132],
+  purple: [147, 52, 230],
+  cyan: [0, 123, 131],
+  orange: [250, 144, 62],
+}
 let polling = false
 let controlledTabId = null
+let controlledGroupId = null
+let accent = DEFAULT_ACCENT
 let creatingOffscreenDocument = null
 let voicePort = null
 let voiceRequestId = 0
@@ -126,6 +149,46 @@ async function autoConnect() {
   throw new Error('Codey is not running or the Chrome Companion bridge is unavailable')
 }
 
+function rgbOf(hex) {
+  const value = /^#?([0-9a-fA-F]{6})$/.exec(String(hex || ''))
+  if (!value) return null
+  const int = parseInt(value[1], 16)
+  return [(int >> 16) & 255, (int >> 8) & 255, int & 255]
+}
+
+/** The Chrome tab-group color name closest to the accent. */
+function nearestGroupColor(hex) {
+  const rgb = rgbOf(hex)
+  if (!rgb) return 'blue'
+  let best = 'blue'
+  let bestDistance = Infinity
+  for (const [name, target] of Object.entries(GROUP_COLORS)) {
+    const distance = target.reduce((sum, channel, index) => sum + (channel - rgb[index]) ** 2, 0)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = name
+    }
+  }
+  return best
+}
+
+/**
+ * Adopt the accent the Mac app reports on each poll. Repaints the live
+ * indicators immediately so a palette switch shows up without a reload.
+ */
+async function applyAccent(hex) {
+  const next = rgbOf(hex) ? String(hex).toLowerCase() : DEFAULT_ACCENT
+  if (next === accent) return
+  accent = next
+  await chrome.storage.local.set({ [ACCENT_KEY]: accent })
+  if (typeof controlledTabId === 'number') await markControlledTab(controlledTabId)
+}
+
+async function restoreAccent() {
+  const saved = await chrome.storage.local.get({ [ACCENT_KEY]: DEFAULT_ACCENT })
+  if (rgbOf(saved[ACCENT_KEY])) accent = String(saved[ACCENT_KEY]).toLowerCase()
+}
+
 async function activeTab() {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true })
   const tab = tabs[0]
@@ -143,20 +206,44 @@ async function setPageIndicator(tabId, enabled) {
   try {
     await chrome.scripting.executeScript({
       target: { tabId },
-      args: [enabled, CONTROLLED_TITLE_PREFIX],
-      func: (shouldShow, prefix) => {
+      args: [enabled, CONTROLLED_TITLE_PREFIX, accent],
+      func: (shouldShow, prefix, color) => {
         const stateKey = '__codeyChromeCompanionIndicator'
+        const frameId = '__codey-companion-frame'
         const existing = window[stateKey]
         if (existing?.observer) existing.observer.disconnect()
 
         const removePrefix = () => {
           if (document.title.startsWith(prefix)) document.title = document.title.slice(prefix.length)
         }
+        const removeFrame = () => document.getElementById(frameId)?.remove()
         removePrefix()
+        removeFrame()
         if (!shouldShow) {
           delete window[stateKey]
           return
         }
+
+        // A viewport-pinned frame so the controlled page is obvious even when the
+        // tab strip is too crowded to show the title prefix.
+        const drawFrame = () => {
+          if (!document.body || document.getElementById(frameId)) return
+          const frame = document.createElement('div')
+          frame.id = frameId
+          frame.setAttribute('aria-hidden', 'true')
+          frame.style.cssText = [
+            'position:fixed',
+            'inset:0',
+            'pointer-events:none',
+            'z-index:2147483647',
+            `border:3px solid ${color}`,
+            `box-shadow:inset 0 0 12px ${color}73`,
+            'border-radius:2px',
+          ].join(';')
+          document.body.appendChild(frame)
+        }
+        drawFrame()
+        if (!document.body) document.addEventListener('DOMContentLoaded', drawFrame, { once: true })
 
         let applying = false
         const applyPrefix = () => {
@@ -178,7 +265,36 @@ async function setPageIndicator(tabId, enabled) {
   }
 }
 
+// Tab groups are the only Chrome-supported way to tint the tab strip itself.
+// Tabs the user already grouped are left alone so we never break their layout.
+async function groupControlledTab(tabId) {
+  try {
+    const tab = await chrome.tabs.get(tabId)
+    if (typeof tab.groupId === 'number' && tab.groupId !== chrome.tabGroups.TAB_GROUP_ID_NONE) {
+      if (tab.groupId !== controlledGroupId) return
+    }
+    const groupId = await chrome.tabs.group({ tabIds: [tabId] })
+    controlledGroupId = groupId
+    await chrome.tabGroups.update(groupId, { title: CONTROLLED_GROUP_TITLE, color: nearestGroupColor(accent) })
+  } catch {
+    // Grouping is unavailable in some windows (e.g. popups); badges still apply.
+  }
+}
+
+async function ungroupControlledTab(tabId) {
+  try {
+    const tab = await chrome.tabs.get(tabId)
+    if (tab.groupId !== controlledGroupId) return
+    await chrome.tabs.ungroup(tabId)
+  } catch {
+    // The tab or group is already gone.
+  } finally {
+    controlledGroupId = null
+  }
+}
+
 async function clearTabIndicator(tabId) {
+  await ungroupControlledTab(tabId)
   await Promise.allSettled([
     chrome.action.setBadgeText({ tabId, text: '' }),
     chrome.action.setTitle({ tabId, title: 'Codey' }),
@@ -192,11 +308,12 @@ async function markControlledTab(tabId) {
   await chrome.storage.local.set({ [CONTROLLED_TAB_KEY]: tabId })
   if (typeof previous === 'number' && previous !== tabId) await clearTabIndicator(previous)
   await Promise.allSettled([
-    chrome.action.setBadgeBackgroundColor({ tabId, color: '#3377D5' }),
-    chrome.action.setBadgeTextColor({ tabId, color: '#FFFFFF' }),
-    chrome.action.setBadgeText({ tabId, text: 'ON' }),
+    chrome.action.setBadgeBackgroundColor({ tabId, color: BADGE_BG }),
+    chrome.action.setBadgeTextColor({ tabId, color: BADGE_FG }),
+    chrome.action.setBadgeText({ tabId, text: BADGE_TEXT }),
     chrome.action.setTitle({ tabId, title: 'Codey is controlling this tab' }),
     setPageIndicator(tabId, true),
+    groupControlledTab(tabId),
   ])
 }
 
@@ -313,6 +430,7 @@ async function pollOnce() {
     ;({ endpoint, token } = await autoConnect())
     response = await call(endpoint, '/v1/poll', { token })
   }
+  if (response.accent) await applyAccent(response.accent)
   if (!response.command) return true
   const command = response.command
   try {
@@ -414,6 +532,6 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return true
 })
 
-runSafely(restoreControlledTab)
+runSafely(async () => { await restoreAccent(); await restoreControlledTab() })
 runSafely(configureSidePanel)
 runSafely(pollLoop)

--- a/codey-mac/electron/chrome-companion.test.ts
+++ b/codey-mac/electron/chrome-companion.test.ts
@@ -92,6 +92,25 @@ describe('ChromeCompanionBridge', () => {
     expect(response.status).toBe(403)
   })
 
+  it('reports the accent color on every poll and rejects junk values', async () => {
+    const { bridge, endpoint } = await setup()
+    const token = await connect(endpoint)
+    const poll = async () => {
+      const response = await fetch(`${endpoint}/v1/poll`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: '{}',
+      })
+      return await response.json() as { accent: string }
+    }
+
+    expect((await poll()).accent).toBe('#3377d5')
+    bridge.setAccent('#2BE69B')
+    expect((await poll()).accent).toBe('#2be69b')
+    bridge.setAccent('javascript:alert(1)')
+    expect((await poll()).accent).toBe('#3377d5')
+  })
+
   it('round-trips a command through the extension protocol', async () => {
     const { bridge, endpoint } = await setup()
     const token = await connect(endpoint)

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -127,6 +127,10 @@ type PersistedPairing = {
   pairedAt: number
 }
 
+/** Fallback accent (Classic palette blue) until the renderer reports its theme. */
+const DEFAULT_ACCENT = '#3377d5'
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/
+
 function safeJson(value: string): unknown {
   try { return JSON.parse(value) } catch { throw new Error('Request body must be valid JSON') }
 }
@@ -150,6 +154,9 @@ export class ChromeCompanionBridge {
   private pairedAt: number | null = null
   private lastSeenAt: number | null = null
   private queue: PendingCommand[] = []
+  // The Mac app's current accent color, mirrored to the extension so the
+  // controlled-tab highlight matches whatever palette the user picked.
+  private accent = DEFAULT_ACCENT
   private pending = new Map<string, PendingCommand>()
   private uploadedAttachments = new Map<string, { chatId: string; attachment: ChromeCompanionAttachment }>()
 
@@ -189,6 +196,14 @@ export class ChromeCompanionBridge {
 
   private emitStatus(): void {
     this.onStatus?.(this.status())
+  }
+
+  /**
+   * Mirror the renderer's accent color. Picked up by the extension on its next
+   * poll, so switching palettes recolors the controlled tab without a reload.
+   */
+  setAccent(hex: string): void {
+    this.accent = HEX_COLOR.test(hex) ? hex.toLowerCase() : DEFAULT_ACCENT
   }
 
   status(): ChromeCompanionStatus {
@@ -393,8 +408,8 @@ export class ChromeCompanionBridge {
       if (request.method === 'POST' && url.pathname === '/v1/poll') {
         const command = this.queue.shift()
         this.reply(request, response, 200, command
-          ? { ok: true, command: { id: command.id, command: command.command, input: command.input } }
-          : { ok: true, command: null })
+          ? { ok: true, accent: this.accent, command: { id: command.id, command: command.command, input: command.input } }
+          : { ok: true, accent: this.accent, command: null })
         return
       }
       if (request.method === 'POST' && url.pathname === '/v1/result') {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2429,6 +2429,10 @@ app.whenReady().then(async () => {
     if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
     return chromeCompanion.navigate(String(url || ''))
   }))
+  ipcMain.handle('chromeCompanion:setAccent', (event, hex: string) => browserCall(event, () => {
+    chromeCompanion?.setAccent(String(hex || ''))
+    return { ok: true }
+  }))
   ipcMain.handle('chromeCompanion:showExtensionFolder', event => browserCall(event, async () => {
     const extensionPath = chromeCompanionExtensionPath()
     const fsMod = await import('fs')

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -465,6 +465,7 @@ contextBridge.exposeInMainWorld('codey', {
     snapshot: () => ipcRenderer.invoke('chromeCompanion:snapshot'),
     exportSession: (name: string) => ipcRenderer.invoke('chromeCompanion:exportSession', name),
     navigate: (url: string) => ipcRenderer.invoke('chromeCompanion:navigate', url),
+    setAccent: (hex: string) => ipcRenderer.invoke('chromeCompanion:setAccent', hex),
     showExtensionFolder: () => ipcRenderer.invoke('chromeCompanion:showExtensionFolder'),
     onStatus: (handler: (state: any) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, state: any) => handler(state)

--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -23,6 +23,7 @@ import {
   getStoredThemeMode,
   getStoredPalette,
   resolveEffectiveTheme,
+  syncAccentToChrome,
   paletteThemeCss,
 } from './theme'
 
@@ -256,6 +257,7 @@ const Shell: React.FC = () => {
     const onChange = () => {
       if (getStoredThemeMode() === 'system') {
         document.documentElement.dataset.theme = resolveEffectiveTheme('system')
+        syncAccentToChrome()
       }
     }
     mql.addEventListener('change', onChange)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -603,6 +603,7 @@ declare global {
         snapshot: () => Promise<IpcResult<ChromePageSnapshot>>
         exportSession: (name: string) => Promise<IpcResult<{ profile: BrowserProfileSummary; tab: ChromeTabInfo }>>
         navigate: (url: string) => Promise<IpcResult<ChromeTabInfo>>
+        setAccent: (hex: string) => Promise<IpcResult<{ ok: true }>>
         showExtensionFolder: () => Promise<IpcResult<string>>
         onStatus: (handler: (state: ChromeCompanionStatus) => void) => () => void
       }

--- a/codey-mac/src/theme.ts
+++ b/codey-mac/src/theme.ts
@@ -319,6 +319,7 @@ export function applyTheme(mode: ThemeMode): EffectiveTheme {
   const effective = resolveEffectiveTheme(mode)
   document.documentElement.dataset.theme = effective
   try { localStorage.setItem(STORAGE_KEY, mode) } catch {}
+  syncAccentToChrome()
   return effective
 }
 
@@ -360,6 +361,21 @@ export function getStoredPalette(): PaletteName {
 export function applyPalette(name: PaletteName): void {
   document.documentElement.dataset.palette = name
   try { localStorage.setItem(PALETTE_KEY, name) } catch {}
+  syncAccentToChrome()
+}
+
+/** The accent hex actually in effect right now (palette x light/dark). */
+export function currentAccent(): string {
+  const definition = PALETTES[getStoredPalette()]
+  return definition[resolveEffectiveTheme(getStoredThemeMode())].accent
+}
+
+/**
+ * Mirror the accent to the Chrome companion bridge. The extension picks it up
+ * on its next poll and recolors the controlled-tab highlight — no reload.
+ */
+export function syncAccentToChrome(): void {
+  try { void window.codey?.chromeCompanion?.setAccent(currentAccent()) } catch {}
 }
 
 export function usePaletteName(): [PaletteName, (n: PaletteName) => void] {


### PR DESCRIPTION
## Why

The tab Codey is driving was only marked by a toolbar badge and a `● Codey · ` title prefix. Once the tab strip is crowded, both disappear — a narrow tab shows nothing but a favicon.

## What

- **Tab strip color** — the controlled tab goes into a blue "Codey" tab group. Tab groups are the only Chrome-supported way to tint the strip itself; there is no API to color a tab directly. A tab the user already grouped is left alone so we never rearrange their layout.
- **Page frame** — a viewport-pinned border in the accent color, `pointer-events: none`, redrawn on navigation.
- **Accent follows the app theme** — `/v1/poll` now reports the renderer's accent hex. Switching palettes in the Mac app recolors both marks within one poll, no extension reload. The tab group snaps to the nearest of Chrome's nine allowed group colors.
- **Badge** — a green check replaces `ON`. Fixed green, deliberately not the accent, so it always reads as an OK signal.

Adds the `tabGroups` permission, so the extension needs one reload after this lands.

## Test

`npm test -w codey-mac` (815 pass), `npx tsc --noEmit -p tsconfig.electron.json`, `npm run lint`. New bridge test covers the accent on poll and the rejection of non-hex input.

Not yet exercised in real Chrome — the tab-group behavior and the frame need a manual look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)