### PR TITLE
feat(mac): reveal folded chats ten at a time

### DIFF
--- a/codey-mac/src/components/ChatListPanel.tsx
+++ b/codey-mac/src/components/ChatListPanel.tsx
@@ -23,6 +23,10 @@ const HOVER_CARD_DELAY_MS = 550
  *  "Show more" — enough that a busy workspace never buries its neighbours. */
 const CHATS_PER_WORKSPACE = 8
 
+/** How many extra chats one "Show more" click reveals, so a long history
+ *  unrolls in readable steps instead of flooding the sidebar at once. */
+const CHATS_PER_SHOW_MORE = 10
+
 interface Props {
   onOpenSettings: (tab?: string) => void
   onOpenAutomations: () => void
@@ -73,7 +77,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
   const [chatMenu, setChatMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [chatMenuView, setChatMenuView] = useState<'main' | 'connect'>('main')
   const [hoveredChatId, setHoveredChatId] = useState<string | null>(null)
-  const [expandedChatGroups, setExpandedChatGroups] = useState<Record<string, boolean>>({})
+  const [revealedChatGroups, setRevealedChatGroups] = useState<Record<string, number>>({})
   const [hoverCard, setHoverCard] = useState<{
     chatId: string
     top: number
@@ -400,7 +404,7 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
         )}
         {groupNames.map(ws => {
           const collapsed = !!state.collapsedWorkspaces[ws]
-          const shown = visibleChatCount(groups[ws], CHATS_PER_WORKSPACE, !!expandedChatGroups[ws], activeChatId)
+          const shown = visibleChatCount(groups[ws], CHATS_PER_WORKSPACE, revealedChatGroups[ws] ?? 0, activeChatId)
           const hidden = groups[ws].length - shown
           const unreadCount = groups[ws].reduce(
             (count, chat) => count + (state.unreadChats[chat.id] ? 1 : 0),
@@ -617,12 +621,18 @@ export const ChatListPanel: React.FC<Props> = ({ onOpenSettings, onOpenAutomatio
                   </div>
                 )
               })}
-              {!collapsed && (hidden > 0 || expandedChatGroups[ws]) && (
+              {!collapsed && (hidden > 0 || (revealedChatGroups[ws] ?? 0) > 0) && (
                 <button
                   style={styles.showMoreBtn}
-                  onClick={() => setExpandedChatGroups(prev => ({ ...prev, [ws]: !prev[ws] }))}
+                  onClick={() => setRevealedChatGroups(prev => (
+                    hidden > 0
+                      ? { ...prev, [ws]: (prev[ws] ?? 0) + CHATS_PER_SHOW_MORE }
+                      : { ...prev, [ws]: 0 }
+                  ))}
                 >
-                  {hidden > 0 ? `Show ${hidden} more` : 'Show less'}
+                  {hidden > 0
+                    ? `Show ${Math.min(hidden, CHATS_PER_SHOW_MORE)} more`
+                    : 'Show less'}
                 </button>
               )}
             </div>

--- a/codey-mac/src/components/chatListVisible.test.ts
+++ b/codey-mac/src/components/chatListVisible.test.ts
@@ -5,26 +5,31 @@ const chats = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `c${i}` 
 
 describe('visibleChatCount', () => {
   it('shows everything when the group fits under the limit', () => {
-    expect(visibleChatCount(chats(3), 8, false, null)).toBe(3)
+    expect(visibleChatCount(chats(3), 8, 0, null)).toBe(3)
   })
 
   it('cuts the group at the limit when folded', () => {
-    expect(visibleChatCount(chats(20), 8, false, null)).toBe(8)
+    expect(visibleChatCount(chats(20), 8, 0, null)).toBe(8)
   })
 
-  it('shows everything once expanded', () => {
-    expect(visibleChatCount(chats(20), 8, true, null)).toBe(20)
+  it('grows by the revealed step instead of jumping to the end', () => {
+    expect(visibleChatCount(chats(40), 8, 10, null)).toBe(18)
+    expect(visibleChatCount(chats(40), 8, 20, null)).toBe(28)
+  })
+
+  it('stops at the group size once everything is revealed', () => {
+    expect(visibleChatCount(chats(20), 8, 30, null)).toBe(20)
   })
 
   it('keeps an active chat that sits past the cut visible', () => {
-    expect(visibleChatCount(chats(20), 8, false, 'c12')).toBe(13)
+    expect(visibleChatCount(chats(20), 8, 0, 'c12')).toBe(13)
   })
 
   it('ignores an active chat that is already above the cut', () => {
-    expect(visibleChatCount(chats(20), 8, false, 'c2')).toBe(8)
+    expect(visibleChatCount(chats(20), 8, 0, 'c2')).toBe(8)
   })
 
   it('ignores an active chat from another workspace', () => {
-    expect(visibleChatCount(chats(20), 8, false, 'elsewhere')).toBe(8)
+    expect(visibleChatCount(chats(20), 8, 0, 'elsewhere')).toBe(8)
   })
 })

--- a/codey-mac/src/components/chatListVisible.ts
+++ b/codey-mac/src/components/chatListVisible.ts
@@ -1,15 +1,19 @@
-/** How many chats of a workspace group the sidebar renders while the group is
- *  folded, and how the fold interacts with the chat the user is looking at.
+/** How many chats of a workspace group the sidebar renders, and how the fold
+ *  interacts with the chat the user is looking at.
  *
- *  A folded group never hides the active chat: if it sits past the cut, the
- *  slice grows to reach it rather than dropping the selection out of view. */
+ *  A group starts at `limit` rows and grows by whatever the user has revealed
+ *  through "Show more", one step at a time. A folded group never hides the
+ *  active chat: if it sits past the cut, the slice grows to reach it rather
+ *  than dropping the selection out of view. */
 export function visibleChatCount<T extends { id: string }>(
   chats: readonly T[],
   limit: number,
-  expanded: boolean,
+  revealed: number,
   activeChatId: string | null,
 ): number {
-  if (expanded || limit <= 0 || chats.length <= limit) return chats.length
+  if (limit <= 0) return chats.length
+  const base = limit + Math.max(0, revealed)
+  if (chats.length <= base) return chats.length
   const activeIndex = activeChatId ? chats.findIndex(chat => chat.id === activeChatId) : -1
-  return Math.max(limit, activeIndex + 1)
+  return Math.max(base, activeIndex + 1)
 }


### PR DESCRIPTION
Follow-up to #408. The chat-list fold's "Show more" button expanded a workspace group all the way to its full history in one click, which floods the sidebar when a workspace has dozens of chats.

Each click now reveals ten more rows. The button reads `Show 10 more` (or the real remainder when fewer are left) and only turns into `Show less` once everything is visible, which resets the group back to its folded size.

- `chatListVisible.ts` takes a `revealed` count instead of an `expanded` boolean; the active-chat protection is unchanged.
- Tests: 7 passing in `chatListVisible.test.ts`; `tsc --noEmit` clean.

Not smoke-tested in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)