### PR TITLE
feat(browser): sync this site's Chrome login from the Codey Browser toolbar

### DIFF
--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -392,20 +392,78 @@ async function exportSession() {
   const storage = results[0]?.result
   return {
     tab,
-    cookies: cookies.map(cookie => ({
-      name: cookie.name,
-      value: cookie.value,
-      domain: cookie.domain.replace(/^\./, ''),
-      path: cookie.path || '/',
-      expires: typeof cookie.expirationDate === 'number' ? cookie.expirationDate : -1,
-      httpOnly: cookie.httpOnly === true,
-      secure: cookie.secure === true,
-      sameSite: cookie.sameSite || 'unspecified',
-      ...(cookie.hostOnly ? { hostOnly: true } : {}),
-    })),
+    cookies: cookies.map(toExportedCookie),
     origins: storage?.origin
       ? [{ origin: storage.origin, localStorage: storage.localStorage || [] }]
       : [],
+  }
+}
+
+/** Chrome's cookie shape in the profile format Codey stores. */
+function toExportedCookie(cookie) {
+  return {
+    name: cookie.name,
+    value: cookie.value,
+    domain: cookie.domain.replace(/^\./, ''),
+    path: cookie.path || '/',
+    expires: typeof cookie.expirationDate === 'number' ? cookie.expirationDate : -1,
+    httpOnly: cookie.httpOnly === true,
+    secure: cookie.secure === true,
+    sameSite: cookie.sameSite || 'unspecified',
+    ...(cookie.hostOnly ? { hostOnly: true } : {}),
+  }
+}
+
+/**
+ * Export the session for a URL Codey names, rather than for whatever tab
+ * happens to be in front. This is what the Codey Browser's Sync button asks
+ * for: the user is looking at a signed-out page there and wants this Chrome
+ * profile's login for that same site.
+ *
+ * Cookies come straight from the cookie store, so no tab has to be open.
+ * localStorage cannot be read without running in the page, so it is taken
+ * from a tab already on that origin when there is one and skipped otherwise -
+ * cookies alone carry the login for nearly every site, and opening a tab
+ * behind the user's back to read storage would be a worse trade.
+ */
+async function exportSessionForUrl(rawUrl) {
+  let target
+  try {
+    target = new URL(String(rawUrl || ''))
+  } catch {
+    throw new Error(`Invalid URL: ${rawUrl}`)
+  }
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    throw new Error('Only http(s) site sessions can be exported')
+  }
+  const cookies = await chrome.cookies.getAll({ url: target.toString() })
+  if (cookies.length === 0) throw new Error(`Chrome has no cookies for ${target.hostname}`)
+  let origins = []
+  const tabs = await chrome.tabs.query({ url: `${target.origin}/*` })
+  const open = tabs.find(tab => typeof tab.id === 'number')
+  if (open) {
+    try {
+      const results = await chrome.scripting.executeScript({
+        target: { tabId: open.id },
+        func: () => ({
+          origin: location.origin,
+          localStorage: Array.from({ length: localStorage.length }, (_, index) => {
+            const name = localStorage.key(index)
+            return name === null ? null : { name, value: localStorage.getItem(name) || '' }
+          }).filter(Boolean),
+        }),
+      })
+      const storage = results[0]?.result
+      if (storage?.origin) origins = [{ origin: storage.origin, localStorage: storage.localStorage || [] }]
+    } catch {
+      // A tab that refuses injection just costs us its storage, not the login.
+    }
+  }
+  return {
+    url: target.toString(),
+    origin: target.origin,
+    cookies: cookies.map(toExportedCookie),
+    origins,
   }
 }
 
@@ -506,6 +564,9 @@ async function execute(command) {
       await markControlledTab(session.tab.id)
       return session
     }
+    // No tab is touched, so there is nothing to mark as controlled.
+    case 'exportSessionForUrl':
+      return await exportSessionForUrl(command.input?.url)
     case 'click':
     case 'fill':
     case 'select':

--- a/codey-mac/electron/chrome-companion.test.ts
+++ b/codey-mac/electron/chrome-companion.test.ts
@@ -166,6 +166,39 @@ describe('ChromeCompanionBridge', () => {
     await expect(exported).resolves.toEqual(session)
   })
 
