### PR TITLE
fix(chrome): make the Chrome Companion installable and reachable from chat

### DIFF
--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -22,9 +22,16 @@ localStorage into a named Codey Browser profile. This requires Chrome's
 and does not export passwords, page contents, form fields, history, or data
 from unrelated sites.
 
-Development installation:
+Installation from the Codey Mac app: use **Open chrome://extensions** and
+**Reveal folder & copy path** on the Plugins settings page. The app stages a
+copy of this directory at `~/Library/Application Support/Codey/chrome-extension`,
+because Chrome's picker cannot descend into the `Codey.app` bundle where the
+shipped copy lives.
 
-1. Open `chrome://extensions` in Chrome.
+Development installation from this repository:
+
+1. Open `chrome://extensions` in Chrome. (Chrome blocks links to its own pages,
+   so this URL has to be typed or opened from the Codey Mac app.)
 2. Enable **Developer mode**.
 3. Choose **Load unpacked** and select this directory.
 4. Keep Codey running. The extension discovers it and connects automatically.

--- a/codey-mac/electron/chrome-extension-stage.test.ts
+++ b/codey-mac/electron/chrome-extension-stage.test.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { stageChromeExtension, stagedVersion } from './chrome-extension-stage'
+
+const temps: string[] = []
+
+function temp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ext-stage-'))
+  temps.push(dir)
+  return dir
+}
+
+function bundledExtension(version: string): string {
+  const dir = temp()
+  fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify({ version, name: 'Codey' }))
+  fs.writeFileSync(path.join(dir, 'service-worker.js'), `// ${version}`)
+  fs.mkdirSync(path.join(dir, 'icons'))
+  fs.writeFileSync(path.join(dir, 'icons', 'codey-16.png'), 'png')
+  return dir
+}
+
+afterEach(() => {
+  while (temps.length) fs.rmSync(temps.pop()!, { force: true, recursive: true })
+})
+
+describe('stageChromeExtension', () => {
+  it('copies the whole extension, subdirectories included, out of the bundle', () => {
+    const target = stageChromeExtension(bundledExtension('1.0.0'), temp())
+    expect(path.basename(target)).toBe('chrome-extension')
+    expect(fs.readFileSync(path.join(target, 'service-worker.js'), 'utf8')).toBe('// 1.0.0')
+    expect(fs.existsSync(path.join(target, 'icons', 'codey-16.png'))).toBe(true)
+  })
+
+  it('creates a staging root that does not exist yet', () => {
+    const root = path.join(temp(), 'nested', 'deeper')
+    expect(fs.existsSync(stageChromeExtension(bundledExtension('1.0.0'), root))).toBe(true)
+  })
+
+  it('refreshes the staged copy when the bundled version moves on', () => {
+    const root = temp()
+    stageChromeExtension(bundledExtension('1.0.0'), root)
+    const target = stageChromeExtension(bundledExtension('1.1.0'), root)
+    expect(stagedVersion(target)).toBe('1.1.0')
+    expect(fs.readFileSync(path.join(target, 'service-worker.js'), 'utf8')).toBe('// 1.1.0')
+  })
+
+  it('drops files the new version no longer ships', () => {
+    const root = temp()
+    const staged = stageChromeExtension(bundledExtension('1.0.0'), root)
+    fs.writeFileSync(path.join(staged, 'removed.js'), 'old')
+    stageChromeExtension(bundledExtension('1.1.0'), root)
+    expect(fs.existsSync(path.join(staged, 'removed.js'))).toBe(false)
+  })
+
+  it('leaves an up-to-date copy alone', () => {
+    const root = temp()
+    const source = bundledExtension('1.0.0')
+    const staged = stageChromeExtension(source, root)
+    const before = fs.statSync(path.join(staged, 'manifest.json')).mtimeMs
+    stageChromeExtension(source, root)
+    expect(fs.statSync(path.join(staged, 'manifest.json')).mtimeMs).toBe(before)
+  })
+
+  it('restores a staged copy the user deleted, even at an unchanged version', () => {
+    const root = temp()
+    const source = bundledExtension('1.0.0')
+    fs.rmSync(stageChromeExtension(source, root), { force: true, recursive: true })
+    expect(fs.existsSync(path.join(stageChromeExtension(source, root), 'manifest.json'))).toBe(true)
+  })
+
+  it('refuses a build whose extension is missing', () => {
+    expect(() => stageChromeExtension(path.join(temp(), 'absent'), temp()))
+      .toThrow(/missing from this build/)
+  })
+})
+
+describe('stagedVersion', () => {
+  it('reads the manifest version', () => {
+    expect(stagedVersion(bundledExtension('0.9.2'))).toBe('0.9.2')
+  })
+
+  it('returns null for a missing or damaged manifest', () => {
+    const dir = temp()
+    expect(stagedVersion(dir)).toBe(null)
+    fs.writeFileSync(path.join(dir, 'manifest.json'), '{ not json')
+    expect(stagedVersion(dir)).toBe(null)
+  })
+})

