### PR TITLE
feat(mac): fold chat history and preview links

### DIFF
--- a/codey-mac/electron/link-preview.test.ts
+++ b/codey-mac/electron/link-preview.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { isSafePreviewUrl, parseLinkPreview } from './link-preview'
+
+describe('parseLinkPreview', () => {
+  it('prefers Open Graph tags', () => {
+    const html = `
+      <html><head>
+        <title>Fallback title</title>
+        <meta property="og:title" content="OG title">
+        <meta property="og:description" content="OG blurb">
+        <meta property="og:image" content="/img/hero.png">
+        <meta property="og:site_name" content="Example">
+      </head></html>`
+    expect(parseLinkPreview(html, 'https://example.com/post')).toEqual({
+      url: 'https://example.com/post',
+      title: 'OG title',
+      description: 'OG blurb',
+      image: 'https://example.com/img/hero.png',
+      siteName: 'Example',
+    })
+  })
+
+  it('falls back to twitter tags, then plain html', () => {
+    const html = `
+      <head>
+        <title>Plain &amp; title</title>
+        <meta name="description" content="Plain blurb">
+        <meta name="twitter:image" content="https://cdn.example.com/t.jpg">
+      </head>`
+    const preview = parseLinkPreview(html, 'https://www.example.com/x')
+    expect(preview.title).toBe('Plain & title')
+    expect(preview.description).toBe('Plain blurb')
+    expect(preview.image).toBe('https://cdn.example.com/t.jpg')
+    expect(preview.siteName).toBe('example.com')
+  })
+
+  it('uses a favicon link when no social image exists', () => {
+    const html = `<head><link rel="apple-touch-icon" href="/icon.png"><title>T</title></head>`
+    expect(parseLinkPreview(html, 'https://example.com/').image).toBe('https://example.com/icon.png')
+  })
+
+  it('handles single-quoted and unquoted attributes', () => {
+    const html = `<head><meta property='og:title' content=Hello></head>`
+    expect(parseLinkPreview(html, 'https://example.com/').title).toBe('Hello')
+  })
+
+  it('drops a non-http image scheme', () => {
+    const html = `<head><meta property="og:image" content="data:image/png;base64,AAAA"></head>`
+    expect(parseLinkPreview(html, 'https://example.com/').image).toBeUndefined()
+  })
+
+  it('collapses whitespace and truncates a long description', () => {
+    const html = `<head><meta name="description" content="${'x'.repeat(400)}"></head>`
+    const desc = parseLinkPreview(html, 'https://example.com/').description!
+    expect(desc).toHaveLength(220)
+    expect(desc.endsWith('…')).toBe(true)
+  })
+
+  it('survives a page with no metadata at all', () => {
+    const preview = parseLinkPreview('<html><body>hi</body></html>', 'https://example.com/a')
+    expect(preview.title).toBeUndefined()
+    expect(preview.siteName).toBe('example.com')
+  })
+})
+
+describe('isSafePreviewUrl', () => {
+  it('rejects local and private literal addresses', async () => {
+    await expect(isSafePreviewUrl('http://localhost:3000')).resolves.toBe(false)
+    await expect(isSafePreviewUrl('http://127.0.0.1/admin')).resolves.toBe(false)
+    await expect(isSafePreviewUrl('http://169.254.169.254/latest/meta-data')).resolves.toBe(false)
+    await expect(isSafePreviewUrl('http://[::1]/')).resolves.toBe(false)
+    await expect(isSafePreviewUrl('http://[::ffff:127.0.0.1]/')).resolves.toBe(false)
+  })
+
+  it('rejects non-http protocols', async () => {
+    await expect(isSafePreviewUrl('file:///etc/passwd')).resolves.toBe(false)
+  })
+})

