### PR TITLE
fix(mac): an interrupt pauses the queue instead of emptying it

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -445,9 +445,12 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
   chat,
 }) => {
   const outerRef = useRef<HTMLDivElement>(null)
-  const { state, createChat, sendMessage, removeQueuedMessage, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
+  const { state, createChat, sendMessage, removeQueuedMessage, resumeQueue, stopChat, clearRestore, setSelection, setAgentModel, setEffort, setExecutionMode, bindWorktree, createWorktree, setPullRequest, setContextPanelOpen, setSoloAdvisor, linkChannel, unlinkChannel, resolvePermission, generateTaskBrief } = useChats()
   const flight = state.inFlight[chatId]
   const queuedMessages = state.queuedMessages[chatId] ?? []
+  // A stop holds the queue instead of emptying it, so these prompts stay put
+  // until you resume them, send something new, or drop them one by one.
+  const queuePaused = !!state.pausedQueues[chatId]
 
   // Voice: capture, playback and the turn itself live above this component
   // (see VoiceTurnProvider) so they survive switching chats. What stays here
@@ -976,12 +979,13 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       // Escape stops the running turn, and — once nothing is running — still
-      // clears anything queued behind it, so one press ends the whole thing.
-      if (e.key === 'Escape' && (flight || queuedMessages.length > 0)) stopChat(chatId)
+      // holds back anything queued behind it, so one press ends the whole run.
+      // An already-paused queue has nothing left to stop.
+      if (e.key === 'Escape' && (flight || (queuedMessages.length > 0 && !queuePaused))) stopChat(chatId)
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [flight, chatId, queuedMessages.length])
+  }, [flight, chatId, queuedMessages.length, queuePaused])
   // Refresh the Status task brief on each turn boundary — when a turn is sent
   // and again when it completes — while the Status tab is open, so it reflects
   // the live history. The tab-switch trigger alone misses these: nothing
