### PR TITLE
fix(mac): fold worker name into the turn header row

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -25,9 +25,9 @@ import { isTaskBriefStale, extractSidecarBrief } from './taskHudView'
 import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
-import { formatTokens, turnHeaderMeta } from './turnHeaderModel'
+import { formatTokens } from './turnHeaderModel'
 import {
-  TurnHeader, IdentityLabel, MESSAGE_ROW_INSET, TURN_RAIL_WIDTH, TURN_TEXT_PADDING, TURN_TEXT_INSET,
+  TurnHeader, MESSAGE_ROW_INSET, TURN_RAIL_WIDTH, TURN_TEXT_PADDING, TURN_TEXT_INSET,
   USER_BUBBLE_PADDING_X,
 } from './TurnHeader'
 import { ACTIVITY_LABEL } from './agentActivity'
@@ -2177,17 +2177,9 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
               }}>
                 {/* Aide, Advisor and the team final answer read like a plain
                     Codey reply: no member header at all. Only real workers
-                    get a name and an avatar. */}
-                {!isUser && isWorkerMessage && (() => {
-                  const identity = turnHeaderMeta(msg).identity
-                  return (
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
-                      <WorkerAvatar name={msg.worker!} config={member?.config.avatar} state={memberState} />
-                      <strong>{msg.worker}</strong>
-                      {identity && <IdentityLabel identity={identity} />}
-                    </div>
-                  )
-                })()}
+                    get a name and an avatar, folded into TurnHeader's own row
+                    so the name sits directly above the rule instead of on a
+                    separate row with a gap under it. */}
                 {!isUser && (() => {
                   const thinking = msg.thinking?.trim() ?? ''
                   // Keyed off the in-flight turn rather than msg.isComplete:
@@ -2208,7 +2200,12 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                         expanded={expanded}
                         onToggle={() => setThinkingToggles(p => ({ ...p, [msg.id]: !expanded }))}
                         onAskAgentAboutFallback={(detail, fb) => { void askAgentAboutFallback(detail, fb) }}
-                        hideIdentity={isWorkerMessage}
+                        leftPrefix={isWorkerMessage ? (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <WorkerAvatar name={msg.worker!} config={member?.config.avatar} state={memberState} />
+                            <strong>{msg.worker}</strong>
+                          </div>
+                        ) : undefined}
                       />
                       {!!thinking && expanded && (
                         <div style={styles.thinkingBody}>{thinking}</div>

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -51,9 +51,10 @@ interface Props {
    *  surface exists, which hides the "Ask Agent" action rather than offering a
    *  button that does nothing. */
   onAskAgentAboutFallback?: (detail: string, fallback: { from: string; to: string }) => void
-  /** True for a worker turn, where the identity already renders next to the
-   *  worker's name/avatar. Keeps this header from repeating it. */
-  hideIdentity?: boolean
+  /** A worker turn's avatar + name, rendered at the start of this same row so
+   *  the identity that follows it sits right next to the name it belongs to
+   *  instead of on a second, mostly-empty row of its own. */
+  leftPrefix?: React.ReactNode
 }
 
 /** An `agent · model` label, invisible until hovered.
@@ -92,12 +93,12 @@ export const IdentityLabel: React.FC<{ identity: string }> = ({ identity }) => {
  *  gaining a line when the turn lands. The metadata row renders only when there
  *  is something to put in it, so a turn with no metadata is a bare hairline
  *  rather than a blank row. */
-export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback, hideIdentity }) => {
+export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback, leftPrefix }) => {
   const elapsedSec = useElapsedSeconds(!turnComplete, msg.timestamp)
   const meta = turnHeaderMeta(msg, { elapsedSec })
-  // With the identity hidden (a worker turn shows it beside its name instead),
-  // a turn with nothing else to say is empty even though meta.identity is set.
-  const isEmpty = hideIdentity ? !meta.stats.length && !meta.fallback : meta.isEmpty
+  // A worker's avatar/name makes the row worth drawing even when there's
+  // otherwise nothing to show.
+  const isEmpty = leftPrefix ? false : meta.isEmpty
   const rule = <div style={styles.rule} />
   if (isEmpty && !hasThinking) return rule
 
@@ -105,6 +106,7 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
     <div>
       <div style={styles.row}>
         <div style={styles.left}>
+          {leftPrefix}
           {hasThinking ? (
             <button
               type="button"
@@ -114,12 +116,12 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
               aria-label={`${expanded ? 'Hide' : 'Show'} thinking${meta.identity ? ` for ${meta.identity}` : ''}`}
               title={expanded ? 'Hide thinking' : 'Show thinking'}
             >
-              {meta.identity && !hideIdentity && <IdentityLabel identity={meta.identity} />}
+              {meta.identity && <IdentityLabel identity={meta.identity} />}
               <span style={{ ...styles.chevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
                 <UIIcon name="chevron" size={14} strokeWidth={2} />
               </span>
             </button>
-          ) : meta.identity && !hideIdentity ? (
+          ) : meta.identity ? (
             <IdentityLabel identity={meta.identity} />
           ) : null}
           {meta.fallback && (

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -242,7 +242,7 @@ const styles: Record<string, React.CSSProperties> = {
   left: { display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 },
   right: { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, marginLeft: 'auto' },
   identity: {
-    fontFamily: 'SF Mono, Menlo, monospace',
+    fontFamily: 'SF Mono, Menlo, monospace', color: C.fg3,
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
   },
   disclosure: {

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -57,27 +57,19 @@ interface Props {
   leftPrefix?: React.ReactNode
 }
 
-/** An `agent · model` label, invisible until hovered.
+/** An `agent · model` label, invisible until the row it lives in is hovered.
  *
  *  It's noise on every turn but useful on demand, so it reserves its layout
- *  space (no reflow on hover) and only reveals itself on hover/focus — the
- *  same interaction FallbackWarning below already uses for its popover. */
-export const IdentityLabel: React.FC<{ identity: string }> = ({ identity }) => {
-  const [hovered, setHovered] = React.useState(false)
-  return (
-    <span
-      tabIndex={0}
-      style={{ ...styles.identity, opacity: hovered ? 1 : 0, transition: 'opacity 0.1s ease' }}
-      title={identity}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onFocus={() => setHovered(true)}
-      onBlur={() => setHovered(false)}
-    >
-      {identity}
-    </span>
-  )
-}
+ *  space (no reflow on reveal) and dims in at the same tone as the stats on
+ *  the other end of the row rather than declaring its own. The hover/focus
+ *  state lives on the row (see TurnHeader), not here, so pointing anywhere in
+ *  the row — the worker name, the disclosure button, empty space between them
+ *  — reveals it, not just the exact pixels of the text itself. */
+export const IdentityLabel: React.FC<{ identity: string; visible: boolean }> = ({ identity, visible }) => (
+  <span style={{ ...styles.identity, opacity: visible ? 0.55 : 0 }} title={identity}>
+    {identity}
+  </span>
+)
 
 /** Identifies an assistant turn and bounds it.
  *
@@ -96,6 +88,10 @@ export const IdentityLabel: React.FC<{ identity: string }> = ({ identity }) => {
 export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback, leftPrefix }) => {
   const elapsedSec = useElapsedSeconds(!turnComplete, msg.timestamp)
   const meta = turnHeaderMeta(msg, { elapsedSec })
+  // Lives on the whole row, not on the identity label itself, so pointing
+  // anywhere in the row — the worker name, the disclosure button, the gap
+  // between them — reveals it, not just its own (usually invisible) pixels.
+  const [identityHovered, setIdentityHovered] = React.useState(false)
   // A worker's avatar/name makes the row worth drawing even when there's
   // otherwise nothing to show.
   const isEmpty = leftPrefix ? false : meta.isEmpty
@@ -104,7 +100,15 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
 
   return (
     <div>
-      <div style={styles.row}>
+      <div
+        style={styles.row}
+        onMouseEnter={() => setIdentityHovered(true)}
+        onMouseLeave={() => setIdentityHovered(false)}
+        onFocus={() => setIdentityHovered(true)}
+        onBlur={e => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setIdentityHovered(false)
+        }}
+      >
         <div style={styles.left}>
           {leftPrefix}
           {hasThinking ? (
@@ -116,13 +120,13 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
               aria-label={`${expanded ? 'Hide' : 'Show'} thinking${meta.identity ? ` for ${meta.identity}` : ''}`}
               title={expanded ? 'Hide thinking' : 'Show thinking'}
             >
-              {meta.identity && <IdentityLabel identity={meta.identity} />}
+              {meta.identity && <IdentityLabel identity={meta.identity} visible={identityHovered} />}
               <span style={{ ...styles.chevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
                 <UIIcon name="chevron" size={14} strokeWidth={2} />
               </span>
             </button>
           ) : meta.identity ? (
-            <IdentityLabel identity={meta.identity} />
+            <IdentityLabel identity={meta.identity} visible={identityHovered} />
           ) : null}
           {meta.fallback && (
             <FallbackWarning fallback={meta.fallback} onAskAgent={onAskAgentAboutFallback} />
@@ -244,6 +248,7 @@ const styles: Record<string, React.CSSProperties> = {
   identity: {
     fontFamily: 'SF Mono, Menlo, monospace', color: C.fg3,
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    transition: 'opacity 0.1s ease',
   },
   disclosure: {
     appearance: 'none', border: 0, background: 'transparent', color: 'inherit',


### PR DESCRIPTION
## Summary
- Worker name/avatar no longer sits in a separate row above the turn header — it's now the first item in the same row, directly against the rule.
- The hover-revealed agent/model text sits right after the name, on that same row, instead of stranded on its own row underneath.

## Test plan
- [ ] Manual: worker turn — name hugs the rule, no big gap
- [ ] Manual: hover next to the worker name reveals agent/model text
- [ ] Manual: non-worker turn still shows hover-reveal identity as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)