### PR TITLE
fix(mac): stop a chat from claiming another chat's PR

### DIFF
--- a/codey-mac/electron/delivery-status.test.ts
+++ b/codey-mac/electron/delivery-status.test.ts
@@ -2,18 +2,23 @@ import { describe, expect, it } from 'vitest'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
 
 describe('shouldRediscoverPr', () => {
-  it('re-resolves when the checkout moved to another branch', () => {
-    expect(shouldRediscoverPr({ pinnedHeadBranch: 'old-work', currentBranch: 'new-work' })).toBe(true)
+  it('re-resolves when a chat-owned checkout moved to another branch', () => {
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'old-work', currentBranch: 'new-work', ownsCheckout: true })).toBe(true)
   })
 
   it('keeps the pinned PR on its own branch', () => {
-    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: 'work' })).toBe(false)
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: 'work', ownsCheckout: true })).toBe(false)
   })
 
   it('keeps the pinned PR when the branch is unknown or detached', () => {
-    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: '' })).toBe(false)
-    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: 'HEAD' })).toBe(false)
-    expect(shouldRediscoverPr({ currentBranch: 'work' })).toBe(false)
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: '', ownsCheckout: true })).toBe(false)
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'work', currentBranch: 'HEAD', ownsCheckout: true })).toBe(false)
+    expect(shouldRediscoverPr({ currentBranch: 'work', ownsCheckout: true })).toBe(false)
+  })
+
+  it('never adopts another chat\'s branch in a shared checkout', () => {
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'old-work', currentBranch: 'new-work' })).toBe(false)
+    expect(shouldRediscoverPr({ pinnedHeadBranch: 'old-work', currentBranch: 'new-work', ownsCheckout: false })).toBe(false)
   })
 })
 

--- a/codey-mac/electron/delivery-status.ts
+++ b/codey-mac/electron/delivery-status.ts
@@ -4,12 +4,18 @@ export type DeliveryState = 'pr-open' | 'merged' | 'merged-with-changes' | 'clos
  *  different branch, that PR no longer describes the chat's work and its state
  *  (typically `merged`) would stick forever — re-resolve from the branch we're
  *  actually on. `HEAD` (detached) and an unknown head branch are not evidence
- *  of drift, so they keep the pinned PR. */
+ *  of drift, so they keep the pinned PR.
+ *
+ *  Only the owner of a checkout may re-resolve. In a shared checkout the branch
+ *  is global: another chat switching branches would otherwise hand this chat
+ *  that other branch's PR, so a chat that opened #367 starts claiming #370. */
 export function shouldRediscoverPr(input: {
   pinnedHeadBranch?: string
   currentBranch?: string
+  ownsCheckout?: boolean
 }): boolean {
-  const { pinnedHeadBranch, currentBranch } = input
+  const { pinnedHeadBranch, currentBranch, ownsCheckout } = input
+  if (!ownsCheckout) return false
   if (!pinnedHeadBranch || !currentBranch || currentBranch === 'HEAD') return false
   return pinnedHeadBranch !== currentBranch
 }

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2984,7 +2984,7 @@ app.whenReady().then(async () => {
     })
   )
 
