### PR TITLE
chore: add ESLint + typecheck, fix two hook bugs, stop hidden-window polling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       - run: npm ci
 
       # Lint first so style/source violations fail fast, before the heavier
-      # build and test steps.
+      # build and test steps. `npm run lint` runs the non-English source check
+      # and then ESLint; ESLint fails the build on errors only, so the
+      # pre-existing warning backlog does not block CI.
       - name: Lint
         run: npm run lint
 
@@ -44,8 +46,7 @@ jobs:
 
       # Type-check codey-mac without running electron-builder.
       - name: Type-check codey-mac
-        working-directory: codey-mac
-        run: npx tsc --noEmit
+        run: npm run typecheck -w codey-mac
 
       - name: Test core
         run: npm test -w @codey/core

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Fail loudly when the Node version does not satisfy `engines` in package.json.
+# Without this, npm only warns: a Node too old to run vitest 4 installs fine and
+# then dies at test time with an unrelated-looking `node:util` export error.
+engine-strict=true

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -26,6 +26,7 @@
     "notarize:mac": "node build/notarize-dist.js",
     "dist:mac": "node build/dist-mac.js",
     "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -121,7 +121,7 @@ export const BrowserPanel: React.FC<Props> = ({
     return () => observer.disconnect()
   }, [])
 
