### PR TITLE
fix(mac): simplify worker avatar settings and summary display

### DIFF
--- a/codey-mac/src/components/AvatarPicker.tsx
+++ b/codey-mac/src/components/AvatarPicker.tsx
@@ -1,19 +1,73 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { WorkerAvatar } from './WorkerAvatar'
 import { avatarShapes, avatarColors, type WorkerAvatarConfig } from './workerAvatarModel'
 import { C } from '../theme'
-export function AvatarPicker({ value, onChange }: { value: WorkerAvatarConfig; onChange: (avatar: WorkerAvatarConfig) => void }) {
+import './avatarPicker.css'
+
+export function AvatarPicker({ value, onChange, name = 'Member' }: {
+  value: WorkerAvatarConfig
+  onChange: (avatar: WorkerAvatarConfig) => void
+  name?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const trigger = useRef<HTMLButtonElement>(null)
+  const dialog = useRef<HTMLDialogElement>(null)
+  const titleId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const element = dialog.current
+    element?.showModal()
+    return () => {
+      element?.close()
+      trigger.current?.focus()
+    }
+  }, [open])
+
   return <>
-    <p>Shape</p>
-    <div style={{ display: 'flex', gap: 8 }}>
-      {avatarShapes.map(shape => <button type="button" key={shape} aria-label={shape} aria-pressed={value.shape === shape} onClick={() => onChange({ ...value, shape })}
-        style={{ background: C.surface2, border: `2px solid ${value.shape === shape ? C.accent : C.border}`, borderRadius: 10, padding: 5, cursor: 'pointer' }}>
-        <WorkerAvatar name={shape} config={{ ...value, shape }} size={44} />
-      </button>)}
-    </div>
-    <p>Color</p>
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-      {avatarColors.map(color => <button type="button" key={color} aria-label={`Color ${color}`} aria-pressed={value.color === color} onClick={() => onChange({ ...value, color })}
-        style={{ width: 28, height: 28, background: color, border: `3px solid ${value.color === color ? C.fg : 'transparent'}`, borderRadius: '50%', cursor: 'pointer' }} />)}
-    </div>
+    <button ref={trigger} type="button" onClick={() => setOpen(true)} aria-label={`Change ${name} avatar`}
+      aria-haspopup="dialog" aria-expanded={open}
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 14, padding: '10px 14px', background: C.surface2,
+        border: `1px solid ${C.border}`, borderRadius: 14, color: C.fg, cursor: 'pointer', textAlign: 'left' }}>
+      <WorkerAvatar name={name} config={value} size={56} />
+      <span><span style={{ display: 'block', fontWeight: 600, fontSize: 13 }}>Avatar</span>
+        <span style={{ display: 'block', color: C.fg3, fontSize: 12, marginTop: 4 }}>Click to change</span></span>
+    </button>
+    {open && createPortal(<dialog ref={dialog} className="member-avatar-dialog" aria-labelledby={titleId}
+      onCancel={event => { event.preventDefault(); setOpen(false) }}
+      onClick={event => { if (event.target === event.currentTarget) setOpen(false) }}
+      style={{ padding: 0, width: 360, maxWidth: 'calc(100vw - 40px)', maxHeight: 'calc(100vh - 48px)',
+        margin: 'auto', border: `1px solid ${C.border}`, borderRadius: 18, color: C.fg, background: C.bg,
+        boxShadow: '0 18px 70px rgba(0,0,0,.25)' }}>
+      <div style={{ padding: 22 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 22 }}>
+          <WorkerAvatar name={name} config={value} size={52} />
+          <h3 id={titleId} style={{ margin: 0, fontSize: 15 }}>{name} avatar</h3>
+        </div>
+        <div role="group" aria-label="Shape">
+          <div style={{ marginBottom: 10, color: C.fg3, fontSize: 12 }}>Shape</div>
+          <div style={{ display: 'flex', gap: 10 }}>
+            {avatarShapes.map(shape => <button type="button" key={shape} aria-label={shape} aria-pressed={value.shape === shape}
+              autoFocus={value.shape === shape} onClick={() => onChange({ ...value, shape })}
+              style={{ background: C.surface2, border: `2px solid ${value.shape === shape ? C.accent : C.border}`, borderRadius: 12, padding: 5, cursor: 'pointer' }}>
+              <WorkerAvatar name={shape} config={{ ...value, shape }} size={44} />
+            </button>)}
+          </div>
+        </div>
+        <div role="group" aria-label="Color" style={{ marginTop: 20 }}>
+          <div style={{ marginBottom: 12, color: C.fg3, fontSize: 12 }}>Color</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 32px)', gap: 14 }}>
+            {avatarColors.map(color => <button type="button" key={color} aria-label={`Color ${color}`} aria-pressed={value.color === color}
+              onClick={() => onChange({ ...value, color })}
+              style={{ width: 32, height: 32, background: color, border: `3px solid ${value.color === color ? C.fg : 'transparent'}`, borderRadius: '50%', cursor: 'pointer' }} />)}
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 24 }}>
+          <button type="button" onClick={() => setOpen(false)} style={{ border: 'none', borderRadius: 8, padding: '8px 18px',
+            background: C.accent, color: C.onAccent, fontWeight: 600, cursor: 'pointer' }}>Done</button>
+        </div>
+      </div>
+    </dialog>, document.body)}
   </>
 }

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -17,10 +17,9 @@ import type { ContextPanelTab } from './ChatContextPanel'
 import { useQuickQuestion } from '../hooks/useQuickQuestion'
 import { parseTeamMessage } from './teamMessageFormat'
 import { groupMessages } from './teamGroup'
