### PR TITLE
feat(browser): let several profiles be enabled at once

### DIFF
--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { describe, expect, it, vi } from 'vitest'
 import { BROWSER_PARTITION, BrowserController, isSafeBrowserNavigationUrl, normalizeBrowserUrl, sanitizeBounds } from './browser-controller'
+import { BrowserProfileStore } from './browser-profiles'
 
 describe('normalizeBrowserUrl', () => {
   it('adds HTTPS to ordinary hosts', () => {
@@ -503,6 +504,100 @@ describe('BrowserController profiles', () => {
       const stored = JSON.parse(fs.readFileSync(path.join(dir, 'work.json'), 'utf8'))
       expect(stored.name).toBe('work')
       expect(controller.listProfiles()[0]).toMatchObject({ name: 'work', cookieCount: 1, originCount: 1, active: false })
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps several profiles enabled at once and unions their cookies', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller, cookiesSet } = makeFixture(dir)
+      const store = new BrowserProfileStore(dir)
+      store.write('gh', {
+        cookies: [{ name: 'gh', value: '1', domain: 'github.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'lax' }],
+        origins: [],
+      }, null)
+      store.write('jira', {
+        cookies: [{ name: 'jira', value: '2', domain: 'jira.example.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'lax' }],
+        origins: [],
+      }, null)
+
+      await controller.enableProfile('gh')
+      await controller.enableProfile('jira')
+      expect(controller.activeProfileNames()).toEqual(['gh', 'jira'])
+      expect(controller.listProfiles().filter(profile => profile.active).map(profile => profile.name)).toEqual(['gh', 'jira'])
+
+      // The last apply carries both logins, not just the one just enabled.
+      const applied = cookiesSet.mock.calls.map(call => (call as any[])[0].name)
+      expect(applied).toContain('gh')
+      expect(applied).toContain('jira')
+
+      // Turning one off rebuilds the session from what is left.
+      cookiesSet.mockClear()
+      await controller.disableProfile('gh')
+      expect(controller.activeProfileNames()).toEqual(['jira'])
+      expect(cookiesSet.mock.calls.map(call => (call as any[])[0].name)).toEqual(['jira'])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses to enable two profiles that disagree about the same cookie', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller } = makeFixture(dir)
+      const store = new BrowserProfileStore(dir)
+      const cookie = (value: string) => ({
+        cookies: [{ name: 'session', value, domain: 'github.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'lax' as const }],
+        origins: [],
+      })
+      store.write('work', cookie('work-token'), null)
+      store.write('personal', cookie('personal-token'), null)
+
+      await controller.enableProfile('work')
+      // One value would silently win, so this is refused and named instead.
+      await expect(controller.enableProfile('personal')).rejects.toThrow(/session cookie for github\.com/)
+      expect(controller.activeProfileNames()).toEqual(['work'])
+
+      // Switching outright is still allowed - that is an identity change.
+      await controller.activateProfile('personal')
+      expect(controller.activeProfileNames()).toEqual(['personal'])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses to save the combined session over one of the enabled profiles', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller } = makeFixture(dir)
+      const store = new BrowserProfileStore(dir)
+      store.write('gh', { cookies: [], origins: [] }, null)
+      store.write('jira', { cookies: [], origins: [] }, null)
+      await controller.enableProfile('gh')
+      await controller.enableProfile('jira')
+
+      await expect(controller.saveProfile('gh')).rejects.toThrow(/would pull jira into it/)
+      // A new name is honest about being everything the browser now carries.
+      await expect(controller.saveProfile('combined')).resolves.toMatchObject({ name: 'combined' })
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves the other profiles enabled when one is deleted', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller } = makeFixture(dir)
+      const store = new BrowserProfileStore(dir)
+      store.write('gh', { cookies: [], origins: [] }, null)
+      store.write('jira', { cookies: [], origins: [] }, null)
+      await controller.enableProfile('gh')
+      await controller.enableProfile('jira')
+
+      await controller.deleteProfile('gh')
+      expect(controller.activeProfileNames()).toEqual(['jira'])
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -12,6 +12,7 @@ import type { BrowserSitePermissionDetails, BrowserSitePermissionManager } from 
 import {
   assertProfileName,
   BrowserProfileStore,
+  conflictingCookie,
   cookieMatchesUrl,
   mergeProfileData,
   parseProfileJsonText,
@@ -949,9 +950,22 @@ export class BrowserController {
 
   /** Snapshot the live session (cookies + reachable per-site storage) into a
    *  named profile. Saving does not activate the profile — call activateProfile
-   *  (or import with activate) to switch the browser to it. */
+   *  (or import with activate) to switch the browser to it.
+   *
+   *  With several profiles enabled the live session is their union, so writing
+   *  it back over one of them would quietly swallow the others. Saving to a new
+   *  name is still fine: that snapshot is honestly everything the browser
+   *  currently carries. */
   async saveProfile(name: string): Promise<BrowserProfile> {
     assertProfileName(name)
+    const enabled = this.profiles().activeNames()
+    if (enabled.length > 1 && enabled.includes(name)) {
+      throw new Error(
+        `${enabled.length} profiles are enabled, so the live session is their combined logins. `
+        + `Saving it over "${name}" would pull ${enabled.filter(entry => entry !== name).join(', ')} into it. `
+        + 'Save to a new name, or leave only that profile enabled first.',
+      )
+    }
     const data = await this.captureProfileData()
     const sourceUrl = this.view?.webContents.getURL() || null
     return this.profiles().write(name, data, sourceUrl)
@@ -1016,45 +1030,138 @@ export class BrowserController {
     const existing = this.profiles().read(name)
     const merged = mergeProfileData(existing, parseProfileJsonText(source.json), scopeUrl)
     const profile = this.profiles().write(name, merged, existing.sourceUrl ?? scopeUrl)
-    if (this.profiles().active() === name) await this.applyProfileData(profile)
+    if (this.profiles().activeNames().includes(name)) await this.applyLiveProfiles()
     return profile
   }
 
-  /** Switch the live session to a saved profile: the session's cookies are
-   *  replaced with the profile's and its site storage is applied best-effort.
-   *  Activating a profile that is already enabled is a no-op — the live
-   *  session already carries that snapshot. */
+  /** Names of every enabled profile, in the order they were enabled. */
+  activeProfileNames(): string[] {
+    return this.profiles().activeNames()
+  }
+
+  /** Switch the live session to a single saved profile, replacing whatever was
+   *  enabled. This is the identity switch: leftovers from the profiles that
+   *  were enabled cannot leak into the new one. Use `enableProfile` to add a
+   *  profile alongside the ones already on. */
   async activateProfile(name: string): Promise<BrowserProfileSummary> {
     assertProfileName(name)
-    if (this.profiles().active() === name) {
+    const enabled = this.profiles().activeNames()
+    if (enabled.length === 1 && enabled[0] === name) {
       const current = this.profiles().list().find(profile => profile.name === name)
       if (current) return current
       throw new Error(`Profile ${name} is enabled but missing on disk`)
     }
+    this.profiles().read(name)
+    await this.setEnabledProfiles([name])
+    return this.summaryOf(name)
+  }
+
+  /** Turn a profile on alongside the ones already enabled, so a browser can
+   *  hold several logins at once (a GitHub profile and a Jira one, say). The
+   *  live session becomes the union of every enabled profile.
+   *
+   *  Two profiles that carry the same cookie cannot both be honoured - one
+   *  value would silently win - so an overlap is refused and named instead. */
+  async enableProfile(name: string): Promise<BrowserProfileSummary> {
+    assertProfileName(name)
+    const enabled = this.profiles().activeNames()
+    if (enabled.includes(name)) return this.summaryOf(name)
+    const incoming = this.profiles().read(name)
+    for (const other of enabled) {
+      let held: BrowserProfile
+      try {
+        held = this.profiles().read(other)
+      } catch {
+        continue
+      }
+      const clash = conflictingCookie(held, incoming)
+      if (clash) {
+        throw new Error(
+          `"${name}" and "${other}" both hold a different ${clash.name} cookie for ${clash.domain}. `
+          + `Turn "${other}" off first, or switch to "${name}" instead of adding it.`,
+        )
+      }
+    }
+    await this.setEnabledProfiles([...enabled, name])
+    return this.summaryOf(name)
+  }
+
+  /** Turn one profile off and leave the rest enabled. The live session is
+   *  rebuilt from what remains rather than having cookies picked out of it, so
+   *  nothing of the disabled profile can survive by accident. */
+  async disableProfile(name: string): Promise<BrowserProfileSummary> {
+    assertProfileName(name)
+    const enabled = this.profiles().activeNames()
+    if (!enabled.includes(name)) return this.summaryOf(name)
+    await this.setEnabledProfiles(enabled.filter(entry => entry !== name))
+    return this.summaryOf(name)
+  }
+
+  private summaryOf(name: string): BrowserProfileSummary {
+    const summary = this.profiles().list().find(entry => entry.name === name)
+    if (summary) return summary
     const profile = this.profiles().read(name)
-    await this.applyProfileData(profile)
-    this.profiles().setActive(name)
-    return this.profiles().list().find(summary => summary.name === name) ?? {
+    return {
       name,
       avatar: profile.avatar ?? null,
       createdAt: profile.createdAt,
       updatedAt: profile.updatedAt,
       cookieCount: profile.cookies.length,
       originCount: profile.origins.length,
-      active: true,
+      active: this.profiles().activeNames().includes(name),
       sourceUrl: profile.sourceUrl,
     }
+  }
+
+  /** Record the enabled set and make the live session match it. */
+  private async setEnabledProfiles(names: string[]): Promise<void> {
+    this.profiles().setActive(names)
+    await this.applyLiveProfiles()
+  }
+
+  /** Rebuild the live session from every enabled profile. Always a full
+   *  replace, so disabling a profile really removes it and re-syncing one
+   *  cannot leave a stale copy of itself behind. */
+  private async applyLiveProfiles(): Promise<void> {
+    const names = this.profiles().activeNames()
+    const cookies: BrowserProfileCookie[] = []
+    const origins: BrowserProfileStorageOrigin[] = []
+    let sourceUrl: string | null = null
+    let createdAt = Date.now()
+    for (const name of names) {
+      let profile: BrowserProfile
+      try {
+        profile = this.profiles().read(name)
+      } catch {
+        continue
+      }
+      cookies.push(...profile.cookies)
+      origins.push(...profile.origins)
+      sourceUrl = sourceUrl ?? profile.sourceUrl
+      createdAt = Math.min(createdAt, profile.createdAt || createdAt)
+    }
+    await this.applyProfileData({
+      name: names.join('+'),
+      cookies,
+      origins,
+      avatar: null,
+      createdAt,
+      updatedAt: Date.now(),
+      sourceUrl,
+    })
   }
 
   setProfileAvatar(name: string, avatar: string): BrowserProfileSummary {
     return this.profiles().setAvatar(name, avatar)
   }
 
-  /** Remove a saved profile. Deleting the enabled profile disables it. */
+  /** Remove a saved profile. Deleting an enabled profile turns it off and
+   *  rebuilds the live session from whichever profiles are still on. */
   async deleteProfile(name: string): Promise<{ deleted: boolean }> {
     assertProfileName(name)
+    const enabled = this.profiles().activeNames()
     this.profiles().remove(name)
-    if (this.profiles().active() === name) this.profiles().setActive(null)
+    if (enabled.includes(name)) await this.setEnabledProfiles(enabled.filter(entry => entry !== name))
     return { deleted: true }
   }
 

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -7,6 +7,7 @@ import {
   assertProfileName,
   BrowserProfileStore,
   availableProfileName,
+  conflictingCookie,
   cookieMatchesUrl,
   mergeProfileData,
   deriveProfileNameFromFile,
@@ -155,16 +156,48 @@ describe('BrowserProfileStore', () => {
     }
   })
 
-  it('tracks the active profile in a dot-file', () => {
+  it('tracks the enabled profiles in a dot-file, one per line', () => {
     const { dir, store } = makeStore()
     try {
+      expect(store.activeNames()).toEqual([])
       expect(store.active()).toBeNull()
       store.setActive('work')
+      expect(store.activeNames()).toEqual(['work'])
       expect(store.active()).toBe('work')
-      expect(fs.readFileSync(path.join(dir, ACTIVE_PROFILE_FILE), 'utf8')).toBe('work')
+      expect(fs.readFileSync(path.join(dir, ACTIVE_PROFILE_FILE), 'utf8')).toBe('work\n')
+
+      // Several at once, in the order they were enabled.
+      store.setActive(['work', 'personal'])
+      expect(store.activeNames()).toEqual(['work', 'personal'])
+      expect(store.active()).toBe('work')
+
       store.setActive(null)
-      expect(store.active()).toBeNull()
+      expect(store.activeNames()).toEqual([])
       expect(fs.existsSync(path.join(dir, ACTIVE_PROFILE_FILE))).toBe(false)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads a pre-upgrade single-name file as one enabled profile', () => {
+    const { dir, store } = makeStore()
+    try {
+      // The old format had no trailing newline; an install must not come back
+      // signed out just because the file grew a list.
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(path.join(dir, ACTIVE_PROFILE_FILE), 'work')
+      expect(store.activeNames()).toEqual(['work'])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores blank, duplicate and unusable names in the dot-file', () => {
+    const { dir, store } = makeStore()
+    try {
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(path.join(dir, ACTIVE_PROFILE_FILE), 'work\n\nwork\n../escape\npersonal\n')
+      expect(store.activeNames()).toEqual(['work', 'personal'])
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }
@@ -179,6 +212,10 @@ describe('BrowserProfileStore', () => {
       const summaries = store.list()
       expect(summaries.find(profile => profile.name === 'b')?.active).toBe(true)
       expect(summaries.find(profile => profile.name === 'a')?.active).toBe(false)
+
+      // Both flagged once both are enabled.
+      store.setActive(['a', 'b'])
+      expect(store.list().filter(profile => profile.active).map(profile => profile.name)).toEqual(['a', 'b'])
     } finally {
       // store() dir cleanup handled by each test's own dir; nothing to do.
     }
@@ -283,5 +320,36 @@ describe('mergeProfileData', () => {
 
   it('rejects a scope URL it cannot reason about rather than merging blindly', () => {
     expect(() => mergeProfileData(existing, incoming, 'not a url')).toThrow(/scope URL/)
+  })
+})
+
+describe('conflictingCookie', () => {
+  const withValue = (value: string) => ({
+    cookies: [{
+      name: 'session', value, domain: 'github.com', path: '/', expires: -1,
+      httpOnly: true, secure: true, sameSite: 'lax' as const,
+    }],
+    origins: [],
+  })
+
+  it('finds the cookie two profiles disagree about', () => {
+    const clash = conflictingCookie(withValue('work'), withValue('personal'))
+    expect(clash).toMatchObject({ name: 'session', domain: 'github.com' })
+  })
+
+  it('is not a conflict when both hold the same value', () => {
+    expect(conflictingCookie(withValue('same'), withValue('same'))).toBeNull()
+  })
+
+  it('is not a conflict when the cookies are for different scopes', () => {
+    const other = {
+      cookies: [{
+        name: 'session', value: 'x', domain: 'gitlab.com', path: '/', expires: -1,
+        httpOnly: true, secure: true, sameSite: 'lax' as const,
+      }],
+      origins: [],
+    }
+    expect(conflictingCookie(withValue('work'), other)).toBeNull()
+    expect(conflictingCookie({ cookies: [], origins: [] }, withValue('work'))).toBeNull()
   })
 })

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -63,7 +63,9 @@ export interface BrowserProfileSummary {
   sourceUrl: string | null
 }
 
-/** The dot-file that records which profile is enabled. */
+/** The dot-file that records which profiles are enabled, one name per line.
+ *  It used to hold a single name; that reads back as a one-profile set, so an
+ *  existing install keeps its browser signed in across the upgrade. */
 export const ACTIVE_PROFILE_FILE = '.active'
 
 export const BROWSER_PROFILE_AVATARS = [
@@ -267,6 +269,22 @@ export function mergeProfileData(
   }
 }
 
+/** The first cookie two profiles both hold with different values, or null when
+ *  they can safely be enabled together. Same key and same value is not a
+ *  conflict - honouring either one gives the same live session. */
+export function conflictingCookie(
+  left: BrowserProfileData,
+  right: BrowserProfileData,
+): BrowserProfileCookie | null {
+  const key = (cookie: BrowserProfileCookie) => `${cookie.domain}\u0000${cookie.path}\u0000${cookie.name}`
+  const held = new Map(left.cookies.map(cookie => [key(cookie), cookie]))
+  for (const cookie of right.cookies) {
+    const other = held.get(key(cookie))
+    if (other && other.value !== cookie.value) return cookie
+  }
+  return null
+}
+
 /** File store for profiles. One \`.json\` per profile plus a dot-file that
  *  records which profile is enabled. */
 export class BrowserProfileStore {
@@ -280,9 +298,9 @@ export class BrowserProfileStore {
     return path.join(this.dir, ACTIVE_PROFILE_FILE)
   }
 
-  /** All profiles in the store, sorted by name, with the active one flagged. */
+  /** All profiles in the store, sorted by name, with the enabled ones flagged. */
   list(): BrowserProfileSummary[] {
-    const active = this.active()
+    const active = this.activeNames()
     let names: string[] = []
     try {
       names = fs.readdirSync(this.dir)
@@ -294,7 +312,7 @@ export class BrowserProfileStore {
     return names.sort().map(name => this.summary(name, active))
   }
 
-  private summary(name: string, activeName: string | null): BrowserProfileSummary {
+  private summary(name: string, activeNames: readonly string[]): BrowserProfileSummary {
     let profile: BrowserProfile | null = null
     try {
       profile = this.read(name)
@@ -308,7 +326,7 @@ export class BrowserProfileStore {
       updatedAt: profile?.updatedAt ?? 0,
       cookieCount: profile?.cookies.length ?? 0,
       originCount: profile?.origins.length ?? 0,
-      active: activeName === name,
+      active: activeNames.includes(name),
       sourceUrl: profile?.sourceUrl ?? null,
     }
   }
@@ -370,7 +388,7 @@ export class BrowserProfileStore {
     const file = this.file(name)
     fs.writeFileSync(file, JSON.stringify(next, null, 2), { encoding: 'utf8', mode: 0o600 })
     try { fs.chmodSync(file, 0o600) } catch { /* best-effort */ }
-    return this.summary(name, this.active())
+    return this.summary(name, this.activeNames())
   }
 
   remove(name: string): void {
@@ -382,24 +400,42 @@ export class BrowserProfileStore {
     }
   }
 
-  /** Name of the enabled profile, or null when none is enabled. */
-  active(): string | null {
+  /** Names of the enabled profiles, in the order they were enabled. */
+  activeNames(): string[] {
+    let text: string
     try {
-      const name = fs.readFileSync(this.activeFile(), 'utf8').trim()
-      assertProfileName(name)
-      return name
+      text = fs.readFileSync(this.activeFile(), 'utf8')
     } catch {
-      return null
+      return []
     }
+    const names: string[] = []
+    for (const line of text.split('\n')) {
+      const name = line.trim()
+      if (!name || names.includes(name)) continue
+      try {
+        assertProfileName(name)
+      } catch {
+        continue
+      }
+      names.push(name)
+    }
+    return names
   }
 
-  setActive(name: string | null): void {
-    if (name === null) {
+  /** First enabled profile, or null. Kept for the callers that only ever
+   *  needed one name (the agent bridge's status lines). */
+  active(): string | null {
+    return this.activeNames()[0] ?? null
+  }
+
+  setActive(names: string | string[] | null): void {
+    const list = names === null ? [] : (Array.isArray(names) ? names : [names])
+    if (list.length === 0) {
       try { fs.unlinkSync(this.activeFile()) } catch { /* already absent */ }
       return
     }
-    assertProfileName(name)
+    for (const name of list) assertProfileName(name)
     fs.mkdirSync(this.dir, { recursive: true })
-    fs.writeFileSync(this.activeFile(), name, { encoding: 'utf8', mode: 0o600 })
+    fs.writeFileSync(this.activeFile(), `${list.join('\n')}\n`, { encoding: 'utf8', mode: 0o600 })
   }
 }

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2356,23 +2356,45 @@ app.whenReady().then(async () => {
   // and Settings) manages through the same controller the agents use.
   ipcMain.handle('browser:profiles:list', event => browserCall(event, () => ({
     active: browserController.activeProfileName(),
+    activeNames: browserController.activeProfileNames(),
     profiles: browserController.listProfiles(),
   })))
   ipcMain.handle('browser:profiles:save', (event, name: string) =>
     browserCall(event, () => browserController.saveProfile(String(name || ''))))
   ipcMain.handle('browser:profiles:activate', (event, name: string) =>
     browserCall(event, () => browserController.activateProfile(String(name || ''))))
+  // Enabling adds a profile to the live session instead of replacing it, so the
+  // browser can hold several logins at once.
+  ipcMain.handle('browser:profiles:enable', (event, name: string) =>
+    browserCall(event, () => browserController.enableProfile(String(name || ''))))
+  ipcMain.handle('browser:profiles:disable', (event, name: string) =>
+    browserCall(event, () => browserController.disableProfile(String(name || ''))))
   // The Sync button in the browser toolbar: pull the login Chrome holds for the
-  // page Codey Browser is showing into the profile that is enabled here. It is
-  // scoped to that one site, so a profile carrying several logins keeps the
-  // rest, and it names the URL rather than using Chrome's front tab - the user
-  // is looking at the signed-out page here, not over there.
+  // page Codey Browser is showing into the profile that already owns this site.
+  // It is scoped to that one site, so a profile carrying several logins keeps
+  // the rest, and it names the URL rather than using Chrome's front tab - the
+  // user is looking at the signed-out page here, not over there.
   ipcMain.handle('browser:profiles:syncFromChrome', (event, url: string) => browserCall(event, async () => {
     if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
     if (!chromeCompanion.status().connected) throw new Error('Connect the Codey extension in Chrome first')
     const target = String(url || '')
-    const name = browserController.activeProfileName()
-    if (!name) throw new Error('Enable a browser profile first - there is nothing to sync into')
+    const enabled = browserController.activeProfileNames()
+    if (enabled.length === 0) throw new Error('Enable a browser profile first - there is nothing to sync into')
+    // With several profiles on, "the active profile" is not a single answer.
+    // The one that already holds this site is the one going stale, so prefer
+    // it; say so rather than guessing when that does not pin it down.
+    const owners = browserController.profilesForUrl(target).filter(name => enabled.includes(name))
+    let name: string
+    if (owners.length === 1) name = owners[0]
+    else if (owners.length > 1) {
+      throw new Error(`${owners.join(' and ')} both hold this site - turn all but one off, then sync`)
+    } else if (enabled.length === 1) name = enabled[0]
+    else {
+      throw new Error(
+        `None of the ${enabled.length} profiles in use hold this site yet. `
+        + 'Leave only the one it belongs in enabled, then sync.',
+      )
+    }
     const session = await chromeCompanion.exportSessionForUrl(target)
     await browserController.resyncProfile(name, {
       json: JSON.stringify({ cookies: session.cookies, origins: session.origins }),

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -505,6 +505,8 @@ contextBridge.exposeInMainWorld('codey', {
       list: () => ipcRenderer.invoke('browser:profiles:list'),
       save: (name: string) => ipcRenderer.invoke('browser:profiles:save', name),
       activate: (name: string) => ipcRenderer.invoke('browser:profiles:activate', name),
+      enable: (name: string) => ipcRenderer.invoke('browser:profiles:enable', name),
+      disable: (name: string) => ipcRenderer.invoke('browser:profiles:disable', name),
       setAvatar: (name: string, avatar: string) => ipcRenderer.invoke('browser:profiles:setAvatar', name, avatar),
       delete: (name: string) => ipcRenderer.invoke('browser:profiles:delete', name),
       import: () => ipcRenderer.invoke('browser:profiles:import'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -642,9 +642,11 @@ declare global {
         closeTab: (id: string) => Promise<IpcResult<BrowserState>>
         resetSession: () => Promise<IpcResult<BrowserState>>
         profiles: {
-          list: () => Promise<IpcResult<{ active: string | null; profiles: BrowserProfileSummary[] }>>
+          list: () => Promise<IpcResult<{ active: string | null; activeNames: string[]; profiles: BrowserProfileSummary[] }>>
           save: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
           activate: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
+          enable: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
+          disable: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
           setAvatar: (name: string, avatar: string) => Promise<IpcResult<BrowserProfileSummary>>
           delete: (name: string) => Promise<IpcResult<{ deleted: boolean }>>
           import: () => Promise<IpcResult<{ imported: boolean; profile: BrowserProfileSummary | null }>>

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -293,11 +293,31 @@ export const BrowserPanel: React.FC<Props> = ({
 
   useEffect(() => { void refreshProfiles() }, [])
 
+  // Several profiles can be on at once, so the menu toggles rather than picks.
+  // The menu stays open: turning on a working set is usually more than one
+  // click, and closing after each would make that tedious.
+  const toggleProfile = async (name: string, enabled: boolean) => {
+    setProfileBusy(true)
+    try {
+      const result = enabled
+        ? await window.codey.browser.profiles.disable(name)
+        : await window.codey.browser.profiles.enable(name)
+      if (!result.ok) setLocalError(result.error)
+      else setLocalError(null)
+      await refreshProfiles()
+    } finally {
+      setProfileBusy(false)
+    }
+  }
+
+  // "Only this one" is still worth one click: it is the identity switch, and
+  // it is the way out of a set that has grown confusing.
   const activateProfile = async (name: string) => {
     setProfileBusy(true)
     try {
       const result = await window.codey.browser.profiles.activate(name)
       if (!result.ok) setLocalError(result.error)
+      else setLocalError(null)
       await refreshProfiles()
     } finally {
       setProfileBusy(false)
@@ -351,7 +371,11 @@ export const BrowserPanel: React.FC<Props> = ({
 
   const displayedError = localError ?? state.error
   const secure = state.url.startsWith('https://')
+  const enabledProfiles = profiles.filter(profile => profile.active)
   const currentProfile = profiles.find(profile => profile.name === activeProfile)
+  const profileLabel = enabledProfiles.length === 0
+    ? 'No profile'
+    : enabledProfiles.length === 1 ? enabledProfiles[0].name : `${enabledProfiles.length} profiles`
 
   const usePageInChat = async () => {
     if (!chatId) return
@@ -561,7 +585,9 @@ export const BrowserPanel: React.FC<Props> = ({
           ref={profileButtonRef}
           type="button"
           style={{ ...styles.profileButton, ...(profileMenuOpen ? styles.profileButtonActive : null) }}
-          title={activeProfile ? `Browser profile: ${activeProfile} — click to switch` : 'No browser profile active — click to pick one'}
+          title={enabledProfiles.length > 0
+            ? `Browser profiles in use: ${enabledProfiles.map(profile => profile.name).join(', ')} — click to change`
+            : 'No browser profile active — click to pick one'}
           aria-label="Browser profile"
           aria-haspopup="menu"
           aria-expanded={profileMenuOpen}
@@ -573,7 +599,7 @@ export const BrowserPanel: React.FC<Props> = ({
           }}
         >
           <span aria-hidden="true" style={styles.profileAvatarSmall}>{browserProfileAvatar(currentProfile)}</span>
-          {panelWidth >= 640 && <span style={styles.profileButtonLabel}>{activeProfile ?? 'No profile'}</span>}
+          {panelWidth >= 640 && <span style={styles.profileButtonLabel}>{profileLabel}</span>}
         </button>
         <button
           type="button"
@@ -612,25 +638,40 @@ export const BrowserPanel: React.FC<Props> = ({
 
       {profileMenuOpen && (
         <div ref={profileMenuRef} style={styles.profileMenu} role="menu" aria-label="Browser profiles">
-          <div style={styles.profileMenuHeading}>Active profile</div>
+          <div style={styles.profileMenuHeading}>Profiles in use</div>
           {profiles.length === 0 && (
             <div style={styles.profileMenuEmpty}>No profiles saved yet.</div>
           )}
           {profiles.map(profile => (
-            <button
-              key={profile.name}
-              type="button"
-              role="menuitemradio"
-              aria-checked={profile.active}
-              disabled={profileBusy || profile.active}
-              style={{ ...styles.menuButton, ...(profile.active ? styles.profileMenuItemActive : null) }}
-              onClick={() => void activateProfile(profile.name)}
-            >
-              <span aria-hidden="true" style={styles.profileMenuAvatar}>{browserProfileAvatar(profile)}</span>
-              <span style={styles.profileMenuName}>{profile.name}</span>
-              <span aria-hidden="true" style={styles.profileMenuCheck}>{profile.active ? '✓' : ''}</span>
-            </button>
+            <div key={profile.name} style={styles.profileMenuRow}>
+              <button
+                type="button"
+                role="menuitemcheckbox"
+                aria-checked={profile.active}
+                disabled={profileBusy}
+                style={{ ...styles.menuButton, flex: 1, ...(profile.active ? styles.profileMenuItemActive : null) }}
+                onClick={() => void toggleProfile(profile.name, profile.active)}
+              >
+                <span aria-hidden="true" style={styles.profileMenuAvatar}>{browserProfileAvatar(profile)}</span>
+                <span style={styles.profileMenuName}>{profile.name}</span>
+                <span aria-hidden="true" style={styles.profileMenuCheck}>{profile.active ? '✓' : ''}</span>
+              </button>
+              {!(profile.active && enabledProfiles.length === 1) && (
+                <button
+                  type="button"
+                  style={styles.profileMenuOnly}
+                  disabled={profileBusy}
+                  title={`Use only ${profile.name}, turning the others off`}
+                  onClick={() => void activateProfile(profile.name)}
+                >Only</button>
+              )}
+            </div>
           ))}
+          {enabledProfiles.length > 1 && (
+            <div style={styles.profileMenuNote}>
+              The browser is carrying all {enabledProfiles.length} logins at once.
+            </div>
+          )}
           <div style={styles.profileMenuDivider} />
           <button type="button" style={styles.menuButton} onClick={() => { setProfileMenuOpen(false); openProfiles() }}>
             <UIIcon name="settings" size={13} /> Manage profiles…
@@ -1091,6 +1132,9 @@ const styles: Record<string, React.CSSProperties> = {
   profileMenuCheck: { width: 12, flexShrink: 0, textAlign: 'center' },
   profileMenuAvatar: { width: 20, flexShrink: 0, textAlign: 'center', fontSize: 15 },
   profileMenuName: { flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  profileMenuRow: { display: 'flex', alignItems: 'center', gap: 2 },
+  profileMenuOnly: { flexShrink: 0, marginRight: 4, padding: '3px 7px', border: 'none', borderRadius: 6, background: 'transparent', color: C.fg3, cursor: 'pointer', fontSize: 10 },
+  profileMenuNote: { padding: '4px 10px 6px', color: C.fg3, fontSize: 10, lineHeight: 1.4 },
   profileMenuDivider: { height: 1, margin: '4px 0', background: C.border },
   contextButton: { height: 31, padding: '0 10px', border: `1px solid ${C.accent}66`, borderRadius: 7, display: 'flex', alignItems: 'center', gap: 6, background: C.accentDim, color: C.accent, cursor: 'pointer', fontSize: 11, fontWeight: 650, whiteSpace: 'nowrap' },
   permissionBadge: { height: 28, padding: '0 8px', borderRadius: 7, display: 'flex', alignItems: 'center', gap: 5, cursor: 'pointer', fontSize: 10, fontWeight: 650, whiteSpace: 'nowrap' },

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -21,7 +21,7 @@ function formatWhen(timestamp: number): string {
  *  session file, activate, export and delete profiles through the main
  *  process's `window.codey.browser.profiles` bridge. */
 export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
-  const [active, setActive] = useState<string | null>(null)
+  // Derived from the list itself, so it cannot disagree with the rows shown.
   const [profiles, setProfiles] = useState<BrowserProfileSummary[]>([])
   const [name, setName] = useState('')
   const [busy, setBusy] = useState(false)
@@ -42,7 +42,6 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
     try {
       const result = await window.codey.browser.profiles.list()
       if (result.ok) {
-        setActive(result.data.active)
         setProfiles(result.data.profiles)
         setError(null)
       } else {
@@ -52,6 +51,8 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
       setError(caught instanceof Error ? caught.message : String(caught))
     }
   }, [])
+
+  const activeCount = profiles.filter(profile => profile.active).length
 
   useEffect(() => { void refresh() }, [refresh])
 
@@ -191,22 +192,38 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
                 <span style={{
                   background: C.green + '22', color: C.green, borderRadius: 999, padding: '1px 7px',
                   fontSize: compact ? 10 : 11, fontWeight: 600,
-                }}>ACTIVE</span>
+                }}>IN USE</span>
               )}
             </div>
             <div style={{ color: C.fg3, fontSize: compact ? 10 : 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={title(profile)}>
               {meta(profile) || (profile.sourceUrl ? 'saved session' : 'empty profile')}
             </div>
           </div>
+          {/* Several profiles can be on at once, so this turns one on or off
+              rather than switching to it. "Only" is the identity switch, and it
+              is offered whenever it would actually change something. */}
           <button
             type="button"
-            disabled={busy || profile.active}
-            onClick={() => void run(() => window.codey.browser.profiles.activate(profile.name))}
+            disabled={busy}
+            onClick={() => void run(() => profile.active
+              ? window.codey.browser.profiles.disable(profile.name)
+              : window.codey.browser.profiles.enable(profile.name))}
             style={profile.active ? activeBadgeStyle(compact) : buttonStyle(compact)}
-            title={profile.active ? 'This profile is active' : 'Switch the live session to this profile'}
+            title={profile.active
+              ? 'This profile\u2019s logins are in use \u2014 click to turn it off'
+              : 'Add this profile\u2019s logins to the live session'}
           >
-            {profile.active ? 'Active' : 'Activate'}
+            {profile.active ? 'In use' : 'Use'}
           </button>
+          {!(profile.active && activeCount === 1) && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void run(() => window.codey.browser.profiles.activate(profile.name))}
+              style={buttonStyle(compact)}
+              title={`Use only ${profile.name}, turning every other profile off`}
+            >Only</button>
+          )}
           <button
             type="button"
             disabled={busy}


### PR DESCRIPTION
A profile was an identity you switched between, so using a GitHub login and a Jira login in the same browser meant keeping both in one profile — and then re-syncing either one had to be careful not to disturb the other. The profiles were separate everywhere except where it mattered.

## What changes

Profiles are now a **set**. The live session is the union of everything enabled.

- The toolbar profile menu and Settings ▸ Profiles **toggle** rather than pick. The chip reads `3 profiles` when three are on, and its tooltip names them.
- **Only** is still one click away on every row — switching outright is a different intent from adding, and it is the way out of a set that has grown confusing.

## The conflict rule

Two profiles that hold the same cookie with **different values** cannot both be honoured — one would silently win. Enabling is refused and the offending cookie and domain are named:

> `"personal" and "work" both hold a different session cookie for github.com. Turn "work" off first, or switch to "personal" instead of adding it.`

Same cookie with the same value is not a conflict — honouring either gives the same session.

## The parts that assumed one

- **`.active`** holds one name per line. A pre-upgrade file with a single bare name reads back as one enabled profile, so nobody comes back signed out after the upgrade.
- **Enabling, disabling and deleting** all rebuild the live session from the whole enabled set rather than patching it, so a disabled profile cannot survive in the cookie jar by accident.
- **`saveProfile`** refuses to write the combined session over one of several enabled profiles — that would quietly pull the others into it. Saving to a *new* name is still allowed: that snapshot really is everything the browser carries.
- **`activateProfile`** keeps its exclusive-switch meaning, so the agent bridge and its `full`-tier permission gate are unchanged.

## Verification

`npm test` (889 tests, all passing), `tsc --noEmit` clean, `npm run lint` clean.

New tests cover: the dot-file list format and its pre-upgrade single-name fallback, blank/duplicate/unsafe lines in it, the cookie union and the rebuild on disable, the conflict refusal (and that switching is still allowed), the `saveProfile` guard, and delete leaving the rest enabled.

Not yet exercised on a real machine.

Independent of #388 and #390 — all three branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)