### PR TITLE
chore: remove config fields nothing reads

### DIFF
--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -29,8 +29,6 @@ interface VoiceCfg {
   localModel: string
   realtimeUrl: string
   realtimeModel: string
-  /** Legacy setting kept for config compatibility. The two hotkeys now have fixed destinations. */
-  mode: 'inject' | 'converse'
   /** Preferred spellings, handed to the recognizer as a prompt hint. */
   vocabulary: string[]
   /** Add words to the dictionary from corrections made in a Codey chat before sending. */
@@ -83,7 +81,6 @@ const VOICE_DEFAULT: VoiceCfg = {
   localModel: 'openai_whisper-large-v3_turbo_954MB',
   realtimeUrl: 'wss://api.openai.com/v1/realtime?intent=transcription',
   realtimeModel: 'gpt-4o-mini-transcribe',
-  mode: 'inject',
   vocabulary: [],
   vocabularyAutoLearn: true,
   polish: { enabled: false, model: '', timeoutMs: 10000, extraInstructions: '' },
@@ -347,9 +344,6 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
         enabled: dictationEnabled || conversationEnabled,
         dictationEnabled,
         conversationEnabled,
-        // Dictation and talk-to-chat now have separate triggers. Migrate old
-        // configs so the primary hotkey always keeps its dictation meaning.
-        mode: 'inject',
         vocabulary,
         // Same one-level-deeper merge as tts, and for the same reason: a
         // config written before this section existed must not blank it out.
@@ -416,7 +410,6 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
     const next = {
       ...patched,
       enabled: patched.dictationEnabled || patched.conversationEnabled,
-      mode: 'inject' as const,
     }
     setVoice(next)
     try {

--- a/gateway.json.example
+++ b/gateway.json.example
@@ -1,7 +1,6 @@
 {
   "gateway": {
-    "port": 3000,
-    "defaultAgent": "claude-code"
+    "port": 3000
   },
   "channels": {
     "telegram": {
@@ -47,15 +46,6 @@
       ]
     }
   },
-  "profiles": [
-    {
-      "name": "default",
-      "anthropic": { "apiKey": "", "baseUrl": "" },
-      "openai": { "apiKey": "", "baseUrl": "" },
-      "google": { "apiKey": "" }
-    }
-  ],
-  "activeProfile": "default",
   "context": {
     "ttlMinutes": 60
   },

--- a/gateway.json.example
+++ b/gateway.json.example
@@ -96,10 +96,5 @@
     "apiKeyRef": "voice-main",
     "apiModel": "whisper-1",
     "localModel": "openai_whisper-large-v3-turbo"
-  },
-  "plugins": {
-    "browser": {
-      "enabled": false
-    }
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -393,7 +393,6 @@ export interface SharedMemorySettings {
 export interface MemorySettings {
   enabled?: boolean;
   autoExtract?: boolean;
-  maxAutoMemories?: number;
 }
 
 // Gateway configuration

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -30,10 +30,9 @@ export interface GatewayConfigJson {
     imessage?: { enabled: boolean; allowedSenders?: string[]; pollIntervalMs?: number };
   };
   /**
-   * Reserved per-agent settings slot. Currently empty — enablement is derived
-   * from membership in `fallback.order`, and per-agent default model lives on
-   * those fallback entries. Kept in the schema for forward compatibility so
-   * future per-agent options (custom env vars, timeouts, …) have a home.
+   * Per-agent settings. Holds the agent's default reasoning effort; enablement
+   * is derived from membership in `fallback.order`, and per-agent default
+   * model lives on those fallback entries.
    */
   agents: {
     'claude-code'?: AgentSlot;
@@ -95,8 +94,6 @@ export interface GatewayConfigJson {
     enabled?: boolean;
     /** Let Codey record entries by itself from interactions. Default true. */
     autoExtract?: boolean;
-    /** Cap on auto-recorded entries kept per store. */
-    maxAutoMemories?: number;
   };
   /**
    * One shared knowledge base that every agent reads. Codey keeps the text in
@@ -147,9 +144,6 @@ export interface GatewayConfigJson {
     converseHotkey?: string;
     language: string;
     injection: 'paste' | 'ax';
-    /** Legacy compatibility field. The primary hotkey always dictates and
-     *  converseHotkey always talks to the selected Chat. */
-    mode?: 'inject' | 'converse';
     /** Transcription backend: hosted API or on-device WhisperKit. */
     provider: 'api' | 'local';
     /** Base URL of an OpenAI-compatible transcription endpoint (e.g. https://api.openai.com/v1). */


### PR DESCRIPTION
## What

Traced every field in `GatewayConfigJson` back to a reader. Five turned out to have none.

| Field | Why it is dead |
|---|---|
| `plugins.browser.enabled` (example) | Legacy opt-in, read once by the Mac app to migrate an old user. Copying it into a fresh config does nothing but suggest the plugin is toggled from config — it is toggled from the Plugins tab. |
| `profiles` / `activeProfile` (example) | Zero references in `packages/`. API keys live in `apiKeys` + `~/.codey/secrets.json`. |
| `gateway.defaultAgent` (example) | `getDefaultAgent()` reads `fallback.order[0].agent`. Editing this field has no effect. |
| `voice.mode` | Dead since dictation and talk-to-chat got separate hotkeys. |
| `memory.maxAutoMemories` | Declared in two type files, caps nothing. |

## The one that is not just noise

`profiles` looks like the place to put an API key:

```json
"profiles": [{ "name": "default", "anthropic": { "apiKey": "", "baseUrl": "" } }]
```

`stripSecrets` does not know that shape. A key typed there stays in plaintext in `gateway.json` instead of being migrated to the 0600 store — the opposite of what the rest of the config does.

## On `voice.mode`

`WhisperTab` overwrote it with `'inject'` on every read (`:352`) and every write (`:419`), and nothing branched on it. The Swift helper decodes it as `decodeIfPresent(...) ?? .inject`, so removing it from the JSON leaves that side unchanged too.

An old config that still carries the key keeps it — `normalize` spreads `voice` through — it is simply no longer declared or written.

## Also

Corrected the `agents` comment. It claimed the slot is "currently empty"; it holds `defaultEffort`.

## Testing

`npm test` green across all three workspaces (639 / 457 / 824). `tsc --noEmit` clean for core, gateway, and codey-mac. `gateway.json.example` still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)