### PR TITLE
feat(voice): on-device streaming transcription via Nemotron

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { randomUUID } from 'crypto'
 import { captureAccelerator, screenshotAccelerator, resolveCaptureSubmit, normalizeAccelerator } from './capture'
 import { hudStateCommand, hudLevelCommand, conversationToggleCommand } from './voice-hud'
-import { allStreamingModelIds, FileProbe, isOnDeviceVoiceProvider, selectedOnDeviceModel, streamingModelDir, streamingModelIsComplete } from './voice-models'
+import { allStreamingModelIds, FileProbe, isOnDeviceVoiceProvider, selectedOnDeviceModel, streamingModelDir, streamingModelIsComplete, isBogusWarmMarkerKey, warmMarkerDeleteKeys, warmMarkerWriteKeys } from './voice-models'
 import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
 import { clampZoom, formatZoom, zoomIn, zoomOut, DEFAULT_ZOOM } from './zoom'
@@ -1738,6 +1738,7 @@ function warmedVoiceModels(): string[] {
   const helperId = currentHelperId()
   const markers = readWarmMarkers()
   return Object.keys(markers).filter(k => {
+    if (isBogusWarmMarkerKey(k)) return false
     const m = markers[k]
     return m?.osBuild === build && m?.helperId === helperId
   })
@@ -1757,13 +1758,8 @@ function writeWarmMarker(model: string, loadSeconds: number) {
   try {
     const fs = require('fs') as typeof import('fs')
     const cur = readWarmMarkers()
-    // Store under both forms so lookups work whether UI sends the prefixed
-    // (`openai_whisper-...`) or bare (`large-v3...`) variant string.
-    const bare = model.startsWith('openai_whisper-') ? model.slice('openai_whisper-'.length) : model
     const entry = { warmedAt: new Date().toISOString(), loadSeconds, osBuild: currentOsBuild(), helperId: currentHelperId() }
-    cur[model] = entry
-    cur[bare] = entry
-    cur[`openai_whisper-${bare}`] = entry
+    for (const key of warmMarkerWriteKeys(model)) cur[key] = entry
     fs.writeFileSync(warmMarkerPath(), JSON.stringify(cur, null, 2))
   } catch (e) {
     console.warn('writeWarmMarker failed:', e)
@@ -4135,8 +4131,11 @@ app.whenReady().then(async () => {
         }
         try {
           const markers = readWarmMarkers()
-          if (modelName in markers) {
-            delete markers[modelName]
+          let changed = false
+          for (const key of warmMarkerDeleteKeys(modelName)) {
+            if (key in markers) { delete markers[key]; changed = true }
+          }
+          if (changed) {
             fsMod.writeFileSync(warmMarkerPath(), JSON.stringify(markers, null, 2))
           }
         } catch (e) {
@@ -4162,7 +4161,7 @@ app.whenReady().then(async () => {
       try {
         const markers = readWarmMarkers()
         let changed = false
-        for (const v of variants) {
+        for (const v of warmMarkerDeleteKeys(modelName)) {
           if (v in markers) { delete markers[v]; changed = true }
         }
         if (changed) {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { randomUUID } from 'crypto'
 import { captureAccelerator, screenshotAccelerator, resolveCaptureSubmit, normalizeAccelerator } from './capture'
 import { hudStateCommand, hudLevelCommand, conversationToggleCommand } from './voice-hud'
+import { allStreamingModelIds, FileProbe, isOnDeviceVoiceProvider, selectedOnDeviceModel, streamingModelDir, streamingModelIsComplete } from './voice-models'
 import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
 import { clampZoom, formatZoom, zoomIn, zoomOut, DEFAULT_ZOOM } from './zoom'
@@ -1444,7 +1445,8 @@ async function transcribeChromeVoiceLocally(data: Buffer, voice: any): Promise<s
   try {
     const args = ['--transcribe-file', audioPath]
     if (voice.language && voice.language !== 'auto') args.push('--lang', voice.language)
-    if (voice.localModel) args.push('--model', voice.localModel)
+    const model = selectedOnDeviceModel(voice)
+    if (model) args.push('--model', model)
     const vocabulary = normalizeVocabulary(voice.vocabulary)
     if (vocabulary.length) args.push('--vocab', vocabulary.join(','))
     return await new Promise<string>((resolve, reject) => {
@@ -1545,6 +1547,23 @@ function listDownloadedVoiceModels(): string[] {
         if (allWeightsOK) found.add(entry)
       } catch { /* skip */ }
     }
+  }
+  // Streaming (Nemotron) variants live in FluidAudio's own cache. metadata.json
+  // arrives with the bundles rather than after them, so an interrupted
+  // download leaves it next to a half-written weight blob. Check the weights
+  // instead, or the UI advertises a model that fails CoreML warm-up with
+  // execution-plan error -14 and offers no way back to Download.
+  const probe: FileProbe = {
+    size(p: string) {
+      try {
+        const st = fsMod.statSync(p)
+        return st.isFile() ? st.size : null
+      } catch { return null }
+    },
+  }
+  for (const id of allStreamingModelIds()) {
+    const dir = streamingModelDir(home, id)
+    if (dir && streamingModelIsComplete(dir, probe)) found.add(id)
   }
   return Array.from(found)
 }
@@ -1658,8 +1677,8 @@ async function warmSelectedVoiceModelOnStartup(): Promise<void> {
   try {
     const voice = (coreConfigManager?.get() as any)?.voice
     if (!voice?.enabled) return
-    if (voice.provider !== 'local') return
-    const model = String(voice.localModel ?? '')
+    if (!isOnDeviceVoiceProvider(voice.provider)) return
+    const model = selectedOnDeviceModel(voice)
     if (!model) return
 
     // Nothing to warm if the weights aren't on disk — that is a Download
@@ -1807,7 +1826,7 @@ async function applyVoiceHelper(rawCfg: any) {
   // available for their shared on-device WhisperKit path even when both
   // global bindings are turned off.
   const enabled = !voiceHotkeyCaptureActive
-    && (dictationEnabled || conversationEnabled || voice?.provider === 'local')
+    && (dictationEnabled || conversationEnabled || isOnDeviceVoiceProvider(voice?.provider))
   if (!enabled) {
     if (voiceHelperStarted) sendToRenderer('gateway-log', `[voice] disabled — stopping helper`)
     stopVoiceHelper()
@@ -2211,7 +2230,7 @@ app.whenReady().then(async () => {
         if (!coreConfigManager) throw new Error('Codey configuration is unavailable')
         const voice = coreConfigManager.getResolvedVoiceConfig()
         if (!voice) throw new Error('Configure Voice in Codey Settings first')
-        if (voice.provider === 'local') {
+        if (isOnDeviceVoiceProvider(voice.provider)) {
           if (mimeType !== 'audio/wav') throw new Error('Reload the Codey Chrome extension to enable local voice transcription')
           return { text: await transcribeChromeVoiceLocally(data, voice) }
         }
@@ -3799,7 +3818,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('voice:toggleNativeConversation', async (_e, fromHotkey: boolean) =>
     wrap(async () => {
       const provider = coreConfigManager?.get().voice?.provider
-      if (provider !== 'local') return { native: false }
+      if (!isOnDeviceVoiceProvider(provider)) return { native: false }
       // Carried on the command instead of stashed here first: the helper
       // silently declines a toggle that arrives mid-transcription, and a
       // pre-emptive assignment then had nothing to reset it.
@@ -3813,7 +3832,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('voice:toggleNativeDictation', async () =>
     wrap(async () => {
       const provider = coreConfigManager?.get().voice?.provider
-      if (provider !== 'local') return { native: false }
+      if (!isOnDeviceVoiceProvider(provider)) return { native: false }
       if (!sendVoiceHelperCommand('composer-dictation-toggle')) {
         throw new Error('Voice Helper is not available')
       }
@@ -3973,7 +3992,7 @@ app.whenReady().then(async () => {
       if (!coreConfigManager) throw new Error('Gateway configuration is not available')
       const voice = coreConfigManager.getResolvedVoiceConfig()
       if (!voice) throw new Error('Voice is not configured')
-      if (voice.provider === 'local') {
+      if (isOnDeviceVoiceProvider(voice.provider)) {
         throw new Error('Conversation recording currently requires API transcription; choose API under Voice → Speech recognition.')
       }
       if (!voice.apiKey) throw new Error('Select a Transcription key under Voice → Speech recognition.')
@@ -4105,6 +4124,26 @@ app.whenReady().then(async () => {
         : modelName
       const variants = new Set([modelName, bare, `openai_whisper-${bare}`])
       const home = app.getPath('home')
+      // A streaming id maps to exactly one FluidAudio cache folder; the
+      // WhisperKit roots below never contain it, so this is the whole job.
+      const streamingDir = streamingModelDir(home, modelName)
+      if (streamingDir) {
+        const removed: string[] = []
+        if (fsMod.existsSync(streamingDir)) {
+          fsMod.rmSync(streamingDir, { recursive: true, force: true })
+          removed.push(streamingDir)
+        }
+        try {
+          const markers = readWarmMarkers()
+          if (modelName in markers) {
+            delete markers[modelName]
+            fsMod.writeFileSync(warmMarkerPath(), JSON.stringify(markers, null, 2))
+          }
+        } catch (e) {
+          console.warn('voice:deleteModel: failed to update warm markers:', e)
+        }
+        return { removed }
+      }
       const roots = [
         pathMod.join(home, 'Documents', 'huggingface', 'models', 'argmaxinc', 'whisperkit-coreml'),
         pathMod.join(home, 'Library', 'Application Support', 'huggingface', 'models', 'argmaxinc', 'whisperkit-coreml'),

--- a/codey-mac/electron/voice-models.test.ts
+++ b/codey-mac/electron/voice-models.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
   allStreamingModelIds,
+  isBogusWarmMarkerKey,
   isOnDeviceVoiceProvider,
   parseStreamingModelId,
   selectedOnDeviceModel,
   streamingModelDir,
   streamingModelId,
   streamingModelIsComplete,
+  warmMarkerDeleteKeys,
+  warmMarkerWriteKeys,
 } from './voice-models'
 
 describe('isOnDeviceVoiceProvider', () => {
@@ -104,5 +107,47 @@ describe('streamingModelIsComplete', () => {
     const missing = { ...full }
     delete missing[`${DIR}/tokenizer.json`]
     expect(streamingModelIsComplete(DIR, probeFor(missing))).toBe(false)
+  })
+})
+
+describe('warm marker keys', () => {
+  it('aliases a Whisper id so either spelling looks up', () => {
+    expect(new Set(warmMarkerWriteKeys('openai_whisper-large-v3_turbo_954MB'))).toEqual(
+      new Set(['large-v3_turbo_954MB', 'openai_whisper-large-v3_turbo_954MB'])
+    )
+    expect(new Set(warmMarkerWriteKeys('large-v3_turbo_954MB'))).toEqual(
+      new Set(['large-v3_turbo_954MB', 'openai_whisper-large-v3_turbo_954MB'])
+    )
+  })
+
+  it('stores a streaming id under its own name only', () => {
+    expect(warmMarkerWriteKeys('nemotron/multilingual/1120ms')).toEqual(['nemotron/multilingual/1120ms'])
+  })
+
+  it('clears the bogus prefixed alias older builds wrote for streaming ids', () => {
+    // Without this the leftover key still matched in the UI's variant check
+    // and a deleted streaming model kept reporting "Ready".
+    expect(warmMarkerDeleteKeys('nemotron/multilingual/1120ms')).toEqual([
+      'nemotron/multilingual/1120ms',
+      'openai_whisper-nemotron/multilingual/1120ms',
+    ])
+  })
+
+  it('deletes every key it would have written for a Whisper id', () => {
+    const written = new Set(warmMarkerWriteKeys('large-v3_turbo_954MB'))
+    for (const key of written) {
+      expect(warmMarkerDeleteKeys('large-v3_turbo_954MB')).toContain(key)
+    }
+  })
+})
+
+describe('isBogusWarmMarkerKey', () => {
+  it('flags the prefixed streaming alias left by older builds', () => {
+    expect(isBogusWarmMarkerKey('openai_whisper-nemotron/multilingual/1120ms')).toBe(true)
+  })
+
+  it('leaves real Whisper and streaming keys alone', () => {
+    expect(isBogusWarmMarkerKey('openai_whisper-large-v3_turbo_954MB')).toBe(false)
+    expect(isBogusWarmMarkerKey('nemotron/multilingual/1120ms')).toBe(false)
   })
 })

--- a/codey-mac/electron/voice-models.test.ts
+++ b/codey-mac/electron/voice-models.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  allStreamingModelIds,
+  isOnDeviceVoiceProvider,
+  parseStreamingModelId,
+  selectedOnDeviceModel,
+  streamingModelDir,
+  streamingModelId,
+  streamingModelIsComplete,
+} from './voice-models'
+
+describe('isOnDeviceVoiceProvider', () => {
+  it('treats both local engines as on-device and the API ones as not', () => {
+    expect(isOnDeviceVoiceProvider('local')).toBe(true)
+    expect(isOnDeviceVoiceProvider('localStreaming')).toBe(true)
+    expect(isOnDeviceVoiceProvider('api')).toBe(false)
+    expect(isOnDeviceVoiceProvider('realtime')).toBe(false)
+    expect(isOnDeviceVoiceProvider(undefined)).toBe(false)
+  })
+})
+
+describe('parseStreamingModelId', () => {
+  it('parses the canonical id shape', () => {
+    expect(parseStreamingModelId('nemotron/multilingual/1120ms')).toEqual({ languageDir: 'multilingual', chunkMs: 1120 })
+    expect(parseStreamingModelId('nemotron/latin/560ms')).toEqual({ languageDir: 'latin', chunkMs: 560 })
+  })
+
+  it('rejects WhisperKit names and malformed ids', () => {
+    expect(parseStreamingModelId('openai_whisper-large-v3_turbo_954MB')).toBeNull()
+    expect(parseStreamingModelId('nemotron/multilingual')).toBeNull()
+    expect(parseStreamingModelId('nemotron/klingon/1120ms')).toBeNull()
+    expect(parseStreamingModelId('nemotron/multilingual/fast')).toBeNull()
+    expect(parseStreamingModelId('nemotron/multilingual/999ms')).toBeNull()
+    expect(parseStreamingModelId(undefined)).toBeNull()
+  })
+
+  it('round-trips through streamingModelId', () => {
+    for (const id of allStreamingModelIds()) {
+      expect(streamingModelId(parseStreamingModelId(id)!)).toBe(id)
+    }
+  })
+})
+
+describe('selectedOnDeviceModel', () => {
+  it('picks the model that matches the provider, never the other engine', () => {
+    const voice = { provider: 'local', localModel: 'openai_whisper-small', streamingModel: 'nemotron/multilingual/1120ms' }
+    expect(selectedOnDeviceModel(voice)).toBe('openai_whisper-small')
+    expect(selectedOnDeviceModel({ ...voice, provider: 'localStreaming' })).toBe('nemotron/multilingual/1120ms')
+  })
+
+  it('is null for API providers and for a blank model', () => {
+    expect(selectedOnDeviceModel({ provider: 'api', localModel: 'x', streamingModel: 'y' })).toBeNull()
+    expect(selectedOnDeviceModel({ provider: 'realtime' })).toBeNull()
+    expect(selectedOnDeviceModel({ provider: 'localStreaming', streamingModel: '  ' })).toBeNull()
+    expect(selectedOnDeviceModel(null)).toBeNull()
+  })
+})
+
+describe('streamingModelDir', () => {
+  it('mirrors the helper cache layout', () => {
+    expect(streamingModelDir('/Users/me', 'nemotron/multilingual/2240ms')).toBe(
+      '/Users/me/Library/Application Support/FluidAudio/Models/nemotron-multilingual/multilingual/2240ms',
+    )
+  })
+
+  it('is null for a non-streaming id so a WhisperKit folder is never deleted by mistake', () => {
+    expect(streamingModelDir('/Users/me', 'openai_whisper-base')).toBeNull()
+  })
+})
+
+describe('streamingModelIsComplete', () => {
+  const DIR = '/cache/1120ms'
+  // What a finished download looks like on disk.
+  const full: Record<string, number> = {
+    [`${DIR}/metadata.json`]: 3005,
+    [`${DIR}/tokenizer.json`]: 284969,
+    [`${DIR}/encoder.mlmodelc/coremldata.bin`]: 572,
+    [`${DIR}/encoder.mlmodelc/weights/weight.bin`]: 564646848,
+    [`${DIR}/decoder.mlmodelc/coremldata.bin`]: 433,
+    [`${DIR}/decoder.mlmodelc/weights/weight.bin`]: 29870592,
+    [`${DIR}/joint.mlmodelc/coremldata.bin`]: 341,
+    [`${DIR}/joint.mlmodelc/weights/weight.bin`]: 18911744,
+  }
+  const probeFor = (files: Record<string, number>) => ({
+    size: (p: string) => (p in files ? files[p] : null),
+  })
+
+  it('accepts a finished download', () => {
+    expect(streamingModelIsComplete(DIR, probeFor(full))).toBe(true)
+  })
+
+  it('rejects an interrupted download that only left weight.bin.partial behind', () => {
+    const partial = { ...full }
+    delete partial[`${DIR}/encoder.mlmodelc/weights/weight.bin`]
+    partial[`${DIR}/encoder.mlmodelc/weights/weight.bin.partial`] = 215602925
+    expect(streamingModelIsComplete(DIR, probeFor(partial))).toBe(false)
+  })
+
+  it('rejects a zero-byte weight stub', () => {
+    expect(streamingModelIsComplete(DIR, probeFor({ ...full, [`${DIR}/joint.mlmodelc/weights/weight.bin`]: 0 }))).toBe(false)
+  })
+
+  it('rejects a folder whose tokenizer never arrived', () => {
+    const missing = { ...full }
+    delete missing[`${DIR}/tokenizer.json`]
+    expect(streamingModelIsComplete(DIR, probeFor(missing))).toBe(false)
+  })
+})

--- a/codey-mac/electron/voice-models.ts
+++ b/codey-mac/electron/voice-models.ts
@@ -1,0 +1,125 @@
+// Pure helpers for the two on-device speech engines the CodeyVoice helper
+// can run: WhisperKit (`provider: 'local'`) and Nemotron streaming via
+// FluidAudio (`provider: 'localStreaming'`). No Electron or fs imports so it
+// is unit-testable; main.ts owns the file-system and child-process glue.
+//
+// The two engines are a *switch*, not a pair: only the selected one is ever
+// loaded, so offering both costs one model's worth of memory, not two. That
+// is why everything here asks "which on-device model is selected" rather
+// than dealing with both at once.
+
+export type VoiceProvider = 'api' | 'local' | 'localStreaming' | 'realtime'
+
+/** Streaming model ids look like `nemotron/multilingual/1120ms`. */
+export const STREAMING_MODEL_PREFIX = 'nemotron/'
+
+/** FluidAudio's cache folder for the multilingual Nemotron repo. */
+export const STREAMING_REPO_FOLDER = 'nemotron-multilingual'
+
+/** Chunk tiers the repo ships. Smaller = snappier, larger = a touch more accurate. */
+export const STREAMING_CHUNK_TIERS = [560, 1120, 2240] as const
+
+const STREAMING_LANGUAGE_DIRS = ['multilingual', 'latin'] as const
+export type StreamingLanguageDir = (typeof STREAMING_LANGUAGE_DIRS)[number]
+
+export interface StreamingModel {
+  languageDir: StreamingLanguageDir
+  chunkMs: number
+}
+
+/** Both local engines run inside the helper; the API providers stay in Electron. */
+export function isOnDeviceVoiceProvider(provider: unknown): boolean {
+  return provider === 'local' || provider === 'localStreaming'
+}
+
+/** Parse `nemotron/<multilingual|latin>/<ms>ms`; null for anything else (incl. WhisperKit names). */
+export function parseStreamingModelId(id: unknown): StreamingModel | null {
+  if (typeof id !== 'string' || !id.startsWith(STREAMING_MODEL_PREFIX)) return null
+  const parts = id.slice(STREAMING_MODEL_PREFIX.length).split('/')
+  if (parts.length !== 2) return null
+  const [languageDir, tier] = parts
+  if (!(STREAMING_LANGUAGE_DIRS as readonly string[]).includes(languageDir)) return null
+  const m = /^(\d+)ms$/.exec(tier)
+  if (!m) return null
+  const chunkMs = Number(m[1])
+  if (!(STREAMING_CHUNK_TIERS as readonly number[]).includes(chunkMs)) return null
+  return { languageDir: languageDir as StreamingLanguageDir, chunkMs }
+}
+
+export function streamingModelId(model: StreamingModel): string {
+  return `${STREAMING_MODEL_PREFIX}${model.languageDir}/${model.chunkMs}ms`
+}
+
+/**
+ * The model the selected on-device engine will load, or null for the API
+ * providers. Mirrors `activeEngine` in VoiceCoordinator.swift.
+ */
+export function selectedOnDeviceModel(voice: { provider?: unknown; localModel?: unknown; streamingModel?: unknown } | null | undefined): string | null {
+  if (!voice) return null
+  if (voice.provider === 'local') {
+    const m = typeof voice.localModel === 'string' ? voice.localModel.trim() : ''
+    return m || null
+  }
+  if (voice.provider === 'localStreaming') {
+    const m = typeof voice.streamingModel === 'string' ? voice.streamingModel.trim() : ''
+    return m || null
+  }
+  return null
+}
+
+/**
+ * Where FluidAudio caches a streaming variant. Mirrors `NemotronVariant.directory`
+ * in the helper: `~/Library/Application Support/FluidAudio/Models/<repo>/<dir>/<ms>ms`.
+ * Path segments are joined with `/` so callers can hand it to `path.join`
+ * or use it as-is on macOS, the only platform the helper runs on.
+ */
+export function streamingModelDir(home: string, id: string): string | null {
+  const model = parseStreamingModelId(id)
+  if (!model) return null
+  return [home, 'Library', 'Application Support', 'FluidAudio', 'Models', STREAMING_REPO_FOLDER, model.languageDir, `${model.chunkMs}ms`].join('/')
+}
+
+/** Every streaming id the helper knows how to download, for the on-disk scan. */
+export function allStreamingModelIds(): string[] {
+  const ids: string[] = []
+  for (const languageDir of STREAMING_LANGUAGE_DIRS) {
+    for (const chunkMs of STREAMING_CHUNK_TIERS) ids.push(streamingModelId({ languageDir, chunkMs }))
+  }
+  return ids
+}
+
+/**
+ * Bundles the streaming engine must be able to load. FluidAudio downloads
+ * these alongside `metadata.json`, so the presence of that file says nothing
+ * about whether the transfer finished.
+ */
+export const STREAMING_REQUIRED_BUNDLES = ['encoder.mlmodelc', 'decoder.mlmodelc', 'joint.mlmodelc'] as const
+
+/** Any real CoreML weight blob is megabytes; this only rules out empty stubs. */
+export const STREAMING_MIN_WEIGHT_BYTES = 1024
+
+/** Reads the disk so `streamingModelIsComplete` stays free of `fs`. */
+export interface FileProbe {
+  /** Byte size of a file, or null when it is missing or not a file. */
+  size(path: string): number | null
+}
+
+/**
+ * Whether a downloaded streaming variant is actually loadable.
+ *
+ * An interrupted download leaves the folder, `metadata.json` and the
+ * `.mlmodelc` skeletons in place while a weight blob is still a
+ * `weight.bin.partial`. CoreML then fails with execution-plan error -14 at
+ * warm-up time. Mirrors `NemotronVariant.isDownloaded` in the helper so the
+ * UI offers Download instead of a warm error that never clears.
+ */
+export function streamingModelIsComplete(dir: string, probe: FileProbe): boolean {
+  for (const plain of ['metadata.json', 'tokenizer.json']) {
+    if (probe.size(`${dir}/${plain}`) === null) return false
+  }
+  return STREAMING_REQUIRED_BUNDLES.every(bundle => {
+    if (probe.size(`${dir}/${bundle}/coremldata.bin`) === null) return false
+    const weights = probe.size(`${dir}/${bundle}/weights/weight.bin`)
+    return weights !== null && weights > STREAMING_MIN_WEIGHT_BYTES
+  })
+}

--- a/codey-mac/electron/voice-models.ts
+++ b/codey-mac/electron/voice-models.ts
@@ -123,3 +123,42 @@ export function streamingModelIsComplete(dir: string, probe: FileProbe): boolean
     return weights !== null && weights > STREAMING_MIN_WEIGHT_BYTES
   })
 }
+
+/**
+ * Keys a warm marker is stored under when `model` is warmed.
+ *
+ * Whisper ids get all three spellings so a lookup succeeds whether the caller
+ * holds the prefixed (`openai_whisper-large-v3`) or bare (`large-v3`) form.
+ * A streaming id has no prefixed form, so it is stored once.
+ */
+export function warmMarkerWriteKeys(model: string): string[] {
+  if (parseStreamingModelId(model)) return [model]
+  const bare = model.startsWith('openai_whisper-')
+    ? model.slice('openai_whisper-'.length)
+    : model
+  return [model, bare, `openai_whisper-${bare}`]
+}
+
+/**
+ * Keys to clear when `model` is deleted.
+ *
+ * Same as the write keys, except a streaming id also clears the bogus
+ * `openai_whisper-nemotron/...` alias that builds through 0.12.14 wrote. Left
+ * behind, that alias still matches the model in the UI's variant check, so a
+ * deleted streaming model kept reporting "Ready".
+ */
+export function warmMarkerDeleteKeys(model: string): string[] {
+  if (parseStreamingModelId(model)) return [model, `openai_whisper-${model}`]
+  return warmMarkerWriteKeys(model)
+}
+
+/**
+ * True for the `openai_whisper-nemotron/...` alias that builds through 0.12.14
+ * wrote for streaming models. Existing installs still carry it, and one left
+ * over from a delete that happened before the fix would keep reporting the
+ * model as warm, so warm listings drop it on sight.
+ */
+export function isBogusWarmMarkerKey(key: string): boolean {
+  return key.startsWith('openai_whisper-')
+    && parseStreamingModelId(key.slice('openai_whisper-'.length)) !== null
+}

--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -130,6 +130,35 @@ const STREAMING_MODELS: Array<{ value: string; label: string; size: string; note
   { value: 'nemotron/latin/1120ms', label: 'Nemotron Latin-script · 1.1s chunks', size: '610MB', note: 'Pruned vocabulary, a little faster. English, Spanish, French, Italian, Portuguese, German only — no Chinese or Japanese.' },
 ]
 
+// Guidance shown under the Transcription source / Engine pills. The two
+// on-device engines differ in ways a model name doesn't convey — Whisper
+// computes once after you release the key, Nemotron computes continuously
+// while you speak — so hardware advice and caveats live here rather than in
+// release notes nobody reads.
+const ENGINE_GUIDE: Record<'api' | 'local' | 'localStreaming' | 'realtime', { summary: string }> = {
+  local: { summary: 'Runs privately on this Mac with WhisperKit. Audio never leaves the machine; the selected model downloads once before first use.' },
+  localStreaming: { summary: 'Runs privately on this Mac with Nemotron streaming: words appear while you are still talking.' },
+  api: { summary: 'Uploads each completed recording to an OpenAI-compatible transcription endpoint.' },
+  realtime: { summary: 'Streams audio to OpenAI for lower-latency partial transcripts while you speak.' },
+}
+
+// Rendered as a two-column table so both on-device engines are visible at
+// once, whichever one is currently selected.
+const ENGINE_COMPARE: Array<{ label: string; local: string; streaming: string }> = [
+  { label: 'Text appears', local: 'After you release the hotkey', streaming: 'While you are still talking' },
+  { label: 'Languages', local: '~99, including Korean', streaming: '8 (6 on the Latin-script build)' },
+  { label: 'Best on', local: 'Any Apple silicon — fine on an M1 Air or on battery', streaming: 'M2 or newer, or plugged in' },
+  { label: 'Battery', local: 'One burst after you stop', streaming: 'Runs the whole time you speak' },
+  { label: 'Download', local: '75MB – 3GB depending on model', streaming: '610 – 660MB' },
+]
+
+// True of both on-device engines, so they sit below the table rather than
+// being repeated in each column.
+const ENGINE_SHARED_NOTES: string[] = [
+  'First use compiles the model for your Mac (30–90s, one time). Later presses are instant.',
+  'The model loads when the voice helper starts and unloads after 30 minutes idle. Switching engines unloads the other one, so only one model is ever in memory.',
+]
+
 const VOICE_LANGUAGES: Array<{ value: string; label: string }> = [
   { value: 'auto', label: 'Auto-detect' },
   { value: 'en', label: 'English' },
@@ -170,6 +199,10 @@ const inputStyle: React.CSSProperties = {
   color: C.fg, fontSize: 13, padding: '6px 10px', outline: 'none', width: 180,
 }
 const selectStyle: React.CSSProperties = { ...inputStyle, cursor: 'pointer' }
+const engineColHeadStyle: React.CSSProperties = {
+  fontSize: 11, fontWeight: 600, paddingBottom: 4,
+  borderBottom: `1px solid ${C.border}`,
+}
 const pillButton = (variant: 'primary' | 'danger' | 'ghost'): React.CSSProperties => ({
   padding: '6px 12px', borderRadius: 7, fontSize: 12, fontWeight: 600,
   border: 'none', cursor: 'pointer',
@@ -808,14 +841,36 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
           </div>
         )}
         <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.5, marginTop: 2 }}>
-          {voice.provider === 'local'
-            ? 'Runs privately on this Mac with WhisperKit. The selected model downloads once before first use.'
-            : isStreaming
-              ? 'Runs privately on this Mac with Nemotron streaming: words appear while you are still talking. Switching engines unloads the other one, so only one model is ever in memory.'
-            : voice.provider === 'realtime'
-              ? 'Streams audio to OpenAI for lower-latency partial transcripts while you speak.'
-              : 'Uploads each completed recording to an OpenAI-compatible transcription endpoint.'}
+          {ENGINE_GUIDE[voice.provider].summary}
         </div>
+        {isOnDevice && (
+          <div style={{ marginTop: 8 }}>
+            {/* Both engines side by side, always — picking between them is the
+                whole decision, and a description that only appears after you
+                already clicked can't help you make it. The selected column is
+                highlighted rather than being the only one rendered. */}
+            <div style={{
+              display: 'grid', gridTemplateColumns: '78px 1fr 1fr', gap: '0 10px',
+              fontSize: 11, lineHeight: 1.45,
+            }}>
+              <div />
+              <div style={{ ...engineColHeadStyle, color: !isStreaming ? C.fg : C.fg3 }}>Whisper</div>
+              <div style={{ ...engineColHeadStyle, color: isStreaming ? C.fg : C.fg3 }}>Streaming</div>
+              {ENGINE_COMPARE.map(row => (
+                <React.Fragment key={row.label}>
+                  <div style={{ color: C.fg3, padding: '4px 0' }}>{row.label}</div>
+                  <div style={{ color: !isStreaming ? C.fg2 : C.fg3, padding: '4px 0' }}>{row.local}</div>
+                  <div style={{ color: isStreaming ? C.fg2 : C.fg3, padding: '4px 0' }}>{row.streaming}</div>
+                </React.Fragment>
+              ))}
+            </div>
+            <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.5, marginTop: 8 }}>
+              {ENGINE_SHARED_NOTES.map((n, i) => (
+                <div key={i} style={{ paddingLeft: 10, textIndent: -10 }}>· {n}</div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {isOnDevice && (() => {

--- a/codey-mac/src/components/WhisperTab.tsx
+++ b/codey-mac/src/components/WhisperTab.tsx
@@ -22,11 +22,17 @@ interface VoiceCfg {
   converseHotkey: string
   language: string
   injection: 'paste' | 'ax'
-  provider: 'api' | 'local' | 'realtime'
+  /**
+   * `local` = on-device WhisperKit, `localStreaming` = on-device Nemotron
+   * streaming. A switch, not a pair: only the selected engine is loaded.
+   */
+  provider: 'api' | 'local' | 'localStreaming' | 'realtime'
   apiUrl: string
   apiKeyRef: string
   apiModel: string
   localModel: string
+  /** Streaming model id, `nemotron/<multilingual|latin>/<ms>ms`. */
+  streamingModel: string
   realtimeUrl: string
   realtimeModel: string
   /** Preferred spellings, handed to the recognizer as a prompt hint. */
@@ -79,6 +85,7 @@ const VOICE_DEFAULT: VoiceCfg = {
   apiKeyRef: '',
   apiModel: 'gpt-4o-mini-transcribe',
   localModel: 'openai_whisper-large-v3_turbo_954MB',
+  streamingModel: 'nemotron/multilingual/1120ms',
   realtimeUrl: 'wss://api.openai.com/v1/realtime?intent=transcription',
   realtimeModel: 'gpt-4o-mini-transcribe',
   vocabulary: [],
@@ -101,15 +108,26 @@ interface SavedApiKey { name: string; apiKey: string; openaiBaseUrl?: string; pu
 
 // Values must match real folder names in argmaxinc/whisperkit-coreml on HF.
 // The helper strips the `openai_whisper-` prefix before passing to WhisperKit.
-const LOCAL_MODELS: Array<{ value: string; label: string; note: string }> = [
-  { value: 'openai_whisper-large-v3_turbo_954MB', label: 'large-v3 turbo · 954MB (recommended)', note: 'Quantized — near large-v3 quality at small-model speed. Best balance for most users.' },
-  { value: 'openai_whisper-large-v3_turbo', label: 'large-v3 turbo · ~1.6GB', note: 'Full-precision turbo. Highest accuracy, but larger download and slower inference.' },
-  { value: 'openai_whisper-large-v3', label: 'large-v3 · ~3GB (full precision)', note: 'Original large-v3 (non-turbo). Maximum accuracy at the cost of speed and disk space.' },
-  { value: 'openai_whisper-large-v3-v20240930_turbo_632MB', label: 'large-v3 turbo · Sep 2024 · 632MB', note: 'Compact quantized turbo. Lower disk usage but slightly weaker on non-English languages.' },
-  { value: 'openai_whisper-small_216MB', label: 'small · 216MB', note: 'Quantized small. Moderate quality, acceptable for English; weaker on other languages.' },
-  { value: 'openai_whisper-small', label: 'small · ~480MB', note: 'Full-precision small. Mid-range accuracy and speed.' },
-  { value: 'openai_whisper-base', label: 'base · ~150MB', note: 'Minimal footprint. Low accuracy — useful only for quick testing.' },
-  { value: 'openai_whisper-tiny', label: 'tiny · ~75MB', note: 'Smallest model. Very fast but accuracy is poor; not recommended for real use.' },
+const LOCAL_MODELS: Array<{ value: string; label: string; size: string; note: string }> = [
+  { value: 'openai_whisper-large-v3_turbo_954MB', label: 'large-v3 turbo (recommended)', size: '954MB', note: 'Quantized — near large-v3 quality at small-model speed. Best balance for most users.' },
+  { value: 'openai_whisper-large-v3_turbo', label: 'large-v3 turbo (full precision)', size: '~1.6GB', note: 'Full-precision turbo. Highest accuracy, but larger download and slower inference.' },
+  { value: 'openai_whisper-large-v3', label: 'large-v3 (full precision)', size: '~3GB', note: 'Original large-v3 (non-turbo). Maximum accuracy at the cost of speed and disk space.' },
+  { value: 'openai_whisper-large-v3-v20240930_turbo_632MB', label: 'large-v3 turbo · Sep 2024', size: '632MB', note: 'Compact quantized turbo. Lower disk usage but slightly weaker on non-English languages.' },
+  { value: 'openai_whisper-small_216MB', label: 'small (quantized)', size: '216MB', note: 'Quantized small. Moderate quality, acceptable for English; weaker on other languages.' },
+  { value: 'openai_whisper-small', label: 'small (full precision)', size: '~480MB', note: 'Full-precision small. Mid-range accuracy and speed.' },
+  { value: 'openai_whisper-base', label: 'base', size: '~150MB', note: 'Minimal footprint. Low accuracy — useful only for quick testing.' },
+  { value: 'openai_whisper-tiny', label: 'tiny', size: '~75MB', note: 'Smallest model. Very fast but accuracy is poor; not recommended for real use.' },
+]
+
+// Streaming (Nemotron via FluidAudio) builds. The id encodes the vocabulary
+// build and the chunk tier; the helper's NemotronVariant parses the same
+// shape. "multilingual" covers en/es/fr/it/pt/de/zh/ja; "latin" is a pruned,
+// slightly faster build for the six Latin-script languages only.
+const STREAMING_MODELS: Array<{ value: string; label: string; size: string; note: string }> = [
+  { value: 'nemotron/multilingual/1120ms', label: 'Nemotron multilingual · 1.1s chunks (recommended)', size: '660MB', note: 'Words appear about a second after you say them. English, Spanish, French, Italian, Portuguese, German, Chinese, Japanese.' },
+  { value: 'nemotron/multilingual/560ms', label: 'Nemotron multilingual · 0.56s chunks', size: '660MB', note: 'Lowest latency. Punctuation thins out on very long takes; fine for dictation-length turns.' },
+  { value: 'nemotron/multilingual/2240ms', label: 'Nemotron multilingual · 2.2s chunks', size: '660MB', note: 'Slightly more accurate and better punctuated, at the cost of a two-second lag.' },
+  { value: 'nemotron/latin/1120ms', label: 'Nemotron Latin-script · 1.1s chunks', size: '610MB', note: 'Pruned vocabulary, a little faster. English, Spanish, French, Italian, Portuguese, German only — no Chinese or Japanese.' },
 ]
 
 const VOICE_LANGUAGES: Array<{ value: string; label: string }> = [
@@ -289,7 +307,7 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
 
   const deleteModel = async (model: string) => {
     if (dlState.active || warmState.active) return
-    const label = LOCAL_MODELS.find(m => m.value === model)?.label ?? model
+    const label = [...LOCAL_MODELS, ...STREAMING_MODELS].find(m => m.value === model)?.label ?? model
     if (!window.confirm(`Delete "${label}"?\n\nThis removes the model files from disk. You can re-download anytime.`)) return
     try {
       const res = await window.codey.voice.deleteModel(model)
@@ -384,15 +402,16 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
   // Covers both "user switched to a different downloaded model" and "app boot
   // with a model that was downloaded in a prior session but never warmed".
   useEffect(() => {
-    if (voice.provider !== 'local') return
-    const m = voice.localModel
+    const m = voice.provider === 'local' ? voice.localModel
+      : voice.provider === 'localStreaming' ? voice.streamingModel
+      : ''
     if (!m) return
     if (dlState.active || warmState.active) return
     if (!isDownloaded(m)) return
     if (isWarmed(m)) return
     if (warmFailed.has(m)) return
     warmModel(m)
-  }, [voice.provider, voice.localModel, downloaded, warmed, dlState.active, warmState.active, isDownloaded, isWarmed, warmModel, warmFailed])
+  }, [voice.provider, voice.localModel, voice.streamingModel, downloaded, warmed, dlState.active, warmState.active, isDownloaded, isWarmed, warmModel, warmFailed])
 
   const handleHotkeyRecordingChange = useCallback((active: boolean) => {
     void window.codey.voice.setHotkeyCaptureActive(active)
@@ -481,6 +500,11 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
   // "API" groups the two cloud modes (batch Whisper + Realtime WebSocket); they
   // share the same API key and only differ in transport. "Local" is on-device.
   const isApi = voice.provider === 'api' || voice.provider === 'realtime'
+  // "On-device" likewise groups the two local engines; they differ in how the
+  // text arrives (WhisperKit decodes the finished clip, Nemotron streams it
+  // while you talk) and only the selected one is loaded.
+  const isOnDevice = voice.provider === 'local' || voice.provider === 'localStreaming'
+  const isStreaming = voice.provider === 'localStreaming'
 
   return (
     <div style={{ padding: 20, height: '100%', overflowY: 'auto' }}>
@@ -748,11 +772,26 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
               style={pillButton(isApi ? 'primary' : 'ghost')}
             >API</button>
             <button
-              onClick={() => updateVoice({ provider: 'local' })}
-              style={pillButton(voice.provider === 'local' ? 'primary' : 'ghost')}
+              onClick={() => { if (!isOnDevice) updateVoice({ provider: 'local' }) }}
+              style={pillButton(isOnDevice ? 'primary' : 'ghost')}
             >On-device</button>
           </div>
         </div>
+        {isOnDevice && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 0 8px' }}>
+            <span style={{ color: C.fg3, fontSize: 12 }}>Engine</span>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button
+                onClick={() => updateVoice({ provider: 'local' })}
+                style={{ ...pillButton(voice.provider === 'local' ? 'primary' : 'ghost'), fontSize: 11 }}
+              >Whisper</button>
+              <button
+                onClick={() => updateVoice({ provider: 'localStreaming' })}
+                style={{ ...pillButton(isStreaming ? 'primary' : 'ghost'), fontSize: 11 }}
+              >Streaming</button>
+            </div>
+          </div>
+        )}
         {isApi && (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 0 8px' }}>
             <span style={{ color: C.fg3, fontSize: 12 }}>API mode</span>
@@ -771,24 +810,33 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
         <div style={{ color: C.fg3, fontSize: 11, lineHeight: 1.5, marginTop: 2 }}>
           {voice.provider === 'local'
             ? 'Runs privately on this Mac with WhisperKit. The selected model downloads once before first use.'
+            : isStreaming
+              ? 'Runs privately on this Mac with Nemotron streaming: words appear while you are still talking. Switching engines unloads the other one, so only one model is ever in memory.'
             : voice.provider === 'realtime'
               ? 'Streams audio to OpenAI for lower-latency partial transcripts while you speak.'
               : 'Uploads each completed recording to an OpenAI-compatible transcription endpoint.'}
         </div>
       </div>
 
-      {voice.provider === 'local' && (() => {
-        const selectedDownloaded = isDownloaded(voice.localModel)
-        const selectedWarmed = isWarmed(voice.localModel)
-        const downloadingThis = dlState.active && dlState.model === voice.localModel
-        const warmingThis = warmState.active && warmState.model === voice.localModel
-        const warmErrorForThis = !warmState.active && warmState.error && warmState.model === voice.localModel
+      {isOnDevice && (() => {
+        // One block serves both engines: same download / warm / delete arc,
+        // different model list and config field.
+        const models = isStreaming ? STREAMING_MODELS : LOCAL_MODELS
+        const selectedModel = isStreaming ? voice.streamingModel : voice.localModel
+        const selectModel = (value: string) => updateVoice(isStreaming ? { streamingModel: value } : { localModel: value })
+        const selectedDownloaded = isDownloaded(selectedModel)
+        const selectedWarmed = isWarmed(selectedModel)
+        const downloadingThis = dlState.active && dlState.model === selectedModel
+        const warmingThis = warmState.active && warmState.model === selectedModel
+        const warmErrorForThis = !warmState.active && warmState.error && warmState.model === selectedModel
         const downloadErrorForThis = dlState.msg && !dlState.active && !selectedDownloaded
-        const note = LOCAL_MODELS.find(m => m.value === voice.localModel)?.note ?? ''
+        const note = models.find(m => m.value === selectedModel)?.note ?? ''
 
         // Three states per model: warmed (instant), downloaded but not warmed
-        // (first use = 30-90s compile), or not downloaded.
-        const prefixFor = (m: string) => isWarmed(m) ? 'Ready · ' : isDownloaded(m) ? 'Downloaded · ' : 'Not downloaded · '
+        // (first use = 30-90s compile), or not on disk. The last one gets no
+        // badge — the download size in the row already says "you'd be fetching
+        // this", so a "Not downloaded" tag is noise on every other line.
+        const prefixFor = (m: string) => isWarmed(m) ? 'Ready · ' : isDownloaded(m) ? 'Downloaded · ' : ''
 
         let statusLine: React.ReactNode = note
         let statusColor: string = C.fg3
@@ -796,7 +844,9 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
           statusLine = dlState.msg
           statusColor = C.red
         } else if (warmErrorForThis) {
-          statusLine = `Warm-up failed: ${warmState.error}. First voice press will trigger CoreML compile (~30-90s).`
+          statusLine = isStreaming
+            ? `Warm-up failed: ${warmState.error}. This streaming model could not be loaded on this Mac/macOS; try another model or switch to Whisper.`
+            : `Warm-up failed: ${warmState.error}. First voice press will trigger CoreML compile (~30-90s).`
           statusColor = C.red
         } else if (warmingThis) {
           statusLine = `Compiling for your Mac… ${warmElapsed}s (one-time, ~30-90s on first use)`
@@ -812,21 +862,21 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
         return (
           <div style={lastSettingBlockStyle}>
             <div style={settingRowStyle}>
-              <span style={{ color: C.fg, fontSize: 13 }}>Local model</span>
+              <span style={{ color: C.fg, fontSize: 13 }}>{isStreaming ? 'Streaming model' : 'Local model'}</span>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <select
-                  value={voice.localModel}
-                  onChange={e => updateVoice({ localModel: e.target.value })}
+                  value={selectedModel}
+                  onChange={e => selectModel(e.target.value)}
                   style={{ ...selectStyle, width: 280 }}
                 >
-                  {LOCAL_MODELS.map(m => (
+                  {models.map(m => (
                     <option key={m.value} value={m.value}>
-                      {prefixFor(m.value)}{m.label}
+                      {prefixFor(m.value)}{m.label} · {m.size}
                     </option>
                   ))}
                 </select>
                 <button
-                  onClick={() => !downloadingThis && !selectedDownloaded && downloadModel(voice.localModel)}
+                  onClick={() => !downloadingThis && !selectedDownloaded && downloadModel(selectedModel)}
                   disabled={dlState.active || selectedDownloaded}
                   title={selectedDownloaded ? 'Already downloaded' : downloadingThis ? 'Downloading…' : 'Download model'}
                   style={{
@@ -845,7 +895,7 @@ export const WhisperTab: React.FC<WhisperTabProps> = ({ isGatewayRunning, onAddV
                 </button>
                 {selectedDownloaded && !downloadingThis && !warmingThis && (
                   <button
-                    onClick={() => deleteModel(voice.localModel)}
+                    onClick={() => deleteModel(selectedModel)}
                     title="Delete this model from disk"
                     style={pillButton('danger')}
                   >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codey-monorepo",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codey-monorepo",
-      "version": "0.12.13",
+      "version": "0.12.14",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -27,7 +27,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.12.13",
+      "version": "0.12.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -13004,7 +13004,7 @@
     },
     "packages/core": {
       "name": "@codey/core",
-      "version": "0.12.13",
+      "version": "0.12.14",
       "license": "MIT",
       "dependencies": {
         "undici": "^5.28.0"
@@ -13016,7 +13016,7 @@
     },
     "packages/gateway": {
       "name": "@codey/gateway",
-      "version": "0.12.13",
+      "version": "0.12.14",
       "license": "MIT",
       "dependencies": {
         "@codey/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codey-monorepo",
   "private": true,
-  "version": "0.12.13",
+  "version": "0.12.14",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/core",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codey/gateway",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -144,8 +144,12 @@ export interface GatewayConfigJson {
     converseHotkey?: string;
     language: string;
     injection: 'paste' | 'ax';
-    /** Transcription backend: hosted API or on-device WhisperKit. */
-    provider: 'api' | 'local';
+    /**
+     * Transcription backend. `local` is on-device WhisperKit, `localStreaming`
+     * is on-device Nemotron streaming (FluidAudio); the two are a switch, only
+     * the selected one is loaded. `realtime` is the OpenAI WebSocket API.
+     */
+    provider: 'api' | 'local' | 'localStreaming' | 'realtime';
     /** Base URL of an OpenAI-compatible transcription endpoint (e.g. https://api.openai.com/v1). */
     apiUrl: string;
     /** Saved Voice key selected from Settings → API Keys. */
@@ -154,6 +158,8 @@ export interface GatewayConfigJson {
     apiModel: string;
     /** WhisperKit model variant for local mode (e.g. openai_whisper-large-v3-turbo). */
     localModel: string;
+    /** Streaming model id for localStreaming mode (e.g. nemotron/multilingual/1120ms). */
+    streamingModel?: string;
     /**
      * Proper nouns the recognizer keeps getting wrong. Each term is hinted to
      * the decoder before transcription; its aliases are rewritten to the term

--- a/voice/Package.resolved
+++ b/voice/Package.resolved
@@ -1,6 +1,14 @@
 {
-  "originHash" : "d58e3b5ddf0bd37f7b5ac967386fc5f019f1f97f03bb93d276b50f4a10bf6bfa",
+  "originHash" : "2ad1223cc0773b929604dccec602430a32f3cdaefc353d84a0da74e53bc12f47",
   "pins" : [
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio",
+      "state" : {
+        "revision" : "5c19d5e12320e22bbfb7a1877b089d2665a69add"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",

--- a/voice/Package.swift
+++ b/voice/Package.swift
@@ -6,12 +6,19 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/argmaxinc/WhisperKit", from: "1.1.0"),
+        // On-device streaming ASR (NVIDIA Nemotron via CoreML). Pinned to a
+        // main-branch commit rather than a tag: the newest tag (0.15.6) has
+        // the multilingual streaming manager but not its custom-vocabulary
+        // biasing, which is what lets the user's dictionary keep working on
+        // this engine. Move to `from:` once the next release ships it.
+        .package(url: "https://github.com/FluidInference/FluidAudio", revision: "5c19d5e12320e22bbfb7a1877b089d2665a69add"),
     ],
     targets: [
         .executableTarget(
             name: "CodeyVoice",
             dependencies: [
                 .product(name: "WhisperKit", package: "WhisperKit"),
+                .product(name: "FluidAudio", package: "FluidAudio"),
             ],
             path: "Sources/CodeyVoice",
             linkerSettings: [

--- a/voice/Sources/CodeyVoice/AudioCapture.swift
+++ b/voice/Sources/CodeyVoice/AudioCapture.swift
@@ -7,10 +7,8 @@ import QuartzCore  // CACurrentMediaTime
 final class AudioCapture {
     private let engine = AVAudioEngine()
     private var pcmBuffer: [Float] = []
-    /// Guards `pcmBuffer` so streaming consumers can read a coherent snapshot
-    /// while the audio tap thread keeps appending. Lock is held only for the
-    /// length of an `append` or a snapshot copy — never across the resample
-    /// math, so contention is minimal.
+    /// Guards `pcmBuffer` while the audio tap thread appends and the control
+    /// path starts, stops, or cancels capture.
     private let bufferLock = NSLock()
     private let sampleRate: Double = 16000
     private let maxDurationSeconds: Double = 300  // 5-minute cap
@@ -25,9 +23,8 @@ final class AudioCapture {
 
     /// Called from the audio tap thread with each freshly resampled 16 kHz mono
     /// chunk (~20-50 ms). Receiver must hop to main if it touches AppKit. Used by
-    /// the realtime transcription engine to forward audio over WebSocket as it
-    /// arrives. Always-accumulate + additionally-emit: the full buffer snapshot
-    /// remains available via currentSamplesSnapshot(). Nil = batch-only behavior.
+    /// true streaming engines to consume audio as it arrives. The full buffer
+    /// is still accumulated for batch transcription and streaming fallback.
     var onChunk: (([Float]) -> Void)?
 
     /// Called from the audio tap thread (~every buffer, ~20-50ms) with a 0..1
@@ -83,15 +80,6 @@ final class AudioCapture {
         let snapshot = pcmBuffer
         bufferLock.unlock()
         onRecordingComplete?(snapshot)
-    }
-
-    /// Coherent copy of the buffer captured so far. Safe to call from any
-    /// thread while recording. Used by the local streaming transcriber to
-    /// pull periodic snapshots without disturbing the audio tap.
-    func currentSamplesSnapshot() -> [Float] {
-        bufferLock.lock()
-        defer { bufferLock.unlock() }
-        return pcmBuffer
     }
 
     /// Stop the engine and DISCARD the buffer without firing the complete

--- a/voice/Sources/CodeyVoice/NemotronStreamingEngine.swift
+++ b/voice/Sources/CodeyVoice/NemotronStreamingEngine.swift
@@ -1,0 +1,468 @@
+import Foundation
+import FluidAudio
+
+/// One downloadable build of the on-device streaming recognizer.
+///
+/// Config and the Mac app refer to it by an id of the form
+/// `nemotron/<multilingual|latin>/<chunkMs>ms`, e.g.
+/// `nemotron/multilingual/1120ms`. `multilingual` is the full-vocabulary
+/// build (en/es/fr/it/pt/de/zh/ja); `latin` is a pruned, faster build for the
+/// six Latin-script languages only. The chunk tier is how much audio the
+/// model waits for before it emits: smaller is snappier, larger is a little
+/// more accurate and punctuates better.
+struct NemotronVariant: Equatable {
+    static let idPrefix = "nemotron/"
+    /// FluidAudio deliberately uses a short, stable cache name rather than
+    /// the Hugging Face repository name. Keep this in sync with
+    /// `Repo.nemotronMultilingual.folderName`.
+    static let repoFolder = "nemotron-multilingual"
+    static let chunkTiers = [560, 1120, 2240]
+    static let `default` = NemotronVariant(languageDir: "multilingual", chunkMs: 1120)
+
+    let languageDir: String
+    let chunkMs: Int
+
+    init(languageDir: String, chunkMs: Int) {
+        self.languageDir = languageDir
+        self.chunkMs = chunkMs
+    }
+
+    /// Parses `nemotron/<dir>/<ms>ms`. Returns nil for anything else, so a
+    /// WhisperKit variant name is never mistaken for a streaming one.
+    init?(id: String) {
+        guard id.hasPrefix(Self.idPrefix) else { return nil }
+        let parts = id.dropFirst(Self.idPrefix.count).split(separator: "/").map(String.init)
+        guard parts.count == 2, parts[1].hasSuffix("ms"),
+              let ms = Int(parts[1].dropLast(2)),
+              Self.chunkTiers.contains(ms),
+              parts[0] == "multilingual" || parts[0] == "latin"
+        else { return nil }
+        self.languageDir = parts[0]
+        self.chunkMs = ms
+    }
+
+    static func isStreamingModelId(_ id: String) -> Bool { NemotronVariant(id: id) != nil }
+
+    var id: String { "\(Self.idPrefix)\(languageDir)/\(chunkMs)ms" }
+
+    /// The language hint FluidAudio's downloader maps onto `languageDir`
+    /// (`languageDirectory(for:)` sends Latin-script codes to `latin` and
+    /// everything else to `multilingual`).
+    var downloadLanguageCode: String { languageDir == "latin" ? "en" : "auto" }
+
+    /// Where FluidAudio caches this variant. Mirrors `downloadVariant`'s
+    /// default so the Mac app can check for the files without loading them.
+    var directory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent(Self.repoFolder, isDirectory: true)
+            .appendingPathComponent(languageDir, isDirectory: true)
+            .appendingPathComponent("\(chunkMs)ms", isDirectory: true)
+    }
+
+    var isDownloaded: Bool {
+        let fm = FileManager.default
+        let plainFiles = ["metadata.json", "tokenizer.json"]
+        guard plainFiles.allSatisfy({ fm.fileExists(atPath: directory.appendingPathComponent($0).path) }) else {
+            return false
+        }
+
+        // metadata.json is downloaded alongside the model bundles, not as a
+        // completion marker. An interrupted transfer can therefore leave it
+        // behind while a CoreML bundle is unusable. Check the load-critical
+        // bundle internals before advertising the variant as downloaded.
+        let bundles = ["encoder.mlmodelc", "decoder.mlmodelc", "joint.mlmodelc"]
+        return bundles.allSatisfy { name in
+            let bundle = directory.appendingPathComponent(name, isDirectory: true)
+            let metadata = bundle.appendingPathComponent("coremldata.bin")
+            let weights = bundle.appendingPathComponent("weights/weight.bin")
+            guard fm.fileExists(atPath: metadata.path),
+                  let attrs = try? fm.attributesOfItem(atPath: weights.path),
+                  let size = attrs[.size] as? NSNumber
+            else { return false }
+            return size.int64Value > 1024
+        }
+    }
+
+    /// Fetch the compiled models from HuggingFace (no-op when cached).
+    /// Progress is reported as a 0...1 fraction.
+    func download(progress: @escaping @Sendable (Double) -> Void) async throws -> URL {
+        try await StreamingNemotronMultilingualAsrManager.downloadVariant(
+            languageCode: downloadLanguageCode,
+            chunkMs: chunkMs,
+            progressHandler: { progress($0.fractionCompleted) }
+        )
+    }
+
+    /// Load a variant and repair a cache whose files have the right names and
+    /// sizes but bad bytes. CoreML reports that case as execution-plan error
+    /// -14; FluidAudio's downloader only validates byte count, so it otherwise
+    /// keeps reusing the poisoned cache forever.
+    func loadManagerWithRecovery(
+        progress: @escaping @Sendable (Double) -> Void = { _ in }
+    ) async throws -> StreamingNemotronMultilingualAsrManager {
+        let dir = isDownloaded ? directory : try await download(progress: progress)
+        let first = StreamingNemotronMultilingualAsrManager()
+        do {
+            try await first.loadModels(from: dir)
+            return first
+        } catch {
+            await first.cleanup()
+            guard Self.isCoreMLLoadFailure(error), !Task.isCancelled else { throw error }
+
+            print("NemotronVariant: CoreML rejected cached model; deleting and downloading a clean copy")
+            try FileManager.default.removeItem(at: directory)
+            let repairedDir = try await download(progress: progress)
+            let retry = StreamingNemotronMultilingualAsrManager()
+            do {
+                try await retry.loadModels(from: repairedDir)
+                return retry
+            } catch {
+                await retry.cleanup()
+                throw error
+            }
+        }
+    }
+
+    private static func isCoreMLLoadFailure(_ error: Error) -> Bool {
+        var current: NSError? = error as NSError
+        while let value = current {
+            if value.domain == "com.apple.CoreML" { return true }
+            current = value.userInfo[NSUnderlyingErrorKey] as? NSError
+        }
+        return false
+    }
+}
+
+/// On-device *streaming* transcription via FluidAudio's Nemotron CoreML port.
+///
+/// Unlike `WhisperKitEngine`, which re-decodes a growing buffer to fake a
+/// live preview, this model consumes audio in fixed chunks and emits tokens
+/// as it goes, so the HUD text is the real decode in progress. The flow
+/// mirrors `RealtimeTranscriptionEngine`:
+///
+///   `startSession(language:)` -> N x `appendAudioChunk(_:)` ->
+///   `transcribe(audio:language:)` (finishes the session) / `cancelSession()`
+///
+/// `transcribe` ignores the full buffer when a session is open because every
+/// sample has already been fed; it only flushes the tail and returns the
+/// final text. Without a session (no chunks were forwarded) it decodes the
+/// buffer from scratch so the protocol contract still holds.
+///
+/// Lazy-loaded and idle-unloaded on the same schedule as WhisperKit; only one
+/// of the two on-device engines is ever resident because the coordinator
+/// unloads whichever one the user switched away from.
+final class NemotronStreamingEngine: TranscriptionEngineProtocol, @unchecked Sendable {
+    private let configLock = NSLock()
+    private var _config: VoiceConfig
+    var onPartial: ((String) -> Void)?
+
+    /// The manager owns both the resident CoreML models and decode state.
+    /// There is one manager because Codey only runs one local stream; using
+    /// FluidAudio's multi-stream shared-model path here would also omit the
+    /// model directory needed for lazy custom-vocabulary decoder loading.
+    private var manager: StreamingNemotronMultilingualAsrManager?
+    private var loadedVariant: NemotronVariant?
+    private let loadQueue = DispatchQueue(label: "codey.voice.nemotron.load")
+    private var loadTask: (variant: NemotronVariant, task: Task<StreamingNemotronMultilingualAsrManager, Error>)?
+    private let loadTaskLock = NSLock()
+
+    private var lastUsed: Date = .distantPast
+    /// Same reasoning as WhisperKit's: long enough to cover a working session,
+    /// short enough to give the memory back when the user walks away.
+    private let idleUnloadAfter: TimeInterval = 1800
+    private static let loadTimeoutSeconds: TimeInterval = 600
+    private static let slowLoadWarnSeconds: TimeInterval = 8
+
+    /// Audio is handed to the actor through a chain of tasks so chunks are
+    /// processed in arrival order; a bare `Task {}` per chunk would not
+    /// guarantee that. `sessionActive` gates the chain so a chunk that lands
+    /// after cancel is dropped rather than decoded into the next turn.
+    private let sessionLock = NSLock()
+    private var _sessionActive = false
+    private var _feedTask: Task<Void, Never>?
+    private var _sessionGeneration = 0
+
+    init(config: VoiceConfig) {
+        self._config = config
+    }
+
+    private var variant: NemotronVariant {
+        let id = configLock.withLock { _config.streamingModel }
+        return NemotronVariant(id: id) ?? .default
+    }
+
+    // MARK: - Session
+
+    /// Open a decode session for a new utterance. Loads the model if needed
+    /// (the coordinator normally refuses the press until `isReady`, so this
+    /// is a fast path in practice).
+    func startSession(language: String) {
+        let generation = sessionLock.withLock { () -> Int in
+            _sessionGeneration += 1
+            _sessionActive = true
+            _feedTask = nil
+            return _sessionGeneration
+        }
+        let terms = configLock.withLock { _config.vocabulary }
+        let lang = Self.languageHint(language)
+        let task = Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                let mgr = try await self.ensureManager()
+                guard self.isSession(generation) else { return }
+                await mgr.reset()
+                await mgr.setLanguage(lang)
+                await mgr.setCustomVocabulary(terms.map { CustomVocabularyTerm(text: $0.term) })
+                await mgr.setPartialCallback { [weak self] text in
+                    guard let self = self, self.isSession(generation) else { return }
+                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty, let cb = self.onPartial else { return }
+                    DispatchQueue.main.async { cb(trimmed) }
+                }
+                self.lastUsed = Date()
+            } catch {
+                print("NemotronStreamingEngine.startSession: load failed — \(error.localizedDescription)")
+                self.sessionLock.withLock {
+                    if self._sessionGeneration == generation { self._sessionActive = false }
+                }
+            }
+        }
+        sessionLock.withLock { _feedTask = task }
+    }
+
+    /// Forward a 16 kHz mono chunk from the microphone. No-op when no
+    /// session is open, so it is safe to leave wired to the audio tap.
+    func appendAudioChunk(_ chunk: [Float]) {
+        let (active, previous, generation) = sessionLock.withLock {
+            (_sessionActive, _feedTask, _sessionGeneration)
+        }
+        guard active, !chunk.isEmpty else { return }
+        let task = Task { [weak self] in
+            await previous?.value
+            guard let self = self, self.isSession(generation), let mgr = self.manager else { return }
+            do {
+                _ = try await mgr.process(samples: chunk)
+            } catch {
+                print("NemotronStreamingEngine: chunk decode error — \(error.localizedDescription)")
+            }
+        }
+        sessionLock.withLock { if _sessionGeneration == generation { _feedTask = task } }
+    }
+
+    /// Drop the open session without producing text.
+    func cancelSession() {
+        let mgr: StreamingNemotronMultilingualAsrManager? = sessionLock.withLock {
+            _sessionActive = false
+            _feedTask = nil
+            _sessionGeneration += 1
+            return manager
+        }
+        if let mgr = mgr {
+            Task { await mgr.reset() }
+        }
+    }
+
+    private func isSession(_ generation: Int) -> Bool {
+        sessionLock.withLock { _sessionActive && _sessionGeneration == generation }
+    }
+
+    // MARK: - TranscriptionEngineProtocol
+
+    func transcribe(audio: [Float], language: String) async throws -> String {
+        let (active, pending) = sessionLock.withLock { (_sessionActive, _feedTask) }
+        if active {
+            // Every sample has been fed already; wait for the chain to drain,
+            // then flush whatever is left in the model's buffer.
+            await pending?.value
+            let mgr = try await withLoadTimeout(seconds: Self.loadTimeoutSeconds) { try await self.ensureManager() }
+            sessionLock.withLock {
+                _sessionActive = false
+                _feedTask = nil
+            }
+            let t0 = Date()
+            let text = try await mgr.finish()
+            lastUsed = Date()
+            print(String(format: "NemotronStreamingEngine: finish took %.2fs (%d samples streamed)", Date().timeIntervalSince(t0), audio.count))
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // No session (nothing was forwarded live) — decode the clip whole.
+        let mgr = try await withLoadTimeout(seconds: Self.loadTimeoutSeconds) { try await self.ensureManager() }
+        let terms = configLock.withLock { _config.vocabulary }
+        await mgr.reset()
+        await mgr.setLanguage(Self.languageHint(language))
+        await mgr.setCustomVocabulary(terms.map { CustomVocabularyTerm(text: $0.term) })
+        await mgr.setPartialCallback { _ in }
+        let t0 = Date()
+        _ = try await mgr.process(samples: audio)
+        let text = try await mgr.finish()
+        lastUsed = Date()
+        print(String(format: "NemotronStreamingEngine: batch decode took %.2fs (%d samples)", Date().timeIntervalSince(t0), audio.count))
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func updateConfig(_ config: VoiceConfig) {
+        let changed = configLock.withLock { config.streamingModel != _config.streamingModel }
+        configLock.withLock { _config = config }
+        if changed {
+            forceUnload(reason: "streaming model changed to \(config.streamingModel)")
+        }
+    }
+
+    func unloadIfIdle() {
+        guard manager != nil else { return }
+        if Date().timeIntervalSince(lastUsed) >= idleUnloadAfter {
+            forceUnload(reason: "idle for >\(Int(idleUnloadAfter))s")
+        }
+    }
+
+    func forceUnload(reason: String) {
+        // Invalidate a prewarm that has not installed its models yet. CoreML
+        // may not observe cancellation until its current load returns, so
+        // `load(_:)` also checks cancellation immediately before publishing
+        // the manager. This prevents a model selected before a provider
+        // switch from becoming resident after the switch.
+        let inFlight = loadTaskLock.withLock { () -> Task<StreamingNemotronMultilingualAsrManager, Error>? in
+            let task = loadTask?.task
+            loadTask = nil
+            return task
+        }
+        inFlight?.cancel()
+        let mgr: StreamingNemotronMultilingualAsrManager? = loadQueue.sync {
+            guard manager != nil else { return nil }
+            print("NemotronStreamingEngine: unloading models (\(reason))")
+            let m = manager
+            manager = nil
+            loadedVariant = nil
+            return m
+        }
+        if let mgr = mgr {
+            Task { await mgr.cleanup() }
+        }
+    }
+
+    /// Whether a press right now would decode immediately rather than first
+    /// sit through a load. Compared by variant so a model switch in Settings
+    /// reports "not ready" until the new one is resident.
+    var isReady: Bool {
+        let wanted = variant
+        return loadQueue.sync { manager != nil && loadedVariant == wanted }
+    }
+
+    func prewarm() {
+        Task.detached(priority: .utility) { [weak self] in
+            guard let self = self else { return }
+            do {
+                _ = try await self.ensureManager()
+                self.lastUsed = Date()
+            } catch {
+                print("NemotronStreamingEngine: prewarm failed — \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Loading
+
+    private func ensureManager() async throws -> StreamingNemotronMultilingualAsrManager {
+        let wanted = variant
+        if let existing = loadQueue.sync(execute: { loadedVariant == wanted ? manager : nil }) {
+            return existing
+        }
+        let task: Task<StreamingNemotronMultilingualAsrManager, Error> = loadTaskLock.withLock {
+            if let existing = loadTask, existing.variant == wanted {
+                return existing.task
+            }
+            let created = Task<StreamingNemotronMultilingualAsrManager, Error> { [weak self] in
+                guard let self = self else {
+                    throw NSError(domain: "NemotronStreamingEngine", code: -3, userInfo: [NSLocalizedDescriptionKey: "Engine deallocated during load"])
+                }
+                defer {
+                    self.loadTaskLock.withLock {
+                        if self.loadTask?.variant == wanted { self.loadTask = nil }
+                    }
+                }
+                return try await self.load(wanted)
+            }
+            loadTask = (wanted, created)
+            return created
+        }
+        return try await task.value
+    }
+
+    private func load(_ variant: NemotronVariant) async throws -> StreamingNemotronMultilingualAsrManager {
+        let t0 = Date()
+        let name = variant.id
+        print("NemotronStreamingEngine: loading '\(name)'")
+        // Same machine-readable markers WhisperKit emits; Electron turns them
+        // into the composer's "preparing" state.
+        print("model:loading \(name)")
+
+        let heartbeat = Task.detached(priority: .utility) {
+            var waited: TimeInterval = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(Self.slowLoadWarnSeconds * 1_000_000_000))
+                if Task.isCancelled { break }
+                waited += Self.slowLoadWarnSeconds
+                print(String(format: "NemotronStreamingEngine: still preparing '%@' (%.0fs) - CoreML is compiling for the Neural Engine, this happens once per app build", name, waited))
+            }
+        }
+        defer { heartbeat.cancel() }
+
+        do {
+            // Standard single-manager loading remembers the variant directory, allowing
+            // FluidAudio to bring up its logits-producing decoder lazily when
+            // the user has custom vocabulary. Codey never needs the shared
+            // path intended for several simultaneous transcription streams.
+            let mgr = try await variant.loadManagerWithRecovery()
+            try Task.checkCancellation()
+            // Drop whatever was resident before installing the new one so two
+            // variants never overlap in memory.
+            let previous: StreamingNemotronMultilingualAsrManager? = loadQueue.sync {
+                let p = manager
+                manager = mgr
+                loadedVariant = variant
+                return p
+            }
+            if let previous = previous { await previous.cleanup() }
+            let elapsed = Date().timeIntervalSince(t0)
+            print(String(format: "NemotronStreamingEngine: '%@' ready (load took %.1fs)", name, elapsed))
+            print(String(format: "model:ready %@ %.1f", name, elapsed))
+            return mgr
+        } catch {
+            print("model:failed \(name)")
+            throw error
+        }
+    }
+
+    private func withLoadTimeout<T: Sendable>(seconds: TimeInterval, _ op: @Sendable @escaping () async throws -> T) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await op() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw NSError(domain: "NemotronStreamingEngine", code: -1, userInfo: [NSLocalizedDescriptionKey: "Model still not ready after \(Int(seconds))s. Try again - the load continues in the background."])
+            }
+            guard let first = try await group.next() else {
+                throw NSError(domain: "NemotronStreamingEngine", code: -2, userInfo: [NSLocalizedDescriptionKey: "Task group returned no result"])
+            }
+            group.cancelAll()
+            return first
+        }
+    }
+
+    // MARK: - Language
+
+    /// Map the config's short codes onto the prompt dictionary's region
+    /// codes. Anything unknown is passed through; the model falls back to
+    /// auto-detect for codes it does not recognise.
+    static func languageHint(_ language: String) -> String {
+        let code = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        if code.isEmpty || code == "auto" { return "auto" }
+        let regioned: [String: String] = [
+            "en": "en-US", "zh": "zh-CN", "ja": "ja-JP", "es": "es-ES",
+            "fr": "fr-FR", "it": "it-IT", "pt": "pt-BR", "de": "de-DE",
+        ]
+        return regioned[code.lowercased()] ?? code
+    }
+}

--- a/voice/Sources/CodeyVoice/VoiceConfig.swift
+++ b/voice/Sources/CodeyVoice/VoiceConfig.swift
@@ -25,6 +25,9 @@ struct VoiceConfig: Codable {
     var apiModel: String = "gpt-4o-mini-transcribe"
     /// WhisperKit model variant id (HuggingFace argmaxinc/whisperkit-coreml).
     var localModel: String = "openai_whisper-large-v3_turbo_954MB"
+    /// On-device streaming model id (`nemotron/<multilingual|latin>/<ms>ms`),
+    /// used when `provider` is `.localStreaming`. See `NemotronVariant`.
+    var streamingModel: String = "nemotron/multilingual/1120ms"
     /// OpenAI Realtime API WebSocket URL. Uses the same apiKey as the batch API.
     /// Requires `?intent=transcription` to open a transcription session.
     var realtimeUrl: String = "wss://api.openai.com/v1/realtime?intent=transcription"
@@ -69,8 +72,16 @@ struct VoiceConfig: Codable {
 
     enum Provider: String, Codable {
         case api
+        /// On-device WhisperKit: decodes the finished clip after recording.
         case local
+        /// On-device Nemotron via FluidAudio: true chunked streaming.
+        case localStreaming
         case realtime
+
+        /// Both local engines run inside this helper; the Mac app routes
+        /// composer capture here for either, and the API providers stay in
+        /// Electron.
+        var isOnDevice: Bool { self == .local || self == .localStreaming }
     }
 
     static var `default`: VoiceConfig {
@@ -101,6 +112,7 @@ struct VoiceConfig: Codable {
         apiKey = try c.decodeIfPresent(String.self, forKey: .apiKey) ?? d.apiKey
         apiModel = try c.decodeIfPresent(String.self, forKey: .apiModel) ?? d.apiModel
         localModel = try c.decodeIfPresent(String.self, forKey: .localModel) ?? d.localModel
+        streamingModel = try c.decodeIfPresent(String.self, forKey: .streamingModel) ?? d.streamingModel
         realtimeUrl = try c.decodeIfPresent(String.self, forKey: .realtimeUrl) ?? d.realtimeUrl
         realtimeModel = try c.decodeIfPresent(String.self, forKey: .realtimeModel) ?? d.realtimeModel
         // A malformed vocabulary entry must not take down the whole config

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -54,6 +54,7 @@ final class VoiceCoordinator {
     private let audioCapture: AudioCapture
     private let apiEngine: TranscriptionEngine
     private let localEngine: WhisperKitEngine
+    private let streamingEngine: NemotronStreamingEngine
     private let realtimeEngine: RealtimeTranscriptionEngine
     private var textInjector: TextInjector
     private var hotkeyManager: HotkeyManager?
@@ -106,6 +107,7 @@ final class VoiceCoordinator {
         self.audioCapture = AudioCapture()
         self.apiEngine = TranscriptionEngine(config: .default)
         self.localEngine = WhisperKitEngine(config: .default)
+        self.streamingEngine = NemotronStreamingEngine(config: .default)
         self.realtimeEngine = RealtimeTranscriptionEngine(config: .default)
         self.textInjector = TextInjector(mode: .paste)
         self.converseClient = ConverseClient(port: gatewayPort)
@@ -114,8 +116,29 @@ final class VoiceCoordinator {
     private var activeEngine: TranscriptionEngineProtocol {
         switch config.provider {
         case .local: return localEngine
+        case .localStreaming: return streamingEngine
         case .api: return apiEngine
         case .realtime: return realtimeEngine
+        }
+    }
+
+    /// Whichever on-device engine the config selects, or nil for the API
+    /// providers. Only one of the two is ever loaded: switching providers
+    /// unloads the other (see `applyConfig`), which is what keeps the memory
+    /// cost of offering both engines at "one model", not two.
+    private var onDeviceReady: Bool {
+        switch config.provider {
+        case .local: return localEngine.isReady
+        case .localStreaming: return streamingEngine.isReady
+        case .api, .realtime: return true
+        }
+    }
+
+    private func prewarmOnDevice() {
+        switch config.provider {
+        case .local: localEngine.prewarm()
+        case .localStreaming: streamingEngine.prewarm()
+        case .api, .realtime: break
         }
     }
 
@@ -161,16 +184,18 @@ final class VoiceCoordinator {
             }
         }
         apiEngine.onPartial = partialHandler
-        localEngine.onPartial = partialHandler
+        streamingEngine.onPartial = partialHandler
         realtimeEngine.onPartial = partialHandler
 
-        // Route audio chunks to the realtime engine during recording.
-        // The engine's appendAudioChunk is a no-op when no session is open,
+        // Route audio chunks to the streaming engines during recording.
+        // Both engines' appendAudioChunk is a no-op when no session is open,
         // so this is safe to leave wired permanently.
         audioCapture.onChunk = { [weak self] chunk in
             guard let self = self else { return }
-            if self.config.provider == .realtime {
-                self.realtimeEngine.appendAudioChunk(chunk)
+            switch self.config.provider {
+            case .realtime: self.realtimeEngine.appendAudioChunk(chunk)
+            case .localStreaming: self.streamingEngine.appendAudioChunk(chunk)
+            case .api, .local: break
             }
         }
 
@@ -207,15 +232,14 @@ final class VoiceCoordinator {
         idleUnloadTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
             guard let self = self, self.state == .idle else { return }
             self.localEngine.unloadIfIdle()
+            self.streamingEngine.unloadIfIdle()
             self.realtimeEngine.unloadIfIdle()
         }
 
-        // Prewarm WhisperKit so the first hotkey press doesn't pay the model
-        // load cost. We only do this when local is the active provider — no
+        // Prewarm the selected on-device engine so the first hotkey press
+        // doesn't pay the model load cost. No-op for API providers — no
         // sense pulling weights for API-only users.
-        if config.provider == .local {
-            localEngine.prewarm()
-        }
+        prewarmOnDevice()
         // Prewarm the audio engine regardless of provider — `engine.prepare()`
         // negotiates the input format with Core Audio so `start()` later on
         // hotkey press is a fast transition rather than a cold open. Also
@@ -234,8 +258,8 @@ final class VoiceCoordinator {
     private func handleConverseToggle() {
         guard config.conversationEnabled else { return }
         // API and Realtime capture remain in Electron. On-device capture must
-        // stay here so it can reuse the already-warmed WhisperKit pipeline.
-        guard config.provider == .local else {
+        // stay here so it can reuse the already-warmed local pipeline.
+        guard config.provider.isOnDevice else {
             Task { await gateway.triggerConverseHotkey() }
             return
         }
@@ -296,9 +320,9 @@ final class VoiceCoordinator {
     /// finished talking, which is the worst moment to discover the wait. Say
     /// "not yet" up front, kick the load, and let them press again.
     private func localModelReady(for destination: CaptureDestination) -> Bool {
-        guard config.provider == .local, !localEngine.isReady else { return true }
+        guard config.provider.isOnDevice, !onDeviceReady else { return true }
         print("handleToggle: refused — the on-device model is not loaded yet")
-        localEngine.prewarm()
+        prewarmOnDevice()
         let message = "Preparing the speech model"
         if destination.composerMode != nil {
             emitConversationEvent(type: "error", payload: ["message": message])
@@ -335,16 +359,11 @@ final class VoiceCoordinator {
             }
             installEscMonitor()
 
-            // Kick off WhisperKit's sliding-window streaming so the HUD can
-            // show partial transcripts while the user is still speaking.
-            // API streaming, by contrast, only kicks in after stop because
-            // /audio/transcriptions takes a complete clip.
-            if config.provider == .local {
-                let capture = audioCapture
-                localEngine.startStreaming(
-                    audioSnapshot: { capture.currentSamplesSnapshot() },
-                    language: config.language
-                )
+            // The Nemotron engine decodes chunks as they arrive via onChunk
+            // (wired in start()); opening the session here resets its state
+            // for this utterance and applies language + vocabulary.
+            if config.provider == .localStreaming {
+                streamingEngine.startSession(language: config.language)
             }
 
             // Start the realtime WebSocket session if using the realtime provider.
@@ -379,10 +398,6 @@ final class VoiceCoordinator {
             setConversationCapsule(.thinking)
             emitConversationEvent(type: "state", payload: ["state": "transcribing"])
         }
-        // Cancel streaming partials before we run the final transcribe so a
-        // late partial can't overwrite the success HUD or trigger a duplicate
-        // injection.
-        localEngine.stopStreaming()
         audioCapture.stopRecording()
         // onRecordingComplete callback handles the rest
     }
@@ -394,8 +409,7 @@ final class VoiceCoordinator {
         print("cancelRecording: Esc pressed — discarding buffer")
         captureGeneration += 1
         removeEscMonitor()
-        localEngine.stopStreaming()
-        audioCapture.onChunk = nil
+        streamingEngine.cancelSession()
         realtimeEngine.cancelSession()
         audioCapture.cancelRecording()
         state = .idle
@@ -423,7 +437,7 @@ final class VoiceCoordinator {
         guard state == .transcribing else { return }
         captureGeneration += 1
         removeEscMonitor()
-        localEngine.stopStreaming()
+        streamingEngine.cancelSession()
         realtimeEngine.cancelSession()
         state = .idle
         statusItem?.updateState(.idle)
@@ -622,11 +636,13 @@ final class VoiceCoordinator {
         Task {
             do {
                 let lang = config.language
-                let providerLabel = config.provider == .local
-                    ? "local(\(config.localModel))"
-                    : config.provider == .realtime
-                    ? "realtime(\(config.realtimeModel))"
-                    : "api(\(config.apiModel))"
+                let providerLabel: String
+                switch config.provider {
+                case .local: providerLabel = "local(\(config.localModel))"
+                case .localStreaming: providerLabel = "localStreaming(\(config.streamingModel))"
+                case .realtime: providerLabel = "realtime(\(config.realtimeModel))"
+                case .api: providerLabel = "api(\(config.apiModel))"
+                }
                 print("transcribe: starting (language=\(lang.isEmpty ? "auto" : lang), provider=\(providerLabel))")
                 let heard = try await activeEngine.transcribe(audio: buffer, language: lang)
 
@@ -916,17 +932,26 @@ final class VoiceCoordinator {
         textInjector = TextInjector(mode: newConfig.injection)
         apiEngine.updateConfig(newConfig)
         localEngine.updateConfig(newConfig)
+        streamingEngine.updateConfig(newConfig)
         realtimeEngine.updateConfig(newConfig)
+        // Leaving an on-device engine releases it right away rather than
+        // waiting for the idle timer: the whole point of making the two
+        // local engines a switch instead of a pair is that only one is
+        // ever resident.
         if oldProvider == .local && newConfig.provider != .local {
             localEngine.forceUnload(reason: "provider switched to \(newConfig.provider.rawValue)")
+        }
+        if oldProvider == .localStreaming && newConfig.provider != .localStreaming {
+            streamingEngine.cancelSession()
+            streamingEngine.forceUnload(reason: "provider switched to \(newConfig.provider.rawValue)")
         }
         if oldProvider == .realtime && newConfig.provider != .realtime {
             realtimeEngine.cancelSession()
         }
-        if oldProvider != .local && newConfig.provider == .local {
-            // User just turned local on (or changed model) — start warming now
-            // so the first press is fast.
-            localEngine.prewarm()
+        if oldProvider != newConfig.provider && newConfig.provider.isOnDevice {
+            // User just turned an on-device engine on — start warming now so
+            // the first press is fast.
+            prewarmOnDevice()
         }
 
         if newConfig.converseHotkey != oldConverseHotkey
@@ -984,6 +1009,7 @@ final class VoiceCoordinator {
         pollTimer?.invalidate()
         idleUnloadTimer?.invalidate()
         localEngine.forceUnload(reason: "app terminating")
+        streamingEngine.forceUnload(reason: "app terminating")
         realtimeEngine.cancelSession()
     }
 

--- a/voice/Sources/CodeyVoice/WhisperKitEngine.swift
+++ b/voice/Sources/CodeyVoice/WhisperKitEngine.swift
@@ -27,12 +27,12 @@ func normalizeVariant(_ raw: String) -> String {
 final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     private var pipeline: WhisperKit?
     private var loadedModel: String?
-    /// Mutable config is behind a lock — detached tasks in startStreaming and
-    /// transcribe can read config concurrently with updateConfig (gateway poll).
+    /// Mutable config is behind a lock because transcription/prewarm tasks can
+    /// read config concurrently with updateConfig (gateway poll).
     private let configLock = NSLock()
     private var _config: VoiceConfig
-    /// Unused by WhisperKit (we don't surface partial decodes today); kept to
-    /// satisfy the protocol. Wire up once we move to streaming decode.
+    /// Whisper is intentionally batch-only: Listening never performs partial
+    /// decoding. Kept only to satisfy the shared engine protocol.
     var onPartial: ((String) -> Void)?
     private var lastUsed: Date = .distantPast
     // Kept the pipeline warm across pauses in dictation. 30s was over-eager —
@@ -79,167 +79,15 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     private let loadQueue = DispatchQueue(label: "codey.voice.whisperkit.load")
     /// The load currently in flight, with the variant it is loading.
     ///
-    /// `ensurePipeline` is reachable from three places at once — the streaming
-    /// task, prewarm, and the final transcribe — and none of them held a lock,
-    /// so a cold start could enter it concurrently and materialize the same
-    /// ~600 MB of weights more than once. Callers now join the in-flight load
-    /// instead. Keyed by variant so a load kicked off before the user switched
-    /// models isn't handed back as if it were the new one.
+    /// `ensurePipeline` is reachable from prewarm and final transcription at
+    /// once. Callers join the in-flight load so a cold start cannot materialize
+    /// the same weights more than once. Keyed by variant so a load kicked off
+    /// before the user switched models isn't handed back as the new one.
     private var loadTask: (model: String, task: Task<WhisperKit, Error>)?
     private let loadTaskLock = NSLock()
-    /// Background sliding-window task that pulls partial transcripts from the
-    /// in-progress recording. Owned by the engine so we can cancel it on
-    /// stop/cancel without the coordinator having to track Task lifetimes.
-    private var streamingTask: Task<Void, Never>?
-    /// Streaming state — protected by `streamingLock` since the streaming
-    /// task writes from a detached priority thread and the final transcribe
-    /// reads on the main task. See `StreamingState` for what each field
-    /// represents.
-    private var streamingState = StreamingState()
-    private let streamingLock = NSLock()
-
-    /// Snapshot of where the sliding-window streamer has progressed so far.
-    /// We split the running transcript into:
-    ///   - "confirmed": segments that have stayed put across multiple decodes
-    ///     and won't be re-decoded again (their audio is below
-    ///     `confirmedEndSeconds`). Text is final.
-    ///   - "tail": the most recent segment, which may still mutate as more
-    ///     audio arrives. Re-decoded every iteration via `clipTimestamps`.
-    /// `lastEmittedFullText` is the joined `confirmed + tail` from the most
-    /// recent emission — used to skip the final decode when the user stops
-    /// recording right after the streamer just emitted.
-    private struct StreamingState {
-        var confirmedText: String = ""
-        var confirmedEndSeconds: Float = 0
-        var tailText: String = ""
-        var lastEmittedFullText: String = ""
-        var lastSnapshotSampleCount: Int = 0
-        var lastSnapshotAt: Date = .distantPast
-        var inProgress: Bool = false
-    }
 
     init(config: VoiceConfig) {
         self._config = config
-    }
-
-    /// Start emitting partial transcripts while the user is still talking.
-    /// Pulls a snapshot of the live audio buffer every iteration, decodes the
-    /// whole thing, and pushes the result through `onPartial`. Re-decoding the
-    /// full buffer each round is wasteful on long recordings but simple and
-    /// correct — turbo on Apple Silicon handles a 30 s clip in ~1–2 s, so the
-    /// partial just lags by one decode round, which is fine for a HUD preview.
-    /// The final, authoritative transcription still runs via the existing
-    /// `transcribe(audio:language:)` path on `stopRecording`.
-    ///
-    /// `audioSnapshot` must return a coherent copy of the captured Float32
-    /// samples at 16 kHz; see `AudioCapture.currentSamplesSnapshot()`.
-    func startStreaming(audioSnapshot: @escaping @Sendable () -> [Float], language: String) {
-        stopStreaming() // idempotent: cancel any previous run
-        // Reset accumulator state — last run's confirmed text is irrelevant.
-        streamingLock.withLock {
-            self.streamingState = StreamingState()
-            self.streamingState.inProgress = true
-        }
-        let lang = language
-        streamingTask = Task.detached(priority: .userInitiated) { [weak self] in
-            guard let self = self else { return }
-            let pipe: WhisperKit
-            do {
-                pipe = try await self.ensurePipeline()
-            } catch {
-                print("WhisperKitEngine.startStreaming: load failed — \(error.localizedDescription)")
-                return
-            }
-
-            // Wait for at least ~1 s of audio before the first decode — turbo
-            // refuses to commit on very short clips and we'd just get empty
-            // strings back.
-            let minSamples = 16_000
-            var lastSnapshotCount = 0
-
-            while !Task.isCancelled {
-                // Tighter sleep (400 ms) means the last emitted partial is on
-                // average ~half-decode-time fresher when the user releases,
-                // which directly improves fast-path hit rate. Each iteration
-                // is still bounded by decode duration (~200–700 ms with
-                // clipTimestamps on tail-only audio), so the loop's actual
-                // period is ~600–1100 ms, not 400 ms.
-                try? await Task.sleep(nanoseconds: 400_000_000)
-                if Task.isCancelled { break }
-
-                let samples = audioSnapshot()
-                let snapshotAt = Date()  // captured at snapshot time, not after decode
-                guard samples.count >= minSamples else { continue }
-                // Skip a decode round if no new audio arrived (e.g. user paused
-                // long enough that the buffer is unchanged).
-                guard samples.count > lastSnapshotCount else { continue }
-                lastSnapshotCount = samples.count
-
-                // Read the confirmed boundary that the last successful decode
-                // settled on. WhisperKit will skip everything before this
-                // timestamp internally, so each iteration only decodes the
-                // unconfirmed tail rather than re-doing the whole buffer.
-                let (clipStart, confirmedTextSoFar) = self.streamingLock.withLock {
-                    (self.streamingState.confirmedEndSeconds, self.streamingState.confirmedText)
-                }
-
-                var options = self.streamingOptions(language: lang, pipe: pipe)
-                if clipStart > 0 { options.clipTimestamps = [clipStart] }
-
-                self.lastUsed = Date()
-                do {
-                    let normalized = self.peakNormalize(samples, target: 0.9)
-                    let results = try await pipe.transcribe(audioArray: normalized, decodeOptions: options)
-                    if Task.isCancelled { break }
-
-                    // Sort segments by start time; treat all-but-last as newly
-                    // confirmed (the trailing segment is still being shaped by
-                    // incoming audio so it can flip wording on the next pass).
-                    let segments = results.flatMap { $0.segments }.sorted { $0.start < $1.start }
-                    var newConfirmedText = confirmedTextSoFar
-                    var newConfirmedEnd = clipStart
-                    if segments.count > 1 {
-                        for seg in segments.dropLast() {
-                            // clipTimestamps is a hint, not a hard cut — a
-                            // segment that re-spans the boundary occasionally
-                            // shows up. Guard against double-appending.
-                            if seg.end > newConfirmedEnd {
-                                newConfirmedText += Self.stripWhisperTags(seg.text)
-                                newConfirmedEnd = seg.end
-                            }
-                        }
-                    }
-                    let tail = Self.stripWhisperTags(segments.last?.text ?? "")
-                    let fullText = (newConfirmedText + tail).trimmingCharacters(in: .whitespacesAndNewlines)
-
-                    self.streamingLock.withLock {
-                        self.streamingState.confirmedText = newConfirmedText
-                        self.streamingState.confirmedEndSeconds = newConfirmedEnd
-                        self.streamingState.tailText = tail
-                        self.streamingState.lastEmittedFullText = fullText
-                        self.streamingState.lastSnapshotSampleCount = samples.count
-                        // Use the snapshot timestamp, not "now" — otherwise
-                        // `elapsed` in the fast-path check is inflated by the
-                        // decode duration itself.
-                        self.streamingState.lastSnapshotAt = snapshotAt
-                    }
-
-                    if !fullText.isEmpty, let cb = self.onPartial {
-                        await MainActor.run { cb(fullText) }
-                    }
-                } catch is CancellationError {
-                    // The user released the hotkey mid-decode. Expected on
-                    // nearly every turn, so it is neither an error to report
-                    // nor a reason to loop again.
-                    break
-                } catch {
-                    if Task.isCancelled { break }
-                    // Partial decode errors are non-fatal — keep the loop going
-                    // so a transient hiccup doesn't kill the live preview.
-                    print("WhisperKitEngine.startStreaming: partial decode error — \(error.localizedDescription)")
-                }
-            }
-        }
     }
 
     /// Tokenized vocabulary hint for `DecodingOptions.promptTokens`, or nil
@@ -270,35 +118,6 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         return tokens.isEmpty ? nil : tokens
     }
 
-    /// Decode options shared by the streaming loop and the post-stop "settle"
-    /// decode. Kept lean — temperature fallback off, fewer workers — because
-    /// these run on a partial buffer and we want fast iteration; the final
-    /// non-streaming `transcribe()` path keeps the more conservative options.
-    private func streamingOptions(language: String, pipe: WhisperKit) -> DecodingOptions {
-        var options = DecodingOptions()
-        options.promptTokens = vocabularyPromptTokens(pipe, language: language)
-        options.task = .transcribe
-        if !language.isEmpty && language != "auto" { options.language = language }
-        options.temperature = 0.0
-        options.sampleLength = 144
-        // We need segment timestamps to track the confirmed/unconfirmed
-        // boundary — `withoutTimestamps = true` would strip them.
-        options.withoutTimestamps = false
-        options.usePrefillPrompt = true
-        options.chunkingStrategy = .vad
-        options.temperatureFallbackCount = 0
-        options.concurrentWorkerCount = 2
-        return options
-    }
-
-    /// Cancel the streaming loop if one is running. Safe to call multiple
-    /// times. The in-flight decode (if any) will finish but its result is
-    /// discarded once the task observes cancellation.
-    func stopStreaming() {
-        streamingTask?.cancel()
-        streamingTask = nil
-    }
-
     /// Eagerly load the model so the first user press doesn't pay the
     /// multi-second load cost. Safe to call multiple times — no-op if already
     /// loaded with the same variant. Errors are logged and swallowed; the
@@ -320,45 +139,11 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         configLock.withLock { _config = config }
         if modelChanged {
             // Drop the pipeline; next transcribe will reload the new variant.
-            loadQueue.sync { self.pipeline = nil; self.loadedModel = nil }
+            forceUnload(reason: "local model changed to \(config.localModel)")
         }
     }
 
     func transcribe(audio: [Float], language: String) async throws -> String {
-        // Fast path: if the streamer ALREADY produced a partial that covers
-        // (essentially) the entire captured buffer and did so very recently,
-        // reuse it as the final result *before* waiting on the cancelled
-        // streaming task. Otherwise an in-flight partial decode that hasn't
-        // observed cancellation yet (500 ms–2 s remaining) would block us
-        // until it finishes — eating most of what fast-path is supposed to
-        // save. The orphan decode is allowed to run to completion in the
-        // background; its result is dropped by the coordinator (state is
-        // already `.idle` by the time `onPartial` fires).
-        let cached = streamingLock.withLock { streamingState }
-        if !cached.lastEmittedFullText.isEmpty {
-            let newSamples = audio.count - cached.lastSnapshotSampleCount
-            let elapsed = Date().timeIntervalSince(cached.lastSnapshotAt)
-            if newSamples < 8_000 && elapsed < 1.5 {
-                print("WhisperKitEngine: reusing streaming partial as final (\(cached.lastEmittedFullText.count) chars, \(newSamples) new samples, \(String(format: "%.2f", elapsed))s old)")
-                streamingLock.withLock { self.streamingState = StreamingState() }
-                // Detach the orphan task — we don't await it. Setting nil here
-                // is racy with the task's own bookkeeping but the cancel was
-                // already issued; the task's eventual write to streamingTask
-                // is irrelevant since the next startStreaming resets it.
-                streamingTask = nil
-                return cached.lastEmittedFullText
-            }
-        }
-
-        // Fast-path didn't fire — we're going to hit the pipeline ourselves,
-        // so first wait for any in-flight streaming decode to finish.
-        // WhisperKit isn't documented as safe under concurrent transcribe
-        // calls; serializing here is the cheap way to guarantee correctness.
-        if let task = streamingTask {
-            _ = await task.value
-            streamingTask = nil
-        }
-
         let pipe = try await withLoadTimeout(seconds: Self.loadTimeoutSeconds) { try await self.ensurePipeline() }
         lastUsed = Date()
 
@@ -396,41 +181,24 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         // threshold often enough that the same audio could run three times.
         // That is the source of the "sometimes 1s, sometimes 5s" spread the
         // user actually feels; the quality it buys back is a marginally
-        // cleaner sentence on the clips that were already marginal. The
-        // streaming pass has always run at 0 for the same reason.
-        //
-        // Empty results are not a risk we are trading away here: the streaming
-        // partial is still there as a fallback.
+        // cleaner sentence on the clips that were already marginal.
         options.temperatureFallbackCount = 0
         // VAD splits long press-to-talk clips into N voiced chunks; with
         // workers > 1 they decode concurrently. 4 saturates ANE+GPU on
         // M-series; short single-chunk clips are unaffected.
         options.concurrentWorkerCount = 4
 
-        // If the streaming pass already confirmed a prefix, skip over it here
-        // so the final "settle decode" only re-does the unconfirmed tail. We
-        // keep `withoutTimestamps = true` (default for the final path) — the
-        // confirmed prefix has its boundary, that's all we need.
-        if cached.confirmedEndSeconds > 0 {
-            options.clipTimestamps = [cached.confirmedEndSeconds]
-        }
-
         let t0 = Date()
         let results = try await pipe.transcribe(audioArray: normalized, decodeOptions: options)
         let elapsed = Date().timeIntervalSince(t0)
-        let tailText = results.map { Self.stripWhisperTags($0.text) }.joined(separator: " ")
-        let merged = (cached.confirmedText + tailText).trimmingCharacters(in: .whitespacesAndNewlines)
-        print(String(format: "WhisperKitEngine: decode took %.2fs (%d samples, %@)", elapsed, normalized.count, cached.confirmedEndSeconds > 0 ? "tail from \(cached.confirmedEndSeconds)s" : "full"))
-        // Drop the cached streaming state — it's been consumed.
-        streamingLock.withLock { self.streamingState = StreamingState() }
-        return merged
+        let text = results.map { Self.stripWhisperTags($0.text) }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        print(String(format: "WhisperKitEngine: decode took %.2fs (%d samples, full)", elapsed, normalized.count))
+        return text
     }
 
-    /// Strip Whisper special tokens (`<|startoftranscript|>`, `<|en|>`,
-    /// `<|transcribe|>`, `<|0.00|>`, …) from segment text. They leak into
-    /// `seg.text` when `withoutTimestamps = false` — which we need on the
-    /// streaming path to get segment boundaries for `clipTimestamps`. Stripping
-    /// here is simpler than juggling decoder options.
+    /// Defensively strip any Whisper special tokens from result text.
     static func stripWhisperTags(_ text: String) -> String {
         guard text.contains("<|") else { return text }
         // Pattern matches `<|...|>` lazily so a single sequence isn't merged
@@ -471,8 +239,18 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
     }
 
     func forceUnload(reason: String) {
-        guard pipeline != nil else { return }
+        // A provider switch can happen while CoreML is still compiling. Mark
+        // that load cancelled even when no pipeline has been installed yet;
+        // `loadPipeline` checks before publishing it so the old engine cannot
+        // quietly become resident after the switch.
+        let inFlight = loadTaskLock.withLock { () -> Task<WhisperKit, Error>? in
+            let task = loadTask?.task
+            loadTask = nil
+            return task
+        }
+        inFlight?.cancel()
         loadQueue.sync {
+            guard pipeline != nil else { return }
             print("WhisperKitEngine: unloading pipeline (\(reason))")
             self.pipeline = nil
             self.loadedModel = nil
@@ -561,6 +339,7 @@ final class WhisperKitEngine: TranscriptionEngineProtocol, @unchecked Sendable {
         let pipe: WhisperKit
         do {
             pipe = try await WhisperKit(kitConfig)
+            try Task.checkCancellation()
         } catch {
             // Electron is holding a "preparing" indicator up on the strength of
             // `model:loading`. Without a terminal marker it would stay there

--- a/voice/Sources/CodeyVoice/main.swift
+++ b/voice/Sources/CodeyVoice/main.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import Darwin
+import FluidAudio
 import WhisperKit
 
 final class ExitCodeBox: @unchecked Sendable {
@@ -16,6 +17,66 @@ setbuf(stderr, nil)
 // is emitted as `download:progress <fraction>` lines so the parent (Electron
 // main) can stream a progress bar to the UI.
 let cliArgs = CommandLine.arguments
+
+// The streaming engine's models share the same two one-shot modes. Its ids
+// carry a `nemotron/` prefix (see `NemotronVariant`), so the same
+// `--download-model` / `--warm-model` flags route by name and Electron does
+// not need a second set of spawn paths or progress parsers.
+if let dlIdx = cliArgs.firstIndex(of: "--download-model"), dlIdx + 1 < cliArgs.count,
+   let variant = NemotronVariant(id: cliArgs[dlIdx + 1]) {
+    print("download:start \(variant.id)")
+    let sema = DispatchSemaphore(value: 0)
+    let exitCodeBox = ExitCodeBox()
+    Task {
+        do {
+            let folder = try await variant.download { fraction in
+                print(String(format: "download:progress %.4f", fraction))
+            }
+            print("download:done \(folder.path)")
+        } catch {
+            print("download:error \(String(describing: error))")
+            exitCodeBox.code = 1
+        }
+        sema.signal()
+    }
+    sema.wait()
+    exit(exitCodeBox.code)
+}
+
+if let wIdx = cliArgs.firstIndex(of: "--warm-model"), wIdx + 1 < cliArgs.count,
+   let variant = NemotronVariant(id: cliArgs[wIdx + 1]) {
+    print("warm:start \(variant.id)")
+    let sema = DispatchSemaphore(value: 0)
+    let exitCodeBox = ExitCodeBox()
+    Task {
+        let t0 = Date()
+        do {
+            // Same load path as the engine so CoreML's per-machine compile
+            // lands in the cache the engine will read. One chunk of silence
+            // through the pipeline forces every sub-model to compile.
+            let manager = try await variant.loadManagerWithRecovery { fraction in
+                print(String(format: "warm:progress %.4f", fraction))
+            }
+            // Exercise the vocabulary-aware logits path as well as the
+            // default fused decoder. Otherwise a user with dictionary terms
+            // could still pay a one-time CoreML compile on first dictation.
+            await manager.setCustomVocabulary([CustomVocabularyTerm(text: "Codey")])
+            await manager.reset()
+            _ = try await manager.process(samples: [Float](repeating: 0, count: 16000 * 2))
+            _ = try await manager.finish()
+            await manager.cleanup()
+            let elapsed = Date().timeIntervalSince(t0)
+            print(String(format: "warm:done %.2f", elapsed))
+        } catch {
+            print("warm:error \(String(describing: error))")
+            exitCodeBox.code = 1
+        }
+        sema.signal()
+    }
+    sema.wait()
+    exit(exitCodeBox.code)
+}
+
 if let dlIdx = cliArgs.firstIndex(of: "--download-model"), dlIdx + 1 < cliArgs.count {
     // WhisperKit's HF lookup uses glob `*openai*<variant>/*`, so the variant
     // must be the bare model name (e.g. `large-v3-turbo`), not the full repo


### PR DESCRIPTION
## What

Voice can now transcribe **while you are still talking**, fully on-device. Previously local mode (WhisperKit) only produced text after you released the key.

New provider `localStreaming`, backed by [FluidAudio](https://github.com/FluidInference/FluidAudio)'s CoreML conversions of NVIDIA's Nemotron streaming ASR models.

## Changes

**Swift helper (`voice/`)**
- `NemotronStreamingEngine.swift` — new streaming engine (multilingual / Latin variants, ~1.1s chunks)
- `VoiceCoordinator` / `AudioCapture` — feed audio to the streaming engine and emit partial text
- `main.swift` — model download + warm-up subcommands
- `VoiceConfig` — `streamingModel` field
- `WhisperKitEngine` — trimmed down; the shared streaming bits moved out

**Gateway (`packages/gateway/src/config.ts`)**
- `provider` union gains `localStreaming` and `realtime`
- new `streamingModel` setting

**Mac app (`codey-mac/`)**
- `electron/voice-models.ts` (+ tests) — single source of truth for model metadata and download state. Completeness is now checked against each `.mlmodelc` weight file size; previously the presence of `metadata.json` was enough, so a half-finished download reported "Downloaded" and then failed warm-up with CoreML error -14.
- `WhisperTab.tsx` — model picker shows download size per option; drops the "Not downloaded ·" prefix
- Whisper mode no longer transcribes during Listening (only Streaming shows live text)
- `WhisperTab.tsx` — On-device settings now show a Whisper vs Streaming comparison table (text timing, languages, recommended hardware, battery, download size) with the selected engine highlighted, plus shared notes on the one-time CoreML compile and the load/unload behaviour

## Testing

- `npm test -w codey-mac` — 1031 passed
- `npm test -w @codey/gateway` — 488 passed
- `swift build -c release` in `voice/` passes; model download + warm-up verified manually on-device

**Not verified:** live microphone transcription quality through the app UI. Needs a real-machine pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
