### PR TITLE
feat(voice): announce learned words in the hotkey capsule

### DIFF
--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, shell, dialog, pr
 import { join } from 'path'
 import { randomUUID } from 'crypto'
 import { captureAccelerator, screenshotAccelerator, resolveCaptureSubmit, normalizeAccelerator } from './capture'
-import { hudStateCommand, hudLevelCommand, conversationToggleCommand } from './voice-hud'
+import { hudStateCommand, hudLevelCommand, conversationToggleCommand, hudVocabularyCommand } from './voice-hud'
 import { allStreamingModelIds, FileProbe, isOnDeviceVoiceProvider, selectedOnDeviceModel, streamingModelDir, streamingModelIsComplete, isBogusWarmMarkerKey, warmMarkerDeleteKeys, warmMarkerWriteKeys } from './voice-models'
 import { pathToFileURL } from 'url'
 import { findAvailablePort } from './portUtils'
@@ -348,6 +348,35 @@ let nativeDictationActive = false
 // clicks override this before sending their stdin command.
 let nativeConverseFromHotkey = true
 
+/**
+ * The word most recently announced on a vocabulary capsule, kept so a click on
+ * that capsule can be turned back into a dictionary edit. The helper reports
+ * the term it showed, but not the mis-hearing behind it, and `forgetCorrection`
+ * needs both to clear the waiting list as well as the dictionary.
+ */
+let capsuleVocabulary: { term: string; alias: string } | null = null
+
+/**
+ * Take a learned word back out of the dictionary *and* off the waiting list, so
+ * undo means "never mind" rather than "not yet". Shared by the composer pill's
+ * IPC and by a click on the vocabulary capsule.
+ */
+function forgetVocabularyEntry(term: string, alias: string): boolean {
+  if (!coreConfigManager || !term || !alias) return false
+  const voice = (coreConfigManager.get() as any)?.voice
+  if (!voice) return false
+  const next = forgetCorrection(
+    normalizeVocabulary(voice.vocabulary),
+    normalizePending(voice.vocabularyPending),
+    { term, alias },
+  )
+  coreConfigManager.update({
+    voice: { ...voice, vocabulary: next.terms, vocabularyPending: next.pending },
+  } as any)
+  mainWindow?.webContents.send('voice:vocabularyLearned', next.terms)
+  return true
+}
+
 function showVoiceHud(state: string) {
   sendVoiceHudCommand(hudStateCommand(state))
 }
@@ -356,13 +385,18 @@ function hideVoiceHud() {
   sendVoiceHudCommand(hudStateCommand('idle'))
 }
 