--- a/codey-mac/electron/chrome-extension-stage.ts
+++ b/codey-mac/electron/chrome-extension-stage.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs'
+import { join } from 'path'
+
+/**
+ * Chrome's "Load unpacked" picker cannot descend into a `.app` bundle, so the
+ * copy of the extension that ships inside `Codey.app/Contents/Resources` is
+ * unreachable for the user who has to select it. Stage a copy in a plain user
+ * directory instead, and keep it in step with the bundled one by version.
+ */
+export function stageChromeExtension(source: string, stagingRoot: string): string {
+  if (!fs.existsSync(join(source, 'manifest.json'))) {
+    throw new Error('The Chrome companion extension is missing from this build')
+  }
+  const target = join(stagingRoot, 'chrome-extension')
+  if (!fs.existsSync(target) || stagedVersion(target) !== stagedVersion(source)) {
+    fs.rmSync(target, { force: true, recursive: true })
+    fs.mkdirSync(stagingRoot, { recursive: true })
+    fs.cpSync(source, target, { recursive: true })
+  }
+  return target
+}
+
+/** The manifest version of an extension directory, or null when unreadable. */
+export function stagedVersion(dir: string): string | null {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(join(dir, 'manifest.json'), 'utf8'))
+    return typeof manifest.version === 'string' ? manifest.version : null
+  } catch { return null }
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -17,6 +17,7 @@ import { runAgentUpdate, updatePlanFor } from './agent-update'
 import { availability, createLatestVersionsCache, fetchAllLatestVersions } from './agent-latest'
 import { SKILL_FILE, markSkillManagedBy, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
+import { stageChromeExtension } from './chrome-extension-stage'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
@@ -2049,7 +2050,6 @@ app.whenReady().then(async () => {
         `${request.text}${pageContext}`,
         () => { /* global listener mirrors events */ },
         request.attachments,
-        { browserTarget: 'chrome' },
       )
       return { chatId: chat.id, response: result.response }
     },
@@ -2437,12 +2437,26 @@ app.whenReady().then(async () => {
     chromeCompanion?.setAccent(String(hex || ''))
     return { ok: true }
   }))
