### PR TITLE
polish(mac): shrink Recheck to an icon and add Update All

### DIFF
--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -12,7 +12,6 @@ import {
   rowHintStyle,
   rowLabelStyle,
   rowStyle,
-  textButtonStyle,
 } from './agentSettingsUi'
 import { publishInstalledAgents, refreshInstalledAgents, useInstalledAgents } from './installedAgents'
 import { AgentUpdateFailureModal } from './AgentUpdateFailureModal'
@@ -40,6 +39,7 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
   const [agents, setAgents] = useState<Record<string, AgentSlot>>({})
   const [error, setError] = useState<string | null>(null)
   const [updating, setUpdating] = useState<string | null>(null)
+  const [updatingAll, setUpdatingAll] = useState(false)
   const [failure, setFailure] = useState<Failure | null>(null)
   const { status: installStatus, checking: checkingInstalls } = useInstalledAgents(isGatewayRunning)
   // Shared with the Settings sidebar, which shows the dot; whichever mounts
@@ -50,19 +50,24 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
   // needs no words — the version on the row changes and the button goes away.
   // Failure gets a dialog, because the only useful thing then is the updater's
   // own output, which does not fit under a settings row.
-  const updateAgent = useCallback(async (name: string) => {
+  const runUpdate = useCallback(async (name: string): Promise<Failure | null> => {
     setUpdating(name)
     try {
       const r = unwrap(await window.codey.agents.update(name))
       publishInstalledAgents(r.status)
       publishAgentUpdates(r.updates)
-      if (!r.ok) setFailure({ agent: name, command: r.command, output: r.output })
+      return r.ok ? null : { agent: name, command: r.command, output: r.output }
     } catch (e: any) {
-      setFailure({ agent: name, command: 'the update', output: e?.message ?? String(e) })
+      return { agent: name, command: 'the update', output: e?.message ?? String(e) }
     } finally {
       setUpdating(null)
     }
   }, [])
+
+  const updateAgent = useCallback(async (name: string) => {
+    const f = await runUpdate(name)
+    if (f) setFailure(f)
+  }, [runUpdate])
 
   const availabilityOf = (name: string): Availability =>
     updates?.[name] ?? { updateAvailable: false, unknown: true }
@@ -81,6 +86,27 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
     if (updating === name) return 'Updating…'
     if (a.updateAvailable) return `Update to ${a.latest}`
     return 'Could not check for a newer version — run the updater anyway'
+  }
+
+  // The agents a per-row button would offer to update. Update All runs exactly
+  // those, one after another: two updaters writing to the same shell at once is
+  // not worth the seconds it would save.
+  const updatableAgents = AGENT_NAMES.filter(a => installStatus?.[a]?.installed && offersUpdate(a))
+
+  // One failure does not stop the rest — the remaining agents still get their
+  // turn, and the first updater's output is what the dialog shows afterwards.
+  const updateAll = async () => {
+    setUpdatingAll(true)
+    try {
+      let first: Failure | null = null
+      for (const a of updatableAgents) {
+        const f = await runUpdate(a)
+        if (f && !first) first = f
+      }
+      if (first) setFailure(first)
+    } finally {
+      setUpdatingAll(false)
+    }
   }
 
   const reload = useCallback(async () => {
@@ -128,15 +154,45 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
       )}
 
       <Section first title="Installed agents" description="CLI availability, thinking effort, and environment for each coding agent." right={
-        <button
-          onClick={() => { void refreshInstalledAgents(true); void refreshAgentUpdates(true) }}
-          style={{ ...textButtonStyle, opacity: checkingInstalls ? 0.65 : 1 }}
-          disabled={checkingInstalls}
-          title="Re-check what is installed, and whether a newer version has been published"
-        >
-          <UIIcon name="refresh" size={13} />
-          {checkingInstalls ? 'Checking…' : 'Recheck'}
-        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={() => { void refreshInstalledAgents(true); void refreshAgentUpdates(true) }}
+            style={iconButtonStyle({ disabled: checkingInstalls })}
+            disabled={checkingInstalls}
+            aria-label="Recheck agents"
+            title="Re-check what is installed, and whether a newer version has been published"
+          >
+            <span style={{
+              display: 'grid',
+              animation: checkingInstalls ? 'codey-agent-update-spin 1s linear infinite' : undefined,
+            }}>
+              <UIIcon name="refresh" size={14} />
+            </span>
+          </button>
+          {/* Same download icon as the per-agent button, because it does the
+              same thing — just to every agent that is offering an update. */}
+          <button
+            onClick={() => { void updateAll() }}
+            style={iconButtonStyle({
+              accent: updatableAgents.some(a => availabilityOf(a).updateAvailable),
+              disabled: updatingAll || updating !== null || updatableAgents.length === 0,
+            })}
+            disabled={updatingAll || updating !== null || updatableAgents.length === 0}
+            aria-label="Update all agents"
+            title={
+              updatingAll ? `Updating ${updating ?? 'agents'}…`
+                : updatableAgents.length === 0 ? 'Every installed agent is up to date'
+                  : `Update all: ${updatableAgents.join(', ')}`
+            }
+          >
+            <span style={{
+              display: 'grid',
+              animation: updatingAll ? 'codey-agent-update-spin 1s linear infinite' : undefined,
+            }}>
+              <UIIcon name={updatingAll ? 'refresh' : 'download-all'} size={14} />
+            </span>
+          </button>
+        </div>
       } />
       {AGENT_NAMES.map(a => {
         const status = installStatus?.[a]

--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -311,7 +311,7 @@ const PluginDetails: React.FC<DetailProps> = ({
               disabled={working}
               style={installed ? detailDangerButton : pillButton('primary')}
             >
-              {working ? 'Working…' : installed ? 'Uninstall plugin' : 'Install plugin'}
+              {working ? 'Working…' : installed ? 'Uninstall' : 'Install plugin'}
             </button>
           </div>
         )}

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -4,7 +4,7 @@ export type IconName =
   | 'activity' | 'add' | 'alert' | 'archive' | 'bell' | 'book' | 'bot' | 'chat' | 'check' | 'chevron' | 'close' | 'disclosure'
   | 'clock' | 'code' | 'copy' | 'edit' | 'folder' | 'folder-open' | 'key' | 'link' | 'mic' | 'more' | 'panel' | 'panel-bottom' | 'panel-right' | 'play' | 'plus'
   | 'waveform' | 'git-branch' | 'git-merge' | 'pull-request' | 'globe' | 'match-case' | 'overview' | 'refresh' | 'search' | 'server' | 'settings' | 'sparkle' | 'split' | 'terminal' | 'tools' | 'trash' | 'users' | 'workspace'
-  | 'telegram' | 'discord' | 'imessage' | 'undo' | 'download'
+  | 'telegram' | 'discord' | 'imessage' | 'undo' | 'download' | 'download-all'
 
 interface Props {
   name: IconName
@@ -34,6 +34,8 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     // Arrow into a tray: the update glyph everywhere, and unmistakable next to
     // a version number even at 14px.
     download: <><path {...common} d="M12 4v10" /><path {...common} d="M8 11l4 4 4-4" /><path {...common} d="M5 19h14" /></>,
+    // `download` with a second arrow: the same action, aimed at every agent.
+    'download-all': <><path {...common} d="M8 4v8" /><path {...common} d="M5 9.5l3 3 3-3" /><path {...common} d="M16 4v8" /><path {...common} d="M13 9.5l3 3 3-3" /><path {...common} d="M5 19h14" /></>,
     disclosure: <path fill="currentColor" stroke="none" d="M9 6.5L16 12l-7 5.5z" />,
     code: <><path {...common} d="M8 9l-3 3 3 3M16 9l3 3-3 3M14 6l-4 12" /></>,
     copy: <><rect {...common} x="9" y="9" width="11" height="11" rx="2" /><path {...common} d="M5 15V5a2 2 0 012-2h10" /></>,

--- a/codey-mac/src/components/agentSettingsUi.tsx
+++ b/codey-mac/src/components/agentSettingsUi.tsx
@@ -43,13 +43,6 @@ export const iconButtonStyle = (opts: { accent?: boolean; danger?: boolean; disa
   opacity: opts.disabled ? 0.45 : 1,
 })
 
-/** Text button for the one place a label is needed — the page-level Recheck. */
-export const textButtonStyle: React.CSSProperties = {
-  display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 9px', fontSize: 12,
-  background: 'transparent', color: C.fg2, border: `1px solid ${C.border2}`,
-  borderRadius: 7, cursor: 'pointer',
-}
-
 /**
  * Whether the gateway will find this agent's CLI: probe in flight, installed,
  * or missing. The installed pill carries the resolved path as its tooltip, so


### PR DESCRIPTION
## What

Settings ▸ Agents, section header:

- **Recheck** is now icon-only (the round arrow), matching every other action on the page. It spins while the check runs.
- **Update All** sits next to it — a double-down-arrow icon button that updates every installed agent offering an update, sequentially. Accent-tinted when a real update exists, disabled when there is nothing to do or another update is running, and its tooltip names the agents it will run.
- One failed updater does not stop the others; the first failure's output goes to the existing failure dialog.
- `textButtonStyle` is gone — it existed for that one label.

Drive-by: the plugin detail button says "Uninstall" instead of "Uninstall plugin".

## Test

- `npx tsc --noEmit` clean
- `npm test -w codey-mac` — 824 passed
- `npm run lint` clean

Not yet clicked in a packaged build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)