### PR TITLE
feat(browser): show what a profile actually holds

### DIFF
--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -645,6 +645,32 @@ describe('BrowserController profiles', () => {
     }
   })
 
+  it('describes what a profile holds without handing over its secrets', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
+    try {
+      const { controller } = makeFixture(dir)
+      new BrowserProfileStore(dir).write('work', {
+        cookies: [{
+          name: 'session', value: 'SUPER-SECRET', domain: 'github.com', path: '/', expires: -1,
+          httpOnly: true, secure: true, sameSite: 'lax' as const,
+        }],
+        origins: [{ origin: 'https://github.com', localStorage: [{ name: 'token', value: 'ALSO-SECRET' }] }],
+      }, 'https://github.com/')
+
+      const contents = controller.profileContents('work')
+      expect(contents).toMatchObject({ name: 'work', sourceUrl: 'https://github.com/' })
+      expect(contents.sites).toEqual([{
+        domain: 'github.com',
+        cookieCount: 1,
+        cookieNames: ['session'],
+        storage: [{ origin: 'https://github.com', keys: 1 }],
+      }])
+      expect(JSON.stringify(contents)).not.toContain('SECRET')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('rejects unsafe profile names', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
     try {

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -17,10 +17,12 @@ import {
   mergeProfileData,
   mergeProfileSites,
   parseProfileJsonText,
+  summarizeProfileSites,
   readProfileJson,
   type BrowserProfile,
   type BrowserProfileCookie,
   type BrowserProfileData,
+  type BrowserProfileSiteSummary,
   type BrowserProfileStorageOrigin,
   type BrowserProfileSummary,
 } from './browser-profiles'
@@ -1033,6 +1035,25 @@ export class BrowserController {
     const profile = this.profiles().write(name, merged, existing.sourceUrl ?? scopeUrl)
     if (this.profiles().activeNames().includes(name)) await this.applyLiveProfiles()
     return profile
+  }
+
+  /** What a saved profile actually holds, site by site, so it can be looked at
+   *  before it is trusted or refreshed. Values are left behind on purpose -
+   *  the caller wants to know which logins are in there, not what they are. */
+  profileContents(name: string): {
+    name: string
+    updatedAt: number
+    sourceUrl: string | null
+    sites: BrowserProfileSiteSummary[]
+  } {
+    assertProfileName(name)
+    const profile = this.profiles().read(name)
+    return {
+      name,
+      updatedAt: profile.updatedAt,
+      sourceUrl: profile.sourceUrl,
+      sites: summarizeProfileSites(profile),
+    }
   }
 
   /** The registrable domains a profile holds cookies for - what a refresh of

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -12,6 +12,7 @@ import {
   mergeProfileData,
   mergeProfileSites,
   siteCoversHost,
+  summarizeProfileSites,
   deriveProfileNameFromFile,
   parseProfileData,
   parseProfileJsonText,
@@ -396,5 +397,48 @@ describe('siteCoversHost / mergeProfileSites', () => {
   it('leaves a profile untouched when the refresh covered nothing', () => {
     const existing = { cookies: [cookie('gitlab.com', 'keep')], origins: [] }
     expect(mergeProfileSites(existing, { cookies: [], origins: [] }, [])).toEqual(existing)
+  })
+})
+
+describe('summarizeProfileSites', () => {
+  const data = {
+    cookies: [
+      { name: 'session', value: 'SECRET-A', domain: 'github.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'lax' as const },
+      { name: 'csrf', value: 'SECRET-B', domain: '.github.com', path: '/', expires: -1, httpOnly: false, secure: true, sameSite: 'lax' as const },
+      { name: 'sid', value: 'SECRET-C', domain: 'jira.example.com', path: '/', expires: -1, httpOnly: true, secure: true, sameSite: 'lax' as const },
+    ],
+    origins: [
+      { origin: 'https://github.com', localStorage: [{ name: 'token', value: 'SECRET-D' }, { name: 'theme', value: 'dark' }] },
+    ],
+  }
+
+  it('groups by domain, most cookies first, folding the leading dot away', () => {
+    const sites = summarizeProfileSites(data)
+    expect(sites.map(site => [site.domain, site.cookieCount])).toEqual([
+      ['github.com', 2],
+      ['jira.example.com', 1],
+    ])
+    expect(sites[0].cookieNames).toEqual(['session', 'csrf'])
+    expect(sites[0].storage).toEqual([{ origin: 'https://github.com', keys: 2 }])
+  })
+
+  it('never carries a single value out of the profile', () => {
+    // This is the whole point of the summary: it says which logins are in
+    // there, never what they are. A regression here leaks credentials into a
+    // window that has no use for them.
+    const serialized = JSON.stringify(summarizeProfileSites(data))
+    for (const secret of ['SECRET-A', 'SECRET-B', 'SECRET-C', 'SECRET-D', 'dark']) {
+      expect(serialized).not.toContain(secret)
+    }
+  })
+
+  it('lists an origin that has storage but no cookies', () => {
+    const sites = summarizeProfileSites({
+      cookies: [],
+      origins: [{ origin: 'https://app.example.com', localStorage: [{ name: 'token', value: 'x' }] }],
+    })
+    expect(sites).toEqual([
+      { domain: 'app.example.com', cookieCount: 0, cookieNames: [], storage: [{ origin: 'https://app.example.com', keys: 1 }] },
+    ])
   })
 })

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -322,6 +322,48 @@ export function mergeProfileSites(
   }
 }
 
+/** What one site inside a profile holds, described without the secrets. Cookie
+ *  and localStorage *values* are deliberately absent: the point is to let
+ *  someone see which logins a profile carries, not to hand the logins to a
+ *  window that has no use for them. Names are kept - they are what tells a
+ *  session cookie apart from a theme preference at a glance. */
+export interface BrowserProfileSiteSummary {
+  domain: string
+  cookieCount: number
+  cookieNames: string[]
+  storage: Array<{ origin: string; keys: number }>
+}
+
+/** Describe a profile site by site, most cookies first. */
+export function summarizeProfileSites(data: BrowserProfileData): BrowserProfileSiteSummary[] {
+  const rows = new Map<string, BrowserProfileSiteSummary>()
+  const rowFor = (host: string): BrowserProfileSiteSummary => {
+    const domain = host.replace(/^\./, '').toLowerCase()
+    let row = rows.get(domain)
+    if (!row) {
+      row = { domain, cookieCount: 0, cookieNames: [], storage: [] }
+      rows.set(domain, row)
+    }
+    return row
+  }
+  for (const cookie of data.cookies) {
+    const row = rowFor(cookie.domain)
+    row.cookieCount += 1
+    if (!row.cookieNames.includes(cookie.name)) row.cookieNames.push(cookie.name)
+  }
+  for (const origin of data.origins) {
+    let host = origin.origin
+    try {
+      host = new URL(origin.origin).hostname
+    } catch {
+      // An origin we cannot parse still deserves a row under its own text.
+    }
+    rowFor(host).storage.push({ origin: origin.origin, keys: origin.localStorage.length })
+  }
+  return [...rows.values()].sort((left, right) =>
+    right.cookieCount - left.cookieCount || left.domain.localeCompare(right.domain))
+}
+
 /** File store for profiles. One \`.json\` per profile plus a dot-file that
  *  records which profile is enabled. */
 export class BrowserProfileStore {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2374,6 +2374,10 @@ app.whenReady().then(async () => {
   // It is scoped to that one site, so a profile carrying several logins keeps
   // the rest, and it names the URL rather than using Chrome's front tab - the
   // user is looking at the signed-out page here, not over there.
+  // What a profile holds, for the disclosure in Settings > Profiles. Cookie and
+  // storage values never come back - the window has no use for them.
+  ipcMain.handle('browser:profiles:contents', (event, name: string) =>
+    browserCall(event, () => browserController.profileContents(String(name || ''))))
   // A profile's own Sync button: refresh every site that profile holds from
   // Chrome in one go. Named explicitly, so it works for a profile that is not
   // even enabled - a saved identity can be brought up to date before it is

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -514,6 +514,7 @@ contextBridge.exposeInMainWorld('codey', {
       export: (name: string) => ipcRenderer.invoke('browser:profiles:export', name),
       syncFromChrome: (url: string) => ipcRenderer.invoke('browser:profiles:syncFromChrome', url),
       syncProfile: (name: string) => ipcRenderer.invoke('browser:profiles:syncProfile', name),
+      contents: (name: string) => ipcRenderer.invoke('browser:profiles:contents', name),
     },
     extensions: {
       list: () => ipcRenderer.invoke('browser:extensions:list'),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -264,6 +264,16 @@ export interface ChromeTabInfo {
 /** One site the paired Chrome profile holds cookies for. `openTabs` decides
  *  whether its localStorage can come along - it can only be read from a page
  *  that is actually open. */
+/** What one site inside a saved profile holds. Cookie and storage *values* are
+ *  deliberately absent - this describes which logins a profile carries, not
+ *  what they are. */
+export interface BrowserProfileSiteSummary {
+  domain: string
+  cookieCount: number
+  cookieNames: string[]
+  storage: Array<{ origin: string; keys: number }>
+}
+
 export interface ChromeSessionSite {
   site: string
   cookieCount: number
@@ -671,6 +681,12 @@ declare global {
             profile: BrowserProfileSummary
             siteCount: number
             cookieCount: number
+          }>>
+          contents: (name: string) => Promise<IpcResult<{
+            name: string
+            updatedAt: number
+            sourceUrl: string | null
+            sites: BrowserProfileSiteSummary[]
           }>>
         }
         extensions: {

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -1,8 +1,15 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
 import { UIIcon } from './UIIcons'
-import type { BrowserProfileSummary } from '../codey-api'
+import type { BrowserProfileSiteSummary, BrowserProfileSummary } from '../codey-api'
 import { BROWSER_PROFILE_AVATARS, browserProfileAvatar } from './browserProfileAvatars'
+
+type BrowserProfileContents = {
+  name: string
+  updatedAt: number
+  sourceUrl: string | null
+  sites: BrowserProfileSiteSummary[]
+}
 
 type IpcLike = { ok: boolean; error?: string }
 
@@ -27,6 +34,8 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [synced, setSynced] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [contents, setContents] = useState<Record<string, BrowserProfileContents>>({})
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
   // True once the user tried to save with an empty name. Greying the button
   // out hid what was missing, so say it and mark the field instead.
@@ -66,8 +75,29 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
       setError(caught instanceof Error ? caught.message : String(caught))
     } finally {
       setBusy(false)
+      setContents({})
+      if (expanded) void toggleContentsAgain(expanded)
       void refresh()
     }
+  }
+
+  // Read on demand rather than with the list: a profile's contents are only
+  // interesting when someone asks, and the list is refreshed constantly.
+  const toggleContents = async (name: string) => {
+    if (expanded === name) {
+      setExpanded(null)
+      return
+    }
+    setExpanded(name)
+    const result = await window.codey.browser.profiles.contents(name)
+    if (result.ok) setContents(current => ({ ...current, [name]: result.data }))
+    else setError(result.error)
+  }
+
+  // Re-read after a change, without the toggle's open/close behaviour.
+  const toggleContentsAgain = async (name: string) => {
+    const result = await window.codey.browser.profiles.contents(name)
+    if (result.ok) setContents(current => ({ ...current, [name]: result.data }))
   }
 
   const saveCurrent = () => {
@@ -160,108 +190,147 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
 
       {profiles.map(profile => (
         <div key={profile.name} style={{
-          display: 'flex', alignItems: 'center', flexWrap: compact ? 'wrap' : 'nowrap', gap: 8,
+          display: 'flex', flexDirection: 'column', gap: 8,
           background: C.surface, border: `1px solid ${C.border}`, borderRadius: 10, padding: compact ? '10px' : '9px 11px',
         }}>
-          <div style={styles.avatarControl}>
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => setAvatarPicker(current => current === profile.name ? null : profile.name)}
-              style={{ ...styles.avatarButton, ...(profile.active ? styles.avatarButtonActive : null) }}
-              title={`Choose an avatar for ${profile.name}`}
-              aria-label={`Choose an avatar for ${profile.name}`}
-              aria-expanded={avatarPicker === profile.name}
-            >{browserProfileAvatar(profile)}</button>
-            {avatarPicker === profile.name && (
-              <div style={styles.avatarPicker} role="menu" aria-label={`Avatars for ${profile.name}`}>
-                {BROWSER_PROFILE_AVATARS.map(avatar => (
-                  <button
-                    key={avatar}
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={profile.avatar === avatar}
-                    style={{ ...styles.avatarOption, ...(browserProfileAvatar(profile) === avatar ? styles.avatarOptionActive : null) }}
-                    onClick={() => {
-                      setAvatarPicker(null)
-                      void run(() => window.codey.browser.profiles.setAvatar(profile.name, avatar))
-                    }}
-                  >{avatar}</button>
-                ))}
-              </div>
-            )}
-          </div>
-          <div style={{ flex: 1, minWidth: compact ? 180 : 0 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span style={{ color: C.fg, fontSize: compact ? 12 : 13, fontWeight: 600 }}>{profile.name}</span>
-              {profile.active && (
-                <span style={{
-                  background: C.green + '22', color: C.green, borderRadius: 999, padding: '1px 7px',
-                  fontSize: compact ? 10 : 11, fontWeight: 600,
-                }}>IN USE</span>
+          <div style={{ display: 'flex', alignItems: 'center', flexWrap: compact ? 'wrap' : 'nowrap', gap: 8 }}>
+            <div style={styles.avatarControl}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => setAvatarPicker(current => current === profile.name ? null : profile.name)}
+                style={{ ...styles.avatarButton, ...(profile.active ? styles.avatarButtonActive : null) }}
+                title={`Choose an avatar for ${profile.name}`}
+                aria-label={`Choose an avatar for ${profile.name}`}
+                aria-expanded={avatarPicker === profile.name}
+              >{browserProfileAvatar(profile)}</button>
+              {avatarPicker === profile.name && (
+                <div style={styles.avatarPicker} role="menu" aria-label={`Avatars for ${profile.name}`}>
+                  {BROWSER_PROFILE_AVATARS.map(avatar => (
+                    <button
+                      key={avatar}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={profile.avatar === avatar}
+                      style={{ ...styles.avatarOption, ...(browserProfileAvatar(profile) === avatar ? styles.avatarOptionActive : null) }}
+                      onClick={() => {
+                        setAvatarPicker(null)
+                        void run(() => window.codey.browser.profiles.setAvatar(profile.name, avatar))
+                      }}
+                    >{avatar}</button>
+                  ))}
+                </div>
               )}
             </div>
-            <div style={{ color: C.fg3, fontSize: compact ? 10 : 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={title(profile)}>
-              {meta(profile) || (profile.sourceUrl ? 'saved session' : 'empty profile')}
+            <div style={{ flex: 1, minWidth: compact ? 180 : 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={{ color: C.fg, fontSize: compact ? 12 : 13, fontWeight: 600 }}>{profile.name}</span>
+                {profile.active && (
+                  <span style={{
+                    background: C.green + '22', color: C.green, borderRadius: 999, padding: '1px 7px',
+                    fontSize: compact ? 10 : 11, fontWeight: 600,
+                  }}>IN USE</span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => void toggleContents(profile.name)}
+                aria-expanded={expanded === profile.name}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 4, padding: 0, border: 'none', background: 'none',
+                  color: C.fg3, fontSize: compact ? 10 : 11, cursor: 'pointer', textAlign: 'left',
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}
+                title={`${title(profile)} — click to see which sites it holds`}
+              >
+                <span style={{ transform: expanded === profile.name ? 'rotate(90deg)' : 'none', display: 'inline-flex' }}>
+                  <UIIcon name="disclosure" size={9} />
+                </span>
+                {meta(profile) || (profile.sourceUrl ? 'saved session' : 'empty profile')}
+              </button>
             </div>
-          </div>
-          {/* Several profiles can be on at once, so a profile is simply in use
-              or not. There is nothing to switch between. */}
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => void run(() => profile.active
-              ? window.codey.browser.profiles.disable(profile.name)
-              : window.codey.browser.profiles.enable(profile.name))}
-            style={profile.active ? activeBadgeStyle(compact) : buttonStyle(compact)}
-            title={profile.active
-              ? 'This profile\u2019s logins are in use \u2014 click to turn it off'
-              : 'Add this profile\u2019s logins to the live session'}
-          >
-            {profile.active ? 'In use' : 'Use'}
-          </button>
-          {/* Logins expire. Refreshing the whole profile from Chrome is one
-              click here, and works whether or not it is currently in use. */}
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => void run(async () => {
-              const result = await window.codey.browser.profiles.syncProfile(profile.name)
-              if (result.ok) {
-                setSynced(`\u201c${profile.name}\u201d refreshed: ${result.data.cookieCount} cookies from ${result.data.siteCount} site${result.data.siteCount === 1 ? '' : 's'}`)
-              }
-              return result
-            })}
-            style={buttonStyle(compact)}
-            title={`Refresh every login in ${profile.name} from Chrome`}
-            aria-label={`Refresh ${profile.name} from Chrome`}
-          ><UIIcon name="refresh" size={12} /></button>
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => void run(() => window.codey.browser.profiles.export(profile.name))}
-            style={buttonStyle(compact)}
-            title="Write this profile to a shareable JSON file"
-          ><UIIcon name="copy" size={12} /></button>
-          {confirmDelete === profile.name ? (
+            {/* Several profiles can be on at once, so a profile is simply in use
+                or not. There is nothing to switch between. */}
             <button
               type="button"
               disabled={busy}
-              onClick={() => { setConfirmDelete(null); void run(() => window.codey.browser.profiles.delete(profile.name)) }}
-              style={{ ...buttonStyle(compact), background: C.red, borderColor: C.red, color: '#fff' }}
-              title="Click again to confirm"
-            >Confirm</button>
-          ) : (
+              onClick={() => void run(() => profile.active
+                ? window.codey.browser.profiles.disable(profile.name)
+                : window.codey.browser.profiles.enable(profile.name))}
+              style={profile.active ? activeBadgeStyle(compact) : buttonStyle(compact)}
+              title={profile.active
+                ? 'This profile\u2019s logins are in use \u2014 click to turn it off'
+                : 'Add this profile\u2019s logins to the live session'}
+            >
+              {profile.active ? 'In use' : 'Use'}
+            </button>
+            {/* Logins expire. Refreshing the whole profile from Chrome is one
+                click here, and works whether or not it is currently in use. */}
             <button
               type="button"
               disabled={busy}
-              onClick={() => {
-                setConfirmDelete(profile.name)
-                setTimeout(() => setConfirmDelete(current => current === profile.name ? null : current), 3000)
-              }}
+              onClick={() => void run(async () => {
+                const result = await window.codey.browser.profiles.syncProfile(profile.name)
+                if (result.ok) {
+                  setSynced(`\u201c${profile.name}\u201d refreshed: ${result.data.cookieCount} cookies from ${result.data.siteCount} site${result.data.siteCount === 1 ? '' : 's'}`)
+                }
+                return result
+              })}
               style={buttonStyle(compact)}
-              title="Delete this profile"
-            ><UIIcon name="trash" size={12} /></button>
+              title={`Refresh every login in ${profile.name} from Chrome`}
+              aria-label={`Refresh ${profile.name} from Chrome`}
+            ><UIIcon name="refresh" size={12} /></button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void run(() => window.codey.browser.profiles.export(profile.name))}
+              style={buttonStyle(compact)}
+              title="Write this profile to a shareable JSON file"
+            ><UIIcon name="copy" size={12} /></button>
+            {confirmDelete === profile.name ? (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => { setConfirmDelete(null); void run(() => window.codey.browser.profiles.delete(profile.name)) }}
+                style={{ ...buttonStyle(compact), background: C.red, borderColor: C.red, color: '#fff' }}
+                title="Click again to confirm"
+              >Confirm</button>
+            ) : (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => {
+                  setConfirmDelete(profile.name)
+                  setTimeout(() => setConfirmDelete(current => current === profile.name ? null : current), 3000)
+                }}
+                style={buttonStyle(compact)}
+                title="Delete this profile"
+              ><UIIcon name="trash" size={12} /></button>
+            )}
+          </div>
+
+          {/* What this profile actually holds. Worth being able to look at
+              before trusting it with a task - and before handing it to an
+              agent - without ever putting the values on screen. */}
+          {expanded === profile.name && (
+            <div style={styles.contents}>
+              {!contents[profile.name] && <div style={styles.contentsEmpty}>Reading…</div>}
+              {contents[profile.name]?.sites.length === 0 && (
+                <div style={styles.contentsEmpty}>This profile holds no cookies or site storage.</div>
+              )}
+              {contents[profile.name]?.sites.map(site => (
+                <div key={site.domain} style={styles.contentsRow}>
+                  <span style={styles.contentsDomain} title={site.domain}>{site.domain}</span>
+                  <span style={styles.contentsMeta} title={site.cookieNames.join(', ')}>
+                    {site.cookieCount} cookie{site.cookieCount === 1 ? '' : 's'}
+                    {site.storage.length > 0 && ` · ${site.storage.reduce((total, entry) => total + entry.keys, 0)} storage keys`}
+                  </span>
+                </div>
+              ))}
+              {contents[profile.name] && (
+                <div style={styles.contentsNote}>Cookie names are shown on hover. Their values stay in Codey and are never displayed.</div>
+              )}
+            </div>
           )}
         </div>
       ))}
@@ -286,6 +355,12 @@ function activeBadgeStyle(compact: boolean): React.CSSProperties {
 }
 
 const styles: Record<string, React.CSSProperties> = {
+  contents: { display: 'flex', flexDirection: 'column', gap: 1, maxHeight: 200, overflowY: 'auto', padding: '5px 6px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}` },
+  contentsRow: { display: 'flex', alignItems: 'baseline', gap: 8, padding: '2px 4px' },
+  contentsDomain: { flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: C.fg2, fontSize: 11 },
+  contentsMeta: { flexShrink: 0, color: C.fg3, fontSize: 10 },
+  contentsEmpty: { color: C.fg3, fontSize: 11, padding: '4px 4px' },
+  contentsNote: { marginTop: 4, paddingTop: 5, borderTop: `1px solid ${C.border}`, color: C.fg3, fontSize: 10, lineHeight: 1.4 },
   avatarControl: { position: 'relative', flexShrink: 0 },
   avatarButton: { width: 34, height: 34, display: 'grid', placeItems: 'center', padding: 0, borderRadius: 10, border: `1px solid ${C.border}`, background: C.surface2, cursor: 'pointer', fontSize: 18 },
   avatarButtonActive: { borderColor: C.green, background: `${C.green}14` },


### PR DESCRIPTION
> Stacked on #394 — both edit the same profile rows. Base is `browser-profile-sync`; retarget to `main` once #394 lands.

A profile said *"12 cookies · 3 sites"* and nothing more. That is enough to know it is not empty and not enough to decide whether to turn it on, refresh it, or hand it to an agent — **which** sites are in there is exactly the question, and the only way to answer it was to export the file and read the JSON.

## What this adds

The line under each profile name is now a **disclosure**. Opening it lists the profile site by site:

```
github.com            5 cookies · 12 storage keys
jira.example.com      3 cookies
mail.google.com       2 cookies
```

Most cookies first. Cookie names are on hover, since that is what tells a session cookie apart from a theme preference.

## Values never leave the main process

The summary is built from **names and counts only**. The window that draws this list never receives a credential it has no use for. There is a test that serializes the summary and fails if any value appears in it — that is the property worth protecting, not the shape of the output.

Read on demand rather than alongside the list (which refreshes constantly), and re-read after anything that changes the profile.

## Verification

`npm test` (904 tests, all passing), `tsc --noEmit` clean, `npm run lint` clean.

New tests cover the grouping and ordering, the leading-dot fold (`.github.com` and `github.com` are one row), an origin that has storage but no cookies, and the no-secrets guarantee at both the helper and the controller level.

Not yet exercised on a real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)