### PR TITLE
polish(mac): drop the rule above the Plugins list

### DIFF
--- a/codey-mac/src/components/PluginsTab.tsx
+++ b/codey-mac/src/components/PluginsTab.tsx
@@ -341,7 +341,7 @@ const styles: Record<string, React.CSSProperties> = {
     background: C.dangerBg, color: C.dangerFg, border: `1px solid ${C.dangerBorder}`,
     padding: '9px 11px', borderRadius: 9, marginBottom: 14, fontSize: 12,
   },
-  list: { borderTop: `1px solid ${C.border}` },
+  list: { borderTop: '1px solid transparent' },
   row: {
     display: 'flex', alignItems: 'center', gap: 10, minHeight: 66, padding: '8px 8px 8px 12px',
     background: 'transparent',


### PR DESCRIPTION
## What

The Plugins list drew a top border above the first row. With the intro blurb gone (#380) that rule sits right under the tab chrome and reads as noise.

Keeps the 1px as a transparent border so spacing is untouched; the between-row separators stay.

## Testing

- `npx tsc --noEmit` in `codey-mac` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)