### PR TITLE
fix(mac): clean up worker and team run presentation

### DIFF
--- a/codey-mac/src/components/ChatContextPanel.tsx
+++ b/codey-mac/src/components/ChatContextPanel.tsx
@@ -63,7 +63,7 @@ interface Props {
 
 export const ChatContextPanel: React.FC<Props> = ({
   chat, selectedTurnId, followLatest,
-  effectiveAgent, effectiveModel, workerName, teamName, teamGraph, workingDir,
+  workingDir,
   width, onFollowLatest, onClose, onResize, onRevealFile, onScrollToStep, isTurnStreaming,
   activeTab, onTabChange, qqInputRef,
   onAnswerNextAction, taskBriefLoading, onTaskTabShown,
@@ -92,6 +92,12 @@ export const ChatContextPanel: React.FC<Props> = ({
     }
     return null
   })()
+
+  const teamBlackboard = turn?.teamTurnId
+    ? [...chat.messages].reverse().find(message =>
+        message.teamTurnId === turn.teamTurnId && message.teamBlackboard
+      )?.teamBlackboard
+    : undefined
 
   const [localTab, setLocalTab] = React.useState<ContextPanelTab>('current')
   const requestedTab: ContextPanelTab = activeTab ?? localTab
@@ -178,15 +184,7 @@ export const ChatContextPanel: React.FC<Props> = ({
           />
         ) : tab === 'current' ? (
           <>
-            {/* Run target */}
-            <Section title="Run target">
-              <div style={styles.runTargetRow}>
-                {teamName ? `Team: ${teamName}` : workerName ? `Worker: ${workerName}` : 'Direct chat'}
-              </div>
-              <div style={styles.runTargetSub}>
-                {effectiveAgent}{effectiveModel ? ` · ${effectiveModel}` : ''}
-              </div>
-            </Section>
+            {turn?.teamTurnId && <BlackboardSection blackboard={teamBlackboard} />}
 
             {turn && <ToolTimeline toolCalls={turn.toolCalls ?? []} />}
             {turn && <FilesTouched toolCalls={turn.toolCalls ?? []} workingDir={workingDir} onReveal={onRevealFile} />}
@@ -218,6 +216,35 @@ export const ChatContextPanel: React.FC<Props> = ({
 }
 
 const FILE_TOOLS = new Set(['Read', 'Edit', 'Write', 'NotebookEdit'])
+
+const BlackboardSection: React.FC<{
+  blackboard?: NonNullable<ChatMessage['teamBlackboard']>
+}> = ({ blackboard }) => {
+  const groups = blackboard ? [
+    { label: 'Decisions', entries: blackboard.decisions, color: C.accent },
+    { label: 'Open questions', entries: blackboard.open, color: C.yellow },
+    { label: 'Facts', entries: blackboard.facts, color: C.fg2 },
+    { label: 'Handoffs', entries: blackboard.handoffs, color: C.purple },
+  ].filter(group => group.entries.length > 0) : []
+
+  return (
+    <Section title="Blackboard">
+      {groups.length === 0 ? (
+        <div style={styles.emptyHint}>Workers have not added anything yet.</div>
+      ) : groups.map(group => (
+        <div key={group.label} style={styles.blackboardGroup}>
+          <div style={{ ...styles.blackboardGroupTitle, color: group.color }}>{group.label}</div>
+          {group.entries.map((entry, index) => (
+            <div key={`${entry.worker}-${entry.step}-${index}`} style={styles.blackboardEntry}>
+              <div style={styles.blackboardText}>{entry.text}</div>
+              <div style={styles.blackboardMeta}>{entry.worker} · step {entry.step}</div>
+            </div>
+          ))}
+        </div>
+      ))}
+    </Section>
+  )
+}
 
 const FilesTouched: React.FC<{
   toolCalls: import('../types').ToolCallEntry[]
@@ -1276,7 +1303,10 @@ const styles: Record<string, React.CSSProperties> = {
     color: C.fg3, fontSize: 10, fontWeight: 600, letterSpacing: 0.6,
     textTransform: 'uppercase', marginBottom: 6,
   },
-  runTargetRow: { color: C.fg, fontSize: 12 },
-  runTargetSub: { color: C.fg3, fontSize: 11, marginTop: 2 },
+  blackboardGroup: { marginBottom: 10 },
+  blackboardGroupTitle: { fontSize: 10, fontWeight: 700, letterSpacing: 0.35, marginBottom: 4 },
+  blackboardEntry: { padding: '7px 8px', marginBottom: 5, borderRadius: 7, background: C.surface2, border: `1px solid ${C.border}` },
+  blackboardText: { color: C.fg, fontSize: 12, lineHeight: 1.4, overflowWrap: 'anywhere' },
+  blackboardMeta: { color: C.fg3, fontSize: 10, marginTop: 3 },
   emptyHint: { color: C.fg3, fontSize: 11, fontStyle: 'italic', padding: '12px 0' },
 }

--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -73,6 +73,19 @@ describe('team reducer routing', () => {
     expect(s.chats.c1.messages.find(x => x.id === 'w1')!.workerStatus).toBe('done');
   });
 
+  it('stores live blackboard updates on the worker message', () => {
+    let s = baseState();
+    s = reducer(s, { type: 'workerStart', chatId: 'c1', teamTurnId: 'tt1', messageId: 'w1', step: 1, worker: 'a', reason: '' });
+    const blackboard = {
+      facts: [{ worker: 'a', step: 1, text: 'The API is stable' }],
+      decisions: [],
+      handoffs: [],
+      open: [],
+    };
+    s = reducer(s, { type: 'blackboardUpdate', chatId: 'c1', teamTurnId: 'tt1', messageId: 'w1', blackboard });
+    expect(s.chats.c1.messages.find(message => message.id === 'w1')?.teamBlackboard).toEqual(blackboard);
+  });
+
   it('attaches a terminal team summary only when teamEnd arrives', () => {
     let s = baseState();
     s = reducer(s, { type: 'workerStart', chatId: 'c1', teamTurnId: 'tt1', messageId: 'w1', step: 1, worker: 'a', reason: '' });

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef } from 'react'
 import { apiService } from '../services/api'
 import type { Chat, ChatSelection, ChatMessage, ChecklistItem, ToolCallEntry, FileAttachment, TaskBrief, TeamRunSummary } from '../types'
+import type { BlackboardSnapshot } from '@codey/core'
 import type { ChatStreamEvent } from '../../../packages/gateway/src/chat-runner'
 import { activityForTool, type AgentActivity } from '../components/agentActivity'
 import type { UnreadKind } from '../components/notificationLogic'
@@ -81,6 +82,7 @@ type Action =
   | { type: 'teamStart'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'roundtable'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string }> }
   | { type: 'workerStart'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string; reason?: string }
   | { type: 'workerEnd'; chatId: string; messageId: string; step: number; status: 'running' | 'done' | 'failed' | 'askedUser'; failureReason?: string; nextUserAction?: ChatMessage['workerNextUserAction'] }
+  | { type: 'blackboardUpdate'; chatId: string; teamTurnId: string; messageId: string; blackboard: BlackboardSnapshot }
   | { type: 'teamEnd'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
 
 function reorder(order: string[], chatId: string): string[] {
@@ -89,7 +91,7 @@ function reorder(order: string[], chatId: string): string[] {
 
 const EXTERNAL_TURN_EVENTS = new Set([
   'tool_start', 'tool_end', 'info', 'stream', 'thinking',
-  'team_start', 'worker_start', 'worker_end', 'team_end',
+  'team_start', 'worker_start', 'worker_end', 'blackboard_update', 'team_end',
 ])
 
 /**
@@ -430,6 +432,16 @@ export function reducer(state: State, action: Action): State {
       const chat = state.chats[action.chatId]
       if (!chat) return state
       const messages = chat.messages.map(m => m.id === action.messageId ? { ...m, workerStatus: action.status, isComplete: action.status !== 'running', workerFailureReason: action.failureReason, workerNextUserAction: action.nextUserAction } : m)
+      return { ...state, chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } } }
+    }
+    case 'blackboardUpdate': {
+      const chat = state.chats[action.chatId]
+      if (!chat) return state
+      const messages = chat.messages.map(message =>
+        message.id === action.messageId && message.teamTurnId === action.teamTurnId
+          ? { ...message, teamBlackboard: action.blackboard }
+          : message
+      )
       return { ...state, chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } } }
     }
     case 'teamFinal': {
@@ -773,6 +785,9 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           break
         case 'worker_end':
           dispatch({ type: 'workerEnd', chatId: ev.chatId, messageId: ev.messageId, step: ev.step, status: ev.status, failureReason: ev.failureReason, nextUserAction: ev.nextUserAction })
+          break
+        case 'blackboard_update':
+          dispatch({ type: 'blackboardUpdate', chatId: ev.chatId, teamTurnId: ev.teamTurnId, messageId: ev.messageId, blackboard: ev.blackboard })
           break
         case 'team_final':
           dispatch({ type: 'teamFinal', chatId: ev.chatId, message: ev.message })

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -1,6 +1,7 @@
 // IPC proxy — all calls go through window.codey.* (Electron preload)
 
 import type { ChatMessage, Chat, ChatSelection, ChecklistItem, TaskBrief, TeamRunSummary } from '../types'
+import type { BlackboardSnapshot } from '@codey/core'
 import type { TeamConfigRaw } from '../../../packages/core/src/workspace'
 
 // Inline ChatStreamEvent to avoid cross-package import
@@ -17,6 +18,7 @@ export type ChatStreamEvent =
   | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'roundtable'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string }> }
   | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; reason?: string }
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number; failureReason?: string; nextUserAction?: { text: string; options?: string[] } }
+  | { type: 'blackboard_update'; chatId: string; teamTurnId: string; messageId: string; blackboard: BlackboardSnapshot }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
   | { type: 'workspace_ready'; chatId: string }
   | { type: 'done'; chatId: string; response: string; worker?: string; workerStatus?: 'pending' | 'running' | 'done' | 'failed' | 'askedUser'; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string; reason?: string }; teamTurnId?: string }

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -1,6 +1,7 @@
 import { ChatRoute } from './route';
 import { PendingTeamState } from './pending-team';
 import type { CodingAgent, ThinkingEffort } from './index';
+import type { BlackboardSnapshot } from '../team-blackboard';
 
 /** The three CLIs report task lists in three shapes; the adapters normalize
  *  onto this one. codex has only a completed boolean, so it never produces
@@ -126,6 +127,8 @@ export interface ChatMessage {
   workerSummaryExcluded?: boolean;
   /** Gateway-authored terminal aggregate for this teamTurnId. */
   teamSummary?: TeamRunSummary;
+  /** Latest shared blackboard snapshot after this worker completed a step. */
+  teamBlackboard?: BlackboardSnapshot;
   /** Option labels when this assistant message ended in [ASK_USER:choice]. */
   choices?: string[];
   /** Structured question from AskUserQuestion tool call, with option descriptions. */

--- a/packages/gateway/src/chat-runner.ts
+++ b/packages/gateway/src/chat-runner.ts
@@ -1,4 +1,4 @@
-import { Chat, ChatMessage, ChecklistItem, CodingAgent, FileAttachment, TaskBrief, TeamRunSummary, ToolCallEntry, TranscriptSlice, renderSliceSection, WriteDiff } from '@codey/core';
+import { BlackboardSnapshot, Chat, ChatMessage, ChecklistItem, CodingAgent, FileAttachment, TaskBrief, TeamRunSummary, ToolCallEntry, TranscriptSlice, renderSliceSection, WriteDiff } from '@codey/core';
 
 export const MAX_CONCURRENT_AGENTS = 4;
 export const CHAT_CONTEXT_WINDOW = 40;
@@ -56,6 +56,7 @@ export type ChatStreamEvent =
   | { type: 'team_start'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'roundtable'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: CodingAgent; model?: string }> }
   | { type: 'worker_start'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: CodingAgent; model?: string; reason?: string }
   | { type: 'worker_end'; chatId: string; messageId: string; step: number; status: 'done' | 'failed' | 'askedUser'; tokens?: number; durationSec?: number; failureReason?: string; nextUserAction?: { text: string; options?: string[] } }
+  | { type: 'blackboard_update'; chatId: string; teamTurnId: string; messageId: string; blackboard: BlackboardSnapshot }
   | { type: 'team_end'; chatId: string; teamTurnId: string; summary: TeamRunSummary; taskBrief?: TaskBrief }
   | { type: 'workspace_ready'; chatId: string }
   | { type: 'done'; chatId: string; response: string; worker?: string; workerStatus?: 'pending' | 'running' | 'done' | 'failed' | 'askedUser'; thinking?: string; tokens?: number; durationSec?: number; agent?: 'claude-code' | 'opencode' | 'codex' | 'pi'; model?: string; title?: string; choices?: string[]; userQuestion?: { question: string; options: Array<{ label: string; description?: string }> }; fallback?: { from: string; to: string; reason?: string }; teamTurnId?: string }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -2,7 +2,7 @@ import { publishTeamFinal, planTeamFooter, isSoloMentionRun } from './team-final
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { writeTranscriptSlice, TranscriptSlice, AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, runAide, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, parseWorkerMentions, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, needsPolish, buildVoicePolishPrompt, sanitizePolished, DEFAULT_POLISH_TIMEOUT_MS, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType, unwiredAllProtocols } from '@codey/core';
+import { writeTranscriptSlice, TranscriptSlice, AgentRequest, AgentResponse, AideOptions, ChannelKind, Chat, ChatCompaction, ChatRoute, FallbackEntry, GatewayConfig, GatewayResponse, UserMessage, CodingAgent, ModelConfig, ChannelType, ChannelConfig, ChatMessage, ToolCallEntry, runAdvisor, summarizeChatMessages, generateChatTitle, generateTaskBrief, generateAideTurnDigest, runAide, TaskBrief, AdvisorTurn, AdvisorHistoryEntry, parseAskUser, parseAsk, parseWorkerMentions, PendingTeamState, discussionDir, controlPath, summaryPath, topicPath, opinionPath, initDiscussionDir, TeamBlackboard, BlackboardSnapshot, WorkerAnchor, lastParagraphPreview, parseAskAdvisor, stripAskAdvisor, buildSoloAdvisorPrompt, buildSoloAdvisorFollowupPrompt, SoloAdvisorInput, SoloAdvisorFollowupInput, TeamGraph, validateGraph, startRun, advance, resolveEdge, outgoingEdges, eligibleEdges, runJudge, JudgeInput, JudgeDecision, TeamGraphEdge, GraphRunState, SkillEntry, SkillStore, RunTrace, DistillDeps, DistillResult, matchSkill, confirmMatch, applySkill, distillCandidate, evolveSkill, isLowSignalTrace, stepsFrom, clusterProcedures, induceTemplate, nameTemplate, ClusterReport, ProcedureCluster, hasProcedureData, RECENT_TRACES_MAX, Automation, AutomationRun, AutomationEvent, AutomationCheck, renderBrief, automationChatTurn, classifyDryRun, DryRunVerdict, parseVoiceCommand, VoiceCommand, pickVoiceAck, needsDigest, buildSpeechDigestPrompt, stripForSpeech, needsPolish, buildVoicePolishPrompt, sanitizePolished, DEFAULT_POLISH_TIMEOUT_MS, splitIntoSentences, SentenceAccumulator, ConversationDigestCache, VoiceConverseEvent, buildTeamFastPathPrompt, parseTeamFastPathDecision, TeamFastPathDecision, finalizeTeamRunSummary, TeamRunSummary, ThinkingEffort, DEFAULT_THINKING_EFFORT, ApiType, unwiredAllProtocols } from '@codey/core';
 import { randomUUID } from 'crypto';
 import { AutomationStore } from './automations/store';
 import { AutomationEngine, TargetResult } from './automations/engine';
@@ -3835,7 +3835,7 @@ Example: /model gpt-4.1 write a Python script`;
     chatModel: ModelConfig | undefined,
     perStep: (msg:
       | { kind: 'route'; step: number; worker: string; reason: string; isRevision: boolean }
-      | { kind: 'blackboard'; step: number; worker: string; summary: string }
+      | { kind: 'blackboard'; step: number; worker: string; summary: string; blackboard: BlackboardSnapshot }
     ) => void | Promise<void>,
     runWorker: (worker: string, prompt: string, codingAgent: CodingAgent, modelConfig: ModelConfig | undefined, blackboard: TeamBlackboard) => Promise<{ success: boolean; output: string; error?: string; thinking?: string }>,
     onStepDone?: (d: { step: number; worker: string; failed: boolean; error?: string }) => void,
@@ -4004,7 +4004,7 @@ Example: /model gpt-4.1 write a Python script`;
       const ingested = blackboard.ingest(turnNext, step, response.output);
       const cleanOutput = ingested.stripped;
       const deltaSummary = blackboard.summarizeDelta(ingested.added);
-      if (deltaSummary) await perStep({ kind: 'blackboard', step, worker: turnNext, summary: deltaSummary });
+      if (deltaSummary) await perStep({ kind: 'blackboard', step, worker: turnNext, summary: deltaSummary, blackboard: blackboard.toJSON() });
 
       parts.push({ step, worker: turnNext, output: cleanOutput, isRevision });
       onStepDone?.({ step, worker: turnNext, failed: false });
@@ -4404,7 +4404,8 @@ Example: /model gpt-4.1 write a Python script`;
       response.output = ingested.stripped;
       const deltaSummary = blackboard.summarizeDelta(ingested.added);
       if (deltaSummary) {
-        await emitter.status(deltaSummary);
+        if (emitter.updateBlackboard) emitter.updateBlackboard(blackboard.toJSON());
+        else await emitter.status(deltaSummary);
       }
       const ask = parseAskUser(response.output);
       if (ask) {
@@ -4632,7 +4633,8 @@ Example: /model gpt-4.1 write a Python script`;
       const cleanOutput = ingested.stripped;
       const deltaSummary = blackboard.summarizeDelta(ingested.added);
       if (deltaSummary) {
-        await emitter.status(deltaSummary);
+        if (emitter.updateBlackboard) emitter.updateBlackboard(blackboard.toJSON());
+        else await emitter.status(deltaSummary);
       }
       const ask = parseAskUser(cleanOutput);
       if (ask) {
@@ -4855,6 +4857,9 @@ Example: /model gpt-4.1 write a Python script`;
       if (!resp.success) { results.push(`**${worker.name}**: ❌ Failed - ${resp.error}`); emitter.endWorker?.('failed', { failureReason: resp.error ?? 'Worker failed without an error message' }); break; }
 
       const ingested = blackboard.ingest(workerName, stepIndex, resp.output);
+      if (blackboard.summarizeDelta(ingested.added)) {
+        emitter.updateBlackboard?.(blackboard.toJSON());
+      }
       results.push(`**${worker.name}**:\n${ingested.stripped}`);
       lastWorkerOutput = ingested.stripped;
       lastWorkerName = workerName;
@@ -5265,7 +5270,7 @@ Example: /model gpt-4.1 write a Python script`;
               model: workerModel?.model,
             });
           } else {
-            sink({ type: 'info', chatId, message: msg.summary });
+            workerMsgs.updateBlackboard(msg.blackboard);
           }
         },
         runOneWorker,

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -1,4 +1,4 @@
-import { publishTeamFinal } from './team-finalizer';
+import { publishTeamFinal, planTeamFooter, isSoloMentionRun } from './team-finalizer';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -6427,8 +6427,7 @@ Example: /model gpt-4.1 write a Python script`;
       const messages = this.chatManager.get(chatId)!.messages;
       // A lone "@worker" mention speaks for itself; the Aide only closes a
       // real team run (a named team, or an ad-hoc team with several members).
-      const memberCount = new Set(messages.filter(m => m.teamTurnId === activeTeamId && m.worker && !m.builtinMember).map(m => m.worker)).size;
-      if (chat.selection.type !== 'team' && memberCount < 2) return null;
+      if (isSoloMentionRun(messages, activeTeamId, chat.selection.type === 'team')) return null;
       const message = await publishTeamFinal({
         teamTurnId: activeTeamId, teamName: activeTeamName, messages, context, task: pendingTeam?.task ?? userText,
         reason: reason || teamTermination, stopped, signal: abortController.signal,
@@ -6728,6 +6727,15 @@ Example: /model gpt-4.1 write a Python script`;
       // group-level footer (Advisor summary / formatted blackboard), identified
       // by teamTurnId and no worker, rather than a standalone duplicate bubble.
       let teamSummaryMessageId: string | undefined;
+      const footerPlan = teamTurnId ? planTeamFooter({
+        hasFinal: !!finalTeamMessage,
+        footerText: output,
+        hasSummary: !!terminalTeamSummary,
+        pending: !!this.chatManager.get(chatId)?.pendingTeam,
+        boundToTeam: chat.selection.type === 'team',
+        messages: terminalTeamMessages,
+        teamTurnId,
+      }) : 'none';
       if (!teamTurnId) {
         const updated = this.chatManager.appendMessage(chatId, assistantMessage);
 
@@ -6752,7 +6760,7 @@ Example: /model gpt-4.1 write a Python script`;
         if (plainAskOptions && !updated.pendingTeam) {
           this.chatManager.setLastAskedOptions(chatId, assistantMessage.id, plainAskOptions);
         }
-      } else if (!finalTeamMessage && output.trim()) {
+      } else if (footerPlan === 'append') {
         const workerMessage = this.chatManager.get(chatId)?.messages.find(m => m.teamTurnId === teamTurnId && m.worker);
         this.chatManager.appendMessage(chatId, {
           ...assistantMessage,
@@ -6761,7 +6769,7 @@ Example: /model gpt-4.1 write a Python script`;
           teamMode: workerMessage?.teamMode,
         });
         teamSummaryMessageId = assistantMessage.id;
-      } else if (!finalTeamMessage && terminalTeamSummary) {
+      } else if (footerPlan === 'attach') {
         const lastWorkerMessage = this.chatManager.get(chatId)?.messages
           .filter(message => message.teamTurnId === teamTurnId && message.worker)
           .pop();
@@ -6790,7 +6798,10 @@ Example: /model gpt-4.1 write a Python script`;
 
       const adoptedWorkspace = await this.adoptAgentCreatedWorktree(chatId);
       if (adoptedWorkspace) sink({ type: 'workspace_ready', chatId });
-      sink({ type: 'done', chatId, response: output, worker: assistantMessage.worker, workerStatus: assistantMessage.workerStatus, thinking: singleAgentResponse?.thinking, tokens, durationSec, agent: responseAgent, ...(responseModel ? { model: responseModel } : {}), title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion, fallback: singleAgentResponse?.fallback, ...(teamTurnId ? { teamTurnId } : {}) });
+      // The Mac app turns a non-empty team response into a footer bubble, so
+      // it only travels when a footer was actually persisted.
+      const doneResponse = teamTurnId && footerPlan !== 'append' ? '' : output;
+      sink({ type: 'done', chatId, response: doneResponse, worker: assistantMessage.worker, workerStatus: assistantMessage.workerStatus, thinking: singleAgentResponse?.thinking, tokens, durationSec, agent: responseAgent, ...(responseModel ? { model: responseModel } : {}), title: finalTitle, choices: surfacedChoices, userQuestion: agentUserQuestion, fallback: singleAgentResponse?.fallback, ...(teamTurnId ? { teamTurnId } : {}) });
 
       // ── Skills: post-run pass (fire-and-forget, response already delivered) ──
       // Skip the whole pass when this turn ended PAUSED — i.e. the team run

--- a/packages/gateway/src/team-emitter.ts
+++ b/packages/gateway/src/team-emitter.ts
@@ -1,4 +1,4 @@
-import { ChannelType, CodingAgent } from '@codey/core';
+import { BlackboardSnapshot, ChannelType, CodingAgent } from '@codey/core';
 import type { EndWorkerMeta, WorkerMessageEmitter } from './worker-message-emitter';
 
 /** Surface-agnostic sink for team continuation output. */
@@ -16,6 +16,8 @@ export interface TeamEmitter {
   beginWorker?(args: { step: number; worker: string; reason?: string; agent?: CodingAgent; model?: string }): void;
   /** Finalize the active per-worker chat message (chat surface only). */
   endWorker?(status: 'done' | 'failed' | 'askedUser', meta?: EndWorkerMeta): void;
+  /** Publish the latest shared blackboard (chat surface only). */
+  updateBlackboard?(blackboard: BlackboardSnapshot): void;
   /** Accumulated assistant transcript (chat surface); '' for channels. */
   readonly transcript: string;
   /** Latest choices passed to notify (for the chat return contract). */
@@ -49,6 +51,7 @@ export class ChatEmitter implements TeamEmitter {
   }
   beginWorker(args: { step: number; worker: string; reason?: string; agent?: CodingAgent; model?: string }): void { this.workerMsgs?.beginWorker(args); }
   endWorker(status: 'done' | 'failed' | 'askedUser', meta?: EndWorkerMeta): void { this.workerMsgs?.endWorker(status, meta); }
+  updateBlackboard(blackboard: BlackboardSnapshot): void { this.workerMsgs?.updateBlackboard(blackboard); }
   get transcript(): string { return this.parts.join('\n\n'); }
   get choices(): string[] | undefined { return this._choices; }
 }

--- a/packages/gateway/src/team-finalizer.test.ts
+++ b/packages/gateway/src/team-finalizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { composeTeamFinal, publishTeamFinal } from './team-finalizer';
+import { composeTeamFinal, publishTeamFinal, planTeamFooter } from './team-finalizer';
 import type { ChatMessage } from '@codey/core';
 import { ChatManager } from './chats';
 import * as fs from 'fs';
@@ -78,5 +78,30 @@ describe('Aide terminal message', () => {
       const reloaded = new ChatManager(root);
       expect(reloaded.get(chat.id)!.messages.at(-1)).toMatchObject({ builtinMember: 'aide', id: 'team-final:t' });
     } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+});
+
+describe('planTeamFooter', () => {
+  const msgs = (...workers: string[]): ChatMessage[] =>
+    workers.map((w, i) => worker('done', { id: `w${i}`, worker: w }));
+
+  it('drops the transcript footer for a finished lone "@worker" run — the member bubble already shows it', () => {
+    expect(planTeamFooter({ hasFinal: false, footerText: '📊 Team **pm** results\n\n**pm**: done', hasSummary: true, pending: false, boundToTeam: false, messages: msgs('pm'), teamTurnId: 't' })).toBe('attach');
+  });
+
+  it('keeps the footer while a lone "@worker" run is paused on a question', () => {
+    expect(planTeamFooter({ hasFinal: false, footerText: 'Which one?', hasSummary: false, pending: true, boundToTeam: false, messages: msgs('pm'), teamTurnId: 't' })).toBe('append');
+  });
+
+  it('keeps the footer for a multi-member run without an Aide final', () => {
+    expect(planTeamFooter({ hasFinal: false, footerText: 'x', hasSummary: true, pending: false, boundToTeam: false, messages: msgs('a', 'b'), teamTurnId: 't' })).toBe('append');
+  });
+
+  it('never appends a footer next to an Aide final', () => {
+    expect(planTeamFooter({ hasFinal: true, footerText: 'x', hasSummary: true, pending: false, boundToTeam: true, messages: msgs('a', 'b'), teamTurnId: 't' })).toBe('none');
+  });
+
+  it('does nothing when there is neither footer text nor a summary', () => {
+    expect(planTeamFooter({ hasFinal: false, footerText: '  ', hasSummary: false, pending: false, boundToTeam: false, messages: msgs('pm'), teamTurnId: 't' })).toBe('none');
   });
 });

--- a/packages/gateway/src/team-finalizer.ts
+++ b/packages/gateway/src/team-finalizer.ts
@@ -81,3 +81,39 @@ export async function publishTeamFinal(input: TeamFinalInput, store: {
   store.emit(message);
   return message;
 }
+
+/** Distinct human members that ran in a team turn (Aide/Advisor excluded). */
+export function teamMemberCount(messages: ChatMessage[], teamTurnId: string | undefined): number {
+  return new Set(messages.filter(m => m.teamTurnId === teamTurnId && m.worker && !m.builtinMember).map(m => m.worker)).size;
+}
+
+/** A lone "@worker" mention in a chat not bound to a team. It gets no Aide
+ * final: the single member bubble speaks for itself. */
+export function isSoloMentionRun(messages: ChatMessage[], teamTurnId: string | undefined, boundToTeam: boolean): boolean {
+  return !boundToTeam && teamMemberCount(messages, teamTurnId) < 2;
+}
+
+export type TeamFooterPlan = 'append' | 'attach' | 'none';
+
+/** What to persist after a team turn besides the member bubbles.
+ *  - `append`: a group-level footer message (the transcript / question text).
+ *  - `attach`: no footer; hang the run summary on the last member bubble.
+ *  - `none`: nothing extra (an Aide final already closes the run).
+ * A finished solo "@worker" run never gets a footer: the transcript would
+ * repeat the member bubble word for word. While it is paused on a question
+ * the footer still carries the question and its choices, so it stays. */
+export function planTeamFooter(args: {
+  hasFinal: boolean;
+  footerText: string;
+  hasSummary: boolean;
+  pending: boolean;
+  boundToTeam: boolean;
+  messages: ChatMessage[];
+  teamTurnId: string | undefined;
+}): TeamFooterPlan {
+  if (args.hasFinal) return 'none';
+  const soloDone = !args.pending && isSoloMentionRun(args.messages, args.teamTurnId, args.boundToTeam);
+  if (args.footerText.trim() && !soloDone) return 'append';
+  if (args.hasSummary) return 'attach';
+  return 'none';
+}

--- a/packages/gateway/src/worker-message-emitter.test.ts
+++ b/packages/gateway/src/worker-message-emitter.test.ts
@@ -82,6 +82,22 @@ describe('WorkerMessageEmitter — serial', () => {
     expect(h.events.at(-1)).toMatchObject({ type: 'worker_end', messageId: id, status: 'done' });
   });
 
+  it('persists and emits the latest team blackboard snapshot', () => {
+    const h = harness();
+    const id = h.em.beginWorker({ step: 1, worker: 'pm' });
+    const blackboard = {
+      facts: [],
+      decisions: [{ worker: 'pm', step: 1, text: 'Ship the live panel' }],
+      handoffs: [],
+      open: [],
+    };
+    h.em.updateBlackboard(blackboard);
+    expect(h.patched.at(-1)).toEqual({ id, patch: { teamBlackboard: blackboard } });
+    expect(h.events.at(-1)).toMatchObject({
+      type: 'blackboard_update', teamTurnId: 'tt1', messageId: id, blackboard,
+    });
+  });
+
   it('persists thinking tokens without translating or normalizing them', () => {
     const h = harness();
     const source = `\n\u4FDD\u7559\u539F\u59CB\u8BED\u8A00\nEnglish follows  `;

--- a/packages/gateway/src/worker-message-emitter.ts
+++ b/packages/gateway/src/worker-message-emitter.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { ChatMessage, ToolCallEntry, WriteDiff } from '@codey/core';
+import type { BlackboardSnapshot, ChatMessage, ToolCallEntry, WriteDiff } from '@codey/core';
 import type { ChatStreamEvent } from './chat-runner';
 
 type Sink = (e: ChatStreamEvent) => void;
@@ -100,6 +100,20 @@ export class WorkerMessageEmitter {
       type: 'tool_end', chatId: this.chatId, tool: entry.tool, message: entry.message ?? '', output: entry.output, messageId: buf.messageId, step: buf.step,
       ...(entry.writes?.length ? { writes: entry.writes } : {}),
       ...(entry.writeDiffs?.length ? { writeDiffs: entry.writeDiffs } : {}),
+    });
+  }
+
+  /** Persist and publish the authoritative board after a worker contributes. */
+  updateBlackboard(blackboard: BlackboardSnapshot, worker?: string): void {
+    const buf = this.target(worker);
+    if (!buf) return;
+    this.store.updateMessage(this.chatId, buf.messageId, { teamBlackboard: blackboard });
+    this.sink({
+      type: 'blackboard_update',
+      chatId: this.chatId,
+      teamTurnId: this.meta.teamTurnId,
+      messageId: buf.messageId,
+      blackboard,
     });
   }
 


### PR DESCRIPTION
## Summary

- prevent a lone @worker reply from appearing twice
- show the shared team Blackboard live in the right-side Tools panel
- persist Blackboard snapshots so they remain after chat reload
- remove the redundant Run target section from the panel
- keep Blackboard delta notices out of the Mac tool timeline

## Verification

- npm run typecheck
- full test suite: core 656, gateway 488, Mac 1043
- targeted PR branch tests: gateway 32, Mac reducer 24