### PR TITLE
feat(browser): bind each Chrome profile to one Codey profile

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Codey",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1+DxZ4LtqCNXKrmvuwl2d6perIWziIQWgkBVn5RbieIAF7g8knl39m3UOq/BZuSHp2VS1CQtk1EfwTzK0pnjdzikr00O+7iee4lVf8oduovxxi83CzRsZxzEreb3Jht3qfZcw3P94FwYk4wZM3YoRGJF99fWJQy/ybMvmIFSeFAHn9/3m56Xe5j0vCPSkmST1zLVuypW2DB23KojXxx4cKd9i+qcKnvfCEFwydjHRDpL4eUqk1nTU/NDlu3p0Fy5XQhvC6s98JBXXBEtD31l6oUq+wE1ap3yi1l3aK4I07bgWSdJSokwMZOJz22owdzaYra/c8loiVnx4efajwNbWwIDAQAB",
   "description": "Securely connects your existing Chrome tabs and signed-in sites to Codey.",
   "permissions": ["alarms", "cookies", "offscreen", "scripting", "sidePanel", "storage", "tabGroups", "tabs"],

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -125,7 +125,17 @@ async function voiceCommand(message) {
 }
 
 async function settings() {
-  return await chrome.storage.local.get({ endpoint: DEFAULT_ENDPOINT, token: '', clientName: 'Chrome' })
+  const saved = await chrome.storage.local.get({
+    endpoint: DEFAULT_ENDPOINT,
+    token: '',
+    tokenProfileId: '',
+    profileId: '',
+  })
+  if (!saved.profileId) {
+    saved.profileId = crypto.randomUUID()
+    await chrome.storage.local.set({ profileId: saved.profileId })
+  }
+  return saved
 }
 
 async function call(endpoint, path, options = {}) {
@@ -185,14 +195,19 @@ async function autoConnect() {
         extensionIdentity: true,
         discovery: true,
         body: secret
-          ? { clientName, nonce, proof: await hmacHex(secret, `codey-client:${nonce}`) }
-          : { clientName },
+          ? { profileId: current.profileId, clientName, nonce, proof: await hmacHex(secret, `codey-client:${nonce}`) }
+          : { profileId: current.profileId, clientName },
       })
       if (secret) {
         const expected = await hmacHex(secret, `codey-server:${nonce}:${value.token}`)
         if (value.serverProof !== expected) throw new Error('The endpoint could not prove it is Codey')
       }
-      await chrome.storage.local.set({ endpoint, token: value.token, lastError: '' })
+      await chrome.storage.local.set({
+        endpoint,
+        token: value.token,
+        tokenProfileId: current.profileId,
+        lastError: '',
+      })
       return { endpoint, token: value.token }
     } catch { /* Codey may be on the next port in the local discovery range. */ }
   }
