### PR TITLE
feat(mac): chat message navigator + wider panel resize handles

### DIFF
--- a/codey-mac/src/App.tsx
+++ b/codey-mac/src/App.tsx
@@ -439,7 +439,7 @@ const styles: Record<string, React.CSSProperties> = {
   body: { flex: 1, display: 'flex', overflow: 'hidden', position: 'relative' },
   sidebarShell: { position: 'relative', height: '100%', flexShrink: 0 },
   sidebarResizeHandle: {
-    position: 'absolute', top: 0, right: -3, width: 7, height: '100%', zIndex: 5,
+    position: 'absolute', top: 0, right: -7, width: 14, height: '100%', zIndex: 5,
     cursor: 'col-resize',
   },
   content: { flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' },

--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -1334,7 +1334,7 @@ const styles: Record<string, React.CSSProperties> = {
   rootEmbedded: { borderLeft: 'none' },
   resizer: {
     position: 'absolute',
-    left: -3, top: 0, bottom: 0, width: 6,
+    left: -7, top: 0, bottom: 0, width: 14,
     cursor: 'col-resize',
     zIndex: 5,
   },

--- a/codey-mac/src/components/ChatMessageNavigator.test.ts
+++ b/codey-mac/src/components/ChatMessageNavigator.test.ts
@@ -1,0 +1,30 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { CHAT_NAV_MIN_ITEMS, ChatMessageNavigator, type ChatNavigationItem } from './ChatMessageNavigator'
+
+const makeItems = (count: number): ChatNavigationItem[] => Array.from({ length: count }, (_, index) => ({
+  id: `message-${index}`,
+  title: `Message ${index + 1}`,
+  preview: `Preview ${index + 1}`,
+  role: index % 2 === 0 ? 'user' : 'assistant',
+}))
+
+const renderNavigator = (count: number) => renderToStaticMarkup(React.createElement(ChatMessageNavigator, {
+  containerRef: React.createRef<HTMLDivElement>(),
+  items: makeItems(count),
+  revision: String(count),
+}))
+
+describe('ChatMessageNavigator', () => {
+  it('stays hidden for short conversations', () => {
+    expect(renderNavigator(CHAT_NAV_MIN_ITEMS - 1)).toBe('')
+  })
+
+  it('renders one jump target per message once the threshold is reached', () => {
+    const html = renderNavigator(CHAT_NAV_MIN_ITEMS)
+    expect(html).toContain('aria-label="Conversation message navigation"')
+    expect(html.match(/aria-label="Jump to Message/g)).toHaveLength(CHAT_NAV_MIN_ITEMS)
+    expect(html).toContain('aria-current="location"')
+  })
+})

--- a/codey-mac/src/components/ChatMessageNavigator.tsx
+++ b/codey-mac/src/components/ChatMessageNavigator.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { C } from '../theme'
+
+export const CHAT_NAV_MIN_ITEMS = 8
+
+export interface ChatNavigationItem {
+  id: string
+  title: string
+  preview: string
+  role: 'user' | 'assistant' | 'team'
+}
+
+interface Props {
+  containerRef: React.RefObject<HTMLDivElement>
+  items: ChatNavigationItem[]
+  revision: string
+  onNavigate?: () => void
+}
+
+const rowFor = (container: HTMLDivElement, id: string): HTMLElement | undefined =>
+  Array.from(container.querySelectorAll<HTMLElement>('[data-chat-navigation-id]'))
+    .find(row => row.dataset.chatNavigationId === id)
+
+/** A compact message map for long transcripts. The native scrollbar still
+ * handles free scrolling; these markers provide semantic, message-level jumps. */
+export const ChatMessageNavigator: React.FC<Props> = ({ containerRef, items, revision, onNavigate }) => {
+  const [activeId, setActiveId] = useState<string | null>(() => items.at(-1)?.id ?? null)
+  const [hovered, setHovered] = useState<{ item: ChatNavigationItem; top: number; right: number } | null>(null)
+
+  const updateActive = useCallback(() => {
+    const container = containerRef.current
+    if (!container || items.length < CHAT_NAV_MIN_ITEMS) return
+    const viewport = container.getBoundingClientRect()
+    const focusY = viewport.top + viewport.height * 0.38
+    let closest: { id: string; distance: number } | null = null
+    for (const item of items) {
+      const row = rowFor(container, item.id)
+      if (!row) continue
+      const rect = row.getBoundingClientRect()
+      const distance = focusY < rect.top ? rect.top - focusY : focusY > rect.bottom ? focusY - rect.bottom : 0
+      if (!closest || distance < closest.distance) closest = { id: item.id, distance }
+    }
+    if (closest) setActiveId(current => current === closest.id ? current : closest.id)
+  }, [containerRef, items])
+
+  useLayoutEffect(() => {
+    updateActive()
+    const frame = requestAnimationFrame(updateActive)
+    return () => cancelAnimationFrame(frame)
+  }, [revision, updateActive])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || items.length < CHAT_NAV_MIN_ITEMS) return
+    let frame = 0
+    const schedule = () => {
+      cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(updateActive)
+    }
+    container.addEventListener('scroll', schedule, { passive: true })
+    const resize = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(schedule) : null
+    resize?.observe(container)
+    return () => {
+      cancelAnimationFrame(frame)
+      container.removeEventListener('scroll', schedule)
+      resize?.disconnect()
+    }
+  }, [containerRef, items.length, updateActive])
+
+  if (items.length < CHAT_NAV_MIN_ITEMS) return null
+
+  const jumpTo = (item: ChatNavigationItem) => {
+    const container = containerRef.current
+    const row = container ? rowFor(container, item.id) : undefined
+    if (!row) return
+    setActiveId(item.id)
+    setHovered(null)
+    onNavigate?.()
+    row.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+
+  return (
+    <>
+      <nav
+        style={{ ...styles.rail, height: Math.min(420, Math.max(140, (items.length - 1) * 20)) }}
+        aria-label="Conversation message navigation"
+      >
+        {items.map((item, index) => {
+          const active = item.id === activeId
+          const width = active ? 40 : Math.min(28, 8 + Math.round(item.preview.length / 18) * 4)
+          return (
+            <button
+              key={item.id}
+              type="button"
+              aria-label={`Jump to ${item.title}`}
+              aria-current={active ? 'location' : undefined}
+              style={{
+                ...styles.markerButton,
+                top: items.length === 1 ? '50%' : `${index / (items.length - 1) * 100}%`,
+              }}
+              onClick={() => jumpTo(item)}
+              onMouseEnter={event => {
+                const rect = event.currentTarget.getBoundingClientRect()
+                setHovered({
+                  item,
+                  top: Math.max(12, Math.min(window.innerHeight - 150, rect.top - 42)),
+                  right: Math.max(18, window.innerWidth - rect.left + 12),
+                })
+              }}
+              onMouseLeave={() => setHovered(current => current?.item.id === item.id ? null : current)}
+            >
+              <span style={{
+                ...styles.marker,
+                width,
+                background: active ? C.fg : C.fg3,
+                opacity: active ? 0.96 : 0.55,
+              }} />
+            </button>
+          )
+        })}
+      </nav>
+      {hovered && createPortal(
+        <div style={{ ...styles.previewCard, top: hovered.top, right: hovered.right }} role="tooltip">
+          <div style={styles.previewMeta}>{hovered.item.role === 'user' ? 'You' : hovered.item.role === 'team' ? 'Team' : 'Codey'}</div>
+          <div style={styles.previewTitle}>{hovered.item.title}</div>
+          {hovered.item.preview !== hovered.item.title && (
+            <div style={styles.previewBody}>{hovered.item.preview}</div>
+          )}
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  rail: {
+    position: 'absolute', zIndex: 18, right: 7, top: '50%',
+    width: 46, maxHeight: 'calc(100% - 48px)', pointerEvents: 'none',
+    transform: 'translateY(-50%)',
+  },
+  markerButton: {
+    position: 'absolute', right: 0, width: 46, height: 18, padding: 0,
+    border: 'none', background: 'transparent', cursor: 'pointer', pointerEvents: 'auto',
+    display: 'flex', justifyContent: 'flex-end', alignItems: 'center',
+    transform: 'translateY(-50%)',
+  },
+  marker: { height: 3, borderRadius: 2, transition: 'width 0.14s ease, opacity 0.14s ease, background 0.14s ease' },
+  previewCard: {
+    position: 'fixed', zIndex: 2000, width: 'min(320px, calc(100vw - 72px))',
+    padding: '14px 16px', borderRadius: 12, pointerEvents: 'none',
+    color: C.fg, background: C.surface2, border: `1px solid ${C.border2}`,
+    boxShadow: '0 14px 36px rgba(0,0,0,0.34)',
+  },
+  previewMeta: { color: C.fg3, fontSize: 10, fontWeight: 650, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 5 },
+  previewTitle: { color: C.fg, fontSize: 14, fontWeight: 700, lineHeight: 1.35 },
+  previewBody: {
+    color: C.fg2, fontSize: 12, lineHeight: 1.55, marginTop: 7,
+    display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden',
+  },
+}

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -61,6 +61,7 @@ import { groupTeamMessagesByMember, type TeamMemberMessageGroup } from './teamRu
 import { ToolCallList } from './ToolCallList'
 import { useVoiceTurn } from '../hooks/useVoiceTurn'
 import { VoiceMeter } from './VoiceMeter'
+import { ChatMessageNavigator, type ChatNavigationItem } from './ChatMessageNavigator'
 
 const EDITOR_LOGOS: Partial<Record<string, string>> = {
   vscode: vscodeLogo,
@@ -1331,6 +1332,32 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
     })()
   }, [isGatewayRunning])
   const lastMsg = chat?.messages?.[chat.messages.length - 1]
+  const renderItems = useMemo(() => groupMessages(chat?.messages ?? []), [chat?.messages])
+  const navigationItems = useMemo<ChatNavigationItem[]>(() => renderItems.map(item => {
+    if (item.kind === 'team') {
+      const source = [...item.messages].reverse().find(message => message.content.trim())
+      const preview = (source?.content || `${item.messages.length} team updates`).replace(/\s+/g, ' ').trim()
+      return {
+        id: `team:${item.teamTurnId}`,
+        title: item.teamName || 'Team run',
+        preview: preview.slice(0, 180),
+        role: 'team',
+      }
+    }
+    const msg = item.message
+    const plain = (msg.content || msg.userQuestion?.question || (msg.role === 'assistant' ? 'Agent update' : 'Message'))
+      .replace(/```[\s\S]*?```/g, ' Code block ')
+      .replace(/[#>*_`~\[\]]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+    const firstSentence = plain.split(/(?<=[.!?。！？])\s+|\n/)[0] || plain
+    return {
+      id: msg.id,
+      title: firstSentence.slice(0, 48),
+      preview: plain.slice(0, 180),
+      role: msg.role === 'user' ? 'user' : 'assistant',
+    }
+  }), [renderItems])
   // Cheap stand-in for "the rendered conversation changed": switching chats,
   // a new message, or a streaming reply growing. Find-in-chat re-scans on it,
   // because its highlight ranges point at text nodes React may have replaced.
@@ -2490,24 +2517,26 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
         </button>
       </div>
 
-      <div
-        ref={messagesRef}
-        style={{ ...styles.messages, position: 'relative' }}
-        onScroll={updateLatestMessageVisibility}
-      >
-        <ChatFindBar
-          containerRef={messagesRef}
-          revision={findRevision}
-          onNavigate={() => setFollowLatest(false)}
-        />
-        {groupMessages(chat.messages).map((item, idx) => {
+      <div style={styles.transcriptShell}>
+        <div
+          ref={messagesRef}
+          style={{ ...styles.messages, position: 'relative' }}
+          onScroll={updateLatestMessageVisibility}
+        >
+          <ChatFindBar
+            containerRef={messagesRef}
+            revision={findRevision}
+            onNavigate={() => setFollowLatest(false)}
+          />
+          {renderItems.map((item, idx) => {
           if (item.kind === 'team') {
             return (
-              <TeamRunGroup
-                key={item.teamTurnId}
-                item={item}
-                isStreaming={!!flight && item.messages[item.messages.length - 1]?.id === lastMsg?.id}
-              />
+              <div key={item.teamTurnId} data-chat-navigation-id={`team:${item.teamTurnId}`}>
+                <TeamRunGroup
+                  item={item}
+                  isStreaming={!!flight && item.messages[item.messages.length - 1]?.id === lastMsg?.id}
+                />
+              </div>
             )
           }
           const msg = item.message
@@ -2515,7 +2544,7 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
           const isSelected = !isUser && msg.id === selectedTurnId && overviewOpen
           const isEditing = isUser && editingMsgId === msg.id
           return (
-            <div key={msg.id}
+            <div key={msg.id} data-chat-navigation-id={msg.id}
               onMouseEnter={isUser ? () => setHoveredMsgId(msg.id) : undefined}
               onMouseLeave={isUser ? () => setHoveredMsgId(id => (id === msg.id ? null : id)) : undefined}
               onDoubleClick={isUser ? undefined : () => {
@@ -2841,12 +2870,19 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
               )}
             </div>
           )
-        })}
-        {statusLabel && (
-          <div style={styles.typingRow}>
-            <ShimmerStatus label={statusLabel} />
-          </div>
-        )}
+          })}
+          {statusLabel && (
+            <div style={styles.typingRow}>
+              <ShimmerStatus label={statusLabel} />
+            </div>
+          )}
+        </div>
+        <ChatMessageNavigator
+          containerRef={messagesRef}
+          items={navigationItems}
+          revision={findRevision}
+          onNavigate={() => setFollowLatest(false)}
+        />
       </div>
 
       {orphaned && (
@@ -3437,7 +3473,8 @@ const styles: Record<string, React.CSSProperties> = {
   },
   editorOpeningLabel: { color: C.fg2, fontSize: 11, whiteSpace: 'nowrap' },
   editorMenuEmpty: { color: C.fg3, fontSize: 11, lineHeight: 1.4, padding: '8px 9px', maxWidth: 220 },
-  messages: { flex: 1, overflowY: 'auto', padding: '22px max(22px, 5%)', background: C.bg },
+  transcriptShell: { flex: 1, minHeight: 0, position: 'relative', background: C.bg },
+  messages: { height: '100%', overflowY: 'auto', padding: '22px max(22px, 5%)', background: C.bg },
   // The status row is a direct child of `messages`, not of a message row, so it
   // carries the full inset rather than the remainder.
   typingRow: {

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1350,7 +1350,7 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
       .replace(/[#>*_`~\[\]]/g, '')
       .replace(/\s+/g, ' ')
       .trim()
-    const firstSentence = plain.split(/(?<=[.!?。！？])\s+|\n/)[0] || plain
+    const firstSentence = plain.split(/(?<=[.!?\u3002\uFF01\uFF1F])\s+|\n/)[0] || plain
     return {
       id: msg.id,
       title: firstSentence.slice(0, 48),

--- a/codey-mac/src/components/WorkspaceDock.tsx
+++ b/codey-mac/src/components/WorkspaceDock.tsx
@@ -119,7 +119,7 @@ const styles: Record<string, React.CSSProperties> = {
     background: C.surface, borderLeft: `1px solid ${C.border2}`,
   },
   rootOverlay: { position: 'absolute', top: 0, right: 0, bottom: 0, zIndex: 35, boxShadow: '-16px 0 36px rgba(0,0,0,0.28)' },
-  resizer: { position: 'absolute', left: -3, top: 0, bottom: 0, width: 7, cursor: 'col-resize', zIndex: 20 },
+  resizer: { position: 'absolute', left: -7, top: 0, bottom: 0, width: 14, cursor: 'col-resize', zIndex: 20 },
   toolbar: {
     minHeight: 43, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 4,
     padding: '6px 8px', background: C.sidebarBg, borderBottom: `1px solid ${C.sidebarBorder}`,


### PR DESCRIPTION
## Summary
- Add a right-edge message navigator to the chat view once a chat has more than 8 messages. The current message is highlighted and tracks scroll, hovering shows a role/title/content preview, and clicking smooth-scrolls to that message. Team-run messages collapse into a single marker.
- Widen the left/right panel drag handles from ~7px to 14px so they are easier to grab.

## Test Plan
- [x] `tsc` type check passes
- [x] Production build passes
- [x] `npm test` — 92 files / 934 tests pass (includes new `ChatMessageNavigator.test.ts`)
- [ ] Manual: open a chat with 9+ messages, confirm navigator appears, hover previews, click jumps, highlight follows scroll
- [ ] Manual: drag the left/right panel edges, confirm the grab zone feels wider

🤖 Generated with [Claude Code](https://claude.com/claude-code)