### PR TITLE
fix(mac): let a Browser plugin uninstall stick across restarts

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -1000,9 +1000,14 @@ async function bootInProcessCore() {
     try {
       const [fsMod, osMod, pathMod] = await Promise.all([import('fs'), import('os'), import('path')])
       removeLegacyManagedSkills(fsMod, pathMod, osMod.homedir(), CODEY_SKILL_DISCOVERY_SUBDIRS)
-      if (coreConfigManager.isPluginEnabled('browser') && browserSkillStatus().state === 'absent') {
-        await installBrowserSkill()
-        await syncCodeyGlobalSkills()
+      if (coreConfigManager.isPluginEnabled('browser')) {
+        if (browserSkillStatus().state === 'absent') {
+          await installBrowserSkill()
+          await syncCodeyGlobalSkills()
+        }
+        // The skill on disk is now the only source of truth. Drop the flag so a
+        // later uninstall stays uninstalled instead of being undone at startup.
+        coreConfigManager.clearLegacyPluginFlags()
       }
 
     } catch { /* best-effort: the Plugins tab can install it by hand */ }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -756,6 +756,16 @@ export class ConfigManager extends EventEmitter {
     return this.config.plugins?.[name]?.enabled === true;
   }
 
+  /** Forget the legacy opt-in once it has been carried over. `update()` merges
+   *  and so can never drop a key; the migration needs the flag gone from disk,
+   *  or "install it for them once" quietly becomes "reinstall it every launch"
+   *  and a deliberate uninstall cannot stick. */
+  clearLegacyPluginFlags(): void {
+    if (this.config.plugins === undefined) return;
+    delete this.config.plugins;
+    this.save();
+  }
+
   // ── External MCP servers ───────────────────────────────────────────
   /** Add or replace one external MCP server entry. Saves and emits change. */
   setExternalMcpServer(name: string, cfg: ExternalMcpServerConfig): void {

--- a/packages/gateway/src/plugins-config.test.ts
+++ b/packages/gateway/src/plugins-config.test.ts
@@ -45,3 +45,35 @@ describe('plugins config', () => {
     expect(mgr.isPluginEnabled('browser')).toBe(true);
   });
 });
+
+describe('clearing the legacy plugin opt-in', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-plugins-clear-'));
+    file = path.join(dir, 'gateway.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes the flag from disk so the migration runs only once', () => {
+    fs.writeFileSync(file, JSON.stringify({ plugins: { browser: { enabled: true } } }));
+    const mgr = new ConfigManager(file);
+    expect(mgr.isPluginEnabled('browser')).toBe(true);
+
+    mgr.clearLegacyPluginFlags();
+
+    expect(mgr.isPluginEnabled('browser')).toBe(false);
+    expect(JSON.parse(fs.readFileSync(file, 'utf8')).plugins).toBeUndefined();
+    expect(new ConfigManager(file).isPluginEnabled('browser')).toBe(false);
+  });
+
+  it('is a no-op when the flag was never there', () => {
+    const mgr = new ConfigManager(file);
+    mgr.clearLegacyPluginFlags();
+    expect(mgr.isPluginEnabled('browser')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`plugins.browser.enabled` in `gateway.json` is a legacy opt-in from before plugins were installed as skills. It exists to carry a pre-existing opt-in forward **once** — but nothing ever cleared it.

So every launch re-read it and reinstalled the skill. Uninstalling the Browser plugin from the Plugins tab worked, and then silently undid itself on the next start.

## Change

Clear the flag once the migration has done its job.

- `ConfigManager.clearLegacyPluginFlags()` deletes the `plugins` key and saves. `update()` merges, so it can never drop a key — this needs its own method.
- `main.ts` calls it whenever the flag is set, not only when an install happened. An old user whose skill is already on disk has finished migrating too, so their flag should go as well.

## Not affected

New users. `plugins` is absent from a fresh config, `isPluginEnabled` requires `=== true`, and nothing writes the field any more.

## Testing

Two new cases in `plugins-config.test.ts` — the flag is gone from disk and from a reloaded manager, and clearing an absent flag is a no-op. Both were confirmed red before the implementation landed.

`npm test` green across all three workspaces (core 459, gateway, mac 838). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)