### PR TITLE
feat(mac): slimmer left-side message navigator with a hover magnify wave

### DIFF
--- a/codey-mac/src/components/ChatMessageNavigator.test.ts
+++ b/codey-mac/src/components/ChatMessageNavigator.test.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { CHAT_NAV_MIN_ITEMS, ChatMessageNavigator, type ChatNavigationItem } from './ChatMessageNavigator'
+import { CHAT_NAV_MIN_ITEMS, ChatMessageNavigator, tickWidthFor, type ChatNavigationItem } from './ChatMessageNavigator'
 
 const makeItems = (count: number): ChatNavigationItem[] => Array.from({ length: count }, (_, index) => ({
   id: `message-${index}`,
@@ -26,5 +26,18 @@ describe('ChatMessageNavigator', () => {
     expect(html).toContain('aria-label="Conversation message navigation"')
     expect(html.match(/aria-label="Jump to Message/g)).toHaveLength(CHAT_NAV_MIN_ITEMS)
     expect(html).toContain('aria-current="location"')
+  })
+})
+
+describe('tickWidthFor', () => {
+  it('keeps every tick at the same base width when the pointer is away', () => {
+    expect(tickWidthFor(null)).toBe(7)
+  })
+
+  it('grows the nearest tick the most and tapers with distance', () => {
+    expect(tickWidthFor(0)).toBe(20)
+    expect(tickWidthFor(10)).toBeLessThan(tickWidthFor(0))
+    expect(tickWidthFor(30)).toBeLessThan(tickWidthFor(10))
+    expect(tickWidthFor(200)).toBeCloseTo(7, 5)
   })
 })

--- a/codey-mac/src/components/ChatMessageNavigator.tsx
+++ b/codey-mac/src/components/ChatMessageNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { C } from '../theme'
 
@@ -18,15 +18,30 @@ interface Props {
   onNavigate?: () => void
 }
 
+const RAIL_WIDTH = 22
+const RAIL_LEFT = 5
+const TICK_BASE = 7
+const TICK_MAX = 20
+/** How far (px) the hover "wave" spreads to neighbouring ticks. */
+const WAVE_SIGMA = 26
+
 const rowFor = (container: HTMLDivElement, id: string): HTMLElement | undefined =>
   Array.from(container.querySelectorAll<HTMLElement>('[data-chat-navigation-id]'))
     .find(row => row.dataset.chatNavigationId === id)
 
+const railHeightFor = (count: number) => Math.min(380, Math.max(120, (count - 1) * 11))
+
+/** Tick width for a marker `distance` px away from the pointer: the nearest
+ * tick grows to TICK_MAX and neighbours fall off on a bell curve. */
+export const tickWidthFor = (distance: number | null): number =>
+  distance === null ? TICK_BASE : TICK_BASE + (TICK_MAX - TICK_BASE) * Math.exp(-((distance / WAVE_SIGMA) ** 2))
+
 /** A compact message map for long transcripts. The native scrollbar still
  * handles free scrolling; these markers provide semantic, message-level jumps. */
 export const ChatMessageNavigator: React.FC<Props> = ({ containerRef, items, revision, onNavigate }) => {
+  const railRef = useRef<HTMLElement>(null)
   const [activeId, setActiveId] = useState<string | null>(() => items.at(-1)?.id ?? null)
-  const [hovered, setHovered] = useState<{ item: ChatNavigationItem; top: number; right: number } | null>(null)
+  const [pointerY, setPointerY] = useState<number | null>(null)
 
   const updateActive = useCallback(() => {
     const container = containerRef.current
@@ -70,62 +85,80 @@ export const ChatMessageNavigator: React.FC<Props> = ({ containerRef, items, rev
 
   if (items.length < CHAT_NAV_MIN_ITEMS) return null
 
+  const railHeight = railHeightFor(items.length)
+  const yFor = (index: number) => items.length === 1 ? railHeight / 2 : index / (items.length - 1) * railHeight
+
+  let hoveredIndex = -1
+  if (pointerY !== null) {
+    let best = Infinity
+    items.forEach((_, index) => {
+      const d = Math.abs(yFor(index) - pointerY)
+      if (d < best) { best = d; hoveredIndex = index }
+    })
+  }
+  const hovered = hoveredIndex >= 0 ? items[hoveredIndex] : null
+
   const jumpTo = (item: ChatNavigationItem) => {
     const container = containerRef.current
     const row = container ? rowFor(container, item.id) : undefined
     if (!row) return
     setActiveId(item.id)
-    setHovered(null)
+    setPointerY(null)
     onNavigate?.()
     row.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+
+  const previewPosition = () => {
+    const rail = railRef.current?.getBoundingClientRect()
+    if (!rail || hoveredIndex < 0) return { top: 0, left: 0 }
+    const y = rail.top + yFor(hoveredIndex)
+    return {
+      top: Math.max(12, Math.min(window.innerHeight - 150, y - 34)),
+      left: rail.left + RAIL_WIDTH + 10,
+    }
   }
 
   return (
     <>
       <nav
-        style={{ ...styles.rail, height: Math.min(420, Math.max(140, (items.length - 1) * 20)) }}
+        ref={railRef}
+        style={{ ...styles.rail, height: railHeight }}
         aria-label="Conversation message navigation"
+        onMouseMove={event => {
+          const rect = event.currentTarget.getBoundingClientRect()
+          setPointerY(event.clientY - rect.top)
+        }}
+        onMouseLeave={() => setPointerY(null)}
       >
         {items.map((item, index) => {
           const active = item.id === activeId
-          const width = active ? 40 : Math.min(28, 8 + Math.round(item.preview.length / 18) * 4)
+          const isHovered = index === hoveredIndex
+          const distance = pointerY === null ? null : Math.abs(yFor(index) - pointerY)
           return (
             <button
               key={item.id}
               type="button"
               aria-label={`Jump to ${item.title}`}
               aria-current={active ? 'location' : undefined}
-              style={{
-                ...styles.markerButton,
-                top: items.length === 1 ? '50%' : `${index / (items.length - 1) * 100}%`,
-              }}
+              style={{ ...styles.markerButton, top: yFor(index) }}
               onClick={() => jumpTo(item)}
-              onMouseEnter={event => {
-                const rect = event.currentTarget.getBoundingClientRect()
-                setHovered({
-                  item,
-                  top: Math.max(12, Math.min(window.innerHeight - 150, rect.top - 42)),
-                  right: Math.max(18, window.innerWidth - rect.left + 12),
-                })
-              }}
-              onMouseLeave={() => setHovered(current => current?.item.id === item.id ? null : current)}
             >
               <span style={{
                 ...styles.marker,
-                width,
+                width: tickWidthFor(distance),
                 background: active ? C.fg : C.fg3,
-                opacity: active ? 0.96 : 0.55,
+                opacity: active ? 0.96 : isHovered ? 0.9 : 0.5,
               }} />
             </button>
           )
         })}
       </nav>
       {hovered && createPortal(
-        <div style={{ ...styles.previewCard, top: hovered.top, right: hovered.right }} role="tooltip">
-          <div style={styles.previewMeta}>{hovered.item.role === 'user' ? 'You' : hovered.item.role === 'team' ? 'Team' : 'Codey'}</div>
-          <div style={styles.previewTitle}>{hovered.item.title}</div>
-          {hovered.item.preview !== hovered.item.title && (
-            <div style={styles.previewBody}>{hovered.item.preview}</div>
+        <div style={{ ...styles.previewCard, ...previewPosition() }} role="tooltip">
+          <div style={styles.previewMeta}>{hovered.role === 'user' ? 'You' : hovered.role === 'team' ? 'Team' : 'Codey'}</div>
+          <div style={styles.previewTitle}>{hovered.title}</div>
+          {hovered.preview !== hovered.title && (
+            <div style={styles.previewBody}>{hovered.preview}</div>
           )}
         </div>,
         document.body,
@@ -136,17 +169,17 @@ export const ChatMessageNavigator: React.FC<Props> = ({ containerRef, items, rev
 
 const styles: Record<string, React.CSSProperties> = {
   rail: {
-    position: 'absolute', zIndex: 18, right: 7, top: '50%',
-    width: 46, maxHeight: 'calc(100% - 48px)', pointerEvents: 'none',
-    transform: 'translateY(-50%)',
+    position: 'absolute', zIndex: 18, left: RAIL_LEFT, top: '50%',
+    width: RAIL_WIDTH, maxHeight: 'calc(100% - 48px)',
+    transform: 'translateY(-50%)', cursor: 'pointer',
   },
   markerButton: {
-    position: 'absolute', right: 0, width: 46, height: 18, padding: 0,
-    border: 'none', background: 'transparent', cursor: 'pointer', pointerEvents: 'auto',
-    display: 'flex', justifyContent: 'flex-end', alignItems: 'center',
+    position: 'absolute', left: 0, width: RAIL_WIDTH, height: 10, padding: 0,
+    border: 'none', background: 'transparent', cursor: 'pointer',
+    display: 'flex', justifyContent: 'flex-start', alignItems: 'center',
     transform: 'translateY(-50%)',
   },
-  marker: { height: 3, borderRadius: 2, transition: 'width 0.14s ease, opacity 0.14s ease, background 0.14s ease' },
+  marker: { height: 2, borderRadius: 1, transition: 'width 0.12s ease-out, opacity 0.12s ease-out, background 0.12s ease-out' },
   previewCard: {
     position: 'fixed', zIndex: 2000, width: 'min(320px, calc(100vw - 72px))',
     padding: '14px 16px', borderRadius: 12, pointerEvents: 'none',


### PR DESCRIPTION
## Summary
Follow-up to #399 based on feedback:
- Move the message navigator to the left edge and shrink it (22px wide, denser 11px pitch).
- Every tick is the same base width. Message length no longer changes tick length.
- On hover, the tick nearest the pointer grows and neighbours taper off on a bell curve. It animates as the pointer moves. Ticks outside the wave stay at the short base width.
- The active message is still marked by colour, not length.
- Preview card opens to the right of the rail.

## Test Plan
- [x] `tsc` type check passes (0 errors)
- [x] `npm run lint` passes (0 errors)
- [x] codey-mac tests: 94 files / 976 tests pass, incl. new `tickWidthFor` cases
- [ ] Manual: open a chat with 9+ messages, hover the left rail, confirm the wave follows the pointer and the preview card shows to the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)