### PR TITLE
feat(chrome): pick which Chrome logins the Codey Browser may have

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Codey",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1+DxZ4LtqCNXKrmvuwl2d6perIWziIQWgkBVn5RbieIAF7g8knl39m3UOq/BZuSHp2VS1CQtk1EfwTzK0pnjdzikr00O+7iee4lVf8oduovxxi83CzRsZxzEreb3Jht3qfZcw3P94FwYk4wZM3YoRGJF99fWJQy/ybMvmIFSeFAHn9/3m56Xe5j0vCPSkmST1zLVuypW2DB23KojXxx4cKd9i+qcKnvfCEFwydjHRDpL4eUqk1nTU/NDlu3p0Fy5XQhvC6s98JBXXBEtD31l6oUq+wE1ap3yi1l3aK4I07bgWSdJSokwMZOJz22owdzaYra/c8loiVnx4efajwNbWwIDAQAB",
   "description": "Securely connects your existing Chrome tabs and signed-in sites to Codey.",
   "permissions": ["alarms", "cookies", "offscreen", "scripting", "sidePanel", "storage", "tabGroups", "tabs"],

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -1,3 +1,6 @@
+// `siteOfHost`: kept in its own file so it can be tested without Chrome.
+importScripts('site-grouping.js')
+
 const DEFAULT_ENDPOINT = 'http://127.0.0.1:49321'
 const ENDPOINT_COUNT = 10
 const EXTENSION_ID = 'nkfblackdfiplaekehijkgimhmlhlfib'
@@ -467,6 +470,79 @@ async function exportSessionForUrl(rawUrl) {
   }
 }
 
+/**
+ * Every site this Chrome profile holds a login-shaped cookie for, so Codey can
+ * show the user a list to pick from instead of copying the whole cookie jar.
+ * Counts come from the cookie store, and `openTabs` says whether localStorage
+ * would come along - it can only be read from a page that is actually open.
+ */
+async function listSessionSites() {
+  const cookies = await chrome.cookies.getAll({})
+  const sites = new Map()
+  for (const cookie of cookies) {
+    const site = siteOfHost(cookie.domain)
+    if (!site) continue
+    const entry = sites.get(site) || { site, cookieCount: 0, openTabs: 0 }
+    entry.cookieCount += 1
+    sites.set(site, entry)
+  }
+  const tabs = await chrome.tabs.query({})
+  for (const tab of tabs) {
+    if (!/^https?:\/\//i.test(tab.url || '')) continue
+    try {
+      const entry = sites.get(siteOfHost(new URL(tab.url).hostname))
+      if (entry) entry.openTabs += 1
+    } catch { /* a URL Chrome accepted but we cannot parse is not a site */ }
+  }
+  // Most cookies first: that is roughly "most signed in", and it puts the
+  // sites a user actually recognises at the top of a long list.
+  return { sites: [...sites.values()].sort((a, b) => b.cookieCount - a.cookieCount || a.site.localeCompare(b.site)) }
+}
+
+/**
+ * Export only the sites the user ticked. Cookies come from the cookie store, so
+ * nothing has to be open; localStorage is read from whatever tabs happen to be
+ * on those sites and skipped otherwise, because reading it means running in the
+ * page and opening tabs behind the user's back is the worse trade.
+ */
+async function exportSessionForSites(requested) {
+  const wanted = new Set((Array.isArray(requested) ? requested : [])
+    .map(site => siteOfHost(site))
+    .filter(Boolean))
+  if (wanted.size === 0) throw new Error('Pick at least one site to copy')
+  const cookies = (await chrome.cookies.getAll({}))
+    .filter(cookie => wanted.has(siteOfHost(cookie.domain)))
+  if (cookies.length === 0) throw new Error('Chrome has no cookies for the sites you picked')
+  const origins = []
+  const seen = new Set()
+  for (const tab of await chrome.tabs.query({})) {
+    if (typeof tab.id !== 'number' || !/^https?:\/\//i.test(tab.url || '')) continue
+    let origin
+    try {
+      const parsed = new URL(tab.url)
+      if (!wanted.has(siteOfHost(parsed.hostname)) || seen.has(parsed.origin)) continue
+      origin = parsed.origin
+    } catch {
+      continue
+    }
+    seen.add(origin)
+    try {
+      const results = await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: () => Array.from({ length: localStorage.length }, (_, index) => {
+          const name = localStorage.key(index)
+          return name === null ? null : { name, value: localStorage.getItem(name) || '' }
+        }).filter(Boolean),
+      })
+      const items = results[0]?.result
+      if (items && items.length > 0) origins.push({ origin, localStorage: items })
+    } catch {
+      // A tab that refuses injection costs us its storage, not its cookies.
+    }
+  }
+  return { sites: [...wanted], cookies: cookies.map(toExportedCookie), origins }
+}
+
 // ── Acting on a page ────────────────────────────────────────────────────
 // Every action resolves a ref stamped by the last `snapshot`, runs inside the
 // page, and reports back what it touched so the caller never has to assume an
