### PR TITLE
fix(mac): hide fallback warning triangle until hover

### DIFF
--- a/codey-mac/package.json
+++ b/codey-mac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codey-mac",
-  "version": "0.12.16",
+  "version": "0.12.17",
   "description": "Codey - macOS menu bar application for coding agents",
   "main": "dist-electron/main.js",
   "author": "its-ahoh",

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -139,7 +139,7 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
             ) : null}
           </div>
           {meta.fallback && (
-            <FallbackWarning fallback={meta.fallback} onAskAgent={onAskAgentAboutFallback} />
+            <FallbackWarning fallback={meta.fallback} onAskAgent={onAskAgentAboutFallback} visible={identityVisible} />
           )}
         </div>
         <div style={styles.right}>
@@ -170,7 +170,11 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
 const FallbackWarning: React.FC<{
   fallback: { from: string; to: string; reason?: string }
   onAskAgent?: (detail: string, fallback: { from: string; to: string }) => void
-}> = ({ fallback, onAskAgent }) => {
+  /** Same reveal-on-hover gate as the identity label beside it, so the two
+   *  read as one piece of on-demand metadata instead of the triangle
+   *  permanently drawing the eye on every fallback turn. */
+  visible: boolean
+}> = ({ fallback, onAskAgent, visible }) => {
   const [open, setOpen] = React.useState(false)
   const [copied, setCopied] = React.useState(false)
   const detail = fallbackErrorText(fallback)
@@ -211,7 +215,7 @@ const FallbackWarning: React.FC<{
       <span
         tabIndex={0}
         role="button"
-        style={styles.fallbackButton}
+        style={{ ...styles.fallbackButton, opacity: visible ? 1 : 0, transition: 'opacity 0.1s ease' }}
         aria-label={`Fallback warning. Failed agent and model: ${fallback.from}. Fallback agent and model: ${fallback.to}. Error: ${detail}`}
       >
         <UIIcon name="alert" size={13} strokeWidth={1.8} />


### PR DESCRIPTION
## Summary
- The fallback warning triangle used to always render, defeating the hover-to-reveal treatment already applied to the agent/model identity beside it.
- It now shares the same `identityVisible` gate, so the triangle and the identity text fade in together on hover.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Manual: hover an assistant turn with a fallback and confirm the triangle appears alongside the model name; confirm it's hidden at rest.