### PR TITLE
fix(mac): reveal identity across the full message

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -569,8 +569,8 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
     return () => { stale = true }
   }, [isGatewayRunning, runSettingsOpen])
   const [followLatest, setFollowLatest] = useState(true)
-  // A user bubble keeps its footer (timestamp + actions) hidden until the
-  // pointer is on that message, so a quiet transcript stays quiet.
+  // Shared message hover state reveals a user's footer or an assistant turn's
+  // agent/model identity without giving either feature a narrower hit area.
   const [hoveredMsgId, setHoveredMsgId] = useState<string | null>(null)
   // The message being edited in place, plus its working text. Saving sends the
   // edited text as a fresh turn; the original stays in the transcript.
@@ -2118,8 +2118,8 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
           const isEditing = isUser && editingMsgId === msg.id
           return (
             <div key={msg.id} data-chat-navigation-id={msg.id}
-              onMouseEnter={isUser ? () => setHoveredMsgId(msg.id) : undefined}
-              onMouseLeave={isUser ? () => setHoveredMsgId(id => (id === msg.id ? null : id)) : undefined}
+              onMouseEnter={() => setHoveredMsgId(msg.id)}
+              onMouseLeave={() => setHoveredMsgId(id => (id === msg.id ? null : id))}
               onDoubleClick={isUser ? undefined : () => {
                 setSelectedTurnIdState(msg.id)
                 setFollowLatest(false)
@@ -2208,6 +2208,7 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                           <WorkerAvatar name={msg.worker!} config={member?.config.avatar} state={memberState} />
                         ) : undefined}
                         leftLabel={isWorkerMessage ? <strong>{msg.worker}</strong> : undefined}
+                        messageHovered={hoveredMsgId === msg.id}
                       />
                       {!!thinking && expanded && (
                         <div style={styles.thinkingBody}>{thinking}</div>

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -59,6 +59,10 @@ interface Props {
    *  in the same baseline-aligned text group instead of the identity landing
    *  on a second, mostly-empty row of its own. */
   leftLabel?: React.ReactNode
+  /** Whether the containing assistant message is hovered. The header also
+   *  tracks focus/hover locally for standalone keyboard and pointer access,
+   *  but the parent owns the full-turn hit area (reply, tools and footer). */
+  messageHovered?: boolean
 }
 
 /** An `agent · model` label, invisible until the row it lives in is hovered.
@@ -66,9 +70,8 @@ interface Props {
  *  It's noise on every turn but useful on demand, so it reserves its layout
  *  space (no reflow on reveal) and dims in at the same tone as the stats on
  *  the other end of the row rather than declaring its own. The hover/focus
- *  state lives on the whole row (see TurnHeader), not here, so pointing
- *  anywhere in it — the worker name, the disclosure button, the stats/timer
- *  on the right — reveals it, not just the exact pixels of the text itself. */
+ *  state lives outside this label, so pointing anywhere in the assistant turn
+ *  reveals it, not just the exact pixels of the text itself. */
 export const IdentityLabel: React.FC<{ identity: string; visible: boolean }> = ({ identity, visible }) => (
   <span style={{ ...styles.identity, opacity: visible ? 0.55 : 0 }} title={identity}>
     {identity}
@@ -89,13 +92,13 @@ export const IdentityLabel: React.FC<{ identity: string; visible: boolean }> = (
  *  gaining a line when the turn lands. The metadata row renders only when there
  *  is something to put in it, so a turn with no metadata is a bare hairline
  *  rather than a blank row. */
-export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback, leftAvatar, leftLabel }) => {
+export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onToggle, turnComplete, onAskAgentAboutFallback, leftAvatar, leftLabel, messageHovered = false }) => {
   const elapsedSec = useElapsedSeconds(!turnComplete, msg.timestamp)
   const meta = turnHeaderMeta(msg, { elapsedSec })
-  // Lives on the whole row, not on the identity label itself, so pointing
-  // anywhere in it — the worker name, the disclosure button, the stats/timer
-  // on the right — reveals it, not just its own (usually invisible) pixels.
-  const [identityHovered, setIdentityHovered] = React.useState(false)
+  // Keep a local state for focus and direct header hover, while ChatTab passes
+  // the containing assistant turn's hover state to cover the reply body too.
+  const [headerActive, setHeaderActive] = React.useState(false)
+  const identityVisible = messageHovered || headerActive
   // A worker's avatar/name makes the row worth drawing even when there's
   // otherwise nothing to show.
   const isEmpty = (leftAvatar || leftLabel) ? false : meta.isEmpty
@@ -106,11 +109,11 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
     <div>
       <div
         style={styles.row}
-        onMouseEnter={() => setIdentityHovered(true)}
-        onMouseLeave={() => setIdentityHovered(false)}
-        onFocus={() => setIdentityHovered(true)}
+        onMouseEnter={() => setHeaderActive(true)}
+        onMouseLeave={() => setHeaderActive(false)}
+        onFocus={() => setHeaderActive(true)}
         onBlur={e => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setIdentityHovered(false)
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setHeaderActive(false)
         }}
       >
         <div style={styles.left}>
@@ -126,13 +129,13 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
                 aria-label={`${expanded ? 'Hide' : 'Show'} thinking${meta.identity ? ` for ${meta.identity}` : ''}`}
                 title={expanded ? 'Hide thinking' : 'Show thinking'}
               >
-                {meta.identity && <IdentityLabel identity={meta.identity} visible={identityHovered} />}
+                {meta.identity && <IdentityLabel identity={meta.identity} visible={identityVisible} />}
                 <span style={{ ...styles.chevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
                   <UIIcon name="chevron" size={14} strokeWidth={2} />
                 </span>
               </button>
             ) : meta.identity ? (
-              <IdentityLabel identity={meta.identity} visible={identityHovered} />
+              <IdentityLabel identity={meta.identity} visible={identityVisible} />
             ) : null}
           </div>
           {meta.fallback && (


### PR DESCRIPTION
## Summary
- reveal the assistant agent/model identity while hovering anywhere on the full message turn, including the reply body
- retain direct header hover and keyboard focus behavior
- bump the macOS app version to 0.12.16

## Verification
- `npm run typecheck -w codey-mac`
- `npm test -w codey-mac -- --run` (99 files, 1047 tests)