+  // `chrome://` URLs cannot be linked to from any page or opened through
+  // LaunchServices, so the only way to put a user on the extensions page is to
+  // hand the URL to Chrome itself on the command line.
+  ipcMain.handle('chromeCompanion:openExtensionsPage', event => browserCall(event, async () => {
+    const { execFile } = await import('child_process')
+    await new Promise<void>((resolve, reject) => {
+      execFile('/usr/bin/open', ['-a', 'Google Chrome', 'chrome://extensions'], { timeout: 8000 }, error => {
+        if (error) reject(new Error('Google Chrome could not be opened. Install Chrome, then try again.'))
+        else resolve()
+      })
+    })
+    return { ok: true as const }
+  }))
   ipcMain.handle('chromeCompanion:showExtensionFolder', event => browserCall(event, async () => {
-    const extensionPath = chromeCompanionExtensionPath()
-    const fsMod = await import('fs')
-    if (!fsMod.existsSync(extensionPath)) throw new Error('The Chrome companion extension is missing from this build')
-    shell.showItemInFolder(join(extensionPath, 'manifest.json'))
-    return extensionPath
+    const staged = stageChromeExtension(chromeCompanionExtensionPath(), app.getPath('userData'))
+    shell.showItemInFolder(join(staged, 'manifest.json'))
+    // Chrome's picker has no address bar; the path on the clipboard is what
+    // makes Cmd+Shift+G a one-paste step.
+    clipboard.writeText(staged)
+    return staged
   }))
   ipcMain.handle('browser:controlPermission:get', event => browserCall(event, () =>
     browserControlPermission?.getState() ?? { approved: false, pending: null }

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -473,6 +473,7 @@ contextBridge.exposeInMainWorld('codey', {
     navigate: (url: string) => ipcRenderer.invoke('chromeCompanion:navigate', url),
     setAccent: (hex: string) => ipcRenderer.invoke('chromeCompanion:setAccent', hex),
     showExtensionFolder: () => ipcRenderer.invoke('chromeCompanion:showExtensionFolder'),
+    openExtensionsPage: () => ipcRenderer.invoke('chromeCompanion:openExtensionsPage'),
     onStatus: (handler: (state: any) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, state: any) => handler(state)
       ipcRenderer.on('chromeCompanion:status', listener)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -612,6 +612,7 @@ declare global {
         navigate: (url: string) => Promise<IpcResult<ChromeTabInfo>>
         setAccent: (hex: string) => Promise<IpcResult<{ ok: true }>>
         showExtensionFolder: () => Promise<IpcResult<string>>
+        openExtensionsPage: () => Promise<IpcResult<{ ok: true }>>
         onStatus: (handler: (state: ChromeCompanionStatus) => void) => () => void
       }
       browser: {

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -23,6 +23,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
   const [error, setError] = useState<string | null>(null)
   const [profileName, setProfileName] = useState('chrome-session')
   const [exported, setExported] = useState<string | null>(null)
+  const [copiedPath, setCopiedPath] = useState<string | null>(null)
 
   const useResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | null => {
     if (!result.ok) { setError(result.error); return null }
@@ -66,17 +67,24 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
       {shouldShowChromeInstallInstructions(status) && (
         <div style={styles.card}>
           <div style={styles.title}>Install the Chrome extension</div>
-          <div style={styles.copy}>Installation is one-time. After loading the extension, clicking the Codey avatar in Chrome opens its chat Side Panel; connection happens automatically in the background.</div>
+          <div style={styles.copy}>Installation is one-time, and there is nothing to configure afterwards — the extension finds Codey and pairs itself within about 30 seconds, as long as Codey stays running. Clicking the Codey avatar in Chrome then opens its chat Side Panel.</div>
           <ol style={styles.steps}>
-            <li>Open <code style={styles.code}>chrome://extensions</code> in Google Chrome.</li>
+            <li>Open Chrome’s <code style={styles.code}>chrome://extensions</code> page with the button below. (Chrome blocks links to its own pages, so it has to be opened this way.)</li>
             <li>Turn on <strong>Developer mode</strong>, then click <strong>Load unpacked</strong>.</li>
-            <li>Select the <code style={styles.code}>chrome-extension</code> folder shown by the button below.</li>
+            <li>Click the second button below: it reveals the folder in Finder and copies its path. In Chrome’s picker, press <strong>⌘⇧G</strong>, paste, and press Return — or just drag the revealed folder onto the extensions page.</li>
           </ol>
           <div style={{ ...styles.actions, ...(compact ? styles.stack : null) }}>
             <button style={styles.primary} disabled={busy} onClick={() => void run(async () => {
-              useResult(await window.codey.chromeCompanion.showExtensionFolder())
-            })}>Show chrome-extension folder</button>
+              useResult(await window.codey.chromeCompanion.openExtensionsPage())
+            })}>Open chrome://extensions</button>
+            <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
+              const path = useResult(await window.codey.chromeCompanion.showExtensionFolder())
+              if (path) setCopiedPath(path)
+            })}>Reveal folder &amp; copy path</button>
           </div>
+          {copiedPath && (
+            <div style={styles.success}>Path copied. Paste it into Chrome’s picker with ⌘⇧G: <code style={styles.code}>{copiedPath}</code></div>
+          )}
         </div>
       )}
 

