### PR TITLE
feat(mac): worker header shows avatar + name, click either to edit

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -47,7 +47,7 @@ import * as pty from 'node-pty'
 protocol.registerSchemesAsPrivileged([
   { scheme: 'codey-asset', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
 ])
-import { browserSkillStatus, checkBrowserSkillUpdate, chromeCompanionSkillStatus, checkChromeCompanionSkillUpdate, CODEY_GLOBAL_SKILLS_SUBDIR, CODEY_SKILL_DISCOVERY_SUBDIRS, CODEY_SKILLS_SUBDIR, installBrowserSkill, installChromeCompanionSkill, setChromeCompanionSkillEnabled, syncCodeyGlobalSkills, syncCodeyProjectSkills, uninstallBrowserSkill, uninstallChromeCompanionSkill, WorkerManager, WorkspaceManager } from '@codey/core'
+import { browserSkillStatus, checkBrowserSkillUpdate, chromeCompanionSkillStatus, checkChromeCompanionSkillUpdate, CODEY_GLOBAL_SKILLS_SUBDIR, CODEY_SKILL_DISCOVERY_SUBDIRS, CODEY_SKILLS_SUBDIR, installBrowserSkill, installChromeCompanionSkill, setChromeCompanionSkillEnabled, syncCodeyGlobalSkills, syncCodeyProjectSkills, uninstallBrowserSkill, uninstallChromeCompanionSkill, renameWorkerInTeams, WorkerManager, WorkspaceManager } from '@codey/core'
 import { listPlaybooks, playbookDetail, playbookHistory, archivePlaybook, deletePlaybook, restorePlaybook, rollbackPlaybook, promotePlaybook } from './playbooks'
 import { Codey } from '@codey/gateway/dist/gateway'
 import { ConfigManager } from '@codey/gateway/dist/config'
@@ -3440,6 +3440,20 @@ app.whenReady().then(async () => {
       // Invalidate any warm `--resume` sessions bootstrapped under the
       // previous personality; next run rebuilds with the new definition.
       inProcessGateway?.invalidateWorkerSessions(name)
+    })
+  )
+
+  ipcMain.handle('workers:rename', async (_e, oldName: string, newName: string) =>
+    wrap(async () => {
+      if (!workerManager) throw new Error('Workers are not loaded yet')
+      await workerManager.renameWorker(oldName, newName)
+      inProcessGateway?.invalidateWorkerSessions(oldName)
+      // Cascade: every team member list and flow-graph node that pointed at
+      // the old name now points at the new one.
+      if (coreConfigManager) {
+        const { teams, changed } = renameWorkerInTeams(coreConfigManager.getTeams(), oldName, newName)
+        if (changed) coreConfigManager.setTeams(teams)
+      }
     })
   )
 

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('codey', {
     save: (name: string, personality: any, config: any) =>
       ipcRenderer.invoke('workers:save', name, personality, config),
     delete: (name: string) => ipcRenderer.invoke('workers:delete', name),
+    rename: (oldName: string, newName: string) => ipcRenderer.invoke('workers:rename', oldName, newName),
     generate: (prompt: string) => ipcRenderer.invoke('workers:generate', prompt),
   },
   workspaces: {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -299,6 +299,7 @@ declare global {
         get: (name: string) => Promise<IpcResult<any>>
         save: (name: string, personality: any, config: any) => Promise<IpcResult<void>>
         delete: (name: string) => Promise<IpcResult<void>>
+        rename: (oldName: string, newName: string) => Promise<IpcResult<void>>
         generate: (prompt: string) => Promise<IpcResult<any>>
       }
       workspaces: {

--- a/codey-mac/src/components/AvatarPicker.tsx
+++ b/codey-mac/src/components/AvatarPicker.tsx
@@ -1,19 +1,19 @@
-import { useEffect, useId, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { WorkerAvatar } from './WorkerAvatar'
 import { avatarShapes, avatarColors, type WorkerAvatarConfig } from './workerAvatarModel'
 import { C } from '../theme'
 import './avatarPicker.css'
 
-export function AvatarPicker({ value, onChange, name = 'Member' }: {
+export function AvatarPicker({ value, onChange, name = 'Member', size = 56 }: {
   value: WorkerAvatarConfig
   onChange: (avatar: WorkerAvatarConfig) => void
   name?: string
+  size?: number
 }) {
   const [open, setOpen] = useState(false)
   const trigger = useRef<HTMLButtonElement>(null)
   const dialog = useRef<HTMLDialogElement>(null)
-  const titleId = useId()
 
   useEffect(() => {
     if (!open) return
@@ -27,24 +27,17 @@ export function AvatarPicker({ value, onChange, name = 'Member' }: {
 
   return <>
     <button ref={trigger} type="button" onClick={() => setOpen(true)} aria-label={`Change ${name} avatar`}
-      aria-haspopup="dialog" aria-expanded={open}
-      style={{ display: 'inline-flex', alignItems: 'center', gap: 14, padding: '10px 14px', background: C.surface2,
-        border: `1px solid ${C.border}`, borderRadius: 14, color: C.fg, cursor: 'pointer', textAlign: 'left' }}>
-      <WorkerAvatar name={name} config={value} size={56} />
-      <span><span style={{ display: 'block', fontWeight: 600, fontSize: 13 }}>Avatar</span>
-        <span style={{ display: 'block', color: C.fg3, fontSize: 12, marginTop: 4 }}>Click to change</span></span>
+      title="Change avatar" aria-haspopup="dialog" aria-expanded={open}
+      style={{ display: 'inline-flex', padding: 0, background: 'transparent', border: 'none', borderRadius: '50%', cursor: 'pointer', lineHeight: 0 }}>
+      <WorkerAvatar name={name} config={value} size={size} />
     </button>
-    {open && createPortal(<dialog ref={dialog} className="member-avatar-dialog" aria-labelledby={titleId}
+    {open && createPortal(<dialog ref={dialog} className="member-avatar-dialog" aria-label={`Change ${name} avatar`}
       onCancel={event => { event.preventDefault(); setOpen(false) }}
       onClick={event => { if (event.target === event.currentTarget) setOpen(false) }}
       style={{ padding: 0, width: 360, maxWidth: 'calc(100vw - 40px)', maxHeight: 'calc(100vh - 48px)',
         margin: 'auto', border: `1px solid ${C.border}`, borderRadius: 18, color: C.fg, background: C.bg,
         boxShadow: '0 18px 70px rgba(0,0,0,.25)' }}>
       <div style={{ padding: 22 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 22 }}>
-          <WorkerAvatar name={name} config={value} size={52} />
-          <h3 id={titleId} style={{ margin: 0, fontSize: 15 }}>{name} avatar</h3>
-        </div>
         <div role="group" aria-label="Shape">
           <div style={{ marginBottom: 10, color: C.fg3, fontSize: 12 }}>Shape</div>
           <div style={{ display: 'flex', gap: 10 }}>

--- a/codey-mac/src/components/WorkersTab.tsx
+++ b/codey-mac/src/components/WorkersTab.tsx
@@ -43,7 +43,9 @@ export default function WorkersTab() {
       <div style={{ flex: 1, overflowY: 'auto' }}>
         {mode.kind === 'idle' && <EmptyState />}
         {mode.kind === 'create' && <CreatePanel loading={loading} setLoading={setLoading} onCreated={async (w) => { await reload(); setMode({ kind: 'select', name: w.name }) }} onCancel={() => setMode({ kind: 'idle' })} />}
-        {mode.kind === 'select' && selected && <EditorPanel key={selected.name} worker={selected} onSaved={reload} onDeleted={async () => { await reload(); setMode({ kind: 'idle' }) }} />}
+        {mode.kind === 'select' && selected && <EditorPanel key={selected.name} worker={selected}
+          onSaved={async (name) => { await reload(); setMode({ kind: 'select', name }) }}
+          onDeleted={async () => { await reload(); setMode({ kind: 'idle' }) }} />}
       </div>
     </div>
   )
@@ -89,8 +91,10 @@ function CreatePanel({ loading, setLoading, onCreated, onCancel }: { loading: bo
   )
 }
 
-function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSaved: () => void; onDeleted: () => void }) {
+function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSaved: (name: string) => void; onDeleted: () => void }) {
   const [avatar, setAvatar] = useState(() => resolveWorkerAvatar(worker.name, worker.config.avatar))
+  const [name, setName] = useState(worker.name)
+  const [editingName, setEditingName] = useState(false)
   const [role, setRole] = useState(worker.personality.role)
   const [soul, setSoul] = useState(worker.personality.soul)
   const [instructions, setInstructions] = useState(worker.personality.instructions)
@@ -118,6 +122,7 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
     setRole(worker.personality.role); setSoul(worker.personality.soul); setInstructions(worker.personality.instructions)
     setCodingAgent(worker.config.codingAgent); setModel(worker.config.model); setToolsText(worker.config.tools.join(', '))
     setAvatar(resolveWorkerAvatar(worker.name, worker.config.avatar))
+    setName(worker.name); setEditingName(false)
     setEffort(worker.config.effort ?? '')
     setSaved(false); setError(null)
   }, [worker.name])
@@ -127,8 +132,10 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
 
   const save = async () => {
     setSaving(true); setError(null)
+    const nextName = name.trim()
     try {
-      await apiService.updateWorker(worker.name, {
+      if (nextName !== worker.name) await apiService.renameWorker(worker.name, nextName)
+      await apiService.updateWorker(nextName, {
         personality: { role, soul, instructions },
         config: {
           ...worker.config,
@@ -140,7 +147,7 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
         },
       })
       window.dispatchEvent(new Event('codey:workers-changed'))
-      setSaved(true); setTimeout(() => setSaved(false), 1500); onSaved()
+      setSaved(true); setTimeout(() => setSaved(false), 1500); onSaved(nextName)
     } catch (err: any) {
       setError(err.message || String(err))
     } finally {
@@ -158,13 +165,26 @@ function EditorPanel({ worker, onSaved, onDeleted }: { worker: WorkerDto; onSave
 
   return (
     <div style={{ padding: 20, maxWidth: 720 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
-        <div style={{ fontSize: 18, fontWeight: 600 }}>{worker.name}</div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
+          <AvatarPicker name={name.trim() || worker.name} value={avatar} onChange={setAvatar} />
+          {editingName
+            ? <input autoFocus value={name} aria-label="Worker name"
+                onChange={e => setName(e.target.value)}
+                onBlur={() => { setEditingName(false); if (!name.trim()) setName(worker.name) }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') e.currentTarget.blur()
+                  if (e.key === 'Escape') { setName(worker.name); setEditingName(false) }
+                }}
+                style={{ fontSize: 18, fontWeight: 600, padding: '2px 6px', background: C.surface2, color: C.fg, border: `1px solid ${C.accent}`, borderRadius: 6, fontFamily: 'inherit', minWidth: 0 }} />
+            : <button type="button" onClick={() => setEditingName(true)} title="Rename" aria-label={`Rename ${name}`}
+                style={{ fontSize: 18, fontWeight: 600, padding: '2px 6px', margin: '0 -6px', background: 'transparent', color: C.fg, border: 'none', borderRadius: 6, cursor: 'text', fontFamily: 'inherit', textAlign: 'left' }}>
+                {name}</button>}
+        </div>
         <button onClick={confirmDelete} style={{ background: 'transparent', color: C.dangerFg, border: `1px solid ${C.dangerBorder}`, padding: '6px 10px', borderRadius: 6, cursor: 'pointer', fontSize: 12 }}>Delete</button>
       </div>
       {error && <div style={{ background: C.dangerBg, border: `1px solid ${C.dangerBorder}`, color: C.dangerFg, padding: 10, borderRadius: 6, fontSize: 12 }}>{error}</div>}
 
-      <div style={{ margin: '18px 0' }}><AvatarPicker name={worker.name} value={avatar} onChange={setAvatar} /></div>
       <label style={labelStyle}>Role</label>
       <textarea value={role} onChange={e => setRole(e.target.value)} style={{ ...fieldStyle, minHeight: 60 }} />
 

--- a/codey-mac/src/services/api.ts
+++ b/codey-mac/src/services/api.ts
@@ -70,6 +70,9 @@ export const apiService = {
   deleteWorker: async (name: string): Promise<void> =>
     unwrap(await window.codey.workers.delete(name)),
 
+  renameWorker: async (oldName: string, newName: string): Promise<void> =>
+    unwrap(await window.codey.workers.rename(oldName, newName)),
+
   generateWorker: async (prompt: string): Promise<WorkerDto> =>
     unwrap(await window.codey.workers.generate(prompt)),
 

--- a/packages/core/src/workers.test.ts
+++ b/packages/core/src/workers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { WorkerManager } from './workers';
+import { WorkerManager, renameWorkerInTeams } from './workers';
 
 function seedWorkers(workersDir: string, names: string[]) {
   for (const n of names) {
@@ -78,5 +78,91 @@ describe('worker avatar persistence', () => {
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe('WorkerManager.renameWorker', () => {
+  it('moves the folder, rewrites the personality heading, and reloads under the new name', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'worker-rename-'));
+    try {
+      seedWorkers(root, ['alice', 'bob']);
+      const manager = new WorkerManager(root);
+      await manager.loadWorkers();
+      await manager.renameWorker('alice', 'alicia');
+
+      expect(fs.existsSync(path.join(root, 'alice'))).toBe(false);
+      expect(fs.readFileSync(path.join(root, 'alicia', 'personality.md'), 'utf-8')).toMatch(/^# Worker: alicia\n/);
+      expect(manager.getWorker('alice')).toBeUndefined();
+      expect(manager.getWorker('alicia')!.personality.role).toBe('ROLE_OF_alice');
+      expect(manager.getWorker('bob')).toBeDefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid, missing, and already-taken names without touching disk', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'worker-rename-'));
+    try {
+      seedWorkers(root, ['alice', 'bob']);
+      const manager = new WorkerManager(root);
+      await manager.loadWorkers();
+      await expect(manager.renameWorker('alice', 'Bad Name')).rejects.toThrow(/lowercase/);
+      await expect(manager.renameWorker('ghost', 'x')).rejects.toThrow(/not found/i);
+      await expect(manager.renameWorker('alice', 'bob')).rejects.toThrow(/already exists/i);
+      expect(fs.existsSync(path.join(root, 'alice'))).toBe(true);
+      expect(manager.getWorker('alice')).toBeDefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op when the name does not change', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'worker-rename-'));
+    try {
+      seedWorkers(root, ['alice']);
+      const manager = new WorkerManager(root);
+      await manager.loadWorkers();
+      await manager.renameWorker('alice', 'alice');
+      expect(manager.getWorker('alice')).toBeDefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('renameWorkerInTeams', () => {
+  it('rewrites members and graph worker nodes in every team that references the worker', () => {
+    const teams = {
+      legacy: ['alice', 'bob'],
+      flow: {
+        members: ['alice'],
+        dispatch: 'sequential' as const,
+        graph: {
+          entry: 'start', maxHops: 5,
+          nodes: [
+            { id: 'start', type: 'start' as const, x: 0, y: 0 },
+            { id: 'n1', type: 'worker' as const, worker: 'alice', x: 0, y: 0 },
+            { id: 'end', type: 'end' as const, x: 0, y: 0 },
+          ],
+          edges: [{ id: 'e1', from: 'start', to: 'n1' }, { id: 'e2', from: 'n1', to: 'end' }],
+        },
+      },
+      untouched: ['bob'],
+    };
+    const { teams: next, changed } = renameWorkerInTeams(teams, 'alice', 'alicia');
+    expect(changed).toBe(true);
+    expect(next.legacy).toEqual(['alicia', 'bob']);
+    expect((next.flow as any).members).toEqual(['alicia']);
+    expect((next.flow as any).graph.nodes[1].worker).toBe('alicia');
+    expect((next.flow as any).graph.edges).toEqual(teams.flow.graph.edges);
+    expect(next.untouched).toBe(teams.untouched);
+    expect(teams.legacy).toEqual(['alice', 'bob']);
+  });
+
+  it('reports no change when nothing references the worker', () => {
+    const teams = { a: ['bob'] };
+    const result = renameWorkerInTeams(teams, 'alice', 'alicia');
+    expect(result.changed).toBe(false);
+    expect(result.teams).toEqual(teams);
   });
 });

--- a/packages/core/src/workers.ts
+++ b/packages/core/src/workers.ts
@@ -402,4 +402,63 @@ export class WorkerManager {
     await fs.promises.rm(dir, { recursive: true, force: true });
     this.workers.delete(name.toLowerCase());
   }
+
+  /**
+   * Moves `<workersDir>/<oldName>` to `<workersDir>/<newName>` and rewrites the
+   * personality heading. Team references are the caller's job — see
+   * `renameWorkerInTeams`, which needs the gateway config this manager never sees.
+   */
+  async renameWorker(oldName: string, newName: string): Promise<void> {
+    if (oldName === newName) return;
+    if (!WORKER_NAME_RE.test(newName)) {
+      throw new Error(`Worker name "${newName}" must be lowercase letters, digits and dashes, starting with a letter`);
+    }
+    const existing = this.workers.get(oldName.toLowerCase());
+    if (!existing) throw new Error(`Worker not found: ${oldName}`);
+    if (newName.toLowerCase() !== oldName.toLowerCase() && this.workers.has(newName.toLowerCase())) {
+      throw new Error(`Worker "${newName}" already exists`);
+    }
+    const from = path.join(this.workersDir, existing.name);
+    const to = path.join(this.workersDir, newName);
+    await fs.promises.rename(from, to);
+    const mdPath = path.join(to, 'personality.md');
+    const content = await fs.promises.readFile(mdPath, 'utf-8');
+    await fs.promises.writeFile(mdPath, content.replace(/^# .*(\r?\n|$)/, `# Worker: ${newName}$1`), 'utf-8');
+    await this.loadWorkers();
+  }
+}
+
+const WORKER_NAME_RE = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * Pure cascade for a worker rename: swaps `oldName` for `newName` in every
+ * team's member list and in every flow-graph worker node. Untouched teams keep
+ * their original object identity so callers can skip a config write when
+ * `changed` is false.
+ */
+export function renameWorkerInTeams<T extends Record<string, any>>(
+  teams: T, oldName: string, newName: string,
+): { teams: T; changed: boolean } {
+  const swap = (name: string) => (name === oldName ? newName : name);
+  let changed = false;
+  const next: Record<string, any> = {};
+  for (const [teamName, raw] of Object.entries(teams)) {
+    if (Array.isArray(raw)) {
+      const members = raw.map(swap);
+      const hit = members.some((m, i) => m !== raw[i]);
+      next[teamName] = hit ? members : raw;
+      changed ||= hit;
+      continue;
+    }
+    const members: string[] = (raw.members ?? []).map(swap);
+    let hit = members.some((m: string, i: number) => m !== raw.members?.[i]);
+    let graph = raw.graph;
+    if (graph?.nodes?.some((n: any) => n.worker === oldName)) {
+      graph = { ...graph, nodes: graph.nodes.map((n: any) => (n.worker === oldName ? { ...n, worker: newName } : n)) };
+      hit = true;
+    }
+    next[teamName] = hit ? { ...raw, members, ...(graph ? { graph } : {}) } : raw;
+    changed ||= hit;
+  }
+  return { teams: next as T, changed };
 }


### PR DESCRIPTION
## Summary
- Worker editor: the "Avatar / Click to change" card is gone. The avatar now sits beside the name in the header; clicking it opens the picker.
- Avatar picker dialog drops its "<name> avatar" heading. Only Shape and Color remain.
- Clicking the name turns it into an inline input (Enter/blur commits, Esc cancels). The rename is applied on Save, so unsaved role/soul edits survive the remount.
- New `WorkerManager.renameWorker` moves the worker folder and rewrites the personality heading. Names must match `^[a-z][a-z0-9-]*$`.
- New pure `renameWorkerInTeams` cascades the rename into team member lists and flow-graph worker nodes. The `workers:rename` IPC calls it.

## Test plan
- [x] `@codey/core` workers tests: 8 pass (5 new rename tests)
- [x] codey-mac vitest: 1038 pass; renderer + electron `tsc --noEmit` clean
- [ ] Real-machine: rename a worker that belongs to a team, confirm the folder moves and the team still lists it under the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)