### PR TITLE
fix(mac): persist thinking disclosure and collapse from the bottom

### DIFF
--- a/codey-mac/src/components/ChatTab.tsx
+++ b/codey-mac/src/components/ChatTab.tsx
@@ -25,6 +25,7 @@ import { isTaskBriefStale, extractSidecarBrief } from './taskHudView'
 import { onTeamsChanged } from './teamsChanged'
 import { formatHeadline, normalizeTool, ToolDetail, hasDetail } from './toolFormat'
 import { defaultThinkingExpanded } from './thinkingState'
+import { getThinkingToggles, rememberThinkingToggle } from './thinkingToggles'
 import { formatTokens } from './turnHeaderModel'
 import {
   TurnHeader, MESSAGE_ROW_INSET, TURN_RAIL_WIDTH, TURN_TEXT_PADDING, TURN_TEXT_INSET,
@@ -362,7 +363,18 @@ const ThinkingBlock: React.FC<{
         <span>{expanded ? 'Hide thinking' : 'Show thinking'}</span>
       </div>
       {expanded && (
-        <div style={styles.thinkingBody}>{thinking}</div>
+        <div style={styles.thinkingWrap}>
+          <div style={{ ...styles.thinkingBody, marginLeft: 0, marginBottom: 0, paddingBottom: 40 }}>{thinking}</div>
+          <div style={styles.thinkingFade}>
+            <button
+              type="button"
+              style={styles.thinkingFadeBtn}
+              onClick={() => setUserToggled(false)}
+            >
+              Hide thinking ▲
+            </button>
+          </div>
+        </div>
       )}
     </div>
   )
@@ -586,8 +598,10 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
   // The turn header owns the thinking chevron, so the disclosure state has to
   // live above it. Only a user's explicit toggle is stored; `undefined` means
   // fall back to defaultThinkingExpanded, which auto-opens thinking while the
-  // agent is still working and has produced no answer yet.
-  const [thinkingToggles, setThinkingToggles] = useState<Record<string, boolean>>({})
+  // agent is still working and has produced no answer yet. Seeded from the
+  // module store (thinkingToggles.ts) so an explicit toggle survives the
+  // remount that happens when switching chats.
+  const [thinkingToggles, setThinkingToggles] = useState<Record<string, boolean>>(() => getThinkingToggles())
   const [taskBriefLoading, setTaskBriefLoading] = useState(false)
   // This is a single app-wide display preference, not chat state. ChatTab is
   // remounted on chat switches, so seed it from localStorage and write changes
@@ -2199,6 +2213,10 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                       hasAnswer: !!msg.content.trim(),
                       isComplete: msg.isComplete ?? false,
                     })
