### PR TITLE
feat(mac): open a file path from a message with one click

### DIFF
--- a/codey-mac/electron/file-ref.test.ts
+++ b/codey-mac/electron/file-ref.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs'
+import { tmpdir, homedir } from 'os'
+import { join } from 'path'
+import { resolveRefPath, locateRefPath } from './file-ref'
+
+describe('resolveRefPath', () => {
+  it('keeps an absolute path', () => {
+    expect(resolveRefPath('/tmp/a.ts')).toBe('/tmp/a.ts')
+  })
+
+  it('expands ~', () => {
+    expect(resolveRefPath('~/notes.md')).toBe(join(homedir(), 'notes.md'))
+  })
+
+  it('resolves a relative path against the working dir', () => {
+    expect(resolveRefPath('src/app.ts', '/repo')).toBe('/repo/src/app.ts')
+    expect(resolveRefPath('./src/app.ts', '/repo')).toBe('/repo/src/app.ts')
+  })
+
+  it('refuses a relative path with no working dir', () => {
+    expect(resolveRefPath('src/app.ts')).toBeNull()
+    expect(resolveRefPath('')).toBeNull()
+  })
+})
+
+describe('locateRefPath', () => {
+  it('reports a file, a directory and a miss', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'file-ref-'))
+    mkdirSync(join(root, 'src'))
+    writeFileSync(join(root, 'src', 'app.ts'), 'x')
+
+    await expect(locateRefPath('src/app.ts', root)).resolves.toEqual({
+      absPath: join(root, 'src/app.ts'), exists: true, isDirectory: false,
+    })
+    await expect(locateRefPath('src', root)).resolves.toEqual({
+      absPath: join(root, 'src'), exists: true, isDirectory: true,
+    })
+    await expect(locateRefPath('src/nope.ts', root)).resolves.toEqual({
+      absPath: join(root, 'src/nope.ts'), exists: false, isDirectory: false,
+    })
+    await expect(locateRefPath('src/app.ts', null)).resolves.toEqual({
+      absPath: null, exists: false, isDirectory: false,
+    })
+  })
+})

