### PR TITLE
feat(mac): refine worker avatar expressions and sleepy waiting state

### DIFF
--- a/codey-mac/src/components/WorkerAvatar.tsx
+++ b/codey-mac/src/components/WorkerAvatar.tsx
@@ -5,20 +5,39 @@ export function WorkerAvatar({ name, config, state = 'idle', size = 36 }: {
   name: string; config?: Partial<WorkerAvatarConfig>; state?: AvatarState; size?: number
 }) {
   const { shape, color } = resolveWorkerAvatar(name, config)
+  const resting = state === 'idle' || state === 'stopped'
   return <svg className={`worker-avatar worker-avatar--${state}`} width={size} height={size} viewBox="0 0 100 100" role="img" aria-label={`${name}: ${avatarStateLabels[state]}`} style={{ flexShrink: 0 }}>
-    {shape === 'circle' && <circle cx="50" cy="50" r="45" fill={color} />}
-    {shape === 'square' && <rect x="5" y="5" width="90" height="90" rx="25" fill={color} />}
-    {shape === 'capsule' && <rect x="4" y="15" width="92" height="70" rx="35" fill={color} />}
-    {shape === 'triangle' && <path d="M43 12 Q50 0 57 12 L94 79 Q102 94 85 94 H15 Q-2 94 6 79 Z" fill={color} />}
-    <g transform={shape === 'triangle' ? 'translate(0 10)' : undefined}>
-      {state === 'done' ? <g fill="none" stroke="#34434A" strokeWidth="5" strokeLinecap="round"><path d="M25 53 Q34 39 43 53"/><path d="M57 53 Q66 39 75 53"/></g> :
-        <g className="worker-avatar-eyes">
-          {[34, 66].map((x, i) => <g key={x} transform={state === 'reply' && i === 1 ? 'translate(0 -5)' : undefined}>
-            <ellipse cx={x} cy="49" rx="12" ry={state === 'working' ? 11 : state === 'failed' ? 9 : 16} fill="#FFFDF8"/>
-            <ellipse className="worker-avatar-pupil" cx={x + (state === 'reply' ? 2 : 0)} cy={state === 'failed' ? 53 : 50} rx="5" ry="6" fill="#34434A"/>
-            {state === 'failed' && <path d={`M${x - 11} 42 L${x + 10} 47`} stroke={color} strokeWidth="7"/>}
-          </g>)}
-        </g>}
+    <g className="worker-avatar-body">
+      {shape === 'circle' && <path d="M50 7 C76 5 94 27 94 53 C94 80 75 94 49 93 C22 95 6 78 6 53 C5 27 23 8 50 7Z" fill={color} />}
+      {shape === 'square' && <path d="M29 9 Q50 6 72 9 Q90 11 91 30 L93 70 Q92 90 72 92 L29 92 Q8 91 8 71 L9 31 Q9 11 29 9Z" fill={color} />}
+      {shape === 'capsule' && <path d="M36 18 L64 18 C84 18 96 31 96 51 C96 73 82 84 62 84 L37 84 C16 84 4 72 4 51 C4 31 17 18 36 18Z" fill={color} />}
+      {shape === 'triangle' && <path d="M39 16 Q50 -1 62 17 L90 66 Q107 92 77 94 L23 94 Q-6 92 10 67Z" fill={color} />}
+      <g transform={shape === 'triangle' ? 'translate(0 9)' : undefined}>
+        {state === 'done' ? <g fill="none" stroke="#303C42" strokeWidth="5" strokeLinecap="round"><path d="M23 50 Q33 36 42 50"/><path d="M58 50 Q67 36 77 50"/></g> :
+          state === 'failed' ? <g>
+            <path d="M22 51 Q34 54 46 44 C46 65 22 65 22 51Z" fill="#FFFDF5"/>
+            <path d="M54 44 Q66 54 78 51 C78 65 54 65 54 44Z" fill="#FFFDF5"/>
+            <ellipse cx="35" cy="56" rx="4.5" ry="4" fill="#303C42"/>
+            <ellipse cx="65" cy="56" rx="4.5" ry="4" fill="#303C42"/>
+          </g> :
+          <g className="worker-avatar-eyes">
+            {[34, 66].map((x, i) => <g key={x} transform={state === 'reply' && i === 1 ? 'translate(0 -6)' : undefined}>
+              {state === 'waiting' ? <>
+                <path d={`M${x - 10} 51 Q${x} 56 ${x + 10} 51`} fill="none" stroke="#303C42" strokeWidth="5" strokeLinecap="round"/>
+              </> : state === 'working' ? <>
+                <path d={i === 0 ? `M${x - 12} 39 L${x + 12} 45 C${x + 12} 65 ${x - 12} 65 ${x - 12} 39Z` : `M${x - 12} 45 L${x + 12} 39 C${x + 12} 65 ${x - 12} 65 ${x - 12} 45Z`} fill="#FFFDF5"/>
+                <ellipse className="worker-avatar-pupil" cx={x + (i === 0 ? 2 : -2)} cy="51" rx="5" ry="7" fill="#303C42"/>
+              </> : <>
+                <ellipse cx={x} cy="48" rx="12" ry={resting ? 12 : 16} fill="#FFFDF5"/>
+                <ellipse cx={x + (state === 'reply' ? 3 : 0)} cy={resting ? 51 : 49} rx="5.5" ry={resting ? 6 : 8} fill="#303C42"/>
+              </>}
+
+            </g>)}
+          </g>}
+        {state === 'waiting' && <path className="worker-avatar-sleep-bubble"
+          d="M51 59 C54 60 55 64 57 66 C61 69 69 66 69 61 C69 55 62 53 58 56 C55 58 53 59 51 59Z"
+          fill="#FFFDF5" fillOpacity=".65" stroke="#FFFDF5" strokeWidth="1.5" />}
+      </g>
     </g>
   </svg>
 }