--- a/packages/core/src/agents/browser-tools.test.ts
+++ b/packages/core/src/agents/browser-tools.test.ts
@@ -6,7 +6,6 @@ const base = (): AgentRequest => ({
   prompt: 'do the thing',
   context: { workingDir: '/tmp/work' },
   browserTools: true,
-  browserTarget: 'codey-browser',
 } as AgentRequest);
 
 const env = {
@@ -51,43 +50,35 @@ describe('addCodeyBrowserTools', () => {
   });
 
   it('can expose only the independent Chrome Companion capability', () => {
-    const request = addCodeyBrowserTools({ ...base(), browserTarget: 'chrome' }, false, env, true);
+    const request = addCodeyBrowserTools(base(), false, env, true);
     expect(request.extraEnv).toMatchObject({
       CODEY_CHROME_COMPANION_PLUGIN_ENABLED: '1',
       CODEY_CHROME_COMPANION_TOKEN: env.CODEY_CHROME_COMPANION_TOKEN,
       CODEY_BROWSER_SOCKET: env.CODEY_BROWSER_SOCKET,
     });
     expect(request.extraEnv).not.toHaveProperty('CODEY_BROWSER_PLUGIN_ENABLED');
-  });
-
-  it('exposes only Chrome Companion for turns originating in the Chrome side panel', () => {
-    const request = addCodeyBrowserTools(
-      { ...base(), browserTarget: 'chrome' },
-      true,
-      env,
-      true,
-    );
-    expect(request.extraEnv).toMatchObject({
-      CODEY_CHROME_COMPANION_PLUGIN_ENABLED: '1',
-      CODEY_CHROME_COMPANION_TOKEN: env.CODEY_CHROME_COMPANION_TOKEN,
-    });
-    expect(request.extraEnv).not.toHaveProperty('CODEY_BROWSER_PLUGIN_ENABLED');
     expect(request.extraEnv).not.toHaveProperty('CODEY_BROWSER_TOKEN');
   });
 
-  it('exposes neither browser when the turn target is none', () => {
-    const request = addCodeyBrowserTools(
-      { ...base(), browserTarget: 'none' },
-      true,
-      env,
-      true,
-    );
-    expect(request.extraEnv).toBeUndefined();
+  it('offers both browsers when both plugins are enabled, whatever the surface', () => {
+    const request = addCodeyBrowserTools(base(), true, env, true);
+    expect(request.extraEnv).toMatchObject({
+      CODEY_BROWSER_PLUGIN_ENABLED: '1',
+      CODEY_BROWSER_TOKEN: env.CODEY_BROWSER_TOKEN,
+      CODEY_CHROME_COMPANION_PLUGIN_ENABLED: '1',
+      CODEY_CHROME_COMPANION_TOKEN: env.CODEY_CHROME_COMPANION_TOKEN,
+    });
   });
 
-  it('does not infer a browser target when none was supplied', () => {
-    const { browserTarget: _target, ...request } = base();
-    expect(addCodeyBrowserTools(request as AgentRequest, true, env, true).extraEnv).toBeUndefined();
+  it('exposes neither browser when neither plugin is enabled', () => {
+    expect(addCodeyBrowserTools(base(), false, env, false).extraEnv).toBeUndefined();
+  });
+
+  it('omits the Chrome token when its credential is missing from env', () => {
+    const { CODEY_CHROME_COMPANION_TOKEN: _omitted, ...partial } = env as Record<string, string>;
+    const request = addCodeyBrowserTools(base(), true, partial as NodeJS.ProcessEnv, true);
+    expect(request.extraEnv).toMatchObject({ CODEY_BROWSER_PLUGIN_ENABLED: '1' });
+    expect(request.extraEnv).not.toHaveProperty('CODEY_CHROME_COMPANION_TOKEN');
   });
 
   it('does nothing when the bridge env is missing', () => {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -31,19 +31,21 @@ export * from './chrome-companion-skill';
  */
 export function addCodeyBrowserTools(
   request: AgentRequest,
-  skillActive: boolean,
+  browserSkillActive: boolean,
   env: NodeJS.ProcessEnv = process.env,
-  chromeCompanionActive = false,
+  chromeSkillActive = false,
 ): AgentRequest {
   const socket = env.CODEY_BROWSER_SOCKET;
-  const token = env.CODEY_BROWSER_TOKEN;
+  const browserToken = env.CODEY_BROWSER_TOKEN;
   const chromeToken = env.CODEY_CHROME_COMPANION_TOKEN;
   const runtime = env.CODEY_BROWSER_RUNTIME;
   const cli = env.CODEY_BROWSER_CLI;
-  // Browser selection is a capability boundary, not a prompt hint. Supplying
-  // only the chosen token makes it impossible for the other browser to win.
-  const browserReady = request.browserTarget === 'codey-browser' && skillActive && !!token;
-  const chromeReady = request.browserTarget === 'chrome' && chromeCompanionActive && !!chromeToken;
+  // Every installed browser skill is offered on every tool-capable turn, and
+  // the skills' own precedence rules decide which one a request means. The
+  // gate here is installation, not the surface the turn came from. A skill is
+  // useless without its bridge credential, so both must be present.
+  const browserReady = browserSkillActive && !!browserToken;
+  const chromeReady = chromeSkillActive && !!chromeToken;
   if ((!browserReady && !chromeReady) || !socket || !runtime || !cli) return request;
   if (request.browserTools !== true || !request.context?.workingDir || request.allowedTools) {
     return request;
@@ -54,7 +56,7 @@ export function addCodeyBrowserTools(
     extraEnv: {
       ...(request.extraEnv ?? {}),
       CODEY_BROWSER_SOCKET: socket,
-      ...(browserReady ? { CODEY_BROWSER_TOKEN: token } : {}),
+      ...(browserReady ? { CODEY_BROWSER_TOKEN: browserToken } : {}),
       ...(chromeReady ? { CODEY_CHROME_COMPANION_TOKEN: chromeToken } : {}),
       CODEY_BROWSER_CLI: cli,
       CODEY_BROWSER_RUNTIME: runtime,
@@ -159,15 +161,15 @@ export class AgentFactory {
     // Plugins tab, disabling from the Skills tab and deleting the directory by
     // hand are the same fact, and the agent must see whichever the user did
     // last without a restart.
-    let browserActive = false;
-    let chromeCompanionActive = false;
+    let browserSkillActive = false;
+    let chromeSkillActive = false;
     try {
-      browserActive = isBrowserSkillActive();
-      chromeCompanionActive = isChromeCompanionSkillActive();
+      browserSkillActive = isBrowserSkillActive();
+      chromeSkillActive = isChromeCompanionSkillActive();
     } catch {
       // Unreadable home: no skill, so no capability.
     }
-    request = addCodeyBrowserTools(request, browserActive, process.env, chromeCompanionActive);
+    request = addCodeyBrowserTools(request, browserSkillActive, process.env, chromeSkillActive);
     request = addExternalMcpServers(request, this.externalMcpProvider?.());
 
     // `~/.codey/skills` and `<project>/.codey/skills` are Codey's global and

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -171,9 +171,6 @@ export interface McpServerSpec {
   url?: string;
 }
 
-/** Browser capability made available to one agent turn. */
-export type BrowserTarget = 'codey-browser' | 'chrome' | 'none';
-
 export interface AgentRequest {
   prompt: string;
   agent: CodingAgent;
@@ -240,12 +237,6 @@ export interface AgentRequest {
    * the UI, because the user may switch chats while the watcher is active.
    */
   browserChatId?: string;
-  /**
-   * Exact browser capability selected for this turn. This is enforced by
-   * credential injection rather than prompt wording: an agent can only see
-   * the selected browser's token. `none` (and an absent value) expose neither.
-   */
-  browserTarget?: BrowserTarget;
   /**
    * MCP servers to expose to this agent turn. Populated by AgentFactory from
    * enabled plugins; each adapter serializes the record into its CLI's native

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { writeTranscriptSlice, TranscriptSlice, AgentRequest, AgentResponse, AideOptions, BrowserTarget, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, needsPolish, buildVoicePolishPrompt, sanitizePolished, DEFAULT_POLISH_TIMEOUT_MS, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType, unwiredAllProtocols } from '@codey/core';
+import { writeTranscriptSlice, TranscriptSlice, AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, needsPolish, buildVoicePolishPrompt, sanitizePolished, DEFAULT_POLISH_TIMEOUT_MS, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType, unwiredAllProtocols } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -272,7 +272,6 @@ export class Codey {
     signal?: AbortSignal;
     workingDir?: string;
     browserChatId?: string;
-    browserTarget?: BrowserTarget;
     interactive?: boolean;
     skipPermissions?: boolean;
   }): Promise<{ response: AgentResponse; usedResume: boolean }> {
@@ -292,7 +291,6 @@ export class Codey {
       context: { workingDir: opts.workingDir ?? this.workingDir },
       browserTools: true,
       browserChatId: opts.browserChatId,
-      browserTarget: opts.browserTarget ?? 'codey-browser',
       onStream: opts.onStream,
       onThinking: opts.onThinking,
       onStatus: opts.onStatus,
@@ -2482,7 +2480,6 @@ export class Codey {
       onStream: onStream ? (text: string) => { streamed.active = true; onStream(text); } : undefined,
       context: { workingDir: this.workingDir },
       browserTools: true,
-      browserTarget: 'codey-browser',
       resumeSessionId: p.resumeSessionId,
       newSessionId: p.newSessionId,
     });
@@ -3710,8 +3707,7 @@ Example: /model gpt-4.1 write a Python script`;
           model: this.getDefaultModelConfig(agent),
           context: { workingDir: this.workingDir },
           browserTools: true,
-          browserTarget: 'codey-browser',
-        })
+            })
       )
     );
 
@@ -4954,7 +4950,6 @@ Example: /model gpt-4.1 write a Python script`;
     opts: { forceAll?: boolean; routingTask?: string } = {},
     chatAgent?: CodingAgent,
     chatModel?: ModelConfig,
-    browserTarget: BrowserTarget = 'codey-browser',
   ): Promise<{ response: string; tokens?: number; choices?: string[]; thinkingByStep?: Record<number, string>; teamTurnId?: string }> {
     if (!team || !team.members || team.members.length === 0) {
       throw new Error(`Team not found or empty: ${teamName}`);
@@ -4996,7 +4991,6 @@ Example: /model gpt-4.1 write a Python script`;
       const { response } = await this.runWorkerStep({
         conversationId: teamConv,
         browserChatId: chatId,
-        browserTarget,
         workerName,
         task: prompt,
         blackboard,
@@ -5127,8 +5121,7 @@ Example: /model gpt-4.1 write a Python script`;
           context: { workingDir },
           browserTools: true,
           browserChatId: chatId,
-          browserTarget,
-          onStream: (text: string) => workerMsgs.onStream(text, workerName),
+            onStream: (text: string) => workerMsgs.onStream(text, workerName),
           onThinking: (text: string) => workerMsgs.onThinking(text, workerStep.get(workerName) ?? 0, workerName),
           onStatus: (update: any) => {
             // Route per-worker tool events through workerMsgs for parallel mode,
@@ -5750,7 +5743,6 @@ Example: /model gpt-4.1 write a Python script`;
       model,
       context: { workingDir: this.workingDir },
       browserTools: true,
-      browserTarget: 'codey-browser',
       onStream,
       onStatus,
       resumeSessionId: p.resumeSessionId,
@@ -5962,7 +5954,6 @@ Example: /model gpt-4.1 write a Python script`;
       channel?: ChannelType;
       channelUserId?: string;
       skillInvoke?: SkillInvoke;
-      browserTarget?: BrowserTarget;
     },
   ): Promise<{ response: string; chatId: string; tokens?: number; durationSec?: number }> {
     let chat = this.chatManager.get(chatId);
@@ -6207,10 +6198,6 @@ Example: /model gpt-4.1 write a Python script`;
       : agentWorktreeParent
         ? `\n\n[Codey chat workspace]\nThis chat uses the shared checkout. Work there; do not create a worktree on your own initiative. Only when the user explicitly asks for one, choose a short semantic lower-kebab name with no slash, then run \`git worktree add -b <name> ${JSON.stringify(path.join(agentWorktreeParent, '<name>'))} HEAD\` and perform all subsequent work in that new directory. Create it only as a direct child of ${JSON.stringify(agentWorktreeParent)} so Codey can bind and display it.`
         : '\n\n[Codey chat workspace]\nThis chat already has a user-managed worktree. Continue using the selected checkout; do not create another worktree.';
-    // The UI chooses a browser capability explicitly. Ordinary Codey chat
-    // uses the embedded Browser; Chrome's Side Panel supplies `chrome`.
-    // Core enforces this choice by exposing only the corresponding token.
-    const browserTarget: BrowserTarget = origin?.browserTarget ?? 'codey-browser';
     if (warmAnchor) {
       // Resume the agent's own session. If other agents produced messages
       // while it was inactive, replay only that unseen gap before the new turn.
@@ -6404,7 +6391,7 @@ Example: /model gpt-4.1 write a Python script`;
         }
         const team: TeamConfig = wsTeam ?? fallbackTeam;
         this.logger.info(`[parallel-debug] teamName=${teamName} dispatch=${team.dispatch} hasParallel=${!!team.parallel} wsTeam=${!!wsTeam} fallbackDispatch=${fallbackDispatch} members=${team.members.join(',')}`);
-        const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, chat, abortController.signal, { routingTask: userText }, agent, model, browserTarget);
+        const r = await this.runTeamForChat(teamName, team, prompt, workingDir, sink, chatId, chat, abortController.signal, { routingTask: userText }, agent, model);
         output = r.response;
         tokens = r.tokens;
         teamChoices = r.choices;
@@ -6419,8 +6406,7 @@ Example: /model gpt-4.1 write a Python script`;
           context: { workingDir },
           browserTools: true,
           browserChatId: chatId,
-          browserTarget,
-          skipPermissions: this.getSkipPermissions(),
+            skipPermissions: this.getSkipPermissions(),
           onStream,
           onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text }),
           onStatus,
@@ -6449,8 +6435,7 @@ Example: /model gpt-4.1 write a Python script`;
             context: { workingDir },
             browserTools: true,
             browserChatId: chatId,
-            browserTarget,
-            skipPermissions: this.getSkipPermissions(),
+                skipPermissions: this.getSkipPermissions(),
             onStream,
             onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text }),
             onStatus,
@@ -6498,8 +6483,7 @@ Example: /model gpt-4.1 write a Python script`;
             context: { workingDir },
             browserTools: true,
             browserChatId: chatId,
-            browserTarget,
-            skipPermissions: this.getSkipPermissions(),
+                skipPermissions: this.getSkipPermissions(),
             onStream,
             onThinking: (text: string) => sink({ type: 'thinking', chatId, token: text }),
             onStatus,


### PR DESCRIPTION
Three things stood between a new user and a working Chrome Companion.

## 1. Installation was impossible on a packaged build

The extension ships inside `Codey.app/Contents/Resources`, and Chrome's **Load unpacked** picker cannot descend into a `.app` bundle — so the folder the setup steps told the user to select could not be selected.

`chrome-extension-stage.ts` stages a copy under the app's userData directory (`~/Library/Application Support/Codey/chrome-extension`), refreshed whenever the bundled manifest version moves on, and the reveal button now also puts the path on the clipboard so ⌘⇧G is a one-paste step.

## 2. The first setup step could not be performed

Chrome blocks links to its own pages, so the `chrome://extensions` URL in the instructions was inert text. A new button hands the URL to Chrome on the command line.

## 3. The companion was unreachable from Codey's own chat

Browser capability was gated on `browserTarget`, a per-surface value that only the Chrome Side Panel ever set to `'chrome'`. Desktop chat always got `'codey-browser'`, so the Chrome bridge credential was withheld and every attempt failed with `Chrome Companion credentials are unavailable` — including an explicit `@chrome-companion` invoke, since naming a skill shows the agent the instructions but cannot hand it a credential.

`browserTarget` is removed. Each installed browser skill is offered on every tool-capable turn and the skills' own precedence rules choose; both `SKILL.md` files already document that routing.

### Behaviour change to be aware of

A turn from Telegram, Discord or iMessage can now drive the signed-in Chrome on the desktop, which `browserTarget` incidentally prevented. Easy to restrict again if that is not wanted.

## Verification

- `npm test` — 1949 passing (639 core / 457 gateway / 853 mac), including 9 new tests for extension staging and reworked coverage for the capability gate
- `npx tsc --noEmit` on both `codey-mac` tsconfigs — clean
- `npm run lint` — clean
- Not exercised on a real machine: the install flow and a Chrome request from desktop chat still need a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)