@@ -2597,6 +2601,16 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
           </div>
           {queuedMessages.length > 0 && (
             <div style={styles.queuedRow}>
+              {queuePaused && (
+                <div style={styles.queuedPausedRow}>
+                  <span style={styles.queuedPausedLabel}>
+                    Paused · {queuedMessages.length} queued
+                  </span>
+                  <button onClick={() => resumeQueue(chatId)} style={styles.queuedResumeBtn}>
+                    Resume
+                  </button>
+                </div>
+              )}
               {queuedMessages.map((queued, i) => (
                 <div key={queued.id} style={styles.queuedChip} title={queued.text}>
                   <span style={styles.queuedIndex}>{i + 1}</span>
@@ -3277,6 +3291,15 @@ const styles: Record<string, React.CSSProperties> = {
   queuedText: {
     flex: 1, fontSize: 12, color: C.fg2,
     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+  },
+  queuedPausedRow: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
+    padding: '0 2px',
+  },
+  queuedPausedLabel: { fontSize: 11, color: C.fg3 },
+  queuedResumeBtn: {
+    border: `1px solid ${C.border2}`, background: 'transparent', borderRadius: 6,
+    color: C.fg2, cursor: 'pointer', fontSize: 11, padding: '2px 8px',
   },
   queuedRemoveBtn: {
     flexShrink: 0, border: 'none', background: 'transparent',

--- a/codey-mac/src/hooks/messageQueue.ts
+++ b/codey-mac/src/hooks/messageQueue.ts
@@ -1,17 +1,19 @@
 import type { QueuedMessage } from './useChats'
 
 /** Which queued prompts are ready to go out right now: the head of every
- *  chat's queue whose turn has finished and that is not already being
- *  delivered. Pure so the drain rule can be tested without a DOM. */
+ *  chat's queue whose turn has finished, that is not already being delivered,
+ *  and whose queue is not paused by a stop. Pure so the drain rule can be
+ *  tested without a DOM. */
 export function readyDeliveries(
   queuedMessages: Record<string, QueuedMessage[]>,
   inFlight: Record<string, unknown>,
   draining: ReadonlySet<string>,
+  pausedQueues: Record<string, true> = {},
 ): Array<{ chatId: string; message: QueuedMessage }> {
   const ready: Array<{ chatId: string; message: QueuedMessage }> = []
   for (const [chatId, queue] of Object.entries(queuedMessages)) {
     const head = queue[0]
-    if (!head || inFlight[chatId] || draining.has(chatId)) continue
+    if (!head || inFlight[chatId] || draining.has(chatId) || pausedQueues[chatId]) continue
     ready.push({ chatId, message: head })
   }
   return ready

--- a/codey-mac/src/hooks/useChats.reducer.test.ts
+++ b/codey-mac/src/hooks/useChats.reducer.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { reducer, shouldAdoptExternalTurn, type State } from './useChats'
+import { readyDeliveries } from './messageQueue'
 import type { Chat } from '../types'
 
 const emptyState = (): State => ({
   chats: {}, order: [], selectedChatId: null, inFlight: {},
   collapsedWorkspaces: {}, workspaces: [], pendingRestores: {},
-  unreadChats: {}, pendingPermissions: {}, queuedMessages: {},
+  unreadChats: {}, pendingPermissions: {}, queuedMessages: {}, pausedQueues: {},
 })
 
 // A chat as it exists server-side at turn start: the user message is already
@@ -22,7 +23,7 @@ function baseState(): State {
     chats: { c1: { id: 'c1', title: 't', workspaceName: 'ws', selection: { type: 'team', name: 'team' }, messages: [], createdAt: 0, updatedAt: 0 } },
     order: ['c1'], selectedChatId: 'c1',
     inFlight: { c1: { assistantMessageId: 'asst-x', userMessageId: 'u1', agentStatus: 'thinking' } },
-    collapsedWorkspaces: {}, workspaces: ['ws'], pendingRestores: {}, unreadChats: {}, pendingPermissions: {}, queuedMessages: {},
+    collapsedWorkspaces: {}, workspaces: ['ws'], pendingRestores: {}, unreadChats: {}, pendingPermissions: {}, queuedMessages: {}, pausedQueues: {},
   };
 }
 
@@ -239,7 +240,7 @@ describe('message queue', () => {
     expect(s.queuedMessages.c1.map(m => m.text)).toEqual(['two'])
   })
 
-  it('stopping a turn drops the queue so nothing fires after an interrupt', () => {
+  it('stopping a turn pauses the queue so nothing fires after an interrupt', () => {
     let s = baseState()
     s.chats.c1.messages = [
       { id: 'u1', role: 'user', content: 'go', timestamp: 1, isComplete: true },
@@ -247,14 +248,36 @@ describe('message queue', () => {
     ]
     s = reducer(s, q('one', 'q1'))
     s = reducer(s, { type: 'stoppedSend', chatId: 'c1', text: 'go' })
-    expect(s.queuedMessages.c1).toBeUndefined()
+    expect(s.queuedMessages.c1.map(m => m.text)).toEqual(['one'])
+    expect(s.pausedQueues.c1).toBe(true)
+    expect(readyDeliveries(s.queuedMessages, s.inFlight, new Set(), s.pausedQueues)).toEqual([])
   })
 
-  it('clearing a stale in-flight turn drops the queue too', () => {
+  it('resuming lets the paused queue drain again', () => {
     let s = baseState()
     s = reducer(s, q('one', 'q1'))
     s = reducer(s, { type: 'clearInFlight', chatId: 'c1' })
+    expect(s.pausedQueues.c1).toBe(true)
+    s = reducer(s, { type: 'resumeQueue', chatId: 'c1' })
+    expect(s.pausedQueues.c1).toBeUndefined()
+    expect(readyDeliveries(s.queuedMessages, s.inFlight, new Set(), s.pausedQueues).map(r => r.message.text)).toEqual(['one'])
+  })
+
+  it('dropping the last paused prompt ends the pause', () => {
+    let s = baseState()
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, { type: 'clearInFlight', chatId: 'c1' })
+    s = reducer(s, { type: 'removeQueuedMessage', chatId: 'c1', id: 'q1' })
     expect(s.queuedMessages.c1).toBeUndefined()
+    expect(s.pausedQueues.c1).toBeUndefined()
+  })
+
+  it('clearing a stale in-flight turn pauses the queue too', () => {
+    let s = baseState()
+    s = reducer(s, q('one', 'q1'))
+    s = reducer(s, { type: 'clearInFlight', chatId: 'c1' })
+    expect(s.queuedMessages.c1.map(m => m.text)).toEqual(['one'])
+    expect(s.pausedQueues.c1).toBe(true)
   })
 
   it('deleting a chat drops its queue', () => {

--- a/codey-mac/src/hooks/useChats.tsx
+++ b/codey-mac/src/hooks/useChats.tsx
@@ -42,6 +42,10 @@ export interface State {
   // Prompts typed while a turn was in flight, per chat, oldest first. Drained
   // one at a time by the provider as soon as the chat has no inFlight turn.
   queuedMessages: Record<string, QueuedMessage[]>
+  // Chats whose queue is held back after a stop. The prompts are kept — an
+  // interrupt pauses the run rather than throwing away what was typed — and
+  // stay put until the user resumes or sends something new.
+  pausedQueues: Record<string, true>
 }
 
 type Action =
@@ -79,6 +83,7 @@ type Action =
   | { type: 'enqueueMessage'; chatId: string; message: QueuedMessage }
   | { type: 'dequeueMessage'; chatId: string }
   | { type: 'removeQueuedMessage'; chatId: string; id: string }
+  | { type: 'resumeQueue'; chatId: string }
   | { type: 'teamStart'; chatId: string; teamTurnId: string; teamName: string; mode: 'sequential' | 'graph' | 'auto' | 'roundtable'; workers?: Array<{ messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string }> }
   | { type: 'workerStart'; chatId: string; teamTurnId: string; messageId: string; step: number; worker: string; agent?: ChatMessage['agent']; model?: string; reason?: string }
   | { type: 'workerEnd'; chatId: string; messageId: string; step: number; status: 'running' | 'done' | 'failed' | 'askedUser'; failureReason?: string; nextUserAction?: ChatMessage['workerNextUserAction'] }
@@ -126,8 +131,24 @@ function setQueue(
   return next
 }
 
-function dropQueue(map: Record<string, QueuedMessage[]>, chatId: string): Record<string, QueuedMessage[]> {
-  return setQueue(map, chatId, [])
+/** Hold this chat's queue back after a stop. A chat with nothing queued has
+ *  nothing to pause, so the flag is only set when prompts are actually
+ *  waiting — that keeps "paused" true only while the UI has something to show. */
+function pauseQueue(
+  paused: Record<string, true>,
+  queues: Record<string, QueuedMessage[]>,
+  chatId: string,
+): Record<string, true> {
+  if (!queues[chatId]?.length) return unpauseQueue(paused, chatId)
+  if (paused[chatId]) return paused
+  return { ...paused, [chatId]: true }
+}
+
+function unpauseQueue(paused: Record<string, true>, chatId: string): Record<string, true> {
+  if (!paused[chatId]) return paused
+  const next = { ...paused }
+  delete next[chatId]
+  return next
 }
 
 export function reducer(state: State, action: Action): State {
@@ -257,12 +278,25 @@ export function reducer(state: State, action: Action): State {
     case 'dequeueMessage': {
       const queue = state.queuedMessages[action.chatId]
       if (!queue || queue.length === 0) return state
-      return { ...state, queuedMessages: setQueue(state.queuedMessages, action.chatId, queue.slice(1)) }
+      const queuedMessages = setQueue(state.queuedMessages, action.chatId, queue.slice(1))
+      const pausedQueues = queuedMessages[action.chatId]
+        ? state.pausedQueues
+        : unpauseQueue(state.pausedQueues, action.chatId)
+      return { ...state, queuedMessages, pausedQueues }
     }
     case 'removeQueuedMessage': {
       const queue = state.queuedMessages[action.chatId]
       if (!queue) return state
-      return { ...state, queuedMessages: setQueue(state.queuedMessages, action.chatId, queue.filter(m => m.id !== action.id)) }
+      const queuedMessages = setQueue(state.queuedMessages, action.chatId, queue.filter(m => m.id !== action.id))
+      // Dropping the last paused prompt ends the pause: there is nothing left
+      // to resume, and a stale flag would hold back the next queue.
+      const pausedQueues = queuedMessages[action.chatId]
+        ? state.pausedQueues
+        : unpauseQueue(state.pausedQueues, action.chatId)
+      return { ...state, queuedMessages, pausedQueues }
+    }
+    case 'resumeQueue': {
+      return { ...state, pausedQueues: unpauseQueue(state.pausedQueues, action.chatId) }
     }
     case 'remove': {
       const chats = { ...state.chats }
@@ -273,7 +307,7 @@ export function reducer(state: State, action: Action): State {
       delete inFlight[action.chatId]
       const queuedMessages = { ...state.queuedMessages }
       delete queuedMessages[action.chatId]
-      return { ...state, chats, order, selectedChatId, inFlight, queuedMessages }
+      return { ...state, chats, order, selectedChatId, inFlight, queuedMessages, pausedQueues: unpauseQueue(state.pausedQueues, action.chatId) }
     }
     case 'select': {
       const unreadChats = { ...state.unreadChats }
@@ -549,7 +583,10 @@ export function reducer(state: State, action: Action): State {
     case 'stoppedSend': {
       const chat = state.chats[action.chatId]
       const fl = state.inFlight[action.chatId]
-      if (!chat || !fl) return state
+      // The pause holds even when the turn is already gone from local state —
+      // a stop is a stop, and the queue must not run on without it.
+      const paused = pauseQueue(state.pausedQueues, state.queuedMessages, action.chatId)
+      if (!chat || !fl) return paused === state.pausedQueues ? state : { ...state, pausedQueues: paused }
       // Drop both the user prompt and the assistant placeholder for this turn.
       // The prompt text is stashed in pendingRestores so ChatTab can lift it
       // back into the input box.
@@ -563,20 +600,21 @@ export function reducer(state: State, action: Action): State {
         chats: { ...state.chats, [chat.id]: { ...chat, messages, updatedAt: Date.now() } },
         inFlight,
         // An interrupt means "stop", so anything queued behind this turn is
-        // dropped rather than fired the instant the turn clears.
-        queuedMessages: dropQueue(state.queuedMessages, action.chatId),
+        // paused rather than fired the instant the turn clears. The prompts
+        // are kept; the user resumes them or drops them one by one.
+        pausedQueues: paused,
         pendingRestores: { ...state.pendingRestores, [action.chatId]: action.text },
       }
     }
     case 'clearInFlight': {
-      const queuedMessages = dropQueue(state.queuedMessages, action.chatId)
-      if (!state.inFlight[action.chatId]) return { ...state, queuedMessages }
-      const inFlight = { ...state.inFlight }
-      delete inFlight[action.chatId]
       // Same rule as 'stoppedSend': this only fires from Stop/Escape, and a
       // stop must not let the next queued prompt fire the instant the turn
       // clears.
-      return { ...state, inFlight, queuedMessages }
+      const pausedQueues = pauseQueue(state.pausedQueues, state.queuedMessages, action.chatId)
+      if (!state.inFlight[action.chatId]) return { ...state, pausedQueues }
+      const inFlight = { ...state.inFlight }
+      delete inFlight[action.chatId]
+      return { ...state, inFlight, pausedQueues }
     }
     case 'clearRestore': {
       if (!(action.chatId in state.pendingRestores)) return state
@@ -641,6 +679,7 @@ interface ChatsContextValue {
   stopChat: (chatId: string) => Promise<void>
   /** Drop a prompt that is still waiting behind the running turn. */
   removeQueuedMessage: (chatId: string, id: string) => void
+  resumeQueue: (chatId: string) => void
   resolvePermission: (chatId: string, allow: boolean) => Promise<void>
   clearRestore: (chatId: string) => void
   toggleWorkspace: (workspaceName: string) => void
@@ -667,6 +706,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     unreadChats: {},
     pendingPermissions: {},
     queuedMessages: {},
+    pausedQueues: {},
   })
 
   const pendingAssistantId = useRef<Record<string, string>>({})
@@ -916,6 +956,9 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     identity?: { agent?: ChatMessage['agent']; model?: string },
   ) => {
     const busy = !!stateRef.current.inFlight[chatId] || (stateRef.current.queuedMessages[chatId]?.length ?? 0) > 0
+    // Sending again is how you say "carry on": a queue paused by a stop starts
+    // moving once more, with the new prompt at the back of it.
+    if (stateRef.current.pausedQueues[chatId]) dispatch({ type: 'resumeQueue', chatId })
     if (busy) {
       dispatch({
         type: 'enqueueMessage',
@@ -931,13 +974,13 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   // a second pass firing the same head before `startSend` lands in state.
   const draining = useRef<Set<string>>(new Set())
   useEffect(() => {
-    for (const { chatId, message } of readyDeliveries(state.queuedMessages, state.inFlight, draining.current)) {
+    for (const { chatId, message } of readyDeliveries(state.queuedMessages, state.inFlight, draining.current, state.pausedQueues)) {
       draining.current.add(chatId)
       dispatch({ type: 'dequeueMessage', chatId })
       void deliverMessage(chatId, message.text, message.attachments, message.identity)
         .finally(() => { draining.current.delete(chatId) })
     }
-  }, [state.queuedMessages, state.inFlight, deliverMessage])
+  }, [state.queuedMessages, state.inFlight, state.pausedQueues, deliverMessage])
 
   const value = useMemo<ChatsContextValue>(() => ({
     state,
@@ -1035,6 +1078,7 @@ export const ChatsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     },
     sendMessage,
     removeQueuedMessage(chatId, id) { dispatch({ type: 'removeQueuedMessage', chatId, id }) },
+    resumeQueue(chatId) { dispatch({ type: 'resumeQueue', chatId }) },
     async stopChat(chatId) {
       let stopped = false
       try { stopped = await apiService.chats.stop(chatId) } catch { /* treated as nothing to stop */ }


### PR DESCRIPTION
Follow-up to #420. That PR stopped the queue from running on after an interrupt by **dropping** it. Throwing away what you typed is the wrong call — a stop should pause the run, not delete the backlog.

## Behaviour now

- Stop / Escape halts the running turn and **holds** the queued prompts. They stay in the strip above the composer, which grows a `Paused · N queued` row with a **Resume** button.
- Sending a new prompt also resumes: it joins the back of the queue and everything starts moving again.
- Removing the last paused prompt, or deleting the chat, ends the pause, so a later queue is not held back by a stale flag.
- Escape is a no-op once the queue is already paused.

## Where

- `useChats.tsx`: new `pausedQueues` state; `stoppedSend` and the `clearInFlight` fallback pause instead of drop; `resumeQueue` action; a new send clears the pause.
- `messageQueue.ts`: `readyDeliveries` skips paused chats.
- `ChatTab.tsx`: paused row + Resume button; Escape skips an already-paused queue.

## Tests

`npm test -w codey-mac` → 1047 pass, including new reducer cases for pause, resume, and the last-prompt-removed unpause. Real-machine smoke test still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)