### PR TITLE
fix(codex): drop --cd when resuming a codex session

### DIFF
--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -140,7 +140,9 @@ export class CodexAdapter extends BaseAgentAdapter {
       if (request.model?.model) {
         args.push('--model', request.model.model);
       }
-      if (request.context?.workingDir) {
+      // `--cd` only exists on a fresh `codex exec`; `codex exec resume` rejects
+      // it. The spawn `cwd` below already puts the run in the right directory.
+      if (request.context?.workingDir && !request.resumeSessionId) {
         args.push('--cd', request.context.workingDir);
       }
       if (request.mcpServers && Object.keys(request.mcpServers).length > 0) {


### PR DESCRIPTION
`codex exec resume` does not accept `--cd` (only a fresh `codex exec` does). Every resumed codex turn therefore failed with:

```
error: unexpected argument '--cd' found
```

and the gateway fell back to another agent. Surfaced once chat-session resume landed in #428.

The flag was redundant anyway — the spawn `cwd` a few lines below already runs codex in the workspace directory, so this only skips `--cd` on the resume path.

Verified: `codex exec resume --help` on codex-cli 0.153.4 lists no `--cd`; core typechecks and builds.
Not verified: real-machine resumed codex turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)