### PR TITLE
feat(mac): let the user choose where the Chrome extension installs

### DIFF
--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -22,11 +22,12 @@ localStorage into a named Codey Browser profile. This requires Chrome's
 and does not export passwords, page contents, form fields, history, or data
 from unrelated sites.
 
-Installation from the Codey Mac app: use **Open chrome://extensions** and
-**Reveal folder & copy path** on the Plugins settings page. The app stages a
-copy of this directory at `~/Library/Application Support/Codey/chrome-extension`,
-because Chrome's picker cannot descend into the `Codey.app` bundle where the
-shipped copy lives.
+Installation from the Codey Mac app: on the Plugins settings page, click
+**Choose folder & install**, pick somewhere you can find again, then use
+**Open chrome://extensions** and load the installed folder unpacked. Codey
+copies this directory there and refreshes it on every launch, so the installed
+copy tracks Codey's releases. The copy is needed because Chrome's picker cannot
+descend into the `Codey.app` bundle where the shipped extension lives.
 
 Development installation from this repository:
 

--- a/codey-mac/electron/chrome-extension-stage.test.ts
+++ b/codey-mac/electron/chrome-extension-stage.test.ts
@@ -2,7 +2,14 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { stageChromeExtension, stagedVersion } from './chrome-extension-stage'
+import {
+  installedExtensionDir,
+  refreshRememberedInstall,
+  rememberedInstallDir,
+  rememberInstallDir,
+  stageChromeExtension,
+  stagedVersion,
+} from './chrome-extension-stage'
 
 const temps: string[] = []
 
@@ -86,5 +93,67 @@ describe('stagedVersion', () => {
     expect(stagedVersion(dir)).toBe(null)
     fs.writeFileSync(path.join(dir, 'manifest.json'), '{ not json')
     expect(stagedVersion(dir)).toBe(null)
+  })
+})
+
+describe('a user-chosen install location', () => {
+  it('is remembered and read back', () => {
+    const userData = temp()
+    expect(rememberedInstallDir(userData)).toBe(null)
+    rememberInstallDir(userData, '/Users/x/Documents/codey-chrome-extension')
+    expect(rememberedInstallDir(userData)).toBe('/Users/x/Documents/codey-chrome-extension')
+  })
+
+  it('installs under the folder name the user will recognise', () => {
+    const target = stageChromeExtension(bundledExtension('1.0.0'), temp(), 'codey-chrome-extension')
+    expect(path.basename(target)).toBe('codey-chrome-extension')
+    expect(fs.existsSync(path.join(target, 'manifest.json'))).toBe(true)
+  })
+
+  it('is refreshed on launch when Codey ships a newer extension', () => {
+    const userData = temp()
+    const chosen = stageChromeExtension(bundledExtension('1.0.0'), temp(), 'codey-chrome-extension')
+    rememberInstallDir(userData, chosen)
+    expect(refreshRememberedInstall(bundledExtension('1.1.0'), userData)).toBe(chosen)
+    expect(stagedVersion(chosen)).toBe('1.1.0')
+  })
+
+  it('is left untouched when it already matches', () => {
+    const userData = temp()
+    const source = bundledExtension('1.0.0')
+    const chosen = stageChromeExtension(source, temp(), 'codey-chrome-extension')
+    rememberInstallDir(userData, chosen)
+    const before = fs.statSync(path.join(chosen, 'manifest.json')).mtimeMs
+    refreshRememberedInstall(source, userData)
+    expect(fs.statSync(path.join(chosen, 'manifest.json')).mtimeMs).toBe(before)
+  })
+
+  it('does nothing when nothing was ever chosen', () => {
+    expect(refreshRememberedInstall(bundledExtension('1.0.0'), temp())).toBe(null)
+  })
+
+  it('does not recreate a tree under a parent that is gone', () => {
+    const userData = temp()
+    const parent = temp()
+    const chosen = stageChromeExtension(bundledExtension('1.0.0'), parent, 'codey-chrome-extension')
+    rememberInstallDir(userData, chosen)
+    fs.rmSync(parent, { force: true, recursive: true })
+    expect(refreshRememberedInstall(bundledExtension('1.1.0'), userData)).toBe(null)
+    expect(fs.existsSync(parent)).toBe(false)
+  })
+
+  it('is the folder Chrome should be pointed at once chosen', () => {
+    const userData = temp()
+    const chosen = stageChromeExtension(bundledExtension('1.0.0'), temp(), 'codey-chrome-extension')
+    rememberInstallDir(userData, chosen)
+    expect(installedExtensionDir(bundledExtension('1.0.0'), userData)).toBe(chosen)
+  })
+
+  it('falls back to the default staging copy when the chosen one is gone', () => {
+    const userData = temp()
+    rememberInstallDir(userData, path.join(temp(), 'deleted-by-the-user'))
+    const dir = installedExtensionDir(bundledExtension('1.0.0'), userData)
+    expect(dir).toBe(path.join(userData, 'chrome-extension'))
+    expect(fs.existsSync(path.join(dir, 'manifest.json'))).toBe(true)
   })
 })