--- a/codey-mac/electron/file-ref.ts
+++ b/codey-mac/electron/file-ref.ts
@@ -1,0 +1,44 @@
+// Turn a path written inside a chat message into a real path on disk.
+//
+// Messages carry paths in three shapes: absolute ("/Users/me/x.ts"), home
+// relative ("~/x.ts") and workspace relative ("src/app.ts"). Only the last one
+// needs the chat's working dir, which the renderer passes along.
+
+import { isAbsolute, join, normalize, resolve } from 'path'
+import { homedir } from 'os'
+import { stat } from 'fs/promises'
+
+export interface LocatedPath {
+  /** Absolute path, or null when the reference could not be resolved at all. */
+  absPath: string | null
+  exists: boolean
+  isDirectory: boolean
+}
+
+/**
+ * Expand `~` and resolve a relative path against `cwd`. Returns null when the
+ * path is relative and no working dir is known — guessing against the app's
+ * own cwd would open unrelated files.
+ */
+export function resolveRefPath(path: string, cwd?: string | null): string | null {
+  const trimmed = typeof path === 'string' ? path.trim() : ''
+  if (!trimmed) return null
+  if (trimmed === '~' || trimmed.startsWith('~/')) {
+    return normalize(join(homedir(), trimmed.slice(1)))
+  }
+  if (isAbsolute(trimmed)) return normalize(trimmed)
+  if (!cwd) return null
+  return resolve(cwd, trimmed)
+}
+
+/** Resolve a reference and ask the filesystem what, if anything, is there. */
+export async function locateRefPath(path: string, cwd?: string | null): Promise<LocatedPath> {
+  const absPath = resolveRefPath(path, cwd)
+  if (!absPath) return { absPath: null, exists: false, isDirectory: false }
+  try {
+    const info = await stat(absPath)
+    return { absPath, exists: true, isDirectory: info.isDirectory() }
+  } catch {
+    return { absPath, exists: false, isDirectory: false }
+  }
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -20,6 +20,7 @@ import { isKnownPlugin, listPlugins } from './plugins'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
+import { locateRefPath } from './file-ref'
 import type { ScannedSkill } from './skills'
 import { AGENT_MEMORY, scanProjectMemory, scanUserMemory } from './memory'
 import { legacySharedFilePath, renderSharedBody, sharedMemoryTargets, syncSharedMemory } from './shared-memory'
@@ -3252,6 +3253,42 @@ app.whenReady().then(async () => {
       await new Promise<void>((resolve, reject) => {
         execFile('open', ['-a', appPath, target], (error) => error ? reject(error) : resolve())
       })
+    })
+  )
+
+  // A path mentioned in a chat message. `locate` tells the renderer whether the
+  // reference is real (only then is it styled as a link); `open` hands the
+  // resolved path to the preferred editor, or to Finder for a directory or a
+  // reveal.
+  ipcMain.handle('fileRef:locate', async (_e, target: string, cwd: string | null) =>
+    wrap(async () => locateRefPath(target, cwd))
+  )
+
+  ipcMain.handle('fileRef:open', async (
+    _e,
+    target: string,
+    cwd: string | null,
+    options: { editorId?: string; reveal?: boolean } = {},
+  ) =>
+    wrap(async () => {
+      const located = await locateRefPath(target, cwd)
+      if (!located.absPath || !located.exists) throw new Error('Path is unavailable')
+      if (options.reveal) { shell.showItemInFolder(located.absPath); return }
+      if (!located.isDirectory && options.editorId) {
+        const editor = supportedEditors.find(candidate => candidate.id === options.editorId)
+        const appPath = editor ? await findEditorApp(editor) : null
+        if (appPath) {
+          const { execFile } = await import('child_process')
+          await new Promise<void>((resolve, reject) => {
+            execFile('open', ['-a', appPath, located.absPath!], (error) => error ? reject(error) : resolve())
+          })
+          return
+        }
+      }
+      // No editor (or a directory): let the OS decide — Finder for a folder,
+      // the default app for a file.
+      const error = await shell.openPath(located.absPath)
+      if (error) throw new Error(error)
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -27,6 +27,11 @@ contextBridge.exposeInMainWorld('codey', {
     list: () => ipcRenderer.invoke('editors:list'),
     open: (editorId: string, path: string) => ipcRenderer.invoke('editors:open', editorId, path),
   },
+  fileRef: {
+    locate: (path: string, cwd: string | null) => ipcRenderer.invoke('fileRef:locate', path, cwd),
+    open: (path: string, cwd: string | null, options?: { editorId?: string; reveal?: boolean }) =>
+      ipcRenderer.invoke('fileRef:open', path, cwd, options ?? {}),
+  },
   globalTeams: {
     get: () => ipcRenderer.invoke('globalTeams:get'),
     set: (teams: Record<string, unknown>) => ipcRenderer.invoke('globalTeams:set', teams),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -289,6 +289,11 @@ declare global {
         /** Open a file or directory in the given editor. */
         open: (editorId: string, path: string) => Promise<IpcResult<void>>
       }
+      /** Paths mentioned inside a chat message. */
+      fileRef: {
+        locate: (path: string, cwd: string | null) => Promise<IpcResult<{ absPath: string | null; exists: boolean; isDirectory: boolean }>>
+        open: (path: string, cwd: string | null, options?: { editorId?: string; reveal?: boolean }) => Promise<IpcResult<void>>
+      }
       globalTeams: {
         get: () => Promise<IpcResult<Record<string, TeamConfigRaw>>>
         set: (teams: Record<string, TeamConfigRaw>) => Promise<IpcResult<void>>

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -5,6 +5,7 @@ import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
 import { Markdown } from './Markdown'
+import { FilePathCwd } from './FilePathLink'
 import { PairingModal } from './PairingModal'
 import { AttachmentPreview } from './AttachmentPreview'
 import { consumePendingPairing } from './pendingPairing'
@@ -2195,6 +2196,8 @@ export const ChatTab: React.FC<Props> = ({
   }, [panelTeamName])
 
   return (
+    // Paths written in this chat's messages resolve against its working dir.
+    <FilePathCwd.Provider value={workingDir ?? null}>
     <div ref={outerRef} style={styles.outer}>
       <div
         style={styles.container}
@@ -3336,6 +3339,7 @@ export const ChatTab: React.FC<Props> = ({
         )
       })()}
     </div>
+    </FilePathCwd.Provider>
   )
 }
 

--- a/codey-mac/src/components/FilePathLink.tsx
+++ b/codey-mac/src/components/FilePathLink.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { C } from '../theme'
+import { opensInSystemApp } from './filePathRef'
+
+/**
+ * Working dir that message-relative paths are resolved against. Chat provides
+ * it; other Markdown surfaces leave it undefined, where only absolute and `~`
+ * paths become links.
+ */
+export const FilePathCwd = React.createContext<string | null>(null)
+
+/** Editor preference shared with the chat toolbar's "Open in" button. */
+const PREFERRED_KEY = 'codey.preferredEditor'
+
+type Located = { absPath: string | null; exists: boolean; isDirectory: boolean }
+
+/** One lookup per (cwd, path) for the life of the window: a long chat repeats
+ *  the same path dozens of times, and re-rendering must not re-stat it. */
+const locateCache = new Map<string, Promise<Located | null>>()
+
+function locate(path: string, cwd: string | null): Promise<Located | null> {
+  const key = `${cwd ?? ''}\u0000${path}`
+  const cached = locateCache.get(key)
+  if (cached) return cached
+  const pending = (window.codey?.fileRef?.locate?.(path, cwd) ?? Promise.resolve(null))
+    .then((res: any) => (res && res.ok ? res.data as Located : null))
+    .catch(() => null)
+  locateCache.set(key, pending)
+  return pending
+}
+
+async function preferredEditorId(): Promise<string | undefined> {
+  const saved = localStorage.getItem(PREFERRED_KEY) ?? ''
+  const res = await window.codey.editors.list()
+  const editors = res.ok ? res.data : []
+  const installed = editors.filter(editor => editor.installed)
+  return installed.find(editor => editor.id === saved)?.id ?? installed[0]?.id
+}
+
+interface FilePathLinkProps {
+  /** The path exactly as written in the message. */
+  path: string
+  /** Line number, when the message wrote one; passed through for the tooltip. */
+  line?: number
+  /** Rendered as-is until the path is confirmed to exist. */
+  children: React.ReactNode
+  style: React.CSSProperties
+  linkColor: string
+}
+
+/**
+ * An inline-code span that turned out to be a real path: click opens it (in
+ * the preferred editor for a file, in Finder for a directory), ⌘/⇧-click
+ * reveals it in Finder. A path that does not exist stays plain text, so a
+ * backticked command or MIME type never grows a dead link.
+ */
+export const FilePathLink: React.FC<FilePathLinkProps> = ({ path, line, children, style, linkColor }) => {
+  const cwd = React.useContext(FilePathCwd)
+  const [located, setLocated] = React.useState<Located | null>(null)
+  const [hover, setHover] = React.useState(false)
+
+  React.useEffect(() => {
+    let alive = true
+    void locate(path, cwd).then(res => { if (alive) setLocated(res) })
+    return () => { alive = false }
+  }, [path, cwd])
+
+  const live = located?.exists === true
+  if (!live) return <code style={style}>{children}</code>
+
+  const open = async (event: React.MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    const reveal = event.metaKey || event.shiftKey
+    // A directory, a PDF, an image or an archive belongs to the OS; only text
+    // goes to the editor. Passing no editorId makes the main process fall back
+    // to `shell.openPath`, which is exactly the macOS double-click behaviour.
+    const editorId = reveal || located?.isDirectory || opensInSystemApp(path)
+      ? undefined
+      : await preferredEditorId()
+    const res = await window.codey.fileRef.open(path, cwd, { editorId, reveal })
+    if (!res.ok) alert(`Couldn't open ${path}: ${res.error}`)
+  }
+
+  const what = located?.isDirectory
+    ? 'folder in Finder'
+    : opensInSystemApp(path)
+      ? 'file in its default app'
+      : 'file in your editor'
+  return (
+    <code
+      role="link"
+      tabIndex={0}
+      onClick={event => { void open(event) }}
+      onKeyDown={event => {
+        if (event.key !== 'Enter' && event.key !== ' ') return
+        event.preventDefault()
+        void open(event as unknown as React.MouseEvent)
+      }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      title={`Click to open the ${what}${line ? ` (line ${line})` : ''} · ⌘-click to reveal in Finder\n${located?.absPath ?? path}`}
+      style={{
+        ...style,
+        color: linkColor,
+        cursor: 'pointer',
+        textDecoration: hover ? 'underline' : 'none',
+        textUnderlineOffset: 2,
+        boxShadow: hover ? `inset 0 0 0 1px ${C.border2}` : 'none',
+      }}
+    >
+      {children}
+    </code>
+  )
+}

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { C } from '../theme'
+import { FilePathLink } from './FilePathLink'
+import { parseFileRef } from './filePathRef'
 
 interface MarkdownProps {
   children: string
@@ -345,26 +347,36 @@ const MarkdownInner: React.FC<MarkdownProps> = ({ children, variant = 'assistant
             if (isBlock) {
               return <code className={className} style={{ fontFamily: MONO, background: 'transparent', padding: 0 }}>{children}</code>
             }
-            return (
-              <code
-                {...props}
-                style={{
-                  background: inlineCodeBg,
-                  color: inlineCodeFg,
-                  padding: '1px 6px',
-                  borderRadius: 4,
-                  fontSize: 12,
-                  fontFamily: MONO,
-                  // Preserve spaces while still allowing long inline snippets
-                  // to wrap inside a narrow message bubble.
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-word',
-                  overflowWrap: 'anywhere',
-                }}
-              >
-                {children}
-              </code>
-            )
+            const inlineStyle: React.CSSProperties = {
+              background: inlineCodeBg,
+              color: inlineCodeFg,
+              padding: '1px 6px',
+              borderRadius: 4,
+              fontSize: 12,
+              fontFamily: MONO,
+              // Preserve spaces while still allowing long inline snippets
+              // to wrap inside a narrow message bubble.
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              overflowWrap: 'anywhere',
+            }
+            // A backticked path is the way agents name files, so offer the
+            // same affordance links get. FilePathLink falls back to plain
+            // inline code when the path does not exist on disk.
+            const text = typeof children === 'string'
+              ? children
+              : Array.isArray(children) && children.every(c => typeof c === 'string')
+                ? children.join('')
+                : null
+            const ref = text ? parseFileRef(text) : null
+            if (ref) {
+              return (
+                <FilePathLink path={ref.path} line={ref.line} style={inlineStyle} linkColor={linkColor}>
+                  {children}
+                </FilePathLink>
+              )
+            }
+            return <code {...props} style={inlineStyle}>{children}</code>
           },
         }}
       >

--- a/codey-mac/src/components/filePathRef.test.ts
+++ b/codey-mac/src/components/filePathRef.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { opensInSystemApp, parseFileRef } from './filePathRef'
+
+describe('parseFileRef', () => {
+  it('accepts absolute, home and relative paths', () => {
+    expect(parseFileRef('/Users/me/project/src/app.ts')).toEqual({ path: '/Users/me/project/src/app.ts' })
+    expect(parseFileRef('~/notes/todo.md')).toEqual({ path: '~/notes/todo.md' })
+    expect(parseFileRef('./scripts/build.sh')).toEqual({ path: './scripts/build.sh' })
+    expect(parseFileRef('src/gateway.ts')).toEqual({ path: 'src/gateway.ts' })
+  })
+
+  it('accepts a bare filename and a dotfile', () => {
+    expect(parseFileRef('package.json')).toEqual({ path: 'package.json' })
+    expect(parseFileRef('.env')).toEqual({ path: '.env' })
+  })
+
+  it('accepts a directory, without its trailing slash', () => {
+    expect(parseFileRef('src/components/')).toEqual({ path: 'src/components' })
+    expect(parseFileRef('/tmp')).toEqual({ path: '/tmp' })
+  })
+
+  it('pulls out a line number', () => {
+    expect(parseFileRef('src/app.ts:42')).toEqual({ path: 'src/app.ts', line: 42 })
+    expect(parseFileRef('src/app.ts:42:7')).toEqual({ path: 'src/app.ts', line: 42 })
+  })
+
+  it('drops punctuation that got swept in', () => {
+    expect(parseFileRef('(src/app)')).toEqual({ path: 'src/app' })
+    expect(parseFileRef('src/app.ts')).toEqual({ path: 'src/app.ts' })
+  })
+
+  it('rejects URLs and mail addresses', () => {
+    expect(parseFileRef('https://example.com/a.ts')).toBeNull()
+    expect(parseFileRef('mailto:me@example.com')).toBeNull()
+  })
+
+  it('rejects commands, prose and globs', () => {
+    expect(parseFileRef('npm run build')).toBeNull()
+    expect(parseFileRef('src/**/*.ts')).toBeNull()
+    expect(parseFileRef('gateway')).toBeNull()
+    expect(parseFileRef('')).toBeNull()
+    expect(parseFileRef('x'.repeat(500))).toBeNull()
+  })
+})
+
+describe('opensInSystemApp', () => {
+  it('sends documents, media and archives to the OS', () => {
+    expect(opensInSystemApp('docs/spec.pdf')).toBe(true)
+    expect(opensInSystemApp('/tmp/shot.PNG')).toBe(true)
+    expect(opensInSystemApp('build/app.zip')).toBe(true)
+  })
+
+  it('keeps text-ish files in the editor', () => {
+    expect(opensInSystemApp('src/app.ts')).toBe(false)
+    expect(opensInSystemApp('icon.svg')).toBe(false)
+    expect(opensInSystemApp('notes.md')).toBe(false)
+    expect(opensInSystemApp('Makefile')).toBe(false)
+    expect(opensInSystemApp('data.weirdext')).toBe(false)
+  })
+})

--- a/codey-mac/src/components/filePathRef.ts
+++ b/codey-mac/src/components/filePathRef.ts
@@ -1,0 +1,86 @@
+// Decide whether an inline-code span in a message is a file path worth
+// turning into a clickable link.
+//
+// This is deliberately a *candidate* filter, not a verdict: agents write
+// plenty of backticked things that look path-ish (`npm run build`, `a/b`
+// branch names, `text/plain`). Being liberal here is safe because the
+// renderer only styles a candidate as a link after the main process confirms
+// the path actually exists on disk — so a false positive costs one `stat`,
+// never a dead link.
+
+export interface FileRef {
+  /** The path as written, minus any trailing `:line[:col]` and punctuation. */
+  path: string
+  /** 1-based line number when the reference carried one. */
+  line?: number
+}
+
+/** `https://`, `file://`, `mailto:` … — links, not paths. */
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/|\S*@)/
+
+/** Characters that never appear in a path we would open. */
+const ILLEGAL_RE = /[\s*?<>|"'`$\\]/
+
+/** A file extension: `.ts`, `.tsx`, `.json`, `.md` … */
+const EXT_RE = /\.[A-Za-z0-9_]{1,10}$/
+
+/** Sentence punctuation that got swept into the span. */
+const TRAILING_RE = /[.,;:!?)\]}]+$/
+const LEADING_RE = /^[(\[{]+/
+
+/** Longest path we bother considering; anything longer is prose. */
+const MAX_LEN = 400
+
+/**
+ * Parse one inline-code span into a file reference, or null when it does not
+ * look like a path at all.
+ */
+export function parseFileRef(raw: string): FileRef | null {
+  const text = raw.trim()
+  if (!text || text.length > MAX_LEN) return null
+  if (SCHEME_RE.test(text)) return null
+  if (ILLEGAL_RE.test(text)) return null
+
+  // `src/app.ts:42` and `src/app.ts:42:7` both point at line 42.
+  const lineMatch = /^(.*?):(\d+)(?::\d+)?$/.exec(text)
+  let path = lineMatch ? lineMatch[1] : text
+  const line = lineMatch ? Number(lineMatch[2]) : undefined
+
+  // Drop a trailing "." or ")" only when it is not part of the name — a bare
+  // dotfile like ".env" and a directory like "dist/" must survive.
+  path = path.replace(LEADING_RE, '')
+  if (!EXT_RE.test(path)) path = path.replace(TRAILING_RE, '')
+  path = path.replace(/\/+$/, '') || '/'
+  if (!path || path.length > MAX_LEN) return null
+
+  const looksAnchored = /^(\/|~\/|\.{1,2}\/)/.test(path)
+  const hasSeparator = path.includes('/')
+  const hasExtension = EXT_RE.test(path) || /^\.[A-Za-z0-9_.-]+$/.test(path)
+  if (!looksAnchored && !hasSeparator && !hasExtension) return null
+
+  return line !== undefined ? { path, line } : { path }
+}
+
+/**
+ * Formats that are not text: a code editor either refuses them or shows bytes,
+ * so these go to the macOS default app instead (Preview for a PDF or an image,
+ * QuickTime for a clip, Numbers for a spreadsheet…). Anything not listed —
+ * including unknown extensions — is assumed to be text and opens in the
+ * editor, which is the safe default for source files.
+ */
+const SYSTEM_APP_EXTENSIONS = new Set([
+  'pdf', 'epub',
+  'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'pages', 'numbers', 'key', 'rtf',
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'heic', 'tiff', 'tif', 'bmp', 'ico', 'avif',
+  'mp4', 'mov', 'avi', 'mkv', 'webm', 'm4v',
+  'mp3', 'wav', 'm4a', 'aac', 'flac', 'ogg',
+  'zip', 'tar', 'gz', 'tgz', 'bz2', 'rar', '7z', 'dmg', 'pkg', 'app',
+  'psd', 'ai', 'sketch', 'fig', 'xcf',
+  'ttf', 'otf', 'woff', 'woff2',
+])
+
+/** True when the path should be handed to the OS rather than to an editor. */
+export function opensInSystemApp(path: string): boolean {
+  const ext = /\.([A-Za-z0-9]+)$/.exec(path)?.[1]?.toLowerCase()
+  return !!ext && SYSTEM_APP_EXTENSIONS.has(ext)
+}


### PR DESCRIPTION
## What

URLs in a message were clickable; file paths were not, so acting on a path meant selecting the text and pasting it somewhere.

A backticked path in a chat message is now a link:

- **text file** → the preferred editor (same `codey.preferredEditor` the chat toolbar's "Open in" uses)
- **directory** → Finder
- **PDF / image / video / archive / office doc** → the macOS default app, i.e. what a double-click in Finder would do. An editor shows those as bytes, so they go through `shell.openPath` instead.
- **⌘- or ⇧-click** → reveal in Finder, whatever the kind
- `src/app.ts:42` is understood; the line number shows in the tooltip.

## How it avoids dead links

The candidate filter is deliberately liberal, because a span is only *styled* as a link after the main process confirms the path exists on disk. `npm run build` and `text/plain` reach the filter, fail the stat, and stay plain inline code. The lookup is cached per (working dir, path) — a long chat repeats the same path dozens of times.

Relative paths resolve against the chat's working dir, passed down through a context. Markdown surfaces without one (team panels, automations) still linkify absolute and `~` paths.

Unknown extensions are treated as text: source-file extensions are unbounded, and the editor is the safe guess.

## Tests

- `filePathRef.test.ts` — what counts as a path, line-number parsing, URL/glob/command rejection, editor-vs-system-app routing
- `file-ref.test.ts` — `~` expansion, working-dir resolution, refusing a relative path with no working dir, file/dir/miss stat

`tsc` (renderer + electron), 838 unit tests and lint all pass. **Not yet run in the real app** — worth a click-through before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)