### PR TITLE
fix(mac): count voice-vocabulary sightings by the corrected word alone

### DIFF
--- a/codey-mac/src/components/voiceVocabulary.test.ts
+++ b/codey-mac/src/components/voiceVocabulary.test.ts
@@ -180,6 +180,16 @@ describe('recordCorrections', () => {
     expect(second.promoted).toHaveLength(1)
   })
 
+  it('counts sightings by the corrected word, not by how it was misheard', () => {
+    // The recognizer rarely fails the same way twice ("Wisber", "wsper"),
+    // so keying on the alias would leave every word stuck at one sighting.
+    const first = recordCorrections([], [], [{ term: 'Whisper', alias: 'Wisber' }])
+    const second = recordCorrections(first.pending, [], [{ term: 'Whisper', alias: 'wsper' }])
+    expect(first.pending).toHaveLength(1)
+    expect(second.promoted.map(p => p.term)).toEqual(['Whisper'])
+    expect(second.pending).toEqual([])
+  })
+
   it('ignores a correction whose word is already in the dictionary', () => {
     const r = recordCorrections([], ['Codey'], [codey])
     expect(r.promoted).toEqual([])

--- a/codey-mac/src/components/voiceVocabulary.ts
+++ b/codey-mac/src/components/voiceVocabulary.ts
@@ -8,9 +8,9 @@
  */
 
 /** A word swap observed by comparing what was dictated against what the user
- *  actually sent. `alias` never reaches the dictionary — it is the evidence
- *  that `term` is a word the recognizer cannot spell, and the key the waiting
- *  list counts sightings under. */
+ *  actually sent. `alias` never reaches the dictionary — it is only the
+ *  evidence that `term` is a word the recognizer cannot spell. The waiting
+ *  list counts sightings by `term` alone. */
 export interface LearnedCorrection {
   /** The corrected spelling — what the user left in the composer. */
   term: string
@@ -358,8 +358,12 @@ export function normalizePending(raw: unknown): PendingCorrection[] {
   })
 }
 
-function pendingKey(term: string, alias: string): string {
-  return `${alias.toLowerCase()}\u0000${term.toLowerCase()}`
+/** Sightings are counted by the corrected word alone. The recognizer rarely
+ *  fails the same way twice ("Wisber" one turn, "wsper" the next), so keying
+ *  on the alias as well left every word stuck at one sighting forever. The
+ *  alias is kept only as evidence of the first mis-hearing. */
+function pendingKey(term: string, _alias?: string): string {
+  return term.toLowerCase()
 }
 
 /**


### PR DESCRIPTION
## Why

Auto-learning for the voice dictionary never fired. A real `gateway.json` had 12 pending corrections, every one stuck at `count: 1`.

The waiting list keyed each sighting on **(alias, term)** — what was misheard plus what the user typed. But the recognizer rarely mishears a word the same way twice (`Wisber` → `Whisper`, then `wsper` → `Whisper`), so each sighting landed under a different key and nothing ever reached the 2-sighting threshold.

## What

- `pendingKey` now keys on the corrected `term` only. The `alias` is kept on the pending row as evidence of the first mis-hearing but no longer takes part in counting.
- Updated the doc comment on `LearnedCorrection` to match.
- New test: two different mis-hearings of the same word promote it on the second sighting.

## Verification

- `codey-mac` vocabulary suite: 48/48
- Full `codey-mac` vitest: 1020/1020
- `tsc --noEmit` clean

Not yet exercised on a real machine; existing pending rows stay at 1 and will promote on their next correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)