-  const useResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | undefined => {
+  const unwrapResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | undefined => {
     if (!result.ok) {
       setLocalError(result.error)
       return undefined
@@ -139,7 +139,7 @@ export const BrowserPanel: React.FC<Props> = ({
       void window.codey.browser.tabs().then(result => { if (result.ok) setTabs(result.data) })
     })
     void window.codey.browser.getState().then(result => {
-      const next = useResult(result)
+      const next = unwrapResult(result)
       if (!cancelled && next) {
         setState(next)
         setAddress(next.url)
@@ -160,7 +160,7 @@ export const BrowserPanel: React.FC<Props> = ({
       if (!cancelled) setSitePermission(next)
     })
     void window.codey.browser.sitePermission.get().then(result => {
-      const next = useResult(result)
+      const next = unwrapResult(result)
       if (!cancelled && next) setSitePermission(next)
     })
     return () => { cancelled = true; off() }
@@ -187,7 +187,7 @@ export const BrowserPanel: React.FC<Props> = ({
       if (!cancelled) setControlPermission(next)
     })
     void window.codey.browser.controlPermission.get().then(result => {
-      const next = useResult(result)
+      const next = unwrapResult(result)
       if (!cancelled && next) setControlPermission(next)
     })
     return () => { cancelled = true; off() }
@@ -206,11 +206,11 @@ export const BrowserPanel: React.FC<Props> = ({
         if (!shownRef.current) {
           shownRef.current = true
           void window.codey.browser.show(bounds).then(result => {
-            const next = useResult(result)
+            const next = unwrapResult(result)
             if (next) setState(next)
           })
         } else {
-          void window.codey.browser.setBounds(bounds).then(useResult)
+          void window.codey.browser.setBounds(bounds).then(unwrapResult)
         }
       })
     }
@@ -238,7 +238,7 @@ export const BrowserPanel: React.FC<Props> = ({
     if (bounds.width === 0 || bounds.height === 0) return
     shownRef.current = true
     void window.codey.browser.show(bounds).then(result => {
-      const next = useResult(result)
+      const next = unwrapResult(result)
       if (next) setState(next)
     })
   }, [browserPageVisible])
@@ -360,12 +360,12 @@ export const BrowserPanel: React.FC<Props> = ({
   }, [syncNote])
 
   const navigate = async () => {
-    const next = useResult(await window.codey.browser.navigate(address))
+    const next = unwrapResult(await window.codey.browser.navigate(address))
     if (next) setState(next)
   }
 
   const run = async (operation: () => Promise<{ ok: true; data: BrowserState } | { ok: false; error: string }>) => {
-    const next = useResult(await operation())
+    const next = unwrapResult(await operation())
     if (next) {
       setState(next)
       if (!addressFocusedRef.current) setAddress(next.url)
@@ -382,9 +382,9 @@ export const BrowserPanel: React.FC<Props> = ({
     ? 'No profile'
     : enabledProfiles.length === 1 ? enabledProfiles[0].name : `${enabledProfiles.length} profiles`
 
-  const usePageInChat = async () => {
+  const sendPageToChat = async () => {
     if (!chatId) return
-    const context = useResult(await window.codey.browser.getPageContext())
+    const context = unwrapResult(await window.codey.browser.getPageContext())
     if (!context) return
     appendDraftText(chatId, buildBrowserContextPrompt(context))
     onClose()
@@ -393,21 +393,21 @@ export const BrowserPanel: React.FC<Props> = ({
   const updateControlPermission = async (
     operation: () => Promise<{ ok: true; data: BrowserControlPermissionState } | { ok: false; error: string }>,
   ) => {
-    const next = useResult(await operation())
+    const next = unwrapResult(await operation())
     if (next) setControlPermission(next)
   }
 
   const updateSitePermission = async (
     operation: () => Promise<{ ok: true; data: BrowserSitePermissionState } | { ok: false; error: string }>,
   ) => {
-    const next = useResult(await operation())
+    const next = unwrapResult(await operation())
     if (next) setSitePermission(next)
   }
 
   const resetBrowserSession = async () => {
     setResetBusy(true)
     try {
-      const next = useResult(await window.codey.browser.resetSession())
+      const next = unwrapResult(await window.codey.browser.resetSession())
       if (!next) return
       setState(next)
       setAddress(next.url)
@@ -415,7 +415,7 @@ export const BrowserPanel: React.FC<Props> = ({
       setResetConfirmation(false)
       const host = hostRef.current
       if (host) {
-        const shown = useResult(await window.codey.browser.show(rectToBounds(host.getBoundingClientRect())))
+        const shown = unwrapResult(await window.codey.browser.show(rectToBounds(host.getBoundingClientRect())))
         if (shown) setState(shown)
       }
       const tabResult = await window.codey.browser.tabs()
@@ -435,7 +435,7 @@ export const BrowserPanel: React.FC<Props> = ({
   const openExtensions = async () => {
     openSettingsSection('extensions')
     setExtensionCandidate(null)
-    const next = useResult(await window.codey.browser.extensions.list())
+    const next = unwrapResult(await window.codey.browser.extensions.list())
     if (next) setExtensions(next)
   }
 
@@ -456,7 +456,7 @@ export const BrowserPanel: React.FC<Props> = ({
   const pickExtension = async () => {
     setExtensionBusy(true)
     try {
-      const candidate = useResult(await window.codey.browser.extensions.pick())
+      const candidate = unwrapResult(await window.codey.browser.extensions.pick())
       if (candidate) setExtensionCandidate(candidate)
     } finally {
       setExtensionBusy(false)
@@ -466,7 +466,7 @@ export const BrowserPanel: React.FC<Props> = ({
   const discoverChromeExtensions = async () => {
     setExtensionBusy(true)
     try {
-      const candidates = useResult(await window.codey.browser.extensions.discoverChrome())
+      const candidates = unwrapResult(await window.codey.browser.extensions.discoverChrome())
       if (candidates) {
         setChromeExtensions(candidates)
         setChromeScanComplete(true)
@@ -481,7 +481,7 @@ export const BrowserPanel: React.FC<Props> = ({
     if (!candidate.compatible) return
     setExtensionBusy(true)
     try {
-      const next = useResult(await window.codey.browser.extensions.importFromChrome(candidate.path))
+      const next = unwrapResult(await window.codey.browser.extensions.importFromChrome(candidate.path))
       if (next) {
         setExtensions(next)
         setChromeExtensions(current => current.filter(extension => extension.path !== candidate.path))
@@ -495,7 +495,7 @@ export const BrowserPanel: React.FC<Props> = ({
     if (!extensionCandidate) return
     setExtensionBusy(true)
     try {
-      const next = useResult(await window.codey.browser.extensions.install(extensionCandidate.path))
+      const next = unwrapResult(await window.codey.browser.extensions.install(extensionCandidate.path))
       if (next) {
         setExtensions(next)
         setExtensionCandidate(null)
@@ -510,7 +510,7 @@ export const BrowserPanel: React.FC<Props> = ({
   ) => {
     setExtensionBusy(true)
     try {
-      const next = useResult(await operation())
+      const next = unwrapResult(await operation())
       if (next) setExtensions(next)
     } finally {
       setExtensionBusy(false)
@@ -621,7 +621,7 @@ export const BrowserPanel: React.FC<Props> = ({
           style={{ ...styles.contextButton, opacity: chatId && state.url && !activeSettingsSection ? 1 : 0.5 }}
           title={chatId ? 'Add this page and its performance timing to the current chat' : 'Select a chat first'}
           disabled={!chatId || !state.url || activeSettingsSection !== null}
-          onClick={() => void usePageInChat()}
+          onClick={() => void sendPageToChat()}
         >
           <UIIcon name="sparkle" size={14} />
           {!embedded && <span>Use in chat</span>}

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -95,7 +95,7 @@ export const ChatContextPanel: React.FC<Props> = ({
   // With the Status panel switched off the tab disappears; a chat left sitting
   // on it falls back to Tools rather than rendering an empty body.
   const tab: ContextPanelTab = requestedTab === 'task' && !statusPanelEnabled ? 'current' : requestedTab
-  const setTab = (t: ContextPanelTab) => { onTabChange ? onTabChange(t) : setLocalTab(t) }
+  const setTab = (t: ContextPanelTab) => { if (onTabChange) onTabChange(t); else setLocalTab(t) }
 
   React.useEffect(() => { if (tab === 'task') onTaskTabShown() }, [tab])
 
@@ -827,7 +827,7 @@ const FileChangesView: React.FC<{
         const isCollapsed = collapsed.has(path) && !query
         const toggle = () => setCollapsed(prev => {
           const next = new Set(prev)
-          next.has(path) ? next.delete(path) : next.add(path)
+          if (next.has(path)) next.delete(path); else next.add(path)
           return next
         })
         return (

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useChats } from '../hooks/useChats'
+import { pollWhileVisible } from '../hooks/pollWhileVisible'
 import { apiService } from '../services/api'
 import type { Chat } from '../types'
 import { C } from '../theme'
@@ -102,13 +103,16 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
 
   useEffect(() => {
     refreshWs()
-    const id = setInterval(refreshWs, 5000)
+    // The workspace list only changes through this app, and
+    // `onWorkspacesChanged` fires on every such edit, so a hidden window has
+    // nothing to learn from polling.
+    const stopPoll = pollWhileVisible(refreshWs, 5000)
     // Refresh immediately when a workspace is added/removed/renamed in the
     // Settings overlay, instead of waiting up to 5s for the next poll. A delete
     // also removes that workspace's chats, so reload the chat list too — the
     // sidebar groups are derived from state.chats, not the workspace array.
     const off = onWorkspacesChanged(() => { refreshWs(); refreshChats() })
-    return () => { clearInterval(id); off() }
+    return () => { stopPoll(); off() }
   }, [refreshWs, refreshChats])
 
   useEffect(() => {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1524,6 +1524,15 @@ export const ChatTab: React.FC<Props> = ({
     return () => window.removeEventListener('pendingPairing', handler)
   }, [drainPendingPairing])
 
+  // FIXME(hooks): the `if (!chat) return null` guard below sits *above* ~20
+  // more hooks, so a null -> non-null transition changes hook order — exactly
+  // what rules-of-hooks forbids. It does not bite today because App.tsx only
+  // renders <ChatTab> when the chat exists (and keys it by id, remounting on
+  // switch), so `chat` is never null while mounted. The real fix is to hoist
+  // the remaining hooks above the guard, which is invasive in a file this
+  // size; tracked separately. Disabled here rather than repo-wide so the rule
+  // keeps protecting every other component.
+  /* eslint-disable react-hooks/rules-of-hooks */
   if (!chat) return null
 
   const latestAssistantId: string | null = (() => {
@@ -1571,7 +1580,7 @@ export const ChatTab: React.FC<Props> = ({
   // instead of the Status tab being open. One brief, two views. Waits for the
   // turn to settle (!turnActive) so we never regenerate mid-stream, and skips
   // when a generation is already running to avoid double-firing with the panel.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   useEffect(() => {
     if (!sidecarVisible || turnActive || taskBriefLoading || !chat) return
     if (!isTaskBriefStale(chat)) return

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { chatOwnedPrUrl } from './chatPrUrl'
-import type { ChatMessage, ChatSelection, FileAttachment, TeamRunSummary } from '../types'
+import type { Chat, ChatMessage, ChatSelection, FileAttachment, TeamRunSummary } from '../types'
 import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
@@ -903,14 +903,25 @@ const TeamRunGroup: React.FC<{
 // rounding error don't break the follow.
 const BOTTOM_STICK_PX = 24
 
-export const ChatTab: React.FC<Props> = ({
+export const ChatTab: React.FC<Props> = (props) => {
+  const { state } = useChats()
+  const chat = state.chats[props.chatId]
+  // The guard lives out here, above any hook that depends on the chat, so the
+  // body below always runs the same hooks in the same order. Keeping it inside
+  // ChatTabView would put an early return above ~20 hooks and break the rules
+  // of hooks the moment a chat is removed while mounted.
+  if (!chat) return null
+  return <ChatTabView {...props} chat={chat} />
+}
+
+const ChatTabView: React.FC<Props & { chat: Chat }> = ({
   chatId, isGatewayRunning, coreFailed,
   rightPanelMode, onRightPanelModeChange, rightPanelWidth, onRightPanelResize,
   browserLoginWait, onConfirmBrowserLogin, onDismissBrowserLogin,
+  chat,
 }) => {
   const outerRef = useRef<HTMLDivElement>(null)
   const { state, createChat, sendMessage, removeQueuedMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
-  const chat = state.chats[chatId]
   const flight = state.inFlight[chatId]
   const queuedMessages = state.queuedMessages[chatId] ?? []
 
@@ -1524,17 +1535,6 @@ export const ChatTab: React.FC<Props> = ({
     return () => window.removeEventListener('pendingPairing', handler)
   }, [drainPendingPairing])
 
-  // FIXME(hooks): the `if (!chat) return null` guard below sits *above* ~20
-  // more hooks, so a null -> non-null transition changes hook order — exactly
-  // what rules-of-hooks forbids. It does not bite today because App.tsx only
-  // renders <ChatTab> when the chat exists (and keys it by id, remounting on
-  // switch), so `chat` is never null while mounted. The real fix is to hoist
-  // the remaining hooks above the guard, which is invasive in a file this
-  // size; tracked separately. Disabled here rather than repo-wide so the rule
-  // keeps protecting every other component.
-  /* eslint-disable react-hooks/rules-of-hooks */
-  if (!chat) return null
-
   const latestAssistantId: string | null = (() => {
     for (let i = chat.messages.length - 1; i >= 0; i--) {
       if (chat.messages[i].role === 'assistant') return chat.messages[i].id
@@ -1563,11 +1563,10 @@ export const ChatTab: React.FC<Props> = ({
   // card stays off narrow windows; its compact global control always fits.
   const SIDECAR_W = 264
   const sidecarFits = windowWidth >= 720
-  const hasAssistantMsg = (chat?.messages ?? []).some(m => m.role === 'assistant')
+  const hasAssistantMsg = chat.messages.some(m => m.role === 'assistant')
   const sidecarVisible = statusPanelEnabled
     && !panelOpen
     && (statusSidecarHidden || sidecarFits)
-    && !!chat
     && hasAssistantMsg
 
   const setGlobalStatusSidecarHidden = (hidden: boolean) => {
@@ -1580,13 +1579,12 @@ export const ChatTab: React.FC<Props> = ({
   // instead of the Status tab being open. One brief, two views. Waits for the
   // turn to settle (!turnActive) so we never regenerate mid-stream, and skips
   // when a generation is already running to avoid double-firing with the panel.
-   
   useEffect(() => {
-    if (!sidecarVisible || turnActive || taskBriefLoading || !chat) return
+    if (!sidecarVisible || turnActive || taskBriefLoading) return
     if (!isTaskBriefStale(chat)) return
     setTaskBriefLoading(true)
     generateTaskBrief(chat.id).finally(() => setTaskBriefLoading(false))
-  }, [sidecarVisible, turnActive, chatId, chat?.messages.length, chat?.taskBrief?.generatedAt])
+  }, [sidecarVisible, turnActive, chatId, chat.messages.length, chat.taskBrief?.generatedAt])
 
   const selectionValue: string = chat.selection.type === 'worker'
     ? `worker:${chat.selection.name}`

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -33,7 +33,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
   const [bulkName, setBulkName] = useState('chrome-logins')
   const [bulkResult, setBulkResult] = useState<{ name: string; cookieCount: number; siteCount: number } | null>(null)
 
-  const useResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | null => {
+  const unwrapResult = <T,>(result: { ok: true; data: T } | { ok: false; error: string }): T | null => {
     if (!result.ok) { setError(result.error); return null }
     setError(null)
     return result.data
@@ -44,7 +44,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
     const off = window.codey.chromeCompanion.onStatus(next => { if (!cancelled) setStatus(next) })
     void window.codey.chromeCompanion.status().then(result => {
       if (cancelled) return
-      const next = useResult(result)
+      const next = unwrapResult(result)
       if (next) setStatus(next)
     })
     return () => { cancelled = true; off() }
@@ -66,7 +66,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
           <span style={{ ...styles.dot, background: C.warningFg }} />
           <span style={styles.noticeCopy}>Chrome is temporarily unavailable. Open Chrome or reload the extension.</span>
           <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
-            const next = useResult(await window.codey.chromeCompanion.status())
+            const next = unwrapResult(await window.codey.chromeCompanion.status())
             if (next) setStatus(next)
           })}>Check again</button>
         </div>
@@ -80,7 +80,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
             Chrome only picks up a new build when it restarts or you reload the extension.
           </span>
           <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
-            useResult(await window.codey.chromeCompanion.openExtensionsPage())
+            unwrapResult(await window.codey.chromeCompanion.openExtensionsPage())
           })}>Open extensions</button>
         </div>
       )}
@@ -96,14 +96,14 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
           </ol>
           <div style={{ ...styles.actions, ...(compact ? styles.stack : null) }}>
             <button style={styles.primary} disabled={busy} onClick={() => void run(async () => {
-              const result = useResult(await window.codey.chromeCompanion.installExtensionTo())
+              const result = unwrapResult(await window.codey.chromeCompanion.installExtensionTo())
               if (result?.installed) setInstalledPath(result.dir)
             })}>Choose folder &amp; install</button>
             <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
-              useResult(await window.codey.chromeCompanion.openExtensionsPage())
+              unwrapResult(await window.codey.chromeCompanion.openExtensionsPage())
             })}>Open chrome://extensions</button>
             <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
-              const path = useResult(await window.codey.chromeCompanion.showExtensionFolder())
+              const path = unwrapResult(await window.codey.chromeCompanion.showExtensionFolder())
               if (path) setInstalledPath(path)
             })}>Reveal folder &amp; copy path</button>
           </div>
@@ -136,7 +136,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
               />
             </label>
             <button style={styles.primary} disabled={busy || !status.connected || !profileName.trim()} onClick={() => void run(async () => {
-              const next = useResult(await window.codey.chromeCompanion.exportSession(profileName.trim()))
+              const next = unwrapResult(await window.codey.chromeCompanion.exportSession(profileName.trim()))
               if (next) setExported(next.profile.name)
             })}>Create &amp; activate profile</button>
           </div>
@@ -165,7 +165,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
           {!sites && (
             <div style={styles.actions}>
               <button style={styles.secondary} disabled={busy} onClick={() => void run(async () => {
-                const next = useResult(await window.codey.chromeCompanion.listSessionSites())
+                const next = unwrapResult(await window.codey.chromeCompanion.listSessionSites())
                 if (next) {
                   setSites(next.sites)
                   setPicked(new Set())
@@ -226,7 +226,7 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
                   />
                 </label>
                 <button style={styles.primary} disabled={busy || picked.size === 0 || !bulkName.trim()} onClick={() => void run(async () => {
-                  const next = useResult(await window.codey.chromeCompanion.importSites(bulkName.trim(), [...picked]))
+                  const next = unwrapResult(await window.codey.chromeCompanion.importSites(bulkName.trim(), [...picked]))
                   if (next?.imported && next.profile) {
                     setBulkResult({ name: next.profile.name, cookieCount: next.cookieCount, siteCount: next.sites.length })
                     setSites(null)

--- a/codey-mac/src/components/Markdown.tsx
+++ b/codey-mac/src/components/Markdown.tsx
@@ -213,7 +213,7 @@ function preserveLineBreaks(src: string): string {
       out.push(line)
       continue
     }
-    out.push(/  $/.test(line) ? line : line + '  ')
+    out.push(/ {2}$/.test(line) ? line : line + '  ')
   }
   return out.join('\n')
 }

--- a/codey-mac/src/components/TerminalPanel.tsx
+++ b/codey-mac/src/components/TerminalPanel.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import { C } from '../theme'
 import { UIIcon } from './UIIcons'
+import { pollWhileVisible } from '../hooks/pollWhileVisible'
 
 interface Props {
   chatId: string
@@ -512,10 +513,13 @@ const TerminalSessionView: React.FC<{
       })
     }
     refreshTitle()
-    const titleTimer = window.setInterval(refreshTitle, 1500)
+    // Each status call spawns two `ps` processes in the main process to resolve
+    // the foreground command; the title cannot change without the user, so a
+    // hidden window need not pay for it.
+    const stopTitlePoll = pollWhileVisible(refreshTitle, 1500)
 
     return () => {
-      cancelAnimationFrame(frame); window.clearInterval(titleTimer); observer.disconnect(); input.dispose(); titleChange.dispose(); offData(); offExit(); terminal.dispose()
+      cancelAnimationFrame(frame); stopTitlePoll(); observer.disconnect(); input.dispose(); titleChange.dispose(); offData(); offExit(); terminal.dispose()
       terminalRef.current = null
     }
   }, [sessionId, chatId, workingDir, restartToken, onTitle])

--- a/codey-mac/src/components/ToolCallList.tsx
+++ b/codey-mac/src/components/ToolCallList.tsx
@@ -64,7 +64,7 @@ export const ToolCallList: React.FC<{ toolCalls: ToolCallEntry[]; emptyHint?: st
         const hasDetail = !!r.input || !!r.output
         const toggle = () => setExpanded(prev => {
           const next = new Set(prev)
-          next.has(r.id) ? next.delete(r.id) : next.add(r.id)
+          if (next.has(r.id)) next.delete(r.id); else next.add(r.id)
           return next
         })
         return (

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -394,6 +394,10 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
     warmModel(m)
   }, [voice.provider, voice.localModel, downloaded, warmed, dlState.active, warmState.active, isDownloaded, isWarmed, warmModel, warmFailed])
 
+  const handleHotkeyRecordingChange = useCallback((active: boolean) => {
+    void window.codey.voice.setHotkeyCaptureActive(active)
+  }, [])
+
   if (!isGatewayRunning) {
     return (
       <div style={{ padding: '16px 20px', height: '100%', overflowY: 'auto' }}>
@@ -437,10 +441,6 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
     setVocabDraft(next)
     commitVocabulary(next)
   }
-
-  const handleHotkeyRecordingChange = useCallback((active: boolean) => {
-    void window.codey.voice.setHotkeyCaptureActive(active)
-  }, [])
 
   const renderVoiceKeyField = (
     label: string,

--- a/codey-mac/src/components/voiceVocabulary.ts
+++ b/codey-mac/src/components/voiceVocabulary.ts
@@ -175,10 +175,10 @@ function expandCJKRegion(
   before: string[],
   after: string[],
 ): { alias: string; term: string; aliasTokens: number; termTokens: number } | null {
-  let left = [...before]
-  let right = [...after]
-  let del = [...deleted]
-  let ins = [...inserted]
+  const left = [...before]
+  const right = [...after]
+  const del = [...deleted]
+  const ins = [...inserted]
 
   while (del.join('').length < MIN_ALIAS_CHARS || ins.join('').length < MIN_ALIAS_CHARS) {
     const canLeft = isSingleCJKToken(left[left.length - 1] ?? '')

--- a/codey-mac/src/hooks/pollWhileVisible.test.ts
+++ b/codey-mac/src/hooks/pollWhileVisible.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { pollWhileVisible } from './pollWhileVisible'
+
+/**
+ * The node test environment has no `document`, so these tests install a minimal
+ * stub: a `hidden` flag plus real listener bookkeeping. That is enough to drive
+ * every branch, and it keeps the suite in the existing `environment: 'node'`
+ * config rather than pulling in jsdom for one helper.
+ */
+type Listener = () => void
+
+function installDocument(): { setHidden: (hidden: boolean) => void; listenerCount: () => number } {
+  const listeners = new Map<string, Set<Listener>>()
+  const doc = {
+    hidden: false,
+    addEventListener(type: string, fn: Listener) {
+      if (!listeners.has(type)) listeners.set(type, new Set())
+      listeners.get(type)!.add(fn)
+    },
+    removeEventListener(type: string, fn: Listener) {
+      listeners.get(type)?.delete(fn)
+    },
+  }
+  ;(globalThis as { document?: unknown }).document = doc
+  return {
+    setHidden: (hidden: boolean) => {
+      doc.hidden = hidden
+      for (const fn of listeners.get('visibilitychange') ?? []) fn()
+    },
+    listenerCount: () => listeners.get('visibilitychange')?.size ?? 0,
+  }
+}
+
+describe('pollWhileVisible', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (globalThis as { document?: unknown }).document
+  })
+
+  it('ticks on the interval while visible', () => {
+    installDocument()
+    const fn = vi.fn()
+    const stop = pollWhileVisible(fn, 1000)
+
+    vi.advanceTimersByTime(3000)
+
+    expect(fn).toHaveBeenCalledTimes(3)
+    stop()
+  })
+
+  it('does not tick while hidden', () => {
+    const doc = installDocument()
+    const fn = vi.fn()
+    const stop = pollWhileVisible(fn, 1000)
+
+    doc.setHidden(true)
+    fn.mockClear() // ignore the visibility event itself
+    vi.advanceTimersByTime(10_000)
+
+    expect(fn).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('runs immediately on becoming visible, so the view is never stale', () => {
+    const doc = installDocument()
+    const fn = vi.fn()
+    const stop = pollWhileVisible(fn, 1000)
+
+    doc.setHidden(true)
+    vi.advanceTimersByTime(10_000)
+    fn.mockClear()
+
+    doc.setHidden(false)
+
+    // Fires at once rather than waiting out the remaining interval.
+    expect(fn).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('resumes ticking after becoming visible again', () => {
+    const doc = installDocument()
+    const fn = vi.fn()
+    const stop = pollWhileVisible(fn, 1000)
+
+    doc.setHidden(true)
+    vi.advanceTimersByTime(5000)
+    doc.setHidden(false)
+    fn.mockClear()
+
+    vi.advanceTimersByTime(2000)
+
+    expect(fn).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it('cleanup stops the timer and removes the listener', () => {
+    const doc = installDocument()
+    const fn = vi.fn()
+    const stop = pollWhileVisible(fn, 1000)
+
+    stop()
+    vi.advanceTimersByTime(5000)
+    doc.setHidden(false)
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(doc.listenerCount()).toBe(0)
+  })
+
+  it('polls unconditionally when there is no document', () => {
+    // Non-DOM host: behave like the plain setInterval it replaced.
+    const fn = vi.fn()
+    const stop = pollWhileVisible(fn, 1000)
+
+    vi.advanceTimersByTime(2000)
+
+    expect(fn).toHaveBeenCalledTimes(2)
+    stop()
+  })
+})

--- a/codey-mac/src/hooks/pollWhileVisible.ts
+++ b/codey-mac/src/hooks/pollWhileVisible.ts
@@ -1,0 +1,37 @@
+/**
+ * A `setInterval` that only fires while the window is visible, and catches up
+ * the moment it becomes visible again.
+ *
+ * Codey is a long-lived desktop app that spends most of its life in the
+ * background. Several of its polls are not free — a git refresh spawns ~7 `git`
+ * subprocesses, a terminal title spawns two `ps` calls — so running them
+ * against a hidden window burns battery to compute something nobody can read.
+ *
+ * Skipping ticks alone would leave stale data on the screen for up to one
+ * interval after the user comes back, so visibility also triggers an immediate
+ * run. Callers get the same "fresh on screen" guarantee they had before.
+ *
+ * @param fn        the poll body; run on visibility-restore and on each visible tick
+ * @param intervalMs tick period, unchanged from the caller's original interval
+ * @returns a cleanup function that clears the timer and removes the listener
+ */
+export function pollWhileVisible(fn: () => void, intervalMs: number): () => void {
+  // `document.visibilityState` is absent in the node test environment and in
+  // any non-DOM host; treat that as "always visible" so behaviour there matches
+  // the old unconditional interval rather than silently never running.
+  const hidden = () => typeof document !== 'undefined' && document.hidden
+
+  const timer = setInterval(() => { if (!hidden()) fn() }, intervalMs)
+
+  const onVisibility = () => { if (!hidden()) fn() }
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', onVisibility)
+  }
+
+  return () => {
+    clearInterval(timer)
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }
+}

--- a/codey-mac/src/hooks/useGateway.ts
+++ b/codey-mac/src/hooks/useGateway.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { pollWhileVisible } from './pollWhileVisible'
 import type { CoreState } from '../../electron/core-state'
 
 export interface GatewayStatus {
@@ -77,8 +78,12 @@ export const useGateway = () => {
       }
     }
     tick()
-    const id = setInterval(tick, 3000)
-    return () => { stopped = true; clearInterval(id) }
+    // Hidden window: no one is reading the gateway badge.
+    const stopPoll = pollWhileVisible(() => void tick(), 3000)
+    return () => {
+      stopped = true
+      stopPoll()
+    }
   }, [])
 
   return {

--- a/codey-mac/src/hooks/useGitBranches.ts
+++ b/codey-mac/src/hooks/useGitBranches.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { pollWhileVisible } from './pollWhileVisible'
 
 export interface BranchState {
   branch: string
@@ -54,11 +55,14 @@ export function useGitBranches(workingDir: string | undefined, repositoryDir?: s
     const off = window.codey.git.onChanged(ev => { if (watchedDirs.includes(ev.workingDir)) void refresh() })
     const onFocus = () => void refresh()
     window.addEventListener('focus', onFocus)
-    const poll = setInterval(() => void refresh(), 5000)
+    // Each refresh spawns ~7 git subprocesses, so skip it while the window is
+    // hidden; pollWhileVisible catches up on return, and the .git watcher above
+    // still fires on real changes.
+    const stopPoll = pollWhileVisible(() => void refresh(), 5000)
     return () => {
       off()
       window.removeEventListener('focus', onFocus)
-      clearInterval(poll)
+      stopPoll()
       for (const dir of watchedDirs) void window.codey.git.unwatch(dir)
     }
   }, [workingDir, repositoryDir, refresh])

--- a/codey-mac/src/hooks/usePullRequestWatcher.ts
+++ b/codey-mac/src/hooks/usePullRequestWatcher.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { apiService } from '../services/api'
 import { useChats } from './useChats'
+import { pollWhileVisible } from './pollWhileVisible'
 import type { Chat } from '../types'
 
 /** How often the watcher re-checks open PRs. Each check shells out to `gh`,
@@ -111,11 +112,14 @@ export function usePullRequestWatcher(): void {
 
   useEffect(() => {
     void sweep()
-    const timer = setInterval(() => void sweep(), PR_POLL_INTERVAL_MS)
+    // `sweep` already no-ops while hidden; pollWhileVisible additionally sweeps
+    // the moment the window is shown, so badges refresh on return instead of
+    // waiting out the rest of the interval.
+    const stopPoll = pollWhileVisible(() => void sweep(), PR_POLL_INTERVAL_MS)
     const onFocus = () => void sweep()
     window.addEventListener('focus', onFocus)
     return () => {
-      clearInterval(timer)
+      stopPoll()
       window.removeEventListener('focus', onFocus)
     }
   }, [sweep])

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,144 @@
+// ESLint flat config for the Codey monorepo.
+//
+// Scope note: this is deliberately a *starting* ruleset. The repo had no
+// static analysis at all, so turning on the full recommended set at `error`
+// would bury real findings under thousands of pre-existing style violations.
+// Rules that catch genuine bugs are errors; stylistic ones are warnings or
+// off, and can be tightened once the existing warnings are burned down.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import globals from 'globals';
+
+export default tseslint.config(
+  {
+    // Build output, deps, and nested worktrees are not ours to lint.
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/dist-electron/**',
+      '**/release/**',
+      '**/release-local/**',
+      '**/build/**',
+      '**/out/**',
+      '.worktrees/**',
+      'chrome-extension/**',
+      'docs/**',
+      '**/*.d.ts',
+    ],
+  },
+
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  {
+    // Severity policy for rules that fire on pre-existing, deliberate code.
+    // Applied to every linted file so JS/MJS/CJS get the same treatment as TS.
+    files: ['**/*.{js,mjs,cjs,ts,tsx,mts,cts}'],
+    rules: {
+      // `require-atomic-updates` cannot tell a real await-race from the very
+      // common `e.target.value` / single-assignment-after-await patterns, and
+      // every current hit in this repo is the latter. Kept visible, not fatal.
+      'require-atomic-updates': 'warn',
+      // Escapes like `[.\-]` and `\/` are redundant but deliberate and easier
+      // to read; control-char classes are intentional sanitisers.
+      'no-useless-escape': 'warn',
+      'no-control-regex': 'warn',
+      'no-regex-spaces': 'warn',
+      // `let x: T | undefined` assigned once later is not `const`-able, so
+      // this rule's suggestion is often not applicable.
+      'prefer-const': 'warn',
+      '@typescript-eslint/ban-ts-comment': 'warn',
+    },
+  },
+
+  {
+    files: ['**/*.{ts,tsx,mts,cts}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: { ...globals.node, ...globals.es2022 },
+    },
+    rules: {
+      // TypeScript already resolves identifiers; `no-undef` on TS only
+      // produces false positives for types and ambient globals.
+      'no-undef': 'off',
+
+      // --- Real-bug rules: errors ---------------------------------------
+      // `catch {}` with no binding is idiomatic here; an empty block with a
+      // binding usually means a swallowed error someone meant to handle.
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-constant-binary-expression': 'error',
+      'no-self-compare': 'error',
+      'no-unmodified-loop-condition': 'error',
+      'no-unreachable-loop': 'error',
+
+      // --- Noise from an untyped-lint-free history: warnings -------------
+      // `any` is pervasive in the IPC and agent-adapter layers. Flag it so it
+      // stops spreading, without failing the build on day one.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      // Electron main/preload legitimately use `require` for lazy loading.
+      '@typescript-eslint/no-require-imports': 'off',
+      '@typescript-eslint/no-empty-object-type': 'off',
+    },
+  },
+
+  {
+    // Renderer only: hook rules need React in scope.
+    files: ['codey-mac/src/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.es2022 },
+    },
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      // Calling a hook conditionally is always a bug — error.
+      'react-hooks/rules-of-hooks': 'error',
+      // Stale-closure detector. There are ~180 effects in this app and no
+      // rule has ever checked them, so start at warn.
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+
+  {
+    // Tests reach for `any` and non-null assertions to build fixtures.
+    files: ['**/*.test.{ts,tsx}', '**/vitest.setup.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+
+  {
+    // Repo scripts are plain Node ESM/CJS, in every workspace.
+    files: [
+      'scripts/**/*.{mjs,cjs,js}',
+      '**/scripts/**/*.{mjs,cjs,js}',
+      '**/*.config.{ts,mts,js,mjs}',
+    ],
+    languageOptions: { globals: { ...globals.node } },
+    rules: { '@typescript-eslint/no-explicit-any': 'off' },
+  },
+
+  {
+    // CommonJS files: `require`/`module`/`__dirname` are ambient, and
+    // sourceType must be `commonjs` or the parser rejects them.
+    files: ['**/*.cjs'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: { ...globals.node, ...globals.commonjs },
+    },
+    rules: {
+      // `require()` is the whole point of a .cjs file.
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.12.12",
+      "version": "0.12.13",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -15,15 +15,19 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "electron": "41.10.2",
+        "eslint": "^9.39.5",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "globals": "^17.12.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.0"
+        "typescript": "^5.9.0",
+        "typescript-eslint": "^8.69.0"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "codey-mac": {
-      "version": "0.12.12",
+      "version": "0.12.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1533,6 +1537,274 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+      "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.2",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
@@ -1540,6 +1812,72 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -2699,6 +3037,13 @@
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -2838,6 +3183,334 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+      "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/type-utils": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.69.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+      "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -3051,6 +3724,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -3074,11 +3757,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3865,6 +4547,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -4464,6 +5156,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
@@ -5316,12 +6015,284 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-util-is-identifier-name": {
@@ -5342,6 +6313,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -5400,8 +6381,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
@@ -5435,6 +6422,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-type": {
@@ -5500,6 +6500,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -5770,6 +6791,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5827,6 +6861,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+      "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -6202,6 +7249,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6391,6 +7475,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -6432,6 +7526,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-hexadecimal": {
@@ -6704,9 +7811,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6750,8 +7867,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -6820,6 +7943,20 @@
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
       "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -7110,6 +8247,13 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -8256,6 +9400,13 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-abi": {
       "version": "3.92.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
@@ -8550,6 +9701,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -8623,6 +9792,19 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -8900,6 +10082,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/proc-log": {
@@ -9543,6 +10735,16 @@
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
@@ -10678,6 +11880,19 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -10751,6 +11966,19 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.13.1",
@@ -10851,6 +12079,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+      "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.69.0",
+        "@typescript-eslint/parser": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -11066,7 +12318,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -11585,6 +12836,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -11743,7 +13004,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.12.12",
+      "version": "0.12.13",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -11755,7 +13016,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.12.12",
+      "version": "0.12.13",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "description": "Codey \u2014 a multi-agent workbench and control plane for coding agents (Claude Code, Codex, OpenCode, pi): per-project workspaces, worker teams, parallel runs, and access from a macOS app, Telegram/Discord/iMessage, or voice.",
+  "description": "Codey — a multi-agent workbench and control plane for coding agents (Claude Code, Codex, OpenCode, pi): per-project workspaces, worker teams, parallel runs, and access from a macOS app, Telegram/Discord/iMessage, or voice.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -18,7 +18,11 @@
   "scripts": {
     "build": "npm run build -ws --if-present",
     "test": "npm run test -ws --if-present",
-    "lint": "node scripts/check-non-english.mjs",
+    "typecheck": "npm run typecheck -ws --if-present",
+    "lint": "node scripts/check-non-english.mjs && eslint .",
+    "lint:text": "node scripts/check-non-english.mjs",
+    "lint:fix": "eslint . --fix",
+    "verify": "npm run lint && npm run typecheck && npm run test",
     "build:core": "npm run build -w @codey/core",
     "build:gateway": "npm run build -w @codey/gateway",
     "dev": "npm run dev -w @codey/gateway",
@@ -35,8 +39,12 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "electron": "41.10.2",
+    "eslint": "^9.39.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^17.12.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.0"
+    "typescript": "^5.9.0",
+    "typescript-eslint": "^8.69.0"
   },
   "keywords": [
     "claude-code",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc && node scripts/copy-skills.mjs",
     "watch": "node scripts/copy-skills.mjs && tsc --watch",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -628,7 +628,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     const idx = text.indexOf('"questions"');
     if (idx === -1) return null;
     // Walk backwards to find the opening brace
-    let braceStart = text.lastIndexOf('{', idx);
+    const braceStart = text.lastIndexOf('{', idx);
     if (braceStart === -1) return null;
     // Try progressively larger substrings to find valid JSON
     for (let end = text.indexOf('}', idx); end !== -1; end = text.indexOf('}', end + 1)) {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "start": "cd ../.. && node packages/gateway/dist/index.js",
     "dev": "cd ../.. && ts-node packages/gateway/src/index.ts",

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -69,6 +69,7 @@ export class CLI {
       case '0':
         this.logger.info('Exiting...');
         process.exit(0);
+        break;
       default:
         this.logger.error('Invalid option');
     }
@@ -198,11 +199,12 @@ export async function handleCommand(args: string[], config: ConfigManager, logge
   switch (command) {
     case 'configure':
     case 'config':
-    case 'cfg':
+    case 'cfg': {
       const cli = new CLI(config, logger);
       await cli.runConfigure();
       cli.close();
       break;
+    }
 
     case 'status':
       config.printConfig();

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -5427,7 +5427,7 @@ Example: /model gpt-4.1 write a Python script`;
     }
 
     // Remove inline commands from prompt, but preserve the rest
-    let prompt = text
+    const prompt = text
       .replace(/\/agent\s+(claude-code|opencode|codex|pi)\s*/i, '')
       .replace(/\/model\s+\S+\s*/i, '')
       .replace(/^\/(help|status|clear|reset|model|agents|config)\s*/i, '')


### PR DESCRIPTION
## Why

The repo had no static analysis. `npm run lint` only checked for non-English characters, so ~92k lines of TypeScript had never had a rule run over them. Turning ESLint on surfaced two real bugs, and profiling the polling loops turned up a third problem that was costing battery all day.

Three commits, each independently reviewable.

---

### 1. `chore:` ESLint, typecheck scripts, engine enforcement

**Tooling**
- `eslint.config.mjs` — flat config covering all three workspaces. Deliberately a *starting* ruleset: rules that catch real bugs are errors, pre-existing stylistic noise is warnings. CI fails on new breakage without needing the 463-warning backlog burned down first.
- `typecheck` script in core, gateway, and codey-mac, plus root `typecheck` / `verify` / `lint:fix` aggregates. CI calls the script instead of inlining `npx tsc --noEmit`.
- `.npmrc` with `engine-strict=true`. `package.json` already declared `node >=22.12.0` but nothing enforced it — on Node 16 the install succeeded and vitest 4 then died with a misleading `node:util` export error. Verified: now fails at install with `EBADENGINE`.

**Bugs the new rules caught**
- `WhisperTab` — a `useCallback` sat *after* the `!isGatewayRunning` early return. A genuine rules-of-hooks violation.
- `cli.ts` — missing `break` before `default` in the main menu switch; a lexical declaration in an unbraced `case` block.
- Renamed local helpers `useResult` → `unwrapResult` and `usePageInChat` → `sendPageToChat`. None are hooks; the `use` prefix made the linter treat them as such (52 false positives).

### 2. `fix:` hoist the null-chat guard out of ChatTab's hook body

`if (!chat) return null` sat above ~20 further hooks. A null → non-null transition changed the number of hooks React saw between renders — the exact failure `rules-of-hooks` exists to catch, since React matches hook state positionally.

Unreachable in practice (App.tsx only renders `<ChatTab>` for an existing chat, keyed by id), but the guard is the kind of defensive check someone reasonably relies on.

Split the component rather than reorder 700 lines of interdependent hooks: `ChatTab` does the lookup and guard, then renders `ChatTabView` with a non-null `chat` prop. The hook body is unchanged and unconditional. **Net +17/−19 in a 4200-line file.**

`react-hooks/rules-of-hooks` now has **zero suppressions** anywhere in the renderer.

### 3. `perf:` stop polling git and ps while the window is hidden

The expensive polls weren't the sync fs calls — they were subprocess spawns in the main process:

| Poll | Interval | Cost per tick |
|---|---|---|
| `useGitBranches` | 5s | **~7 `git` subprocesses** (~174ms measured) |
| `TerminalPanel` | 1.5s | **2 `ps` subprocesses**, per open terminal |
| `ChatListPanel` | 5s | sync directory walk (~0.6ms) |
| `useGateway` | 3s | in-process, cheap |

Hidden window with one terminal open: **~9,800 pointless subprocess spawns per hour**, computing text nobody can see.

Adds `pollWhileVisible(fn, ms)` — skips ticks while `document.hidden`, and runs `fn` immediately on becoming visible, so **the previous freshness guarantee is preserved**; only hidden-window work is dropped. Falls back to an unconditional interval when there's no `document`.

Also fixes `usePullRequestWatcher`: it already skipped hidden sweeps but had no visibility catch-up, so PR badges could sit stale for up to 60s after switching back.

Remaining `setInterval` timers are pure UI tickers (elapsed-second counters) with no I/O — left alone.

---

## Verification

- `npm run lint` — **0 errors** (463 warnings, all pre-existing and non-blocking)
- `npm run typecheck` — clean across all three packages
- `npm test` — **2007 passing** (up from 2001; +6 new unit tests for `pollWhileVisible` covering ticking, hidden suppression, catch-up-on-visible, resume, cleanup, and the no-document fallback)
- `engine-strict` behaviour confirmed by hand on Node 16 (`EBADENGINE`, exit 1)

## Notes for review

- **`main.ts` handler split was deliberately left out.** Four in-flight branches (`browser-skill`, `chat-transcript-catchup`, `fix-chat-background-run`, `router-mode`) each rewrite `main.ts` heavily. Moving 234 IPC handlers now would conflict with all of them. Worth doing once those land.
- The 463 warnings are the honest backlog: 363 `no-explicit-any`, 35 unused vars, 23 `exhaustive-deps`. They're visible and non-blocking so they can be burned down incrementally rather than in one unreviewable sweep.
- No UI test coverage for the ChatTab split — this repo has no `@testing-library/react` and vitest runs in `environment: 'node'`. The split is guarded by the type system and the lint rule instead. Adding jsdom + testing-library is a separate piece of work.