--- a/codey-mac/src/components/workerAvatar.css
+++ b/codey-mac/src/components/workerAvatar.css
@@ -1,6 +1,14 @@
 .worker-avatar-eyes { transform-box: fill-box; transform-origin: center; }
-.worker-avatar--waiting .worker-avatar-eyes { animation: worker-blink 7s ease-in-out infinite; }
+.worker-avatar--waiting .worker-avatar-body { animation: worker-doze 5s ease-in-out infinite; }
 .worker-avatar--working .worker-avatar-pupil { animation: worker-look 3s ease-in-out infinite; }
 @keyframes worker-blink { 0%, 90%, 100% { transform: scaleY(1); } 95% { transform: scaleY(.12); } }
 @keyframes worker-look { 0%, 100% { transform: translateX(-2px); } 50% { transform: translateX(2px); } }
+.worker-avatar-body { transform-origin: 50px 86px; }
+.worker-avatar--working .worker-avatar-body { animation: worker-bob 3s ease-in-out infinite; }
+@keyframes worker-bob { 0%, 100% { transform: translateY(0) scale(1, 1); } 50% { transform: translateY(-1px) scale(.99, 1.01); } }
+
+@keyframes worker-doze { 0%, 100% { transform: rotate(0deg); } 50% { transform: rotate(3deg) translateY(1px); } }
+
+.worker-avatar-sleep-bubble { transform-origin: 51px 59px; animation: worker-sleep-bubble 5s ease-in-out infinite; }
+@keyframes worker-sleep-bubble { 0%, 100% { transform: scale(.88); } 50% { transform: scale(1.08); } }
 @media (prefers-reduced-motion: reduce) { .worker-avatar * { animation: none !important; } }


### PR DESCRIPTION
Refine worker avatars with softer silhouettes while retaining the four existing shapes, configured colors, and all status mappings (including stopped).

Waiting now has sleepy closed eyes and a small translucent nose bubble that gently scales with its nod. Working uses focused eyes; failed uses slightly open, sad eyes with visible pupils. Reply, idle, and done remain distinct without additional facial decoration. Animations respect reduced-motion preferences.

Validation:
- Rebuilt @codey/core and passed desktop TypeScript checks.
- Desktop Vite build passed for renderer, Electron main, and preload (existing deprecation and chunk-size warnings).
- Reviewed a preview rendered from the actual component, including 36px samples; runtime animation was not manually verified.
- git diff --check passed.
