### PR TITLE
fix(mac): identify a chat's PR by what the chat reported, not by the branch

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -150,8 +150,15 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
             .filter(item => workingDir === item.path || workingDir.startsWith(`${item.path}/`))
             .sort((a, b) => b.path.length - a.path.length)[0]
         : undefined
+      // A shared checkout's live branch is whoever moved it last, not this
+      // chat's work — when we know the branch its PR went to, that is the
+      // truthful answer to "what branch is this chat on?".
+      const live = status.ok && status.data ? status.data.branch : undefined
+      const owned = chat.executionMode === 'isolated-worktree'
+        ? live
+        : chat.pullRequest?.headBranch || live
       return {
-        branch: status.ok && status.data ? status.data.branch : chat.pullRequest?.headBranch,
+        branch: owned || chat.pullRequest?.headBranch,
         worktree: registered?.path || chat.chatWorkspace?.worktreePath || chat.workingDirOverride || info.workingDir,
       }
     } catch {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { chatOwnedPrUrl } from './chatPrUrl'
 import type { ChatMessage, ChatSelection, FileAttachment, TeamRunSummary } from '../types'
 import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
@@ -1224,29 +1225,29 @@ export const ChatTab: React.FC<Props> = ({
   const { status: gitStatus, refresh: refreshGit } = useGitStatus(workingDir)
   const [showPrModal, setShowPrModal] = useState(false)
   // Only an isolated worktree belongs to this chat. In a shared checkout the
-  // branch is global, so "whatever PR the current branch has" is somebody
-  // else's work — we may only adopt a branch's PR right after this chat's own
-  // run, or when the PR url is handed to us explicitly.
+  // branch is global — "whatever PR the current branch has" is whoever moved
+  // that branch last, so the chat has to prove which PR is its own instead.
   const ownsCheckout = chat?.executionMode === 'isolated-worktree'
-  const refreshPullRequestStatus = useCallback(async (
-    opts: { url?: string; discover?: boolean } = {},
-  ) => {
-    const url = opts.url || chat?.pullRequest?.url
+  // Evidence beats the pin: a chat that once adopted the wrong PR (or opened a
+  // second one) corrects itself from its own transcript.
+  const ownedPrUrl = useMemo(() => (ownsCheckout ? undefined : chatOwnedPrUrl(chat)), [ownsCheckout, chat])
+  const refreshPullRequestStatus = useCallback(async (opts: { url?: string } = {}) => {
+    const url = opts.url || ownedPrUrl || chat?.pullRequest?.url
     if (!workingDir) return
     const branch = gitStatus?.branch
-    const discover = (opts.discover ?? false) || ownsCheckout
-    const canDiscover = discover
+    // Resolving a PR from the branch is only honest when the branch is ours.
+    const canDiscover = ownsCheckout
       && !!branch && branch !== 'HEAD' && branch !== (gitStatus?.defaultBranch ?? 'main')
     if (!url && !canDiscover) return
     try {
-      const result = await window.codey.git.prStatus(workingDir, url, discover)
+      const result = await window.codey.git.prStatus(workingDir, url, ownsCheckout)
       if (result.ok) await setPullRequest(chatId, result.data)
     } catch { /* PR status is best effort */ }
-  }, [workingDir, chatId, chat?.pullRequest?.url, ownsCheckout, gitStatus?.branch, gitStatus?.defaultBranch])
+  }, [workingDir, chatId, ownedPrUrl, chat?.pullRequest?.url, ownsCheckout, gitStatus?.branch, gitStatus?.defaultBranch])
 
   useEffect(() => {
     void refreshPullRequestStatus()
-  }, [chat?.id, chat?.pullRequest?.url, workingDir, gitStatus?.branch])
+  }, [chat?.id, chat?.pullRequest?.url, ownedPrUrl, workingDir, gitStatus?.branch])
 
   useEffect(() => {
     const onFocus = () => void refreshPullRequestStatus()
@@ -1257,13 +1258,11 @@ export const ChatTab: React.FC<Props> = ({
   // An agent that opens the PR itself (`gh pr create` in a shell step) leaves
   // no trace the other triggers watch, so the badge used to stay blank until
   // the window lost and regained focus. Re-check the moment a run settles —
-  // and this is also the one moment a shared-checkout chat may claim the
-  // current branch's PR: it just ran, so the branch it sits on is the branch
-  // it worked on.
+  // by then the reply carrying the PR url has landed.
   const wasRunningRef = useRef(false)
   useEffect(() => {
     const running = !!flight
-    if (wasRunningRef.current && !running) void refreshPullRequestStatus({ discover: true })
+    if (wasRunningRef.current && !running) void refreshPullRequestStatus()
     wasRunningRef.current = running
   }, [!!flight]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/codey-mac/src/components/chatPrUrl.test.ts
+++ b/codey-mac/src/components/chatPrUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { chatOwnedPrUrl } from './chatPrUrl'
+import type { Chat, ChatMessage } from '../types'
+
+const message = (role: ChatMessage['role'], content: string, id = content.slice(0, 8)): ChatMessage =>
+  ({ id, role, content, timestamp: 1 })
+
+const chat = (messages: ChatMessage[]): Chat => ({
+  id: 'c1', title: 'Ship it', workspaceName: 'codey',
+  selection: { type: 'none' }, createdAt: 1, updatedAt: 1, messages,
+})
+
+describe('chatOwnedPrUrl', () => {
+  it('finds the PR the agent reported', () => {
+    expect(chatOwnedPrUrl(chat([
+      message('user', 'open a pr'),
+      message('assistant', 'PR is up: https://github.com/its-ahoh/codey/pull/376\n\nMerge when green.'),
+    ]))).toBe('https://github.com/its-ahoh/codey/pull/376')
+  })
+
+  it('takes the newest mention when the chat opened a second PR', () => {
+    expect(chatOwnedPrUrl(chat([
+      message('assistant', 'https://github.com/its-ahoh/codey/pull/374', 'a1'),
+      message('user', 'another one'),
+      message('assistant', 'https://github.com/its-ahoh/codey/pull/376', 'a2'),
+    ]))).toBe('https://github.com/its-ahoh/codey/pull/376')
+  })
+
+  it('takes the last url within a single reply', () => {
+    expect(chatOwnedPrUrl(chat([
+      message('assistant', 'rebased on https://github.com/its-ahoh/codey/pull/370, opened https://github.com/its-ahoh/codey/pull/376'),
+    ]))).toBe('https://github.com/its-ahoh/codey/pull/376')
+  })
+
+  it('ignores a PR the user pasted — that is usually somebody else’s', () => {
+    expect(chatOwnedPrUrl(chat([
+      message('user', 'review https://github.com/its-ahoh/codey/pull/370'),
+      message('assistant', 'Looks fine to me.'),
+    ]))).toBeUndefined()
+  })
+
+  it('ignores links that are not pull requests', () => {
+    expect(chatOwnedPrUrl(chat([
+      message('assistant', 'see https://github.com/its-ahoh/codey/issues/376 and https://github.com/its-ahoh/codey'),
+    ]))).toBeUndefined()
+  })
+
+  it('is quiet on an empty chat', () => {
+    expect(chatOwnedPrUrl(chat([]))).toBeUndefined()
+    expect(chatOwnedPrUrl(undefined)).toBeUndefined()
+  })
+})

--- a/codey-mac/src/components/chatPrUrl.ts
+++ b/codey-mac/src/components/chatPrUrl.ts
@@ -1,0 +1,29 @@
+import type { Chat } from '../types'
+
+/** `https://github.com/<owner>/<repo>/pull/<n>` — the shape `gh pr create`
+ *  prints and the one the PR modal hands back. Trailing path segments
+ *  (`/files`, `/conflicts`) and a query string are dropped so two mentions of
+ *  the same PR resolve to one url. */
+const PR_URL = /https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/gi
+
+/** The PR this chat can prove is its own.
+ *
+ *  A shared checkout's branch belongs to whoever moved it last, so the branch
+ *  cannot say which PR a chat delivered — and an agent that opens its PR from
+ *  a scratch worktree never moves the shared branch at all. What it does do is
+ *  report the url in its reply, which is evidence tied to this chat and no
+ *  other. The newest mention wins: a chat that opens a second PR has moved on
+ *  to it.
+ *
+ *  Assistant turns only. A user pasting a github link is usually asking about
+ *  someone else's PR, not claiming it. */
+export function chatOwnedPrUrl(chat: Chat | undefined): string | undefined {
+  const messages = chat?.messages ?? []
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message.role !== 'assistant') continue
+    const found = message.content?.match(PR_URL)
+    if (found?.length) return found[found.length - 1]
+  }
+  return undefined
+}


### PR DESCRIPTION
Follow-up to #374 — the same symptom, one layer deeper.

## What was still wrong

#374 stopped a shared-checkout chat from adopting another chat's PR when the branch moved *between* runs, but kept trusting the branch at one moment: right after the chat's own run settled. The reasoning was "it just ran, so the branch it sits on is the branch it worked on".

That is not true. An agent that opens its PR from a scratch worktree (or that switched back to `main` afterwards) never moves the shared branch at all. So a chat that had just opened **#376** came back showing **#375 · merged** — the PR of whatever branch the shared checkout happened to be parked on.

## The rule that actually holds

A shared checkout has no branch to identify a chat with. It does have the chat's own transcript, where the agent reports the url it opened.

- `chatOwnedPrUrl(chat)` takes the newest PR url from the chat's **assistant** turns and pins the status lookup to it. User turns are ignored — a pasted github link is usually somebody else's PR being discussed, not claimed.
- That url **outranks the stored pin**, so a chat that already adopted the wrong PR corrects itself on the next render instead of staying wrong forever.
- Branch-based resolution (`gh pr view` with no url) now happens only for a chat that **owns** its checkout — an isolated worktree.
- The hover card follows the same rule: a shared-checkout chat shows the branch its PR went to, not whatever branch the checkout is parked on.

## Tests

`codey-mac`: 830 passed (6 new for `chatOwnedPrUrl`), `tsc --noEmit` clean, `npm run lint` clean.

## Not fixed by this

Nothing rewrites history: a chat that never printed a PR url and holds a wrong pin keeps it. Every chat that reported its PR in the reply — which is how every agent-opened PR in this repo reads — is corrected on the next open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)