### PR TITLE
fix(mac): refresh the PR badge without waiting for a window focus

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1235,6 +1235,25 @@ export const ChatTab: React.FC<Props> = ({
     window.addEventListener('focus', onFocus)
     return () => window.removeEventListener('focus', onFocus)
   }, [refreshPullRequestStatus])
+
+  // An agent that opens the PR itself (`gh pr create` in a shell step) leaves
+  // no trace the other triggers watch, so the badge used to stay blank until
+  // the window lost and regained focus. Re-check the moment a run settles.
+  const wasRunningRef = useRef(false)
+  useEffect(() => {
+    const running = !!flight
+    if (wasRunningRef.current && !running) void refreshPullRequestStatus()
+    wasRunningRef.current = running
+  }, [!!flight]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Same blind spot for a PR opened outside Codey (github.com, another
+  // terminal). One quiet poll per minute, only while the chat is on screen.
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (document.visibilityState === 'visible') void refreshPullRequestStatus()
+    }, 60_000)
+    return () => clearInterval(timer)
+  }, [refreshPullRequestStatus])
   // Derived from the gitStatus useGitStatus already fetches — no extra IPC round-trip.
   // PR-able: on a non-default branch with commits the default branch doesn't have
   // (ahead is null when there's no remote default ref — fall back to branch check only).


### PR DESCRIPTION
## What

The chat list's pull-request badge only re-checked GitHub on a few triggers: opening a chat, a branch change, and the window regaining focus.

A PR opened by the agent itself (a `gh pr create` shell step) fires none of them, so the badge stayed blank while the user sat watching the app — it only filled in on the next cycle, once the window happened to lose and regain focus.

## Change

`codey-mac/src/components/ChatTab.tsx`:

- Re-check PR status when a run settles (running → idle). That is exactly when an agent-opened PR shows up.
- Poll once a minute while the chat is visible, covering a PR opened on github.com or in another terminal.

## Testing

- `npx tsc --noEmit` passes for this change.
- Not yet exercised on a real run in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)