### PR TITLE
feat(chrome): give Chrome Companion hands, session handoff and re-sync

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Codey",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1+DxZ4LtqCNXKrmvuwl2d6perIWziIQWgkBVn5RbieIAF7g8knl39m3UOq/BZuSHp2VS1CQtk1EfwTzK0pnjdzikr00O+7iee4lVf8oduovxxi83CzRsZxzEreb3Jht3qfZcw3P94FwYk4wZM3YoRGJF99fWJQy/ybMvmIFSeFAHn9/3m56Xe5j0vCPSkmST1zLVuypW2DB23KojXxx4cKd9i+qcKnvfCEFwydjHRDpL4eUqk1nTU/NDlu3p0Fy5XQhvC6s98JBXXBEtD31l6oUq+wE1ap3yi1l3aK4I07bgWSdJSokwMZOJz22owdzaYra/c8loiVnx4efajwNbWwIDAQAB",
   "description": "Securely connects your existing Chrome tabs and signed-in sites to Codey.",
   "permissions": ["alarms", "cookies", "offscreen", "scripting", "sidePanel", "storage", "tabGroups", "tabs"],

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Codey",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1+DxZ4LtqCNXKrmvuwl2d6perIWziIQWgkBVn5RbieIAF7g8knl39m3UOq/BZuSHp2VS1CQtk1EfwTzK0pnjdzikr00O+7iee4lVf8oduovxxi83CzRsZxzEreb3Jht3qfZcw3P94FwYk4wZM3YoRGJF99fWJQy/ybMvmIFSeFAHn9/3m56Xe5j0vCPSkmST1zLVuypW2DB23KojXxx4cKd9i+qcKnvfCEFwydjHRDpL4eUqk1nTU/NDlu3p0Fy5XQhvC6s98JBXXBEtD31l6oUq+wE1ap3yi1l3aK4I07bgWSdJSokwMZOJz22owdzaYra/c8loiVnx4efajwNbWwIDAQAB",
   "description": "Securely connects your existing Chrome tabs and signed-in sites to Codey.",
   "permissions": ["alarms", "cookies", "offscreen", "scripting", "sidePanel", "storage", "tabGroups", "tabs"],

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -6,6 +6,9 @@ const CONTROLLED_TAB_KEY = 'controlledTabId'
 const CONTROLLED_TITLE_PREFIX = '● Codey · '
 const OFFSCREEN_DOCUMENT = 'offscreen.html'
 const CONTROLLED_GROUP_TITLE = 'Codey'
+// Stamped on interactive elements by `snapshot` so click/fill can address the
+// same element later. Renumbered on every snapshot.
+const REF_ATTR = 'data-codey-ref'
 const ACCENT_KEY = 'accent'
 // Toolbar badge: a green chip with a white check, independent of the accent so
 // "Codey is driving this tab" always reads as an OK signal.
@@ -336,19 +339,36 @@ async function snapshot() {
   if (!/^https?:\/\//i.test(tab.url)) throw new Error('Only http(s) pages can be read')
   const results = await chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    func: () => ({
-      text: (document.body?.innerText || '').slice(0, 100000),
-      links: Array.from(document.querySelectorAll('a[href]')).slice(0, 250).map(link => ({
-        text: (link.textContent || '').trim().slice(0, 300),
-        href: link.href,
-      })),
-      forms: Array.from(document.querySelectorAll('input, textarea, select, button')).slice(0, 250).map(element => ({
-        tag: element.tagName.toLowerCase(),
-        type: element.getAttribute('type') || '',
-        name: element.getAttribute('name') || '',
-        placeholder: element.getAttribute('placeholder') || '',
-      })),
-    }),
+    args: [REF_ATTR],
+    func: refAttr => {
+      // Refs are stamped onto the live DOM so a later click/fill can find the
+      // same element without re-running the whole snapshot. Every snapshot
+      // renumbers from scratch, so a stale ref fails loudly instead of acting
+      // on whatever element inherited the number.
+      document.querySelectorAll(`[${refAttr}]`).forEach(element => element.removeAttribute(refAttr))
+      let counter = 0
+      const stamp = element => {
+        const ref = `e${++counter}`
+        element.setAttribute(refAttr, ref)
+        return ref
+      }
+      return {
+        text: (document.body?.innerText || '').slice(0, 100000),
+        links: Array.from(document.querySelectorAll('a[href]')).slice(0, 250).map(link => ({
+          ref: stamp(link),
+          text: (link.textContent || '').trim().slice(0, 300),
+          href: link.href,
+        })),
+        forms: Array.from(document.querySelectorAll('input, textarea, select, button, [role="button"], [contenteditable="true"]')).slice(0, 250).map(element => ({
+          ref: stamp(element),
+          tag: element.tagName.toLowerCase(),
+          type: element.getAttribute('type') || '',
+          name: element.getAttribute('name') || '',
+          placeholder: element.getAttribute('placeholder') || '',
+          label: (element.getAttribute('aria-label') || element.value || element.textContent || '').trim().slice(0, 120),
+        })),
+      }
+    },
   })
   const page = results[0]?.result
   if (!page) throw new Error('Chrome did not return a page snapshot')
@@ -389,6 +409,86 @@ async function exportSession() {
   }
 }
 
