### PR TITLE
fix(mac): hide agent/model identity until hover

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -25,9 +25,9 @@ import { isTaskBriefStale, extractSidecarBrief } from './taskHudView'
 import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
-import { formatTokens } from './turnHeaderModel'
+import { formatTokens, turnHeaderMeta } from './turnHeaderModel'
 import {
-  TurnHeader, MESSAGE_ROW_INSET, TURN_RAIL_WIDTH, TURN_TEXT_PADDING, TURN_TEXT_INSET,
+  TurnHeader, IdentityLabel, MESSAGE_ROW_INSET, TURN_RAIL_WIDTH, TURN_TEXT_PADDING, TURN_TEXT_INSET,
   USER_BUBBLE_PADDING_X,
 } from './TurnHeader'
 import { ACTIVITY_LABEL } from './agentActivity'
@@ -2178,10 +2178,16 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                 {/* Aide, Advisor and the team final answer read like a plain
                     Codey reply: no member header at all. Only real workers
                     get a name and an avatar. */}
-                {!isUser && isWorkerMessage && <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
-                  <WorkerAvatar name={msg.worker!} config={member?.config.avatar} state={memberState} />
-                  <strong>{msg.worker}</strong>
-                </div>}
+                {!isUser && isWorkerMessage && (() => {
+                  const identity = turnHeaderMeta(msg).identity
+                  return (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+                      <WorkerAvatar name={msg.worker!} config={member?.config.avatar} state={memberState} />
+                      <strong>{msg.worker}</strong>
+                      {identity && <IdentityLabel identity={identity} />}
+                    </div>
+                  )
+                })()}
                 {!isUser && (() => {
                   const thinking = msg.thinking?.trim() ?? ''
                   // Keyed off the in-flight turn rather than msg.isComplete:
@@ -2202,6 +2208,7 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                         expanded={expanded}
                         onToggle={() => setThinkingToggles(p => ({ ...p, [msg.id]: !expanded }))}
                         onAskAgentAboutFallback={(detail, fb) => { void askAgentAboutFallback(detail, fb) }}
+                        hideIdentity={isWorkerMessage}
                       />
                       {!!thinking && expanded && (
                         <div style={styles.thinkingBody}>{thinking}</div>

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -51,6 +51,31 @@ interface Props {
    *  surface exists, which hides the "Ask Agent" action rather than offering a
    *  button that does nothing. */
   onAskAgentAboutFallback?: (detail: string, fallback: { from: string; to: string }) => void
+  /** True for a worker turn, where the identity already renders next to the
+   *  worker's name/avatar. Keeps this header from repeating it. */
+  hideIdentity?: boolean
+}
+
+/** An `agent · model` label, invisible until hovered.
+ *
+ *  It's noise on every turn but useful on demand, so it reserves its layout
+ *  space (no reflow on hover) and only reveals itself on hover/focus — the
+ *  same interaction FallbackWarning below already uses for its popover. */
+export const IdentityLabel: React.FC<{ identity: string }> = ({ identity }) => {
+  const [hovered, setHovered] = React.useState(false)
+  return (
+    <span
+      tabIndex={0}
+      style={{ ...styles.identity, opacity: hovered ? 1 : 0, transition: 'opacity 0.1s ease' }}
+      title={identity}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
+    >
+      {identity}
+    </span>
+  )
 }
 
 /** Identifies an assistant turn and bounds it.
@@ -67,11 +92,14 @@ interface Props {
  *  gaining a line when the turn lands. The metadata row renders only when there
  *  is something to put in it, so a turn with no metadata is a bare hairline
  *  rather than a blank row. */
-export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback }) => {
+export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback, hideIdentity }) => {
   const elapsedSec = useElapsedSeconds(!turnComplete, msg.timestamp)
   const meta = turnHeaderMeta(msg, { elapsedSec })
+  // With the identity hidden (a worker turn shows it beside its name instead),
+  // a turn with nothing else to say is empty even though meta.identity is set.
+  const isEmpty = hideIdentity ? !meta.stats.length && !meta.fallback : meta.isEmpty
   const rule = <div style={styles.rule} />
-  if (meta.isEmpty && !hasThinking) return rule
+  if (isEmpty && !hasThinking) return rule
 
   return (
     <div>
@@ -86,15 +114,13 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
               aria-label={`${expanded ? 'Hide' : 'Show'} thinking${meta.identity ? ` for ${meta.identity}` : ''}`}
               title={expanded ? 'Hide thinking' : 'Show thinking'}
             >
-              {meta.identity && (
-                <span style={styles.identity} title={meta.identity}>{meta.identity}</span>
-              )}
+              {meta.identity && !hideIdentity && <IdentityLabel identity={meta.identity} />}
               <span style={{ ...styles.chevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
                 <UIIcon name="chevron" size={14} strokeWidth={2} />
               </span>
             </button>
-          ) : meta.identity ? (
-            <span style={styles.identity} title={meta.identity}>{meta.identity}</span>
+          ) : meta.identity && !hideIdentity ? (
+            <IdentityLabel identity={meta.identity} />
           ) : null}
           {meta.fallback && (
             <FallbackWarning fallback={meta.fallback} onAskAgent={onAskAgentAboutFallback} />


### PR DESCRIPTION
## Summary
- `agent · model` text no longer shows by default on a turn; it reveals on hover/focus.
- For worker turns, that text moves next to the worker's avatar/name instead of the turn header.
- Fallback warning icon (⚠️) behavior unchanged — still shown by default.
- Bumped codey-mac to 0.12.15.

## Test plan
- [ ] `npx tsc --noEmit` passes (done)
- [ ] Manual: open a non-worker turn, confirm identity hidden until hover
- [ ] Manual: open a worker turn, confirm identity sits beside worker name, hidden until hover
- [ ] Manual: trigger a fallback, confirm warning icon still shows by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)