### PR TITLE
fix(mac): one interrupt stops the queue too

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -1012,11 +1012,13 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
   }, [])
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && flight) stopChat(chatId)
+      // Escape stops the running turn, and — once nothing is running — still
+      // clears anything queued behind it, so one press ends the whole thing.
+      if (e.key === 'Escape' && (flight || queuedMessages.length > 0)) stopChat(chatId)
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [flight, chatId])
+  }, [flight, chatId, queuedMessages.length])
   // Refresh the Status task brief on each turn boundary — when a turn is sent
   // and again when it completes — while the Status tab is open, so it reflects
   // the live history. The tab-switch trigger alone misses these: nothing

--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -250,6 +250,13 @@ describe('message queue', () => {
     expect(s.queuedMessages.c1).toBeUndefined()
   })
 
+  it('clearing a stale in-flight turn drops the queue too', () => {
+    let s = baseState()
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, { type: 'clearInFlight', chatId: 'c1' })
+    expect(s.queuedMessages.c1).toBeUndefined()
+  })
+
   it('deleting a chat drops its queue', () => {
     let s = baseState()
     s = reducer(s, q('one', 'q1'))

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -569,10 +569,14 @@ export function reducer(state: State, action: Action): State {
       }
     }
     case 'clearInFlight': {
-      if (!state.inFlight[action.chatId]) return state
+      const queuedMessages = dropQueue(state.queuedMessages, action.chatId)
+      if (!state.inFlight[action.chatId]) return { ...state, queuedMessages }
       const inFlight = { ...state.inFlight }
       delete inFlight[action.chatId]
-      return { ...state, inFlight }
+      // Same rule as 'stoppedSend': this only fires from Stop/Escape, and a
+      // stop must not let the next queued prompt fire the instant the turn
+      // clears.
+      return { ...state, inFlight, queuedMessages }
     }
     case 'clearRestore': {
       if (!(action.chatId in state.pendingRestores)) return state

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -6209,13 +6209,30 @@ Example: /model gpt-4.1 write a Python script`;
       userText = chatSkillTask;
     }
 
+    const abortController = new AbortController();
+    // Register the abort handle BEFORE waiting for a slot: a turn parked on the
+    // semaphore is stoppable too. Without this, Stop reports "nothing to abort"
+    // for it, the client falls back to clearing its own spinner, and the turn
+    // then starts anyway. Only claim the slot when no other run owns it, so a
+    // second turn queued behind a running one can't steal its abort handle.
+    const ownsAbort = !this.chatAborts.has(chatId);
+    if (ownsAbort) this.chatAborts.set(chatId, abortController);
+
     // Queue if at capacity
     if ((this.chatSemaphore as any).running >= (this.chatSemaphore as any).max) {
       sink({ type: 'queued', chatId, position: this.chatSemaphore.queueLength + 1 });
     }
     await this.chatSemaphore.acquire();
 
-    const abortController = new AbortController();
+    if (abortController.signal.aborted) {
+      // Stopped while queued: nothing has run and no user message is persisted
+      // yet, so just hand the prompt back for the input box.
+      this.chatSemaphore.release();
+      if (this.chatAborts.get(chatId) === abortController) this.chatAborts.delete(chatId);
+      sink({ type: 'stopped', chatId, userMessageId: '', text: userText });
+      return { response: '', chatId };
+    }
+
     this.chatAborts.set(chatId, abortController);
 
     const started = Date.now();


### PR DESCRIPTION
## Problem

With prompts queued behind a running turn, pressing Escape stopped the turn but the queue kept going — the next queued prompt fired immediately, so you had to press Escape again.

## Cause

Two holes on the stop path:

1. The client marks a turn in-flight before the gateway has registered it (and a turn waiting on the chat semaphore never registers an abort handle at all). Stop then reports "nothing to abort", and the client's fallback cleared only the spinner — not the queue — so the drain effect saw an idle chat and sent the next prompt.
2. Escape was a no-op when nothing was in flight, even with prompts still queued.

## Fix

- `useChats.tsx`: the `clearInFlight` fallback drops the queue, same as a real `stoppedSend`.
- `ChatTab.tsx`: Escape also fires when the queue is non-empty.
- `gateway.ts`: the abort handle is registered *before* waiting on the semaphore (only when no other run owns it), and after acquiring a slot the turn checks the signal — if it was stopped while queued it releases, emits `stopped`, and hands the prompt back to the input box.

## Tests

`npm test -w codey-mac` (1045) and `npm test -w @codey/gateway` (495) pass, plus a new reducer test for the queue drop. Real-machine smoke test still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)