@@ -564,9 +640,13 @@ async function execute(command) {
       await markControlledTab(session.tab.id)
       return session
     }
-    // No tab is touched, so there is nothing to mark as controlled.
+    // None of these act on a page, so no tab is marked as controlled.
     case 'exportSessionForUrl':
       return await exportSessionForUrl(command.input?.url)
+    case 'listSessionSites':
+      return await listSessionSites()
+    case 'exportSessionForSites':
+      return await exportSessionForSites(command.input?.sites)
     case 'click':
     case 'fill':
     case 'select':

--- a/chrome-extension/site-grouping.js
+++ b/chrome-extension/site-grouping.js
@@ -1,0 +1,25 @@
+// Folding a cookie's host down to the site a user would recognise.
+//
+// A user picks "github.com" and means its api. and gist. cookies too, so the
+// picker has to group hosts. Chrome exposes no public-suffix API to an
+// extension and shipping the whole PSL for this would be absurd, so this uses
+// the usual heuristic: two labels, or three when the last is a country code
+// sitting behind one of the common second levels (co.uk, com.cn, com.au).
+//
+// It over-groups shared-suffix hosting (every user site under github.io reads
+// as one site), which is why the picker shows cookie counts and the copy is
+// confirmed - the user sees how much is going before it goes.
+//
+// Kept in its own file, free of Chrome APIs, so the service worker can
+// `importScripts` it and the tests can evaluate it on its own.
+
+const MULTI_LABEL_SUFFIXES = new Set(['co', 'com', 'net', 'org', 'gov', 'edu', 'ac'])
+
+function siteOfHost(host) {
+  const labels = String(host || '').replace(/^\./, '').toLowerCase().split('.').filter(Boolean)
+  if (labels.length <= 2) return labels.join('.')
+  const last = labels[labels.length - 1]
+  const secondLast = labels[labels.length - 2]
+  const take = last.length === 2 && MULTI_LABEL_SUFFIXES.has(secondLast) ? 3 : 2
+  return labels.slice(-take).join('.')
+}

--- a/codey-mac/electron/chrome-companion.test.ts
+++ b/codey-mac/electron/chrome-companion.test.ts
@@ -199,6 +199,39 @@ describe('ChromeCompanionBridge', () => {
     await expect(exported).resolves.toEqual(session)
   })
 