+// ── Acting on a page ────────────────────────────────────────────────────
+// Every action resolves a ref stamped by the last `snapshot`, runs inside the
+// page, and reports back what it touched so the caller never has to assume an
+// action landed. Codey asks the user to approve these before they get here.
+async function interact(action, ref, payload) {
+  const tab = await activeTab()
+  if (!/^https?:\/\//i.test(tab.url)) throw new Error('Only http(s) pages can be acted on')
+  if (!/^e\d+$/.test(String(ref || ''))) throw new Error(`Invalid element ref: ${ref}. Run "chrome view" first.`)
+  const results = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    args: [REF_ATTR, action, String(ref), payload ?? null],
+    func: (refAttr, kind, elementRef, input) => {
+      const element = document.querySelector(`[${refAttr}="${elementRef}"]`)
+      if (!element) return { ok: false, error: `No element ${elementRef} on this page. Run "chrome view" again to refresh refs.` }
+      const describe = () => ({
+        tag: element.tagName.toLowerCase(),
+        text: (element.getAttribute('aria-label') || element.value || element.textContent || '').trim().slice(0, 200),
+      })
+      const fire = (...names) => names.forEach(name => element.dispatchEvent(new Event(name, { bubbles: true })))
+      // Frameworks like React track the input value on the DOM node itself, so
+      // a plain `element.value = x` is silently reverted on the next render.
+      // Going through the prototype setter is what makes the change stick.
+      const setValue = value => {
+        const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype
+        const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set
+        if (setter) setter.call(element, value)
+        else element.value = value
+      }
+      try {
+        element.scrollIntoView({ block: 'center', inline: 'center' })
+        switch (kind) {
+          case 'click':
+            element.click()
+            break
+          case 'fill': {
+            const value = String(input ?? '')
+            element.focus()
+            if (element.isContentEditable) {
+              element.textContent = value
+              fire('input', 'change')
+              break
+            }
+            setValue(value)
+            fire('input', 'change')
+            break
+          }
+          case 'select':
+            element.value = String(input ?? '')
+            if (element.selectedIndex === -1) return { ok: false, error: `No option "${input}" in ${elementRef}` }
+            fire('input', 'change')
+            break
+          case 'check':
+            if (element.checked !== Boolean(input)) element.click()
+            break
+          case 'press': {
+            const key = String(input ?? '')
+            element.focus()
+            for (const type of ['keydown', 'keypress', 'keyup']) {
+              element.dispatchEvent(new KeyboardEvent(type, { key, bubbles: true, cancelable: true }))
+            }
+            // Synthetic key events never submit a form on their own, so Enter
+            // inside a form is completed the way the browser would.
+            if (key === 'Enter' && element.form) element.form.requestSubmit()
+            break
+          }
+          default:
+            return { ok: false, error: `Unsupported page action: ${kind}` }
+        }
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) }
+      }
+      return { ok: true, element: describe(), url: location.href, title: document.title }
+    },
+  })
+  const outcome = results[0]?.result
+  if (!outcome) throw new Error('Chrome did not report the result of the action')
+  if (!outcome.ok) throw new Error(outcome.error || 'The page action failed')
+  return { tab: { ...tab, url: outcome.url, title: outcome.title }, element: outcome.element }
+}
+
 async function execute(command) {
   switch (command.command) {
     case 'activeTab': {
@@ -405,6 +505,15 @@ async function execute(command) {
       const session = await exportSession()
       await markControlledTab(session.tab.id)
       return session
+    }
+    case 'click':
+    case 'fill':
+    case 'select':
+    case 'check':
+    case 'press': {
+      const result = await interact(command.command, command.input?.ref, command.input?.value)
+      await markControlledTab(result.tab.id)
+      return result
     }
     case 'navigate': {
       const url = String(command.input?.url || '')

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -528,17 +528,36 @@ async function execute(command) {
   }
 }
 
+// Reported on every poll rather than only when pairing: reloading the
+// extension keeps the stored token, so it never pairs again, and a version
+// captured at pairing time would stay stale forever.
+function ownVersion() {
+  try { return chrome.runtime.getManifest().version || '' } catch { return '' }
+}
+
+// Codey re-stages the new extension files on its own launch, but Chrome only
+// re-reads an unpacked extension when it restarts or the user reloads it. Codey
+// tells us which version is on disk so the panel can say so out loud.
+async function noteExpectedVersion(expected) {
+  const stale = typeof expected === 'string' && expected && expected !== ownVersion() ? expected : ''
+  const saved = await chrome.storage.local.get({ updateAvailable: '' })
+  if (saved.updateAvailable === stale) return
+  await chrome.storage.local.set({ updateAvailable: stale })
+}
+
 async function pollOnce() {
   let { endpoint, token } = await settings()
   if (!token) ({ endpoint, token } = await autoConnect())
+  const body = { version: ownVersion() }
   let response
   try {
-    response = await call(endpoint, '/v1/poll', { token })
+    response = await call(endpoint, '/v1/poll', { token, body })
   } catch (error) {
     if (!/Unauthorized/i.test(error instanceof Error ? error.message : String(error))) throw error
     ;({ endpoint, token } = await autoConnect())
-    response = await call(endpoint, '/v1/poll', { token })
+    response = await call(endpoint, '/v1/poll', { token, body })
   }
+  await noteExpectedVersion(response.expectedVersion)
   if (response.accent) await applyAccent(response.accent)
   if (!response.command) return true
   const command = response.command

--- a/chrome-extension/sidepanel.css
+++ b/chrome-extension/sidepanel.css
@@ -75,6 +75,11 @@ button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px s
 .handoff-row button { flex: none; padding: 4px 9px; border: 1px solid var(--border-2); border-radius: 6px; background: var(--surface); color: var(--fg); font: inherit; font-size: 11px; cursor: pointer; }
 .handoff-row button.handoff-save { border-color: transparent; background: var(--accent); color: var(--on-accent); }
 .handoff-row button:disabled { opacity: 0.55; cursor: default; }
+.handoff-resync { display: flex; gap: 6px; align-items: center; margin-top: 7px; padding-top: 7px; border-top: 1px solid var(--border); font-size: 11px; }
+.handoff-resync[hidden] { display: none; }
+.handoff-resync select { flex: 1 1 auto; min-width: 0; padding: 3px 5px; border: 1px solid var(--border-2); border-radius: 6px; background: var(--surface); color: var(--fg); font: inherit; font-size: 11px; }
+.handoff-resync button { flex: none; padding: 4px 9px; border: 1px solid var(--border-2); border-radius: 6px; background: var(--surface); color: var(--fg); font: inherit; font-size: 11px; cursor: pointer; }
+.handoff-resync button:disabled { opacity: 0.55; cursor: default; }
 
 .messages { flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; padding: 18px 12px 12px; scrollbar-color: var(--border-2) transparent; }
 .welcome { margin: auto; max-width: 250px; padding: 24px 12px; text-align: center; color: var(--muted); }

--- a/chrome-extension/sidepanel.css
+++ b/chrome-extension/sidepanel.css
@@ -149,3 +149,8 @@ textarea::placeholder { color: var(--muted); }
 .send { width: 32px; height: 32px; display: grid; place-items: center; padding: 0; border: 0; border-radius: 9px; background: var(--accent); color: var(--on-accent); cursor: pointer; }
 .send:hover { filter: brightness(1.06); }
 .send:disabled { opacity: .4; cursor: default; filter: none; }
+
+.update-notice { flex: none; margin: 8px 12px 0; padding: 7px 9px; display: flex; align-items: center; gap: 8px; border: 1px solid var(--warning-border, var(--border-2)); border-radius: 8px; background: var(--warning-bg, var(--surface-2)); color: var(--fg); font-size: 11.5px; }
+.update-notice[hidden] { display: none; }
+.update-notice span { flex: 1 1 auto; }
+.update-notice button { flex: none; padding: 3px 8px; border: 1px solid var(--border-2); border-radius: 999px; background: var(--surface); color: var(--fg); font: inherit; font-size: 11px; cursor: pointer; }

--- a/chrome-extension/sidepanel.css
+++ b/chrome-extension/sidepanel.css
@@ -63,6 +63,18 @@ button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px s
 .page-context[hidden] { display: none; }
 .page-dot { width: 6px; height: 6px; border-radius: 50%; background: #48c78e; flex-shrink: 0; }
 .page-title { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.handoff { flex: none; margin-left: auto; padding: 3px 8px; border: 1px solid var(--border); border-radius: 999px; background: var(--surface); color: var(--muted); font: inherit; font-size: 11px; cursor: pointer; }
+.handoff:hover:not(:disabled) { color: var(--fg); border-color: var(--border-2); }
+.handoff:disabled { opacity: 0.55; cursor: default; }
+
+.handoff-form { flex: none; margin: 6px 12px 0; padding: 8px 9px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface-2); font-size: 11.5px; color: var(--muted); }
+.handoff-form[hidden] { display: none; }
+.handoff-form label { display: block; margin-bottom: 5px; }
+.handoff-row { display: flex; gap: 6px; align-items: center; }
+.handoff-row input { flex: 1 1 auto; min-width: 0; padding: 4px 7px; border: 1px solid var(--border-2); border-radius: 6px; background: var(--surface); color: var(--fg); font: inherit; font-size: 11.5px; }
+.handoff-row button { flex: none; padding: 4px 9px; border: 1px solid var(--border-2); border-radius: 6px; background: var(--surface); color: var(--fg); font: inherit; font-size: 11px; cursor: pointer; }
+.handoff-row button.handoff-save { border-color: transparent; background: var(--accent); color: var(--on-accent); }
+.handoff-row button:disabled { opacity: 0.55; cursor: default; }
 
 .messages { flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; padding: 18px 12px 12px; scrollbar-color: var(--border-2) transparent; }
 .welcome { margin: auto; max-width: 250px; padding: 24px 12px; text-align: center; color: var(--muted); }

--- a/chrome-extension/sidepanel.html
+++ b/chrome-extension/sidepanel.html
@@ -15,6 +15,11 @@
         </select>
       </div>
 
+      <div id="update-notice" class="update-notice" hidden>
+        <span id="update-copy"></span>
+        <button id="update-open" type="button">Reload it</button>
+      </div>
+
       <div id="status" class="status" hidden>
         <span id="status-text"></span>
         <button id="status-retry" type="button">Retry</button>

--- a/chrome-extension/sidepanel.html
+++ b/chrome-extension/sidepanel.html
@@ -23,7 +23,17 @@
       <div id="page-context" class="page-context" hidden>
         <span class="page-dot"></span>
         <span id="page-title" class="page-title"></span>
+        <button id="handoff" class="handoff" type="button" title="Copy this site's signed-in session into a Codey Browser profile">Hand off login</button>
       </div>
+
+      <form id="handoff-form" class="handoff-form" hidden>
+        <label for="handoff-name">Save this login as</label>
+        <div class="handoff-row">
+          <input id="handoff-name" type="text" maxlength="64" spellcheck="false" autocomplete="off" aria-label="Codey Browser profile name">
+          <button id="handoff-save" class="handoff-save" type="submit">Save</button>
+          <button id="handoff-cancel" class="handoff-cancel" type="button">Cancel</button>
+        </div>
+      </form>
 
       <section id="messages" class="messages" aria-live="polite">
         <div id="welcome" class="welcome">

--- a/chrome-extension/sidepanel.html
+++ b/chrome-extension/sidepanel.html
@@ -38,6 +38,11 @@
           <button id="handoff-save" class="handoff-save" type="submit">Save</button>
           <button id="handoff-cancel" class="handoff-cancel" type="button">Cancel</button>
         </div>
+        <div id="handoff-resync" class="handoff-resync" hidden>
+          <span>Already saved:</span>
+          <select id="handoff-resync-name" aria-label="Codey Browser profile to refresh"></select>
+          <button id="handoff-resync-save" class="handoff-resync-save" type="button" title="Replace this site's login in that profile with the one Chrome is using now">Re-sync</button>
+        </div>
       </form>
 
       <section id="messages" class="messages" aria-live="polite">

--- a/chrome-extension/sidepanel.js
+++ b/chrome-extension/sidepanel.js
@@ -9,6 +9,11 @@ const sendNode = document.querySelector('#send')
 const includePageNode = document.querySelector('#include-page')
 const pageContextNode = document.querySelector('#page-context')
 const pageTitleNode = document.querySelector('#page-title')
+const handoffNode = document.querySelector('#handoff')
+const handoffFormNode = document.querySelector('#handoff-form')
+const handoffNameNode = document.querySelector('#handoff-name')
+const handoffSaveNode = document.querySelector('#handoff-save')
+const handoffCancelNode = document.querySelector('#handoff-cancel')
 const chatSelectNode = document.querySelector('#chat-select')
 const agentSelectNode = document.querySelector('#agent-select')
 const modelSelectNode = document.querySelector('#model-select')
@@ -517,6 +522,79 @@ function typingNode() {
   return node
 }
 
+// Copying the current site's signed-in session into a Codey Browser profile.
+// Codey does the export and the import; the panel only reports the outcome,
+// and it reports it on the button itself so nothing is added to the chat.
+let handoffResetTimer = null
+let handoffPageUrl = null
+
+// The name is asked for rather than assumed, but the field arrives prefilled
+// with a name Codey has already checked is free, so accepting the default is
+// still a single extra keystroke.
+async function openHandoffForm() {
+  if (!activePage || handoffNode.disabled) return
+  if (handoffResetTimer) clearTimeout(handoffResetTimer)
+  handoffNode.disabled = true
+  handoffNode.textContent = 'Naming\u2026'
+  let suggestion = ''
+  try {
+    const hostname = new URL(activePage.url).hostname
+    suggestion = (await codeyApi('/v1/session/handoff/name', { method: 'POST', body: { hostname } })).name
+  } catch (error) {
+    handoffNode.disabled = false
+    handoffNode.textContent = 'Handoff failed'
+    handoffNode.title = error instanceof Error ? error.message : String(error)
+    handoffResetTimer = setTimeout(resetHandoffButton, 6000)
+    return
+  }
+  handoffNode.textContent = 'Hand off login'
+  handoffFormNode.hidden = false
+  handoffNameNode.value = suggestion
+  handoffNameNode.focus()
+  handoffNameNode.select()
+}
+
+function closeHandoffForm() {
+  handoffFormNode.hidden = true
+  handoffNameNode.value = ''
+  handoffSaveNode.disabled = false
+  handoffNode.disabled = false
+}
+
+async function handOffSession() {
+  const name = handoffNameNode.value.trim()
+  if (!name) {
+    handoffNameNode.focus()
+    return
+  }
+  handoffSaveNode.disabled = true
+  handoffSaveNode.textContent = 'Saving\u2026'
+  try {
+    const result = await codeyApi('/v1/session/handoff', { method: 'POST', body: { name } })
+    closeHandoffForm()
+    handoffNode.textContent = `Saved as ${result.profileName}`
+    handoffNode.title = `${result.cookieCount} cookies from ${result.origin} are now in the Codey Browser profile "${result.profileName}"`
+    handoffResetTimer = setTimeout(resetHandoffButton, 6000)
+  } catch (error) {
+    // The form stays open on failure so a rejected name can just be retyped.
+    handoffSaveNode.disabled = false
+    handoffNode.textContent = 'Handoff failed'
+    handoffNode.title = error instanceof Error ? error.message : String(error)
+    handoffNameNode.focus()
+    handoffNameNode.select()
+  } finally {
+    handoffSaveNode.textContent = 'Save'
+  }
+}
+
+function resetHandoffButton() {
+  if (handoffResetTimer) clearTimeout(handoffResetTimer)
+  handoffResetTimer = null
+  closeHandoffForm()
+  handoffNode.textContent = 'Hand off login'
+  handoffNode.title = "Copy this site's signed-in session into a Codey Browser profile"
+}
+
 async function refreshActivePage() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
   activePage = tab && /^https?:\/\//i.test(tab.url || '')
@@ -525,6 +603,11 @@ async function refreshActivePage() {
   pageContextNode.hidden = !activePage
   pageTitleNode.textContent = activePage ? activePage.title : ''
   pageContextNode.title = activePage?.url || ''
+  // A result from the previous site would be misleading here.
+  if (activePage?.url !== handoffPageUrl) {
+    handoffPageUrl = activePage?.url || null
+    resetHandoffButton()
+  }
 }
 
 async function ensurePreparedChat() {
@@ -738,6 +821,10 @@ inputNode.addEventListener('input', () => {
   inputNode.style.height = `${Math.max(42, Math.min(inputNode.scrollHeight, 140))}px`
 })
 settingsToggleNode.addEventListener('click', () => { if (!busy) toggleSettings() })
+handoffNode.addEventListener('click', () => { void openHandoffForm() })
+handoffFormNode.addEventListener('submit', event => { event.preventDefault(); void handOffSession() })
+handoffCancelNode.addEventListener('click', () => resetHandoffButton())
+handoffNameNode.addEventListener('keydown', event => { if (event.key === 'Escape') resetHandoffButton() })
 chatSelectNode.addEventListener('change', () => {
   if (!busy) void selectChat(chatSelectNode.value)
 })

--- a/chrome-extension/sidepanel.js
+++ b/chrome-extension/sidepanel.js
@@ -17,6 +17,9 @@ const handoffFormNode = document.querySelector('#handoff-form')
 const handoffNameNode = document.querySelector('#handoff-name')
 const handoffSaveNode = document.querySelector('#handoff-save')
 const handoffCancelNode = document.querySelector('#handoff-cancel')
+const handoffResyncNode = document.querySelector('#handoff-resync')
+const handoffResyncNameNode = document.querySelector('#handoff-resync-name')
+const handoffResyncSaveNode = document.querySelector('#handoff-resync-save')
 const chatSelectNode = document.querySelector('#chat-select')
 const agentSelectNode = document.querySelector('#agent-select')
 const modelSelectNode = document.querySelector('#model-select')
@@ -559,9 +562,12 @@ async function openHandoffForm() {
   handoffNode.disabled = true
   handoffNode.textContent = 'Naming\u2026'
   let suggestion = ''
+  let existing = []
   try {
     const hostname = new URL(activePage.url).hostname
-    suggestion = (await codeyApi('/v1/session/handoff/name', { method: 'POST', body: { hostname } })).name
+    const named = await codeyApi('/v1/session/handoff/name', { method: 'POST', body: { hostname } })
+    suggestion = named.name
+    existing = Array.isArray(named.existing) ? named.existing : []
   } catch (error) {
     handoffNode.disabled = false
     handoffNode.textContent = 'Handoff failed'
@@ -572,6 +578,16 @@ async function openHandoffForm() {
   handoffNode.textContent = 'Hand off login'
   handoffFormNode.hidden = false
   handoffNameNode.value = suggestion
+  // A profile that already holds this site is almost always what the user
+  // means when they come back after signing in again, so it is offered next
+  // to the create field instead of making them delete and redo the handoff.
+  handoffResyncNameNode.replaceChildren(...existing.map(name => {
+    const option = document.createElement('option')
+    option.value = name
+    option.textContent = name
+    return option
+  }))
+  handoffResyncNode.hidden = existing.length === 0
   handoffNameNode.focus()
   handoffNameNode.select()
 }
@@ -580,6 +596,10 @@ function closeHandoffForm() {
   handoffFormNode.hidden = true
   handoffNameNode.value = ''
   handoffSaveNode.disabled = false
+  handoffResyncNode.hidden = true
+  handoffResyncSaveNode.disabled = false
+  handoffResyncSaveNode.textContent = 'Re-sync'
+  handoffResyncNameNode.replaceChildren()
   handoffNode.disabled = false
 }
 
@@ -606,6 +626,27 @@ async function handOffSession() {
     handoffNameNode.select()
   } finally {
     handoffSaveNode.textContent = 'Save'
+  }
+}
+
+// Refreshing an existing profile rather than creating one: same export, but
+// only this site's part of the saved profile is replaced.
+async function resyncSession() {
+  const name = handoffResyncNameNode.value
+  if (!name) return
+  handoffResyncSaveNode.disabled = true
+  handoffResyncSaveNode.textContent = 'Syncing\u2026'
+  try {
+    const result = await codeyApi('/v1/session/handoff', { method: 'POST', body: { name, resync: true } })
+    closeHandoffForm()
+    handoffNode.textContent = `Re-synced ${result.profileName}`
+    handoffNode.title = `${result.cookieCount} cookies from ${result.origin} replaced this site's login in the Codey Browser profile "${result.profileName}"`
+    handoffResetTimer = setTimeout(resetHandoffButton, 6000)
+  } catch (error) {
+    handoffResyncSaveNode.disabled = false
+    handoffResyncSaveNode.textContent = 'Re-sync'
+    handoffNode.textContent = 'Re-sync failed'
+    handoffNode.title = error instanceof Error ? error.message : String(error)
   }
 }
 
@@ -851,6 +892,7 @@ void refreshUpdateNotice()
 handoffNode.addEventListener('click', () => { void openHandoffForm() })
 handoffFormNode.addEventListener('submit', event => { event.preventDefault(); void handOffSession() })
 handoffCancelNode.addEventListener('click', () => resetHandoffButton())
+handoffResyncSaveNode.addEventListener('click', () => { void resyncSession() })
 handoffNameNode.addEventListener('keydown', event => { if (event.key === 'Escape') resetHandoffButton() })
 chatSelectNode.addEventListener('change', () => {
   if (!busy) void selectChat(chatSelectNode.value)

--- a/chrome-extension/sidepanel.js
+++ b/chrome-extension/sidepanel.js
@@ -10,6 +10,9 @@ const includePageNode = document.querySelector('#include-page')
 const pageContextNode = document.querySelector('#page-context')
 const pageTitleNode = document.querySelector('#page-title')
 const handoffNode = document.querySelector('#handoff')
+const updateNoticeNode = document.querySelector('#update-notice')
+const updateCopyNode = document.querySelector('#update-copy')
+const updateOpenNode = document.querySelector('#update-open')
 const handoffFormNode = document.querySelector('#handoff-form')
 const handoffNameNode = document.querySelector('#handoff-name')
 const handoffSaveNode = document.querySelector('#handoff-save')
@@ -522,6 +525,25 @@ function typingNode() {
   return node
 }
 
+// Codey refreshes the extension's files on its own launch, but Chrome keeps
+// running the build it loaded until the extension is reloaded. The service
+// worker records the mismatch while polling; surfacing it here is the only
+// thing that tells the user their Codey is newer than their Chrome extension.
+async function refreshUpdateNotice() {
+  const { updateAvailable } = await chrome.storage.local.get({ updateAvailable: '' })
+  updateNoticeNode.hidden = !updateAvailable
+  updateCopyNode.textContent = updateAvailable
+    ? `Codey ${updateAvailable} is installed. Reload the extension to use it.`
+    : ''
+}
+
+// Reloading from here re-reads the files Codey already staged, so the user
+// never has to find chrome://extensions themselves.
+function reloadExtension() {
+  updateOpenNode.disabled = true
+  chrome.runtime.reload()
+}
+
 // Copying the current site's signed-in session into a Codey Browser profile.
 // Codey does the export and the import; the panel only reports the outcome,
 // and it reports it on the button itself so nothing is added to the chat.
@@ -821,6 +843,11 @@ inputNode.addEventListener('input', () => {
   inputNode.style.height = `${Math.max(42, Math.min(inputNode.scrollHeight, 140))}px`
 })
 settingsToggleNode.addEventListener('click', () => { if (!busy) toggleSettings() })
+updateOpenNode.addEventListener('click', reloadExtension)
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes.updateAvailable) void refreshUpdateNotice()
+})
+void refreshUpdateNotice()
 handoffNode.addEventListener('click', () => { void openHandoffForm() })
 handoffFormNode.addEventListener('submit', event => { event.preventDefault(); void handOffSession() })
 handoffCancelNode.addEventListener('click', () => resetHandoffButton())

--- a/codey-mac/electron/browser-agent-bridge.test.ts
+++ b/codey-mac/electron/browser-agent-bridge.test.ts
@@ -113,6 +113,10 @@ describe('BrowserAgentBridge', () => {
         text: 'Signed in through Chrome', links: [], forms: [],
       })),
       navigate: vi.fn(async (url: string) => ({ id: 9, windowId: 2, title: 'Chrome', url })),
+      act: vi.fn(async (action: string, ref: string) => ({
+        tab: { id: 9, windowId: 2, title: 'Chrome account', url: 'https://example.com/account' },
+        element: { tag: 'button', text: `${action} ${ref}` },
+      })),
     }
     const bridge = new BrowserAgentBridge(controller, onOpen, requestControl, event => loginEvents.push(event), 5, companion)
     const info = await bridge.start()
@@ -142,13 +146,32 @@ describe('BrowserAgentBridge', () => {
       expect(chromeOpened.body.url).toBe('https://github.com')
       expect(companion.navigate).toHaveBeenCalledWith('https://github.com')
 
+      // Acting on the real Chrome page asks about Chrome's URL, not the
+      // embedded browser's, so the approval prompt names the page being changed.
+      const chromeClicked = await call(info, 'POST', '/chrome/click', { ref: 'e4' }, info.chromeToken)
+      expect(chromeClicked.status).toBe(200)
+      expect(companion.act).toHaveBeenCalledWith('click', 'e4', undefined)
+      expect(requestControl).toHaveBeenLastCalledWith({
+        command: 'chrome click', url: 'https://example.com/account', surface: 'chrome', level: 'write',
+      })
+
+      const chromeFilled = await call(info, 'POST', '/chrome/fill', { ref: 'e5', value: 'hello' }, info.chromeToken)
+      expect(chromeFilled.status).toBe(200)
+      expect(companion.act).toHaveBeenLastCalledWith('fill', 'e5', 'hello')
+
+      // A denied action must never reach Chrome.
+      requestControl.mockResolvedValueOnce(false)
+      const chromeDenied = await call(info, 'POST', '/chrome/click', { ref: 'e6' }, info.chromeToken)
+      expect(chromeDenied.status).toBeGreaterThanOrEqual(400)
+      expect(companion.act).not.toHaveBeenCalledWith('click', 'e6', undefined)
+
       const snapshot = await call(info, 'GET', '/snapshot')
       expect(snapshot.body.elements[0]).toMatchObject({ ref: 'e1', label: 'Post' })
 
       const clicked = await call(info, 'POST', '/click', { ref: 'e1' })
       expect(clicked.status).toBe(200)
       expect(controller.click).toHaveBeenCalledWith('e1')
-      expect(requestControl).toHaveBeenCalledWith({ command: 'click', url: state.url })
+      expect(requestControl).toHaveBeenCalledWith({ command: 'click', url: state.url, surface: 'browser', level: 'write' })
 
       const controlCallsAfterButton = requestControl.mock.calls.length
       const followed = await call(info, 'POST', '/click', { ref: 'e2' })
@@ -190,7 +213,7 @@ describe('BrowserAgentBridge', () => {
       expect(imported.status).toBe(200)
       expect(controller.importProfile).toHaveBeenCalledWith('gh', { json: '{"cookies":[]}' }, true)
       // Import activates by default, so it goes through the user approval gate.
-      expect(requestControl).toHaveBeenCalledWith({ command: 'activate-profile', url: state.url })
+      expect(requestControl).toHaveBeenCalledWith({ command: 'activate-profile', url: state.url, surface: 'browser', level: 'full' })
 
       const activated = await call(info, 'POST', '/profile/activate', { name: 'work' })
       expect(activated.status).toBe(200)
@@ -266,7 +289,7 @@ describe('BrowserAgentBridge', () => {
       expect(JSON.parse(profileCli.stdout).text).toBe('Hello from the page')
       expect(controller.activateProfile).toHaveBeenLastCalledWith('cli')
       // Switching identity mid-command needs the same approval as an explicit activate.
-      expect(requestControl).toHaveBeenLastCalledWith({ command: 'activate-profile', url: state.url })
+      expect(requestControl).toHaveBeenLastCalledWith({ command: 'activate-profile', url: state.url, surface: 'browser', level: 'full' })
 
       const profileListCli = await execFileAsync(process.execPath, [cli, 'profile', 'list'], {
         env: {

--- a/codey-mac/electron/browser-agent-bridge.test.ts
+++ b/codey-mac/electron/browser-agent-bridge.test.ts
@@ -106,6 +106,7 @@ describe('BrowserAgentBridge', () => {
       status: vi.fn(() => ({
         endpoint: 'http://127.0.0.1:49321', paired: true, connected: true,
         clientName: 'Test Chrome', pairedAt: 1, lastSeenAt: 2,
+        clientVersion: '0.10.0', expectedVersion: '0.10.0', updateAvailable: false,
       })),
       activeTab: vi.fn(async () => ({ id: 9, windowId: 2, title: 'Chrome account', url: 'https://example.com/account' })),
       snapshot: vi.fn(async () => ({

--- a/codey-mac/electron/browser-agent-bridge.ts
+++ b/codey-mac/electron/browser-agent-bridge.ts
@@ -4,8 +4,10 @@ import * as os from 'os'
 import * as path from 'path'
 import { randomBytes } from 'crypto'
 import type { BrowserController, BrowserLoginStatus } from './browser-controller'
-import type { BrowserControlRequest } from './browser-control-permission'
-import type { ChromeCompanionBridge } from './chrome-companion'
+import { levelForCommand, type BrowserControlRequest } from './browser-control-permission'
+import type { ChromeCompanionBridge, ChromePageActionName } from './chrome-companion'
+
+const CHROME_PAGE_ACTIONS: readonly ChromePageActionName[] = ['click', 'fill', 'select', 'check', 'press']
 
 type BridgeController = Pick<
   BrowserController,
@@ -17,7 +19,7 @@ type BridgeController = Pick<
   | 'listProfiles' | 'activeProfileName' | 'saveProfile' | 'importProfile' | 'activateProfile' | 'deleteProfile' | 'exportProfile'
 >
 
-type CompanionController = Pick<ChromeCompanionBridge, 'status' | 'activeTab' | 'snapshot' | 'navigate'>
+type CompanionController = Pick<ChromeCompanionBridge, 'status' | 'activeTab' | 'snapshot' | 'navigate' | 'act'>
 
 export interface BrowserAgentBridgeInfo {
   socketPath: string
@@ -371,6 +373,17 @@ export class BrowserAgentBridge {
         json(res, 200, await this.companion.navigate(String(body.url || '')))
         return
       }
+      // Acting on the real Chrome page. Navigation above only moves the tab;
+      // everything here changes page state, so each one asks the user first.
+      for (const action of CHROME_PAGE_ACTIONS) {
+        if (req.method === 'POST' && route === `/chrome/${action}`) {
+          const body = await readJson(req)
+          const ref = String(body.ref || '')
+          const value = body.value === undefined ? undefined : String(body.value)
+          json(res, 200, await this.controlledChrome(action, () => this.companion!.act(action, ref, value)))
+          return
+        }
+      }
       // ── Profiles ──────────────────────────────────────────────────────
       if (req.method === 'GET' && route === '/profiles') {
         json(res, 200, { active: this.controller.activeProfileName(), profiles: this.controller.listProfiles() })
@@ -437,9 +450,32 @@ export class BrowserAgentBridge {
   }
 
   private async controlled<T>(command: string, operation: () => Promise<T> | T): Promise<T> {
-    const approved = await this.requestControl({ command, url: this.controller.getState().url })
+    const approved = await this.requestControl({
+      command,
+      url: this.controller.getState().url,
+      surface: 'browser',
+      level: levelForCommand(command),
+    })
     if (!approved) throw new BrowserControlDeniedError()
     return await this.exclusive(operation)
+  }
+
+  /**
+   * The Chrome twin of `controlled`. It asks about the real Chrome tab's URL
+   * rather than the embedded browser's, and deliberately skips `exclusive` -
+   * that lock serialises the embedded browser, and Chrome is a separate target.
+   */
+  private async controlledChrome<T>(command: string, operation: () => Promise<T>): Promise<T> {
+    if (!this.companion) throw new Error('Chrome companion is unavailable')
+    const tab = await this.companion.activeTab()
+    const approved = await this.requestControl({
+      command: `chrome ${command}`,
+      url: tab.url,
+      surface: 'chrome',
+      level: levelForCommand(command),
+    })
+    if (!approved) throw new BrowserControlDeniedError()
+    return await operation()
   }
 
   private async startLoginWait(chatId: string, requestedTimeoutMs: number): Promise<BrowserLoginWaitEvent> {

--- a/codey-mac/electron/browser-agent-cli.cjs
+++ b/codey-mac/electron/browser-agent-cli.cjs
@@ -69,7 +69,19 @@ function usage() {
     '  chrome tab                 Read the active real-Chrome tab',
     '  chrome view                Read the active real-Chrome page',
     '  chrome open <url>          Navigate the active real-Chrome tab',
+    '  chrome click <ref>         Click an element in the active real-Chrome tab',
+    '  chrome fill <ref> <text>   Type into a real-Chrome field',
+    '  chrome select <ref> <value>  Pick a real-Chrome dropdown option',
+    '  chrome check <ref> [false] Tick or untick a real-Chrome checkbox',
+    '  chrome press <key> <ref>   Send a key to a real-Chrome element',
   ].join('\n')
+}
+
+function chromeRef(ref) {
+  if (!/^e\d+$/.test(String(ref || ''))) {
+    throw new Error(`Chrome needs an element ref like e3 (got ${ref || 'nothing'}). Run "chrome view" first.`)
+  }
+  return String(ref)
 }
 
 function authHeaders() {
@@ -279,6 +291,19 @@ async function main() {
         const url = rest.slice(1).join(' ').trim()
         if (!url) throw new Error(`Missing Chrome URL\n${usage()}`)
         value = await request('POST', '/chrome/open', { url })
+      } else if (sub === 'click') {
+        value = await request('POST', '/chrome/click', { ref: chromeRef(rest[1]) })
+      } else if (sub === 'fill') {
+        value = await request('POST', '/chrome/fill', { ref: chromeRef(rest[1]), value: rest.slice(2).join(' ') })
+      } else if (sub === 'select') {
+        value = await request('POST', '/chrome/select', { ref: chromeRef(rest[1]), value: rest.slice(2).join(' ') })
+      } else if (sub === 'check') {
+        value = await request('POST', '/chrome/check', { ref: chromeRef(rest[1]), value: rest[2] === 'false' ? 'false' : 'true' })
+      } else if (sub === 'press') {
+        // `press <key> <ref>` mirrors the embedded browser's argument order.
+        const key = rest[1]
+        if (!key) throw new Error(`Missing key to press\n${usage()}`)
+        value = await request('POST', '/chrome/press', { ref: chromeRef(rest[2]), value: key })
       } else {
         throw new Error(`Unknown Chrome command: ${sub || ''}\n${usage()}`)
       }

--- a/codey-mac/electron/browser-control-permission.test.ts
+++ b/codey-mac/electron/browser-control-permission.test.ts
@@ -1,43 +1,104 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { describe, expect, it, vi } from 'vitest'
-import { BrowserControlPermissionGate } from './browser-control-permission'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BrowserControlPermissionGate, levelForCommand } from './browser-control-permission'
+
+function tempFile(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `codey-browser-permission-${label}-`))
+  directories.push(dir)
+  return path.join(dir, 'permission.json')
+}
+
+const directories: string[] = []
+afterEach(() => {
+  for (const dir of directories.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('levelForCommand', () => {
+  it('treats adding and changing as write, and destroying as full', () => {
+    for (const command of ['click', 'fill', 'submit', 'upload', 'chrome click', 'chrome fill']) {
+      expect(levelForCommand(command)).toBe('write')
+    }
+    for (const command of ['delete-profile', 'activate-profile']) {
+      expect(levelForCommand(command)).toBe('full')
+    }
+  })
+})
 
 describe('BrowserControlPermissionGate', () => {
   it('starts view-only, waits for approval, persists it, and can revoke it', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-browser-permission-'))
-    const file = path.join(dir, 'permission.json')
+    const file = tempFile('grant')
     const onChange = vi.fn()
-    try {
-      const gate = new BrowserControlPermissionGate(file, onChange)
-      const waiting = gate.request({ command: 'fill', url: 'https://example.com/form' })
-      expect(gate.getState()).toEqual({
-        approved: false,
-        pending: { command: 'fill', url: 'https://example.com/form' },
-      })
-      gate.approve()
-      await expect(waiting).resolves.toBe(true)
-      expect(new BrowserControlPermissionGate(file, vi.fn()).getState().approved).toBe(true)
+    const gate = new BrowserControlPermissionGate(file, onChange)
+    const waiting = gate.request({ command: 'fill', url: 'https://example.com/form', surface: 'browser', level: 'write' })
+    expect(gate.getState()).toEqual({
+      granted: { browser: 'none', chrome: 'none' },
+      pending: { command: 'fill', url: 'https://example.com/form', surface: 'browser', level: 'write' },
+    })
 
-      gate.revoke()
-      expect(gate.getState().approved).toBe(false)
-      expect(new BrowserControlPermissionGate(file, vi.fn()).getState().approved).toBe(false)
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true })
-    }
+    gate.approve('write')
+    await expect(waiting).resolves.toBe(true)
+    expect(new BrowserControlPermissionGate(file, vi.fn()).getState().granted).toEqual({ browser: 'write', chrome: 'none' })
+
+    gate.revoke('browser')
+    expect(new BrowserControlPermissionGate(file, vi.fn()).getState().granted).toEqual({ browser: 'none', chrome: 'none' })
+  })
+
+  it('lets a write grant through repeat writes but still stops a full-access command', async () => {
+    const gate = new BrowserControlPermissionGate(tempFile('tier'), vi.fn())
+    const first = gate.request({ command: 'click', url: 'https://example.com', surface: 'browser', level: 'write' })
+    gate.approve('write')
+    await expect(first).resolves.toBe(true)
+
+    // A second write needs no prompt at all.
+    await expect(gate.request({ command: 'fill', url: 'https://example.com', surface: 'browser', level: 'write' })).resolves.toBe(true)
+    expect(gate.getState().pending).toBeNull()
+
+    // Deleting is past what they granted, so it asks again.
+    const destructive = gate.request({ command: 'delete-profile', url: 'https://example.com', surface: 'browser', level: 'full' })
+    expect(gate.getState().pending).toMatchObject({ command: 'delete-profile', level: 'full' })
+    gate.approve('full')
+    await expect(destructive).resolves.toBe(true)
+    expect(gate.getState().granted.browser).toBe('full')
+  })
+
+  it('never lets one browser\'s grant apply to the other', async () => {
+    const gate = new BrowserControlPermissionGate(tempFile('surface'), vi.fn())
+    const inBrowser = gate.request({ command: 'click', url: 'https://example.com', surface: 'browser', level: 'write' })
+    gate.approve('full')
+    await expect(inBrowser).resolves.toBe(true)
+    expect(gate.getState().granted).toEqual({ browser: 'full', chrome: 'none' })
+
+    // The user's real Chrome was never approved, so it must still prompt.
+    const inChrome = gate.request({ command: 'chrome click', url: 'https://github.com', surface: 'chrome', level: 'write' })
+    expect(gate.getState().pending).toMatchObject({ surface: 'chrome' })
+    gate.deny()
+    await expect(inChrome).resolves.toBe(false)
+    expect(gate.getState().granted.chrome).toBe('none')
+  })
+
+  it('raises a write approval to full when the command needs full', async () => {
+    const gate = new BrowserControlPermissionGate(tempFile('raise'), vi.fn())
+    const waiting = gate.request({ command: 'delete-profile', url: 'https://example.com', surface: 'browser', level: 'full' })
+    gate.approve('write')
+    // Approving less than the command needs would leave it blocked forever.
+    await expect(waiting).resolves.toBe(true)
+    expect(gate.getState().granted.browser).toBe('full')
+  })
+
+  it('reads a legacy blanket approval as the embedded browser only', () => {
+    const file = tempFile('legacy')
+    fs.writeFileSync(file, JSON.stringify({ agentControlApproved: true }))
+    // Chrome had no gate when that flag was written, so it must not inherit one.
+    expect(new BrowserControlPermissionGate(file, vi.fn()).getState().granted).toEqual({ browser: 'full', chrome: 'none' })
   })
 
   it('resolves a pending command as denied without granting future access', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-browser-permission-deny-'))
-    try {
-      const gate = new BrowserControlPermissionGate(path.join(dir, 'permission.json'), vi.fn())
-      const waiting = gate.request({ command: 'submit', url: 'https://example.com/post' })
-      gate.deny()
-      await expect(waiting).resolves.toBe(false)
-      expect(gate.getState()).toEqual({ approved: false, pending: null })
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true })
-    }
+    const gate = new BrowserControlPermissionGate(tempFile('deny'), vi.fn())
+    const waiting = gate.request({ command: 'submit', url: 'https://example.com/post', surface: 'browser', level: 'write' })
+    gate.deny()
+    await expect(waiting).resolves.toBe(false)
+    expect(gate.getState()).toEqual({ granted: { browser: 'none', chrome: 'none' }, pending: null })
   })
 })

--- a/codey-mac/electron/browser-control-permission.ts
+++ b/codey-mac/electron/browser-control-permission.ts
@@ -1,19 +1,45 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
+/** Which browser a request is about. Codey's own sandboxed browser and the
+ *  user's real Chrome carry very different stakes - Chrome holds their live
+ *  logins - so they are approved separately and never imply each other. */
+export type BrowserControlSurface = 'browser' | 'chrome'
+
+/** How far a command reaches.
+ *  - `write` adds or changes something (click, fill, upload, submit).
+ *  - `full` also destroys or replaces state that cannot be typed back in
+ *    (deleting a saved profile, swapping the live session's cookies). */
+export type BrowserControlLevel = 'write' | 'full'
+
+/** What the user has granted for one surface, `none` meaning view-only. */
+export type BrowserControlGrant = 'none' | BrowserControlLevel
+
+const GRANT_RANK: Record<BrowserControlGrant, number> = { none: 0, write: 1, full: 2 }
+
+/** Commands that reach past "add or change" and so need `full`. Everything
+ *  else that mutates is `write`; reads are never gated at all. */
+const FULL_ACCESS_COMMANDS = new Set(['delete-profile', 'activate-profile'])
+
+export function levelForCommand(command: string): BrowserControlLevel {
+  return FULL_ACCESS_COMMANDS.has(command) ? 'full' : 'write'
+}
+
 export interface BrowserControlRequest {
   command: string
   url: string
+  surface: BrowserControlSurface
+  level: BrowserControlLevel
 }
 
 export interface BrowserControlPermissionState {
-  approved: boolean
+  granted: Record<BrowserControlSurface, BrowserControlGrant>
   pending: BrowserControlRequest | null
 }
 
 /** Persistent, user-approved gate for mutating browser agent commands. */
 export class BrowserControlPermissionGate {
-  private approved = false
+  private granted: Record<BrowserControlSurface, BrowserControlGrant> = { browser: 'none', chrome: 'none' }
   private pending: BrowserControlRequest | null = null
   private waiters: Array<(approved: boolean) => void> = []
 
@@ -21,15 +47,15 @@ export class BrowserControlPermissionGate {
     private readonly filePath: string,
     private readonly onChange: (state: BrowserControlPermissionState) => void,
   ) {
-    this.approved = this.readApproval()
+    this.granted = this.readApproval()
   }
 
   getState(): BrowserControlPermissionState {
-    return { approved: this.approved, pending: this.pending ? { ...this.pending } : null }
+    return { granted: { ...this.granted }, pending: this.pending ? { ...this.pending } : null }
   }
 
   async request(request: BrowserControlRequest): Promise<boolean> {
-    if (this.approved) return true
+    if (GRANT_RANK[this.granted[request.surface]] >= GRANT_RANK[request.level]) return true
     if (!this.pending) {
       this.pending = { ...request }
       this.emit()
@@ -37,9 +63,17 @@ export class BrowserControlPermissionGate {
     return await new Promise<boolean>(resolve => this.waiters.push(resolve))
   }
 
-  approve(): BrowserControlPermissionState {
-    this.approved = true
-    this.persist()
+  /** Grant `level` on the pending request's surface and let it through.
+   *  Approving `write` for a command that needs `full` would not actually
+   *  unblock it, so the grant is raised to whatever the request asked for. */
+  approve(level: BrowserControlLevel): BrowserControlPermissionState {
+    const pending = this.pending
+    if (!pending) return this.getState()
+    const effective = GRANT_RANK[level] >= GRANT_RANK[pending.level] ? level : pending.level
+    if (GRANT_RANK[effective] > GRANT_RANK[this.granted[pending.surface]]) {
+      this.granted[pending.surface] = effective
+      this.persist()
+    }
     this.finishPending(true)
     return this.getState()
   }
@@ -49,8 +83,10 @@ export class BrowserControlPermissionGate {
     return this.getState()
   }
 
-  revoke(): BrowserControlPermissionState {
-    this.approved = false
+  revoke(surface?: BrowserControlSurface): BrowserControlPermissionState {
+    for (const key of surface ? [surface] : (['browser', 'chrome'] as BrowserControlSurface[])) {
+      this.granted[key] = 'none'
+    }
     this.persist()
     this.finishPending(false)
     return this.getState()
@@ -71,19 +107,28 @@ export class BrowserControlPermissionGate {
     this.onChange(this.getState())
   }
 
-  private readApproval(): boolean {
+  private readApproval(): Record<BrowserControlSurface, BrowserControlGrant> {
     try {
       const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8'))
-      return parsed?.agentControlApproved === true
+      // The old format was a single blanket boolean covering the embedded
+      // browser; real Chrome had no gate of its own yet. Carrying it over as
+      // Chrome access would grant something the user was never asked about.
+      if (parsed?.agentControlApproved === true && !parsed?.agentControl) {
+        return { browser: 'full', chrome: 'none' }
+      }
+      const stored = parsed?.agentControl
+      const read = (value: unknown): BrowserControlGrant =>
+        value === 'write' || value === 'full' ? value : 'none'
+      return { browser: read(stored?.browser), chrome: read(stored?.chrome) }
     } catch {
-      return false
+      return { browser: 'none', chrome: 'none' }
     }
   }
 
   private persist(): void {
     try {
       fs.mkdirSync(path.dirname(this.filePath), { recursive: true })
-      fs.writeFileSync(this.filePath, JSON.stringify({ agentControlApproved: this.approved }, null, 2), {
+      fs.writeFileSync(this.filePath, JSON.stringify({ agentControl: this.granted }, null, 2), {
         encoding: 'utf8',
         mode: 0o600,
       })

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -12,6 +12,8 @@ import type { BrowserSitePermissionDetails, BrowserSitePermissionManager } from 
 import {
   assertProfileName,
   BrowserProfileStore,
+  cookieMatchesUrl,
+  mergeProfileData,
   parseProfileJsonText,
   readProfileJson,
   type BrowserProfile,
@@ -973,6 +975,48 @@ export class BrowserController {
       await this.applyProfileData(profile)
       this.profiles().setActive(name)
     }
+    return profile
+  }
+
+  /** Names of saved profiles that already hold a cookie scoped to `url` -
+   *  the profiles a handoff of that page would be refreshing rather than
+   *  creating. Unreadable profiles are simply not offered. */
+  profilesForUrl(url: string): string[] {
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      return []
+    }
+    const store = this.profiles()
+    return store.list()
+      .filter(summary => {
+        try {
+          return store.read(summary.name).cookies.some(cookie => cookieMatchesUrl(cookie, parsed))
+        } catch {
+          return false
+        }
+      })
+      .map(summary => summary.name)
+  }
+
+  /** Refresh part of a saved profile from a freshly exported session, so a
+   *  login that was renewed elsewhere stops being stale here. The profile must
+   *  already exist - this is the "my Chrome login changed" path, not a second
+   *  way to create one - and only the scope URL's cookies and the exported
+   *  origins' storage are replaced, so other sites saved in the same profile
+   *  survive. Refreshing the enabled profile re-applies it too: the live
+   *  session would otherwise keep serving the cookies it was activated with. */
+  async resyncProfile(
+    name: string,
+    source: { json: string },
+    scopeUrl: string,
+  ): Promise<BrowserProfile> {
+    assertProfileName(name)
+    const existing = this.profiles().read(name)
+    const merged = mergeProfileData(existing, parseProfileJsonText(source.json), scopeUrl)
+    const profile = this.profiles().write(name, merged, existing.sourceUrl ?? scopeUrl)
+    if (this.profiles().active() === name) await this.applyProfileData(profile)
     return profile
   }
 

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -6,6 +6,7 @@ import {
   ACTIVE_PROFILE_FILE,
   assertProfileName,
   BrowserProfileStore,
+  availableProfileName,
   deriveProfileNameFromFile,
   parseProfileData,
   parseProfileJsonText,
@@ -193,6 +194,25 @@ describe('BrowserProfileStore', () => {
       expect(summary).toMatchObject({ cookieCount: 0, originCount: 0 })
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('availableProfileName', () => {
+  it('names a handoff after the site, without the www', () => {
+    expect(availableProfileName('www.github.com', [])).toBe('github.com')
+    expect(availableProfileName('mail.google.com', [])).toBe('mail.google.com')
+  })
+
+  it('takes the next free suffix instead of failing on a collision', () => {
+    expect(availableProfileName('github.com', ['github.com'])).toBe('github.com-2')
+    expect(availableProfileName('github.com', ['github.com', 'github.com-2'])).toBe('github.com-3')
+  })
+
+  it('always returns a name the profile store will accept', () => {
+    for (const host of ['', '...', 'exa mple.com', '-weird-', 'a'.repeat(200)]) {
+      const name = availableProfileName(host, [])
+      expect(() => assertProfileName(name)).not.toThrow()
     }
   })
 })

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -7,6 +7,8 @@ import {
   assertProfileName,
   BrowserProfileStore,
   availableProfileName,
+  cookieMatchesUrl,
+  mergeProfileData,
   deriveProfileNameFromFile,
   parseProfileData,
   parseProfileJsonText,
@@ -214,5 +216,72 @@ describe('availableProfileName', () => {
       const name = availableProfileName(host, [])
       expect(() => assertProfileName(name)).not.toThrow()
     }
+  })
+})
+
+const cookie = (over: Partial<Parameters<typeof cookieMatchesUrl>[0]> = {}) => ({
+  name: 'session',
+  value: 'abc',
+  domain: 'example.com',
+  path: '/',
+  expires: -1,
+  httpOnly: true,
+  secure: true,
+  sameSite: 'lax' as const,
+  ...over,
+})
+
+describe('cookieMatchesUrl', () => {
+  it('matches a domain cookie on its subdomains but not a host-only one', () => {
+    const url = new URL('https://app.example.com/')
+    expect(cookieMatchesUrl(cookie(), url)).toBe(true)
+    expect(cookieMatchesUrl(cookie({ hostOnly: true }), url)).toBe(false)
+    expect(cookieMatchesUrl(cookie({ hostOnly: true, domain: 'app.example.com' }), url)).toBe(true)
+  })
+
+  it('does not match a lookalike host that merely ends the same way', () => {
+    expect(cookieMatchesUrl(cookie(), new URL('https://notexample.com/'))).toBe(false)
+  })
+
+  it('respects the secure flag and path scope', () => {
+    expect(cookieMatchesUrl(cookie(), new URL('http://example.com/'))).toBe(false)
+    expect(cookieMatchesUrl(cookie({ secure: false }), new URL('http://example.com/'))).toBe(true)
+    const scoped = cookie({ path: '/app' })
+    expect(cookieMatchesUrl(scoped, new URL('https://example.com/app/inbox'))).toBe(true)
+    expect(cookieMatchesUrl(scoped, new URL('https://example.com/apple'))).toBe(false)
+  })
+})
+
+describe('mergeProfileData', () => {
+  const existing = {
+    cookies: [
+      cookie({ name: 'session', value: 'stale' }),
+      cookie({ name: 'dropped', value: 'gone' }),
+      cookie({ name: 'other-site', domain: 'gitlab.com' }),
+    ],
+    origins: [
+      { origin: 'https://example.com', localStorage: [{ name: 'token', value: 'stale' }] },
+      { origin: 'https://gitlab.com', localStorage: [{ name: 'token', value: 'keep' }] },
+    ],
+  }
+  const incoming = {
+    cookies: [cookie({ name: 'session', value: 'fresh' })],
+    origins: [{ origin: 'https://example.com', localStorage: [{ name: 'token', value: 'fresh' }] }],
+  }
+
+  it('replaces the refreshed site and leaves the profile\'s other sites alone', () => {
+    const merged = mergeProfileData(existing, incoming, 'https://example.com/')
+    expect(merged.cookies.map(entry => [entry.domain, entry.name, entry.value])).toEqual([
+      ['gitlab.com', 'other-site', 'abc'],
+      ['example.com', 'session', 'fresh'],
+    ])
+    expect(merged.origins).toEqual([
+      { origin: 'https://gitlab.com', localStorage: [{ name: 'token', value: 'keep' }] },
+      { origin: 'https://example.com', localStorage: [{ name: 'token', value: 'fresh' }] },
+    ])
+  })
+
+  it('rejects a scope URL it cannot reason about rather than merging blindly', () => {
+    expect(() => mergeProfileData(existing, incoming, 'not a url')).toThrow(/scope URL/)
   })
 })

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -113,6 +113,25 @@ export function deriveProfileNameFromFile(filePath: string): string {
   }
 }
 
+/** Pick a profile name for a one-click handoff of `hostname`'s session. The
+ *  user never typed this name, so a collision must not be an error - the next
+ *  free suffix is taken instead. */
+export function availableProfileName(hostname: string, taken: readonly string[]): string {
+  const base = String(hostname || '')
+    .replace(/^www\./i, '')
+    .replace(/[^a-zA-Z0-9._-]/g, '-')
+    .replace(/^[.\-]+|[.\-]+$/g, '')
+    .replace(/-+/g, '-')
+    .slice(0, 56) || 'chrome'
+  const used = new Set(taken)
+  if (!used.has(base)) return base
+  for (let suffix = 2; suffix < 1000; suffix += 1) {
+    const candidate = `${base}-${suffix}`
+    if (!used.has(candidate)) return candidate
+  }
+  throw new Error(`Too many saved profiles for ${base} - delete some in Codey Browser settings`)
+}
+
 export function profileFileName(name: string): string {
   assertProfileName(name)
   return `${name}.json`

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -225,6 +225,48 @@ export function readProfileJson(filePath: string): BrowserProfileData {
   }
 }
 
+/** Does `cookie` apply to `url`? This mirrors the scope Chrome answers
+ *  `cookies.getAll({ url })` with, so a profile we already hold can be asked
+ *  which of its cookies a fresh export of that URL would have spoken for. */
+export function cookieMatchesUrl(cookie: BrowserProfileCookie, url: URL): boolean {
+  const host = url.hostname.toLowerCase()
+  const domain = cookie.domain.toLowerCase()
+  const domainMatches = cookie.hostOnly ? host === domain : host === domain || host.endsWith(`.${domain}`)
+  if (!domainMatches) return false
+  if (cookie.secure && url.protocol !== 'https:') return false
+  const cookiePath = cookie.path || '/'
+  if (cookiePath === '/') return true
+  const requestPath = url.pathname || '/'
+  if (!requestPath.startsWith(cookiePath)) return false
+  return requestPath.length === cookiePath.length
+    || cookiePath.endsWith('/')
+    || requestPath[cookiePath.length] === '/'
+}
+
+/** Fold a freshly exported session for one URL into a profile that already
+ *  exists. Only what that export can speak for is replaced - cookies in the
+ *  URL's scope, and the localStorage of the origins the export actually
+ *  carried - so a profile holding several sites keeps the others intact.
+ *  Replacing rather than layering also means a cookie the site has since
+ *  dropped disappears here instead of lingering as a stale credential. */
+export function mergeProfileData(
+  existing: BrowserProfileData,
+  incoming: BrowserProfileData,
+  scopeUrl: string,
+): BrowserProfileData {
+  let url: URL
+  try {
+    url = new URL(scopeUrl)
+  } catch {
+    throw new Error(`Invalid session scope URL: ${scopeUrl}`)
+  }
+  const refreshed = new Set(incoming.origins.map(origin => origin.origin))
+  return {
+    cookies: [...existing.cookies.filter(cookie => !cookieMatchesUrl(cookie, url)), ...incoming.cookies],
+    origins: [...existing.origins.filter(origin => !refreshed.has(origin.origin)), ...incoming.origins],
+  }
+}
+
 /** File store for profiles. One \`.json\` per profile plus a dot-file that
  *  records which profile is enabled. */
 export class BrowserProfileStore {

--- a/codey-mac/electron/chrome-companion.test.ts
+++ b/codey-mac/electron/chrome-companion.test.ts
@@ -268,6 +268,7 @@ describe('ChromeCompanionBridge', () => {
 
   it('hands the current site\'s session to Codey from the side panel', async () => {
     const handoffs: Array<string | undefined> = []
+    const resyncs: boolean[] = []
     const features = {
       options: async () => ({
         agents: [], models: [], defaultAgent: null, defaultModel: null, defaultModels: {}, chat: null,
@@ -278,11 +279,12 @@ describe('ChromeCompanionBridge', () => {
       }),
       upload: async () => ({ id: 'a', name: 'n', mimeType: 'text/plain', size: 0, path: '/tmp/n' }),
       transcribe: async () => ({ text: '' }),
-      handoffSession: async (name?: string) => {
+      handoffSession: async (name?: string, resync?: boolean) => {
         handoffs.push(name)
-        return { profileName: name || 'example.com-2', origin: 'https://example.com', cookieCount: 4 }
+        resyncs.push(resync === true)
+        return { profileName: name || 'example.com-2', origin: 'https://example.com', cookieCount: 4, resynced: resync === true }
       },
-      suggestProfileName: async (hostname: string) => ({ name: `${hostname}-free` }),
+      suggestProfileName: async (hostname: string) => ({ name: `${hostname}-free`, existing: [`${hostname}-saved`] }),
     } as unknown as ChromeCompanionFeatures
     const { endpoint } = await setup(undefined, undefined, undefined, features)
     const token = await connect(endpoint)
@@ -298,7 +300,9 @@ describe('ChromeCompanionBridge', () => {
     const suggested = await fetch(`${endpoint}/v1/session/handoff/name`, {
       method: 'POST', headers, body: JSON.stringify({ hostname: 'example.com' }),
     })
-    await expect(suggested.json()).resolves.toEqual({ ok: true, name: 'example.com-free' })
+    await expect(suggested.json()).resolves.toEqual({
+      ok: true, name: 'example.com-free', existing: ['example.com-saved'],
+    })
 
     // A name the user typed is passed through untouched.
     const named = await fetch(`${endpoint}/v1/session/handoff`, {
@@ -306,7 +310,7 @@ describe('ChromeCompanionBridge', () => {
     })
     expect(named.status).toBe(200)
     await expect(named.json()).resolves.toEqual({
-      ok: true, profileName: 'my-github', origin: 'https://example.com', cookieCount: 4,
+      ok: true, profileName: 'my-github', origin: 'https://example.com', cookieCount: 4, resynced: false,
     })
 
     // An omitted or blank name means "you pick one".
@@ -315,7 +319,21 @@ describe('ChromeCompanionBridge', () => {
     })
     await expect(auto.json()).resolves.toMatchObject({ profileName: 'example.com-2' })
 
-    expect(handoffs).toEqual(['my-github', undefined])
+    // Refreshing an existing profile goes down the same route with a flag.
+    const refreshed = await fetch(`${endpoint}/v1/session/handoff`, {
+      method: 'POST', headers, body: JSON.stringify({ name: 'my-github', resync: true }),
+    })
+    await expect(refreshed.json()).resolves.toMatchObject({ profileName: 'my-github', resynced: true })
+
+    // "Refresh whichever" is not a thing - there would be no way to guess which.
+    const nameless = await fetch(`${endpoint}/v1/session/handoff`, {
+      method: 'POST', headers, body: JSON.stringify({ resync: true }),
+    })
+    expect(nameless.status).toBe(400)
+    await expect(nameless.json()).resolves.toMatchObject({ error: 'Choose which profile to re-sync' })
+
+    expect(handoffs).toEqual(['my-github', undefined, 'my-github'])
+    expect(resyncs).toEqual([false, false, true])
   })
 
   it('routes authenticated side-panel chat through Codey', async () => {
@@ -367,8 +385,8 @@ describe('ChromeCompanionBridge', () => {
         id: 'attachment-1', name, mimeType, size: data.length, path: '/safe/upload.txt',
       }),
       transcribe: async (_mimeType, data) => ({ text: `heard ${data.length} bytes` }),
-      handoffSession: async () => ({ profileName: 'example.com', origin: 'https://example.com', cookieCount: 3 }),
-      suggestProfileName: async hostname => ({ name: hostname }),
+      handoffSession: async () => ({ profileName: 'example.com', origin: 'https://example.com', cookieCount: 3, resynced: false }),
+      suggestProfileName: async hostname => ({ name: hostname, existing: [] }),
     }
     const { endpoint } = await setup(
       async request => { received.push(request); return { chatId: 'chat-2', response: 'Attached' } },

--- a/codey-mac/electron/chrome-companion.test.ts
+++ b/codey-mac/electron/chrome-companion.test.ts
@@ -166,6 +166,52 @@ describe('ChromeCompanionBridge', () => {
     await expect(exported).resolves.toEqual(session)
   })
 
+  it('notices Chrome is running an older extension than the one on disk', async () => {
+    const { bridge, endpoint } = await setup()
+    const token = await connect(endpoint)
+    bridge.setExpectedVersion('0.10.0')
+
+    const poll = (version?: string) => fetch(`${endpoint}/v1/poll`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(version === undefined ? {} : { version }),
+    }).then(response => response.json() as Promise<{ expectedVersion: string | null }>)
+
+    // Chrome is still running the build it loaded before Codey updated.
+    await expect(poll('0.9.2')).resolves.toMatchObject({ expectedVersion: '0.10.0' })
+    expect(bridge.status()).toMatchObject({
+      clientVersion: '0.9.2', expectedVersion: '0.10.0', updateAvailable: true,
+    })
+
+    // After the user reloads it, the warning has to clear itself.
+    await poll('0.10.0')
+    expect(bridge.status().updateAvailable).toBe(false)
+  })
+
+  it('explains an unsupported command as an extension that needs reloading', async () => {
+    const { bridge, endpoint } = await setup()
+    const token = await connect(endpoint)
+    bridge.setExpectedVersion('0.10.0')
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    await fetch(`${endpoint}/v1/poll`, { method: 'POST', headers, body: JSON.stringify({ version: '0.9.2' }) })
+
+    // Captured as a value: the rejection lands while the poll below is still
+    // in flight, and an unhandled one would fail the suite.
+    const clicked = bridge.act('click', 'e1').catch((error: Error) => error)
+    const work = await fetch(`${endpoint}/v1/poll`, { method: 'POST', headers, body: '{}' })
+      .then(response => response.json() as Promise<{ command: { id: string } }>)
+    await fetch(`${endpoint}/v1/result`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ id: work.command.id, ok: false, error: 'Unsupported Codey command: click' }),
+    })
+
+    // The raw message reads like a Codey bug; the user needs the actual fix.
+    const failure = await clicked
+    expect(String(failure)).toMatch(/Reload the Codey extension/)
+    expect(String(failure)).toMatch(/0\.9\.2/)
+  })
+
   it('validates navigation before it reaches Chrome', async () => {
     const { bridge, endpoint } = await setup()
     await connect(endpoint)

--- a/codey-mac/electron/chrome-companion.test.ts
+++ b/codey-mac/electron/chrome-companion.test.ts
@@ -172,6 +172,106 @@ describe('ChromeCompanionBridge', () => {
     await expect(bridge.navigate('file:///etc/passwd')).rejects.toThrow('Only http(s)')
   })
 
+  it('rejects a page action whose ref did not come from a snapshot', async () => {
+    const { bridge, endpoint } = await setup()
+    await connect(endpoint)
+    await expect(bridge.act('click', 'button.submit')).rejects.toThrow('Invalid element ref')
+    await expect(bridge.act('click', '')).rejects.toThrow('Invalid element ref')
+    await expect(bridge.act('fill', 'e2')).rejects.toThrow('needs a value')
+  })
+
+  it('round-trips a click through the extension protocol', async () => {
+    const { bridge, endpoint } = await setup()
+    const token = await connect(endpoint)
+    const clicked = bridge.act('click', 'e4')
+
+    const poll = await fetch(`${endpoint}/v1/poll`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    const work = await poll.json() as { command: { id: string; command: string; input: { ref: string } } }
+    expect(work.command.command).toBe('click')
+    expect(work.command.input).toEqual({ ref: 'e4' })
+
+    const outcome = {
+      tab: { id: 7, windowId: 3, title: 'Sent', url: 'https://example.com/done' },
+      element: { tag: 'button', text: 'Send' },
+    }
+    await fetch(`${endpoint}/v1/result`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: work.command.id, ok: true, data: outcome }),
+    })
+    await expect(clicked).resolves.toEqual(outcome)
+  })
+
+  it('sends check as a boolean so "false" unticks instead of ticking', async () => {
+    const { bridge, endpoint } = await setup()
+    const token = await connect(endpoint)
+    void bridge.act('check', 'e9', 'false').catch(() => undefined)
+
+    const poll = await fetch(`${endpoint}/v1/poll`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    const work = await poll.json() as { command: { input: { ref: string; value: boolean } } }
+    expect(work.command.input).toEqual({ ref: 'e9', value: false })
+  })
+
+  it('hands the current site\'s session to Codey from the side panel', async () => {
+    const handoffs: Array<string | undefined> = []
+    const features = {
+      options: async () => ({
+        agents: [], models: [], defaultAgent: null, defaultModel: null, defaultModels: {}, chat: null,
+      }),
+      updateSettings: async () => undefined,
+      prepareChat: async () => ({
+        id: 'chat-1', title: 'Chat', workspaceName: 'w', updatedAt: 1, messageCount: 0,
+      }),
+      upload: async () => ({ id: 'a', name: 'n', mimeType: 'text/plain', size: 0, path: '/tmp/n' }),
+      transcribe: async () => ({ text: '' }),
+      handoffSession: async (name?: string) => {
+        handoffs.push(name)
+        return { profileName: name || 'example.com-2', origin: 'https://example.com', cookieCount: 4 }
+      },
+      suggestProfileName: async (hostname: string) => ({ name: `${hostname}-free` }),
+    } as unknown as ChromeCompanionFeatures
+    const { endpoint } = await setup(undefined, undefined, undefined, features)
+    const token = await connect(endpoint)
+
+    // Unauthenticated callers must not be able to lift a session.
+    const anonymous = await fetch(`${endpoint}/v1/session/handoff`, { method: 'POST' })
+    expect(anonymous.status).toBe(401)
+    expect(handoffs).toHaveLength(0)
+
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+
+    // The panel prefills its field with a name Codey says is free.
+    const suggested = await fetch(`${endpoint}/v1/session/handoff/name`, {
+      method: 'POST', headers, body: JSON.stringify({ hostname: 'example.com' }),
+    })
+    await expect(suggested.json()).resolves.toEqual({ ok: true, name: 'example.com-free' })
+
+    // A name the user typed is passed through untouched.
+    const named = await fetch(`${endpoint}/v1/session/handoff`, {
+      method: 'POST', headers, body: JSON.stringify({ name: '  my-github  ' }),
+    })
+    expect(named.status).toBe(200)
+    await expect(named.json()).resolves.toEqual({
+      ok: true, profileName: 'my-github', origin: 'https://example.com', cookieCount: 4,
+    })
+
+    // An omitted or blank name means "you pick one".
+    const auto = await fetch(`${endpoint}/v1/session/handoff`, {
+      method: 'POST', headers, body: JSON.stringify({ name: '   ' }),
+    })
+    await expect(auto.json()).resolves.toMatchObject({ profileName: 'example.com-2' })
+
+    expect(handoffs).toEqual(['my-github', undefined])
+  })
+
   it('routes authenticated side-panel chat through Codey', async () => {
     const received: ChromeCompanionChatRequest[] = []
     const { endpoint } = await setup(async request => {
@@ -221,6 +321,8 @@ describe('ChromeCompanionBridge', () => {
         id: 'attachment-1', name, mimeType, size: data.length, path: '/safe/upload.txt',
       }),
       transcribe: async (_mimeType, data) => ({ text: `heard ${data.length} bytes` }),
+      handoffSession: async () => ({ profileName: 'example.com', origin: 'https://example.com', cookieCount: 3 }),
+      suggestProfileName: async hostname => ({ name: hostname }),
     }
     const { endpoint } = await setup(
       async request => { received.push(request); return { chatId: 'chat-2', response: 'Attached' } },

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -19,6 +19,12 @@ export interface ChromeCompanionStatus {
   clientName: string | null
   pairedAt: number | null
   lastSeenAt: number | null
+  /** Version of the extension Chrome is actually running, once it has polled. */
+  clientVersion: string | null
+  /** Version Codey has staged on disk for it. */
+  expectedVersion: string | null
+  /** Chrome is running an older build than the one already staged on disk. */
+  updateAvailable: boolean
 }
 
 export interface ChromeTabInfo {
@@ -180,6 +186,8 @@ export class ChromeCompanionBridge {
   // The Mac app's current accent color, mirrored to the extension so the
   // controlled-tab highlight matches whatever palette the user picked.
   private accent = DEFAULT_ACCENT
+  private clientVersion: string | null = null
+  private expectedVersion: string | null = null
   private pending = new Map<string, PendingCommand>()
   private uploadedAttachments = new Map<string, { chatId: string; attachment: ChromeCompanionAttachment }>()
 
@@ -237,10 +245,23 @@ export class ChromeCompanionBridge {
       clientName: this.clientName,
       pairedAt: this.pairedAt,
       lastSeenAt: this.lastSeenAt,
+      clientVersion: this.clientVersion,
+      expectedVersion: this.expectedVersion,
+      updateAvailable: !!this.clientVersion && !!this.expectedVersion && this.clientVersion !== this.expectedVersion,
     }
   }
 
+  /** The extension version Codey has staged on disk, so a Chrome still running
+   *  an older build can be told to reload rather than failing cryptically. */
+  setExpectedVersion(version: string | null): void {
+    const next = version && version.trim() ? version.trim().slice(0, 40) : null
+    if (next === this.expectedVersion) return
+    this.expectedVersion = next
+    this.emitStatus()
+  }
+
   disconnect(): ChromeCompanionStatus {
+    this.clientVersion = null
     this.token = null
     this.clientName = null
     this.pairedAt = null
@@ -325,6 +346,17 @@ export class ChromeCompanionBridge {
     try { parsed = new URL(url) } catch { throw new Error('Enter a valid http(s) URL') }
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') throw new Error('Only http(s) URLs are allowed')
     return await this.command<ChromeTabInfo>('navigate', { url: parsed.toString() })
+  }
+
+  /** An extension too old to know a command reports it as unsupported, which
+   *  reads like a Codey bug. Say what actually needs to happen instead. */
+  private explain(error: string): string {
+    if (!error) return 'Chrome command failed'
+    if (!/Unsupported Codey command/i.test(error)) return error
+    const versions = this.clientVersion && this.expectedVersion
+      ? ` Chrome is running ${this.clientVersion}; ${this.expectedVersion} is already installed on disk.`
+      : ''
+    return `Reload the Codey extension at chrome://extensions to finish updating it.${versions}`
   }
 
   private async command<T>(command: string, input: unknown): Promise<T> {
@@ -445,10 +477,17 @@ export class ChromeCompanionBridge {
       }
       this.touch()
       if (request.method === 'POST' && url.pathname === '/v1/poll') {
+        const input = await this.body(request)
+        const reported = typeof input.version === 'string' ? input.version.trim().slice(0, 40) : ''
+        if (reported && reported !== this.clientVersion) {
+          this.clientVersion = reported
+          this.emitStatus()
+        }
         const command = this.queue.shift()
+        const base = { ok: true, accent: this.accent, expectedVersion: this.expectedVersion }
         this.reply(request, response, 200, command
-          ? { ok: true, accent: this.accent, command: { id: command.id, command: command.command, input: command.input } }
-          : { ok: true, accent: this.accent, command: null })
+          ? { ...base, command: { id: command.id, command: command.command, input: command.input } }
+          : { ...base, command: null })
         return
       }
       if (request.method === 'POST' && url.pathname === '/v1/result') {
@@ -462,7 +501,7 @@ export class ChromeCompanionBridge {
         clearTimeout(command.timer)
         this.pending.delete(id)
         if (input.ok === true) command.resolve(input.data)
-        else command.reject(new Error(typeof input.error === 'string' ? input.error : 'Chrome command failed'))
+        else command.reject(new Error(this.explain(typeof input.error === 'string' ? input.error : '')))
         this.reply(request, response, 200, { ok: true })
         return
       }

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -32,9 +32,17 @@ export interface ChromeTabInfo {
 export interface ChromePageSnapshot {
   tab: ChromeTabInfo
   text: string
-  links: Array<{ text: string; href: string }>
-  forms: Array<{ tag: string; type: string; name: string; placeholder: string }>
+  links: Array<{ ref: string; text: string; href: string }>
+  forms: Array<{ ref: string; tag: string; type: string; name: string; placeholder: string; label: string }>
 }
+
+/** What a page action touched, so a caller never has to assume it landed. */
+export interface ChromePageAction {
+  tab: ChromeTabInfo
+  element: { tag: string; text: string }
+}
+
+export type ChromePageActionName = 'click' | 'fill' | 'select' | 'check' | 'press'
 
 export interface ChromeSessionExport {
   tab: ChromeTabInfo
@@ -100,6 +108,21 @@ export interface ChromeCompanionFeatures {
   prepareChat: (input: { page?: ChromeCompanionChatRequest['page']; agent?: string | null; model?: string | null }) => Promise<ChromeCompanionChatSummary>
   upload: (chatId: string, name: string, mimeType: string, data: Buffer) => Promise<ChromeCompanionAttachment>
   transcribe: (mimeType: string, data: Buffer) => Promise<{ text: string }>
+  /**
+   * Copy the current Chrome tab's signed-in session into a Codey Browser
+   * profile. Without a name Codey picks a free one derived from the site, so
+   * the one-click path never fails merely because the obvious name is taken;
+   * a name the user typed is used as-is and collides loudly.
+   */
+  handoffSession: (name?: string) => Promise<ChromeSessionHandoff>
+  /** The name the handoff would use for `hostname` if the user just accepts it. */
+  suggestProfileName: (hostname: string) => Promise<{ name: string }>
+}
+
+export interface ChromeSessionHandoff {
+  profileName: string
+  origin: string
+  cookieCount: number
 }
 
 export interface ChromeCompanionChatHistory {
@@ -281,6 +304,22 @@ export class ChromeCompanionBridge {
     return await this.command<ChromeSessionExport>('exportSession', {})
   }
 
+  /**
+   * Act on an element the last `snapshot` stamped with `ref`. Refs are
+   * renumbered by every snapshot, so a stale one is rejected by the extension
+   * rather than applied to whatever element inherited the number.
+   */
+  async act(action: ChromePageActionName, ref: string, value?: string): Promise<ChromePageAction> {
+    if (!/^e\d+$/.test(ref)) throw new Error(`Invalid element ref: ${ref || '(empty)'}. Run "chrome view" first.`)
+    if ((action === 'fill' || action === 'select' || action === 'press') && value === undefined) {
+      throw new Error(`Chrome ${action} needs a value`)
+    }
+    const input: Record<string, unknown> = { ref }
+    if (action === 'check') input.value = value !== 'false'
+    else if (value !== undefined) input.value = value
+    return await this.command<ChromePageAction>(action, input)
+  }
+
   async navigate(url: string): Promise<ChromeTabInfo> {
     let parsed: URL
     try { parsed = new URL(url) } catch { throw new Error('Enter a valid http(s) URL') }
@@ -455,6 +494,20 @@ export class ChromeCompanionBridge {
         const result = await this.onChat({ chatId, text, page, agent, model, attachments })
         for (const id of attachmentIds) this.uploadedAttachments.delete(id)
         this.reply(request, response, 200, { ok: true, ...result })
+        return
+      }
+      if (request.method === 'POST' && url.pathname === '/v1/session/handoff/name') {
+        if (!this.features) throw new Error('Session handoff is unavailable')
+        const input = await this.body(request)
+        const hostname = typeof input.hostname === 'string' ? input.hostname.slice(0, 300) : ''
+        this.reply(request, response, 200, { ok: true, ...await this.features.suggestProfileName(hostname) })
+        return
+      }
+      if (request.method === 'POST' && url.pathname === '/v1/session/handoff') {
+        if (!this.features) throw new Error('Session handoff is unavailable')
+        const input = await this.body(request)
+        const name = typeof input.name === 'string' ? input.name.trim() : ''
+        this.reply(request, response, 200, { ok: true, ...await this.features.handoffSession(name || undefined) })
         return
       }
       if (request.method === 'GET' && url.pathname === '/v1/chats') {

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -120,15 +120,21 @@ export interface ChromeCompanionFeatures {
    * the one-click path never fails merely because the obvious name is taken;
    * a name the user typed is used as-is and collides loudly.
    */
-  handoffSession: (name?: string) => Promise<ChromeSessionHandoff>
-  /** The name the handoff would use for `hostname` if the user just accepts it. */
-  suggestProfileName: (hostname: string) => Promise<{ name: string }>
+  handoffSession: (name?: string, resync?: boolean) => Promise<ChromeSessionHandoff>
+  /**
+   * The name the handoff would use for `hostname` if the user just accepts it,
+   * plus the profiles that already hold this site's session - those are the
+   * ones a re-sync would refresh rather than a handoff create.
+   */
+  suggestProfileName: (hostname: string) => Promise<{ name: string; existing: string[] }>
 }
 
 export interface ChromeSessionHandoff {
   profileName: string
   origin: string
   cookieCount: number
+  /** True when an existing profile was refreshed instead of one being created. */
+  resynced: boolean
 }
 
 export interface ChromeCompanionChatHistory {
@@ -546,7 +552,11 @@ export class ChromeCompanionBridge {
         if (!this.features) throw new Error('Session handoff is unavailable')
         const input = await this.body(request)
         const name = typeof input.name === 'string' ? input.name.trim() : ''
-        this.reply(request, response, 200, { ok: true, ...await this.features.handoffSession(name || undefined) })
+        const resync = input.resync === true
+        // A refresh has to say which profile it refreshes; there is no
+        // sensible default for "overwrite one of these".
+        if (resync && !name) throw new Error('Choose which profile to re-sync')
+        this.reply(request, response, 200, { ok: true, ...await this.features.handoffSession(name || undefined, resync) })
         return
       }
       if (request.method === 'GET' && url.pathname === '/v1/chats') {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -17,7 +17,7 @@ import { runAgentUpdate, updatePlanFor } from './agent-update'
 import { availability, createLatestVersionsCache, fetchAllLatestVersions } from './agent-latest'
 import { SKILL_FILE, markSkillManagedBy, removeLegacyManagedSkills, resolveUserPath, samePath, scanClaudePluginSkills, scanSkillsDir, setSkillEnabled, uniqueSkills } from './skills'
 import { isKnownPlugin, listPlugins } from './plugins'
-import { CHOSEN_FOLDER_NAME, installedExtensionDir, refreshRememberedInstall, rememberInstallDir, stageChromeExtension } from './chrome-extension-stage'
+import { CHOSEN_FOLDER_NAME, installedExtensionDir, refreshRememberedInstall, rememberInstallDir, stageChromeExtension, stagedVersion } from './chrome-extension-stage'
 import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
@@ -2565,6 +2565,11 @@ app.whenReady().then(async () => {
   // a copy the user installed themselves has to be refreshed here or it stays
   // on the version that shipped the day they installed it.
   refreshRememberedInstall(chromeCompanionExtensionPath(), app.getPath('userData'))
+  // Refreshing the files is only half of an update - Chrome re-reads an
+  // unpacked extension only when it restarts or the user reloads it. Telling
+  // the bridge which version is on disk lets it say so instead of letting new
+  // commands fail as "unsupported".
+  chromeCompanion?.setExpectedVersion(stagedVersion(chromeCompanionExtensionPath()))
   ipcMain.handle('capture:pickFiles', async () =>
     wrap(async () => {
       capturePickingFiles = true

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2170,12 +2170,25 @@ app.whenReady().then(async () => {
       },
       suggestProfileName: async hostname => ({
         name: availableProfileName(hostname, browserController.listProfiles().map(profile => profile.name)),
+        existing: browserController.profilesForUrl(`https://${hostname}/`),
       }),
-      handoffSession: async requested => {
+      handoffSession: async (requested, resync) => {
         if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
         const sessionState = await chromeCompanion.exportSession()
         const tabUrl = new URL(sessionState.tab.url)
+        const json = JSON.stringify({ cookies: sessionState.cookies, origins: sessionState.origins })
         const taken = browserController.listProfiles().map(profile => profile.name)
+        if (resync) {
+          // Refreshing is the one path where an existing name is required
+          // rather than rejected: the point is to overwrite that login.
+          if (!requested) throw new Error('Choose which profile to re-sync')
+          assertProfileName(requested)
+          if (!taken.includes(requested)) {
+            throw new Error(`No Codey Browser profile named "${requested}" to re-sync - hand the login off instead`)
+          }
+          await browserController.resyncProfile(requested, { json }, sessionState.tab.url)
+          return { profileName: requested, origin: tabUrl.origin, cookieCount: sessionState.cookies.length, resynced: true }
+        }
         let name: string
         if (requested) {
           // The user typed this name, so a collision is a real mistake worth
@@ -2188,10 +2201,8 @@ app.whenReady().then(async () => {
         } else {
           name = availableProfileName(tabUrl.hostname, taken)
         }
-        await browserController.importProfile(name, {
-          json: JSON.stringify({ cookies: sessionState.cookies, origins: sessionState.origins }),
-        }, true, sessionState.tab.url)
-        return { profileName: name, origin: tabUrl.origin, cookieCount: sessionState.cookies.length }
+        await browserController.importProfile(name, { json }, true, sessionState.tab.url)
+        return { profileName: name, origin: tabUrl.origin, cookieCount: sessionState.cookies.length, resynced: false }
       },
       transcribe: async (mimeType, data) => {
         if (!coreConfigManager) throw new Error('Codey configuration is unavailable')
@@ -2452,6 +2463,24 @@ app.whenReady().then(async () => {
     }, true, sessionState.tab.url)
     const profile = browserController.listProfiles().find(item => item.name === requested)
     if (!profile) throw new Error('Chrome session was imported but its Codey Browser profile could not be found')
+    return { profile, tab: sessionState.tab }
+  }))
+  // The counterpart to exportSession: the profile must already exist, and only
+  // the current site's part of it is replaced, so a login renewed in Chrome can
+  // be refreshed without the profile's other sites being lost.
+  ipcMain.handle('chromeCompanion:resyncSession', (event, name: string) => browserCall(event, async () => {
+    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+    const requested = String(name || '').trim()
+    assertProfileName(requested)
+    if (!browserController.listProfiles().some(profile => profile.name === requested)) {
+      throw new Error(`No Codey Browser profile named "${requested}" \u2014 create one first`)
+    }
+    const sessionState = await chromeCompanion.exportSession()
+    await browserController.resyncProfile(requested, {
+      json: JSON.stringify({ cookies: sessionState.cookies, origins: sessionState.origins }),
+    }, sessionState.tab.url)
+    const profile = browserController.listProfiles().find(item => item.name === requested)
+    if (!profile) throw new Error('Chrome session was re-synced but its Codey Browser profile could not be found')
     return { profile, tab: sessionState.tab }
   }))
   ipcMain.handle('chromeCompanion:navigate', (event, url: string) => browserCall(event, () => {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -31,7 +31,7 @@ import { scanSkillUsage } from './skill-usage'
 import type { SkillUsageMap, UsageCacheEntry } from './skill-usage'
 import { BROWSER_PARTITION, BrowserController, type BrowserBounds } from './browser-controller'
 import { BrowserAgentBridge, type BrowserLoginWaitEvent } from './browser-agent-bridge'
-import { assertProfileName, deriveProfileNameFromFile } from './browser-profiles'
+import { assertProfileName, availableProfileName, deriveProfileNameFromFile } from './browser-profiles'
 import { BrowserControlPermissionGate } from './browser-control-permission'
 import { BrowserSitePermissionManager } from './browser-site-permissions'
 import { canConfigureBrowserWebAuthn, configureBrowserWebAuthn, passkeyAccountLabel, type BrowserPasskeyPickerRequest } from './browser-webauthn'
@@ -2168,6 +2168,31 @@ app.whenReady().then(async () => {
         fsMod.writeFileSync(filePath, data)
         return { id: cryptoMod.randomUUID(), name, path: filePath, mimeType, size: data.length }
       },
+      suggestProfileName: async hostname => ({
+        name: availableProfileName(hostname, browserController.listProfiles().map(profile => profile.name)),
+      }),
+      handoffSession: async requested => {
+        if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+        const sessionState = await chromeCompanion.exportSession()
+        const tabUrl = new URL(sessionState.tab.url)
+        const taken = browserController.listProfiles().map(profile => profile.name)
+        let name: string
+        if (requested) {
+          // The user typed this name, so a collision is a real mistake worth
+          // reporting rather than something to silently rename around.
+          assertProfileName(requested)
+          if (taken.includes(requested)) {
+            throw new Error(`A Codey Browser profile named "${requested}" already exists - choose another name`)
+          }
+          name = requested
+        } else {
+          name = availableProfileName(tabUrl.hostname, taken)
+        }
+        await browserController.importProfile(name, {
+          json: JSON.stringify({ cookies: sessionState.cookies, origins: sessionState.origins }),
+        }, true, sessionState.tab.url)
+        return { profileName: name, origin: tabUrl.origin, cookieCount: sessionState.cookies.length }
+      },
       transcribe: async (mimeType, data) => {
         if (!coreConfigManager) throw new Error('Codey configuration is unavailable')
         const voice = coreConfigManager.getResolvedVoiceConfig()
@@ -2476,19 +2501,19 @@ app.whenReady().then(async () => {
     return { installed: true as const, dir }
   }))
   ipcMain.handle('browser:controlPermission:get', event => browserCall(event, () =>
-    browserControlPermission?.getState() ?? { approved: false, pending: null }
+    browserControlPermission?.getState() ?? { granted: { browser: 'none', chrome: 'none' }, pending: null }
   ))
-  ipcMain.handle('browser:controlPermission:approve', event => browserCall(event, () => {
+  ipcMain.handle('browser:controlPermission:approve', (event, level: 'write' | 'full') => browserCall(event, () => {
     if (!browserControlPermission) throw new Error('Browser control permission is unavailable')
-    return browserControlPermission.approve()
+    return browserControlPermission.approve(level === 'full' ? 'full' : 'write')
   }))
   ipcMain.handle('browser:controlPermission:deny', event => browserCall(event, () => {
     if (!browserControlPermission) throw new Error('Browser control permission is unavailable')
     return browserControlPermission.deny()
   }))
-  ipcMain.handle('browser:controlPermission:revoke', event => browserCall(event, () => {
+  ipcMain.handle('browser:controlPermission:revoke', (event, surface?: 'browser' | 'chrome') => browserCall(event, () => {
     if (!browserControlPermission) throw new Error('Browser control permission is unavailable')
-    return browserControlPermission.revoke()
+    return browserControlPermission.revoke(surface === 'browser' || surface === 'chrome' ? surface : undefined)
   }))
   ipcMain.handle('browser:sitePermission:get', event => browserCall(event, () =>
     browserSitePermissions?.getState() ?? { pending: null, savedSiteCount: 0 }

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -470,6 +470,7 @@ contextBridge.exposeInMainWorld('codey', {
     activeTab: () => ipcRenderer.invoke('chromeCompanion:activeTab'),
     snapshot: () => ipcRenderer.invoke('chromeCompanion:snapshot'),
     exportSession: (name: string) => ipcRenderer.invoke('chromeCompanion:exportSession', name),
+    resyncSession: (name: string) => ipcRenderer.invoke('chromeCompanion:resyncSession', name),
     navigate: (url: string) => ipcRenderer.invoke('chromeCompanion:navigate', url),
     setAccent: (hex: string) => ipcRenderer.invoke('chromeCompanion:setAccent', hex),
     showExtensionFolder: () => ipcRenderer.invoke('chromeCompanion:showExtensionFolder'),

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -521,9 +521,9 @@ contextBridge.exposeInMainWorld('codey', {
     },
     controlPermission: {
       get: () => ipcRenderer.invoke('browser:controlPermission:get'),
-      approve: () => ipcRenderer.invoke('browser:controlPermission:approve'),
+      approve: (level?: 'write' | 'full') => ipcRenderer.invoke('browser:controlPermission:approve', level ?? 'write'),
       deny: () => ipcRenderer.invoke('browser:controlPermission:deny'),
-      revoke: () => ipcRenderer.invoke('browser:controlPermission:revoke'),
+      revoke: (surface?: 'browser' | 'chrome') => ipcRenderer.invoke('browser:controlPermission:revoke', surface),
     },
     sitePermission: {
       get: () => ipcRenderer.invoke('browser:sitePermission:get'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -154,9 +154,13 @@ export interface BrowserPageContext {
   }
 }
 
+export type BrowserControlSurface = 'browser' | 'chrome'
+export type BrowserControlLevel = 'write' | 'full'
+export type BrowserControlGrant = 'none' | BrowserControlLevel
+
 export interface BrowserControlPermissionState {
-  approved: boolean
-  pending: { command: string; url: string } | null
+  granted: Record<BrowserControlSurface, BrowserControlGrant>
+  pending: { command: string; url: string; surface: BrowserControlSurface; level: BrowserControlLevel } | null
 }
 
 export type BrowserSitePermission = 'camera' | 'microphone' | 'geolocation' | 'notifications'
@@ -654,9 +658,9 @@ declare global {
         }
         controlPermission: {
           get: () => Promise<IpcResult<BrowserControlPermissionState>>
-          approve: () => Promise<IpcResult<BrowserControlPermissionState>>
+          approve: (level?: BrowserControlLevel) => Promise<IpcResult<BrowserControlPermissionState>>
           deny: () => Promise<IpcResult<BrowserControlPermissionState>>
-          revoke: () => Promise<IpcResult<BrowserControlPermissionState>>
+          revoke: (surface?: BrowserControlSurface) => Promise<IpcResult<BrowserControlPermissionState>>
         }
         sitePermission: {
           get: () => Promise<IpcResult<BrowserSitePermissionState>>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -616,6 +616,7 @@ declare global {
         activeTab: () => Promise<IpcResult<ChromeTabInfo>>
         snapshot: () => Promise<IpcResult<ChromePageSnapshot>>
         exportSession: (name: string) => Promise<IpcResult<{ profile: BrowserProfileSummary; tab: ChromeTabInfo }>>
+        resyncSession: (name: string) => Promise<IpcResult<{ profile: BrowserProfileSummary; tab: ChromeTabInfo }>>
         navigate: (url: string) => Promise<IpcResult<ChromeTabInfo>>
         setAccent: (hex: string) => Promise<IpcResult<{ ok: true }>>
         showExtensionFolder: () => Promise<IpcResult<string>>

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -248,6 +248,9 @@ export interface ChromeCompanionStatus {
   clientName: string | null
   pairedAt: number | null
   lastSeenAt: number | null
+  clientVersion: string | null
+  expectedVersion: string | null
+  updateAvailable: boolean
 }
 
 export interface ChromeTabInfo {

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -38,7 +38,7 @@ const EMPTY_STATE: BrowserState = {
   error: null,
 }
 
-const VIEW_ONLY: BrowserControlPermissionState = { approved: false, pending: null }
+const VIEW_ONLY: BrowserControlPermissionState = { granted: { browser: 'none', chrome: 'none' }, pending: null }
 const NO_SITE_PERMISSION: BrowserSitePermissionState = { pending: null, savedSiteCount: 0 }
 
 type BrowserSettingsSection = 'extensions' | 'profiles'
@@ -608,17 +608,26 @@ export const BrowserPanel: React.FC<Props> = ({
           <button type="button" style={styles.menuButton} disabled={!state.url || activeSettingsSection !== null} onClick={() => { setBrowserMenuOpen(false); if (state.url && !activeSettingsSection) void window.codey.openExternal(state.url) }}>
             <span aria-hidden="true">↗</span> Open externally
           </button>
-          <button
-            type="button"
-            style={{ ...styles.menuButton, ...(controlPermission.approved ? styles.menuButtonWarning : null) }}
-            onClick={() => {
-              setBrowserMenuOpen(false)
-              if (controlPermission.approved) void updateControlPermission(window.codey.browser.controlPermission.revoke)
-            }}
-          >
-            <span aria-hidden="true">{controlPermission.approved ? '●' : '○'}</span>
-            {controlPermission.approved ? 'Revoke agent control' : 'Agent access: view only'}
-          </button>
+          {(['browser', 'chrome'] as const).map(surface => {
+            const grant = controlPermission.granted[surface]
+            const label = surface === 'browser' ? 'this browser' : 'Chrome'
+            return (
+              <button
+                key={surface}
+                type="button"
+                style={{ ...styles.menuButton, ...(grant !== 'none' ? styles.menuButtonWarning : null) }}
+                onClick={() => {
+                  setBrowserMenuOpen(false)
+                  if (grant !== 'none') void updateControlPermission(() => window.codey.browser.controlPermission.revoke(surface))
+                }}
+              >
+                <span aria-hidden="true">{grant === 'none' ? '○' : '●'}</span>
+                {grant === 'none'
+                  ? `Agent access to ${label}: view only`
+                  : `Revoke ${grant === 'full' ? 'full' : 'write'} access to ${label}`}
+              </button>
+            )
+          })}
           <button type="button" style={{ ...styles.menuButton, color: C.red }} onClick={() => { setBrowserMenuOpen(false); setResetConfirmation(true) }}>
             <UIIcon name="trash" size={13} /> Clear data & sign out
           </button>
@@ -837,14 +846,22 @@ export const BrowserPanel: React.FC<Props> = ({
         </div>
       )}
 
-      {controlPermission.pending && !controlPermission.approved && (
+      {controlPermission.pending && (
         <div style={styles.permissionPrompt} role="alertdialog" aria-label="Agent browser control permission">
           <div style={styles.permissionPromptIcon}><UIIcon name="bot" size={18} /></div>
           <div style={styles.permissionPromptText}>
-            <div style={styles.permissionPromptTitle}>Allow the agent to control this browser?</div>
+            <div style={styles.permissionPromptTitle}>
+              {controlPermission.pending.surface === 'chrome'
+                ? 'Allow the agent to act in your Chrome?'
+                : 'Allow the agent to control this browser?'}
+            </div>
             <div style={styles.permissionPromptCopy}>
               The agent wants to <strong>{controlPermission.pending.command}</strong>{pendingDomain ? ` on ${pendingDomain}` : ''}.
-              Full control allows clicking, typing, submitting forms, sending posts, and acting through your signed-in accounts.
+              {' '}Write access allows clicking, typing, submitting forms and acting through your signed-in accounts.
+              Full access also allows deleting saved profiles and replacing the live session.
+              {controlPermission.pending.surface === 'chrome'
+                ? ' This applies to your real Chrome only, not Codey\u2019s browser.'
+                : ' This applies to Codey\u2019s browser only, not your real Chrome.'}
             </div>
           </div>
           <button
@@ -852,11 +869,18 @@ export const BrowserPanel: React.FC<Props> = ({
             style={styles.denyButton}
             onClick={() => void updateControlPermission(window.codey.browser.controlPermission.deny)}
           >Not now</button>
+          {controlPermission.pending.level === 'write' && (
+            <button
+              type="button"
+              style={styles.approveButton}
+              onClick={() => void updateControlPermission(() => window.codey.browser.controlPermission.approve('write'))}
+            >Allow write</button>
+          )}
           <button
             type="button"
             style={styles.approveButton}
-            onClick={() => void updateControlPermission(window.codey.browser.controlPermission.approve)}
-          >Allow full control</button>
+            onClick={() => void updateControlPermission(() => window.codey.browser.controlPermission.approve('full'))}
+          >Allow full access</button>
         </div>
       )}
 

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -26,6 +26,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
   const [error, setError] = useState<string | null>(null)
   const [profileName, setProfileName] = useState('chrome-session')
   const [exported, setExported] = useState<string | null>(null)
+  const [resynced, setResynced] = useState<string | null>(null)
   const [installedPath, setInstalledPath] = useState<string | null>(null)
 
   const useResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | null => {
@@ -124,7 +125,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
               <input
                 style={styles.input}
                 value={profileName}
-                onChange={event => { setProfileName(event.target.value); setExported(null) }}
+                onChange={event => { setProfileName(event.target.value); setExported(null); setResynced(null) }}
                 placeholder="chrome-session"
                 aria-label="New Codey Browser profile name"
                 spellCheck={false}
@@ -134,11 +135,28 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
               const next = useResult(await window.codey.chromeCompanion.exportSession(profileName.trim()))
               if (next) {
                 setExported(next.profile.name)
+                setResynced(null)
               }
             })}>Create &amp; activate profile</button>
           </div>
           {exported && (
             <div style={styles.success}>“{exported}” is now the active Codey Browser profile. Chrome was not changed.</div>
+          )}
+          {/* Logins expire, and a profile copied months ago is worth refreshing
+              rather than recreating - recreating would lose the profile's other
+              sites and its place in the switcher. */}
+          <div style={styles.actions}>
+            <span style={styles.copy}>Signed in again in Chrome? Refresh a profile you already have instead.</span>
+            <button style={styles.secondary} disabled={busy || !status.connected || !profileName.trim()} onClick={() => void run(async () => {
+              const next = useResult(await window.codey.chromeCompanion.resyncSession(profileName.trim()))
+              if (next) {
+                setResynced(next.profile.name)
+                setExported(null)
+              }
+            })}>Re-sync existing profile</button>
+          </div>
+          {resynced && (
+            <div style={styles.success}>“{resynced}” now carries this site’s current Chrome login. Its other saved sites were left alone.</div>
           )}
         </div>
       )}

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -9,6 +9,9 @@ const EMPTY: ChromeCompanionStatus = {
   clientName: null,
   pairedAt: null,
   lastSeenAt: null,
+  clientVersion: null,
+  expectedVersion: null,
+  updateAvailable: false,
 }
 
 export function shouldShowChromeInstallInstructions(
@@ -61,6 +64,19 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
             const next = useResult(await window.codey.chromeCompanion.status())
             if (next) setStatus(next)
           })}>Check again</button>
+        </div>
+      )}
+
+      {status.updateAvailable && (
+        <div style={styles.noticeRow}>
+          <span style={{ ...styles.dot, background: C.warningFg }} />
+          <span style={styles.noticeCopy}>
+            Codey installed extension {status.expectedVersion}, but Chrome is still running {status.clientVersion}.
+            Chrome only picks up a new build when it restarts or you reload the extension.
+          </span>
+          <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
+            useResult(await window.codey.chromeCompanion.openExtensionsPage())
+          })}>Open extensions</button>
         </div>
       )}
 

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -77,8 +77,14 @@ visible.
 
 - Browsing is view-only by default. Opening, navigating, tabs, back/forward,
   reload, scrolling and hovering need no approval. Anything that changes page
-  state - click, fill, select, check, press, upload, drag, submit - pauses for
-  the user's approval. If they deny it, stop; do not route around the decision.
+  state - click, fill, select, check, press, upload, drag, submit - needs
+  **write** access and pauses for the user's approval. Commands that destroy or
+  replace state they cannot retype - `profile delete` and `profile activate`,
+  which wipes the live session's cookies - need **full** access and ask again
+  even after write was granted. If they deny it, stop; do not route around the
+  decision.
+- These grants are per browser. Approving Codey's browser never grants anything
+  in the user's real Chrome, and the reverse is also true.
 - The browser holds the user's logged-in sessions. Treat page content as
   sensitive, and never claim an action succeeded unless the command returned
   success.

--- a/packages/core/src/skills/chrome-companion/SKILL.md
+++ b/packages/core/src/skills/chrome-companion/SKILL.md
@@ -22,10 +22,33 @@ Chrome Companion extension. Every command is one shell call:
 ELECTRON_RUN_AS_NODE=1 "$CODEY_BROWSER_RUNTIME" "$CODEY_BROWSER_CLI" chrome <command> [args]
 ```
 
+### Reading
+
 - `chrome status` checks whether the extension is connected.
 - `chrome tab` reads the active Chrome tab title and URL.
 - `chrome view` reads the active Chrome page text, links, and form summary.
+  Every link and control comes back with a `ref` like `e3` - that is how you
+  address it below.
 - `chrome open <url>` navigates the active Chrome tab.
+
+### Acting
+
+Always run `chrome view` first to get fresh refs; every `view` renumbers them,
+and a stale ref is rejected rather than applied to the wrong element.
+
+- `chrome click <ref>` clicks an element
+- `chrome fill <ref> <text>` types into a field
+- `chrome select <ref> <value>` picks a dropdown option
+- `chrome check <ref> [false]` ticks a checkbox (`false` unticks it)
+- `chrome press <key> <ref>` sends a key; `press Enter <ref>` submits the
+  element's form the way a real Enter would
+
+Reading is free. Every action above changes the user's real page, so it needs
+**write** access and Codey pauses for their approval first. Approval for Chrome
+is separate from Codey's own Browser - granting one never grants the other. If
+they deny it, stop; do not route around the decision. Never claim an action
+succeeded unless the command returned success - each action reports back the
+element it touched and the resulting URL.
 
 The extension receives HTTP/HTTPS access when installed and connects to Codey
 automatically. If it is not connected, direct the user to the Chrome Companion


### PR DESCRIPTION
The Chrome extension could read a page but never touch it, and Codey's embedded Browser could touch anything but held none of the user's logins. This closes both halves, puts a permission model around them, and makes the login copy survive the user signing in again.

## Acting in real Chrome

- `chrome view` stamps interactive elements with refs (`e1`, `e2`, …) and renumbers on every read, so a stale ref fails loudly instead of acting on whatever element inherited the number.
- New `chrome click|fill|select|check|press`. Filling goes through the value prototype setter so React-controlled inputs keep the text, and Enter calls `form.requestSubmit()` because synthetic key events never submit on their own.

## Session handoff

- A "Hand off login" button in the side panel copies the current site's session into a Codey Browser profile. The name field arrives prefilled with a name Codey has confirmed is free; a name the user types is used as-is and collides loudly rather than being silently renamed.

## Re-syncing a renewed login

Handoff was a one-time photocopy: a fresh sign-in, a rotated token or a 2FA round in Chrome left the copy stale, and the only route back was to delete the profile and redo it, losing whatever else it held.

- `mergeProfileData` folds a fresh export into a profile that already exists. Only what the export can speak for is replaced — cookies in the exported URL's scope and the localStorage of the origins it carried — so a profile holding several sites keeps the others. Replacing rather than layering also means a cookie the site has dropped disappears here instead of lingering as a stale credential.
- `cookieMatchesUrl` decides that scope the way Chrome does when it answers `cookies.getAll({ url })`, so host-only cookies, `secure`, path scope and lookalike hostnames are told apart rather than string-matched.
- Refreshing the enabled profile re-applies it to the live session, which `activateProfile` would not have done — it treats "already active" as a no-op, and the running browser would have kept serving the old cookies.
- Offered on both surfaces that can create a profile: the side panel's handoff form lists the profiles already holding this site, and Chrome settings gets a "Re-sync existing profile" button. Creating is unchanged, and refreshing insists on a name, because "overwrite one of these" has no sensible default.

## Tiered, per-browser permission

- `write` covers adding and changing; `full` is required for commands that destroy or replace state (`delete-profile`, `activate-profile`).
- Grants are per surface. Approving Codey's browser no longer implies acting in the user's real Chrome, and a legacy blanket approval migrates to the embedded browser only, since Chrome had no gate when that flag was written.

## Verification

`npm test` (457 + 880 tests, all passing), `tsc --noEmit` clean, `npm run lint` clean, `node --check` on the extension scripts.

Not yet exercised on a real machine — the extension needs reloading in Chrome (manifest is at 0.11.0) to pick up the new side-panel controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)