### PR TITLE
fix(browser): keep a --profile command on the profile it asked for

### DIFF
--- a/codey-mac/electron/browser-agent-bridge.test.ts
+++ b/codey-mac/electron/browser-agent-bridge.test.ts
@@ -15,6 +15,7 @@ function call(
   route: string,
   body?: unknown,
   token = info.token,
+  extraHeaders: Record<string, string> = {},
 ): Promise<{ status: number; body: any }> {
   return new Promise((resolve, reject) => {
     const payload = body === undefined ? undefined : JSON.stringify(body)
@@ -24,6 +25,7 @@ function call(
       method,
       headers: {
         Authorization: `Bearer ${token}`,
+        ...extraHeaders,
         ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}),
       },
     }, res => {
@@ -91,6 +93,7 @@ describe('BrowserAgentBridge', () => {
       submit: vi.fn(async ref => ({ ok: true as const, url: state.url, message: `Submitted ${ref}` })),
       listProfiles: vi.fn(() => []),
       activeProfileName: vi.fn(() => null),
+      activeProfileNames: vi.fn((): string[] => []),
       saveProfile: vi.fn(async name => ({ name, cookies: [], origins: [], createdAt: 1, updatedAt: 1, sourceUrl: null })),
       importProfile: vi.fn(async name => ({ name, cookies: [], origins: [], createdAt: 1, updatedAt: 1, sourceUrl: null })),
       activateProfile: vi.fn(async name => ({
@@ -320,6 +323,59 @@ describe('BrowserAgentBridge', () => {
       } finally {
         try { fs.unlinkSync(screenshotPath) } catch { /* already removed */ }
       }
+    } finally {
+      await bridge.stop()
+    }
+  })
+
+  it('runs each --profile command under the profile it asked for, even when another agent switches', async () => {
+    // Two agents, two identities, one browser. The switch and the command have
+    // to be the same turn. If the switch happens up front instead, a second
+    // agent's switch lands while the first is still queued, and the first then
+    // silently acts as the wrong person.
+    let enabled: string[] = []
+    const observed: string[] = []
+    const release: Array<() => void> = []
+    const controller = {
+      getState: vi.fn(() => ({ url: 'https://example.com/' })),
+      activeProfileName: vi.fn(() => enabled[0] ?? null),
+      activeProfileNames: vi.fn(() => enabled),
+      activateProfile: vi.fn(async (name: string) => {
+        enabled = [name]
+        return { name, active: true, cookieCount: 0, originCount: 0, createdAt: 1, updatedAt: 1, sourceUrl: null }
+      }),
+      // Parks until the test releases it, so commands really do pile up behind
+      // one another the way two busy agents would make them.
+      getPageContext: vi.fn(async () => {
+        observed.push(enabled.join(','))
+        await new Promise<void>(resolve => release.push(resolve))
+        return { url: 'https://example.com/', title: 'Page', description: '', text: '', performance: {} }
+      }),
+    }
+    const bridge = new BrowserAgentBridge(controller as any, vi.fn(), async () => true, vi.fn(), 5)
+    const info = await bridge.start()
+    const settle = async () => { for (let i = 0; i < 5; i += 1) await new Promise(resolve => setImmediate(resolve)) }
+    try {
+      // Something else already holds the browser, so the two profile requests
+      // below have to wait - which is exactly when the identity can drift.
+      const blocker = call(info, 'GET', '/view')
+      await settle()
+
+      const personal = call(info, 'GET', '/view', undefined, info.token, { 'X-Codey-Profile': 'personal' })
+      await settle()
+      const work = call(info, 'GET', '/view', undefined, info.token, { 'X-Codey-Profile': 'work' })
+      await settle()
+
+      for (let attempt = 0; attempt < 60 && observed.length < 3; attempt += 1) {
+        while (release.length > 0) release.shift()!()
+        await settle()
+      }
+      while (release.length > 0) release.shift()!()
+      await Promise.all([blocker, personal, work])
+
+      // The blocker ran with no profile; each of the other two saw its own,
+      // never the other agent's and never both at once.
+      expect(observed).toEqual(['', 'personal', 'work'])
     } finally {
       await bridge.stop()
     }

--- a/codey-mac/electron/browser-agent-bridge.ts
+++ b/codey-mac/electron/browser-agent-bridge.ts
@@ -3,6 +3,7 @@ import * as http from 'http'
 import * as os from 'os'
 import * as path from 'path'
 import { randomBytes } from 'crypto'
+import { AsyncLocalStorage } from 'async_hooks'
 import type { BrowserController, BrowserLoginStatus } from './browser-controller'
 import { levelForCommand, type BrowserControlRequest } from './browser-control-permission'
 import type { ChromeCompanionBridge, ChromePageActionName } from './chrome-companion'
@@ -16,7 +17,7 @@ type BridgeController = Pick<
   | 'waitFor' | 'upload' | 'listDownloads' | 'waitForDownload' | 'submit'
   | 'getLoginStatus'
   | 'getState' | 'back' | 'forward' | 'reload' | 'listTabs' | 'newTab' | 'switchTab' | 'closeTab'
-  | 'listProfiles' | 'activeProfileName' | 'saveProfile' | 'importProfile' | 'activateProfile' | 'deleteProfile' | 'exportProfile'
+  | 'listProfiles' | 'activeProfileName' | 'activeProfileNames' | 'saveProfile' | 'importProfile' | 'activateProfile' | 'deleteProfile' | 'exportProfile'
 >
 
 type CompanionController = Pick<ChromeCompanionBridge, 'status' | 'activeTab' | 'snapshot' | 'navigate' | 'act'>
@@ -79,6 +80,9 @@ export class BrowserAgentBridge {
   private server: http.Server | null = null
   private info: BrowserAgentBridgeInfo | null = null
   private operationTail: Promise<void> = Promise.resolve()
+  // The profile a `--profile` request asked for, carried through that request's
+  // async context so `exclusive` can pin it without every route having to know.
+  private readonly profileScope = new AsyncLocalStorage<{ name: string; held: boolean }>()
   private loginWatches = new Map<string, LoginWatch>()
   private loginWatchSequence = 0
 
@@ -144,19 +148,37 @@ export class BrowserAgentBridge {
     }
     try {
       // An agent can target a specific browser profile by passing
-      // `--profile <name>` to the CLI, which forwards it here. The profile is
-      // activated first, so the command below operates under that identity —
-      // and because that is the same identity switch as `/profile/activate`,
-      // it goes through the same user approval gate.
+      // `--profile <name>` to the CLI, which forwards it here. The command then
+      // runs under that identity alone - and because that is the same identity
+      // switch as `/profile/activate`, it goes through the same approval gate.
+      //
+      // Asking and switching are deliberately split. The prompt can sit
+      // unanswered for as long as the user takes, so holding the browser while
+      // it does would stall every other agent; the switch itself happens inside
+      // the same lock acquisition as the command (see `exclusive`), so no other
+      // agent can change the identity in between. Without that, two agents
+      // could each switch and then both run under whichever switched last.
       const requestedProfile = typeof req.headers['x-codey-profile'] === 'string'
         ? (req.headers['x-codey-profile'] as string).trim()
         : ''
       const isProfileRoute = route === '/profiles' || route.startsWith('/profile/')
       if (requestedProfile && !isProfileRoute) {
-        const active = this.controller.activeProfileName()
-        if (active !== requestedProfile) {
-          await this.controlled('activate-profile', () => this.controller.activateProfile(requestedProfile))
+        if (!this.profileIsExactly(requestedProfile)) {
+          const approved = await this.requestControl({
+            command: 'activate-profile',
+            url: this.controller.getState().url,
+            surface: 'browser',
+            level: levelForCommand('activate-profile'),
+          })
+          if (!approved) throw new BrowserControlDeniedError()
         }
+        this.profileScope.enterWith({ name: requestedProfile, held: false })
+        // The long-polling routes (`/wait`, `/wait-login`, `/wait-download`)
+        // deliberately run outside the lock so one agent's wait cannot block
+        // the rest, which means they cannot pin the identity themselves. Taking
+        // one empty turn puts it in place for them up front. For every other
+        // route this is a no-op: they re-check under their own turn anyway.
+        await this.exclusive(() => undefined)
       }
       if (req.method === 'POST' && route === '/open') {
         const body = await readJson(req)
@@ -443,8 +465,36 @@ export class BrowserAgentBridge {
     }
   }
 
+  /** Is the browser carrying exactly this profile and nothing else? Several
+   *  profiles can be enabled at once, so "one of them is the right one" is not
+   *  good enough for a command that asked to run as a single identity. */
+  private profileIsExactly(name: string): boolean {
+    const enabled = this.controller.activeProfileNames()
+    return enabled.length === 1 && enabled[0] === name
+  }
+
+  /** Run `operation` as the browser's only in-flight operation. When the
+   *  request named a profile, the switch to it happens inside the same turn, so
+   *  a command can never end up running under an identity another agent
+   *  switched to while this one was queued. */
   private async exclusive<T>(operation: () => Promise<T> | T): Promise<T> {
-    const result = this.operationTail.then(operation, operation)
+    const scope = this.profileScope.getStore()
+    // Already inside this request's turn (a route that locks twice, or
+    // `controlled` locking around an operation): re-queueing would deadlock.
+    if (scope?.held) return await operation()
+    const run = async (): Promise<T> => {
+      if (!scope) return await operation()
+      scope.held = true
+      try {
+        // Re-checked here rather than before the queue: another agent may have
+        // switched the browser while this request waited its turn.
+        if (!this.profileIsExactly(scope.name)) await this.controller.activateProfile(scope.name)
+        return await operation()
+      } finally {
+        scope.held = false
+      }
+    }
+    const result = this.operationTail.then(run, run)
     this.operationTail = result.then(() => undefined, () => undefined)
     return await result
   }

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -51,7 +51,12 @@ The browser can save and restore named sessions ("profiles") - the cookies and
 per-site storage that keep a site signed in - so you can switch identity for a
 task or carry a session to another machine.
 
-- `profile list` - names of saved profiles plus which one is active
+The user can have several profiles in use at once, so the browser may be
+carrying more than one login (a work identity and a personal one, say).
+Enabling and disabling profiles is theirs to do - you can see the set, and you
+can borrow one for a command, but you cannot change which ones they keep on.
+
+- `profile list` - saved profiles, with every one currently in use flagged
 - `profile save <name>` - snapshot the current session into a named profile
 - `profile import <path> [name]` - import a session file (a Codey profile or
   a Playwright storageState JSON) and activate it in one step
@@ -60,12 +65,18 @@ task or carry a session to another machine.
 - `profile delete <name>` - remove a saved profile
 
 To run a command under a specific profile, put `--profile <name>` before the
-command - the profile is activated first if it is not already (an identity
-switch, so the user is asked to approve it):
+command. That command then runs under that profile and nothing else, so a task
+meant for one identity cannot reach for another's cookies. It is an identity
+switch, so the user is asked to approve it, and the switch happens as part of
+the command itself - another agent working in the same browser cannot slip its
+own profile in between:
 
 ```
 ELECTRON_RUN_AS_NODE=1 "$CODEY_BROWSER_RUNTIME" "$CODEY_BROWSER_CLI" --profile work open-view "https://github.com"
 ```
+
+Note this leaves that profile in use afterwards: it does not put back whatever
+set was enabled before. Say so if that matters to the user.
 
 `state` reports the active profile. Activating a profile replaces the
 session's cookies with the profile's (an identity switch, so the previous


### PR DESCRIPTION
> Stacked on #391 — it needs `activeProfileNames`. Base is `browser-multi-active`; retarget to `main` once #391 lands.

`--profile personal` is how an agent says *"do this as me, not as the other identity in this browser"*. It switched the profile before dispatching the command and then took the operation lock separately, so the two were never one action. With two agents working:

```
A switches to personal.  B switches to work.  A's command runs — as work.
```

Nothing reports this. The agent believes it acted as personal, and it acted as someone else on a site it was signed into.

## The fix

- The switch now happens **inside the same lock turn as the command**, and re-checks under that turn rather than trusting a check made before queueing.
- **Asking stays outside the lock on purpose.** A permission prompt can sit unanswered for as long as the user takes; holding the browser hostage meanwhile would stall every other agent.
- The long-polling routes (`/wait`, `/wait-login`, `/wait-download`) run outside the lock so one agent's wait cannot block the rest, which means they cannot pin the identity themselves. The request takes one empty turn up front to put it in place for them.

Also fixes the check itself: it compared a single active name, which stopped being the whole truth once several profiles could be in use at once. *"One of the enabled profiles is the right one"* is not good enough for a command that asked to run as a single identity.

## Doc

The skill doc now tells the model that the user may have several logins in use, that `--profile` narrows to one **for that command**, and that it does not put the previous set back.

## Verification

`npm test` (891 tests, all passing), `tsc --noEmit` clean, `npm run lint` clean.

The new test was checked **both ways**: against the previous shape (switch up front, no re-check) it fails with `['', 'work', 'work']` — the personal agent running as work — and passes with the fix.

Not yet exercised on a real machine.

## Still open after this

Agents take turns; they are not isolated. One browser, one cookie jar, so two agents cannot hold different identities *at the same time* — that would need a partition per profile, which turns profiles from snapshots into live browser instances. Worth doing separately, if at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)