### PR TITLE
feat(mac): fold the team stage when a run ends and show the answer on its own

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -57,7 +57,7 @@ import { WorkspaceDock, type WorkspaceDockTool } from './WorkspaceDock'
 import { resolveWorkspaceDockLayout } from './workspaceDockLayout'
 import { TerminalPanel } from './TerminalPanel'
 import { splitWhiteboardMarkers, type WhiteboardMarker } from './teamWhiteboardFormat'
-import { groupTeamMessagesByMember, type TeamMemberMessageGroup } from './teamRunModel'
+import { groupTeamMessagesByMember, teamFinalAnswer, type TeamMemberMessageGroup } from './teamRunModel'
 import { ToolCallList } from './ToolCallList'
 import { useVoiceTurn } from '../hooks/useVoiceTurn'
 import { VoiceMeter } from './VoiceMeter'
@@ -812,7 +812,8 @@ const TeamRunGroup: React.FC<{
   item: Extract<RenderItem, { kind: 'team' }>
   isStreaming: boolean
 }> = ({ item, isStreaming }) => {
-  const [collapsed, setCollapsed] = React.useState(false)
+  // null = follow the run: open while it works, folded once it has answered.
+  const [userCollapsed, setUserCollapsed] = React.useState<boolean | null>(null)
   const [summaryOpen, setSummaryOpen] = React.useState(false)
   const [whiteboardOpen, setWhiteboardOpen] = React.useState(false)
   const [roundExpansion, setRoundExpansion] = React.useState<Map<string, boolean>>(new Map())
@@ -820,6 +821,12 @@ const TeamRunGroup: React.FC<{
   const memberGroups = groupTeamMessagesByMember(workerMessages)
   const footerMessages = item.messages.filter(m => !m.worker && !!m.content.trim())
   const finalSummary = [...item.messages].reverse().find(message => message.teamSummary)?.teamSummary
+  // Once the run is over the stage is just history: fold it and show the
+  // answer on its own, the way a single-agent turn would read.
+  const finalAnswer = isStreaming ? null : teamFinalAnswer(item.messages, item.teamMode)
+  const collapsed = userCollapsed ?? finalAnswer !== null
+  const setCollapsed = (update: boolean | ((current: boolean) => boolean)) =>
+    setUserCollapsed(typeof update === 'function' ? update(collapsed) : update)
   const completedCount = workerMessages.filter(m => m.workerStatus && m.workerStatus !== 'running').length
   const failedCount = workerMessages.filter(m => m.workerStatus === 'failed').length
   const activeCount = workerMessages.filter(m => m.workerStatus === 'running').length
@@ -840,6 +847,7 @@ const TeamRunGroup: React.FC<{
     setRoundExpansion(new Map(workerMessages.map(message => [message.id, expanded])))
   }
   return (
+    <>
     <div style={styles.teamGroup}>
       <div style={styles.teamGroupHeader} onClick={() => setCollapsed(c => !c)}>
         <span style={{ ...styles.teamStepChevron, transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)' }}>▶</span>
@@ -899,6 +907,13 @@ const TeamRunGroup: React.FC<{
         </div>
       )}
     </div>
+    {finalAnswer && (
+      <div style={styles.teamFinalAnswer}>
+        <div style={styles.teamFinalAnswerBy}>{finalAnswer.worker}</div>
+        <Markdown variant="assistant">{finalAnswer.text}</Markdown>
+      </div>
+    )}
+    </>
   )
 }
 
@@ -3932,6 +3947,8 @@ const styles: Record<string, React.CSSProperties> = {
   },
   teamStepBody: { marginTop: 4, marginLeft: 17 },
   teamGroup: { border: `1px solid ${C.border}`, borderRadius: 12, margin: '8px 0 14px', overflow: 'hidden', background: C.surface2 },
+  teamFinalAnswer: { margin: '0 0 14px' },
+  teamFinalAnswerBy: { fontSize: 11, color: C.fg3, marginBottom: 4 },
   teamGroupHeader: { display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', cursor: 'pointer', borderBottom: `1px solid ${C.border}` },
   teamGroupIdentity: { display: 'flex', alignItems: 'center', gap: 7, flex: 1, minWidth: 0 },
   teamGroupTitle: { fontSize: 13, fontWeight: 700, color: C.fg, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const },

--- a/codey-mac/src/components/teamRunModel.test.ts
+++ b/codey-mac/src/components/teamRunModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveWorkerRuns, groupTeamMessagesByMember } from './teamRunModel'
+import { deriveWorkerRuns, groupTeamMessagesByMember, teamFinalAnswer } from './teamRunModel'
 import type { ChatMessage } from '../types'
 
 const teamTurn = (over: Partial<ChatMessage> = {}): ChatMessage => ({
@@ -191,5 +191,57 @@ describe('nodeStatuses', () => {
     const endId = g.nodes.find(n => n.type === 'end')!.id
     expect(nodeStatuses(g, [run(1, 'pm', 'running')])[endId]).toBe('pending')
     expect(nodeStatuses(g, [run(1, 'pm', 'done')])[endId]).toBe('done')
+  })
+})
+
+describe('teamFinalAnswer', () => {
+  const worker = (over: Partial<ChatMessage>): ChatMessage => ({
+    id: over.id ?? `w-${over.step}`, role: 'assistant', timestamp: 0, isComplete: true,
+    content: '', teamTurnId: 'tt1', ...over,
+  })
+
+  it('returns null while any worker is still running', () => {
+    const msgs = [
+      worker({ step: 1, worker: 'a', workerStatus: 'done', content: 'first' }),
+      worker({ step: 2, worker: 'b', workerStatus: 'running', content: '' }),
+    ]
+    expect(teamFinalAnswer(msgs, 'auto')).toBeNull()
+  })
+
+  it('returns null while a worker is waiting on the user', () => {
+    const msgs = [worker({ step: 1, worker: 'a', workerStatus: 'askedUser', content: 'Which one?' })]
+    expect(teamFinalAnswer(msgs, 'sequential')).toBeNull()
+  })
+
+  it('uses the last finished worker output for auto and sequential, without whiteboard markers', () => {
+    const msgs = [
+      worker({ step: 1, worker: 'a', workerStatus: 'done', content: 'first' }),
+      worker({ step: 2, worker: 'b', workerStatus: 'done', content: 'Final answer.\n\n[FACT]: seen' }),
+      worker({ id: 'footer', workerStatus: undefined, content: '📊 Team **t** results\n\n**a**: first\n\n**b**: Final answer.' }),
+    ]
+    expect(teamFinalAnswer(msgs, 'auto')).toEqual({ worker: 'b', text: 'Final answer.' })
+    expect(teamFinalAnswer(msgs, 'sequential')).toEqual({ worker: 'b', text: 'Final answer.' })
+  })
+
+  it('surfaces a failed last worker as the answer', () => {
+    const msgs = [worker({ step: 1, worker: 'a', workerStatus: 'failed', content: '❌ build broke' })]
+    expect(teamFinalAnswer(msgs, 'auto')).toEqual({ worker: 'a', text: '❌ build broke' })
+  })
+
+  it('uses the Advisor summary for roundtable', () => {
+    const footer = [
+      '🪑 Roundtable: **t**', 'Termination reason: consensus', '',
+      '## Advisor Summary', 'We agree on X.', '',
+      '## Viewpoints', '**a**: yes', '', 'Done.',
+    ].join('\n')
+    const msgs = [
+      worker({ step: 1, worker: 'a', workerStatus: 'done', content: 'yes' }),
+      worker({ id: 'footer', workerStatus: undefined, content: footer }),
+    ]
+    expect(teamFinalAnswer(msgs, 'roundtable')).toEqual({ worker: 'Advisor', text: 'We agree on X.' })
+  })
+
+  it('returns null for an empty run', () => {
+    expect(teamFinalAnswer([], 'auto')).toBeNull()
   })
 })

--- a/codey-mac/src/components/teamRunModel.ts
+++ b/codey-mac/src/components/teamRunModel.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, ToolCallEntry } from '../types'
 import { parseTeamMessage } from './teamMessageFormat'