-import { useBuiltinAvatars } from './useBuiltinAvatars'
 import { MemberReply } from './MemberReply'
 import { WorkerAvatar } from './WorkerAvatar'
-import { workerAvatarState, builtinAvatar } from './workerAvatarModel'
+import { workerAvatarState } from './workerAvatarModel'
 import { StatusSidecar } from './StatusSidecar'
 import { useStatusPanelEnabled } from './statusPanelPref'
 import { isTaskBriefStale, extractSidecarBrief } from './taskHudView'
@@ -528,7 +527,6 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
   const [resourceIndex, setResourceIndex] = useState<MentionEntry[]>([])
   const [mention, setMention] = useState<ActiveMention | null>(null)
   const [mentionIdx, setMentionIdx] = useState(0)
-  const builtinAvatars = useBuiltinAvatars()
   const [workers, setWorkers] = useState<WorkerDto[]>([])
   // The full global team library — names drive the picker, members the "@" menu.
   const [teamLib, setTeamLib] = useState<Record<string, TeamConfigRaw>>({})
@@ -2107,7 +2105,8 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
           />
           {renderItems.map((item, idx) => {
           const msg = item.message
-          const member = msg.worker ? workers.find(w => w.name.toLowerCase() === msg.worker!.toLowerCase()) : undefined
+          const isWorkerMessage = !!msg.worker && !msg.builtinMember && !msg.teamFinal
+          const member = isWorkerMessage ? workers.find(w => w.name.toLowerCase() === msg.worker!.toLowerCase()) : undefined
           const memberActive = !!flight && (msg.teamTurnId
             ? chat.messages.slice(chat.messages.findIndex(m => m.id === flight.userMessageId) + 1).some(m => m.id === msg.id)
             : msg === lastMsg)
@@ -2178,22 +2177,19 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                 overflowWrap: 'anywhere', wordBreak: 'break-word',
                 transition: 'border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease',
               }}>
-                {/* The team final answer reads like a plain Codey reply: no
-                    member header. Live state is shown by the footer, so the
-                    header carries only identity. */}
-                {!isUser && msg.worker && !msg.teamFinal && <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
-                  <WorkerAvatar name={msg.worker} config={msg.builtinMember ? builtinAvatar(msg.builtinMember, builtinAvatars) : member?.config.avatar} state={memberState} />
-                  <strong>{msg.builtinMember === 'aide' ? 'Aide' : msg.builtinMember === 'advisor' ? 'Advisor' : msg.worker}</strong>
+                {!isUser && isWorkerMessage && <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+                  <WorkerAvatar name={msg.worker!} config={member?.config.avatar} state={memberState} />
+                  <strong>{msg.worker}</strong>
                 </div>}
                 {!isUser && (() => {
                   const thinking = msg.thinking?.trim() ?? ''
                   // Keyed off the in-flight turn rather than msg.isComplete:
                   // messages persisted before isComplete existed would
                   // otherwise lose their rule and timestamp for good.
-                  const streaming = msg.worker ? memberActive && msg.workerStatus !== 'done' && msg.workerStatus !== 'failed' : !!flight && msg === lastMsg
+                  const streaming = isWorkerMessage ? memberActive && msg.workerStatus !== 'done' && msg.workerStatus !== 'failed' : !!flight && msg === lastMsg
                   const expanded = thinkingToggles[msg.id]
                     ?? defaultThinkingExpanded({
-                      member: !!msg.worker,
+                      member: isWorkerMessage,
                       hasAnswer: !!msg.content.trim(),
                       isComplete: msg.isComplete ?? false,
                     })
@@ -2213,7 +2209,7 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                     </>
                   )
                 })()}
-                {!isUser && (msg.worker ? memberActive && memberState === 'working' : !!flight && msg === lastMsg) && (
+                {!isUser && (isWorkerMessage ? memberActive && memberState === 'working' : !!flight && msg === lastMsg) && (
                   <LiveActivity toolCalls={msg.toolCalls} />
                 )}
                 {(msg.content || (!isUser && msg.userQuestion?.question)) && (() => {
@@ -2245,8 +2241,8 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                     return <UserMessageContent content={msg.content} />
                   }
                   const text = msg.content || msg.userQuestion?.question || ''
-                  if (msg.worker) return <MemberReply content={text}><TeamWorkerContent content={text} /></MemberReply>
-                  const parsed = parseTeamMessage(text)
+                  if (isWorkerMessage) return <MemberReply content={text}><TeamWorkerContent content={text} /></MemberReply>
+                  const parsed = msg.builtinMember || msg.teamFinal ? null : parseTeamMessage(text)
                   const isStreaming = !!flight && msg === lastMsg
                   if (!parsed) return (
                     <div>

--- a/codey-mac/src/components/SettingsTab.tsx
+++ b/codey-mac/src/components/SettingsTab.tsx
@@ -4,9 +4,6 @@ import { C } from '../theme'
 import { fieldStyle, inputStyle, pageStyle, selectStyle, pillButton, Section, Toggle, unwrap } from './settingsAtoms'
 import { UIIcon } from './UIIcons'
 import { AGENT_API_TYPE, AGENT_NAMES, ApiType, agentsPinnedTo, missingAllEndpoints, modelFitsApiType } from './modelApiType'
-import { AvatarPicker } from './AvatarPicker'
-import { useBuiltinAvatars } from './useBuiltinAvatars'
-import { builtinAvatar, type BuiltinMember, type MemberAvatar } from '../../../packages/core/src/member-avatars'
 
 interface SettingsTabProps {
   isGatewayRunning: boolean
@@ -313,11 +310,6 @@ const FallbackList: React.FC<{
 export type { InstallStatus } from './installedAgents'
 
 export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) => {
-  const builtinAvatars = useBuiltinAvatars()
-  const setMemberAvatar = async (member: BuiltinMember, next: MemberAvatar) => {
-    const result = await window.codey.builtinAvatars.set(member, next)
-    if (result.ok) window.dispatchEvent(new Event('codey:workers-changed'))
-  }
   const [models, setModels] = useState<ModelEntry[]>([])
   const [fallback, setFallback] = useState<FallbackCfg>({ enabled: true, order: [] })
   const [advisor, setAdvisor] = useState<{ agent: string; model: string }>({ agent: '', model: '' })
@@ -454,9 +446,6 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
           ))}
         </select>
       </div>
-      <div style={{ marginTop: 8 }}>
-        <AvatarPicker value={builtinAvatar('advisor', builtinAvatars)} onChange={next => setMemberAvatar('advisor', next)} />
-      </div>
 
       <Section title="Aide" description="Background model for summaries, titles, and other lightweight housekeeping."/>
       <div style={{
@@ -494,9 +483,6 @@ export const SettingsTab: React.FC<SettingsTabProps> = ({ isGatewayRunning }) =>
             <option key={m.model} value={m.model}>{m.model} [{m.apiType}]</option>
           ))}
         </select>
-      </div>
-      <div style={{ marginTop: 8 }}>
-        <AvatarPicker value={builtinAvatar('aide', builtinAvatars)} onChange={next => setMemberAvatar('aide', next)} />
       </div>
 
       <Section title="Models" description="Models available to agents and routing settings." right={

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback } from 'react'
 import { apiService, WorkerDto } from '../services/api'
+import { AvatarPicker } from './AvatarPicker'
 import { WorkerAvatar } from './WorkerAvatar'
-import { avatarShapes, avatarColors, resolveWorkerAvatar } from './workerAvatarModel'
+import { resolveWorkerAvatar } from './workerAvatarModel'
 import { C } from '../theme'
 
 import { AGENT_API_TYPE, ApiType, modelFitsApiType } from './modelApiType'
@@ -42,7 +43,7 @@ export default function WorkersTab() {
       <div style={{ flex: 1, overflowY: 'auto' }}>
         {mode.kind === 'idle' && <EmptyState />}
         {mode.kind === 'create' && <CreatePanel loading={loading} setLoading={setLoading} onCreated={async (w) => { await reload(); setMode({ kind: 'select', name: w.name }) }} onCancel={() => setMode({ kind: 'idle' })} />}
-        {mode.kind === 'select' && selected && <EditorPanel worker={selected} onSaved={reload} onDeleted={async () => { await reload(); setMode({ kind: 'idle' }) }} />}
+        {mode.kind === 'select' && selected && <EditorPanel key={selected.name} worker={selected} onSaved={reload} onDeleted={async () => { await reload(); setMode({ kind: 'idle' }) }} />}
       </div>
     </div>
   )
@@ -163,18 +164,7 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
       </div>
       {error && <div style={{ background: C.dangerBg, border: `1px solid ${C.dangerBorder}`, color: C.dangerFg, padding: 10, borderRadius: 6, fontSize: 12 }}>{error}</div>}
 
-      <label style={labelStyle}>Avatar shape</label>
-      <div style={{ display: 'flex', gap: 8 }}>
-        {avatarShapes.map(shape => <button key={shape} type="button" aria-label={shape} aria-pressed={avatar.shape === shape}
-          onClick={() => setAvatar(a => ({ ...a, shape }))} style={{ background: C.surface2, border: `2px solid ${avatar.shape === shape ? C.accent : C.border}`, borderRadius: 10, padding: 5, cursor: 'pointer' }}>
-          <WorkerAvatar name={shape} config={{ ...avatar, shape }} size={44} />
-        </button>)}
-      </div>
-      <label style={labelStyle}>Avatar color</label>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-        {avatarColors.map(color => <button key={color} type="button" aria-label={`Color ${color}`} aria-pressed={avatar.color === color}
-          onClick={() => setAvatar(a => ({ ...a, color }))} style={{ width: 28, height: 28, background: color, border: `3px solid ${avatar.color === color ? C.fg : 'transparent'}`, borderRadius: '50%', cursor: 'pointer' }} />)}
-      </div>
+      <div style={{ margin: '18px 0' }}><AvatarPicker name={worker.name} value={avatar} onChange={setAvatar} /></div>
       <label style={labelStyle}>Role</label>
       <textarea value={role} onChange={e => setRole(e.target.value)} style={{ ...fieldStyle, minHeight: 60 }} />
 

--- a/codey-mac/src/components/avatarPicker.css
+++ b/codey-mac/src/components/avatarPicker.css
@@ -1,0 +1,4 @@
+.member-avatar-dialog::backdrop {
+  background: rgba(0, 0, 0, .32);
+  backdrop-filter: blur(2px);
+}


### PR DESCRIPTION
Worker settings now show the selected avatar first and open a shape/color dialog when clicked. Switching workers resets the editor so the preview matches the selected worker.

Only worker messages display member avatars and names. Aide/Advisor messages and team final summaries use normal assistant rendering, including persisted messages with built-in/final metadata. This builds on the built-in settings removal already merged in #406 and preserves its quieter worker headers.

Validation: `npm run typecheck -w codey-mac`, desktop `npx vite build` (renderer, Electron main and preload), and `git diff --check` passed. Desktop visual interaction was not manually verified; the build retains existing Vite deprecation/chunk-size warnings.