-function sendVoiceHudCommand(command: string | null) {
-  if (!command) return
+/** True when the command actually reached the helper, so a caller that needs to
+ *  know whether the capsule went up (rather than fire-and-forget phases) can
+ *  fall back to its in-window UI. */
+function sendVoiceHudCommand(command: string | null): boolean {
+  if (!command) return false
   if (!sendVoiceHelperCommand(command)) {
     // No helper means no capsule, but it also means capture is already broken;
     // one log line beats a dialog the user cannot act on.
     sendToRenderer('gateway-log', `[voice] helper unavailable, capsule skipped: ${command}`)
+    return false
   }
+  return true
 }
 
 function createCaptureWindow(): BrowserWindow {
@@ -1372,6 +1406,17 @@ function handleVoiceHelperLine(line: string) {
         // isn't — the renderer carries it through the agent run and the reply.
         nativeConverseActive = false
         mainWindow?.webContents.send('voice:nativeConverseTranscript', event.text)
+      }
+    } else if (event.type === 'vocabulary-undo') {
+      // A click on the vocabulary capsule. The helper echoes the word it
+      // showed; the alias it never knew comes from our own copy, and a mismatch
+      // means the capsule outlived the word it announced, so nothing is undone.
+      const term = typeof (event as any).term === 'string' ? (event as any).term : ''
+      const pending = capsuleVocabulary
+      capsuleVocabulary = null
+      const shown = pending ? (hudVocabularyCommand(pending.term) ?? '').slice('hud-vocabulary '.length) : ''
+      if (pending && term && term === shown) {
+        forgetVocabularyEntry(pending.term, pending.alias)
       }
     } else if (event.type === 'cancel') {
       // Esc reached the helper's global monitor while the turn was in
@@ -3924,7 +3969,20 @@ app.whenReady().then(async () => {
       // list entry; it is not stored anywhere and the pill does not show it.
       const promotedFor = (term: string) =>
         seen.promoted.find(p => p.term.toLowerCase() === term.toLowerCase())?.alias ?? ''
-      return { learned: merged.added.map(term => ({ term, alias: promotedFor(term) })) }
+      const learned = merged.added.map(term => ({ term, alias: promotedFor(term) }))
+
+      // Where the news lands depends on where the user is looking. With the
+      // window focused, the composer pill under the textarea is right there and
+      // reads better than a floating panel over it. Focus elsewhere - a send
+      // that happened as they switched apps - and the pill would sit unseen,
+      // so the same capsule the hotkey turn uses carries it instead. Only the
+      // first word: the capsule is one line with one undo target.
+      const first = learned[0]
+      const viaCapsule = Boolean(
+        first && !mainWindow?.isFocused() && sendVoiceHudCommand(hudVocabularyCommand(first.term))
+      )
+      if (viaCapsule && first) capsuleVocabulary = first
+      return { learned: viaCapsule ? learned.slice(1) : learned }
     })
   )
 
@@ -3933,23 +3991,9 @@ app.whenReady().then(async () => {
   // go active on the user's very next correction of it.
   ipcMain.handle('voice:forgetVocabulary', async (_e, payload: { term?: string; alias?: string }) =>
     wrap(async () => {
-      if (!coreConfigManager) return { ok: false }
       const term = String(payload?.term ?? '')
       const alias = String(payload?.alias ?? '')
-      if (!term || !alias) return { ok: false }
-      const voice = (coreConfigManager.get() as any)?.voice
-      if (!voice) return { ok: false }
-
-      const next = forgetCorrection(
-        normalizeVocabulary(voice.vocabulary),
-        normalizePending(voice.vocabularyPending),
-        { term, alias },
-      )
-      coreConfigManager.update({
-        voice: { ...voice, vocabulary: next.terms, vocabularyPending: next.pending },
-      } as any)
-      mainWindow?.webContents.send('voice:vocabularyLearned', next.terms)
-      return { ok: true }
+      return { ok: forgetVocabularyEntry(term, alias) }
     })
   )
 

--- a/codey-mac/electron/voice-hud.test.ts
+++ b/codey-mac/electron/voice-hud.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { hudStateCommand, hudLevelCommand, conversationToggleCommand } from './voice-hud'
+import { hudStateCommand, hudLevelCommand, conversationToggleCommand, hudVocabularyCommand } from './voice-hud'
 
 describe('conversationToggleCommand', () => {
   it('tells the helper which turns own a capsule', () => {
@@ -39,5 +39,25 @@ describe('hudLevelCommand', () => {
     // NaN and poison the meter's sliding window.
     expect(hudLevelCommand(NaN)).toBeNull()
     expect(hudLevelCommand(Infinity)).toBeNull()
+  })
+})
+
+describe('hudVocabularyCommand', () => {
+  it('carries the learned word as one line', () => {
+    expect(hudVocabularyCommand('Codey')).toBe('hud-vocabulary Codey')
+  })
+
+  it('flattens whitespace so the term stays a single stdin line', () => {
+    expect(hudVocabularyCommand(' zhuan\nxie qi ')).toBe('hud-vocabulary zhuan xie qi')
+  })
+
+  it('caps the length rather than pushing a paragraph at the pill', () => {
+    const long = 'a'.repeat(120)
+    expect(hudVocabularyCommand(long)).toBe(`hud-vocabulary ${'a'.repeat(40)}`)
+  })
+
+  it('sends nothing when there is no readable word left', () => {
+    expect(hudVocabularyCommand('   ')).toBeNull()
+    expect(hudVocabularyCommand('')).toBeNull()
   })
 })

--- a/codey-mac/electron/voice-hud.ts
+++ b/codey-mac/electron/voice-hud.ts
@@ -41,3 +41,18 @@ export function hudLevelCommand(level: number): string | null {
   const clamped = Math.min(1, Math.max(0, level))
   return `hud-level ${clamped.toFixed(3)}`
 }
+
+/**
+ * Announce a word the dictionary just learned on the capsule.
+ *
+ * One line of stdin, so the term must survive as a single token: newlines are
+ * flattened (a transcript fragment can carry one) and the length is capped, since
+ * the pill truncates anyway and a pasted paragraph is not a learned word. Returns
+ * null when nothing readable is left, so the caller sends no command at all
+ * rather than raising an empty capsule.
+ */
+export function hudVocabularyCommand(term: string): string | null {
+  const flat = term.replace(/\s+/g, ' ').trim()
+  if (!flat) return null
+  return `hud-vocabulary ${flat.slice(0, 40)}`
+}

--- a/voice/Sources/CodeyVoice/HudOverlay.swift
+++ b/voice/Sources/CodeyVoice/HudOverlay.swift
@@ -29,6 +29,11 @@ final class HudOverlay {
         case notice(String)
         case error(String)
         case dictation(String)
+        /// A word the dictionary just learned, offered with an undo. Wears the
+        /// conversation capsule's chrome on purpose: it is the same floating
+        /// object the hotkey turn just showed, now reporting what that turn
+        /// taught it, rather than a second kind of pill to recognize.
+        case vocabulary(String)
         /// The conversation capsule. Distinct from the dictation pill on
         /// purpose: a conversation is ongoing and two-way, so it gets the live
         /// rainbow rather than a static chrome.
@@ -71,6 +76,12 @@ final class HudOverlay {
     /// is a repeated action and rebuilding the gradient each time is waste.
     private var capsuleLayer: RainbowCapsuleLayer?
     private var isCapsuleMode = false
+    /// True only while a `.vocabulary` capsule is up, so `handleClick` can tell
+    /// "undo that word" from the dictation card's plain dismiss.
+    private var vocabularyClickUndoes = false
+    /// Called when the user clicks a `.vocabulary` capsule. The overlay knows
+    /// nothing about the dictionary — the coordinator reports the click onward.
+    var onVocabularyUndo: (() -> Void)?
     /// Size/radius the blur view's `maskImage` was last drawn for, so a resize
     /// that changes neither skips the redraw.
     private var maskedSize: CGSize = .zero
@@ -108,6 +119,7 @@ final class HudOverlay {
 
         hideWorkItem?.cancel()
         hideWorkItem = nil
+        vocabularyClickUndoes = false
         // Mark the panel as wanted on-screen so an in-flight hide fade-out's
         // completion won't orderOut the panel we're about to (re)show.
         wantVisible = true
@@ -199,6 +211,21 @@ final class HudOverlay {
             // panel floating over whatever they do next.
             panel.ignoresMouseEvents = false
             scheduleHide(after: 5.0)
+        case .vocabulary(let term):
+            // Same rainbow chrome as a converse turn, and no meter: there is no
+            // audio behind this one, it is the turn's result.
+            label.stringValue = "Added \"\(term)\" - click to undo"
+            label.textColor = NSColor.white
+            spinner.stopAnimation(nil)
+            spinner.isHidden = true
+            setMeterVisible(false)
+            setCapsuleMode(true)
+            applyPillLayout()
+            // The only mode besides `.dictation` that takes clicks, and the
+            // only one where a click means something other than "go away".
+            panel.ignoresMouseEvents = false
+            vocabularyClickUndoes = true
+            scheduleHide(after: 6.0)
         case .conversation(let phase):
             label.stringValue = phase.label
             label.textColor = NSColor.white
@@ -407,9 +434,13 @@ final class HudOverlay {
     }
 
     @objc private func handleClick() {
-        // Only dictation mode opts into mouse events, so any click here is a
-        // dismiss request. Cancel the pasteboard restore that paste-injection
-        // schedules — irrelevant here since no paste happened.
+        // Dictation and vocabulary are the only modes that opt into mouse
+        // events. A click on the dictation card just dismisses it; on a
+        // vocabulary capsule it also takes the word back out of the dictionary.
+        if vocabularyClickUndoes {
+            vocabularyClickUndoes = false
+            onVocabularyUndo?()
+        }
         hide()
     }
 

--- a/voice/Sources/CodeyVoice/VoiceCoordinator.swift
+++ b/voice/Sources/CodeyVoice/VoiceCoordinator.swift
@@ -69,6 +69,10 @@ final class VoiceCoordinator {
     /// True while Electron owns the visible half of a conversation turn (the
     /// agent run or the spoken reply). Esc belongs to it in that window.
     private var electronTurnActive = false
+    /// The word currently offered for undo on a `.vocabulary` capsule. Held
+    /// here rather than read back off the label so a click that lands during
+    /// the fade-out reports the word that was actually shown.
+    private var vocabularyCapsuleTerm: String?
     private var escMonitorGlobal: Any?
     private var escMonitorLocal: Any?
     /// Timestamp of the most recent `.partial` HUD push (local streaming).
@@ -210,6 +214,18 @@ final class VoiceCoordinator {
                     self.hud.updateLevel(level)
                 }
             }
+        }
+
+        // A click on the vocabulary capsule. The overlay reports it here so the
+        // dictionary edit stays on Electron's side, where the config lives.
+        hud.onVocabularyUndo = { [weak self] in
+            guard let self = self, let term = self.vocabularyCapsuleTerm else { return }
+            self.vocabularyCapsuleTerm = nil
+            self.emitConversationEvent(
+                type: "vocabulary-undo",
+                payload: ["term": term],
+                modeOverride: "vocabulary"
+            )
         }
 
         // Playback draining is what actually ends a converse turn — the HTTP
@@ -483,6 +499,14 @@ final class VoiceCoordinator {
         // sees the agent working and the reply being read back. `listening` and
         // the first `thinking` are asserted locally in startRecording /
         // stopRecording, so they don't depend on this round trip.
+        // The word the dictionary just learned, shown while the user is looking
+        // at some other app. Dropped rather than queued when a capture is live:
+        // there is one panel, and the turn in flight has the better claim on it.
+        case "hud-vocabulary":
+            let term = argument.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !term.isEmpty, !dictationCaptureInFlight, state == .idle, !electronTurnActive else { break }
+            vocabularyCapsuleTerm = term
+            hud.show(.vocabulary(term))
         case "hud-state": applyConversationHud(argument)
         case "hud-level":
             guard !dictationCaptureInFlight, let level = Float(argument) else { break }


### PR DESCRIPTION
## Summary

- reuse the native voice HUD capsule to announce newly learned vocabulary when Codey is not foregrounded
- allow clicking the vocabulary capsule to undo the learned word, with automatic dismissal
- keep active recording and voice conversations higher priority than vocabulary notifications
- share the vocabulary undo path between the in-app pill and native HUD

## Verification

- TypeScript build passes
- codey-mac test suite passes (1042 tests)
- Swift release build passes
- `git diff --check origin/main...HEAD` passes

## Notes

- the unrelated local `ChatTab.tsx` modification is uncommitted and is not included in this PR