### PR TITLE
feat(mac): preview an attachment in-app when you click it

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -263,6 +263,9 @@ function createWindow() {
       // is behind another app. Throttling can stall MediaRecorder chunks and
       // make the stop hotkey close the capsule without producing audio.
       backgroundThrottling: false,
+      // Chromium's built-in PDF viewer is a "plugin"; without this an attached
+      // PDF previews as a blank frame instead of its pages.
+      plugins: true,
     }
   })
 

--- a/codey-mac/src/components/AttachmentPreview.tsx
+++ b/codey-mac/src/components/AttachmentPreview.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react'
+import { C } from '../theme'
+import type { FileAttachment } from '../types'
+import { previewKind } from './attachmentKind'
+
+const assetUrl = (absPath: string): string =>
+  `codey-asset://file/${encodeURIComponent(absPath)}`
+
+const formatBytes = (n: number): string => {
+  if (!Number.isFinite(n) || n < 0) return ''
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)} KB`
+  return `${(n / (1024 * 1024)).toFixed(n < 10 * 1024 * 1024 ? 1 : 0)} MB`
+}
+
+/**
+ * Full-view of one attachment, opened by clicking its chip or thumbnail.
+ *
+ * Clicking an attachment used to either do nothing (composer chips) or hand the
+ * file to the OS (sent chips), which drops the user out of the app just to see
+ * what they attached. Images and PDFs stream straight off the codey-asset
+ * protocol; text-ish files are read through the existing capped readTextFile
+ * bridge. Anything we can't render keeps the old escape hatch as a button.
+ */
+export const AttachmentPreview: React.FC<{
+  attachment: FileAttachment
+  onClose: () => void
+}> = ({ attachment, onClose }) => {
+  const kind = previewKind(attachment)
+  const [text, setText] = useState<string | null>(null)
+  const [textFailed, setTextFailed] = useState(false)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  useEffect(() => {
+    if (kind !== 'text') return
+    let live = true
+    setText(null)
+    setTextFailed(false)
+    void (async () => {
+      const content = await window.codey?.readTextFile?.(attachment.path).catch(() => null)
+      if (!live) return
+      if (typeof content === 'string') setText(content)
+      else setTextFailed(true)
+    })()
+    return () => { live = false }
+  }, [kind, attachment.path])
+
+  return (
+    <div style={styles.backdrop} onClick={onClose}>
+      <div style={styles.card} onClick={e => e.stopPropagation()} role="dialog" aria-label={attachment.name}>
+        <div style={styles.head}>
+          <div style={styles.headText}>
+            <span style={styles.name}>{attachment.name}</span>
+            <span style={styles.meta}>{formatBytes(attachment.size)}{attachment.mimeType ? ` · ${attachment.mimeType}` : ''}</span>
+          </div>
+          <button style={styles.closeBtn} onClick={onClose} aria-label="Close preview">×</button>
+        </div>
+
+        <div style={styles.body}>
+          {kind === 'image' && (
+            <img src={assetUrl(attachment.path)} alt={attachment.name} style={styles.image} />
+          )}
+          {kind === 'pdf' && (
+            <iframe src={assetUrl(attachment.path)} title={attachment.name} style={styles.frame} />
+          )}
+          {kind === 'text' && (
+            text !== null
+              ? <pre style={styles.text}>{text || '(empty file)'}</pre>
+              : <div style={styles.note}>{textFailed
+                  ? 'Codey couldn’t read this file as text — it may be binary or larger than 2 MB.'
+                  : 'Loading…'}</div>
+          )}
+          {kind === 'other' && (
+            <div style={styles.note}>No preview for this file type. Open it in another app to see the contents.</div>
+          )}
+        </div>
+
+        <div style={styles.row}>
+          <button style={styles.secondary} onClick={() => { void window.codey?.revealInFolder?.(attachment.path) }}>
+            Show in Finder
+          </button>
+          <button style={styles.primary} onClick={() => { void window.codey?.openPath?.(attachment.path) }}>
+            Open in default app
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: {
+    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.55)', zIndex: 60,
+    display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 32,
+  },
+  card: {
+    width: 820, maxWidth: '100%', maxHeight: '100%', background: C.surface2,
+    border: `1px solid ${C.border}`, borderRadius: 12, padding: 14,
+    display: 'flex', flexDirection: 'column', gap: 10, overflow: 'hidden',
+  },
+  head: { display: 'flex', alignItems: 'flex-start', gap: 10 },
+  headText: { display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0, flex: 1 },
+  name: { fontSize: 13, fontWeight: 600, color: C.fg, overflowWrap: 'anywhere' },
+  meta: { fontSize: 11, color: C.fg3 },
+  closeBtn: {
+    background: 'transparent', border: 'none', color: C.fg3, fontSize: 20,
+    lineHeight: 1, cursor: 'pointer', padding: '0 4px',
+  },
+  body: {
+    flex: 1, minHeight: 200, display: 'flex', alignItems: 'center', justifyContent: 'center',
+    background: C.surface3, border: `1px solid ${C.border}`, borderRadius: 8, overflow: 'auto',
+  },
+  image: { maxWidth: '100%', maxHeight: '70vh', objectFit: 'contain' },
+  frame: { width: '100%', height: '70vh', border: 'none', background: '#fff' },
+  text: {
+    margin: 0, padding: 12, width: '100%', alignSelf: 'stretch', color: C.fg2,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 11,
+    lineHeight: 1.55, maxHeight: '70vh', overflow: 'auto',
+    whiteSpace: 'pre-wrap', overflowWrap: 'anywhere',
+  },
+  note: { padding: 24, fontSize: 12, color: C.fg3, textAlign: 'center' },
+  row: { display: 'flex', justifyContent: 'flex-end', gap: 8 },
+  secondary: {
+    background: C.surface3, color: C.fg2, border: `1px solid ${C.border}`, borderRadius: 7,
+    padding: '7px 14px', fontSize: 13, cursor: 'pointer',
+  },
+  primary: {
+    background: C.accent, color: C.onAccent, border: 'none', borderRadius: 7,
+    padding: '7px 14px', fontSize: 13, cursor: 'pointer',
+  },
+}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -6,6 +6,7 @@ import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
 import { Markdown } from './Markdown'
 import { PairingModal } from './PairingModal'
+import { AttachmentPreview } from './AttachmentPreview'
 import { consumePendingPairing } from './pendingPairing'
 import { ChatContextPanel } from './ChatContextPanel'
 import type { ContextPanelTab } from './ChatContextPanel'
@@ -961,6 +962,8 @@ export const ChatTab: React.FC<Props> = ({
   const [advisorConfig, setAdvisorConfig] = useState<{ agent?: string; model?: string }>({})
   const [pendingAttachments, setPendingAttachments] = useState<FileAttachment[]>(() => getDraft(chatId).attachments)
   const [isDragging, setIsDragging] = useState(false)
+  // The attachment the user clicked, shown in a full preview overlay.
+  const [previewAttachment, setPreviewAttachment] = useState<FileAttachment | null>(null)
   const [slashCommands, setSlashCommands] = useState<Array<{ name: string; description: string; source: 'agent' | 'gateway' | 'skill' }>>([])
   const [slashIdx, setSlashIdx] = useState(0)
   const slashMenuRef = useRef<HTMLDivElement>(null)
@@ -2552,7 +2555,7 @@ export const ChatTab: React.FC<Props> = ({
                   <div style={styles.attachmentsContainer}>
                     {msg.attachments.map(att => {
                       const isImage = att.mimeType.startsWith('image/')
-                      const open = () => window.codey?.openPath?.(att.path)
+                      const open = () => setPreviewAttachment(att)
                       if (isImage) {
                         return (
                           <img
@@ -2866,20 +2869,30 @@ export const ChatTab: React.FC<Props> = ({
                 const isImage = att.mimeType.startsWith('image/')
                 if (isImage) {
                   return (
-                    <div key={att.id} style={styles.pendingImageWrap} title={`${att.name} · ${formatBytes(att.size)}`}>
+                    <div
+                      key={att.id}
+                      style={styles.pendingImageWrap}
+                      title={`${att.name} · ${formatBytes(att.size)}`}
+                      onClick={() => setPreviewAttachment(att)}
+                    >
                       <img src={assetUrl(att.path)} alt={att.name} style={styles.pendingImage} />
-                      <button onClick={() => removeAttachment(att.id)} style={styles.pendingRemoveBtn} aria-label="Remove">×</button>
+                      <button onClick={e => { e.stopPropagation(); removeAttachment(att.id) }} style={styles.pendingRemoveBtn} aria-label="Remove">×</button>
                     </div>
                   )
                 }
                 return (
-                  <div key={att.id} style={styles.pendingFileChip} title={`${att.name} · ${formatBytes(att.size)}`}>
+                  <div
+                    key={att.id}
+                    style={styles.pendingFileChip}
+                    title={`${att.name} · ${formatBytes(att.size)}`}
+                    onClick={() => setPreviewAttachment(att)}
+                  >
                     <div style={styles.pendingFileIcon}><FileIcon color={C.fg2} size={16} /></div>
                     <div style={styles.pendingFileMeta}>
                       <span style={styles.pendingFileName}>{att.name}</span>
                       <span style={styles.pendingFileSize}>{formatBytes(att.size)}</span>
                     </div>
-                    <button onClick={() => removeAttachment(att.id)} style={styles.pendingFileRemoveBtn} aria-label="Remove">×</button>
+                    <button onClick={e => { e.stopPropagation(); removeAttachment(att.id) }} style={styles.pendingFileRemoveBtn} aria-label="Remove">×</button>
                   </div>
                 )
               })}
@@ -3082,6 +3095,12 @@ export const ChatTab: React.FC<Props> = ({
           </div>
         </div>
       </div>
+      {previewAttachment && (
+        <AttachmentPreview
+          attachment={previewAttachment}
+          onClose={() => setPreviewAttachment(null)}
+        />
+      )}
       {pairingModal && (
         <PairingModal
           channel={pairingModal}
@@ -3502,6 +3521,7 @@ const styles: Record<string, React.CSSProperties> = {
   pendingImageWrap: {
     position: 'relative' as const, width: 56, height: 56,
     borderRadius: 8, overflow: 'hidden', border: `1px solid ${C.border2}`,
+    cursor: 'pointer' as const,
   },
   pendingImage: {
     width: '100%', height: '100%', objectFit: 'cover' as const, display: 'block',
@@ -3517,6 +3537,7 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', gap: 8,
     background: C.surface2, border: `1px solid ${C.border2}`, borderRadius: 8,
     padding: '6px 6px 6px 10px', height: 56, boxSizing: 'border-box' as const,
+    cursor: 'pointer' as const,
   },
   pendingFileIcon: {
     width: 32, height: 32, borderRadius: 6, background: C.surface3,

--- a/codey-mac/src/components/attachmentKind.test.ts
+++ b/codey-mac/src/components/attachmentKind.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { fileExtension, previewKind } from './attachmentKind'
+
+describe('fileExtension', () => {
+  it('reads the last extension', () => {
+    expect(fileExtension('notes.tar.gz')).toBe('gz')
+  })
+
+  it('ignores directories and dotfiles without an extension', () => {
+    expect(fileExtension('/a/b.c/README')).toBe('')
+    expect(fileExtension('.gitignore')).toBe('')
+    expect(fileExtension('trailing.')).toBe('')
+  })
+})
+
+describe('previewKind', () => {
+  it('shows images as images', () => {
+    expect(previewKind({ name: 'shot.png', mimeType: 'image/png' })).toBe('image')
+  })
+
+  it('shows pdfs as pdfs, even with a useless mime type', () => {
+    expect(previewKind({ name: 'a.pdf', mimeType: 'application/pdf' })).toBe('pdf')
+    expect(previewKind({ name: 'a.pdf', mimeType: 'application/octet-stream' })).toBe('pdf')
+  })
+
+  it('falls back to the extension when the mime type says nothing', () => {
+    expect(previewKind({ name: 'notes.md', mimeType: 'application/octet-stream' })).toBe('text')
+    expect(previewKind({ name: 'main.ts', mimeType: '' })).toBe('text')
+  })
+
+  it('reads svg as text so the markup is inspectable', () => {
+    expect(previewKind({ name: 'logo.svg', mimeType: 'image/svg+xml' })).toBe('text')
+  })
+
+  it('treats unknown binaries as unpreviewable', () => {
+    expect(previewKind({ name: 'archive.zip', mimeType: 'application/zip' })).toBe('other')
+  })
+})

--- a/codey-mac/src/components/attachmentKind.ts
+++ b/codey-mac/src/components/attachmentKind.ts
@@ -1,0 +1,36 @@
+// How a chat attachment should be shown when the user clicks it.
+//
+// Kept out of the component so the mime/extension guessing is testable and so
+// both the composer chips and the sent-message chips classify identically.
+// Some uploads arrive with a useless mime type (browsers send
+// "application/octet-stream" for .md, .ts, .log ...), so the extension is the
+// tie-breaker rather than the other way round.
+
+export type PreviewKind = 'image' | 'pdf' | 'text' | 'other'
+
+const TEXT_EXTENSIONS = new Set([
+  'txt', 'md', 'markdown', 'log', 'csv', 'tsv', 'json', 'jsonl', 'yaml', 'yml',
+  'toml', 'ini', 'cfg', 'conf', 'env', 'xml', 'svg', 'html', 'htm', 'css',
+  'scss', 'less', 'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'py', 'rb', 'go',
+  'rs', 'java', 'kt', 'swift', 'c', 'h', 'cc', 'cpp', 'hpp', 'cs', 'php',
+  'sh', 'bash', 'zsh', 'fish', 'sql', 'diff', 'patch', 'gitignore',
+])
+
+export const fileExtension = (name: string): string => {
+  const base = name.split(/[\\/]/).pop() ?? ''
+  const dot = base.lastIndexOf('.')
+  if (dot <= 0 || dot === base.length - 1) return ''
+  return base.slice(dot + 1).toLowerCase()
+}
+
+export const previewKind = (att: { name: string; mimeType: string }): PreviewKind => {
+  const mime = (att.mimeType || '').toLowerCase()
+  const ext = fileExtension(att.name || '')
+  if (mime.startsWith('image/') && ext !== 'svg') return 'image'
+  if (mime === 'application/pdf' || ext === 'pdf') return 'pdf'
+  if (mime.startsWith('text/')) return 'text'
+  if (mime === 'application/json' || mime === 'application/xml') return 'text'
+  if (TEXT_EXTENSIONS.has(ext)) return 'text'
+  if (mime.startsWith('image/')) return 'image'
+  return 'other'
+}


### PR DESCRIPTION
## Problem

Clicking an attachment did nothing.

- **Composer chips** (staged, not yet sent) had no click handler at all.
- **Sent-message chips** called `shell.openPath`, which hands the file to the OS and drops you out of Codey just to see what you attached.

## Change

Both now open an in-app preview overlay (`AttachmentPreview.tsx`):

- **Images** — rendered full-size off the existing `codey-asset://` protocol.
- **PDFs** — rendered inline in an iframe. Chromium's PDF viewer counts as a "plugin", so the main window needs `plugins: true` or the frame is blank.
- **Text-ish** (md/json/ts/csv/log/svg/…) — read through the existing capped `file:readText` bridge; says so plainly if the file is binary or over 2 MB.
- **Anything else** — keeps the old escape hatch as a button.

Footer has `Show in Finder` and `Open in default app`. Esc or backdrop click closes.

Kind detection lives in `attachmentKind.ts` so both chip sites classify identically and it's unit-tested. Extension beats mime type as the tie-breaker, because browsers hand us `application/octet-stream` for `.md`, `.ts`, `.log`.

## Testing

- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.electron.json`
- `vitest run` in `codey-mac`: 822 passed (7 new)
- `npm run lint` clean

Not yet exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)