### PR TITLE
fix(mac): message navigator keeps a fixed tick pitch on short chats

### DIFF
--- a/codey-mac/src/components/ChatMessageNavigator.tsx
+++ b/codey-mac/src/components/ChatMessageNavigator.tsx
@@ -32,7 +32,9 @@ const rowFor = (container: HTMLDivElement, id: string): HTMLElement | undefined 
   Array.from(container.querySelectorAll<HTMLElement>('[data-chat-navigation-id]'))
     .find(row => row.dataset.chatNavigationId === id)
 
-const railHeightFor = (count: number) => Math.min(380, Math.max(120, (count - 1) * TICK_PITCH))
+/** Ticks keep a fixed pitch, so a short chat gets a short rail. Only very long
+ * transcripts hit the cap and squeeze closer together. */
+const railHeightFor = (count: number) => Math.min(380, (count - 1) * TICK_PITCH)
 
 /** Tick width for a marker `distance` px away from the pointer: the nearest
  * tick grows to TICK_MAX and neighbours fall off on a bell curve. */


### PR DESCRIPTION
## Summary
- The rail had a 120px minimum height, so a chat with a handful of Codey replies got its ticks spread far apart.
- Height is now `(count - 1) * pitch` with only the 380px cap left, so spacing stays constant and a short chat just gets a short rail.

## Test plan
- [x] `tsc --noEmit` in codey-mac
- [x] navigator vitest passes
- [ ] Real-machine: open a chat with 5 to 10 Codey replies and confirm ticks sit at a fixed 9px pitch

🤖 Generated with [Claude Code](https://claude.com/claude-code)