-  ipcMain.handle('git:prStatus', async (_e, workingDir: string, url?: string) =>
+  ipcMain.handle('git:prStatus', async (_e, workingDir: string, url?: string, ownsCheckout?: boolean) =>
     wrap(async () => {
       if (!workingDir) throw new Error('A working directory is required')
       const { execFile } = await import('child_process')
@@ -3020,7 +3020,7 @@ app.whenReady().then(async () => {
       // chat's PR, start the next branch in the same checkout, and the old
       // (merged) PR would keep answering forever. When the pinned PR's head is
       // not the branch we're on, ask again for this branch's own PR.
-      if (shouldRediscoverPr({ pinnedHeadBranch: view.headRefName, currentBranch })) {
+      if (shouldRediscoverPr({ pinnedHeadBranch: view.headRefName, currentBranch, ownsCheckout })) {
         try { view = await view$() } catch { /* no PR for this branch; keep the pinned one */ }
       }
       const sameBranch = !!view.headRefName && currentBranch === view.headRefName

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -252,7 +252,8 @@ contextBridge.exposeInMainWorld('codey', {
       ipcRenderer.invoke('git:worktreeAdd', workingDir, args),
     createPr: (workingDir: string, input: { title: string; body?: string }) =>
       ipcRenderer.invoke('git:createPr', workingDir, input),
-    prStatus: (workingDir: string, url?: string) => ipcRenderer.invoke('git:prStatus', workingDir, url),
+    prStatus: (workingDir: string, url?: string, ownsCheckout?: boolean) =>
+      ipcRenderer.invoke('git:prStatus', workingDir, url, ownsCheckout),
     watch: (workingDir: string) => ipcRenderer.invoke('git:watch', workingDir),
     unwatch: (workingDir: string) => ipcRenderer.invoke('git:unwatch', workingDir),
     onChanged: (handler: (ev: { workingDir: string }) => void) => {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -510,7 +510,7 @@ declare global {
         worktrees: (workingDir: string) => Promise<IpcResult<{ list: { branch: string; path: string; isMain: boolean }[] }>>
         worktreeAdd: (workingDir: string, args: { name: string; path: string }) => Promise<IpcResult<{ ok: boolean; path?: string; error?: string }>>
         createPr: (workingDir: string, input: { title: string; body?: string }) => Promise<IpcResult<{ ok: boolean; url?: string; error?: string }>>
-        prStatus: (workingDir: string, url?: string) => Promise<IpcResult<NonNullable<Chat['pullRequest']>>>
+        prStatus: (workingDir: string, url?: string, ownsCheckout?: boolean) => Promise<IpcResult<NonNullable<Chat['pullRequest']>>>
         watch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
         unwatch: (workingDir: string) => Promise<IpcResult<{ ok: boolean }>>
         onChanged: (handler: (ev: { workingDir: string }) => void) => () => void

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1223,17 +1223,26 @@ export const ChatTab: React.FC<Props> = ({
 
   const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)
   const [showPrModal, setShowPrModal] = useState(false)
-  const refreshPullRequestStatus = useCallback(async (urlOverride?: string) => {
-    const url = urlOverride || chat?.pullRequest?.url
+  // Only an isolated worktree belongs to this chat. In a shared checkout the
+  // branch is global, so "whatever PR the current branch has" is somebody
+  // else's work — we may only adopt a branch's PR right after this chat's own
+  // run, or when the PR url is handed to us explicitly.
+  const ownsCheckout = chat?.executionMode === 'isolated-worktree'
+  const refreshPullRequestStatus = useCallback(async (
+    opts: { url?: string; discover?: boolean } = {},
+  ) => {
+    const url = opts.url || chat?.pullRequest?.url
     if (!workingDir) return
     const branch = gitStatus?.branch
-    const canDiscover = !!branch && branch !== 'HEAD' && branch !== (gitStatus?.defaultBranch ?? 'main')
+    const discover = (opts.discover ?? false) || ownsCheckout
+    const canDiscover = discover
+      && !!branch && branch !== 'HEAD' && branch !== (gitStatus?.defaultBranch ?? 'main')
     if (!url && !canDiscover) return
     try {
-      const result = await window.codey.git.prStatus(workingDir, url)
+      const result = await window.codey.git.prStatus(workingDir, url, discover)
       if (result.ok) await setPullRequest(chatId, result.data)
     } catch { /* PR status is best effort */ }
-  }, [workingDir, chatId, chat?.pullRequest?.url, gitStatus?.branch, gitStatus?.defaultBranch])
+  }, [workingDir, chatId, chat?.pullRequest?.url, ownsCheckout, gitStatus?.branch, gitStatus?.defaultBranch])
 
   useEffect(() => {
     void refreshPullRequestStatus()
@@ -1247,16 +1256,20 @@ export const ChatTab: React.FC<Props> = ({
 
   // An agent that opens the PR itself (`gh pr create` in a shell step) leaves
   // no trace the other triggers watch, so the badge used to stay blank until
-  // the window lost and regained focus. Re-check the moment a run settles.
+  // the window lost and regained focus. Re-check the moment a run settles —
+  // and this is also the one moment a shared-checkout chat may claim the
+  // current branch's PR: it just ran, so the branch it sits on is the branch
+  // it worked on.
   const wasRunningRef = useRef(false)
   useEffect(() => {
     const running = !!flight
-    if (wasRunningRef.current && !running) void refreshPullRequestStatus()
+    if (wasRunningRef.current && !running) void refreshPullRequestStatus({ discover: true })
     wasRunningRef.current = running
   }, [!!flight]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Same blind spot for a PR opened outside Codey (github.com, another
   // terminal). One quiet poll per minute, only while the chat is on screen.
+  // It refreshes a PR the chat already owns; it never adopts a new one.
   useEffect(() => {
     const timer = setInterval(() => {
       if (document.visibilityState === 'visible') void refreshPullRequestStatus()
@@ -3212,7 +3225,7 @@ export const ChatTab: React.FC<Props> = ({
           onCreate={async (input) => {
             if (!workingDir) return { ok: false, error: 'No working dir' }
             const r = await window.codey.git.createPr(workingDir, input)
-            if (r.ok && r.data.ok && r.data.url) await refreshPullRequestStatus(r.data.url)
+            if (r.ok && r.data.ok && r.data.url) await refreshPullRequestStatus({ url: r.data.url })
             return r.ok ? r.data : { ok: false, error: r.error || 'Failed' }
           }}
         />

--- a/codey-mac/src/hooks/usePullRequestWatcher.test.ts
+++ b/codey-mac/src/hooks/usePullRequestWatcher.test.ts
@@ -30,15 +30,19 @@ describe('needsPrRefresh', () => {
     expect(needsPrRefresh(pr({ state: 'merged', headBranch: 'feature' }), 'feature')).toBe(false)
   })
 
-  it('re-checks a merged PR once the checkout moved to another branch', () => {
-    expect(needsPrRefresh(pr({ state: 'merged', headBranch: 'shipped' }), 'next-thing')).toBe(true)
+  it('re-checks a merged PR once a chat-owned checkout moved to another branch', () => {
+    expect(needsPrRefresh(pr({ state: 'merged', headBranch: 'shipped' }), 'next-thing', true)).toBe(true)
+  })
+
+  it('leaves a terminal PR alone in a shared checkout, whoever moved the branch', () => {
+    expect(needsPrRefresh(pr({ state: 'merged', headBranch: 'shipped' }), 'next-thing')).toBe(false)
   })
 
   it('leaves a terminal PR alone when the branch is unknown or detached', () => {
     const merged = pr({ state: 'merged', headBranch: 'shipped' })
-    expect(needsPrRefresh(merged, undefined)).toBe(false)
-    expect(needsPrRefresh(merged, 'HEAD')).toBe(false)
-    expect(needsPrRefresh(pr({ state: 'merged' }), 'next-thing')).toBe(false)
+    expect(needsPrRefresh(merged, undefined, true)).toBe(false)
+    expect(needsPrRefresh(merged, 'HEAD', true)).toBe(false)
+    expect(needsPrRefresh(pr({ state: 'merged' }), 'next-thing', true)).toBe(false)
   })
 
   it('ignores chats with no PR', () => {

--- a/codey-mac/src/hooks/usePullRequestWatcher.ts
+++ b/codey-mac/src/hooks/usePullRequestWatcher.ts
@@ -16,12 +16,19 @@ export function chatsWithTrackedPr(chats: Chat[]): Chat[] {
 }
 
 /** Whether this chat's PR is worth a `gh` call right now. An open PR always is
- *  — that's the merge we're watching for. A terminal one only is when the
- *  checkout has moved off the branch that PR belongs to, which means the badge
- *  is describing finished work and needs to be re-resolved for the new branch. */
-export function needsPrRefresh(pullRequest: PullRequest | undefined, branch: string | undefined): boolean {
+ *  — that's the merge we're watching for. A terminal one only is when the chat
+ *  owns its checkout and that checkout has moved off the branch the PR belongs
+ *  to, which means the badge is describing finished work and needs to be
+ *  re-resolved for the new branch. A shared checkout's branch belongs to
+ *  whichever chat moved it last, so drift there is not this chat's news. */
+export function needsPrRefresh(
+  pullRequest: PullRequest | undefined,
+  branch: string | undefined,
+  ownsCheckout = false,
+): boolean {
   if (!pullRequest?.url) return false
   if (pullRequest.state === 'pr-open') return true
+  if (!ownsCheckout) return false
   return !!branch && branch !== 'HEAD' && !!pullRequest.headBranch && branch !== pullRequest.headBranch
 }
 
@@ -87,9 +94,10 @@ export function usePullRequestWatcher(): void {
         // Local git first: it's cheap, and it tells us whether a terminal-state
         // PR still describes this chat's branch before we pay for a gh call.
         const branch = await currentBranch(workingDir)
-        if (!needsPrRefresh(chat.pullRequest, branch)) continue
+        const ownsCheckout = chat.executionMode === 'isolated-worktree'
+        if (!needsPrRefresh(chat.pullRequest, branch, ownsCheckout)) continue
         try {
-          const result = await window.codey.git.prStatus(workingDir, chat.pullRequest!.url)
+          const result = await window.codey.git.prStatus(workingDir, chat.pullRequest!.url, ownsCheckout)
           const current = chatsRef.current[chat.id]?.pullRequest
           if (result.ok && current && prStatusChanged(current, result.data)) {
             await setPullRequest(chat.id, result.data)


### PR DESCRIPTION
## The bug

In a shared checkout the git branch is global. The PR resolver treated *"the PR of the current branch"* as *"this chat's PR"*, so the moment any other chat switched branches, every open chat re-resolved and adopted that other branch's PR.

Seen in the wild: a chat that had opened **#367** was showing **#370 · open** in its hover card and delivery badge, because a different chat had moved the shared checkout to `chrome-tab-highlight`.

## The fix

Ownership gates resolution:

- **Isolated worktree** — the checkout is the chat's, so branch-based resolution is still correct. Unchanged.
- **Shared checkout** — a branch's PR is adopted at exactly two moments:
  1. right after *this chat's own run settles* (the branch it sits on is the branch it just worked on — this also covers a PR the agent opened itself with `gh`, which leaves no other trace),
  2. when the create-PR modal hands over the url explicitly.

  Background refreshes (mount, window focus, the app-wide watcher) still update a PR the chat already owns, but can no longer swap it for someone else's.

`ownsCheckout` is threaded through `git:prStatus` so `shouldRediscoverPr` in the main process makes the same call, and `needsPrRefresh` in the watcher stops burning a `gh` call on drift that isn't the chat's news.

## Tests

`codey-mac`: 808 passed, `tsc --noEmit` clean. New cases cover shared-checkout non-adoption on both helpers.

## Note

Chats whose stored PR was already overwritten keep the wrong number until they run again or you re-create the PR from the modal — this change stops the corruption, it does not rewrite history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)