### PR TITLE
polish(mac): give Update All its own falling-arrow busy animation

### DIFF
--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -142,7 +142,23 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
 
   return (
     <div style={pageStyle}>
-      <style>{'@keyframes codey-agent-update-spin { to { transform: rotate(360deg) } }'}</style>
+      {/* Two motions, deliberately different: the re-check spins, the updater
+          drops its arrows into the tray one after the other, so a glance at
+          the header says which of the two buttons is busy. */}
+      <style>{`
+        @keyframes codey-agent-update-spin { to { transform: rotate(360deg) } }
+        @keyframes codey-agent-update-fall {
+          0%   { transform: translateY(-3px); opacity: 0 }
+          25%  { opacity: 1 }
+          70%  { transform: translateY(5px); opacity: 1 }
+          100% { transform: translateY(5px); opacity: 0 }
+        }
+        .codey-updating .codey-fall-a,
+        .codey-updating .codey-fall-b {
+          animation: codey-agent-update-fall 1.1s ease-in infinite;
+        }
+        .codey-updating .codey-fall-b { animation-delay: 0.28s }
+      `}</style>
       {error && <div style={{ background: C.red + '22', color: C.red, padding: 10, borderRadius: 8, marginBottom: 10, fontSize: 12 }}>{error}</div>}
       {failure && (
         <AgentUpdateFailureModal
@@ -174,8 +190,10 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
           <button
             onClick={() => { void updateAll() }}
             style={iconButtonStyle({
-              accent: updatableAgents.some(a => availabilityOf(a).updateAvailable),
-              disabled: updatingAll || updating !== null || updatableAgents.length === 0,
+              // Busy is not the same as unavailable: while the run is on, the
+              // button stays lit so the falling arrows are actually visible.
+              accent: updatingAll || updatableAgents.some(a => availabilityOf(a).updateAvailable),
+              disabled: !updatingAll && (updating !== null || updatableAgents.length === 0),
             })}
             disabled={updatingAll || updating !== null || updatableAgents.length === 0}
             aria-label="Update all agents"
@@ -185,11 +203,8 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
                   : `Update all: ${updatableAgents.join(', ')}`
             }
           >
-            <span style={{
-              display: 'grid',
-              animation: updatingAll ? 'codey-agent-update-spin 1s linear infinite' : undefined,
-            }}>
-              <UIIcon name={updatingAll ? 'refresh' : 'download-all'} size={14} />
+            <span style={{ display: 'grid' }} className={updatingAll ? 'codey-updating' : undefined}>
+              <UIIcon name="download-all" size={14} />
             </span>
           </button>
         </div>

--- a/codey-mac/src/components/AgentsTab.tsx
+++ b/codey-mac/src/components/AgentsTab.tsx
@@ -171,20 +171,6 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
 
       <Section first title="Installed agents" description="CLI availability, thinking effort, and environment for each coding agent." right={
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={() => { void refreshInstalledAgents(true); void refreshAgentUpdates(true) }}
-            style={iconButtonStyle({ disabled: checkingInstalls })}
-            disabled={checkingInstalls}
-            aria-label="Recheck agents"
-            title="Re-check what is installed, and whether a newer version has been published"
-          >
-            <span style={{
-              display: 'grid',
-              animation: checkingInstalls ? 'codey-agent-update-spin 1s linear infinite' : undefined,
-            }}>
-              <UIIcon name="refresh" size={14} />
-            </span>
-          </button>
           {/* Same download icon as the per-agent button, because it does the
               same thing — just to every agent that is offering an update. */}
           <button
@@ -205,6 +191,20 @@ export const AgentsTab: React.FC<Props> = ({ isGatewayRunning }) => {
           >
             <span style={{ display: 'grid' }} className={updatingAll ? 'codey-updating' : undefined}>
               <UIIcon name="download-all" size={14} />
+            </span>
+          </button>
+          <button
+            onClick={() => { void refreshInstalledAgents(true); void refreshAgentUpdates(true) }}
+            style={iconButtonStyle({ disabled: checkingInstalls })}
+            disabled={checkingInstalls}
+            aria-label="Recheck agents"
+            title="Re-check what is installed, and whether a newer version has been published"
+          >
+            <span style={{
+              display: 'grid',
+              animation: checkingInstalls ? 'codey-agent-update-spin 1s linear infinite' : undefined,
+            }}>
+              <UIIcon name="refresh" size={14} />
             </span>
           </button>
         </div>

--- a/codey-mac/src/components/UIIcons.tsx
+++ b/codey-mac/src/components/UIIcons.tsx
@@ -35,7 +35,13 @@ export const UIIcon: React.FC<Props> = ({ name, size = 16, strokeWidth = 1.8, fi
     // a version number even at 14px.
     download: <><path {...common} d="M12 4v10" /><path {...common} d="M8 11l4 4 4-4" /><path {...common} d="M5 19h14" /></>,
     // `download` with a second arrow: the same action, aimed at every agent.
-    'download-all': <><path {...common} d="M8 4v8" /><path {...common} d="M5 9.5l3 3 3-3" /><path {...common} d="M16 4v8" /><path {...common} d="M13 9.5l3 3 3-3" /><path {...common} d="M5 19h14" /></>,
+    // The two arrows are grouped and class-named so a caller can make them
+    // fall into the tray while the updater runs (see `codey-fall-*`).
+    'download-all': <>
+      <g className="codey-fall-a"><path {...common} d="M8 4v8" /><path {...common} d="M5 9.5l3 3 3-3" /></g>
+      <g className="codey-fall-b"><path {...common} d="M16 4v8" /><path {...common} d="M13 9.5l3 3 3-3" /></g>
+      <path {...common} d="M5 19h14" />
+    </>,
     disclosure: <path fill="currentColor" stroke="none" d="M9 6.5L16 12l-7 5.5z" />,
     code: <><path {...common} d="M8 9l-3 3 3 3M16 9l3 3-3 3M14 6l-4 12" /></>,
     copy: <><rect {...common} x="9" y="9" width="11" height="11" rx="2" /><path {...common} d="M5 15V5a2 2 0 012-2h10" /></>,


### PR DESCRIPTION
Follow-up to #375.

## What

While Update All runs, the icon no longer spins like Recheck. The `download-all` glyph's two arrows are grouped (`codey-fall-a` / `codey-fall-b`) and drop into the tray in turn — the action itself, and unmistakably different from the re-check spinner sitting right next to it.

The button also stays accent-lit while busy instead of taking the disabled tint, which made the motion nearly invisible. It is still non-clickable during the run.

## Test

- `npx tsc --noEmit` clean
- `npm test -w codey-mac` — 880 passed
- Motion not yet eyeballed in a running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)