### PR TITLE
fix(gateway): resume and reuse Claude chat sessions

### DIFF
--- a/packages/core/src/agents/claude-code.ts
+++ b/packages/core/src/agents/claude-code.ts
@@ -306,13 +306,21 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       let askUserInputJson = '';
       let collectingAskUser = false;
       let timeoutTimer: NodeJS.Timeout | undefined;
+      let timeoutShutdownTimer: NodeJS.Timeout | undefined;
       let abortHandler: (() => void) | undefined;
+      let timedOut = false;
+      // Keep this invocation's session separate from the adapter-level value:
+      // adapters can be used concurrently, and timeout recovery must resume
+      // only a session that this particular CLI process actually announced.
+      let startedSessionId: string | undefined;
 
       const safeResolve = (response: AgentResponse) => {
         if (!resolved) {
           resolved = true;
           if (timeoutTimer) clearTimeout(timeoutTimer);
+          if (timeoutShutdownTimer) clearTimeout(timeoutShutdownTimer);
           if (abortHandler && request.signal) request.signal.removeEventListener('abort', abortHandler);
+          response.startedSessionId = startedSessionId;
           resolve(response);
         }
       };
@@ -356,6 +364,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
 
         if (event.type === 'system' && event.session_id) {
           this.sessionId = event.session_id;
+          startedSessionId = event.session_id;
         } else if (event.type === 'stream_event' && event.event?.type === 'content_block_start') {
           const cb = event.event.content_block;
           if (cb?.type === 'tool_use' && cb.name === 'AskUserQuestion') {
@@ -460,6 +469,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         } else if (event.type === 'result') {
           if (event.session_id) {
             this.sessionId = event.session_id;
+            startedSessionId = event.session_id;
           }
           if (event.result) {
             result = event.result;
@@ -530,6 +540,22 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
         // Fall back to wall-clock duration if the result event didn't include one
         const finalDuration = durationSec ?? Math.round((Date.now() - startTime) / 1000);
 
+        // Do not release the caller until the terminated Claude process has
+        // actually closed. Its session lock can outlive the SIGTERM briefly;
+        // starting --resume before this point recreates the exact
+        // "Session ID is already in use" failure timeout recovery prevents.
+        if (timedOut) {
+          safeResolve(this.createResponse(
+            `Timeout after ${Math.round(timeout / 60000)} minutes`,
+            false,
+            undefined,
+            finalDuration,
+            statusUpdates,
+            states,
+          ));
+          return;
+        }
+
         // Fallback: parse AskUserQuestion JSON from streamed text if the
         // tool_use block detection didn't fire (e.g. assistant event never
         // arrived because CLI blocked on interactive input).
@@ -590,9 +616,23 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       // Timeout (default 15 minutes)
       timeoutTimer = setTimeout(() => {
         if (!resolved) {
+          timedOut = true;
           terminateProcessTree(childProcess);
-          const duration = Math.round((Date.now() - startTime) / 1000);
-          safeResolve(this.createResponse(`Timeout after ${Math.round(timeout / 60000)} minutes`, false, undefined, duration));
+          // terminateProcessTree escalates to SIGKILL after 1.5s. Retain a
+          // bounded escape hatch in case the platform never emits `close`.
+          timeoutShutdownTimer = setTimeout(() => {
+            const duration = Math.round((Date.now() - startTime) / 1000);
+            mcpCleanup?.();
+            safeResolve(this.createResponse(
+              `Timeout after ${Math.round(timeout / 60000)} minutes`,
+              false,
+              undefined,
+              duration,
+              statusUpdates,
+              states,
+            ));
+          }, 3_000);
+          timeoutShutdownTimer.unref?.();
         }
       }, timeout);
 

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -240,7 +240,8 @@ export interface Chat {
     }[];
     inducedFrom?: string[];
   };
-  /** Warm CLI sessions retained independently for each agent/model identity. */
+  /** Warm CLI sessions retained independently for each agent. `model` records
+   *  the most recently used model but is not part of the session identity. */
   sessionAnchors?: Array<{
     agent: CodingAgent;
     model?: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -295,6 +295,12 @@ export interface AgentResponse {
    * the gateway already knows the id it sent.
    */
   sessionId?: string;
+  /**
+   * Session id that the adapter observed the CLI open during this invocation.
+   * Unlike `sessionId`, this is also populated on failed or timed-out runs so
+   * the gateway can safely resume work without reusing `--session-id`.
+   */
+  startedSessionId?: string;
   /** Tools that were denied due to permission settings (only when skipPermissions is false). */
   permissionDenials?: Array<{ toolName: string; toolInput?: Record<string, unknown> }>;
   /**

--- a/packages/gateway/src/chats.ts
+++ b/packages/gateway/src/chats.ts
@@ -300,11 +300,10 @@ export class ChatManager {
     return chat;
   }
 
-  /** Find the warm CLI session belonging to one exact agent/model identity. */
+  /** Find the warm CLI session belonging to an agent, regardless of model. */
   getSessionAnchor(
     chatId: string,
     agent: NonNullable<Chat['sessionAnchor']>['agent'],
-    model?: string,
   ): NonNullable<Chat['sessionAnchor']> | undefined {
     const chat = this.get(chatId);
     if (!chat) return undefined;
@@ -321,40 +320,49 @@ export class ChatManager {
           ?? chat.messages[chat.messages.length - 1]?.id,
       };
       const pooled = [...(chat.sessionAnchors ?? [])]
-        .filter(item => item.agent !== legacy.agent || item.model !== legacy.model)
+        .filter(item => item.agent !== legacy.agent)
         .concat(legacy);
       chat.sessionAnchors = pooled;
       delete chat.sessionAnchor;
       this.persist(chat);
     }
 
-    const pooled = chat.sessionAnchors?.find(anchor => anchor.agent === agent && anchor.model === model);
-    return pooled;
+    // Older pool data may contain one entry per model. Array order reflects
+    // replacement order, so the final matching entry is the agent's current
+    // session. Compact it lazily to keep future reads unambiguous.
+    const matches = chat.sessionAnchors?.filter(anchor => anchor.agent === agent) ?? [];
+    const current = matches[matches.length - 1];
+    if (current && matches.length > 1) {
+      chat.sessionAnchors = chat.sessionAnchors!
+        .filter(anchor => anchor.agent !== agent)
+        .concat(current);
+      this.persist(chat);
+    }
+    return current;
   }
 
-  /** Persist or advance the warm CLI session for one agent/model identity. */
+  /** Persist or advance the warm CLI session for one agent. */
   setSessionAnchor(chatId: string, anchor: NonNullable<Chat['sessionAnchor']>): void {
     const chat = this.cache.get(chatId);
     if (!chat) return;
     const migrated = [...(chat.sessionAnchors ?? [])];
     if (chat.sessionAnchor && !migrated.some(item =>
-      item.agent === chat.sessionAnchor!.agent && item.model === chat.sessionAnchor!.model
+      item.agent === chat.sessionAnchor!.agent
     )) {
       migrated.push(chat.sessionAnchor);
     }
     chat.sessionAnchors = migrated
-      .filter(item => item.agent !== anchor.agent || item.model !== anchor.model)
+      .filter(item => item.agent !== anchor.agent)
       .concat(anchor);
     delete chat.sessionAnchor;
     chat.updatedAt = Date.now();
     this.persist(chat);
   }
 
-  /** Drop one identity's session, or every session when no identity is given. */
+  /** Drop one agent's session, or every session when no agent is given. */
   clearSessionAnchor(
     chatId: string,
     agent?: NonNullable<Chat['sessionAnchor']>['agent'],
-    model?: string,
   ): void {
     const chat = this.cache.get(chatId);
     if (!chat) return;
@@ -364,9 +372,9 @@ export class ChatManager {
       delete chat.sessionAnchors;
     } else {
       const before = chat.sessionAnchors?.length ?? 0;
-      chat.sessionAnchors = chat.sessionAnchors?.filter(item => item.agent !== agent || item.model !== model);
+      chat.sessionAnchors = chat.sessionAnchors?.filter(item => item.agent !== agent);
       if (chat.sessionAnchors?.length === 0) delete chat.sessionAnchors;
-      if (chat.sessionAnchor?.agent === agent && chat.sessionAnchor.model === model) delete chat.sessionAnchor;
+      if (chat.sessionAnchor?.agent === agent) delete chat.sessionAnchor;
       if (before === (chat.sessionAnchors?.length ?? 0) && chat.sessionAnchor) return;
     }
     chat.updatedAt = Date.now();
@@ -383,8 +391,9 @@ export class ChatManager {
     else chat.agent = agent;
     if (model === null || model === undefined || model === '') delete chat.model;
     else chat.model = model;
-    // Keep every agent/model session. The next turn selects the matching
-    // anchor and incrementally synchronizes only the messages it has missed.
+    // Keep every agent session. A model change continues the same session;
+    // switching back to another agent resumes that agent's own anchor and
+    // incrementally synchronizes only the messages it has missed.
     chat.updatedAt = Date.now();
     this.persist(chat);
     return chat;
@@ -395,7 +404,7 @@ export class ChatManager {
    * clear and fall back to the worker/global tiers.
    *
    * Deliberately separate from updateAgentModel: that setter's session-anchor
-   * behavior is tied to agent/model identity, and changing effort must NOT
+   * behavior is tied to agent identity, and changing effort must NOT
    * rotate the session — raising effort and continuing the same thread is the
    * primary use case, and rotating would drop the conversation context.
    */

--- a/packages/gateway/src/chats.workingDirOverride.test.ts
+++ b/packages/gateway/src/chats.workingDirOverride.test.ts
@@ -36,17 +36,19 @@ describe('ChatManager.updateAgentModel', () => {
 
   afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
 
-  it('retains the previous model session when the selection changes', () => {
+  it('reuses the agent session when the model changes', () => {
     const chat = mgr.create({ workspaceName: 'ws', agent: 'codex', model: 'model-a' });
     mgr.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'session-a' });
 
     const updated = mgr.updateAgentModel(chat.id, 'codex', 'model-b');
 
     expect(updated.model).toBe('model-b');
-    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')?.sessionId).toBe('session-a');
+    expect(mgr.getSessionAnchor(chat.id, 'codex')).toMatchObject({
+      model: 'model-a', sessionId: 'session-a',
+    });
   });
 
-  it('stores independent warm sessions for each agent/model identity', () => {
+  it('stores independent warm sessions for each agent', () => {
     const chat = mgr.create({ workspaceName: 'ws' });
     mgr.setSessionAnchor(chat.id, {
       agent: 'codex', model: 'model-a', sessionId: 'session-a', syncedThroughMessageId: 'a1',
@@ -55,10 +57,10 @@ describe('ChatManager.updateAgentModel', () => {
       agent: 'claude-code', model: 'model-b', sessionId: 'session-b', syncedThroughMessageId: 'b1',
     });
 
-    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')).toMatchObject({
+    expect(mgr.getSessionAnchor(chat.id, 'codex')).toMatchObject({
       sessionId: 'session-a', syncedThroughMessageId: 'a1',
     });
-    expect(mgr.getSessionAnchor(chat.id, 'claude-code', 'model-b')).toMatchObject({
+    expect(mgr.getSessionAnchor(chat.id, 'claude-code')).toMatchObject({
       sessionId: 'session-b', syncedThroughMessageId: 'b1',
     });
   });
@@ -68,10 +70,10 @@ describe('ChatManager.updateAgentModel', () => {
     mgr.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'session-a' });
     mgr.setSessionAnchor(chat.id, { agent: 'claude-code', model: 'model-b', sessionId: 'session-b' });
 
-    mgr.clearSessionAnchor(chat.id, 'codex', 'model-a');
+    mgr.clearSessionAnchor(chat.id, 'codex');
 
-    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')).toBeUndefined();
-    expect(mgr.getSessionAnchor(chat.id, 'claude-code', 'model-b')?.sessionId).toBe('session-b');
+    expect(mgr.getSessionAnchor(chat.id, 'codex')).toBeUndefined();
+    expect(mgr.getSessionAnchor(chat.id, 'claude-code')?.sessionId).toBe('session-b');
   });
 
   it('migrates a legacy anchor with the current transcript cursor', () => {
@@ -82,10 +84,39 @@ describe('ChatManager.updateAgentModel', () => {
     stored.sessionAnchor = { agent: 'codex', model: 'model-a', sessionId: 'legacy-session' };
     delete stored.sessionAnchors;
 
-    expect(mgr.getSessionAnchor(chat.id, 'codex', 'model-a')).toMatchObject({
+    expect(mgr.getSessionAnchor(chat.id, 'codex')).toMatchObject({
       sessionId: 'legacy-session', syncedThroughMessageId: 'a1',
     });
     expect(mgr.get(chat.id)?.sessionAnchor).toBeUndefined();
+  });
+
+  it('collapses old per-model anchors to the most recently stored agent session', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    const stored = mgr.get(chat.id)!;
+    stored.sessionAnchors = [
+      { agent: 'codex', model: 'model-a', sessionId: 'session-a' },
+      { agent: 'claude-code', model: 'model-x', sessionId: 'session-x' },
+      { agent: 'codex', model: 'model-b', sessionId: 'session-b' },
+    ];
+
+    expect(mgr.getSessionAnchor(chat.id, 'codex')).toMatchObject({
+      model: 'model-b', sessionId: 'session-b',
+    });
+    expect(mgr.get(chat.id)?.sessionAnchors).toEqual([
+      { agent: 'claude-code', model: 'model-x', sessionId: 'session-x' },
+      { agent: 'codex', model: 'model-b', sessionId: 'session-b' },
+    ]);
+  });
+
+  it('replaces an agent session instead of creating one session per model', () => {
+    const chat = mgr.create({ workspaceName: 'ws' });
+    mgr.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-a', sessionId: 'session-a' });
+    mgr.setSessionAnchor(chat.id, { agent: 'codex', model: 'model-b', sessionId: 'session-b' });
+
+    expect(mgr.getSessionAnchor(chat.id, 'codex')).toMatchObject({
+      model: 'model-b', sessionId: 'session-b',
+    });
+    expect(mgr.get(chat.id)?.sessionAnchors).toHaveLength(1);
   });
 });
 

--- a/packages/gateway/src/gateway.network-retry.test.ts
+++ b/packages/gateway/src/gateway.network-retry.test.ts
@@ -33,4 +33,8 @@ describe('network retry classification', () => {
   it('never retries a successful response', () => {
     expect(isRetryableNetworkFailure({ success: true, output: 'ok' })).toBe(false);
   });
+
+  it('does not misclassify Codey\'s own execution limit as a network failure', () => {
+    expect(isRetryableNetworkFailure(failed('Timeout after 15 minutes'))).toBe(false);
+  });
 });

--- a/packages/gateway/src/gateway.timeout-resume.test.ts
+++ b/packages/gateway/src/gateway.timeout-resume.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { AgentRequest, AgentResponse } from '@codey/core';
 import {
   isOwnTimeoutFailure,
+  isMissingSessionFailure,
   planAgentRetry,
   rebaseForFallbackAgent,
   MAX_TIMEOUT_RESUMES,
@@ -27,6 +28,25 @@ describe('own-timeout classification', () => {
       expect(isOwnTimeoutFailure(failed(text))).toBe(false);
     },
   );
+});
+
+describe('missing-session classification', () => {
+  it.each([
+    'No conversation found with session ID: sess-1',
+    'Session sess-1 does not exist',
+    'Unable to resume conversation because it was not found',
+  ])('recognises an explicitly missing session: %s', text => {
+    expect(isMissingSessionFailure(failed(text))).toBe(true);
+  });
+
+  it.each([
+    'Timeout after 15 minutes',
+    'Session ID sess-1 is already in use',
+    'Request timed out',
+    'Unknown model name',
+  ])('does not discard an anchor for another failure: %s', text => {
+    expect(isMissingSessionFailure(failed(text))).toBe(false);
+  });
 });
 
 describe('planAgentRetry', () => {
@@ -85,15 +105,47 @@ describe('rebaseForFallbackAgent', () => {
     expect(out.newSessionId).toBeUndefined();
   });
 
-  it('mints a fresh id when retrying claude-code on another model', () => {
+  it('resumes the opened session when falling back to another model of the same agent', () => {
     const out = rebaseForFallbackAgent(
       req({ newSessionId: 'sess-1' }),
       'claude-code',
       'claude-code',
       failed('boom', { startedSessionId: 'sess-1' }),
     );
+    expect(out.resumeSessionId).toBe('sess-1');
+    expect(out.newSessionId).toBeUndefined();
+  });
+
+  it('uses a continuation prompt for same-agent fallback after a timeout', () => {
+    const out = rebaseForFallbackAgent(
+      req({ resumeSessionId: 'sess-1' }),
+      'claude-code',
+      'claude-code',
+      failed('Timeout after 15 minutes', { startedSessionId: 'sess-1' }),
+    );
+    expect(out.resumeSessionId).toBe('sess-1');
+    expect(out.prompt).not.toBe('do the thing');
+  });
+
+  it('keeps an existing resume id when falling back within the same agent', () => {
+    const out = rebaseForFallbackAgent(
+      req({ resumeSessionId: 'sess-1' }),
+      'claude-code',
+      'claude-code',
+      failed('boom'),
+    );
+    expect(out.resumeSessionId).toBe('sess-1');
+    expect(out.newSessionId).toBeUndefined();
+  });
+
+  it('keeps an unopened pinned id when falling back within the same agent', () => {
+    const out = rebaseForFallbackAgent(
+      req({ newSessionId: 'sess-1' }),
+      'claude-code',
+      'claude-code',
+      failed('boom'),
+    );
     expect(out.resumeSessionId).toBeUndefined();
-    expect(out.newSessionId).toBeTruthy();
-    expect(out.newSessionId).not.toBe('sess-1');
+    expect(out.newSessionId).toBe('sess-1');
   });
 });

--- a/packages/gateway/src/gateway.timeout-resume.test.ts
+++ b/packages/gateway/src/gateway.timeout-resume.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentRequest, AgentResponse } from '@codey/core';
+import {
+  isOwnTimeoutFailure,
+  planAgentRetry,
+  rebaseForFallbackAgent,
+  MAX_TIMEOUT_RESUMES,
+} from './gateway';
+
+const req = (over: Partial<AgentRequest> = {}): AgentRequest => ({
+  prompt: 'do the thing',
+  agent: 'claude-code',
+  ...over,
+} as AgentRequest);
+
+const failed = (error: string, over: Partial<AgentResponse> = {}): AgentResponse =>
+  ({ success: false, output: '', error, ...over });
+
+describe('own-timeout classification', () => {
+  it.each(['Timeout after 15 minutes', 'timeout after 1 minute'])('recognises %s', text => {
+    expect(isOwnTimeoutFailure(failed(text))).toBe(true);
+  });
+
+  it.each(['Request timed out', 'gateway timeout', '504 Gateway Timeout'])(
+    'leaves provider failure alone: %s',
+    text => {
+      expect(isOwnTimeoutFailure(failed(text))).toBe(false);
+    },
+  );
+});
+
+describe('planAgentRetry', () => {
+  it('resumes the started session after our own timeout instead of restarting', () => {
+    const original = req({ newSessionId: 'sess-1' });
+    const d = planAgentRetry(original, failed('Timeout after 15 minutes', { startedSessionId: 'sess-1' }), 0);
+    expect(d.retry).toBe(true);
+    expect(d.resumedAfterTimeout).toBe(true);
+    expect(d.request.resumeSessionId).toBe('sess-1');
+    expect(d.request.newSessionId).toBeUndefined();
+    expect(d.request.prompt).not.toBe(original.prompt);
+  });
+
+  it('gives up on a timeout that never opened a session', () => {
+    expect(planAgentRetry(req({ newSessionId: 'sess-1' }), failed('Timeout after 15 minutes'), 0).retry).toBe(false);
+  });
+
+  it('resumes after a timeout only once', () => {
+    const r = failed('Timeout after 15 minutes', { startedSessionId: 'sess-1' });
+    expect(planAgentRetry(req(), r, MAX_TIMEOUT_RESUMES).retry).toBe(false);
+  });
+
+  it('never re-pins a session id the CLI already opened', () => {
+    const d = planAgentRetry(
+      req({ newSessionId: 'sess-1' }),
+      failed('fetch failed', { startedSessionId: 'sess-1' }),
+      0,
+    );
+    expect(d.retry).toBe(true);
+    expect(d.request.newSessionId).toBeUndefined();
+    expect(d.request.resumeSessionId).toBe('sess-1');
+    expect(d.request.prompt).toBe('do the thing');
+  });
+
+  it('keeps an unused pinned id on a network retry', () => {
+    const d = planAgentRetry(req({ newSessionId: 'sess-1' }), failed('ECONNRESET'), 0);
+    expect(d.retry).toBe(true);
+    expect(d.request.newSessionId).toBe('sess-1');
+    expect(d.request.resumeSessionId).toBeUndefined();
+  });
+
+  it('does not retry a permanent failure', () => {
+    expect(planAgentRetry(req(), failed('Unknown model name'), 0).retry).toBe(false);
+  });
+});
+
+describe('rebaseForFallbackAgent', () => {
+  it('never hands one agent session id to another agent', () => {
+    const out = rebaseForFallbackAgent(
+      req({ resumeSessionId: 'claude-sess', newSessionId: undefined }),
+      'claude-code',
+      'codex',
+      failed('boom'),
+    );
+    expect(out.resumeSessionId).toBeUndefined();
+    expect(out.newSessionId).toBeUndefined();
+  });
+
+  it('mints a fresh id when retrying claude-code on another model', () => {
+    const out = rebaseForFallbackAgent(
+      req({ newSessionId: 'sess-1' }),
+      'claude-code',
+      'claude-code',
+      failed('boom', { startedSessionId: 'sess-1' }),
+    );
+    expect(out.resumeSessionId).toBeUndefined();
+    expect(out.newSessionId).toBeTruthy();
+    expect(out.newSessionId).not.toBe('sess-1');
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -62,11 +62,92 @@ const SOLO_ADVISOR_MAX_ROUNDS = 2;
 /** A failed run may be retried this many times before fallback routing starts. */
 export const MAX_NETWORK_RETRIES = 5;
 
+/** A timeout continuation gets one fresh execution window, not an endless loop. */
+export const MAX_TIMEOUT_RESUMES = 1;
+
+const TIMEOUT_RESUME_PROMPT = `Continue the task from where you left off. The previous turn was interrupted by Codey's execution time limit. Inspect the current state, complete only the remaining work, verify the result, and report the final outcome.`;
+
+/** Codey's adapter timeout, as distinct from a provider/network timeout. */
+export function isOwnTimeoutFailure(response: AgentResponse): boolean {
+  if (response.success) return false;
+  return [response.error, response.output].some(value =>
+    /^timeout after \d+(?:\.\d+)? minutes?$/i.test(value?.trim() ?? ''),
+  );
+}
+
 /** Keep retries narrow: agent/config/permission failures must not be repeated. */
 export function isRetryableNetworkFailure(response: AgentResponse): boolean {
-  if (response.success) return false;
+  if (response.success || isOwnTimeoutFailure(response)) return false;
   const text = `${response.error ?? ''}\n${response.output ?? ''}`.toLowerCase();
   return /(?:\btimeout\b|timed out|deadline exceeded|etimedout|econnreset|econnrefused|enotfound|eai_again|socket hang up|fetch failed|network (?:error|unavailable)|connection (?:closed|lost|reset|refused|error)|temporarily unavailable|service unavailable|gateway timeout|\b(?:408|429|500|502|503|504)\b)/i.test(text);
+}
+
+export interface AgentRetryPlan {
+  retry: boolean;
+  request: AgentRequest;
+  resumedAfterTimeout: boolean;
+}
+
+/** Decide whether and how to retry without ever re-pinning an opened session. */
+export function planAgentRetry(
+  request: AgentRequest,
+  response: AgentResponse,
+  timeoutResumes: number,
+): AgentRetryPlan {
+  if (isOwnTimeoutFailure(response)) {
+    const sessionId = response.startedSessionId;
+    if (request.agent !== 'claude-code' || !sessionId || timeoutResumes >= MAX_TIMEOUT_RESUMES) {
+      return { retry: false, request, resumedAfterTimeout: false };
+    }
+    return {
+      retry: true,
+      request: {
+        ...request,
+        prompt: TIMEOUT_RESUME_PROMPT,
+        resumeSessionId: sessionId,
+        newSessionId: undefined,
+      },
+      resumedAfterTimeout: true,
+    };
+  }
+
+  if (!isRetryableNetworkFailure(response)) {
+    return { retry: false, request, resumedAfterTimeout: false };
+  }
+
+  // Once Claude has announced the session, --session-id can never be used for
+  // it again. Continue it with --resume even when the first failure was a
+  // transient provider/network error.
+  if (request.agent === 'claude-code' && response.startedSessionId) {
+    return {
+      retry: true,
+      request: {
+        ...request,
+        resumeSessionId: response.startedSessionId,
+        newSessionId: undefined,
+      },
+      resumedAfterTimeout: false,
+    };
+  }
+
+  return { retry: true, request, resumedAfterTimeout: false };
+}
+
+/** Strip source-agent session state before entering a fallback route. */
+export function rebaseForFallbackAgent(
+  request: AgentRequest,
+  _fromAgent: CodingAgent,
+  toAgent: CodingAgent,
+  _response: AgentResponse,
+): AgentRequest {
+  return {
+    ...request,
+    agent: toAgent,
+    resumeSessionId: undefined,
+    // A Claude fallback needs its own id. In particular, another Claude model
+    // must not receive the id already opened by the failed primary model.
+    newSessionId: toAgent === 'claude-code' ? randomUUID() : undefined,
+  };
 }
 
 /** Longest primary-failure text carried into fallback metadata. The full text
@@ -5494,18 +5575,38 @@ Example: /model gpt-4.1 write a Python script`;
   }
 
   private async runAgentWithNetworkRetry(agent: CodingAgent, request: AgentRequest): Promise<AgentResponse> {
-    let response = await this.agentFactory.run(agent, request);
-    for (let retry = 1; retry <= MAX_NETWORK_RETRIES; retry++) {
-      if (request.signal?.aborted || !isRetryableNetworkFailure(response)) break;
-      // 1s, 2s, 4s, 8s, 8s: enough breathing room for transient outages
-      // without leaving the chat apparently frozen for a long time.
-      const delayMs = Math.min(1000 * 2 ** (retry - 1), 8000);
-      const message = `Network error — retrying ${retry}/${MAX_NETWORK_RETRIES} in ${delayMs / 1000}s`;
+    let activeRequest = request;
+    let response = await this.agentFactory.run(agent, activeRequest);
+    let networkRetries = 0;
+    let timeoutResumes = 0;
+
+    while (!activeRequest.signal?.aborted) {
+      const plan = planAgentRetry(activeRequest, response, timeoutResumes);
+      if (!plan.retry) break;
+
+      let delayMs: number;
+      let message: string;
+      if (plan.resumedAfterTimeout) {
+        timeoutResumes++;
+        // Give the terminated CLI a moment to release its session lock before
+        // starting `--resume`.
+        delayMs = 1000;
+        message = `Execution limit reached — resuming Claude session ${timeoutResumes}/${MAX_TIMEOUT_RESUMES} in 1s`;
+      } else {
+        if (networkRetries >= MAX_NETWORK_RETRIES) break;
+        networkRetries++;
+        // 1s, 2s, 4s, 8s, 8s: enough breathing room for transient outages
+        // without leaving the chat apparently frozen for a long time.
+        delayMs = Math.min(1000 * 2 ** (networkRetries - 1), 8000);
+        message = `Network error — retrying ${networkRetries}/${MAX_NETWORK_RETRIES} in ${delayMs / 1000}s`;
+      }
+
       this.logger.warn(`${agent}: ${message}`);
-      request.onStatus?.({ type: 'info', message });
-      await this.waitForNetworkRetry(delayMs, request.signal);
-      if (request.signal?.aborted) break;
-      response = await this.agentFactory.run(agent, request);
+      activeRequest.onStatus?.({ type: 'info', message });
+      await this.waitForNetworkRetry(delayMs, activeRequest.signal);
+      if (activeRequest.signal?.aborted) break;
+      activeRequest = plan.request;
+      response = await this.agentFactory.run(agent, activeRequest);
     }
     return response;
   }
@@ -5571,8 +5672,7 @@ Example: /model gpt-4.1 write a Python script`;
       const label = `${entry.agent}(${resolvedModel.model})`;
       this.logger.warn(`Agent ${agent} failed, trying ${label}...`);
       const fallbackResponse = await this.runAgentWithNetworkRetry(entry.agent, {
-        ...request,
-        agent: entry.agent,
+        ...rebaseForFallbackAgent(request, agent, entry.agent, response),
         model: resolvedModel,
       });
       if (fallbackResponse.success) {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -82,6 +82,16 @@ export function isRetryableNetworkFailure(response: AgentResponse): boolean {
   return /(?:\btimeout\b|timed out|deadline exceeded|etimedout|econnreset|econnrefused|enotfound|eai_again|socket hang up|fetch failed|network (?:error|unavailable)|connection (?:closed|lost|reset|refused|error)|temporarily unavailable|service unavailable|gateway timeout|\b(?:408|429|500|502|503|504)\b)/i.test(text);
 }
 
+/** Only discard a persisted anchor when the CLI explicitly says the session
+ *  cannot be found. Other resume failures (including execution timeouts) must
+ *  surface as-is so the outer bootstrap path cannot grant another retry
+ *  window or repeat work that may already have completed. */
+export function isMissingSessionFailure(response: AgentResponse): boolean {
+  if (response.success) return false;
+  const text = `${response.error ?? ''}\n${response.output ?? ''}`;
+  return /(?:\bno conversation found with session id\b|\b(?:conversation|session)(?: id)?(?:\s+["']?[\w-]+["']?)?\s+(?:was )?(?:not found|does not exist)\b|\b(?:could not|unable to|failed to) (?:find|load|resume) (?:the )?(?:conversation|session)\b)/i.test(text);
+}
+
 export interface AgentRetryPlan {
   retry: boolean;
   request: AgentRequest;
@@ -133,19 +143,29 @@ export function planAgentRetry(
   return { retry: true, request, resumedAfterTimeout: false };
 }
 
-/** Strip source-agent session state before entering a fallback route. */
+/** Keep session state within an agent, but never carry it across agents. */
 export function rebaseForFallbackAgent(
   request: AgentRequest,
-  _fromAgent: CodingAgent,
+  fromAgent: CodingAgent,
   toAgent: CodingAgent,
-  _response: AgentResponse,
+  response: AgentResponse,
 ): AgentRequest {
+  if (fromAgent === toAgent) {
+    const resumeSessionId = response.startedSessionId ?? request.resumeSessionId;
+    return {
+      ...request,
+      agent: toAgent,
+      prompt: resumeSessionId && isOwnTimeoutFailure(response) ? TIMEOUT_RESUME_PROMPT : request.prompt,
+      resumeSessionId,
+      newSessionId: resumeSessionId ? undefined : request.newSessionId,
+    };
+  }
+
   return {
     ...request,
     agent: toAgent,
     resumeSessionId: undefined,
-    // A Claude fallback needs its own id. In particular, another Claude model
-    // must not receive the id already opened by the failed primary model.
+    // A different Claude agent needs an independent pre-allocated id.
     newSessionId: toAgent === 'claude-code' ? randomUUID() : undefined,
   };
 }
@@ -399,7 +419,11 @@ export class Codey {
         });
         return { response: resp, usedResume: true };
       }
-      // Resume failed — drop anchor and fall through to bootstrap.
+      // Only a definitively missing session makes the anchor stale. A timeout
+      // or any other failure must not fall through to a second execution.
+      if (!isMissingSessionFailure(resp)) {
+        return { response: resp, usedResume: true };
+      }
       this.logger.warn(`[worker:${opts.workerName}] resume of ${existing.sessionId} failed; bootstrapping fresh`);
       await this.contextManager.clearWorkerAnchor(ctxWindow.id, opts.workerName);
     } else if (existing && existing.agent !== opts.codingAgent) {
@@ -2572,7 +2596,7 @@ export class Codey {
 
     // Resume failed (CLI may have GC'd the session) — drop the anchor and
     // retry once with a full-history bootstrap so we recover transparently.
-    if (!response.success && prep.resumeSessionId) {
+    if (prep.resumeSessionId && isMissingSessionFailure(response)) {
       this.logger.warn(`[${agent}] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
       await this.contextManager.clearSessionAnchor(ctxWindow.id);
       prep = this.prepareAgentTurn(ctxWindow, agent, runPrompt, memoryContext);
@@ -5878,7 +5902,7 @@ Example: /model gpt-4.1 write a Python script`;
     const initialResume = prep.resumeSessionId;
     let response = await this.runWithFallback(agent, buildHttpRequest(prep));
 
-    if (!response.success && prep.resumeSessionId) {
+    if (prep.resumeSessionId && isMissingSessionFailure(response)) {
       this.logger.warn(`[${agent}] Resume of ${prep.resumeSessionId} failed; retrying with bootstrap`);
       await this.contextManager.clearSessionAnchor(ctxWindow.id);
       prep = this.prepareAgentTurn(ctxWindow, agent, prompt, memoryContext);
@@ -6679,9 +6703,9 @@ Example: /model gpt-4.1 write a Python script`;
           resumeSessionId,
           newSessionId,
         });
-        // If resume failed (stale session id on disk, or agent rejected it),
-        // drop the anchor and retry once with a full bootstrap prompt.
-        if (resumeSessionId && !response?.success && !abortController.signal.aborted) {
+        // If the CLI explicitly reports a stale session id, drop the anchor
+        // and retry once with a full bootstrap prompt.
+        if (resumeSessionId && response && isMissingSessionFailure(response) && !abortController.signal.aborted) {
           this.logger.warn(`[chat ${chatId}] resume of ${resumeSessionId} failed; bootstrapping`);
           this.chatManager.clearSessionAnchor(chatId, agent);
           streamedText = '';
@@ -6863,7 +6887,7 @@ Example: /model gpt-4.1 write a Python script`;
           // A fallback response belongs to the fallback adapter's emitted
           // session, never the primary adapter's resume/new session id.
           const anchorId = singleAgentResponse.fallback
-            ? (singleAgentResponse as any)?.sessionId
+            ? singleAgentResponse.startedSessionId ?? singleAgentResponse.sessionId
             : resumeSessionId ?? newSessionId ?? (singleAgentResponse as any)?.sessionId;
           if (anchorId) {
             this.chatManager.setSessionAnchor(chatId, {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -6389,7 +6389,7 @@ Example: /model gpt-4.1 write a Python script`;
     const selPrefix = assistantPrefixForSelection(chat);
     const canResume = !isTeamTurn;
     const warmAnchor = canResume
-      ? this.chatManager.getSessionAnchor(chatId, agent, model?.model)
+      ? this.chatManager.getSessionAnchor(chatId, agent)
       : undefined;
 
     let prompt: string;
@@ -6683,7 +6683,7 @@ Example: /model gpt-4.1 write a Python script`;
         // drop the anchor and retry once with a full bootstrap prompt.
         if (resumeSessionId && !response?.success && !abortController.signal.aborted) {
           this.logger.warn(`[chat ${chatId}] resume of ${resumeSessionId} failed; bootstrapping`);
-          this.chatManager.clearSessionAnchor(chatId, agent, model?.model);
+          this.chatManager.clearSessionAnchor(chatId, agent);
           streamedText = '';
           resumeSessionId = undefined;
           newSessionId = canResume && agent === 'claude-code' ? randomUUID() : undefined;


### PR DESCRIPTION
## Summary

- distinguish Codey execution-limit timeouts from retryable network failures
- wait for a timed-out Claude process to release its session lock, then continue with `--resume`
- cap timeout continuation at one extra execution window and isolate session state across fallback agents
- key persisted chat sessions by `chatId + agent`, so model changes reuse the same agent session
- migrate legacy per-model session anchors by keeping the most recently updated session
- add regression coverage for timeout classification, resume planning, retry limits, fallback isolation, model switching, and legacy session data

## Verification

- all 2,221 tests passed
- TypeScript type checks passed for core and gateway
- GitHub CI: `build & test (ubuntu)` passed
- `git diff --check` passed

## Notes

Uncommitted macOS and Voice changes in the shared checkout are not included.