+import { splitWhiteboardMarkers } from './teamWhiteboardFormat'
 import type { TeamGraph, TeamGraphNode, TeamGraphEdge } from '../../../packages/core/src/team-graph'
 
 export type NodeRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'askedUser'
@@ -146,4 +147,34 @@ export function nodeStatuses(graph: TeamGraph, runs: WorkerRun[], askingWorker?:
     // condition nodes: omitted -> neutral default styling
   }
   return out
+}
+
+export interface TeamFinalAnswer {
+  worker: string
+  text: string
+}
+
+const ROUNDTABLE_SUMMARY_RE = /##\s+Advisor Summary\s*\n([\s\S]*?)(?:\n##\s|$)/i
+
+/** The one thing to show once a team run is over: the last worker's output for
+ * auto / sequential / graph, or the Advisor summary for roundtable. Returns
+ * null while any member is still working or waiting on the user, so the
+ * live stage stays visible until the run truly ends. */
+export function teamFinalAnswer(messages: ChatMessage[], mode: ChatMessage['teamMode']): TeamFinalAnswer | null {
+  const workers = messages.filter(m => !!m.worker)
+  if (workers.length === 0) return null
+  if (workers.some(m => m.workerStatus === 'running' || m.workerStatus === 'askedUser')) return null
+
+  if (mode === 'roundtable') {
+    const footer = [...messages].reverse().find(m => !m.worker && /^🪑 Roundtable:/.test(m.content.trim()))
+    if (footer) {
+      const summary = ROUNDTABLE_SUMMARY_RE.exec(footer.content)?.[1]?.trim()
+      if (summary && summary !== '(empty)') return { worker: 'Advisor', text: summary }
+    }
+  }
+
+  const last = [...workers].sort((a, b) => (a.step ?? 0) - (b.step ?? 0)).pop()!
+  const text = splitWhiteboardMarkers(last.content).stripped
+  if (!text) return null
+  return { worker: last.worker!, text }
 }


### PR DESCRIPTION
## Summary
- Once every team member is done, `TeamRunGroup` collapses to its header row instead of leaving the full stage (roundtable seats / sequential workflow) on screen.
- The final answer is rendered right below as a plain assistant block: the last worker's output for auto / sequential / graph, or the Advisor summary for roundtable. Whiteboard markers are stripped.
- Click the header to reopen the stage. While a worker is still running, or waiting on the user, nothing changes.
- New pure helper `teamFinalAnswer` in `codey-mac/src/components/teamRunModel.ts` with 6 unit tests.

Follow-up to #400: with a single `@worker` the big stage was left open after a one-line answer.

## Test plan
- [x] `npm test -w codey-mac` (985 passing)
- [x] `tsc --noEmit` on codey-mac
- [ ] Real-machine: `@worker` one member, confirm the run folds to one line + the answer, header click reopens it
- [ ] Real-machine: roundtable run folds to the Advisor summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)