+  it('exports the session for a URL Codey names, not the tab in front', async () => {
+    const { bridge, endpoint } = await setup()
+    const token = await connect(endpoint)
+    const exported = bridge.exportSessionForUrl('https://example.com/inbox')
+
+    const poll = await fetch(`${endpoint}/v1/poll`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    const work = await poll.json() as { command: { id: string; command: string; input: { url: string } } }
+    expect(work.command.command).toBe('exportSessionForUrl')
+    expect(work.command.input).toEqual({ url: 'https://example.com/inbox' })
+
+    // No tab has to be open on the site, so the export carries no tab at all.
+    const session = {
+      url: 'https://example.com/inbox',
+      origin: 'https://example.com',
+      cookies: [{
+        name: 'session', value: 'secret', domain: 'example.com', path: '/', expires: -1,
+        httpOnly: true, secure: true, sameSite: 'lax' as const,
+      }],
+      origins: [],
+    }
+    await fetch(`${endpoint}/v1/result`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: work.command.id, ok: true, data: session }),
+    })
+
+    await expect(exported).resolves.toEqual(session)
+  })
+
   it('notices Chrome is running an older extension than the one on disk', async () => {
     const { bridge, endpoint } = await setup()
     const token = await connect(endpoint)

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -69,6 +69,16 @@ export interface ChromeSessionExport {
   }>
 }
 
+/** A session exported for a URL Codey named, rather than for the tab in front.
+ *  There may be no tab open on it at all, so `origins` is best-effort: without
+ *  a page to run in, localStorage cannot be read. */
+export interface ChromeUrlSessionExport {
+  url: string
+  origin: string
+  cookies: ChromeSessionExport['cookies']
+  origins: ChromeSessionExport['origins']
+}
+
 export interface ChromeCompanionChatRequest {
   chatId?: string | null
   text: string
@@ -329,6 +339,11 @@ export class ChromeCompanionBridge {
 
   async exportSession(): Promise<ChromeSessionExport> {
     return await this.command<ChromeSessionExport>('exportSession', {})
+  }
+
+  /** The session Chrome holds for `url`, whether or not a tab is open on it. */
+  async exportSessionForUrl(url: string): Promise<ChromeUrlSessionExport> {
+    return await this.command<ChromeUrlSessionExport>('exportSessionForUrl', { url })
   }
 
   /**

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2362,6 +2362,23 @@ app.whenReady().then(async () => {
     browserCall(event, () => browserController.saveProfile(String(name || ''))))
   ipcMain.handle('browser:profiles:activate', (event, name: string) =>
     browserCall(event, () => browserController.activateProfile(String(name || ''))))
+  // The Sync button in the browser toolbar: pull the login Chrome holds for the
+  // page Codey Browser is showing into the profile that is enabled here. It is
+  // scoped to that one site, so a profile carrying several logins keeps the
+  // rest, and it names the URL rather than using Chrome's front tab - the user
+  // is looking at the signed-out page here, not over there.
+  ipcMain.handle('browser:profiles:syncFromChrome', (event, url: string) => browserCall(event, async () => {
+    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+    if (!chromeCompanion.status().connected) throw new Error('Connect the Codey extension in Chrome first')
+    const target = String(url || '')
+    const name = browserController.activeProfileName()
+    if (!name) throw new Error('Enable a browser profile first - there is nothing to sync into')
+    const session = await chromeCompanion.exportSessionForUrl(target)
+    await browserController.resyncProfile(name, {
+      json: JSON.stringify({ cookies: session.cookies, origins: session.origins }),
+    }, session.url)
+    return { profileName: name, origin: session.origin, cookieCount: session.cookies.length }
+  }))
   ipcMain.handle('browser:profiles:setAvatar', (event, name: string, avatar: string) =>
     browserCall(event, () => browserController.setProfileAvatar(String(name || ''), String(avatar || ''))))
   ipcMain.handle('browser:profiles:delete', (event, name: string) =>

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -509,6 +509,7 @@ contextBridge.exposeInMainWorld('codey', {
       delete: (name: string) => ipcRenderer.invoke('browser:profiles:delete', name),
       import: () => ipcRenderer.invoke('browser:profiles:import'),
       export: (name: string) => ipcRenderer.invoke('browser:profiles:export', name),
+      syncFromChrome: (url: string) => ipcRenderer.invoke('browser:profiles:syncFromChrome', url),
     },
     extensions: {
       list: () => ipcRenderer.invoke('browser:extensions:list'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -649,6 +649,7 @@ declare global {
           delete: (name: string) => Promise<IpcResult<{ deleted: boolean }>>
           import: () => Promise<IpcResult<{ imported: boolean; profile: BrowserProfileSummary | null }>>
           export: (name: string) => Promise<IpcResult<{ exported: boolean; path: string | null }>>
+          syncFromChrome: (url: string) => Promise<IpcResult<{ profileName: string; origin: string; cookieCount: number }>>
         }
         extensions: {
           list: () => Promise<IpcResult<BrowserExtensionEntry[]>>

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -103,6 +103,8 @@ export const BrowserPanel: React.FC<Props> = ({
   const [profiles, setProfiles] = useState<BrowserProfileSummary[]>([])
   const [activeProfile, setActiveProfile] = useState<string | null>(null)
   const [profileBusy, setProfileBusy] = useState(false)
+  const [syncBusy, setSyncBusy] = useState(false)
+  const [syncNote, setSyncNote] = useState<string | null>(null)
   const [panelWidth, setPanelWidth] = useState(900)
 
   const browserCovered = browserMenuOpen || profileMenuOpen || activeSettingsSection !== null
@@ -302,6 +304,35 @@ export const BrowserPanel: React.FC<Props> = ({
       setProfileMenuOpen(false)
     }
   }
+
+  // Pull this site's login out of the user's real Chrome and into the profile
+  // that is enabled here, without leaving the page. Scoped to this one site, so
+  // a profile carrying several logins keeps the rest. The page is reloaded
+  // afterwards because a signed-out page does not re-check its cookies.
+  const syncProfileFromChrome = async () => {
+    if (!state.url || syncBusy) return
+    setSyncBusy(true)
+    setSyncNote(null)
+    try {
+      const result = await window.codey.browser.profiles.syncFromChrome(state.url)
+      if (!result.ok) {
+        setLocalError(result.error)
+        return
+      }
+      setLocalError(null)
+      setSyncNote(`Synced ${result.data.cookieCount} cookies for ${result.data.origin} into "${result.data.profileName}"`)
+      await refreshProfiles()
+      await run(() => window.codey.browser.reload())
+    } finally {
+      setSyncBusy(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!syncNote) return
+    const timer = setTimeout(() => setSyncNote(null), 6000)
+    return () => clearTimeout(timer)
+  }, [syncNote])
 
   const navigate = async () => {
     const next = useResult(await window.codey.browser.navigate(address))
@@ -544,6 +575,16 @@ export const BrowserPanel: React.FC<Props> = ({
           <span aria-hidden="true" style={styles.profileAvatarSmall}>{browserProfileAvatar(currentProfile)}</span>
           {panelWidth >= 640 && <span style={styles.profileButtonLabel}>{activeProfile ?? 'No profile'}</span>}
         </button>
+        <button
+          type="button"
+          style={{ ...styles.iconButton, ...(syncBusy ? styles.iconButtonActive : null) }}
+          title={activeProfile
+            ? `Sync this site's Chrome login into "${activeProfile}"`
+            : 'Enable a browser profile first, then sync this site\u2019s Chrome login into it'}
+          aria-label="Sync this site's login from Chrome"
+          disabled={syncBusy || !state.url || !activeProfile || activeSettingsSection !== null}
+          onClick={() => void syncProfileFromChrome()}
+        ><UIIcon name="refresh" size={14} /></button>
         <button
           type="button"
           style={{ ...styles.contextButton, opacity: chatId && state.url && !activeSettingsSection ? 1 : 0.5 }}
@@ -964,6 +1005,13 @@ export const BrowserPanel: React.FC<Props> = ({
         </div>
       )}
 
+      {syncNote && !displayedError && (
+        <div style={styles.syncBar} role="status">
+          <span>{syncNote}</span>
+          <button type="button" onClick={() => setSyncNote(null)} style={styles.dismissError}>Dismiss</button>
+        </div>
+      )}
+
       {displayedError && (
         <div style={styles.errorBar} role="status">
           <span>{displayedError}</span>
@@ -1105,6 +1153,7 @@ const styles: Record<string, React.CSSProperties> = {
   extensionWarning: { color: C.warningFg, fontSize: 9.5, lineHeight: 1.35, marginTop: 3 },
   extensionPath: { color: C.fg3, fontSize: 9.5, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   extensionError: { color: C.red, fontSize: 9.5, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  syncBar: { minHeight: 30, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '5px 12px', background: `${C.green}18`, color: C.green, borderBottom: `1px solid ${C.green}55`, fontSize: 11 },
   errorBar: { minHeight: 30, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '5px 12px', background: `${C.red}18`, color: C.red, borderBottom: `1px solid ${C.red}55`, fontSize: 11 },
   downloadBar: { minHeight: 30, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10, padding: '5px 12px', background: `${C.green}12`, color: C.green, borderBottom: `1px solid ${C.green}44`, fontSize: 11 },
   downloadName: { flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },


### PR DESCRIPTION
Follows #386, which added re-syncing a handed-off login — but only on the Chrome side, which is the wrong place to notice you need it. The moment the user finds out is when a page in the **Codey Browser** shows them signed out, and from there the fix meant switching to Chrome, finding the tab, opening the side panel and picking the profile back out of a list.

## What this adds

A refresh button in the browser toolbar, beside the profile chip. It pulls the login Chrome holds for the page on screen into the profile enabled here, then reloads — a signed-out page will not re-check its cookies on its own.

- Disabled with an explanatory title when no profile is enabled, since there would be nothing to sync into.
- Reports what it did in a bar under the toolbar (`Synced N cookies for <origin> into "<profile>"`), and surfaces failures through the existing error bar.

## Why a new extension command

Doing this from the Codey side means naming the URL rather than taking whatever tab Chrome happens to have in front, so `exportSessionForUrl` is new:

- Cookies come from the cookie store and need no tab open at all.
- localStorage still needs a page to run in, so it is read from a tab already on that origin and skipped otherwise. Cookies carry the login for nearly every site, and opening a tab behind the user's back to read storage is the worse trade.

The write goes through the same scoped `resyncProfile` as the side panel, so only this one site is replaced and a profile holding other logins keeps them.

## Verification

`npm test` (881 tests in codey-mac, all passing), `tsc --noEmit` clean, `npm run lint` clean, `node --check` on the extension scripts. A new bridge test covers the URL-scoped export round trip.

Not yet exercised on a real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)