### PR TITLE
feat(mac): message navigator maps only Codey replies, tighter tick pitch

### DIFF
--- a/codey-mac/src/components/ChatMessageNavigator.test.ts
+++ b/codey-mac/src/components/ChatMessageNavigator.test.ts
@@ -7,7 +7,7 @@ const makeItems = (count: number): ChatNavigationItem[] => Array.from({ length: 
   id: `message-${index}`,
   title: `Message ${index + 1}`,
   preview: `Preview ${index + 1}`,
-  role: index % 2 === 0 ? 'user' : 'assistant',
+  role: index % 3 === 0 ? 'team' : 'assistant',
 }))
 
 const renderNavigator = (count: number) => renderToStaticMarkup(React.createElement(ChatMessageNavigator, {

--- a/codey-mac/src/components/ChatMessageNavigator.tsx
+++ b/codey-mac/src/components/ChatMessageNavigator.tsx
@@ -2,13 +2,14 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import { createPortal } from 'react-dom'
 import { C } from '../theme'
 
-export const CHAT_NAV_MIN_ITEMS = 8
+/** Assistant replies (team runs count once) before the rail appears. */
+export const CHAT_NAV_MIN_ITEMS = 5
 
 export interface ChatNavigationItem {
   id: string
   title: string
   preview: string
-  role: 'user' | 'assistant' | 'team'
+  role: 'assistant' | 'team'
 }
 
 interface Props {
@@ -19,6 +20,8 @@ interface Props {
 }
 
 const RAIL_WIDTH = 22
+/** Vertical distance between neighbouring ticks. */
+const TICK_PITCH = 9
 const RAIL_LEFT = 5
 const TICK_BASE = 7
 const TICK_MAX = 20
@@ -29,7 +32,7 @@ const rowFor = (container: HTMLDivElement, id: string): HTMLElement | undefined 
   Array.from(container.querySelectorAll<HTMLElement>('[data-chat-navigation-id]'))
     .find(row => row.dataset.chatNavigationId === id)
 
-const railHeightFor = (count: number) => Math.min(380, Math.max(120, (count - 1) * 11))
+const railHeightFor = (count: number) => Math.min(380, Math.max(120, (count - 1) * TICK_PITCH))
 
 /** Tick width for a marker `distance` px away from the pointer: the nearest
  * tick grows to TICK_MAX and neighbours fall off on a bell curve. */
@@ -155,7 +158,7 @@ export const ChatMessageNavigator: React.FC<Props> = ({ containerRef, items, rev
       </nav>
       {hovered && createPortal(
         <div style={{ ...styles.previewCard, ...previewPosition() }} role="tooltip">
-          <div style={styles.previewMeta}>{hovered.role === 'user' ? 'You' : hovered.role === 'team' ? 'Team' : 'Codey'}</div>
+          <div style={styles.previewMeta}>{hovered.role === 'team' ? 'Team' : 'Codey'}</div>
           <div style={styles.previewTitle}>{hovered.title}</div>
           {hovered.preview !== hovered.title && (
             <div style={styles.previewBody}>{hovered.preview}</div>
@@ -174,7 +177,7 @@ const styles: Record<string, React.CSSProperties> = {
     transform: 'translateY(-50%)', cursor: 'pointer',
   },
   markerButton: {
-    position: 'absolute', left: 0, width: RAIL_WIDTH, height: 10, padding: 0,
+    position: 'absolute', left: 0, width: RAIL_WIDTH, height: TICK_PITCH, padding: 0,
     border: 'none', background: 'transparent', cursor: 'pointer',
     display: 'flex', justifyContent: 'flex-start', alignItems: 'center',
     transform: 'translateY(-50%)',

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1351,30 +1351,33 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
   }, [isGatewayRunning])
   const lastMsg = chat?.messages?.[chat.messages.length - 1]
   const renderItems = useMemo(() => groupMessages(chat?.messages ?? []), [chat?.messages])
-  const navigationItems = useMemo<ChatNavigationItem[]>(() => renderItems.map(item => {
+  // Only Codey's side of the conversation is mapped: user prompts are short and
+  // sit right above their reply, so they would just double the tick count.
+  const navigationItems = useMemo<ChatNavigationItem[]>(() => renderItems.flatMap<ChatNavigationItem>(item => {
     if (item.kind === 'team') {
       const source = [...item.messages].reverse().find(message => message.content.trim())
       const preview = (source?.content || `${item.messages.length} team updates`).replace(/\s+/g, ' ').trim()
-      return {
+      return [{
         id: `team:${item.teamTurnId}`,
         title: item.teamName || 'Team run',
         preview: preview.slice(0, 180),
         role: 'team',
-      }
+      }]
     }
     const msg = item.message
-    const plain = (msg.content || msg.userQuestion?.question || (msg.role === 'assistant' ? 'Agent update' : 'Message'))
+    if (msg.role !== 'assistant') return []
+    const plain = (msg.content || msg.userQuestion?.question || 'Agent update')
       .replace(/```[\s\S]*?```/g, ' Code block ')
       .replace(/[#>*_`~\[\]]/g, '')
       .replace(/\s+/g, ' ')
       .trim()
     const firstSentence = plain.split(/(?<=[.!?\u3002\uFF01\uFF1F])\s+|\n/)[0] || plain
-    return {
+    return [{
       id: msg.id,
       title: firstSentence.slice(0, 48),
       preview: plain.slice(0, 180),
-      role: msg.role === 'user' ? 'user' : 'assistant',
-    }
+      role: 'assistant',
+    }]
   }), [renderItems])
   // Cheap stand-in for "the rendered conversation changed": switching chats,
   // a new message, or a streaming reply growing. Find-in-chat re-scans on it,


### PR DESCRIPTION
## Summary
- The left-side message navigator no longer lists user prompts. They sit right above their reply and only doubled the tick count.
- Tick pitch tightened from 11px to 9px.
- Rail now appears after 5 assistant items (was 8) so it shows up at about the same conversation length as before.

## Test plan
- [x] `tsc --noEmit` in codey-mac
- [x] codey-mac vitest: 94 files / 979 tests pass
- [ ] Real-machine: open a chat with 5+ Codey replies, confirm only Codey ticks show and the spacing feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)