--- a/codey-mac/electron/chrome-extension-stage.ts
+++ b/codey-mac/electron/chrome-extension-stage.ts
@@ -1,5 +1,10 @@
 import * as fs from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
+
+/** Folder name used when the user picks where to install the extension. */
+export const CHOSEN_FOLDER_NAME = 'codey-chrome-extension'
+/** Where the user's chosen install location is remembered. */
+export const INSTALL_RECORD_FILE = 'chrome-extension-install.json'
 
 /**
  * Chrome's "Load unpacked" picker cannot descend into a `.app` bundle, so the
@@ -7,11 +12,15 @@ import { join } from 'path'
  * unreachable for the user who has to select it. Stage a copy in a plain user
  * directory instead, and keep it in step with the bundled one by version.
  */
-export function stageChromeExtension(source: string, stagingRoot: string): string {
+export function stageChromeExtension(
+  source: string,
+  stagingRoot: string,
+  folderName = 'chrome-extension',
+): string {
   if (!fs.existsSync(join(source, 'manifest.json'))) {
     throw new Error('The Chrome companion extension is missing from this build')
   }
-  const target = join(stagingRoot, 'chrome-extension')
+  const target = join(stagingRoot, folderName)
   if (!fs.existsSync(target) || stagedVersion(target) !== stagedVersion(source)) {
     fs.rmSync(target, { force: true, recursive: true })
     fs.mkdirSync(stagingRoot, { recursive: true })
@@ -26,4 +35,49 @@ export function stagedVersion(dir: string): string | null {
     const manifest = JSON.parse(fs.readFileSync(join(dir, 'manifest.json'), 'utf8'))
     return typeof manifest.version === 'string' ? manifest.version : null
   } catch { return null }
+}
+
+/**
+ * Chrome loads an unpacked extension from one fixed path forever, so a copy the
+ * user installed somewhere of their own would silently go stale at the next
+ * Codey update. Remember that path and re-stage into it on launch.
+ */
+export function rememberInstallDir(userData: string, dir: string): void {
+  fs.mkdirSync(userData, { recursive: true })
+  fs.writeFileSync(join(userData, INSTALL_RECORD_FILE), JSON.stringify({ dir }), 'utf8')
+}
+
+export function rememberedInstallDir(userData: string): string | null {
+  try {
+    const record = JSON.parse(fs.readFileSync(join(userData, INSTALL_RECORD_FILE), 'utf8'))
+    return typeof record.dir === 'string' && record.dir ? record.dir : null
+  } catch { return null }
+}
+
+/**
+ * Refresh the copy the user installed themselves, if any. Best-effort: an
+ * external disk that is no longer mounted must not hold up startup.
+ */
+export function refreshRememberedInstall(source: string, userData: string): string | null {
+  const dir = rememberedInstallDir(userData)
+  if (!dir) return null
+  try {
+    // An unplugged external disk should be left alone, not recreated one
+    // directory at a time under an absent mount point.
+    if (!fs.existsSync(dirname(dir))) return null
+    if (stagedVersion(dir) === stagedVersion(source)) return dir
+    fs.rmSync(dir, { force: true, recursive: true })
+    fs.cpSync(source, dir, { recursive: true })
+    return dir
+  } catch { return null }
+}
+
+/**
+ * The folder the user should point Chrome at: their own chosen install when it
+ * is still there, otherwise Codey's default staging copy.
+ */
+export function installedExtensionDir(source: string, userData: string): string {
+  const remembered = rememberedInstallDir(userData)
+  if (remembered && fs.existsSync(join(remembered, 'manifest.json'))) return remembered
+  return stageChromeExtension(source, userData)
 }

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -17,7 +17,7 @@ import { runAgentUpdate, updatePlanFor } from './agent-update'
 import { availability, createLatestVersionsCache, fetchAllLatestVersions } from './agent-latest'
 import { SKILL_FILE, markSkillManagedBy, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
-import { stageChromeExtension } from './chrome-extension-stage'
+import { CHOSEN_FOLDER_NAME, installedExtensionDir, refreshRememberedInstall, rememberInstallDir, stageChromeExtension } from './chrome-extension-stage'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
@@ -2451,12 +2451,29 @@ app.whenReady().then(async () => {
     return { ok: true as const }
   }))
   ipcMain.handle('chromeCompanion:showExtensionFolder', event => browserCall(event, async () => {
-    const staged = stageChromeExtension(chromeCompanionExtensionPath(), app.getPath('userData'))
+    const staged = installedExtensionDir(chromeCompanionExtensionPath(), app.getPath('userData'))
     shell.showItemInFolder(join(staged, 'manifest.json'))
     // Chrome's picker has no address bar; the path on the clipboard is what
     // makes Cmd+Shift+G a one-paste step.
     clipboard.writeText(staged)
     return staged
+  }))
+  // Installing where the user chose beats installing where Codey chose: they
+  // can find the folder again, and Chrome's picker opens there by habit.
+  ipcMain.handle('chromeCompanion:installExtensionTo', event => browserCall(event, async () => {
+    const picked = await dialog.showOpenDialog(mainWindow ?? (undefined as any), {
+      title: 'Choose where to install the Codey Chrome extension',
+      message: 'Codey creates a "codey-chrome-extension" folder here.',
+      buttonLabel: 'Install here',
+      defaultPath: app.getPath('documents'),
+      properties: ['openDirectory', 'createDirectory'],
+    })
+    if (picked.canceled || !picked.filePaths[0]) return { installed: false as const }
+    const dir = stageChromeExtension(chromeCompanionExtensionPath(), picked.filePaths[0], CHOSEN_FOLDER_NAME)
+    rememberInstallDir(app.getPath('userData'), dir)
+    shell.showItemInFolder(join(dir, 'manifest.json'))
+    clipboard.writeText(dir)
+    return { installed: true as const, dir }
   }))
   ipcMain.handle('browser:controlPermission:get', event => browserCall(event, () =>
     browserControlPermission?.getState() ?? { approved: false, pending: null }
@@ -2519,6 +2536,10 @@ app.whenReady().then(async () => {
     sendToRenderer('gateway-log', `[browser] agent bridge failed to start: ${error?.message ?? error}`)
     browserAgentBridge = null
   }
+  // Chrome keeps loading an unpacked extension from the path it was given, so
+  // a copy the user installed themselves has to be refreshed here or it stays
+  // on the version that shipped the day they installed it.
+  refreshRememberedInstall(chromeCompanionExtensionPath(), app.getPath('userData'))
   ipcMain.handle('capture:pickFiles', async () =>
     wrap(async () => {
       capturePickingFiles = true

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -474,6 +474,7 @@ contextBridge.exposeInMainWorld('codey', {
     setAccent: (hex: string) => ipcRenderer.invoke('chromeCompanion:setAccent', hex),
     showExtensionFolder: () => ipcRenderer.invoke('chromeCompanion:showExtensionFolder'),
     openExtensionsPage: () => ipcRenderer.invoke('chromeCompanion:openExtensionsPage'),
+    installExtensionTo: () => ipcRenderer.invoke('chromeCompanion:installExtensionTo'),
     onStatus: (handler: (state: any) => void) => {
       const listener = (_e: Electron.IpcRendererEvent, state: any) => handler(state)
       ipcRenderer.on('chromeCompanion:status', listener)

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -613,6 +613,7 @@ declare global {
         setAccent: (hex: string) => Promise<IpcResult<{ ok: true }>>
         showExtensionFolder: () => Promise<IpcResult<string>>
         openExtensionsPage: () => Promise<IpcResult<{ ok: true }>>
+        installExtensionTo: () => Promise<IpcResult<{ installed: false } | { installed: true; dir: string }>>
         onStatus: (handler: (state: ChromeCompanionStatus) => void) => () => void
       }
       browser: {

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -23,7 +23,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
   const [error, setError] = useState<string | null>(null)
   const [profileName, setProfileName] = useState('chrome-session')
   const [exported, setExported] = useState<string | null>(null)
-  const [copiedPath, setCopiedPath] = useState<string | null>(null)
+  const [installedPath, setInstalledPath] = useState<string | null>(null)
 
   const useResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | null => {
     if (!result.ok) { setError(result.error); return null }
@@ -69,21 +69,25 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
           <div style={styles.title}>Install the Chrome extension</div>
           <div style={styles.copy}>Installation is one-time, and there is nothing to configure afterwards — the extension finds Codey and pairs itself within about 30 seconds, as long as Codey stays running. Clicking the Codey avatar in Chrome then opens its chat Side Panel.</div>
           <ol style={styles.steps}>
-            <li>Open Chrome’s <code style={styles.code}>chrome://extensions</code> page with the button below. (Chrome blocks links to its own pages, so it has to be opened this way.)</li>
-            <li>Turn on <strong>Developer mode</strong>, then click <strong>Load unpacked</strong>.</li>
-            <li>Click the second button below: it reveals the folder in Finder and copies its path. In Chrome’s picker, press <strong>⌘⇧G</strong>, paste, and press Return — or just drag the revealed folder onto the extensions page.</li>
+            <li>Pick a folder to install into. Codey copies the extension there and keeps it up to date with each Codey release.</li>
+            <li>Open Chrome’s <code style={styles.code}>chrome://extensions</code> page and turn on <strong>Developer mode</strong>. (Chrome blocks links to its own pages, so it has to be opened by the button.)</li>
+            <li>Click <strong>Load unpacked</strong> and choose the folder from step 1. Its path is already on the clipboard — press <strong>⌘⇧G</strong> and paste, or drag the revealed folder onto the extensions page.</li>
           </ol>
           <div style={{ ...styles.actions, ...(compact ? styles.stack : null) }}>
             <button style={styles.primary} disabled={busy} onClick={() => void run(async () => {
+              const result = useResult(await window.codey.chromeCompanion.installExtensionTo())
+              if (result?.installed) setInstalledPath(result.dir)
+            })}>Choose folder &amp; install</button>
+            <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
               useResult(await window.codey.chromeCompanion.openExtensionsPage())
             })}>Open chrome://extensions</button>
             <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
               const path = useResult(await window.codey.chromeCompanion.showExtensionFolder())
-              if (path) setCopiedPath(path)
+              if (path) setInstalledPath(path)
             })}>Reveal folder &amp; copy path</button>
           </div>
-          {copiedPath && (
-            <div style={styles.success}>Path copied. Paste it into Chrome’s picker with ⌘⇧G: <code style={styles.code}>{copiedPath}</code></div>
+          {installedPath && (
+            <div style={styles.success}>Installed, and the path is on the clipboard. Select this folder in Chrome’s <strong>Load unpacked</strong> picker: <code style={styles.code}>{installedPath}</code></div>
           )}
         </div>
       )}


### PR DESCRIPTION
Follow-up to #383.

Codey staged its own copy at `~/Library/Application Support/Codey/chrome-extension` — a path the user had no reason to know and would never navigate to twice.

## What changed

**Choose folder & install.** A folder picker; Codey copies the extension into a `codey-chrome-extension` folder wherever the user points it, reveals it in Finder, and puts the path on the clipboard.

**Setup steps reordered** to the order they actually happen in: install first, then Chrome.

1. Pick a folder to install into
2. Open `chrome://extensions`, turn on Developer mode
3. Load unpacked → the folder from step 1 (path is already on the clipboard)

## Staleness, and why the location is remembered

Chrome loads an unpacked extension from the exact path it was given, forever. A copy sitting in the user's Documents would silently stay on the version that shipped the day they installed it, while Codey moved on.

So the chosen location is recorded in `chrome-extension-install.json` and re-staged on every launch. Two guards:

- A parent directory that no longer exists (an unplugged external disk) is left alone rather than recreated one level at a time under an absent mount point.
- Codey's own staging copy remains the fallback for anyone who has not chosen a location, or whose chosen folder is gone.

## Verification

- `npm test` — 1957 passing (639 / 457 / 861), including 8 new tests for the chosen-location path
- `npx tsc --noEmit` on both `codey-mac` tsconfigs — clean
- `npm run lint` — clean
- Not exercised on a real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)