+  it('lists Chrome\'s signed-in sites and exports only the ones picked', async () => {
+    const { bridge, endpoint } = await setup()
+    const token = await connect(endpoint)
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    const poll = () => fetch(`${endpoint}/v1/poll`, { method: 'POST', headers, body: '{}' })
+      .then(response => response.json() as Promise<{ command: { id: string; command: string; input: unknown } }>)
+    const answer = (id: string, data: unknown) => fetch(`${endpoint}/v1/result`, {
+      method: 'POST', headers, body: JSON.stringify({ id, ok: true, data }),
+    })
+
+    const listing = bridge.listSessionSites()
+    const listWork = await poll()
+    expect(listWork.command.command).toBe('listSessionSites')
+    const sites = { sites: [{ site: 'github.com', cookieCount: 12, openTabs: 1 }] }
+    await answer(listWork.command.id, sites)
+    await expect(listing).resolves.toEqual(sites)
+
+    const exported = bridge.exportSessionForSites(['github.com'])
+    const exportWork = await poll()
+    expect(exportWork.command.command).toBe('exportSessionForSites')
+    expect(exportWork.command.input).toEqual({ sites: ['github.com'] })
+    const session = {
+      sites: ['github.com'],
+      cookies: [{
+        name: 'session', value: 'secret', domain: 'github.com', path: '/', expires: -1,
+        httpOnly: true, secure: true, sameSite: 'lax' as const,
+      }],
+      origins: [],
+    }
+    await answer(exportWork.command.id, session)
+    await expect(exported).resolves.toEqual(session)
+  })
+
   it('notices Chrome is running an older extension than the one on disk', async () => {
     const { bridge, endpoint } = await setup()
     const token = await connect(endpoint)

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -79,6 +79,24 @@ export interface ChromeUrlSessionExport {
   origins: ChromeSessionExport['origins']
 }
 
+/** One site this Chrome profile holds cookies for, as offered to the user to
+ *  pick from. `openTabs` is how many tabs are on it right now, which decides
+ *  whether its localStorage can come along at all. */
+export interface ChromeSessionSite {
+  site: string
+  cookieCount: number
+  openTabs: number
+}
+
+/** A session exported for the sites the user ticked, rather than for the tab
+ *  in front. `origins` is best-effort: localStorage can only be read from a
+ *  page that is open, so a site with no tab contributes cookies only. */
+export interface ChromeSitesSessionExport {
+  sites: string[]
+  cookies: ChromeSessionExport['cookies']
+  origins: ChromeSessionExport['origins']
+}
+
 export interface ChromeCompanionChatRequest {
   chatId?: string | null
   text: string
@@ -344,6 +362,16 @@ export class ChromeCompanionBridge {
   /** The session Chrome holds for `url`, whether or not a tab is open on it. */
   async exportSessionForUrl(url: string): Promise<ChromeUrlSessionExport> {
     return await this.command<ChromeUrlSessionExport>('exportSessionForUrl', { url })
+  }
+
+  /** Every site this Chrome profile has cookies for, most first. */
+  async listSessionSites(): Promise<{ sites: ChromeSessionSite[] }> {
+    return await this.command<{ sites: ChromeSessionSite[] }>('listSessionSites', {})
+  }
+
+  /** The session Chrome holds for exactly the sites named, nothing else. */
+  async exportSessionForSites(sites: string[]): Promise<ChromeSitesSessionExport> {
+    return await this.command<ChromeSitesSessionExport>('exportSessionForSites', { sites })
   }
 
   /**

--- a/codey-mac/electron/chrome-site-grouping.test.ts
+++ b/codey-mac/electron/chrome-site-grouping.test.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `siteOfHost` decides which cookies a ticked site takes with it, so getting it
+ * wrong means copying a login the user did not pick. It ships as plain worker
+ * script (Chrome loads it with `importScripts`, which rules out ES exports), so
+ * the test evaluates the file itself rather than a second copy that could drift.
+ */
+const source = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'chrome-extension', 'site-grouping.js'),
+  'utf8',
+)
+const siteOfHost = new Function(`${source}; return siteOfHost`)() as (host: string) => string
+
+describe('siteOfHost', () => {
+  it('folds subdomains into the site a user would recognise', () => {
+    expect(siteOfHost('api.github.com')).toBe('github.com')
+    expect(siteOfHost('gist.github.com')).toBe('github.com')
+    expect(siteOfHost('github.com')).toBe('github.com')
+  })
+
+  it('strips the leading dot of a domain cookie and lowercases', () => {
+    expect(siteOfHost('.GitHub.com')).toBe('github.com')
+  })
+
+  it('keeps three labels behind a country-code second level', () => {
+    expect(siteOfHost('www.bbc.co.uk')).toBe('bbc.co.uk')
+    expect(siteOfHost('shop.example.com.au')).toBe('example.com.au')
+    // Without this, ticking one .co.uk site would drag in every other one.
+    expect(siteOfHost('a.co.uk')).not.toBe(siteOfHost('b.co.uk'))
+  })
+
+  it('does not mistake a long second level for a country code', () => {
+    expect(siteOfHost('mail.example.info')).toBe('example.info')
+    expect(siteOfHost('a.b.corp.example.io')).toBe('example.io')
+  })
+
+  it('returns something harmless for input that is not a host', () => {
+    for (const input of ['', '.', 'localhost']) {
+      expect(typeof siteOfHost(input)).toBe('string')
+    }
+    expect(siteOfHost('localhost')).toBe('localhost')
+  })
+})

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2482,6 +2482,45 @@ app.whenReady().then(async () => {
     if (!profile) throw new Error('Chrome session was imported but its Codey Browser profile could not be found')
     return { profile, tab: sessionState.tab }
   }))
+  // Picking sites instead of copying the whole cookie jar. Listing is a read,
+  // so it is cheap to call before the user has committed to anything.
+  ipcMain.handle('chromeCompanion:listSessionSites', event => browserCall(event, () => {
+    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+    return chromeCompanion.listSessionSites()
+  }))
+  // Copy exactly the sites the user ticked into a new profile. The list is
+  // shown back one last time in a confirmation, because a login copied out of
+  // Chrome cannot be un-copied - it is on disk from then on.
+  ipcMain.handle('chromeCompanion:importSites', (event, name: string, sites: string[]) => browserCall(event, async () => {
+    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+    const requested = String(name || '').trim()
+    assertProfileName(requested)
+    if (browserController.listProfiles().some(profile => profile.name === requested)) {
+      throw new Error(`A Codey Browser profile named "${requested}" already exists — choose another name`)
+    }
+    const picked = (Array.isArray(sites) ? sites : [])
+      .map(site => String(site || '').trim())
+      .filter(Boolean)
+      .slice(0, 500)
+    if (picked.length === 0) throw new Error('Pick at least one site to copy')
+    const sessionState = await chromeCompanion.exportSessionForSites(picked)
+    const preview = sessionState.sites.slice(0, 12).join(', ')
+    const confirmed = await dialog.showMessageBox(mainWindow ?? (undefined as any), {
+      type: 'warning',
+      buttons: ['Copy logins', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      message: `Copy ${sessionState.cookies.length} cookies from ${sessionState.sites.length} site(s) into "${requested}"?`,
+      detail: `${preview}${sessionState.sites.length > 12 ? `, and ${sessionState.sites.length - 12} more` : ''}\n\nThese logins will be written to Codey's profile store on this Mac and used by the Codey Browser. Nothing in Chrome changes.`,
+    })
+    if (confirmed.response !== 0) return { imported: false, profile: null, cookieCount: 0, sites: [] }
+    await browserController.importProfile(requested, {
+      json: JSON.stringify({ cookies: sessionState.cookies, origins: sessionState.origins }),
+    }, true, null)
+    const profile = browserController.listProfiles().find(item => item.name === requested)
+    if (!profile) throw new Error('Chrome sessions were imported but the Codey Browser profile could not be found')
+    return { imported: true, profile, cookieCount: sessionState.cookies.length, sites: sessionState.sites }
+  }))
   // The counterpart to exportSession: the profile must already exist, and only
   // the current site's part of it is replaced, so a login renewed in Chrome can
   // be refreshed without the profile's other sites being lost.

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -470,6 +470,8 @@ contextBridge.exposeInMainWorld('codey', {
     activeTab: () => ipcRenderer.invoke('chromeCompanion:activeTab'),
     snapshot: () => ipcRenderer.invoke('chromeCompanion:snapshot'),
     exportSession: (name: string) => ipcRenderer.invoke('chromeCompanion:exportSession', name),
+    listSessionSites: () => ipcRenderer.invoke('chromeCompanion:listSessionSites'),
+    importSites: (name: string, sites: string[]) => ipcRenderer.invoke('chromeCompanion:importSites', name, sites),
     resyncSession: (name: string) => ipcRenderer.invoke('chromeCompanion:resyncSession', name),
     navigate: (url: string) => ipcRenderer.invoke('chromeCompanion:navigate', url),
     setAccent: (hex: string) => ipcRenderer.invoke('chromeCompanion:setAccent', hex),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -261,6 +261,15 @@ export interface ChromeTabInfo {
   favIconUrl?: string
 }
 
+/** One site the paired Chrome profile holds cookies for. `openTabs` decides
+ *  whether its localStorage can come along - it can only be read from a page
+ *  that is actually open. */
+export interface ChromeSessionSite {
+  site: string
+  cookieCount: number
+  openTabs: number
+}
+
 export interface ChromePageSnapshot {
   tab: ChromeTabInfo
   text: string
@@ -616,6 +625,13 @@ declare global {
         activeTab: () => Promise<IpcResult<ChromeTabInfo>>
         snapshot: () => Promise<IpcResult<ChromePageSnapshot>>
         exportSession: (name: string) => Promise<IpcResult<{ profile: BrowserProfileSummary; tab: ChromeTabInfo }>>
+        listSessionSites: () => Promise<IpcResult<{ sites: ChromeSessionSite[] }>>
+        importSites: (name: string, sites: string[]) => Promise<IpcResult<{
+          imported: boolean
+          profile: BrowserProfileSummary | null
+          cookieCount: number
+          sites: string[]
+        }>>
         resyncSession: (name: string) => Promise<IpcResult<{ profile: BrowserProfileSummary; tab: ChromeTabInfo }>>
         navigate: (url: string) => Promise<IpcResult<ChromeTabInfo>>
         setAccent: (hex: string) => Promise<IpcResult<{ ok: true }>>

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import type { ChromeCompanionStatus } from '../codey-api'
+import type { ChromeCompanionStatus, ChromeSessionSite } from '../codey-api'
 import { C } from '../theme'
 
 const EMPTY: ChromeCompanionStatus = {
@@ -28,6 +28,11 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
   const [exported, setExported] = useState<string | null>(null)
   const [resynced, setResynced] = useState<string | null>(null)
   const [installedPath, setInstalledPath] = useState<string | null>(null)
+  const [sites, setSites] = useState<ChromeSessionSite[] | null>(null)
+  const [picked, setPicked] = useState<Set<string>>(new Set())
+  const [siteFilter, setSiteFilter] = useState('')
+  const [bulkName, setBulkName] = useState('chrome-logins')
+  const [bulkResult, setBulkResult] = useState<{ name: string; cookieCount: number; siteCount: number } | null>(null)
 
   const useResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | null => {
     if (!result.ok) { setError(result.error); return null }
@@ -161,6 +166,98 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
         </div>
       )}
 
+      {/* Copying one site at a time is fine for one login and tedious for a
+          working set. The alternative is not "copy everything" - that would put
+          banking and mail into a file on disk to save a few clicks - so the
+          sites are listed and the user ticks what Codey may have. */}
+      {status.connected && (
+        <div style={styles.card}>
+          <div>
+            <div style={styles.title}>Pick which Chrome logins to copy</div>
+            <div style={styles.copy}>List every site this Chrome profile is signed in to, then choose the ones the Codey Browser may use.</div>
+          </div>
+          {!sites && (
+            <div style={styles.actions}>
+              <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
+                const next = useResult(await window.codey.chromeCompanion.listSessionSites())
+                if (next) {
+                  setSites(next.sites)
+                  setPicked(new Set())
+                  setBulkResult(null)
+                }
+              })}>List Chrome’s signed-in sites</button>
+              <span style={styles.copy}>Nothing is copied until you pick sites and confirm.</span>
+            </div>
+          )}
+          {sites && (
+            <>
+              <div style={styles.impact}>
+                <strong>Cookies are copied for every site you tick.</strong>
+                <span>Site storage (localStorage) can only be read from a page that is open in Chrome right now, so a site with no open tab is copied by its cookies alone — enough for most logins, but not all. Nothing in Chrome is changed.</span>
+              </div>
+              <input
+                style={styles.input}
+                value={siteFilter}
+                onChange={event => setSiteFilter(event.target.value)}
+                placeholder="Filter sites"
+                aria-label="Filter Chrome sites"
+                spellCheck={false}
+              />
+              <div style={styles.siteList}>
+                {sites.length === 0 && <div style={styles.copy}>Chrome has no cookies to copy.</div>}
+                {sites
+                  .filter(entry => entry.site.includes(siteFilter.trim().toLowerCase()))
+                  .map(entry => (
+                    <label key={entry.site} style={styles.siteRow}>
+                      <input
+                        type="checkbox"
+                        checked={picked.has(entry.site)}
+                        onChange={event => setPicked(current => {
+                          const next = new Set(current)
+                          if (event.target.checked) next.add(entry.site)
+                          else next.delete(entry.site)
+                          return next
+                        })}
+                      />
+                      <span style={styles.siteName}>{entry.site}</span>
+                      <span style={styles.siteMeta}>
+                        {entry.cookieCount} cookie{entry.cookieCount === 1 ? '' : 's'}
+                        {entry.openTabs > 0 ? ' · open' : ''}
+                      </span>
+                    </label>
+                  ))}
+              </div>
+              <div style={{ ...styles.navigate, ...(compact ? styles.stack : null) }}>
+                <label style={styles.inputLabel}>
+                  New profile name
+                  <input
+                    style={styles.input}
+                    value={bulkName}
+                    onChange={event => { setBulkName(event.target.value); setBulkResult(null) }}
+                    placeholder="chrome-logins"
+                    aria-label="New Codey Browser profile name for the picked sites"
+                    spellCheck={false}
+                  />
+                </label>
+                <button style={styles.primary} disabled={busy || picked.size === 0 || !bulkName.trim()} onClick={() => void run(async () => {
+                  const next = useResult(await window.codey.chromeCompanion.importSites(bulkName.trim(), [...picked]))
+                  if (next?.imported && next.profile) {
+                    setBulkResult({ name: next.profile.name, cookieCount: next.cookieCount, siteCount: next.sites.length })
+                    setSites(null)
+                    setPicked(new Set())
+                  }
+                })}>Copy {picked.size || ''} site{picked.size === 1 ? '' : 's'} into a profile</button>
+              </div>
+            </>
+          )}
+          {bulkResult && (
+            <div style={styles.success}>
+              “{bulkResult.name}” is now the active Codey Browser profile, carrying {bulkResult.cookieCount} cookies from {bulkResult.siteCount} site{bulkResult.siteCount === 1 ? '' : 's'}. Chrome was not changed.
+            </div>
+          )}
+        </div>
+      )}
+
     </div>
   )
 }
@@ -183,6 +280,10 @@ const styles: Record<string, React.CSSProperties> = {
   noticeRow: { display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderRadius: 8, background: C.surface, border: `1px solid ${C.border}` },
   noticeCopy: { flex: 1, minWidth: 0, color: C.fg3, fontSize: 10.5 },
   navigate: { display: 'flex', alignItems: 'flex-end', gap: 8 },
+  siteList: { display: 'flex', flexDirection: 'column', gap: 1, maxHeight: 220, overflowY: 'auto', padding: 4, borderRadius: 8, border: `1px solid ${C.border}`, background: C.surface2 },
+  siteRow: { display: 'flex', alignItems: 'center', gap: 8, padding: '4px 6px', borderRadius: 6, color: C.fg2, fontSize: 11, cursor: 'pointer' },
+  siteName: { flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  siteMeta: { flexShrink: 0, color: C.fg3, fontSize: 10 },
   inputLabel: { display: 'flex', flex: 1, minWidth: 0, flexDirection: 'column', gap: 4, color: C.fg2, fontSize: 10 },
   input: { flexShrink: 0, width: '100%', minWidth: 0, height: 38, boxSizing: 'border-box', padding: '0 12px', borderRadius: 8, border: `1px solid ${C.border2}`, background: C.surface2, color: C.fg, outline: 'none', fontSize: 12.5 },
 }


### PR DESCRIPTION
Handing a login off one site at a time is fine for one login and tedious for a working set. The obvious shortcut — copy the whole cookie jar — is the wrong one: it would put banking, mail and health logins into a file on disk to save a few clicks. So Codey lists what Chrome is signed in to and the user ticks what it may have.

## What this adds

**Settings ▸ Plugins ▸ Chrome** gets a second card, *"Pick which Chrome logins to copy"*:

1. **List Chrome's signed-in sites** — every site the paired Chrome profile holds cookies for, most cookies first, with a filter box.
2. Tick what Codey may have. Each row shows its cookie count and whether a tab is open on it.
3. **Copy N sites into a profile** — confirms with the real numbers first, then creates and activates the profile.

## Behind it

- `listSessionSites` groups Chrome's cookies by site with counts, and reports which sites have a tab open — that decides whether localStorage can come along at all, since it can only be read from a page that is running.
- `exportSessionForSites` copies exactly the ticked sites. Cookies come from the cookie store, so nothing has to be open; storage is taken from tabs that happen to be on those sites and skipped otherwise, because opening tabs behind the user's back to read it is the worse trade. This is stated in the UI rather than left as a surprise.
- The import confirms before writing — a login copied out of Chrome cannot be un-copied — and says plainly that Chrome is unchanged.

## On the grouping

Grouping decides which cookies a ticked site takes with it, so `siteOfHost` moved into its own Chrome-free file that the worker pulls in with `importScripts`, and the tests evaluate that same file rather than a second copy that could drift.

It is the two-labels heuristic with the country-code exception (`bbc.co.uk` stays whole; `a.co.uk` and `b.co.uk` stay apart). Chrome exposes no public-suffix API to an extension, and this over-groups shared-suffix hosting — every user site under `github.io` reads as one site. That is why the picker shows cookie counts and the copy is confirmed rather than trusting the heuristic silently.

## Verification

`npm test` (886 tests, all passing — 5 new for the grouping, 1 new bridge round trip), `tsc --noEmit` clean, `npm run lint` clean, `node --check` on both extension scripts.

Not yet exercised on a real machine. The extension manifest goes to 0.12.0, so it needs reloading in Chrome.

Stacked conceptually on #388 (the Codey Browser toolbar Sync button), but independent of it — both branch off `main` and touch neighbouring regions of `service-worker.js` and `chrome-companion.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)