### PR TITLE
fix(mac): quieter member bubbles, Aide summary only for real team runs

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -17,9 +17,8 @@ import { parseTeamMessage } from './teamMessageFormat'
 import { groupMessages } from './teamGroup'
 import { useBuiltinAvatars } from './useBuiltinAvatars'
 import { MemberReply } from './MemberReply'
-import { ToolCallList } from './ToolCallList'
 import { WorkerAvatar } from './WorkerAvatar'
-import { workerAvatarState, avatarStateLabels, builtinAvatar } from './workerAvatarModel'
+import { workerAvatarState, builtinAvatar } from './workerAvatarModel'
 import { StatusSidecar } from './StatusSidecar'
 import { useStatusPanelEnabled } from './statusPanelPref'
 import { isTaskBriefStale, extractSidecarBrief } from './taskHudView'
@@ -2169,10 +2168,12 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                 overflowWrap: 'anywhere', wordBreak: 'break-word',
                 transition: 'border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease',
               }}>
-                {!isUser && msg.worker && <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+                {/* The team final answer reads like a plain Codey reply: no
+                    member header. Live state is shown by the footer, so the
+                    header carries only identity. */}
+                {!isUser && msg.worker && !msg.teamFinal && <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
                   <WorkerAvatar name={msg.worker} config={msg.builtinMember ? builtinAvatar(msg.builtinMember, builtinAvatars) : member?.config.avatar} state={memberState} />
                   <strong>{msg.builtinMember === 'aide' ? 'Aide' : msg.builtinMember === 'advisor' ? 'Advisor' : msg.worker}</strong>
-                  <span role="status" style={{ fontSize: 11, color: memberState === 'failed' ? C.red : C.fg3 }}>{msg.teamFinal ? (msg.teamFinal.source === 'fallback' ? 'Execution record summary' : 'Team summary') : avatarStateLabels[memberState]}</span>
                 </div>}
                 {!isUser && (() => {
                   const thinking = msg.thinking?.trim() ?? ''
@@ -2205,10 +2206,6 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                 {!isUser && (msg.worker ? memberActive && memberState === 'working' : !!flight && msg === lastMsg) && (
                   <LiveActivity toolCalls={msg.toolCalls} />
                 )}
-                {!isUser && msg.worker && !!msg.toolCalls?.length && <details style={{ margin: '6px 0' }}>
-                  <summary style={{ cursor: 'pointer', color: C.fg3, fontSize: 11 }}>Tool history</summary>
-                  <ToolCallList toolCalls={msg.toolCalls} />
-                </details>}
                 {(msg.content || (!isUser && msg.userQuestion?.question)) && (() => {
                   if (isUser) {
                     if (isEditing) return (
@@ -2504,7 +2501,7 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                 onMouseEnter={() => setMentionIdx(i)}
               >
                 <span style={styles.mentionIcon}>
-                  {entry.kind === 'worker' ? <UIIcon name="users" size={13} color={C.fg3} />
+                  {entry.kind === 'worker' ? <WorkerAvatar name={entry.name} config={workers.find(w => w.name === entry.name)?.config.avatar} size={14} />
                     : entry.kind === 'skill' ? <UIIcon name="sparkle" size={13} color={C.fg3} />
                     : entry.kind === 'plugin' ? <UIIcon name="tools" size={13} color={C.fg3} />
                     : entry.kind === 'mcp' ? <UIIcon name="server" size={13} color={C.fg3} />

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -4,6 +4,9 @@ import { C } from '../theme'
 import { fieldStyle, inputStyle, pageStyle, selectStyle, pillButton, Section, Toggle, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { AGENT_API_TYPE, AGENT_NAMES, ApiType, agentsPinnedTo, missingAllEndpoints, modelFitsApiType } from './modelApiType'
+import { AvatarPicker } from './AvatarPicker'
+import { useBuiltinAvatars } from './useBuiltinAvatars'
+import { builtinAvatar, type BuiltinMember, type MemberAvatar } from '../../../packages/core/src/member-avatars'
 
 interface SettingsTabProps {
   isGatewayRunning: boolean
@@ -310,6 +313,11 @@ const FallbackList: React.FC<{
 export type { InstallStatus } from './installedAgents'
 
 export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) => {
+  const builtinAvatars = useBuiltinAvatars()
+  const setMemberAvatar = async (member: BuiltinMember, next: MemberAvatar) => {
+    const result = await window.codey.builtinAvatars.set(member, next)
+    if (result.ok) window.dispatchEvent(new Event('codey:workers-changed'))
+  }
   const [models, setModels] = useState<ModelEntry[]>([])
   const [fallback, setFallback] = useState<FallbackCfg>({ enabled: true, order: [] })
   const [advisor, setAdvisor] = useState<{ agent: string; model: string }>({ agent: '', model: '' })
@@ -446,6 +454,9 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
           ))}
         </select>
       </div>
+      <div style={{ marginTop: 8 }}>
+        <AvatarPicker value={builtinAvatar('advisor', builtinAvatars)} onChange={next => setMemberAvatar('advisor', next)} />
+      </div>
 
       <Section title="Aide" description="Background model for summaries, titles, and other lightweight housekeeping."/>
       <div style={{
@@ -483,6 +494,9 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
             <option key={m.model} value={m.model}>{m.model} [{m.apiType}]</option>
           ))}
         </select>
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <AvatarPicker value={builtinAvatar('aide', builtinAvatars)} onChange={next => setMemberAvatar('aide', next)} />
       </div>
 
       <Section title="Models" description="Models available to agents and routing settings." right={

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -1,8 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
 import { apiService, WorkerDto } from '../services/api'
-import { AvatarPicker } from './AvatarPicker'
-import { useBuiltinAvatars } from './useBuiltinAvatars'
-import { builtinAvatar, type BuiltinMember, type MemberAvatar } from '../../../packages/core/src/member-avatars'
 import { WorkerAvatar } from './WorkerAvatar'
 import { avatarShapes, avatarColors, resolveWorkerAvatar } from './workerAvatarModel'
 import { C } from '../theme'
@@ -11,10 +8,9 @@ import { AGENT_API_TYPE, ApiType, modelFitsApiType } from './modelApiType'
 
 interface ModelEntry { apiType: ApiType; model: string }
 
-type Mode = { kind: 'builtin'; member: BuiltinMember } | { kind: 'idle' } | { kind: 'select'; name: string } | { kind: 'create' }
+type Mode = { kind: 'idle' } | { kind: 'select'; name: string } | { kind: 'create' }
 
 export default function WorkersTab() {
-  const builtinAvatars = useBuiltinAvatars()
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   const [mode, setMode] = useState<Mode>({ kind: 'idle' })
   const [loading, setLoading] = useState(false)
@@ -31,11 +27,6 @@ export default function WorkersTab() {
     <div style={{ display: 'flex', height: '100%', background: C.bg, color: C.fg }}>
       <div style={{ width: 240, borderRight: `1px solid ${C.border}`, display: 'flex', flexDirection: 'column' }}>
         <div style={{ overflowY: 'auto', flex: 1 }}>
-          {(['aide', 'advisor'] as const).map(member => <button key={member} onClick={() => setMode({ kind: 'builtin', member })}
-            style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: 12, color: C.fg, border: 'none', background: mode.kind === 'builtin' && mode.member === member ? C.surface2 : 'transparent', cursor: 'pointer' }}>
-            <WorkerAvatar name={member} config={builtinAvatar(member, builtinAvatars)} />
-            <strong>{member === 'aide' ? 'Aide' : 'Advisor'}</strong><span style={{ color: C.fg3, fontSize: 10 }}>Built-in</span>
-          </button>)}
           {workers.map(w => (
             <button key={w.name} onClick={() => setMode({ kind: 'select', name: w.name })}
               style={{ display: 'block', width: '100%', textAlign: 'left', padding: '10px 12px', background: mode.kind === 'select' && mode.name === w.name ? C.surface2 : 'transparent', border: 'none', color: C.fg, cursor: 'pointer' }}>
@@ -49,7 +40,6 @@ export default function WorkersTab() {
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto' }}>
-        {mode.kind === 'builtin' && <BuiltinAvatarEditor key={mode.member} member={mode.member} initial={builtinAvatar(mode.member, builtinAvatars)} />}
         {mode.kind === 'idle' && <EmptyState />}
         {mode.kind === 'create' && <CreatePanel loading={loading} setLoading={setLoading} onCreated={async (w) => { await reload(); setMode({ kind: 'select', name: w.name }) }} onCancel={() => setMode({ kind: 'idle' })} />}
         {mode.kind === 'select' && selected && <EditorPanel worker={selected} onSaved={reload} onDeleted={async () => { await reload(); setMode({ kind: 'idle' }) }} />}
@@ -239,27 +229,4 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
       </div>
     </div>
   )
-}
-
-function BuiltinAvatarEditor({ member, initial }: { member: BuiltinMember; initial: MemberAvatar }) {
-  const [avatar, setAvatar] = useState(initial)
-  const [message, setMessage] = useState('')
-  const [saving, setSaving] = useState(false)
-  const save = async () => {
-    setSaving(true)
-    try {
-      const result = await window.codey.builtinAvatars.set(member, avatar)
-      if (!result.ok) throw new Error(result.error)
-      window.dispatchEvent(new Event('codey:workers-changed'))
-      setMessage('Saved')
-    } catch (error) { setMessage(String(error)) }
-    finally { setSaving(false) }
-  }
-  return <div style={{ padding: 24 }}>
-    <h3>{member === 'aide' ? 'Aide' : 'Advisor'}</h3>
-    <p>{member === 'aide' ? 'Summarizes recorded team results.' : 'Coordinates the team and decides next steps.'}</p>
-    <AvatarPicker value={avatar} onChange={setAvatar} />
-    <button type="button" disabled={saving} onClick={save} style={{ marginTop: 20 }}>{saving ? 'Saving…' : 'Save'}</button>
-    <p role="status">{message}</p>
-  </div>
 }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -6389,6 +6389,10 @@ Example: /model gpt-4.1 write a Python script`;
         }
       }
       const messages = this.chatManager.get(chatId)!.messages;
+      // A lone "@worker" mention speaks for itself; the Aide only closes a
+      // real team run (a named team, or an ad-hoc team with several members).
+      const memberCount = new Set(messages.filter(m => m.teamTurnId === activeTeamId && m.worker && !m.builtinMember).map(m => m.worker)).size;
+      if (chat.selection.type !== 'team' && memberCount < 2) return null;
       const message = await publishTeamFinal({
         teamTurnId: activeTeamId, teamName: activeTeamName, messages, context, task: pendingTeam?.task ?? userText,
         reason: reason || teamTermination, stopped, signal: abortController.signal,


### PR DESCRIPTION
## Summary
Follow-up to #405 from real-machine feedback.

- **Member bubble header** shows only avatar + name. The "Working / Done / Failed" label duplicated the running footer.
- **In-message "Tool history"** disclosure removed for worker messages; the right-hand panel already shows tool calls.
- **Aide final answer only for real team runs**: published when the chat is bound to a named team, or an ad-hoc `@mention` run has 2+ members. A lone `@worker` reply stands on its own (falls back to the pre-#405 path).
- **Final answer renders as a plain Codey reply**: no Aide name, avatar, or "Team summary" label.
- **Aide/Advisor avatar pickers** move from the Workers tab to Settings → AI Models next to their agent/model selectors. The `@` mention dropdown shows each worker's avatar.

## Test plan
- [x] `npm test` — core 47 / gateway 50 / mac 95 test files pass
- [x] `npm run build -w @codey/gateway`, `tsc --noEmit` in `codey-mac`
- [ ] Real machine: `@developer <task>` → no Aide summary, no "Working" label, no Tool history block
- [ ] Real machine: `@a @b <task>` or a named team → one final answer that looks like a normal Codey reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)