+                  const setThinkingExpanded = (next: boolean) => {
+                    rememberThinkingToggle(msg.id, next)
+                    setThinkingToggles(p => ({ ...p, [msg.id]: next }))
+                  }
                   return (
                     <>
                       <TurnHeader
@@ -2206,7 +2224,7 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                         hasThinking={!!thinking}
                         turnComplete={!streaming}
                         expanded={expanded}
-                        onToggle={() => setThinkingToggles(p => ({ ...p, [msg.id]: !expanded }))}
+                        onToggle={() => setThinkingExpanded(!expanded)}
                         onAskAgentAboutFallback={(detail, fb) => { void askAgentAboutFallback(detail, fb) }}
                         leftAvatar={isWorkerMessage ? (
                           <WorkerAvatar name={msg.worker!} config={member?.config.avatar} state={memberState} />
@@ -2215,7 +2233,18 @@ const ChatTabView: React.FC<Props & { chat: Chat }> = ({
                         messageHovered={hoveredMsgId === msg.id}
                       />
                       {!!thinking && expanded && (
-                        <div style={styles.thinkingBody}>{thinking}</div>
+                        <div style={styles.thinkingWrap}>
+                          <div style={{ ...styles.thinkingBody, marginLeft: 0, marginBottom: 0, paddingBottom: 40 }}>{thinking}</div>
+                          <div style={styles.thinkingFade}>
+                            <button
+                              type="button"
+                              style={styles.thinkingFadeBtn}
+                              onClick={() => setThinkingExpanded(false)}
+                            >
+                              Hide thinking ▲
+                            </button>
+                          </div>
+                        </div>
                       )}
                     </>
                   )
@@ -3580,6 +3609,28 @@ const styles: Record<string, React.CSSProperties> = {
     borderLeft: `2px solid ${C.border2}`, opacity: 0.85,
     color: C.fg2, fontSize: 12, lineHeight: 1.55,
     whiteSpace: 'pre-wrap' as const, overflowWrap: 'anywhere' as const,
+  },
+  // Thinking block (single-agent and team-step alike). Carries the 17px indent
+  // the body used to own, so the bottom fade anchors to the same left edge.
+  // The fade is a soft gradient into the page background with a frosted
+  // collapse pill on top, so a long block can be folded from the bottom
+  // instead of scrolling back up to the collapse affordance.
+  thinkingWrap: {
+    position: 'relative' as const,
+    marginLeft: 17, marginBottom: 8,
+  },
+  thinkingFade: {
+    position: 'absolute', left: 0, right: 0, bottom: 0, height: 40,
+    background: `linear-gradient(to bottom, transparent, ${C.bg})`,
+    display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
+    paddingBottom: 6, pointerEvents: 'none' as const,
+  },
+  thinkingFadeBtn: {
+    pointerEvents: 'auto' as const,
+    appearance: 'none', background: 'rgba(128, 128, 128, 0.14)',
+    backdropFilter: 'blur(4px)', border: `1px solid ${C.border2}`,
+    color: C.fg2, fontSize: 11, padding: '3px 10px', borderRadius: 999,
+    cursor: 'pointer',
   },
   // Reads as one quiet line of the transcript rather than a boxed callout: same
   // typography as the tool rows in `ToolCallList` (minimal), no fill, no border.

--- a/codey-mac/src/components/TurnHeader.tsx
+++ b/codey-mac/src/components/TurnHeader.tsx
@@ -99,6 +99,11 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
   // the containing assistant turn's hover state to cover the reply body too.
   const [headerActive, setHeaderActive] = React.useState(false)
   const identityVisible = messageHovered || headerActive
+  // The thinking chevron is part of the same on-demand metadata as the
+  // identity, so it hides with the name instead of dangling alone on an
+  // un-hovered turn. With no identity to reveal it stays visible — it is then
+  // the only affordance for the thinking it discloses.
+  const chevronOpacity = meta.identity && !identityVisible ? 0 : 1
   // A worker's avatar/name makes the row worth drawing even when there's
   // otherwise nothing to show.
   const isEmpty = (leftAvatar || leftLabel) ? false : meta.isEmpty
@@ -130,7 +135,7 @@ export const TurnHeader: React.FC<Props> = ({ msg, hasThinking, expanded, onTogg
                 title={expanded ? 'Hide thinking' : 'Show thinking'}
               >
                 {meta.identity && <IdentityLabel identity={meta.identity} visible={identityVisible} />}
-                <span style={{ ...styles.chevron, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+                <span style={{ ...styles.chevron, opacity: chevronOpacity, transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
                   <UIIcon name="chevron" size={14} strokeWidth={2} />
                 </span>
               </button>
@@ -278,7 +283,8 @@ const styles: Record<string, React.CSSProperties> = {
   },
   chevron: {
     display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-    flexShrink: 0, userSelect: 'none', transition: 'transform 0.15s ease',
+    flexShrink: 0, userSelect: 'none',
+    transition: 'transform 0.15s ease, opacity 0.1s ease',
   },
   stats: { fontVariantNumeric: 'tabular-nums', opacity: 0.55 },
   fallbackWrap: { position: 'relative', display: 'inline-flex', flexShrink: 0 },

--- a/codey-mac/src/components/thinkingToggles.test.ts
+++ b/codey-mac/src/components/thinkingToggles.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getThinkingToggles,
+  rememberThinkingToggle,
+  __resetThinkingToggles,
+} from './thinkingToggles'
+
+describe('thinking toggles', () => {
+  beforeEach(() => { __resetThinkingToggles() })
+
+  it('has no overrides initially', () => {
+    expect(getThinkingToggles()).toEqual({})
+  })
+
+  it('remembers an explicit collapse across a chat switch and back', () => {
+    rememberThinkingToggle('asst-1', false)
+    // The override is keyed by message id, not chat, so it must still be there
+    // after the remount that a chat switch causes.
+    expect(getThinkingToggles()).toEqual({ 'asst-1': false })
+  })
+
+  it('keeps the latest toggle per message', () => {
+    rememberThinkingToggle('asst-1', false)
+    rememberThinkingToggle('asst-1', true)
+    expect(getThinkingToggles()).toEqual({ 'asst-1': true })
+  })
+
+  it('tracks different messages independently', () => {
+    rememberThinkingToggle('asst-1', false)
+    rememberThinkingToggle('asst-2', true)
+    expect(getThinkingToggles()).toEqual({ 'asst-1': false, 'asst-2': true })
+  })
+})

--- a/codey-mac/src/components/thinkingToggles.ts
+++ b/codey-mac/src/components/thinkingToggles.ts
@@ -1,0 +1,22 @@
+// Per-message thinking disclosure overrides. ChatTab is remounted on every chat
+// switch (App.tsx keys it by chat id), so its local `thinkingToggles` state
+// reset and a thinking block the user collapsed would re-expand when they came
+// back (defaultThinkingExpanded auto-opens in-flight thinking). We keep the
+// explicit overrides in a module-level store keyed by message id so they
+// survive that remount, mirroring terminalVisibility.ts.
+const overrides = new Map<string, boolean>()
+
+/** All explicit overrides, used to seed ChatTab's state on mount. */
+export function getThinkingToggles(): Record<string, boolean> {
+  return Object.fromEntries(overrides)
+}
+
+/** Remember a user's explicit expand/collapse for one message. */
+export function rememberThinkingToggle(messageId: string, expanded: boolean): void {
+  overrides.set(messageId, expanded)
+}
+
+// Test-only: reset the store between cases.
+export function __resetThinkingToggles(): void {
+  overrides.clear()
+}


### PR DESCRIPTION
## Summary

Three thinking-disclosure polish items in the Mac app:

1. **Hide the chevron with the model identity.** The thinking chevron in `TurnHeader` used to stay visible while the `agent · model` label faded out on non-hovered turns, leaving a dangling arrow. It now shares the identity's hover reveal.

2. **Keep fold state across chat switches.** `ChatTab` remounts on every chat switch (it's keyed by chat id), which reset the in-component `thinkingToggles` and re-expanded in-flight thinking. Explicit toggles now live in a module-level store keyed by message id (`thinkingToggles.ts`), mirroring `terminalVisibility.ts`, and seed the component state on mount.

3. **Collapse thinking from the bottom.** A long thinking block's only collapse control was at the top, so folding it meant scrolling back up. Both single-agent and team-step thinking now render a bottom collapse pill over a gradient fade into the page background (frosted, semi-transparent), matching the existing user-message fold look.

## Changes

- `codey-mac/src/components/TurnHeader.tsx` — chevron opacity follows `identityVisible`
- `codey-mac/src/components/ChatTab.tsx` — seeded toggle state, shared `thinkingWrap/Fade/FadeBtn` styles + bottom collapse
- `codey-mac/src/components/thinkingToggles.ts` (new) — module store for per-message overrides
- `codey-mac/src/components/thinkingToggles.test.ts` (new) — store tests

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 1068 passed
