### PR TITLE
feat(browser): give every profile its own refresh button

### DIFF
--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -603,6 +603,48 @@ describe('BrowserController profiles', () => {
     }
   })
 
+  it('refreshes a whole profile from a multi-site export, in use or not', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller, cookiesSet } = makeFixture(dir)
+      const store = new BrowserProfileStore(dir)
+      const cookie = (domain: string, value: string) => ({
+        name: 'session', value, domain, path: '/', expires: -1,
+        httpOnly: true, secure: true, sameSite: 'lax' as const,
+      })
+      store.write('work', {
+        cookies: [cookie('github.com', 'old'), cookie('jira.example.com', 'keep')],
+        origins: [],
+      }, null)
+
+      // Every domain the profile holds is what a refresh has to ask about.
+      expect(controller.profileSites('work').sort()).toEqual(['github.com', 'jira.example.com'])
+
+      // Chrome answered for github.com only; the other site must survive.
+      const refreshed = await controller.resyncProfileSites('work', {
+        json: JSON.stringify({ cookies: [cookie('github.com', 'fresh')], origins: [] }),
+      }, ['github.com'])
+      expect(refreshed.cookies.map(entry => [entry.domain, entry.value])).toEqual([
+        ['jira.example.com', 'keep'],
+        ['github.com', 'fresh'],
+      ])
+
+      // A profile that is not enabled is refreshed on disk without touching
+      // the live session.
+      expect(cookiesSet).not.toHaveBeenCalled()
+
+      // Once it is in use, refreshing re-applies it.
+      await controller.enableProfile('work')
+      cookiesSet.mockClear()
+      await controller.resyncProfileSites('work', {
+        json: JSON.stringify({ cookies: [cookie('github.com', 'newer')], origins: [] }),
+      }, ['github.com'])
+      expect(cookiesSet.mock.calls.map(call => (call as any[])[0].value).sort()).toEqual(['keep', 'newer'])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('rejects unsafe profile names', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
     try {

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -15,6 +15,7 @@ import {
   conflictingCookie,
   cookieMatchesUrl,
   mergeProfileData,
+  mergeProfileSites,
   parseProfileJsonText,
   readProfileJson,
   type BrowserProfile,
@@ -1030,6 +1031,35 @@ export class BrowserController {
     const existing = this.profiles().read(name)
     const merged = mergeProfileData(existing, parseProfileJsonText(source.json), scopeUrl)
     const profile = this.profiles().write(name, merged, existing.sourceUrl ?? scopeUrl)
+    if (this.profiles().activeNames().includes(name)) await this.applyLiveProfiles()
+    return profile
+  }
+
+  /** The registrable domains a profile holds cookies for - what a refresh of
+   *  the whole profile has to ask Chrome about. */
+  profileSites(name: string): string[] {
+    assertProfileName(name)
+    const seen = new Set<string>()
+    for (const cookie of this.profiles().read(name).cookies) {
+      const domain = cookie.domain.replace(/^\./, '').toLowerCase()
+      if (domain) seen.add(domain)
+    }
+    return [...seen]
+  }
+
+  /** Refresh every site a profile holds from a fresh multi-site export, so one
+   *  click brings a whole saved identity back up to date. Only the sites the
+   *  export covers are replaced; anything the profile holds from elsewhere
+   *  survives. Refreshing an enabled profile re-applies the live session too. */
+  async resyncProfileSites(
+    name: string,
+    source: { json: string },
+    sites: readonly string[],
+  ): Promise<BrowserProfile> {
+    assertProfileName(name)
+    const existing = this.profiles().read(name)
+    const merged = mergeProfileSites(existing, parseProfileJsonText(source.json), sites)
+    const profile = this.profiles().write(name, merged, existing.sourceUrl)
     if (this.profiles().activeNames().includes(name)) await this.applyLiveProfiles()
     return profile
   }

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -10,6 +10,8 @@ import {
   conflictingCookie,
   cookieMatchesUrl,
   mergeProfileData,
+  mergeProfileSites,
+  siteCoversHost,
   deriveProfileNameFromFile,
   parseProfileData,
   parseProfileJsonText,
@@ -351,5 +353,48 @@ describe('conflictingCookie', () => {
     }
     expect(conflictingCookie(withValue('work'), other)).toBeNull()
     expect(conflictingCookie({ cookies: [], origins: [] }, withValue('work'))).toBeNull()
+  })
+})
+
+describe('siteCoversHost / mergeProfileSites', () => {
+  it('covers a site and its subdomains, and nothing that merely ends alike', () => {
+    expect(siteCoversHost('github.com', 'github.com')).toBe(true)
+    expect(siteCoversHost('github.com', 'api.github.com')).toBe(true)
+    expect(siteCoversHost('github.com', '.github.com')).toBe(true)
+    expect(siteCoversHost('github.com', 'notgithub.com')).toBe(false)
+    expect(siteCoversHost('', 'github.com')).toBe(false)
+  })
+
+  const cookie = (domain: string, value: string) => ({
+    name: 'session', value, domain, path: '/', expires: -1,
+    httpOnly: true, secure: true, sameSite: 'lax' as const,
+  })
+
+  it('replaces only the sites the refresh covers', () => {
+    const existing = {
+      cookies: [cookie('github.com', 'old'), cookie('api.github.com', 'old'), cookie('gitlab.com', 'keep')],
+      origins: [
+        { origin: 'https://github.com', localStorage: [{ name: 'token', value: 'old' }] },
+        { origin: 'https://gitlab.com', localStorage: [{ name: 'token', value: 'keep' }] },
+      ],
+    }
+    const incoming = {
+      cookies: [cookie('github.com', 'fresh')],
+      origins: [{ origin: 'https://github.com', localStorage: [{ name: 'token', value: 'fresh' }] }],
+    }
+    const merged = mergeProfileSites(existing, incoming, ['github.com'])
+    expect(merged.cookies.map(entry => [entry.domain, entry.value])).toEqual([
+      ['gitlab.com', 'keep'],
+      ['github.com', 'fresh'],
+    ])
+    expect(merged.origins).toEqual([
+      { origin: 'https://gitlab.com', localStorage: [{ name: 'token', value: 'keep' }] },
+      { origin: 'https://github.com', localStorage: [{ name: 'token', value: 'fresh' }] },
+    ])
+  })
+
+  it('leaves a profile untouched when the refresh covered nothing', () => {
+    const existing = { cookies: [cookie('gitlab.com', 'keep')], origins: [] }
+    expect(mergeProfileSites(existing, { cookies: [], origins: [] }, [])).toEqual(existing)
   })
 })

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -285,6 +285,43 @@ export function conflictingCookie(
   return null
 }
 
+/** Does `site` (a registrable domain, as Chrome grouped it) cover `host`?
+ *  Used to decide which of a profile's cookies a refresh of that site speaks
+ *  for, without needing the public-suffix guesswork on this side: the sites
+ *  come back from the extension already folded. */
+export function siteCoversHost(site: string, host: string): boolean {
+  const left = site.replace(/^\./, '').toLowerCase()
+  const right = host.replace(/^\./, '').toLowerCase()
+  return !!left && (right === left || right.endsWith(`.${left}`))
+}
+
+/** Fold a fresh multi-site export into a profile. Only the sites the export
+ *  covers are replaced - everything else the profile holds is left alone, so
+ *  refreshing what Chrome knows about cannot delete a login that came from
+ *  somewhere else. Replacing rather than layering means a cookie the site has
+ *  dropped disappears instead of lingering as a stale credential. */
+export function mergeProfileSites(
+  existing: BrowserProfileData,
+  incoming: BrowserProfileData,
+  sites: readonly string[],
+): BrowserProfileData {
+  const covers = (host: string) => sites.some(site => siteCoversHost(site, host));
+  const originHost = (origin: string) => {
+    try {
+      return new URL(origin).hostname
+    } catch {
+      return ''
+    }
+  }
+  return {
+    cookies: [...existing.cookies.filter(cookie => !covers(cookie.domain)), ...incoming.cookies],
+    origins: [
+      ...existing.origins.filter(origin => !covers(originHost(origin.origin))),
+      ...incoming.origins,
+    ],
+  }
+}
+
 /** File store for profiles. One \`.json\` per profile plus a dot-file that
  *  records which profile is enabled. */
 export class BrowserProfileStore {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2374,6 +2374,25 @@ app.whenReady().then(async () => {
   // It is scoped to that one site, so a profile carrying several logins keeps
   // the rest, and it names the URL rather than using Chrome's front tab - the
   // user is looking at the signed-out page here, not over there.
+  // A profile's own Sync button: refresh every site that profile holds from
+  // Chrome in one go. Named explicitly, so it works for a profile that is not
+  // even enabled - a saved identity can be brought up to date before it is
+  // switched on.
+  ipcMain.handle('browser:profiles:syncProfile', (event, name: string) => browserCall(event, async () => {
+    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+    if (!chromeCompanion.status().connected) throw new Error('Connect the Codey extension in Chrome first')
+    const requested = String(name || '').trim()
+    assertProfileName(requested)
+    const sites = browserController.profileSites(requested)
+    if (sites.length === 0) throw new Error(`"${requested}" holds no logins yet - there is nothing to refresh`)
+    const session = await chromeCompanion.exportSessionForSites(sites)
+    await browserController.resyncProfileSites(requested, {
+      json: JSON.stringify({ cookies: session.cookies, origins: session.origins }),
+    }, session.sites)
+    const profile = browserController.listProfiles().find(item => item.name === requested)
+    if (!profile) throw new Error(`"${requested}" was refreshed but could not be read back`)
+    return { profile, siteCount: session.sites.length, cookieCount: session.cookies.length }
+  }))
   ipcMain.handle('browser:profiles:syncFromChrome', (event, url: string) => browserCall(event, async () => {
     if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
     if (!chromeCompanion.status().connected) throw new Error('Connect the Codey extension in Chrome first')
@@ -2542,24 +2561,6 @@ app.whenReady().then(async () => {
     const profile = browserController.listProfiles().find(item => item.name === requested)
     if (!profile) throw new Error('Chrome sessions were imported but the Codey Browser profile could not be found')
     return { imported: true, profile, cookieCount: sessionState.cookies.length, sites: sessionState.sites }
-  }))
-  // The counterpart to exportSession: the profile must already exist, and only
-  // the current site's part of it is replaced, so a login renewed in Chrome can
-  // be refreshed without the profile's other sites being lost.
-  ipcMain.handle('chromeCompanion:resyncSession', (event, name: string) => browserCall(event, async () => {
-    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
-    const requested = String(name || '').trim()
-    assertProfileName(requested)
-    if (!browserController.listProfiles().some(profile => profile.name === requested)) {
-      throw new Error(`No Codey Browser profile named "${requested}" \u2014 create one first`)
-    }
-    const sessionState = await chromeCompanion.exportSession()
-    await browserController.resyncProfile(requested, {
-      json: JSON.stringify({ cookies: sessionState.cookies, origins: sessionState.origins }),
-    }, sessionState.tab.url)
-    const profile = browserController.listProfiles().find(item => item.name === requested)
-    if (!profile) throw new Error('Chrome session was re-synced but its Codey Browser profile could not be found')
-    return { profile, tab: sessionState.tab }
   }))
   ipcMain.handle('chromeCompanion:navigate', (event, url: string) => browserCall(event, () => {
     if (!chromeCompanion) throw new Error('Chrome companion is unavailable')

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -472,7 +472,6 @@ contextBridge.exposeInMainWorld('codey', {
     exportSession: (name: string) => ipcRenderer.invoke('chromeCompanion:exportSession', name),
     listSessionSites: () => ipcRenderer.invoke('chromeCompanion:listSessionSites'),
     importSites: (name: string, sites: string[]) => ipcRenderer.invoke('chromeCompanion:importSites', name, sites),
-    resyncSession: (name: string) => ipcRenderer.invoke('chromeCompanion:resyncSession', name),
     navigate: (url: string) => ipcRenderer.invoke('chromeCompanion:navigate', url),
     setAccent: (hex: string) => ipcRenderer.invoke('chromeCompanion:setAccent', hex),
     showExtensionFolder: () => ipcRenderer.invoke('chromeCompanion:showExtensionFolder'),
@@ -514,6 +513,7 @@ contextBridge.exposeInMainWorld('codey', {
       import: () => ipcRenderer.invoke('browser:profiles:import'),
       export: (name: string) => ipcRenderer.invoke('browser:profiles:export', name),
       syncFromChrome: (url: string) => ipcRenderer.invoke('browser:profiles:syncFromChrome', url),
+      syncProfile: (name: string) => ipcRenderer.invoke('browser:profiles:syncProfile', name),
     },
     extensions: {
       list: () => ipcRenderer.invoke('browser:extensions:list'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -632,7 +632,6 @@ declare global {
           cookieCount: number
           sites: string[]
         }>>
-        resyncSession: (name: string) => Promise<IpcResult<{ profile: BrowserProfileSummary; tab: ChromeTabInfo }>>
         navigate: (url: string) => Promise<IpcResult<ChromeTabInfo>>
         setAccent: (hex: string) => Promise<IpcResult<{ ok: true }>>
         showExtensionFolder: () => Promise<IpcResult<string>>
@@ -668,6 +667,11 @@ declare global {
           import: () => Promise<IpcResult<{ imported: boolean; profile: BrowserProfileSummary | null }>>
           export: (name: string) => Promise<IpcResult<{ exported: boolean; path: string | null }>>
           syncFromChrome: (url: string) => Promise<IpcResult<{ profileName: string; origin: string; cookieCount: number }>>
+          syncProfile: (name: string) => Promise<IpcResult<{
+            profile: BrowserProfileSummary
+            siteCount: number
+            cookieCount: number
+          }>>
         }
         extensions: {
           list: () => Promise<IpcResult<BrowserExtensionEntry[]>>

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -310,18 +310,23 @@ export const BrowserPanel: React.FC<Props> = ({
     }
   }
 
-  // "Only this one" is still worth one click: it is the identity switch, and
-  // it is the way out of a set that has grown confusing.
-  const activateProfile = async (name: string) => {
+  // Refresh one profile's saved logins from Chrome, whether or not it is in
+  // use. The menu stays open: this is maintenance, not a choice.
+  const syncProfile = async (name: string) => {
     setProfileBusy(true)
+    setSyncNote(null)
     try {
-      const result = await window.codey.browser.profiles.activate(name)
-      if (!result.ok) setLocalError(result.error)
-      else setLocalError(null)
+      const result = await window.codey.browser.profiles.syncProfile(name)
+      if (!result.ok) {
+        setLocalError(result.error)
+        return
+      }
+      setLocalError(null)
+      setSyncNote(`Refreshed “${name}”: ${result.data.cookieCount} cookies from ${result.data.siteCount} site${result.data.siteCount === 1 ? '' : 's'}`)
       await refreshProfiles()
+      await run(() => window.codey.browser.reload())
     } finally {
       setProfileBusy(false)
-      setProfileMenuOpen(false)
     }
   }
 
@@ -656,15 +661,14 @@ export const BrowserPanel: React.FC<Props> = ({
                 <span style={styles.profileMenuName}>{profile.name}</span>
                 <span aria-hidden="true" style={styles.profileMenuCheck}>{profile.active ? '✓' : ''}</span>
               </button>
-              {!(profile.active && enabledProfiles.length === 1) && (
-                <button
-                  type="button"
-                  style={styles.profileMenuOnly}
-                  disabled={profileBusy}
-                  title={`Use only ${profile.name}, turning the others off`}
-                  onClick={() => void activateProfile(profile.name)}
-                >Only</button>
-              )}
+              <button
+                type="button"
+                style={styles.profileMenuSync}
+                disabled={profileBusy}
+                title={`Refresh every login in ${profile.name} from Chrome`}
+                aria-label={`Refresh ${profile.name} from Chrome`}
+                onClick={() => void syncProfile(profile.name)}
+              ><UIIcon name="refresh" size={12} /></button>
             </div>
           ))}
           {enabledProfiles.length > 1 && (
@@ -1133,7 +1137,7 @@ const styles: Record<string, React.CSSProperties> = {
   profileMenuAvatar: { width: 20, flexShrink: 0, textAlign: 'center', fontSize: 15 },
   profileMenuName: { flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   profileMenuRow: { display: 'flex', alignItems: 'center', gap: 2 },
-  profileMenuOnly: { flexShrink: 0, marginRight: 4, padding: '3px 7px', border: 'none', borderRadius: 6, background: 'transparent', color: C.fg3, cursor: 'pointer', fontSize: 10 },
+  profileMenuSync: { flexShrink: 0, display: 'flex', alignItems: 'center', marginRight: 4, padding: '3px 6px', border: 'none', borderRadius: 6, background: 'transparent', color: C.fg3, cursor: 'pointer' },
   profileMenuNote: { padding: '4px 10px 6px', color: C.fg3, fontSize: 10, lineHeight: 1.4 },
   profileMenuDivider: { height: 1, margin: '4px 0', background: C.border },
   contextButton: { height: 31, padding: '0 10px', border: `1px solid ${C.accent}66`, borderRadius: 7, display: 'flex', alignItems: 'center', gap: 6, background: C.accentDim, color: C.accent, cursor: 'pointer', fontSize: 11, fontWeight: 650, whiteSpace: 'nowrap' },

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -26,6 +26,7 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
   const [name, setName] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [synced, setSynced] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
   // True once the user tried to save with an empty name. Greying the button
   // out hid what was missing, so say it and mark the field instead.
@@ -52,13 +53,12 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
     }
   }, [])
 
-  const activeCount = profiles.filter(profile => profile.active).length
-
   useEffect(() => { void refresh() }, [refresh])
 
   const run = async (action: () => Promise<IpcLike>) => {
     setBusy(true)
     setError(null)
+    setSynced(null)
     try {
       const result = await action()
       if (!result.ok) setError(result.error ?? 'Something went wrong')
@@ -109,6 +109,12 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
         <div style={{
           background: C.red + '22', color: C.red, padding: '8px 10px', borderRadius: 8, fontSize: compact ? 11 : 12,
         }}>{error}</div>
+      )}
+
+      {synced && !error && (
+        <div style={{
+          background: C.green + '22', color: C.green, padding: '8px 10px', borderRadius: 8, fontSize: compact ? 11 : 12,
+        }}>{synced}. Chrome was not changed.</div>
       )}
 
       <div style={compact ? styles.compactComposer : styles.composer}>
@@ -199,9 +205,8 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
               {meta(profile) || (profile.sourceUrl ? 'saved session' : 'empty profile')}
             </div>
           </div>
-          {/* Several profiles can be on at once, so this turns one on or off
-              rather than switching to it. "Only" is the identity switch, and it
-              is offered whenever it would actually change something. */}
+          {/* Several profiles can be on at once, so a profile is simply in use
+              or not. There is nothing to switch between. */}
           <button
             type="button"
             disabled={busy}
@@ -215,15 +220,22 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
           >
             {profile.active ? 'In use' : 'Use'}
           </button>
-          {!(profile.active && activeCount === 1) && (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => void run(() => window.codey.browser.profiles.activate(profile.name))}
-              style={buttonStyle(compact)}
-              title={`Use only ${profile.name}, turning every other profile off`}
-            >Only</button>
-          )}
+          {/* Logins expire. Refreshing the whole profile from Chrome is one
+              click here, and works whether or not it is currently in use. */}
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void run(async () => {
+              const result = await window.codey.browser.profiles.syncProfile(profile.name)
+              if (result.ok) {
+                setSynced(`\u201c${profile.name}\u201d refreshed: ${result.data.cookieCount} cookies from ${result.data.siteCount} site${result.data.siteCount === 1 ? '' : 's'}`)
+              }
+              return result
+            })}
+            style={buttonStyle(compact)}
+            title={`Refresh every login in ${profile.name} from Chrome`}
+            aria-label={`Refresh ${profile.name} from Chrome`}
+          ><UIIcon name="refresh" size={12} /></button>
           <button
             type="button"
             disabled={busy}

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -26,7 +26,6 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
   const [error, setError] = useState<string | null>(null)
   const [profileName, setProfileName] = useState('chrome-session')
   const [exported, setExported] = useState<string | null>(null)
-  const [resynced, setResynced] = useState<string | null>(null)
   const [installedPath, setInstalledPath] = useState<string | null>(null)
   const [sites, setSites] = useState<ChromeSessionSite[] | null>(null)
   const [picked, setPicked] = useState<Set<string>>(new Set())
@@ -130,7 +129,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
               <input
                 style={styles.input}
                 value={profileName}
-                onChange={event => { setProfileName(event.target.value); setExported(null); setResynced(null) }}
+                onChange={event => { setProfileName(event.target.value); setExported(null) }}
                 placeholder="chrome-session"
                 aria-label="New Codey Browser profile name"
                 spellCheck={false}
@@ -138,31 +137,18 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
             </label>
             <button style={styles.primary} disabled={busy || !status.connected || !profileName.trim()} onClick={() => void run(async () => {
               const next = useResult(await window.codey.chromeCompanion.exportSession(profileName.trim()))
-              if (next) {
-                setExported(next.profile.name)
-                setResynced(null)
-              }
+              if (next) setExported(next.profile.name)
             })}>Create &amp; activate profile</button>
           </div>
           {exported && (
             <div style={styles.success}>“{exported}” is now the active Codey Browser profile. Chrome was not changed.</div>
           )}
-          {/* Logins expire, and a profile copied months ago is worth refreshing
-              rather than recreating - recreating would lose the profile's other
-              sites and its place in the switcher. */}
-          <div style={styles.actions}>
-            <span style={styles.copy}>Signed in again in Chrome? Refresh a profile you already have instead.</span>
-            <button style={styles.secondary} disabled={busy || !status.connected || !profileName.trim()} onClick={() => void run(async () => {
-              const next = useResult(await window.codey.chromeCompanion.resyncSession(profileName.trim()))
-              if (next) {
-                setResynced(next.profile.name)
-                setExported(null)
-              }
-            })}>Re-sync existing profile</button>
+          {/* Keeping a profile up to date belongs with the profile, not here:
+              refreshing is one button per profile in the Codey Browser. This
+              page only creates them. */}
+          <div style={styles.copy}>
+            Already have a profile for this login? Refresh it from the Codey Browser — every profile has its own refresh button.
           </div>
-          {resynced && (
-            <div style={styles.success}>“{resynced}” now carries this site’s current Chrome login. Its other saved sites were left alone.</div>
-          )}
         </div>
       )}
 


### PR DESCRIPTION
Refreshing a saved login lived on the Chrome side, which is backwards. Chrome is where a profile is *created*; keeping it current belongs with the profile itself, next to the switch that turns it on.

## What changes

**Every profile row gets a refresh button** — in the browser toolbar menu and in Settings ▸ Profiles. It asks Chrome for every site that profile holds and folds the answers back in, so one click brings a whole saved identity up to date.

- Works on a profile that is **not in use**, too: a stale identity can be brought current before it is switched on.
- Only the sites the refresh covered are replaced, so a profile that also carries a login imported from somewhere else keeps it — and a cookie the site has dropped disappears rather than lingering as a stale credential.
- Refreshing a profile that *is* in use re-applies the live session.

**"Only" is gone** from both profile lists. Now that several profiles can be in use at once, a profile is simply in use or not — there is nothing to switch between, and offering a switch invited the question of what the others were for.

**The Chrome settings page loses "Re-sync existing profile"** and says where refreshing lives now. That page creates profiles; that is all it needs to do. Its IPC went with it rather than being left dead.

## Verification

`npm test` (900 tests, all passing), `tsc --noEmit` clean, `npm run lint` clean.

New tests cover the site-coverage rule (`api.github.com` is covered by `github.com`, `notgithub.com` is not), that a refresh replaces only the sites it covered, that a profile is left untouched when nothing was covered, and that refreshing touches the live session only when the profile is in use.

Not yet exercised on a real machine.

## One thing left deliberately alone

The **Chrome side panel** still has its per-site "Re-sync" row (from #386). It is the only Chrome-side refresh path remaining. Removing it would make the split completely clean — *Chrome creates, Codey Browser refreshes* — but it is genuinely handy when you are already looking at the site in Chrome, so it seemed worth asking about rather than deleting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)