--- a/codey-mac/electron/link-preview.ts
+++ b/codey-mac/electron/link-preview.ts
@@ -1,0 +1,235 @@
+import { lookup } from 'node:dns/promises'
+import { BlockList, isIP } from 'node:net'
+
+/** Link preview cards.
+ *
+ *  A chat reply that cites a page gets a small card under it — thumbnail,
+ *  title, blurb — so the user can tell what a bare URL points at without
+ *  leaving the app. The fetch lives in main because the renderer has no
+ *  network reach to arbitrary origins (and no cookie jar we'd want to send).
+ *
+ *  Preview fetching is a "visit whatever the model printed" operation, so it
+ *  stays deliberately narrow: http(s) only, one short timeout, a byte cap on
+ *  the body, and only the <head> metadata is ever surfaced. */
+
+export interface LinkPreview {
+  url: string
+  title?: string
+  description?: string
+  image?: string
+  siteName?: string
+}
+
+/** Pages routinely put the whole document in one response; we only need the
+ *  head, so stop reading well before a large page can tie up memory. */
+const MAX_BYTES = 512 * 1024
+const TIMEOUT_MS = 8000
+const CACHE_TTL_MS = 30 * 60 * 1000
+const CACHE_MAX = 200
+const MAX_REDIRECTS = 5
+
+const blockedAddresses = new BlockList()
+blockedAddresses.addSubnet('0.0.0.0', 8, 'ipv4')
+blockedAddresses.addSubnet('10.0.0.0', 8, 'ipv4')
+blockedAddresses.addSubnet('100.64.0.0', 10, 'ipv4')
+blockedAddresses.addSubnet('127.0.0.0', 8, 'ipv4')
+blockedAddresses.addSubnet('169.254.0.0', 16, 'ipv4')
+blockedAddresses.addSubnet('172.16.0.0', 12, 'ipv4')
+blockedAddresses.addSubnet('192.168.0.0', 16, 'ipv4')
+blockedAddresses.addSubnet('224.0.0.0', 4, 'ipv4')
+blockedAddresses.addAddress('::', 'ipv6')
+blockedAddresses.addAddress('::1', 'ipv6')
+blockedAddresses.addSubnet('::ffff:0:0', 96, 'ipv6')
+blockedAddresses.addSubnet('fc00::', 7, 'ipv6')
+blockedAddresses.addSubnet('fe80::', 10, 'ipv6')
+blockedAddresses.addSubnet('ff00::', 8, 'ipv6')
+
+const unsafeIp = (address: string): boolean => {
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, '')
+  const family = isIP(normalized)
+  if (!family) return true
+  return blockedAddresses.check(normalized, family === 4 ? 'ipv4' : 'ipv6')
+}
+
+/** Main-process enforcement for the IPC boundary. Renderer filtering is only
+ *  presentation logic and must not be the thing protecting local services. */
+export async function isSafePreviewUrl(candidate: string): Promise<boolean> {
+  let url: URL
+  try { url = new URL(candidate) } catch { return false }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+  const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  if (!host || host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) return false
+  if (isIP(host)) return !unsafeIp(host)
+  try {
+    const addresses = await lookup(host, { all: true, verbatim: true })
+    return addresses.length > 0 && addresses.every(({ address }) => !unsafeIp(address))
+  } catch {
+    return false
+  }
+}
+
+const decodeEntities = (raw: string): string =>
+  raw
+    .replace(/&(#\d+|#x[0-9a-f]+|[a-z]+);/gi, (whole, body: string) => {
+      if (body.startsWith('#x') || body.startsWith('#X')) {
+        const code = parseInt(body.slice(2), 16)
+        return Number.isFinite(code) ? String.fromCodePoint(code) : whole
+      }
+      if (body.startsWith('#')) {
+        const code = parseInt(body.slice(1), 10)
+        return Number.isFinite(code) ? String.fromCodePoint(code) : whole
+      }
+      const named: Record<string, string> = {
+        amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', '#39': "'",
+      }
+      return named[body.toLowerCase()] ?? whole
+    })
+    .trim()
+
+/** Pull one attribute out of a raw tag, tolerating single, double or bare
+ *  quoting — real-world markup uses all three. */
+const attr = (tag: string, name: string): string | undefined => {
+  const match = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i').exec(tag)
+  if (!match) return undefined
+  const value = match[2] ?? match[3] ?? match[4] ?? ''
+  return value ? decodeEntities(value) : undefined
+}
+
+const absolute = (candidate: string | undefined, base: string): string | undefined => {
+  if (!candidate) return undefined
+  try {
+    const resolved = new URL(candidate, base)
+    return resolved.protocol === 'http:' || resolved.protocol === 'https:' ? resolved.toString() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const clamp = (text: string | undefined, max: number): string | undefined => {
+  if (!text) return undefined
+  const flat = text.replace(/\s+/g, ' ').trim()
+  if (!flat) return undefined
+  return flat.length > max ? `${flat.slice(0, max - 1).trimEnd()}…` : flat
+}
+
+/** Read Open Graph / Twitter / plain-HTML metadata out of a page.
+ *  Later sources never overwrite an earlier, more specific one, so og:*
+ *  wins over twitter:* which wins over <title>/<meta name="description">. */
+export function parseLinkPreview(html: string, url: string): LinkPreview {
+  const head = html.slice(0, MAX_BYTES)
+  const meta: Record<string, string> = {}
+  for (const match of head.matchAll(/<meta\b[^>]*>/gi)) {
+    const tag = match[0]
+    const key = (attr(tag, 'property') || attr(tag, 'name'))?.toLowerCase()
+    const content = attr(tag, 'content')
+    if (key && content && !meta[key]) meta[key] = content
+  }
+
+  const pick = (...keys: string[]): string | undefined => {
+    for (const key of keys) if (meta[key]) return meta[key]
+    return undefined
+  }
+
+  const docTitle = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(head)?.[1]
+  let icon: string | undefined
+  for (const match of head.matchAll(/<link\b[^>]*>/gi)) {
+    const rel = attr(match[0], 'rel')?.toLowerCase() || ''
+    if (/\b(apple-touch-icon|icon|shortcut)\b/.test(rel)) {
+      icon = attr(match[0], 'href')
+      if (rel.includes('apple-touch-icon')) break
+    }
+  }
+
+  let siteName = pick('og:site_name', 'twitter:site', 'application-name')
+  if (!siteName) {
+    try { siteName = new URL(url).hostname.replace(/^www\./, '') } catch { /* keep it unset */ }
+  }
+
+  return {
+    url,
+    title: clamp(pick('og:title', 'twitter:title') || (docTitle ? decodeEntities(docTitle) : undefined), 120),
+    description: clamp(pick('og:description', 'twitter:description', 'description'), 220),
+    image: absolute(pick('og:image:secure_url', 'og:image', 'twitter:image', 'twitter:image:src') || icon, url),
+    siteName: clamp(siteName, 60),
+  }
+}
+
+interface CacheEntry { at: number; preview: LinkPreview | null }
+const cache = new Map<string, CacheEntry>()
+
+/** Read the body but give up once past the cap — a streaming read keeps a
+ *  huge or endless response from filling memory while we wait for the head. */
+async function readCapped(response: Response): Promise<string> {
+  const body = response.body
+  if (!body) return await response.text()
+  const reader = body.getReader()
+  const decoder = new TextDecoder('utf-8')
+  let out = ''
+  let seen = 0
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      seen += value.byteLength
+      out += decoder.decode(value, { stream: true })
+      // The head is all we parse; once it has closed, nothing below matters.
+      if (seen >= MAX_BYTES || /<\/head>/i.test(out)) break
+    }
+  } finally {
+    try { await reader.cancel() } catch { /* the socket is already going away */ }
+  }
+  return out
+}
+
+export async function fetchLinkPreview(url: string): Promise<LinkPreview | null> {
+  let parsed: URL
+  try { parsed = new URL(url) } catch { return null }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+
+  const key = parsed.toString()
+  const hit = cache.get(key)
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.preview
+
+  let preview: LinkPreview | null = null
+  const abort = new AbortController()
+  const timer = setTimeout(() => abort.abort(), TIMEOUT_MS)
+  try {
+    let current = key
+    let response: Response | null = null
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+      if (!(await isSafePreviewUrl(current))) break
+      response = await fetch(current, {
+        signal: abort.signal,
+        redirect: 'manual',
+        headers: {
+          // Some sites serve a JS shell to unknown clients; a normal browser
+          // Accept header gets us the server-rendered head with the og: tags.
+          Accept: 'text/html,application/xhtml+xml',
+          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36 Codey/1.0',
+        },
+      })
+      if (![301, 302, 303, 307, 308].includes(response.status)) break
+      const location = response.headers.get('location')
+      if (!location || redirects === MAX_REDIRECTS) { response = null; break }
+      current = new URL(location, current).toString()
+      response = null
+    }
+    if (response?.ok && /text\/html|application\/xhtml/i.test(response.headers.get('content-type') || '')) {
+      preview = parseLinkPreview(await readCapped(response), response.url || current)
+    }
+  } catch {
+    preview = null
+  } finally {
+    clearTimeout(timer)
+  }
+
+  // A failed fetch is cached too: a dead link should not be retried on every
+  // re-render of the same message.
+  if (cache.size >= CACHE_MAX) cache.delete(cache.keys().next().value as string)
+  cache.set(key, { at: Date.now(), preview })
+  return preview
+}
+
+export function clearLinkPreviewCache(): void {
+  cache.clear()
+}

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -23,6 +23,7 @@ import { validateExternalMcp, type ExternalMcpDraft } from './external-mcp'
 import { scanAgentMcpServers, type AgentMcpServer, type McpAgentKey } from './agent-mcp-scan'
 import { deriveDeliveryState, shouldRediscoverPr } from './delivery-status'
 import { locateRefPath } from './file-ref'
