### PR TITLE
chore: bump version to 0.12.13

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.12.12",
+  "version": "0.12.13",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump all workspace versions from `0.12.12` to `0.12.13`.

- `package.json`
- `packages/core/package.json`
- `packages/gateway/package.json`
- `codey-mac/package.json`

No other files reference the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)