### PR TITLE
feat(mac): let the attach picker accept any file type

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -3045,7 +3045,6 @@ export const ChatTab: React.FC<Props> = ({
               ref={fileInputRef}
               type="file"
               multiple
-              accept="image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql"
               style={{ display: 'none' }}
               onChange={handleFilePick}
             />

--- a/codey-mac/src/components/QuickQuestionView.tsx
+++ b/codey-mac/src/components/QuickQuestionView.tsx
@@ -49,7 +49,6 @@ const formatBytes = (n: number): string => {
 
 const MAX_SIZE = 10 * 1024 * 1024 // 10MB
 const MAX_ATTACHMENTS = 10
-const ACCEPT = 'image/*,text/*,.json,.ts,.tsx,.js,.jsx,.py,.rb,.go,.rs,.java,.c,.cpp,.h,.css,.html,.md,.yaml,.yml,.toml,.xml,.sh,.bash,.zsh,.log,.csv,.sql'
 
 export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
   const { getThread, ask, stop } = useQuickQuestion()
@@ -225,7 +224,6 @@ export const QuickQuestionView: React.FC<Props> = ({ chatId, inputRef }) => {
             ref={fileInputRef}
             type="file"
             multiple
-            accept={ACCEPT}
             style={{ display: 'none' }}
             onChange={handleFilePick}
           />


### PR DESCRIPTION
## What

The attach button's file picker greyed out Excel, PDF, zip — anything outside a hardcoded `accept` list of images plus a few code/text extensions.

Removed that allowlist in both places:
- `codey-mac/src/components/ChatTab.tsx` — chat composer paperclip
- `codey-mac/src/components/QuickQuestionView.tsx` — Quick Question upload

## Why it's safe

Nothing downstream cared about the extension. `chats:upload` in `electron/main.ts` writes the raw bytes to `.codey/uploads/` with whatever MIME the browser reports. The real guards — 10 MB per file, 10 attachments max — are unchanged.

## Testing

`npx tsc --noEmit` clean. Not yet exercised in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)