+import { fetchLinkPreview, type LinkPreview } from './link-preview'
 import type { ScannedSkill } from './skills'
 import { AGENT_MEMORY, scanProjectMemory, scanUserMemory } from './memory'
 import { legacySharedFilePath, renderSharedBody, sharedMemoryTargets, syncSharedMemory } from './shared-memory'
@@ -5352,6 +5353,11 @@ ipcMain.handle('open-external', (_event, url: string) => {
   if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
     shell.openExternal(url)
   }
+})
+
+ipcMain.handle('link-preview', async (_event, url: string): Promise<LinkPreview | null> => {
+  if (typeof url !== 'string' || !url) return null
+  return await fetchLinkPreview(url)
 })
 
 ipcMain.handle('shell:openPath', async (_event, p: string) => {

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -586,6 +586,7 @@ contextBridge.exposeInMainWorld('codey', {
   },
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openPath: (path: string) => ipcRenderer.invoke('shell:openPath', path),
+  linkPreview: (url: string) => ipcRenderer.invoke('link-preview', url),
   revealInFolder: (path: string) => ipcRenderer.invoke('shell:showItemInFolder', path),
   readTextFile: (path: string) => ipcRenderer.invoke('file:readText', path),
   readImageFile: (path: string) => ipcRenderer.invoke('file:readImage', path),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -9,6 +9,7 @@ import type { CoreState } from '../electron/core-state'
 import type { ScannedSkill } from '../electron/skills'
 import type { SkillUsage, SkillUsageMap } from '../electron/skill-usage'
 import type { MemoryEntry } from '../electron/memory'
+import type { LinkPreview } from '../electron/link-preview'
 import type { CodeyMemoryItem, MemoryStoreScope } from '../electron/codey-memory'
 import type { Automation, AutomationRun, AutomationEvent } from '../../packages/core/src/types/automation'
 import type { AutomationDraft } from '../../packages/core/src/aide-automation'
@@ -16,6 +17,7 @@ import type { ChatStep } from '../../packages/gateway/src/automations/chat'
 
 type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
+export type { LinkPreview }
 export type SkillEntry = ScannedSkill
 export type { SkillUsage, SkillUsageMap }
 
@@ -735,6 +737,7 @@ declare global {
       }
       openExternal: (url: string) => Promise<void>
       openPath: (path: string) => Promise<string>
+      linkPreview: (url: string) => Promise<LinkPreview | null>
       revealInFolder: (path: string) => Promise<boolean>
       readTextFile: (path: string) => Promise<string | null>
       readImageFile: (path: string) => Promise<string | null>

--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -12,11 +12,16 @@ import { UIIcon } from './UIIcons'
 import { moveWorkspace, reconcileWorkspaceOrder } from './workspaceOrder'
 import { ChatHoverCard } from './ChatHoverCard'
 import { buildChatHoverCard } from './chatHoverCardView'
+import { visibleChatCount } from './chatListVisible'
 import { useVoiceTurn } from '../hooks/useVoiceTurn'
 
 /** How long the pointer has to rest on a row before its info card appears —
  *  long enough that sweeping the list to reach the footer stays quiet. */
 const HOVER_CARD_DELAY_MS = 550
+
+/** How many chats a workspace shows before it folds the rest behind
+ *  "Show more" — enough that a busy workspace never buries its neighbours. */
+const CHATS_PER_WORKSPACE = 8
 
 interface Props {
   onOpenSettings: (tab?: string) => void
@@ -68,6 +73,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
   const [hoveredChatId, setHoveredChatId] = useState<string | null>(null)
+  const [expandedChatGroups, setExpandedChatGroups] = useState<Record<string, boolean>>({})
   const [hoverCard, setHoverCard] = useState<{
     chatId: string
     top: number
@@ -394,6 +400,8 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
         )}
         {groupNames.map(ws => {
           const collapsed = !!state.collapsedWorkspaces[ws]
+          const shown = visibleChatCount(groups[ws], CHATS_PER_WORKSPACE, !!expandedChatGroups[ws], activeChatId)
+          const hidden = groups[ws].length - shown
           const unreadCount = groups[ws].reduce(
             (count, chat) => count + (state.unreadChats[chat.id] ? 1 : 0),
             0,
@@ -494,7 +502,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                   title={`New chat in "${ws}"`}
                 ><UIIcon name="plus" size={15} /></button>
               </div>
-              {!collapsed && groups[ws].map(chat => {
+              {!collapsed && groups[ws].slice(0, shown).map(chat => {
                 const active = chat.id === activeChatId
                 const flight = state.inFlight[chat.id]
                 const unread = !!state.unreadChats[chat.id]
@@ -609,6 +617,14 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                   </div>
                 )
               })}
+              {!collapsed && (hidden > 0 || expandedChatGroups[ws]) && (
+                <button
+                  style={styles.showMoreBtn}
+                  onClick={() => setExpandedChatGroups(prev => ({ ...prev, [ws]: !prev[ws] }))}
+                >
+                  {hidden > 0 ? `Show ${hidden} more` : 'Show less'}
+                </button>
+              )}
             </div>
           )
         })}
@@ -826,6 +842,12 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex', alignItems: 'center', gap: 6,
     padding: '7px 9px', borderRadius: 8, cursor: 'pointer',
     fontSize: 12, color: C.fg2, margin: '2px 2px 2px 20px', border: '1px solid transparent',
+  },
+  showMoreBtn: {
+    display: 'block', width: 'calc(100% - 22px)', textAlign: 'left',
+    padding: '5px 9px', margin: '2px 2px 4px 20px', borderRadius: 8,
+    background: 'transparent', border: '1px solid transparent',
+    color: C.fg3, fontSize: 11, fontWeight: 600, cursor: 'pointer',
   },
   activitySlot: { width: 8, flexShrink: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' },
   titleGroup: { flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 5 },

--- a/codey-mac/src/components/ChatMessageNavigator.tsx
+++ b/codey-mac/src/components/ChatMessageNavigator.tsx
@@ -160,7 +160,6 @@ export const ChatMessageNavigator: React.FC<Props> = ({ containerRef, items, rev
       </nav>
       {hovered && createPortal(
         <div style={{ ...styles.previewCard, ...previewPosition() }} role="tooltip">
-          <div style={styles.previewMeta}>{hovered.role === 'team' ? 'Team' : 'Codey'}</div>
           <div style={styles.previewTitle}>{hovered.title}</div>
           {hovered.preview !== hovered.title && (
             <div style={styles.previewBody}>{hovered.preview}</div>
@@ -191,7 +190,6 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.fg, background: C.surface2, border: `1px solid ${C.border2}`,
     boxShadow: '0 14px 36px rgba(0,0,0,0.34)',
   },
-  previewMeta: { color: C.fg3, fontSize: 10, fontWeight: 650, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 5 },
   previewTitle: { color: C.fg, fontSize: 14, fontWeight: 700, lineHeight: 1.35 },
   previewBody: {
     color: C.fg2, fontSize: 12, lineHeight: 1.55, marginTop: 7,

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -7,6 +7,7 @@ import { apiService, WorkerDto } from '../services/api'
 import { useChats } from '../hooks/useChats'
 import { C } from '../theme'
 import { Markdown } from './Markdown'
+import { LinkPreviewCards } from './LinkPreviewCards'
 import { FilePathCwd } from './FilePathLink'
 import { PairingModal } from './PairingModal'
 import { AttachmentPreview } from './AttachmentPreview'
@@ -2250,6 +2251,9 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                   if (!parsed) return (
                     <div>
                       <Markdown variant="assistant" layout="roomy">{text}</Markdown>
+                      {/* Cards wait for the stream to settle — a half-typed
+                          URL would fetch a page the reply never meant. */}
+                      {!isStreaming && <LinkPreviewCards text={text} />}
                     </div>
                   )
                   return (

--- a/codey-mac/src/components/LinkPreviewCards.tsx
+++ b/codey-mac/src/components/LinkPreviewCards.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react'
+import { C } from '../theme'
+import { UIIcon } from './UIIcons'
+import { extractPreviewUrls } from './linkPreviewUrls'
+import type { LinkPreview } from '../codey-api'
+
+/** Small cards under a reply for the pages it links to: thumbnail, title and
+ *  blurb, opening in the user's default browser on click. Metadata comes from
+ *  main (`window.codey.linkPreview`), which caches per URL, so re-rendering a
+ *  long chat does not refetch. A URL whose page yields nothing usable is
+ *  simply dropped — a card with only a hostname on it is noise. */
+
+const usePreviews = (urls: string[]): LinkPreview[] => {
+  const [previews, setPreviews] = useState<LinkPreview[]>([])
+  const key = urls.join('\n')
+
+  useEffect(() => {
+    if (!key) { setPreviews([]); return }
+    let live = true
+    void (async () => {
+      const fetched = await Promise.all(
+        key.split('\n').map(async url => {
+          try { return await window.codey?.linkPreview?.(url) ?? null } catch { return null }
+        }),
+      )
+      if (!live) return
+      setPreviews(fetched.filter((p): p is LinkPreview => !!p && !!p.title))
+    })()
+    return () => { live = false }
+  }, [key])
+
+  return previews
+}
+
+const Thumb: React.FC<{ preview: LinkPreview }> = ({ preview }) => {
+  const [broken, setBroken] = useState(false)
+  if (!preview.image || broken) {
+    return <div style={styles.thumbFallback}><UIIcon name="globe" size={16} /></div>
+  }
+  return (
+    <img
+      src={preview.image}
+      alt=""
+      style={styles.thumb}
+      onError={() => setBroken(true)}
+    />
+  )
+}
+
+export const LinkPreviewCards: React.FC<{ text: string }> = ({ text }) => {
+  const previews = usePreviews(extractPreviewUrls(text))
+  if (previews.length === 0) return null
+  return (
+    <div style={styles.list}>
+      {previews.map(preview => (
+        <button
+          key={preview.url}
+          type="button"
+          style={styles.card}
+          title={`Open ${preview.url} in your browser`}
+          onClick={() => void window.codey?.openExternal?.(preview.url)}
+        >
+          <Thumb preview={preview} />
+          <span style={styles.body}>
+            <span style={styles.title}>{preview.title}</span>
+            {preview.description && <span style={styles.desc}>{preview.description}</span>}
+            <span style={styles.site}>
+              <UIIcon name="globe" size={11} />
+              <span style={styles.siteText}>{preview.siteName || preview.url}</span>
+            </span>
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  list: { display: 'flex', flexDirection: 'column', gap: 6, marginTop: 8 },
+  card: {
+    display: 'flex', alignItems: 'stretch', gap: 10, textAlign: 'left',
+    padding: 8, borderRadius: 10, cursor: 'pointer', maxWidth: 420,
+    background: C.surface2, border: `1px solid ${C.border2}`, color: C.fg,
+    font: 'inherit',
+  },
+  thumb: {
+    width: 56, height: 56, flexShrink: 0, borderRadius: 7,
+    objectFit: 'cover', background: C.surface3,
+  },
+  thumbFallback: {
+    width: 56, height: 56, flexShrink: 0, borderRadius: 7,
+    background: C.surface3, color: C.fg3,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+  body: { minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2, justifyContent: 'center' },
+  title: {
+    fontSize: 12.5, fontWeight: 600, color: C.fg, lineHeight: 1.3,
+    display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  },
+  desc: {
+    fontSize: 11.5, color: C.fg2, lineHeight: 1.35,
+    display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  },
+  site: { display: 'flex', alignItems: 'center', gap: 4, color: C.fg3, fontSize: 11, minWidth: 0 },
+  siteText: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+}

--- a/codey-mac/src/components/chatListVisible.test.ts
+++ b/codey-mac/src/components/chatListVisible.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { visibleChatCount } from './chatListVisible'
+
+const chats = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `c${i}` }))
+
+describe('visibleChatCount', () => {
+  it('shows everything when the group fits under the limit', () => {
+    expect(visibleChatCount(chats(3), 8, false, null)).toBe(3)
+  })
+
+  it('cuts the group at the limit when folded', () => {
+    expect(visibleChatCount(chats(20), 8, false, null)).toBe(8)
+  })
+
+  it('shows everything once expanded', () => {
+    expect(visibleChatCount(chats(20), 8, true, null)).toBe(20)
+  })
+
+  it('keeps an active chat that sits past the cut visible', () => {
+    expect(visibleChatCount(chats(20), 8, false, 'c12')).toBe(13)
+  })
+
+  it('ignores an active chat that is already above the cut', () => {
+    expect(visibleChatCount(chats(20), 8, false, 'c2')).toBe(8)
+  })
+
+  it('ignores an active chat from another workspace', () => {
+    expect(visibleChatCount(chats(20), 8, false, 'elsewhere')).toBe(8)
+  })
+})

--- a/codey-mac/src/components/chatListVisible.ts
+++ b/codey-mac/src/components/chatListVisible.ts
@@ -1,0 +1,15 @@
+/** How many chats of a workspace group the sidebar renders while the group is
+ *  folded, and how the fold interacts with the chat the user is looking at.
+ *
+ *  A folded group never hides the active chat: if it sits past the cut, the
+ *  slice grows to reach it rather than dropping the selection out of view. */
+export function visibleChatCount<T extends { id: string }>(
+  chats: readonly T[],
+  limit: number,
+  expanded: boolean,
+  activeChatId: string | null,
+): number {
+  if (expanded || limit <= 0 || chats.length <= limit) return chats.length
+  const activeIndex = activeChatId ? chats.findIndex(chat => chat.id === activeChatId) : -1
+  return Math.max(limit, activeIndex + 1)
+}

--- a/codey-mac/src/components/linkPreviewUrls.test.ts
+++ b/codey-mac/src/components/linkPreviewUrls.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { extractPreviewUrls } from './linkPreviewUrls'
+
+describe('extractPreviewUrls', () => {
+  it('finds a bare url', () => {
+    expect(extractPreviewUrls('see https://example.com/page for details'))
+      .toEqual(['https://example.com/page'])
+  })
+
+  it('drops sentence punctuation stuck to the end', () => {
+    expect(extractPreviewUrls('read https://example.com/a.'))
+      .toEqual(['https://example.com/a'])
+  })
+
+  it('unwraps a markdown link target', () => {
+    expect(extractPreviewUrls('[docs](https://example.com/docs)'))
+      .toEqual(['https://example.com/docs'])
+  })
+
+  it('dedupes repeats', () => {
+    expect(extractPreviewUrls('https://a.com/x and again https://a.com/x'))
+      .toEqual(['https://a.com/x'])
+  })
+
+  it('ignores urls inside code fences and inline code', () => {
+    expect(extractPreviewUrls('```\nhttps://a.com\n```\nand `https://b.com`')).toEqual([])
+  })
+
+  it('ignores localhost and private hosts', () => {
+    expect(extractPreviewUrls('http://localhost:3000 http://192.168.1.4/x http://10.0.0.2')).toEqual([])
+  })
+
+  it('ignores direct image and file links', () => {
+    expect(extractPreviewUrls('https://a.com/pic.png https://a.com/app.dmg')).toEqual([])
+  })
+
+  it('caps the number of cards', () => {
+    const text = 'https://a.com https://b.com https://c.com https://d.com'
+    expect(extractPreviewUrls(text)).toHaveLength(3)
+  })
+
+  it('returns nothing for empty text', () => {
+    expect(extractPreviewUrls('')).toEqual([])
+  })
+})

--- a/codey-mac/src/components/linkPreviewUrls.ts
+++ b/codey-mac/src/components/linkPreviewUrls.ts
@@ -1,0 +1,54 @@
+/** Which URLs in a reply deserve a preview card.
+ *
+ *  Only links the user could plausibly want to open: real http(s) pages, not
+ *  images the markdown already renders, not localhost/gateway plumbing, and
+ *  never more than a couple so a link-heavy answer stays readable. */
+
+const URL_RE = /https?:\/\/[^\s<>"'`)\]}]+/gi
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|bmp|ico|avif)(\?|#|$)/i
+const FILE_EXT = /\.(zip|tar|gz|tgz|dmg|pkg|exe|mp[34]|mov|wav|pdf)(\?|#|$)/i
+
+export const MAX_PREVIEW_CARDS = 3
+
+/** Trailing punctuation belongs to the sentence, not the link — markdown and
+ *  plain prose both leave it stuck to the end. */
+const trimTail = (raw: string): string => {
+  let url = raw
+  for (;;) {
+    const next = url.replace(/[.,;:!?'"“”’)\]}]+$/, '')
+    if (next === url) break
+    url = next
+  }
+  return url
+}
+
+const isLocal = (host: string): boolean =>
+  host === 'localhost'
+  || host === '127.0.0.1'
+  || host === '::1'
+  || host.endsWith('.local')
+  || /^(10|127)\./.test(host)
+  || /^192\.168\./.test(host)
+  || /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+
+export function extractPreviewUrls(text: string, limit = MAX_PREVIEW_CARDS): string[] {
+  if (!text) return []
+  // Fenced code and inline code are quoted material, not links being shared.
+  const prose = text.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`]*`/g, ' ')
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const match of prose.match(URL_RE) || []) {
+    const url = trimTail(match)
+    let parsed: URL
+    try { parsed = new URL(url) } catch { continue }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue
+    if (isLocal(parsed.hostname)) continue
+    if (IMAGE_EXT.test(parsed.pathname) || FILE_EXT.test(parsed.pathname)) continue
+    const key = parsed.toString()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(key)
+    if (out.length >= limit) break
+  }
+  return out
+}


### PR DESCRIPTION
## Summary

- show eight chats per workspace by default, with Show more / Show less controls while keeping the active chat visible
- render metadata preview cards for up to three public web links after assistant streaming completes
- fetch and cache preview metadata in the Electron main process with timeouts, response limits, redirect validation, and local/private-network blocking

## Verification

- `npm test` — 98 files, 1018 tests passed
- `npm run typecheck`
- `npm run build` — Vite, Electron, signed macOS ZIP and DMG completed