@@ -922,8 +937,10 @@ chrome.cookies.onChanged.addListener(({ cookie }) => {
 })
 
 async function pollOnce() {
-  let { endpoint, token } = await settings()
-  if (!token) ({ endpoint, token } = await autoConnect())
+  let { endpoint, token, profileId, tokenProfileId } = await settings()
+  // A token created before per-profile identity existed belongs to the legacy
+  // slot. Re-pair once so this Chrome profile can be bound and routed.
+  if (!token || tokenProfileId !== profileId) ({ endpoint, token } = await autoConnect())
   const body = { version: ownVersion() }
   let response
   try {

--- a/codey-mac/electron/browser-agent-bridge.test.ts
+++ b/codey-mac/electron/browser-agent-bridge.test.ts
@@ -94,15 +94,15 @@ describe('BrowserAgentBridge', () => {
       listProfiles: vi.fn(async () => []),
       activeProfileName: vi.fn(() => null),
       saveProfile: vi.fn(async name => ({
-        name, active: false, autoSync: false, excludedSites: [], cookieCount: 0, originCount: 0,
+        name, active: false, autoSync: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0,
         createdAt: 1, updatedAt: 1, sourceUrl: null,
       })),
       importProfile: vi.fn(async name => ({
-        name, active: false, autoSync: false, excludedSites: [], cookieCount: 0, originCount: 0,
+        name, active: false, autoSync: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0,
         createdAt: 1, updatedAt: 1, sourceUrl: null,
       })),
       setDefaultProfile: vi.fn(async (name: string | null) => name === null ? null : ({
-        name, active: true, autoSync: false, excludedSites: [], cookieCount: 0, originCount: 0, createdAt: 1, updatedAt: 1, sourceUrl: null,
+        name, active: true, autoSync: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0, createdAt: 1, updatedAt: 1, sourceUrl: null,
       })),
       deleteProfile: vi.fn(async () => ({ deleted: true })),
       exportProfile: vi.fn(async () => ({ path: '/tmp/exported.json' })),

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -13,6 +13,7 @@ import {
   assertProfileName,
   BrowserProfileStore,
   DEFAULT_BROWSER_PARTITION,
+  availableProfileName,
   parseProfileJsonText,
   profilePartition,
   siteCoversHost,
@@ -1150,6 +1151,8 @@ export class BrowserController {
         avatar: profile.avatar ?? null,
         autoSync: profile.autoSync === true,
         excludedSites: profile.excludedSites,
+        chromeProfileId: profile.chromeProfileId,
+        chromeProfileLabel: profile.chromeProfileLabel,
         createdAt: profile.createdAt,
         updatedAt: profile.updatedAt,
         cookieCount: 0,
@@ -1204,6 +1207,32 @@ export class BrowserController {
   /** Replace the sites this profile excludes from automatic Chrome refresh. */
   setProfileExcludedSites(name: string, sites: readonly string[]): BrowserProfileSummary {
     return this.profiles().setExcludedSites(name, sites)
+  }
+
+  setProfileChromeBinding(name: string, profileId: string | null, label: string | null): BrowserProfileSummary {
+    return this.profiles().setChromeBinding(name, profileId, label)
+  }
+
+  profileForChrome(profileId: string | null): BrowserProfileSummary | null {
+    return this.profiles().profileForChrome(profileId)
+  }
+
+  chromeBindingForProfile(name: string): { profileId: string; label: string } | null {
+    const profile = this.profiles().read(name)
+    if (!profile.chromeProfileId) return null
+    return { profileId: profile.chromeProfileId, label: profile.chromeProfileLabel || 'Chrome profile' }
+  }
+
+  /** Create and bind the first Codey jar for a newly seen Chrome profile. */
+  ensureProfileForChrome(profileId: string, label: string): BrowserProfileSummary {
+    const existing = this.profiles().profileForChrome(profileId)
+    if (existing) return existing
+    const taken = this.profiles().list().map(profile => profile.name)
+    const seed = label.trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^\.+|\.+$/g, '') || 'Chrome-profile'
+    const name = availableProfileName(seed.slice(0, 64), taken)
+    this.profiles().writeMeta(name, null)
+    this.profiles().setAutoSync(name, true)
+    return this.profiles().setChromeBinding(name, profileId, label)
   }
 
   /** Remove a profile: its metadata record and its whole storage jar. Tabs

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -194,6 +194,28 @@ describe('BrowserProfileStore', () => {
     }
   })
 
+  it('keeps Chrome bindings one-to-one and preserves them across metadata writes', () => {
+    const { dir, store } = makeStore()
+    try {
+      store.writeMeta('work', null)
+      store.writeMeta('personal', null)
+      expect(store.setChromeBinding('work', 'chrome-a', 'Work Chrome')).toMatchObject({
+        chromeProfileId: 'chrome-a', chromeProfileLabel: 'Work Chrome',
+      })
+      store.writeMeta('work', null)
+      expect(store.read('work')).toMatchObject({ chromeProfileId: 'chrome-a', chromeProfileLabel: 'Work Chrome' })
+
+      store.setChromeBinding('personal', 'chrome-a', 'Renamed Chrome')
+      expect(store.read('work')).toMatchObject({ chromeProfileId: null, chromeProfileLabel: null })
+      expect(store.profileForChrome('chrome-a')?.name).toBe('personal')
+
+      store.setChromeBinding('personal', null, null)
+      expect(store.profileForChrome('chrome-a')).toBeNull()
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('safely normalizes exclusions read from existing schema-2 metadata', () => {
     const { dir, store } = makeStore()
     try {

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -63,6 +63,12 @@ export interface BrowserProfileMeta {
   autoSync?: boolean
   /** Chrome sites this profile must never refresh from automatically. */
   excludedSites: string[]
+  /** The Chrome profile this one mirrors, as reported by the extension. The
+   *  relationship is one-to-one: no two profiles may name the same Chrome. */
+  chromeProfileId: string | null
+  /** That Chrome profile's display name, cached so the binding still reads as
+   *  something human when Chrome is not running. */
+  chromeProfileLabel: string | null
   /** Origins whose localStorage belongs to this partition. Electron exposes
    *  no API for enumerating them, so this index lets exports read origins
    *  again after their tabs have closed. Empty storage is indexed too. */
@@ -77,6 +83,8 @@ export interface BrowserProfileSummary {
   avatar?: string | null
   autoSync: boolean
   excludedSites: string[]
+  chromeProfileId: string | null
+  chromeProfileLabel: string | null
   createdAt: number
   updatedAt: number
   cookieCount: number
@@ -312,6 +320,14 @@ function normalizeExcludedSites(value: unknown): string[] {
   return sites
 }
 
+/** A Chrome profile ID as the extension reports it: an opaque UUID. Kept
+ *  forgiving on read so a hand-edited file cannot break the whole listing. */
+function normalizeChromeProfileId(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const id = value.trim().slice(0, 100)
+  return id || null
+}
+
 function normalizeKnownOrigins(value: unknown): string[] {
   if (!Array.isArray(value)) return []
   const origins: string[] = []
@@ -410,6 +426,8 @@ export class BrowserProfileStore {
       avatar: meta?.avatar ?? null,
       autoSync: meta?.autoSync === true,
       excludedSites: meta?.excludedSites ?? [],
+      chromeProfileId: meta?.chromeProfileId ?? null,
+      chromeProfileLabel: meta?.chromeProfileLabel ?? null,
       createdAt: meta?.createdAt ?? 0,
       updatedAt: meta?.updatedAt ?? 0,
       cookieCount: 0,
@@ -436,6 +454,10 @@ export class BrowserProfileStore {
         : null,
       autoSync: record.autoSync === true,
       excludedSites: normalizeExcludedSites(record.excludedSites),
+      chromeProfileId: normalizeChromeProfileId(record.chromeProfileId),
+      chromeProfileLabel: typeof record.chromeProfileLabel === 'string' && record.chromeProfileLabel.trim()
+        ? record.chromeProfileLabel.trim().slice(0, 80)
+        : null,
       knownOrigins: normalizeKnownOrigins(record.knownOrigins),
       createdAt: typeof record.createdAt === 'number' ? record.createdAt : 0,
       updatedAt: typeof record.updatedAt === 'number' ? record.updatedAt : 0,
@@ -459,6 +481,8 @@ export class BrowserProfileStore {
       avatar: existing?.avatar ?? null,
       autoSync: existing?.autoSync === true,
       excludedSites: existing?.excludedSites ?? [],
+      chromeProfileId: existing?.chromeProfileId ?? null,
+      chromeProfileLabel: existing?.chromeProfileLabel ?? null,
       knownOrigins: existing?.knownOrigins ?? [],
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
@@ -575,6 +599,45 @@ export class BrowserProfileStore {
       excludedSites: normalizeExcludedSites(sites),
     })
     return this.summary(name, this.activeNames())
+  }
+
+  /** Bind one Codey jar to one Chrome profile. Both sides are unique: moving a
+   * Chrome profile to a new jar clears its former owner in the same operation. */
+  setChromeBinding(name: string, profileId: string | null, label: string | null): BrowserProfileSummary {
+    assertProfileName(name)
+    const target = this.read(name)
+    const normalizedId = normalizeChromeProfileId(profileId)
+    const normalizedLabel = normalizedId && typeof label === 'string' && label.trim()
+      ? label.trim().slice(0, 80)
+      : null
+
+    if (normalizedId) {
+      for (const profile of this.list()) {
+        if (profile.name === name || profile.chromeProfileId !== normalizedId) continue
+        const previous = this.read(profile.name)
+        this.writeRecord(profile.name, {
+          ...previous,
+          schema: PROFILE_SCHEMA,
+          chromeProfileId: null,
+          chromeProfileLabel: null,
+        })
+      }
+    }
+
+    this.writeRecord(name, {
+      ...target,
+      schema: PROFILE_SCHEMA,
+      chromeProfileId: normalizedId,
+      chromeProfileLabel: normalizedLabel,
+    })
+    return this.summary(name, this.activeNames())
+  }
+
+  /** The Codey profile currently owning a Chrome profile ID, if any. */
+  profileForChrome(profileId: string | null): BrowserProfileSummary | null {
+    const normalizedId = normalizeChromeProfileId(profileId)
+    if (!normalizedId) return null
+    return this.list().find(profile => profile.chromeProfileId === normalizedId) ?? null
   }
 
   remove(name: string): void {

--- a/codey-mac/electron/chrome-companion.test.ts
+++ b/codey-mac/electron/chrome-companion.test.ts
@@ -35,7 +35,7 @@ async function setup(
   return { bridge, endpoint: status.endpoint!, stateFile }
 }
 
-async function connect(endpoint: string): Promise<string> {
+async function connect(endpoint: string, profileId?: string): Promise<string> {
   const response = await fetch(`${endpoint}/v1/connect`, {
     method: 'POST',
     headers: {
@@ -43,7 +43,7 @@ async function connect(endpoint: string): Promise<string> {
       Origin: `chrome-extension://${CHROME_COMPANION_EXTENSION_ID}`,
       'X-Codey-Extension-Id': CHROME_COMPANION_EXTENSION_ID,
     },
-    body: JSON.stringify({ clientName: 'Test Chrome' }),
+    body: JSON.stringify({ clientName: 'Test Chrome', ...(profileId ? { profileId } : {}) }),
   })
   const value = await response.json() as { ok: boolean; token: string }
   expect(response.status).toBe(200)
@@ -59,7 +59,7 @@ describe('ChromeCompanionBridge', () => {
     expect(bridge.status()).toMatchObject({ paired: true, connected: true, clientName: 'Test Chrome' })
 
     const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'))
-    expect(state.token).toBe(token)
+    expect(state.clients).toEqual([expect.objectContaining({ token, profileId: null })])
 
     const disconnected = await fetch(`${endpoint}/v1/disconnect`, {
       method: 'POST',
@@ -185,7 +185,7 @@ describe('ChromeCompanionBridge', () => {
       excludedDomains: () => ['bank.example'],
       revision: () => 7,
       onPoll: () => { polls += 1 },
-      onSessionChanged: domains => reported.push(domains),
+      onSessionChanged: (_profileId, domains) => reported.push(domains),
     })
     await expect(poll()).resolves.toMatchObject({
       watchDomains: ['*'], excludedDomains: ['bank.example'], syncRevision: 7,
@@ -221,7 +221,7 @@ describe('ChromeCompanionBridge', () => {
       onConnected: reconnected,
       onSessionChanged: () => {},
     })
-    ;(bridge as any).lastSeenAt = Date.now() - 60_000
+    ;[...(bridge as any).clientsByKey.values()][0].lastSeenAt = Date.now() - 60_000
 
     await fetch(`${endpoint}/v1/poll`, {
       method: 'POST',
@@ -243,6 +243,40 @@ describe('ChromeCompanionBridge', () => {
     await connect(endpoint)
 
     await vi.waitFor(() => expect(connected).toHaveBeenCalledOnce())
+  })
+
+  it('keeps two Chrome profiles connected and isolates their command queues and results', async () => {
+    const { bridge, endpoint } = await setup()
+    const tokenA = await connect(endpoint, 'chrome-a')
+    const tokenB = await connect(endpoint, 'chrome-b')
+    expect(bridge.clients()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ profileId: 'chrome-a', connected: true }),
+      expect.objectContaining({ profileId: 'chrome-b', connected: true }),
+    ]))
+
+    const commandA = bridge.activeTab('chrome-a')
+    const poll = async (token: string) => fetch(`${endpoint}/v1/poll`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: '{}',
+    }).then(response => response.json() as Promise<{ command: { id: string; command: string } | null }>)
+    expect((await poll(tokenB)).command).toBeNull()
+    const workA = await poll(tokenA)
+    expect(workA.command?.command).toBe('activeTab')
+
+    const wrong = await fetch(`${endpoint}/v1/result`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${tokenB}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: workA.command?.id, ok: true, data: { id: 2 } }),
+    })
+    expect(wrong.status).toBe(404)
+    const right = await fetch(`${endpoint}/v1/result`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${tokenA}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: workA.command?.id, ok: true, data: { id: 1 } }),
+    })
+    expect(right.status).toBe(200)
+    await expect(commandA).resolves.toMatchObject({ id: 1 })
   })
 
   it('lists Chrome\'s signed-in sites and exports only the ones picked', async () => {

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -36,6 +36,22 @@ export interface ChromeCompanionStatus {
   updateAvailable: boolean
 }
 
+/** One paired Chrome profile. The extension's `chrome.storage.local` is scoped
+ *  to a Chrome profile, so `profileId` is stable per profile and unique across
+ *  them. `null` is a pairing made by an extension too old to report one; it
+ *  keeps working until that extension reconnects with an ID. */
+export interface ChromeClientInfo {
+  profileId: string | null
+  /** Codey-assigned display name ("Chrome profile 1"), renameable by the user. */
+  label: string
+  /** What the extension called itself, e.g. "Chrome 140.0.1234.56". */
+  clientName: string
+  clientVersion: string | null
+  pairedAt: number
+  lastSeenAt: number | null
+  connected: boolean
+}
+
 export interface ChromeTabInfo {
   id: number
   windowId: number
@@ -144,9 +160,11 @@ export interface ChromeCompanionFeatures {
    * Copy the current Chrome tab's signed-in session into a Codey Browser
    * profile. Without a name Codey picks a free one derived from the site, so
    * the one-click path never fails merely because the obvious name is taken;
-   * a name the user typed is used as-is and collides loudly.
+   * a name the user typed is used as-is and collides loudly. `profileId` is the
+   * Chrome profile that asked, so the session comes out of that Chrome and not
+   * out of whichever one happens to be active in Codey.
    */
-  handoffSession: (name?: string) => Promise<ChromeSessionHandoff>
+  handoffSession: (name: string | undefined, profileId: string | null) => Promise<ChromeSessionHandoff>
   /**
    * The name the handoff would use for `hostname` if the user just accepts it,
    * plus the profiles that already hold this site's session - the side panel
@@ -156,10 +174,11 @@ export interface ChromeCompanionFeatures {
   /**
    * What the Codey Browser's profiles look like right now, for the side
    * panel's one-line status: which are in use, which mirror Chrome, and which
-   * hold `hostname`. Names and flags only - never session contents.
+   * hold `hostname`. `linked` marks the profile bound to the Chrome profile
+   * that asked. Names and flags only - never session contents.
    */
-  profilesOverview: (hostname?: string) => Promise<{
-    profiles: Array<{ name: string; active: boolean; autoSync: boolean; holdsSite: boolean }>
+  profilesOverview: (hostname: string | undefined, profileId: string | null) => Promise<{
+    profiles: Array<{ name: string; active: boolean; autoSync: boolean; holdsSite: boolean; linked: boolean }>
   }>
 }
 
@@ -173,14 +192,18 @@ export interface ChromeSessionHandoff {
  *  which cookie domains the extension should report changes for (null while
  *  the feature is off), and `onSessionChanged` receives the domains a change
  *  burst actually touched. Notification only - no cookie values travel this
- *  way; Codey pulls a fresh export through the normal command channel. */
+ *  way; Codey pulls a fresh export through the normal command channel.
+ *
+ *  Every hook is per Chrome profile: a watch list describes the one Codey
+ *  profile bound to that Chrome, and a change burst may only write that one.
+ *  `profileId` is null for a legacy pairing, which is bound to nothing. */
 export interface ChromeAutoSyncHooks {
-  watchDomains: () => string[] | null
-  excludedDomains?: () => string[]
-  revision?: () => number
-  onPoll?: () => void
-  onConnected?: () => void
-  onSessionChanged: (domains: string[]) => void
+  watchDomains: (profileId: string | null) => string[] | null
+  excludedDomains?: (profileId: string | null) => string[]
+  revision?: (profileId: string | null) => number
+  onPoll?: (profileId: string | null) => void
+  onConnected?: (profileId: string | null) => void
+  onSessionChanged: (profileId: string | null, domains: string[]) => void
 }
 
 export interface ChromeCompanionChatHistory {
@@ -202,11 +225,34 @@ type PendingCommand = {
   timer: NodeJS.Timeout
 }
 
-type PersistedPairing = {
+/** A paired Chrome profile's live state. Queue, pending map and heartbeat are
+ *  per client so one Chrome can neither read nor stall another's work. */
+type ChromeClient = {
+  profileId: string | null
+  label: string
+  token: string
+  clientName: string
+  clientVersion: string | null
+  pairedAt: number
+  lastSeenAt: number | null
+  queue: PendingCommand[]
+  pending: Map<string, PendingCommand>
+  uploadedAttachments: Map<string, { chatId: string; attachment: ChromeCompanionAttachment }>
+}
+
+type PersistedClient = {
+  profileId: string | null
+  label: string
   token: string
   clientName: string
   pairedAt: number
 }
+
+type PersistedState = { clients: PersistedClient[] }
+
+/** Map key for a pairing from an extension that reports no profile ID. Only one
+ *  can exist: such an extension cannot be told apart from another like it. */
+const LEGACY_CLIENT_KEY = 'legacy:unidentified-chrome'
 
 /** Fallback accent (Classic palette blue) until the renderer reports its theme. */
 const DEFAULT_ACCENT = '#3377d5'
@@ -230,19 +276,17 @@ function timingSafeEqual(left: string, right: string): boolean {
 export class ChromeCompanionBridge {
   private server: http.Server | null = null
   private endpoint: string | null = null
-  private token: string | null = null
-  private clientName: string | null = null
-  private pairedAt: number | null = null
-  private lastSeenAt: number | null = null
-  private queue: PendingCommand[] = []
+  /** Paired Chrome profiles, keyed by their reported profile ID. */
+  private clientsByKey = new Map<string, ChromeClient>()
   // The Mac app's current accent color, mirrored to the extension so the
   // controlled-tab highlight matches whatever palette the user picked.
   private accent = DEFAULT_ACCENT
-  private clientVersion: string | null = null
   private expectedVersion: string | null = null
-  private pending = new Map<string, PendingCommand>()
-  private uploadedAttachments = new Map<string, { chatId: string; attachment: ChromeCompanionAttachment }>()
   private autoSync: ChromeAutoSyncHooks | null = null
+  /** Resolves which Chrome profile a Codey-initiated command belongs to, set by
+   *  the app once bindings are known. Throws a named error when the active Codey
+   *  profile is bound to nothing, or to a Chrome that is not running. */
+  private targetResolver: (() => string | null) | null = null
 
   constructor(
     private readonly stateFile: string,
@@ -261,26 +305,121 @@ export class ChromeCompanionBridge {
     this.loadPairing()
   }
 
+  /** Load pairings. A file still holding the pre-binding single-record shape
+   *  reads back as one legacy client, so an extension that has not been
+   *  upgraded yet stays authorized instead of being silently logged out. */
   private loadPairing(): void {
+    let parsed: unknown
     try {
-      const value = JSON.parse(fs.readFileSync(this.stateFile, 'utf8')) as Partial<PersistedPairing>
-      if (typeof value.token !== 'string' || value.token.length < 32) return
-      this.token = value.token
-      this.clientName = typeof value.clientName === 'string' ? value.clientName : 'Chrome'
-      this.pairedAt = typeof value.pairedAt === 'number' ? value.pairedAt : Date.now()
-    } catch { /* first run or damaged state starts unpaired */ }
+      parsed = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'))
+    } catch { return /* first run or damaged state starts unpaired */ }
+    if (!parsed || typeof parsed !== 'object') return
+    const record = parsed as Record<string, unknown>
+    const rows: unknown[] = Array.isArray(record.clients) ? record.clients : [record]
+    for (const row of rows) {
+      if (!row || typeof row !== 'object') continue
+      const value = row as Record<string, unknown>
+      if (typeof value.token !== 'string' || value.token.length < 32) continue
+      const profileId = typeof value.profileId === 'string' && value.profileId.trim()
+        ? value.profileId.trim().slice(0, 100)
+        : null
+      const key = profileId ?? LEGACY_CLIENT_KEY
+      if (this.clientsByKey.has(key)) continue
+      this.clientsByKey.set(key, {
+        profileId,
+        label: typeof value.label === 'string' && value.label.trim()
+          ? value.label.trim().slice(0, 80)
+          : `Chrome profile ${this.clientsByKey.size + 1}`,
+        token: value.token,
+        clientName: typeof value.clientName === 'string' ? value.clientName : 'Chrome',
+        clientVersion: null,
+        pairedAt: typeof value.pairedAt === 'number' ? value.pairedAt : Date.now(),
+        lastSeenAt: null,
+        queue: [],
+        pending: new Map(),
+        uploadedAttachments: new Map(),
+      })
+    }
   }
 
   private persistPairing(): void {
-    if (!this.token || !this.clientName || !this.pairedAt) return
     fs.mkdirSync(path.dirname(this.stateFile), { recursive: true })
+    const state: PersistedState = {
+      clients: [...this.clientsByKey.values()].map(client => ({
+        profileId: client.profileId,
+        label: client.label,
+        token: client.token,
+        clientName: client.clientName,
+        pairedAt: client.pairedAt,
+      })),
+    }
     const temporary = `${this.stateFile}.${process.pid}.tmp`
-    fs.writeFileSync(temporary, JSON.stringify({
-      token: this.token,
-      clientName: this.clientName,
-      pairedAt: this.pairedAt,
-    } satisfies PersistedPairing, null, 2), { encoding: 'utf8', mode: 0o600 })
+    fs.writeFileSync(temporary, JSON.stringify(state, null, 2), { encoding: 'utf8', mode: 0o600 })
     fs.renameSync(temporary, this.stateFile)
+  }
+
+  /** "Chrome profile <n>" for a newly seen Chrome. Numbered past the highest
+   *  one already in use so deleting a pairing cannot produce two of a name. */
+  private nextLabel(): string {
+    let highest = 0
+    for (const client of this.clientsByKey.values()) {
+      const match = /^Chrome profile (\d+)$/.exec(client.label)
+      if (match) highest = Math.max(highest, Number(match[1]))
+    }
+    return `Chrome profile ${Math.max(highest + 1, this.clientsByKey.size + 1)}`
+  }
+
+  private isConnected(client: ChromeClient): boolean {
+    return !!client.lastSeenAt && Date.now() - client.lastSeenAt < CONNECTED_TTL_MS
+  }
+
+  /** The client a single-target status line should describe: the one most
+   *  recently heard from, so a connected Chrome is never hidden behind a stale
+   *  pairing that happens to sort first. */
+  private primary(): ChromeClient | null {
+    let best: ChromeClient | null = null
+    for (const client of this.clientsByKey.values()) {
+      if (!best
+        || (client.lastSeenAt ?? 0) > (best.lastSeenAt ?? 0)
+        || ((client.lastSeenAt ?? 0) === (best.lastSeenAt ?? 0) && client.pairedAt > best.pairedAt)) {
+        best = client
+      }
+    }
+    return best
+  }
+
+  /** Every paired Chrome profile, most recently seen first. */
+  clients(): ChromeClientInfo[] {
+    return [...this.clientsByKey.values()]
+      .map(client => ({
+        profileId: client.profileId,
+        label: client.label,
+        clientName: client.clientName,
+        clientVersion: client.clientVersion,
+        pairedAt: client.pairedAt,
+        lastSeenAt: client.lastSeenAt,
+        connected: this.isConnected(client),
+      }))
+      .sort((left, right) => (right.lastSeenAt ?? 0) - (left.lastSeenAt ?? 0) || left.pairedAt - right.pairedAt)
+  }
+
+  /** Rename a Chrome profile as shown in Codey. Display only - the binding and
+   *  the token are keyed by the ID the extension reports. */
+  renameClient(profileId: string, label: string): ChromeClientInfo[] {
+    const client = this.clientsByKey.get(String(profileId || ''))
+    if (!client) throw new Error('That Chrome profile is not paired with Codey')
+    const next = String(label || '').trim().slice(0, 80)
+    if (!next) throw new Error('Enter a name for this Chrome profile')
+    client.label = next
+    this.persistPairing()
+    this.emitStatus()
+    return this.clients()
+  }
+
+  /** Tell the bridge how to pick the Chrome a Codey-initiated command targets.
+   *  Without one, a sole paired Chrome is used and anything else is an error. */
+  setTargetResolver(resolve: (() => string | null) | null): void {
+    this.targetResolver = resolve
   }
 
   private emitStatus(): void {
@@ -295,17 +434,23 @@ export class ChromeCompanionBridge {
     this.accent = HEX_COLOR.test(hex) ? hex.toLowerCase() : DEFAULT_ACCENT
   }
 
+  /** A one-line summary across every pairing, for the callers that only ever
+   *  asked "is Chrome there?". Per-profile detail lives in `clients()`. */
   status(): ChromeCompanionStatus {
+    const primary = this.primary()
+    const connected = [...this.clientsByKey.values()].some(client => this.isConnected(client))
+    const stale = [...this.clientsByKey.values()].some(client =>
+      !!client.clientVersion && !!this.expectedVersion && client.clientVersion !== this.expectedVersion)
     return {
       endpoint: this.endpoint,
-      paired: !!this.token,
-      connected: !!this.token && !!this.lastSeenAt && Date.now() - this.lastSeenAt < CONNECTED_TTL_MS,
-      clientName: this.clientName,
-      pairedAt: this.pairedAt,
-      lastSeenAt: this.lastSeenAt,
-      clientVersion: this.clientVersion,
+      paired: this.clientsByKey.size > 0,
+      connected,
+      clientName: primary?.clientName ?? null,
+      pairedAt: primary?.pairedAt ?? null,
+      lastSeenAt: primary?.lastSeenAt ?? null,
+      clientVersion: primary?.clientVersion ?? null,
       expectedVersion: this.expectedVersion,
-      updateAvailable: !!this.clientVersion && !!this.expectedVersion && this.clientVersion !== this.expectedVersion,
+      updateAvailable: stale,
     }
   }
 
@@ -318,14 +463,28 @@ export class ChromeCompanionBridge {
     this.emitStatus()
   }
 
-  disconnect(): ChromeCompanionStatus {
-    this.clientVersion = null
-    this.token = null
-    this.clientName = null
-    this.pairedAt = null
-    this.lastSeenAt = null
-    try { fs.unlinkSync(this.stateFile) } catch { /* already absent */ }
-    this.rejectAll(new Error('Chrome companion was disconnected'))
+  /** Drop one Chrome profile's pairing, or every one of them when no ID is
+   *  given. Dropping one leaves the others authorized and mid-command. */
+  disconnect(profileId?: string | null): ChromeCompanionStatus {
+    if (profileId === undefined || profileId === null) {
+      for (const client of this.clientsByKey.values()) {
+        this.rejectClient(client, new Error('Chrome companion was disconnected'))
+      }
+      this.clientsByKey.clear()
+      try { fs.unlinkSync(this.stateFile) } catch { /* already absent */ }
+    } else {
+      const key = String(profileId)
+      const client = this.clientsByKey.get(key)
+      if (client) {
+        this.rejectClient(client, new Error(`${client.label} was disconnected`))
+        this.clientsByKey.delete(key)
+      }
+      if (this.clientsByKey.size === 0) {
+        try { fs.unlinkSync(this.stateFile) } catch { /* already absent */ }
+      } else {
+        this.persistPairing()
+      }
+    }
     this.emitStatus()
     return this.status()
   }
@@ -366,21 +525,23 @@ export class ChromeCompanionBridge {
     const server = this.server
     this.server = null
     this.endpoint = null
-    this.rejectAll(new Error('Chrome companion bridge stopped'))
+    for (const client of this.clientsByKey.values()) {
+      this.rejectClient(client, new Error('Chrome companion bridge stopped'))
+    }
     if (!server) return
     await new Promise<void>(resolve => server.close(() => resolve()))
   }
 
-  async activeTab(): Promise<ChromeTabInfo> {
-    return await this.command<ChromeTabInfo>('activeTab', {})
+  async activeTab(profileId?: string | null): Promise<ChromeTabInfo> {
+    return await this.command<ChromeTabInfo>('activeTab', {}, COMMAND_TIMEOUT_MS, profileId)
   }
 
-  async snapshot(): Promise<ChromePageSnapshot> {
-    return await this.command<ChromePageSnapshot>('snapshot', {})
+  async snapshot(profileId?: string | null): Promise<ChromePageSnapshot> {
+    return await this.command<ChromePageSnapshot>('snapshot', {}, COMMAND_TIMEOUT_MS, profileId)
   }
 
-  async exportSession(): Promise<ChromeSessionExport> {
-    return await this.command<ChromeSessionExport>('exportSession', {})
+  async exportSession(profileId?: string | null): Promise<ChromeSessionExport> {
+    return await this.command<ChromeSessionExport>('exportSession', {}, COMMAND_TIMEOUT_MS, profileId)
   }
 
   /** Turn change-driven syncing on (or off with null). Takes effect on the
@@ -390,8 +551,8 @@ export class ChromeCompanionBridge {
   }
 
   /** Every site this Chrome profile has cookies for or currently has open. */
-  async listSessionSites(): Promise<{ sites: ChromeSessionSite[] }> {
-    return await this.command<{ sites: ChromeSessionSite[] }>('listSessionSites', {})
+  async listSessionSites(profileId?: string | null): Promise<{ sites: ChromeSessionSite[] }> {
+    return await this.command<{ sites: ChromeSessionSite[] }>('listSessionSites', {}, COMMAND_TIMEOUT_MS, profileId)
   }
 
   /**
@@ -401,11 +562,12 @@ export class ChromeCompanionBridge {
    * sites that have no tab, which is the only way to reach their localStorage.
    * It costs real navigations, so it is never assumed.
    */
-  async exportSessionForSites(sites: string[], openMissing = false): Promise<ChromeSitesSessionExport> {
+  async exportSessionForSites(sites: string[], openMissing = false, profileId?: string | null): Promise<ChromeSitesSessionExport> {
     return await this.command<ChromeSitesSessionExport>(
       'exportSessionForSites',
       { sites, openMissing },
       openMissing ? STORAGE_VISIT_TIMEOUT_MS : COMMAND_TIMEOUT_MS,
+      profileId,
     )
   }
 
@@ -414,7 +576,7 @@ export class ChromeCompanionBridge {
    * renumbered by every snapshot, so a stale one is rejected by the extension
    * rather than applied to whatever element inherited the number.
    */
-  async act(action: ChromePageActionName, ref: string, value?: string): Promise<ChromePageAction> {
+  async act(action: ChromePageActionName, ref: string, value?: string, profileId?: string | null): Promise<ChromePageAction> {
     if (!/^e\d+$/.test(ref)) throw new Error(`Invalid element ref: ${ref || '(empty)'}. Run "chrome view" first.`)
     if ((action === 'fill' || action === 'select' || action === 'press') && value === undefined) {
       throw new Error(`Chrome ${action} needs a value`)
@@ -422,30 +584,56 @@ export class ChromeCompanionBridge {
     const input: Record<string, unknown> = { ref }
     if (action === 'check') input.value = value !== 'false'
     else if (value !== undefined) input.value = value
-    return await this.command<ChromePageAction>(action, input)
+    return await this.command<ChromePageAction>(action, input, COMMAND_TIMEOUT_MS, profileId)
   }
 
-  async navigate(url: string): Promise<ChromeTabInfo> {
+  async navigate(url: string, profileId?: string | null): Promise<ChromeTabInfo> {
     let parsed: URL
     try { parsed = new URL(url) } catch { throw new Error('Enter a valid http(s) URL') }
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') throw new Error('Only http(s) URLs are allowed')
-    return await this.command<ChromeTabInfo>('navigate', { url: parsed.toString() })
+    return await this.command<ChromeTabInfo>('navigate', { url: parsed.toString() }, COMMAND_TIMEOUT_MS, profileId)
   }
 
   /** An extension too old to know a command reports it as unsupported, which
    *  reads like a Codey bug. Say what actually needs to happen instead. */
-  private explain(error: string): string {
+  private explain(client: ChromeClient, error: string): string {
     if (!error) return 'Chrome command failed'
     if (!/Unsupported Codey command/i.test(error)) return error
-    const versions = this.clientVersion && this.expectedVersion
-      ? ` Chrome is running ${this.clientVersion}; ${this.expectedVersion} is already installed on disk.`
+    const versions = client.clientVersion && this.expectedVersion
+      ? ` Chrome is running ${client.clientVersion}; ${this.expectedVersion} is already installed on disk.`
       : ''
     return `Reload the Codey extension at chrome://extensions to finish updating it.${versions}`
   }
 
-  private async command<T>(command: string, input: unknown, timeoutMs = COMMAND_TIMEOUT_MS): Promise<T> {
-    if (!this.token) throw new Error('Install the Chrome companion and keep Codey running')
-    if (!this.status().connected) throw new Error('Chrome companion is paired but not connected')
+  /**
+   * Which Chrome a Codey-initiated command goes to. An explicit ID wins; past
+   * that the app's resolver decides from the active Codey profile's binding,
+   * and with no resolver a sole pairing is the only unambiguous answer.
+   */
+  private target(profileId?: string | null): ChromeClient {
+    if (profileId !== undefined && profileId !== null) {
+      const client = this.clientsByKey.get(String(profileId))
+      if (!client) throw new Error('That Chrome profile is not paired with Codey')
+      if (!this.isConnected(client)) throw new Error(`${client.label} is paired but not running`)
+      return client
+    }
+    if (profileId === undefined && this.targetResolver) {
+      return this.target(this.targetResolver())
+    }
+    if (this.clientsByKey.size === 0) throw new Error('Install the Chrome companion and keep Codey running')
+    const connected = [...this.clientsByKey.values()].filter(client => this.isConnected(client))
+    if (connected.length === 1) return connected[0]
+    if (connected.length === 0) throw new Error('Chrome companion is paired but not connected')
+    throw new Error('Several Chrome profiles are connected - link the active Codey profile to one of them in Browser settings')
+  }
+
+  private async command<T>(
+    command: string,
+    input: unknown,
+    timeoutMs = COMMAND_TIMEOUT_MS,
+    profileId?: string | null,
+  ): Promise<T> {
+    const client = this.target(profileId)
     return await new Promise<T>((resolve, reject) => {
       const id = crypto.randomUUID()
       const item: PendingCommand = {
@@ -455,29 +643,37 @@ export class ChromeCompanionBridge {
         resolve: value => resolve(value as T),
         reject,
         timer: setTimeout(() => {
-          this.pending.delete(id)
-          this.queue = this.queue.filter(entry => entry.id !== id)
+          client.pending.delete(id)
+          client.queue = client.queue.filter(entry => entry.id !== id)
           reject(new Error(`Chrome command timed out: ${command}`))
         }, timeoutMs),
       }
-      this.queue.push(item)
-      this.pending.set(id, item)
+      client.queue.push(item)
+      client.pending.set(id, item)
     })
   }
 
-  private rejectAll(error: Error): void {
-    for (const item of this.pending.values()) {
+  /** Fail one client's in-flight work, leaving every other client alone. */
+  private rejectClient(client: ChromeClient, error: Error): void {
+    for (const item of client.pending.values()) {
       clearTimeout(item.timer)
       item.reject(error)
     }
-    this.pending.clear()
-    this.queue = []
+    client.pending.clear()
+    client.queue = []
   }
 
-  private authorize(request: http.IncomingMessage): boolean {
+  /** Resolve the bearer token to the Chrome profile that holds it. Every
+   *  authenticated route then operates on that client alone, so one Chrome's
+   *  token reaches neither another's command queue nor another's cookies. */
+  private authorize(request: http.IncomingMessage): ChromeClient | null {
     const header = request.headers.authorization
     const supplied = typeof header === 'string' && header.startsWith('Bearer ') ? header.slice(7) : ''
-    return !!this.token && timingSafeEqual(supplied, this.token)
+    if (!supplied) return null
+    for (const client of this.clientsByKey.values()) {
+      if (timingSafeEqual(supplied, client.token)) return client
+    }
+    return null
   }
 
   private headers(request: http.IncomingMessage, response: http.ServerResponse, status = 200): void {
@@ -510,16 +706,16 @@ export class ChromeCompanionBridge {
     return value as Record<string, unknown>
   }
 
-  private touch(): void {
-    const wasConnected = this.status().connected
-    this.lastSeenAt = Date.now()
+  private touch(client: ChromeClient): void {
+    const wasConnected = this.isConnected(client)
+    client.lastSeenAt = Date.now()
     this.emitStatus()
-    if (!wasConnected) this.notifyConnected()
+    if (!wasConnected) this.notifyConnected(client)
   }
 
-  private notifyConnected(): void {
+  private notifyConnected(client: ChromeClient): void {
     if (!this.autoSync?.onConnected) return
-    void Promise.resolve().then(() => this.autoSync?.onConnected?.()).catch(() => { /* advisory hook */ })
+    void Promise.resolve().then(() => this.autoSync?.onConnected?.(client.profileId)).catch(() => { /* advisory hook */ })
   }
 
   private async handle(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
@@ -535,7 +731,7 @@ export class ChromeCompanionBridge {
       }
       const url = new URL(request.url || '/', this.endpoint || 'http://127.0.0.1')
       if (request.method === 'GET' && url.pathname === '/v1/status') {
-        this.reply(request, response, 200, { ok: true, paired: !!this.token })
+        this.reply(request, response, 200, { ok: true, paired: this.clientsByKey.size > 0 })
         return
       }
       if (request.method === 'POST' && url.pathname === '/v1/connect') {
@@ -558,50 +754,76 @@ export class ChromeCompanionBridge {
             return
           }
         }
-        this.token = crypto.randomBytes(32).toString('base64url')
-        this.rejectAll(new Error('Chrome companion was paired again'))
-        this.clientName = typeof input.clientName === 'string' && input.clientName.trim()
-          ? input.clientName.trim().slice(0, 80)
-          : 'Chrome'
-        this.pairedAt = Date.now()
-        this.lastSeenAt = Date.now()
+        // The ID is scoped to the Chrome profile the extension runs in, so one
+        // Chrome reconnecting replaces only its own pairing. An extension too
+        // old to report one lands on the single legacy slot.
+        const reportedId = typeof input.profileId === 'string' && input.profileId.trim()
+          ? input.profileId.trim().slice(0, 100)
+          : null
+        const key = reportedId ?? LEGACY_CLIENT_KEY
+        const token = crypto.randomBytes(32).toString('base64url')
+        const existing = this.clientsByKey.get(key)
+        if (existing) this.rejectClient(existing, new Error(`${existing.label} was paired again`))
+        // A profile that pairs with an ID supersedes the legacy slot: it is the
+        // same extension, now able to say which Chrome profile it speaks for.
+        const legacy = reportedId ? this.clientsByKey.get(LEGACY_CLIENT_KEY) : null
+        if (legacy) {
+          this.rejectClient(legacy, new Error('Chrome companion was paired again'))
+          this.clientsByKey.delete(LEGACY_CLIENT_KEY)
+        }
+        const client: ChromeClient = {
+          profileId: reportedId,
+          label: existing?.label ?? legacy?.label ?? this.nextLabel(),
+          token,
+          clientName: typeof input.clientName === 'string' && input.clientName.trim()
+            ? input.clientName.trim().slice(0, 80)
+            : 'Chrome',
+          clientVersion: existing?.clientVersion ?? null,
+          pairedAt: Date.now(),
+          lastSeenAt: Date.now(),
+          queue: [],
+          pending: new Map(),
+          uploadedAttachments: new Map(),
+        }
+        this.clientsByKey.set(key, client)
         this.persistPairing()
         this.emitStatus()
-        this.notifyConnected()
+        this.notifyConnected(client)
         this.reply(request, response, 200, {
           ok: true,
-          token: this.token,
+          token,
           ...(secret
-            ? { serverProof: crypto.createHmac('sha256', secret).update(`codey-server:${nonce}:${this.token}`).digest('hex') }
+            ? { serverProof: crypto.createHmac('sha256', secret).update(`codey-server:${nonce}:${token}`).digest('hex') }
             : {}),
         })
         return
       }
-      if (!this.authorize(request)) {
+      const client = this.authorize(request)
+      if (!client) {
         this.reply(request, response, 401, { ok: false, error: 'Unauthorized' })
         return
       }
       if (request.method === 'POST' && url.pathname === '/v1/disconnect') {
-        this.disconnect()
+        this.disconnect(client.profileId ?? LEGACY_CLIENT_KEY)
         this.reply(request, response, 200, { ok: true })
         return
       }
-      this.touch()
+      this.touch(client)
       if (request.method === 'POST' && url.pathname === '/v1/poll') {
         const input = await this.body(request)
         const reported = typeof input.version === 'string' ? input.version.trim().slice(0, 40) : ''
-        if (reported && reported !== this.clientVersion) {
-          this.clientVersion = reported
+        if (reported && reported !== client.clientVersion) {
+          client.clientVersion = reported
           this.emitStatus()
         }
-        const command = this.queue.shift()
-        const watchDomains = this.autoSync?.watchDomains() ?? null
-        const excludedDomains = this.autoSync?.excludedDomains?.() ?? []
-        const syncRevision = this.autoSync?.revision?.() ?? 0
+        const command = client.queue.shift()
+        const watchDomains = this.autoSync?.watchDomains(client.profileId) ?? null
+        const excludedDomains = this.autoSync?.excludedDomains?.(client.profileId) ?? []
+        const syncRevision = this.autoSync?.revision?.(client.profileId) ?? 0
         // A poll is a heartbeat from the authorized extension. Let consumers
         // notice config revisions without delaying (or risking) the response.
         const onPoll = this.autoSync?.onPoll
-        if (onPoll) void Promise.resolve().then(() => onPoll()).catch(() => { /* advisory hook */ })
+        if (onPoll) void Promise.resolve().then(() => onPoll(client.profileId)).catch(() => { /* advisory hook */ })
         const base = {
           ok: true,
           accent: this.accent,
@@ -623,22 +845,24 @@ export class ChromeCompanionBridge {
           .filter((domain): domain is string => typeof domain === 'string' && !!domain.trim())
           .map(domain => domain.trim().toLowerCase().slice(0, 300))
           .slice(0, 200)
-        if (domains.length > 0) this.autoSync?.onSessionChanged(domains)
+        if (domains.length > 0) this.autoSync?.onSessionChanged(client.profileId, domains)
         this.reply(request, response, 200, { ok: true })
         return
       }
       if (request.method === 'POST' && url.pathname === '/v1/result') {
         const input = await this.body(request)
         const id = typeof input.id === 'string' ? input.id : ''
-        const command = this.pending.get(id)
+        // Only this client's own pending commands: a result posted with one
+        // Chrome's token must not be able to resolve another Chrome's command.
+        const command = client.pending.get(id)
         if (!command) {
           this.reply(request, response, 404, { ok: false, error: 'Unknown or expired command' })
           return
         }
         clearTimeout(command.timer)
-        this.pending.delete(id)
+        client.pending.delete(id)
         if (input.ok === true) command.resolve(input.data)
-        else command.reject(new Error(this.explain(typeof input.error === 'string' ? input.error : '')))
+        else command.reject(new Error(this.explain(client, typeof input.error === 'string' ? input.error : '')))
         this.reply(request, response, 200, { ok: true })
         return
       }
@@ -653,7 +877,7 @@ export class ChromeCompanionBridge {
         const attachmentIds = Array.isArray(input.attachmentIds)
           ? input.attachmentIds.filter((id): id is string => typeof id === 'string').slice(0, 10)
           : []
-        const attachments = attachmentIds.map(id => this.uploadedAttachments.get(id))
+        const attachments = attachmentIds.map(id => client.uploadedAttachments.get(id))
           .filter((entry): entry is { chatId: string; attachment: ChromeCompanionAttachment } => !!entry && !!chatId && entry.chatId === chatId)
           .map(entry => entry.attachment)
         if (!text && attachments.length === 0) throw new Error('A message or attachment is required')
@@ -668,7 +892,7 @@ export class ChromeCompanionBridge {
           } catch { /* invalid page context is ignored */ }
         }
         const result = await this.onChat({ chatId, text, page, agent, model, attachments })
-        for (const id of attachmentIds) this.uploadedAttachments.delete(id)
+        for (const id of attachmentIds) client.uploadedAttachments.delete(id)
         this.reply(request, response, 200, { ok: true, ...result })
         return
       }
@@ -676,7 +900,7 @@ export class ChromeCompanionBridge {
         if (!this.features) throw new Error('Browser profiles are unavailable')
         const input = await this.body(request)
         const hostname = typeof input.hostname === 'string' ? input.hostname.slice(0, 300) : ''
-        this.reply(request, response, 200, { ok: true, ...await this.features.profilesOverview(hostname || undefined) })
+        this.reply(request, response, 200, { ok: true, ...await this.features.profilesOverview(hostname || undefined, client.profileId) })
         return
       }
       if (request.method === 'POST' && url.pathname === '/v1/session/handoff/name') {
@@ -690,7 +914,7 @@ export class ChromeCompanionBridge {
         if (!this.features) throw new Error('Session handoff is unavailable')
         const input = await this.body(request)
         const name = typeof input.name === 'string' ? input.name.trim() : ''
-        this.reply(request, response, 200, { ok: true, ...await this.features.handoffSession(name || undefined) })
+        this.reply(request, response, 200, { ok: true, ...await this.features.handoffSession(name || undefined, client.profileId) })
         return
       }
       if (request.method === 'GET' && url.pathname === '/v1/chats') {
@@ -757,8 +981,8 @@ export class ChromeCompanionBridge {
         if (!data.length) throw new Error('The selected file is empty')
         if (data.length > MAX_UPLOAD_BYTES) throw new Error(`${name} exceeds 10 MB`)
         const attachment = await this.features.upload(chatId, name, mimeType, data)
-        this.uploadedAttachments.set(attachment.id, { chatId, attachment })
-        while (this.uploadedAttachments.size > 100) this.uploadedAttachments.delete(this.uploadedAttachments.keys().next().value!)
+        client.uploadedAttachments.set(attachment.id, { chatId, attachment })
+        while (client.uploadedAttachments.size > 100) client.uploadedAttachments.delete(client.uploadedAttachments.keys().next().value!)
         this.reply(request, response, 200, { ok: true, attachment: { id: attachment.id, name: attachment.name, mimeType: attachment.mimeType, size: attachment.size } })
         return
       }

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2270,7 +2270,7 @@ app.whenReady().then(async () => {
         name: availableProfileName(hostname, (await browserController.listProfiles()).map(profile => profile.name)),
         existing: await browserController.profilesForUrl(`https://${hostname}/`),
       }),
-      profilesOverview: async hostname => {
+      profilesOverview: async (hostname, profileId) => {
         const holds = new Set(hostname ? await browserController.profilesForUrl(`https://${hostname}/`) : [])
         return {
           profiles: (await browserController.listProfiles()).map(profile => ({
@@ -2278,12 +2278,13 @@ app.whenReady().then(async () => {
             active: profile.active,
             autoSync: profile.autoSync,
             holdsSite: holds.has(profile.name),
+            linked: profile.chromeProfileId === profileId,
           })),
         }
       },
-      handoffSession: async requested => {
+      handoffSession: async (requested, profileId) => {
         if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
-        const sessionState = await chromeCompanion.exportSession()
+        const sessionState = await chromeCompanion.exportSession(profileId)
         const tabUrl = new URL(sessionState.tab.url)
         const json = JSON.stringify({ cookies: sessionState.cookies, origins: sessionState.origins })
         const taken = (await browserController.listProfiles()).map(profile => profile.name)
@@ -2338,6 +2339,20 @@ app.whenReady().then(async () => {
   } catch (error) {
     console.warn(`[browser] Chrome companion unavailable: ${error instanceof Error ? error.message : String(error)}`)
   }
+  // Commands Codey starts - screenshots, navigation, agent `chrome` actions -
+  // go to the Chrome profile linked to the currently active Codey browser
+  // profile. The named failures say what to fix instead of a generic error.
+  chromeCompanion.setTargetResolver(() => {
+    const name = browserController.activeProfileName()
+    if (!name) throw new Error('Activate a browser profile first')
+    const binding = browserController.chromeBindingForProfile(name)
+    if (!binding) throw new Error(`Profile "${name}" is not linked to a Chrome profile`)
+    const client = chromeCompanion!.clients().find(entry => entry.profileId === binding.profileId)
+    if (!client || !client.connected) {
+      throw new Error(`Chrome profile "${binding.label}" (linked to "${name}") is not running`)
+    }
+    return binding.profileId
+  })
   protocol.handle('codey-asset', async (request) => {
     try {
       const url = new URL(request.url)
@@ -2486,146 +2501,165 @@ app.whenReady().then(async () => {
   ipcMain.handle('browser:profiles:syncProfile', (event, name: string) =>
     browserCall(event, () => refreshProfileFromChrome(name)))
 
-  // Auto-sync profiles mirror the whole Chrome session, including sites first
-  // visited after the switch was enabled. An exclusion belongs to a profile,
-  // so isolated personal/work jars may deliberately mirror different subsets.
-  type AutoSyncProfile = { name: string; excludedSites: string[] }
-  let autoSyncProfileCache: AutoSyncProfile[] = []
-  let sharedExclusionCache: string[] = []
-  let autoSyncRevision = 0
-  let autoSyncFingerprint = ''
+  // Each Chrome profile owns its own sync state. A slow or disconnected work
+  // Chrome must neither block nor write into the personal Codey jar.
+  type ClientSyncState = {
+    profileName: string
+    excludedSites: string[]
+    revision: number
+    fingerprint: string
+    pendingDomains: Set<string>
+    pendingFullSync: boolean
+    completedFullSyncRevision: number
+    busy: boolean
+    timer: NodeJS.Timeout | null
+  }
+  const clientSyncStates = new Map<string, ClientSyncState>()
   let autoSyncConfigGeneration = 0
   const refreshWatchDomains = async () => {
     const generation = (autoSyncConfigGeneration += 1)
     const profiles = (await browserController.listProfiles())
-      .filter(profile => profile.autoSync)
-      .map(profile => ({ name: profile.name, excludedSites: profile.excludedSites }))
+      .filter(profile => profile.autoSync && !!profile.chromeProfileId)
     if (generation !== autoSyncConfigGeneration) return
-    const fingerprint = JSON.stringify(profiles)
-    if (fingerprint !== autoSyncFingerprint) {
-      autoSyncFingerprint = fingerprint
-      autoSyncRevision += 1
-      pendingFullSync = profiles.length > 0
+    const liveIds = new Set<string>()
+    for (const profile of profiles) {
+      const profileId = profile.chromeProfileId!
+      liveIds.add(profileId)
+      const fingerprint = JSON.stringify([profile.name, profile.excludedSites])
+      const current = clientSyncStates.get(profileId)
+      if (!current) {
+        clientSyncStates.set(profileId, {
+          profileName: profile.name,
+          excludedSites: [...profile.excludedSites],
+          revision: 1,
+          fingerprint,
+          pendingDomains: new Set(),
+          pendingFullSync: true,
+          completedFullSyncRevision: 0,
+          busy: false,
+          timer: null,
+        })
+      } else {
+        current.profileName = profile.name
+        current.excludedSites = [...profile.excludedSites]
+        if (current.fingerprint !== fingerprint) {
+          current.fingerprint = fingerprint
+          current.revision += 1
+          current.pendingFullSync = true
+        }
+      }
     }
-    autoSyncProfileCache = profiles
-    // The extension may suppress an event only if every syncing profile would
-    // suppress it. Exact intersection is intentionally conservative: broader
-    // parent/subdomain combinations are filtered again per profile below.
-    sharedExclusionCache = profiles.length === 0
-      ? []
-      : profiles[0].excludedSites.filter(site => profiles.every(profile => profile.excludedSites.includes(site)))
+    for (const [profileId, state] of clientSyncStates) {
+      if (liveIds.has(profileId)) continue
+      if (state.timer) clearTimeout(state.timer)
+      clientSyncStates.delete(profileId)
+    }
   }
-  const profileExcludes = (profile: AutoSyncProfile, domain: string): boolean =>
-    profile.excludedSites.some(site => siteCoversHost(site, domain) || siteCoversHost(domain, site))
-  const pendingAutoSyncDomains = new Set<string>()
-  let pendingFullSync = false
-  let completedFullSyncRevision = 0
-  let autoSyncBusy = false
-  let autoSyncTimer: NodeJS.Timeout | null = null
-  const scheduleAutoSync = (delay = 1500) => {
-    if (autoSyncTimer) clearTimeout(autoSyncTimer)
-    autoSyncTimer = setTimeout(() => { autoSyncTimer = null; void runAutoSync() }, delay)
+  const scheduleAutoSync = (profileId: string, delay = 1500) => {
+    const state = clientSyncStates.get(profileId)
+    if (!state) return
+    if (state.timer) clearTimeout(state.timer)
+    state.timer = setTimeout(() => {
+      state.timer = null
+      void runAutoSync(profileId)
+    }, delay)
   }
-  const runAutoSync = async () => {
-    if (autoSyncBusy) return
-    const changed = [...pendingAutoSyncDomains]
-    // Freeze the generation and profile set this pass is actually syncing.
-    // Settings can change while Chrome is answering; success for the old
-    // generation must not accidentally acknowledge the newer one.
-    const passRevision = autoSyncRevision
-    const passProfiles = autoSyncProfileCache.map(profile => ({
-      name: profile.name,
-      excludedSites: [...profile.excludedSites],
-    }))
-    const doFullSync = pendingFullSync && completedFullSyncRevision < passRevision
-    if ((!doFullSync && changed.length === 0) || !chromeCompanion?.status().connected) return
+  const runAutoSync = async (profileId: string) => {
+    const state = clientSyncStates.get(profileId)
+    if (!state || state.busy) return
+    const changed = [...state.pendingDomains]
+    const passRevision = state.revision
+    const passProfileName = state.profileName
+    const passExcludedSites = [...state.excludedSites]
+    const doFullSync = state.pendingFullSync && state.completedFullSyncRevision < passRevision
+    const connected = chromeCompanion?.clients().some(client => client.profileId === profileId && client.connected) === true
+    if ((!doFullSync && changed.length === 0) || !connected) return
     // Keep new notifications distinct from this in-flight batch. Failed work
     // is merged back below; successful work cannot erase a later same-domain
     // change that arrived while Chrome was exporting.
-    for (const domain of changed) pendingAutoSyncDomains.delete(domain)
+    for (const domain of changed) state.pendingDomains.delete(domain)
 
-    autoSyncBusy = true
+    state.busy = true
     let retryDelay = 1500
     try {
-      let allChromeSites: string[] = []
-      let fullSyncSucceeded = true
-      let syncSucceeded = true
+      let sites: string[]
       if (doFullSync) {
         try {
-          allChromeSites = (await chromeCompanion.listSessionSites()).sites.map(entry => entry.site)
+          const allChromeSites = (await chromeCompanion!.listSessionSites(profileId)).sites.map(entry => entry.site)
+          const existingSites = await browserController.profileSites(passProfileName)
+          sites = [...new Set([...allChromeSites, ...existingSites])]
+            .filter(site => !passExcludedSites.some(excluded =>
+              siteCoversHost(excluded, site) || siteCoversHost(site, excluded)))
         } catch (error) {
-          fullSyncSucceeded = false
-          pendingFullSync = true
+          state.pendingFullSync = true
+          retryDelay = 5000
           sendToRenderer('gateway-log', `[browser] initial Chrome mirror failed: ${error instanceof Error ? error.message : String(error)}`)
+          return
         }
-      }
-      for (const profile of passProfiles) {
-        let sites: string[]
-        if (doFullSync) {
-          try {
-            // Include sites already held by Codey. If Chrome deleted their
-            // final cookie while the extension was offline, they no longer
-            // appear in listSessionSites; requesting them explicitly lets the
-            // empty Chrome result clear those stale cookies on reconnect.
-            const existingSites = await browserController.profileSites(profile.name)
-            sites = [...new Set([...allChromeSites, ...existingSites])]
-              .filter(site => !profileExcludes(profile, site))
-          } catch (error) {
-            fullSyncSucceeded = false
-            syncSucceeded = false
-            sendToRenderer('gateway-log', `[browser] could not inspect "${profile.name}" before Chrome sync: ${error instanceof Error ? error.message : String(error)}`)
-            continue
-          }
-        } else {
-          sites = changed.filter(domain => !profileExcludes(profile, domain))
-        }
-        if (sites.length === 0) continue
-        try {
-          const session = await chromeCompanion.exportSessionForSites([...sites])
-          await browserController.resyncProfileSites(profile.name, {
-            json: JSON.stringify({ cookies: session.cookies, origins: session.origins }),
-          }, session.sites)
-        } catch (error) {
-          syncSucceeded = false
-          if (doFullSync) fullSyncSucceeded = false
-          sendToRenderer('gateway-log', `[browser] auto-sync of "${profile.name}" failed: ${error instanceof Error ? error.message : String(error)}`)
-        }
-      }
-      if (doFullSync && fullSyncSucceeded) completedFullSyncRevision = Math.max(completedFullSyncRevision, passRevision)
-      else if (doFullSync) {
-        pendingFullSync = true
-        retryDelay = 5000
-      }
-      if (syncSucceeded && fullSyncSucceeded) {
-        if (doFullSync) pendingFullSync = completedFullSyncRevision < autoSyncRevision
       } else {
-        for (const domain of changed) pendingAutoSyncDomains.add(domain)
-        retryDelay = 5000
+        sites = changed.filter(domain => !passExcludedSites.some(excluded =>
+          siteCoversHost(excluded, domain) || siteCoversHost(domain, excluded)))
       }
+      if (sites.length > 0) {
+        const session = await chromeCompanion!.exportSessionForSites(sites, false, profileId)
+        await browserController.resyncProfileSites(passProfileName, {
+          json: JSON.stringify({ cookies: session.cookies, origins: session.origins }),
+        }, session.sites)
+      }
+      if (doFullSync) {
+        state.completedFullSyncRevision = Math.max(state.completedFullSyncRevision, passRevision)
+        state.pendingFullSync = state.completedFullSyncRevision < state.revision
+      }
+    } catch (error) {
+      for (const domain of changed) state.pendingDomains.add(domain)
+      if (doFullSync) state.pendingFullSync = true
+      retryDelay = 5000
+      sendToRenderer('gateway-log', `[browser] auto-sync of "${passProfileName}" failed: ${error instanceof Error ? error.message : String(error)}`)
     } finally {
-      autoSyncBusy = false
-      if ((pendingFullSync || pendingAutoSyncDomains.size > 0) && !autoSyncTimer) scheduleAutoSync(retryDelay)
+      state.busy = false
+      if ((state.pendingFullSync || state.pendingDomains.size > 0) && !state.timer) scheduleAutoSync(profileId, retryDelay)
     }
   }
+  const ensureClientBinding = async (profileId: string | null) => {
+    if (!profileId || !chromeCompanion) return null
+    const client = chromeCompanion.clients().find(entry => entry.profileId === profileId)
+    if (!client) return null
+    const existing = browserController.profileForChrome(profileId)
+    const profile = existing ?? browserController.ensureProfileForChrome(profileId, client.label)
+    if (profile.chromeProfileLabel !== client.label) {
+      browserController.setProfileChromeBinding(profile.name, profileId, client.label)
+    }
+    await refreshWatchDomains()
+    return profile
+  }
   chromeCompanion?.setAutoSync({
-    watchDomains: () => (autoSyncProfileCache.length === 0 ? null : ['*']),
-    excludedDomains: () => sharedExclusionCache,
-    revision: () => autoSyncRevision,
-    onConnected: () => {
-      if (autoSyncProfileCache.length === 0) return
-      completedFullSyncRevision = Math.min(completedFullSyncRevision, autoSyncRevision - 1)
-      pendingFullSync = true
-      if (!autoSyncTimer) scheduleAutoSync(100)
+    watchDomains: profileId => profileId && clientSyncStates.has(profileId) ? ['*'] : null,
+    excludedDomains: profileId => profileId ? clientSyncStates.get(profileId)?.excludedSites ?? [] : [],
+    revision: profileId => profileId ? clientSyncStates.get(profileId)?.revision ?? 0 : 0,
+    onConnected: async profileId => {
+      await ensureClientBinding(profileId)
+      if (!profileId) return
+      const state = clientSyncStates.get(profileId)
+      if (!state) return
+      state.completedFullSyncRevision = Math.min(state.completedFullSyncRevision, state.revision - 1)
+      state.pendingFullSync = true
+      if (!state.timer) scheduleAutoSync(profileId, 100)
     },
-    onPoll: () => {
-      if (autoSyncProfileCache.length > 0 && completedFullSyncRevision < autoSyncRevision) {
-        pendingFullSync = true
-        if (!autoSyncTimer) scheduleAutoSync(100)
+    onPoll: async profileId => {
+      await ensureClientBinding(profileId)
+      if (!profileId) return
+      const state = clientSyncStates.get(profileId)
+      if (state && state.completedFullSyncRevision < state.revision) {
+        state.pendingFullSync = true
+        if (!state.timer) scheduleAutoSync(profileId, 100)
       }
     },
-    onSessionChanged: domains => {
-      for (const domain of domains) pendingAutoSyncDomains.add(domain)
-      scheduleAutoSync()
+    onSessionChanged: (profileId, domains) => {
+      if (!profileId) return
+      const state = clientSyncStates.get(profileId)
+      if (!state) return
+      for (const domain of domains) state.pendingDomains.add(domain)
+      scheduleAutoSync(profileId)
     },
   })
   void refreshWatchDomains()
@@ -2640,6 +2674,21 @@ app.whenReady().then(async () => {
   ipcMain.handle('browser:profiles:setExcludedSites', (event, name: string, sites: string[]) =>
     browserCall(event, async () => {
       const result = browserController.setProfileExcludedSites(String(name || ''), Array.isArray(sites) ? sites : [])
+      await refreshWatchDomains()
+      return result
+    }))
+  // Which Chrome profile a Codey profile mirrors. The label is only a display
+  // string; the binding is keyed by the Chrome-reported ID, so a rename never
+  // changes where syncing routes. Rebinding to another Chrome (or to none)
+  // re-routes the watch list on the next poll.
+  ipcMain.handle('browser:profiles:setChromeBinding', (event, name: string, chromeProfileId: string | null) =>
+    browserCall(event, async () => {
+      const requested = String(name || '')
+      const profileId = chromeProfileId === null || chromeProfileId === undefined ? null : String(chromeProfileId)
+      const label = profileId
+        ? chromeCompanion?.clients().find(entry => entry.profileId === profileId)?.label ?? null
+        : null
+      const result = browserController.setProfileChromeBinding(requested, profileId, label)
       await refreshWatchDomains()
       return result
     }))
@@ -2726,9 +2775,19 @@ app.whenReady().then(async () => {
     if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
     return chromeCompanion.status()
   }))
-  ipcMain.handle('chromeCompanion:disconnect', event => browserCall(event, () => {
+  ipcMain.handle('chromeCompanion:disconnect', (event, profileId?: string | null) => browserCall(event, () => {
     if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
-    return chromeCompanion.disconnect()
+    return chromeCompanion.disconnect(profileId ?? null)
+  }))
+  // The paired Chrome profiles, for the Settings list and the per-profile
+  // binding picker. Connected ones are marked so a stale pairing is visible.
+  ipcMain.handle('browser:chrome:clients', event => browserCall(event, () => {
+    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+    return chromeCompanion.clients()
+  }))
+  ipcMain.handle('browser:chrome:renameClient', (event, profileId: string, label: string) => browserCall(event, () => {
+    if (!chromeCompanion) throw new Error('Chrome companion is unavailable')
+    return chromeCompanion.renameClient(String(profileId || ''), String(label || ''))
   }))
   ipcMain.handle('chromeCompanion:activeTab', event => browserCall(event, () => {
     if (!chromeCompanion) throw new Error('Chrome companion is unavailable')

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -468,7 +468,9 @@ contextBridge.exposeInMainWorld('codey', {
   },
   chromeCompanion: {
     status: () => ipcRenderer.invoke('chromeCompanion:status'),
-    disconnect: () => ipcRenderer.invoke('chromeCompanion:disconnect'),
+    disconnect: (profileId?: string | null) => ipcRenderer.invoke('chromeCompanion:disconnect', profileId ?? null),
+    clients: () => ipcRenderer.invoke('browser:chrome:clients'),
+    renameClient: (profileId: string, label: string) => ipcRenderer.invoke('browser:chrome:renameClient', profileId, label),
     activeTab: () => ipcRenderer.invoke('chromeCompanion:activeTab'),
     snapshot: () => ipcRenderer.invoke('chromeCompanion:snapshot'),
     listSessionSites: () => ipcRenderer.invoke('chromeCompanion:listSessionSites'),
@@ -514,6 +516,7 @@ contextBridge.exposeInMainWorld('codey', {
       syncProfile: (name: string) => ipcRenderer.invoke('browser:profiles:syncProfile', name),
       setAutoSync: (name: string, enabled: boolean) => ipcRenderer.invoke('browser:profiles:setAutoSync', name, enabled === true),
       setExcludedSites: (name: string, sites: string[]) => ipcRenderer.invoke('browser:profiles:setExcludedSites', name, sites),
+      setChromeBinding: (name: string, chromeProfileId: string | null) => ipcRenderer.invoke('browser:profiles:setChromeBinding', name, chromeProfileId),
       contents: (name: string) => ipcRenderer.invoke('browser:profiles:contents', name),
     },
     extensions: {

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -205,6 +205,10 @@ export interface BrowserProfileSummary {
   autoSync: boolean
   /** Sites that automatic Chrome mirroring must leave untouched. */
   excludedSites: string[]
+  /** The Chrome profile this one mirrors (null when linked to none). */
+  chromeProfileId: string | null
+  /** The linked Chrome profile's display name, cached for when Chrome is off. */
+  chromeProfileLabel: string | null
   createdAt: number
   updatedAt: number
   cookieCount: number
@@ -259,6 +263,17 @@ export interface ChromeCompanionStatus {
   clientVersion: string | null
   expectedVersion: string | null
   updateAvailable: boolean
+}
+
+/** One Chrome profile paired with Codey, as listed in the Chrome settings. */
+export interface ChromeClientInfo {
+  profileId: string | null
+  label: string
+  clientName: string
+  clientVersion: string | null
+  pairedAt: number
+  lastSeenAt: number | null
+  connected: boolean
 }
 
 export interface ChromeTabInfo {
@@ -642,7 +657,9 @@ declare global {
       }
       chromeCompanion: {
         status: () => Promise<IpcResult<ChromeCompanionStatus>>
-        disconnect: () => Promise<IpcResult<ChromeCompanionStatus>>
+        disconnect: (profileId?: string | null) => Promise<IpcResult<ChromeCompanionStatus>>
+        clients: () => Promise<IpcResult<ChromeClientInfo[]>>
+        renameClient: (profileId: string, label: string) => Promise<IpcResult<ChromeClientInfo[]>>
         activeTab: () => Promise<IpcResult<ChromeTabInfo>>
         snapshot: () => Promise<IpcResult<ChromePageSnapshot>>
         listSessionSites: () => Promise<IpcResult<{ sites: ChromeSessionSite[] }>>
@@ -683,6 +700,7 @@ declare global {
           setAvatar: (name: string, avatar: string) => Promise<IpcResult<BrowserProfileSummary>>
           setAutoSync: (name: string, enabled: boolean) => Promise<IpcResult<BrowserProfileSummary>>
           setExcludedSites: (name: string, sites: string[]) => Promise<IpcResult<BrowserProfileSummary>>
+          setChromeBinding: (name: string, chromeProfileId: string | null) => Promise<IpcResult<BrowserProfileSummary>>
           delete: (name: string) => Promise<IpcResult<{ deleted: boolean }>>
           import: () => Promise<IpcResult<{ imported: boolean; profile: BrowserProfileSummary | null }>>
           export: (name: string) => Promise<IpcResult<{ exported: boolean; path: string | null }>>

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { C } from '../theme'
 import { UIIcon } from './UIIcons'
-import type { BrowserProfileSiteSummary, BrowserProfileSummary } from '../codey-api'
+import type { BrowserProfileSiteSummary, BrowserProfileSummary, ChromeClientInfo } from '../codey-api'
 import { BROWSER_PROFILE_AVATARS, browserProfileAvatar } from './browserProfileAvatars'
 import { Toggle } from './settingsAtoms'
 
@@ -41,6 +41,14 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
   // out hid what was missing, so say it and mark the field instead.
   const [nameMissing, setNameMissing] = useState(false)
   const [avatarPicker, setAvatarPicker] = useState<string | null>(null)
+  const [chromeClients, setChromeClients] = useState<ChromeClientInfo[]>([])
+  const [bindingPicker, setBindingPicker] = useState<string | null>(null)
+
+  const refreshChromeClients = useCallback(async () => {
+    if (!window.codey?.chromeCompanion?.clients) return
+    const result = await window.codey.chromeCompanion.clients()
+    if (result.ok) setChromeClients(result.data)
+  }, [])
 
   const refresh = useCallback(async () => {
     // A stale preload (app not restarted since the profiles bridge was added)
@@ -63,6 +71,7 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
   }, [])
 
   useEffect(() => { void refresh() }, [refresh])
+  useEffect(() => { void refreshChromeClients() }, [refreshChromeClients])
 
   const run = async (action: () => Promise<IpcLike>) => {
     setBusy(true)
@@ -77,6 +86,7 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
       setContents({})
       if (expanded) void toggleContentsAgain(expanded)
       void refresh()
+      void refreshChromeClients()
     }
   }
 
@@ -256,6 +266,19 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
                 </span>
                 {meta(profile) || (profile.sourceUrl ? 'saved session' : 'empty profile')}
               </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => setBindingPicker(current => current === profile.name ? null : profile.name)}
+                aria-expanded={bindingPicker === profile.name}
+                style={styles.bindingLink}
+                title="Choose which Chrome profile this Codey profile mirrors"
+              >
+                <UIIcon name="link" size={9} />
+                {profile.chromeProfileId
+                  ? `Chrome: ${profile.chromeProfileLabel ?? 'Chrome profile'}`
+                  : 'Not linked to Chrome'}
+              </button>
             </div>
             <button
               type="button"
@@ -297,6 +320,54 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
               ><UIIcon name="trash" size={12} /></button>
             )}
           </div>
+
+          {bindingPicker === profile.name && (
+            <div style={styles.bindingPicker} role="menu" aria-label={`Chrome profile for ${profile.name}`}>
+              <button
+                type="button"
+                role="menuitemradio"
+                aria-checked={!profile.chromeProfileId}
+                disabled={busy}
+                style={{ ...styles.bindingOption, ...(!profile.chromeProfileId ? styles.bindingOptionActive : null) }}
+                onClick={() => {
+                  setBindingPicker(null)
+                  void run(() => window.codey.browser.profiles.setChromeBinding(profile.name, null))
+                }}
+              >
+                <span style={styles.bindingOptionName}>None</span>
+                <span aria-hidden="true">{!profile.chromeProfileId ? '✓' : ''}</span>
+              </button>
+              {chromeClients.filter(client => client.profileId).map(client => {
+                const owner = profiles.find(profile => profile.chromeProfileId === client.profileId)
+                const moved = !!owner && owner.name !== profile.name
+                return (
+                  <button
+                    key={client.profileId}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={profile.chromeProfileId === client.profileId}
+                    disabled={busy}
+                    style={{ ...styles.bindingOption, ...(profile.chromeProfileId === client.profileId ? styles.bindingOptionActive : null) }}
+                    title={moved ? `Now linked to "${owner!.name}" — picking this moves it here` : undefined}
+                    onClick={() => {
+                      setBindingPicker(null)
+                      void run(() => window.codey.browser.profiles.setChromeBinding(profile.name, client.profileId))
+                    }}
+                  >
+                    <span style={styles.bindingOptionName}>
+                      {client.label}
+                      {client.connected ? '' : ' · offline'}
+                    </span>
+                    {moved && <span style={styles.bindingOptionNote}>from {owner!.name}</span>}
+                    <span aria-hidden="true">{profile.chromeProfileId === client.profileId ? '✓' : ''}</span>
+                  </button>
+                )
+              })}
+              {chromeClients.filter(client => client.profileId).length === 0 && (
+                <div style={styles.bindingEmpty}>No Chrome profiles paired yet — install the Codey extension in Chrome and it appears here.</div>
+              )}
+            </div>
+          )}
 
           {/* What this profile actually holds. Worth being able to look at
               before trusting it with a task - and before handing it to an
@@ -382,6 +453,13 @@ const styles: Record<string, React.CSSProperties> = {
   contentsMeta: { flexShrink: 0, color: C.fg3, fontSize: 10 },
   contentsEmpty: { color: C.fg3, fontSize: 11, padding: '4px 4px' },
   contentsNote: { marginTop: 4, paddingTop: 5, borderTop: `1px solid ${C.border}`, color: C.fg3, fontSize: 10, lineHeight: 1.4 },
+  bindingLink: { display: 'inline-flex', alignItems: 'center', gap: 4, padding: 0, border: 'none', background: 'none', color: C.fg3, fontSize: 10, cursor: 'pointer', textAlign: 'left' },
+  bindingPicker: { display: 'flex', flexDirection: 'column', gap: 2, padding: 6, borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}` },
+  bindingOption: { display: 'flex', alignItems: 'center', gap: 8, padding: '5px 7px', border: 'none', borderRadius: 6, background: 'transparent', color: C.fg2, cursor: 'pointer', fontSize: 11, textAlign: 'left' },
+  bindingOptionActive: { background: C.accentDim, color: C.accent },
+  bindingOptionName: { flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  bindingOptionNote: { flexShrink: 0, color: C.fg3, fontSize: 10 },
+  bindingEmpty: { padding: '5px 7px', color: C.fg3, fontSize: 10.5, lineHeight: 1.4 },
   avatarControl: { position: 'relative', flexShrink: 0 },
   avatarButton: { width: 34, height: 34, display: 'grid', placeItems: 'center', padding: 0, borderRadius: 10, border: `1px solid ${C.border}`, background: C.surface2, cursor: 'pointer', fontSize: 18 },
   avatarButtonActive: { borderColor: C.green, background: `${C.green}14` },

--- a/codey-mac/src/components/ChromeCompanionSettings.tsx
+++ b/codey-mac/src/components/ChromeCompanionSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import type { ChromeCompanionStatus, ChromeSessionSite } from '../codey-api'
+import type { BrowserProfileSummary, ChromeClientInfo, ChromeCompanionStatus, ChromeSessionSite } from '../codey-api'
 import { C } from '../theme'
 
 const EMPTY: ChromeCompanionStatus = {
@@ -53,6 +53,10 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
   // Off by default: reading a site's storage means Chrome actually opening it,
   // and quietly loading eight pages is not something a copy should assume.
   const [openMissing, setOpenMissing] = useState(false)
+  const [clients, setClients] = useState<ChromeClientInfo[]>([])
+  const [profiles, setProfiles] = useState<BrowserProfileSummary[]>([])
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
 
   const section = useRef('status')
 
@@ -72,6 +76,19 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
     })
     return () => { cancelled = true; off() }
   }, [])
+
+  const refreshChromeClients = async () => {
+    if (!window.codey?.chromeCompanion?.clients) return
+    const next = await window.codey.chromeCompanion.clients()
+    if (next.ok) setClients(next.data)
+    const listed = await window.codey.browser.profiles.list()
+    if (listed.ok) setProfiles(listed.data.profiles)
+  }
+
+  useEffect(() => { void refreshChromeClients() }, [status.paired, status.connected])
+
+  const boundProfileFor = (profileId: string | null): BrowserProfileSummary | undefined =>
+    profiles.find(profile => profile.chromeProfileId === profileId)
 
 
   const run = async (at: string, operation: () => Promise<void>) => {
@@ -110,6 +127,78 @@ export const ChromeCompanionSettings: React.FC<{ compact?: boolean }> = ({ compa
           <button style={styles.secondary} disabled={busy} onClick={() => void run('status', async () => {
             unwrapResult(await window.codey.chromeCompanion.openExtensionsPage())
           })}>Open extensions</button>
+        </div>
+      )}
+
+      {status.paired && clients.length > 0 && (
+        <div style={styles.card}>
+          <div>
+            <div style={styles.title}>Connected Chrome profiles</div>
+            <div style={styles.copy}>
+              Each Chrome profile is bound to one Codey Browser profile. A change in Chrome updates only the profile bound to it.
+            </div>
+          </div>
+          {clients.map(client => {
+            const bound = boundProfileFor(client.profileId)
+            return (
+              <div key={client.profileId ?? 'legacy'} style={styles.clientRow}>
+                <span style={{ ...styles.dot, background: client.connected ? C.green : C.warningFg }} />
+                <div style={styles.clientCopy}>
+                  {renamingId === client.profileId ? (
+                    <input
+                      autoFocus
+                      value={renameValue}
+                      onChange={event => setRenameValue(event.target.value)}
+                      onKeyDown={event => {
+                        if (event.key === 'Enter') event.currentTarget.blur()
+                        if (event.key === 'Escape') setRenamingId(null)
+                      }}
+                      onBlur={() => {
+                        const label = renameValue.trim()
+                        setRenamingId(null)
+                        if (!label || label === client.label) return
+                        void run('clients', async () => {
+                          const next = unwrapResult(await window.codey.chromeCompanion.renameClient(client.profileId!, label))
+                          if (next) setClients(next)
+                        })
+                      }}
+                      style={styles.input}
+                      aria-label="Chrome profile name"
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={busy}
+                      style={styles.clientName}
+                      title="Rename this Chrome profile"
+                      onClick={() => {
+                        if (!client.profileId) return
+                        setRenamingId(client.profileId)
+                        setRenameValue(client.label)
+                      }}
+                    >{client.label}</button>
+                  )}
+                  <div style={styles.clientMeta}>
+                    {client.connected ? 'Connected' : 'Not running'}
+                    {bound ? ` · Codey profile “${bound.name}”` : client.profileId ? ' · not linked to a Codey profile' : ' · update the extension to link it'}
+                  </div>
+                </div>
+                {client.profileId && (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    style={{ ...styles.secondary, color: C.red }}
+                    title={`Forget this Chrome profile's pairing`}
+                    onClick={() => void run('clients', async () => {
+                      const next = unwrapResult(await window.codey.chromeCompanion.disconnect(client.profileId))
+                      if (next) { setStatus(next); await refreshChromeClients() }
+                    })}
+                  >Disconnect</button>
+                )}
+              </div>
+            )
+          })}
+          {failure('clients')}
         </div>
       )}
 
@@ -283,6 +372,10 @@ const styles: Record<string, React.CSSProperties> = {
   secondary: { minHeight: 31, padding: '0 11px', border: `1px solid ${C.border2}`, borderRadius: 7, background: C.surface2, color: C.fg2, cursor: 'pointer', fontSize: 10.5 },
   error: { padding: '9px 11px', borderRadius: 8, color: C.red, background: `${C.red}18`, border: `1px solid ${C.red}55`, fontSize: 11 },
   success: { padding: '9px 11px', borderRadius: 8, color: C.green, background: `${C.green}18`, border: `1px solid ${C.green}55`, fontSize: 11 },
+  clientRow: { display: 'flex', alignItems: 'center', gap: 9, padding: '7px 8px', borderRadius: 8, background: C.surface2, border: `1px solid ${C.border}` },
+  clientCopy: { flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 },
+  clientName: { padding: 0, border: 'none', background: 'none', color: C.fg, cursor: 'pointer', fontSize: 11.5, fontWeight: 650, textAlign: 'left' },
+  clientMeta: { color: C.fg3, fontSize: 10.5, lineHeight: 1.4 },
   noticeRow: { display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderRadius: 8, background: C.surface, border: `1px solid ${C.border}` },
   noticeCopy: { flex: 1, minWidth: 0, color: C.fg3, fontSize: 10.5 },
   navigate: { display: 'flex', alignItems: 'flex-end', gap: 8 },

--- a/docs/superpowers/specs/2026-09-09-chrome-profile-binding-design.md
+++ b/docs/superpowers/specs/2026-09-09-chrome-profile-binding-design.md
@@ -1,0 +1,204 @@
+# Chrome profile binding — design
+
+**Date:** 2026-09-09
+**Branch:** `chrome-profile-binding`
+**Builds on:** `f21f932 feat(browser): isolate profiles and mirror Chrome sessions (#429)`
+
+## Problem
+
+Codey's Chrome companion mirrors a real Chrome session into a Codey browser
+profile. Two things are wrong once more than one Chrome profile is involved.
+
+**One pairing.** `ChromeCompanionBridge` holds a single `token`, `clientName`,
+command `queue` and `pending` map. A Chrome extension instance lives per Chrome
+profile, so two Chrome profiles both running the companion fight over that one
+pairing: `/v1/connect` mints a fresh token, calls `rejectAll`, and overwrites
+the previous client. The loser's next poll is rejected as unauthorized, it
+re-connects, and the two ping-pong indefinitely.
+
+**Broadcast sync.** `runAutoSync` in `main.ts` iterates every Codey profile with
+`autoSync` on and writes the *same* Chrome export into each. A work login and a
+personal login land in every mirroring profile, which defeats the per-profile
+partition isolation that #429 introduced.
+
+## Goal
+
+Each Chrome profile is bound to exactly one Codey browser profile. A change made
+in Chrome profile X updates only the Codey profile bound to X. Several Chrome
+profiles can be connected at once.
+
+## Design
+
+### 1. Chrome-side identity
+
+On first run the extension generates `crypto.randomUUID()` and stores it in
+`chrome.storage.local` under `profileId`. `chrome.storage.local` is scoped to
+the Chrome profile, so each profile gets its own stable ID for free, with no new
+manifest permission.
+
+The extension sends `profileId` in the `/v1/connect` body. Every later request
+is identified by its token (see below), so the ID travels once.
+
+The human-readable label is assigned by Codey as `Chrome profile <n>` in order
+of first connection, and is renameable in Codey's UI. Reading the signed-in
+account name instead would require the `identity.email` permission and its
+consent prompt; not worth it for a label.
+
+Extension version bumps to `0.18.0`.
+
+### 2. Bridge: one client becomes many
+
+`ChromeCompanionBridge` replaces its single-client fields with
+`clients: Map<string, ChromeClient>` keyed by `profileId`:
+
+```ts
+type ChromeClient = {
+  profileId: string
+  token: string
+  clientName: string
+  clientVersion: string | null
+  pairedAt: number
+  lastSeenAt: number | null
+  queue: PendingCommand[]
+  pending: Map<string, PendingCommand>
+}
+```
+
+**One token per Chrome profile.** `authorize(request)` resolves the bearer token
+to a client by constant-time comparison against each client's token, and returns
+the client. Every authenticated handler then operates on that client alone. A
+compromised extension in one Chrome profile cannot read another profile's
+command queue or pull another profile's cookies — which is the entire point of
+the feature, so a shared token with a self-declared `profileId` header is
+rejected as a design option.
+
+`/v1/connect` mints a token for the connecting `profileId` only. It rejects the
+pending commands of *that* client (a reconnect invalidates its own in-flight
+work) and leaves every other client untouched. This is the ping-pong fix.
+
+`/v1/poll`, `/v1/result`, `/v1/session/changed` and the side-panel chat routes
+all scope to the resolved client. `command<T>()` gains a `profileId` target and
+uses that client's queue and pending map; each client keeps its own command
+timeout bookkeeping.
+
+**Persistence.** The pairing state file becomes `{ clients: PersistedClient[] }`.
+A file still holding the old single-record shape loads as one client with
+`profileId: null`, which is treated as legacy-unbound: it stays authorized so an
+un-upgraded extension keeps working, and it is replaced by a properly keyed
+client on the extension's next `/v1/connect` after the upgrade.
+
+**Status.** `status()` keeps returning a single summary for existing consumers
+(paired/connected = any client), and a new `clients()` returns the per-profile
+list for the UI and for routing decisions. `disconnect()` takes an optional
+`profileId`; with none it drops every client, as today.
+
+### 3. Binding
+
+`BrowserProfileStore` profile metadata gains:
+
+- `chromeProfileId: string | null`
+- `chromeProfileLabel: string | null` (cached for display when Chrome is offline)
+
+The binding is one-to-one in both directions. Binding a Chrome ID that is
+already bound removes it from its previous Codey profile in the same write, so
+the store can never hold two profiles claiming the same Chrome.
+
+**Auto-create on first sight.** When a `profileId` connects and no Codey profile
+is bound to it, Codey creates one named after the Chrome label (deduped against
+existing names), turns `autoSync` on, and binds it. Zero setup: work in a Chrome
+profile and the matching Codey profile appears. The binding is editable
+afterwards.
+
+### 4. Sync routing
+
+- Each client's poll response carries the watch list, exclusions and revision of
+  *its* bound Codey profile only. The global `autoSyncProfileCache`,
+  `sharedExclusionCache` and single `autoSyncRevision` become per-client state
+  keyed by `profileId`.
+- `runAutoSync` iterates connected clients rather than mirroring profiles. For
+  client C bound to Codey profile P it exports from C and calls
+  `resyncProfileSites(P, …)`. Nothing else is written.
+- `onSessionChanged(domains)` becomes `onSessionChanged(profileId, domains)`.
+  A burst from an unbound client is dropped.
+- `onConnected` / `onPoll` become per-client, so one Chrome reconnecting forces
+  a full sync of its own profile and not of everyone else's.
+- Per-client pending-domain sets, full-sync flags and retry backoff, so a
+  failing Chrome cannot stall another's sync.
+
+### 5. Which Chrome a Codey-initiated command targets
+
+Commands Codey starts — `activeTab`, `snapshot`, `navigate`, `act`,
+`listSessionSites`, `exportSessionForSites`, the agent-facing `chrome`
+subcommands — target the Chrome bound to the **currently active Codey browser
+profile**.
+
+Failure modes get named errors rather than a generic "not connected":
+
+- active profile has no binding → `Profile "X" is not linked to a Chrome profile`
+- bound Chrome is not connected → `Chrome profile "Y" (linked to "X") is not running`
+- no Codey profile is active → `Activate a browser profile first`
+
+### 6. Which Codey profile a Chrome-initiated request feeds
+
+Requests Chrome starts already arrive on an authorized connection, so the client
+is known from the token. Session-change bursts route to that client's bound
+profile. The side panel's `suggestProfileName` and `profilesOverview` default to
+the caller's own bound profile.
+
+### 7. UI
+
+`BrowserProfiles.tsx` — each profile row gains a line under the name:
+`Chrome: <label>` or `Not linked to Chrome`. Clicking opens a picker listing
+every known Chrome profile (connected ones marked) plus "None". Picking a Chrome
+already bound elsewhere shows what it will be moved away from.
+
+`BrowserPanel.tsx` — the Chrome settings section lists all connected Chrome
+profiles with their bound Codey profile, instead of one connection row.
+
+### 8. IPC surface
+
+- `browser:profiles:setChromeBinding(name, chromeProfileId | null)`
+- `browser:chrome:clients()` → the list of known/connected Chrome profiles
+- `browser:chrome:renameClient(chromeProfileId, label)`
+- `browser:chrome:disconnect(chromeProfileId?)` — existing handler gains the
+  optional argument
+
+### 9. Testing
+
+**`chrome-companion.test.ts`**
+- two clients connect; both stay paired and both polls stay authorized
+- a command targeted at client A appears only in A's poll
+- a result posted with A's token cannot resolve B's pending command
+- A's token is rejected on a route scoped to B
+- legacy single-record state file loads, authorizes, and is replaced on reconnect
+
+**`browser-profiles.test.ts`**
+- binding is one-to-one; rebinding clears the previous owner
+- auto-created profile is named, deduped, autoSync on, bound
+- metadata round-trips through read/write
+
+**`main.ts` auto-sync (via existing harness)**
+- a change from Chrome A writes only the profile bound to A
+- an unbound client's change burst is dropped
+- a failing client does not block another client's sync pass
+
+### 10. Files touched
+
+| File | Change |
+| --- | --- |
+| `codey-mac/electron/chrome-companion.ts` | connection layer rewritten for N clients |
+| `codey-mac/electron/main.ts` | per-client auto-sync loop, target resolution, new IPC |
+| `codey-mac/electron/browser-profiles.ts` | binding metadata + one-to-one enforcement |
+| `codey-mac/electron/browser-controller.ts` | binding accessors, active-profile target |
+| `codey-mac/electron/browser-agent-bridge.ts` | agent `chrome` commands resolve a target |
+| `codey-mac/electron/preload.ts`, `src/codey-api.d.ts` | new IPC |
+| `codey-mac/src/components/BrowserProfiles.tsx` | binding row + picker |
+| `codey-mac/src/components/BrowserPanel.tsx` | multi-connection settings |
+| `chrome-extension/service-worker.js`, `sidepanel.js`, `manifest.json` | profile ID, version bump |
+| `packages/core/src/skills/chrome-companion/SKILL.md` | targeting semantics |
+
+## Out of scope
+
+- Reading Chrome's real profile directory or account identity.
+- Syncing Codey → Chrome. The flow stays Chrome → Codey.
+- Any change to how the Codey browser's own partitions work (#429 stands).

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       }
     },
     "codey-mac": {
-      "version": "0.12.14",
+      "version": "0.12.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/core/src/skills/chrome-companion/SKILL.md
+++ b/packages/core/src/skills/chrome-companion/SKILL.md
@@ -22,6 +22,13 @@ Chrome Companion extension. Every command is one shell call:
 ELECTRON_RUN_AS_NODE=1 "$CODEY_BROWSER_RUNTIME" "$CODEY_BROWSER_CLI" chrome <command> [args]
 ```
 
+Every command targets exactly one Chrome profile: the one bound to the Codey
+Browser profile that is currently active. Activate a different Codey profile
+(in Browser settings) and the same command goes to a different Chrome. If no
+profile is active, or the active profile is not linked to Chrome, the command
+fails with a named error that says what to change - relay it to the user
+rather than guessing.
+
 ### Reading
 
 - `chrome status` checks whether the extension is connected.


### PR DESCRIPTION
## What

Each Chrome profile is now bound to exactly one Codey browser profile, so a change made in Chrome profile X updates only the Codey profile bound to X — and several Chrome profiles can be connected and synced at once instead of fighting over a single pairing.

Builds on #429 (per-profile partitions) and the earlier session's spec (`docs/superpowers/specs/2026-09-09-chrome-profile-binding-design.md`).

## Changes

**Bridge (`chrome-companion.ts`)**
- One client per Chrome profile (`Map<profileId, client>`), one token each. A token only reaches its own command queue/pending map and cookies.
- `/v1/connect` re-pairs only its own client (fixes two Chrome profiles ping-ponging over one pairing). Legacy single-record pairing state still loads and authorizes until the upgraded extension reconnects.

**Binding (`browser-profiles.ts`, `browser-controller.ts`)**
- Profile metadata gains `chromeProfileId` / `chromeProfileLabel`, one-to-one enforced in both directions.
- A newly seen Chrome profile auto-creates and binds a mirroring Codey profile (autoSync on, name deduped).

**Sync routing (`main.ts`)**
- Auto-sync state is per client. A change from Chrome A writes only the profile bound to A; a failing/disconnected Chrome no longer stalls another's pass.
- `onSessionChanged` / `onConnected` / `onPoll` are per profile; reconnect forces a full sync of only that profile.

**Targeting**
- Codey-initiated commands (screenshots, navigate, agent `chrome` actions) resolve to the Chrome bound to the active Codey profile, with named failures for unbound/unlinked/offline cases.

**Extension (0.18.0)**
- Reports a stable per-profile UUID from `chrome.storage.local`; re-pairs once when a legacy token lacks one.

**UI**
- Profile rows gain a "Chrome: <label>" binding picker (None / offline / moved-from hint).
- Companion Settings lists connected Chrome profiles with bound Codey profile, rename and per-profile disconnect.

## Verification

- Tests: `1067/1067` pass
- `tsc --noEmit` clean
- `vite build` (renderer + electron main + preload) succeeds
- ESLint: 0 errors

## Out of scope

- Chrome → Codey reverse sync (flow stays Chrome → Codey one-way).
- Real-account smoke test across two Chrome profiles still needs a manual pass.
