### PR TITLE
feat(browser): active-profile wording and drop profile export

### DIFF
--- a/codey-mac/electron/browser-agent-bridge.test.ts
+++ b/codey-mac/electron/browser-agent-bridge.test.ts
@@ -105,7 +105,6 @@ describe('BrowserAgentBridge', () => {
         name, active: true, autoSync: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0, createdAt: 1, updatedAt: 1, sourceUrl: null,
       })),
       deleteProfile: vi.fn(async () => ({ deleted: true })),
-      exportProfile: vi.fn(async () => ({ path: '/tmp/exported.json' })),
     }
     const onOpen = vi.fn()
     const requestControl = vi.fn(async () => true)
@@ -227,10 +226,6 @@ describe('BrowserAgentBridge', () => {
       const madeDefault = await call(info, 'POST', '/profile/default', { name: 'work' })
       expect(madeDefault.status).toBe(200)
       expect(controller.setDefaultProfile).toHaveBeenCalledWith('work')
-
-      const exported = await call(info, 'POST', '/profile/export', { name: 'work', path: '/tmp/work.json' })
-      expect(exported.body).toEqual({ path: '/tmp/exported.json' })
-      expect(controller.exportProfile).toHaveBeenCalledWith('work', '/tmp/work.json')
 
       const deleted = await call(info, 'POST', '/profile/delete', { name: 'work' })
       expect(deleted.body).toEqual({ deleted: true })

--- a/codey-mac/electron/browser-agent-bridge.ts
+++ b/codey-mac/electron/browser-agent-bridge.ts
@@ -17,7 +17,7 @@ type BridgeController = Pick<
   | 'waitFor' | 'upload' | 'listDownloads' | 'waitForDownload' | 'submit'
   | 'getLoginStatus'
   | 'getState' | 'back' | 'forward' | 'reload' | 'listTabs' | 'newTab' | 'switchTab' | 'closeTab'
-  | 'listProfiles' | 'activeProfileName' | 'saveProfile' | 'importProfile' | 'setDefaultProfile' | 'deleteProfile' | 'exportProfile'
+  | 'listProfiles' | 'activeProfileName' | 'saveProfile' | 'importProfile' | 'setDefaultProfile' | 'deleteProfile'
 >
 
 type CompanionController = Pick<ChromeCompanionBridge, 'status' | 'activeTab' | 'snapshot' | 'navigate' | 'act'>
@@ -428,11 +428,6 @@ export class BrowserAgentBridge {
       if (req.method === 'POST' && route === '/profile/delete') {
         const body = await readJson(req)
         json(res, 200, await this.controlled('delete-profile', () => this.controller.deleteProfile(String(body.name || ''))))
-        return
-      }
-      if (req.method === 'POST' && route === '/profile/export') {
-        const body = await readJson(req)
-        json(res, 200, await this.exclusive(() => this.controller.exportProfile(String(body.name || ''), String(body.path || ''))))
         return
       }
       json(res, 404, { error: 'Unknown browser command' })

--- a/codey-mac/electron/browser-agent-cli.cjs
+++ b/codey-mac/electron/browser-agent-cli.cjs
@@ -62,8 +62,7 @@ function usage() {
     '  profile list               List saved profiles and the active one',
     '  profile save <name>        Snapshot the current session into a profile',
     '  profile import <path> [name]  Import a session file into a profile',
-    '  profile default <name>     Choose which profile new tabs open under',
-    '  profile export <name> <path>  Write a profile to a shareable JSON file',
+    '  profile default <name>     Choose the active profile',
     '  profile delete <name>      Remove a profile',
     '  chrome status              Read Chrome Companion connection state',
     '  chrome tab                 Read the active real-Chrome tab',
@@ -271,9 +270,6 @@ async function main() {
           ...(rest[2] ? { name: rest[2] } : {}),
           source: { path: rest[1] },
         })
-      } else if (sub === 'export') {
-        if (!rest[1] || !rest[2]) throw new Error(`profile export needs a profile name and an output path\n${usage()}`)
-        value = await request('POST', '/profile/export', { name: rest[1], path: rest[2] })
       } else {
         throw new Error(`Unknown profile command: ${sub || ''}\n${usage()}`)
       }

--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -1234,24 +1234,8 @@ describe('BrowserController profiles', () => {
     }
   })
 
-  it('exportProfile writes the profile to an arbitrary path', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-profiles-'))
-    try {
-      const { controller } = makeFixture(dir)
-      await controller.importProfile('work', { json: '{"cookies":[]}' }, false)
-      const out = path.join(dir, '..', 'exported-work.json')
-      const result = await controller.exportProfile('work', out)
-      expect(result.path).toBe(path.resolve(out))
-      expect(JSON.parse(fs.readFileSync(out, 'utf8')).name).toBe('work')
-      fs.rmSync(out, { force: true })
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true })
-    }
-  })
-
-  it('exports localStorage from indexed origins after their tabs are closed', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-export-storage-'))
-    const out = path.join(dir, '..', 'exported-storage.json')
+  it('reads localStorage from indexed origins after their tabs are closed', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-read-storage-'))
     try {
       const hidden = {
         webContents: {
@@ -1277,23 +1261,23 @@ describe('BrowserController profiles', () => {
       store.writeMeta('work', null)
       store.rememberOrigins('work', ['https://app.example.com'])
 
-      await controller.exportProfile('work', out)
+      const contents = await controller.profileContents('work')
 
-      expect(JSON.parse(fs.readFileSync(out, 'utf8')).origins).toEqual([{
-        origin: 'https://app.example.com',
-        localStorage: [{ name: 'token', value: 'persisted' }],
+      expect(contents.sites).toEqual([{
+        domain: 'app.example.com',
+        cookieCount: 0,
+        cookieNames: [],
+        storage: [{ origin: 'https://app.example.com', keys: 1 }],
       }])
       expect(hidden.webContents.loadURL).toHaveBeenCalledWith('https://app.example.com/')
       expect(hidden.webContents.close).toHaveBeenCalled()
     } finally {
-      fs.rmSync(out, { force: true })
       fs.rmSync(dir, { recursive: true, force: true })
     }
   })
 
-  it('does not export localStorage from a cross-origin sign-in redirect', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-export-redirect-'))
-    const out = path.join(dir, '..', 'exported-redirect.json')
+  it('does not read localStorage from a cross-origin sign-in redirect', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-read-redirect-'))
     try {
       const hidden = {
         webContents: {
@@ -1319,12 +1303,11 @@ describe('BrowserController profiles', () => {
       store.writeMeta('work', null)
       store.rememberOrigins('work', ['https://app.example.com'])
 
-      await controller.exportProfile('work', out)
+      const contents = await controller.profileContents('work')
 
-      expect(JSON.parse(fs.readFileSync(out, 'utf8')).origins).toEqual([])
+      expect(contents.sites).toEqual([])
       expect(hidden.webContents.close).toHaveBeenCalled()
     } finally {
-      fs.rmSync(out, { force: true })
       fs.rmSync(dir, { recursive: true, force: true })
     }
   })

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -1253,30 +1253,10 @@ export class BrowserController {
     return { deleted: true }
   }
 
-  /** Write a profile's jar to an arbitrary path, so a session can be handed to
-   *  another machine (or another profile-enabled tool). The jar is the source
-   *  of truth, so the export is what the profile can actually sign in with. */
-  async exportProfile(name: string, targetPath: string): Promise<{ path: string }> {
-    const meta = this.profiles().read(name)
-    const data = await this.captureProfileData(name)
-    const file = path.resolve(String(targetPath))
-    fs.mkdirSync(path.dirname(file), { recursive: true })
-    const payload = {
-      ...data,
-      name,
-      createdAt: meta.createdAt,
-      updatedAt: meta.updatedAt,
-      sourceUrl: meta.sourceUrl,
-    }
-    fs.writeFileSync(file, JSON.stringify(payload, null, 2), { encoding: 'utf8', mode: 0o600 })
-    try { fs.chmodSync(file, 0o600) } catch { /* best-effort */ }
-    return { path: file }
-  }
-
   /** Everything a profile's jar holds, in the portable profile shape: its
    *  cookies plus the localStorage of every indexed origin. Open tabs are read
    *  directly; closed origins use a hidden page on the same partition. This is
-   *  the read side of profile export and the detailed contents disclosure.
+   *  the read side of saving a profile and the detailed contents disclosure.
    *  Page text and fields are never read — only the storage that holds login
    *  state. */
   private async captureProfileData(profileName: string | null): Promise<BrowserProfileData> {

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2721,18 +2721,6 @@ app.whenReady().then(async () => {
     await refreshWatchDomains()
     return { imported: true, profile }
   }))
-  ipcMain.handle('browser:profiles:export', (event, name: string) => browserCall(event, async () => {
-    const requested = String(name || '')
-    const result = await dialog.showSaveDialog(mainWindow ?? (undefined as any), {
-      title: 'Export browser profile',
-      buttonLabel: 'Export',
-      defaultPath: requested ? `${requested}.json` : 'profile.json',
-      filters: [{ name: 'Browser profile (JSON)', extensions: ['json'] }],
-    })
-    if (result.canceled || !result.filePath) return { exported: false, path: null }
-    const out = await browserController.exportProfile(requested, result.filePath)
-    return { exported: true, path: out.path }
-  }))
   ipcMain.handle('browser:extensions:list', event => browserCall(event, () => {
     if (!browserExtensionManager) throw new Error('Browser extensions are unavailable')
     return browserExtensionManager.list()

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -512,7 +512,6 @@ contextBridge.exposeInMainWorld('codey', {
       setAvatar: (name: string, avatar: string) => ipcRenderer.invoke('browser:profiles:setAvatar', name, avatar),
       delete: (name: string) => ipcRenderer.invoke('browser:profiles:delete', name),
       import: () => ipcRenderer.invoke('browser:profiles:import'),
-      export: (name: string) => ipcRenderer.invoke('browser:profiles:export', name),
       syncProfile: (name: string) => ipcRenderer.invoke('browser:profiles:syncProfile', name),
       setAutoSync: (name: string, enabled: boolean) => ipcRenderer.invoke('browser:profiles:setAutoSync', name, enabled === true),
       setExcludedSites: (name: string, sites: string[]) => ipcRenderer.invoke('browser:profiles:setExcludedSites', name, sites),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -703,7 +703,6 @@ declare global {
           setChromeBinding: (name: string, chromeProfileId: string | null) => Promise<IpcResult<BrowserProfileSummary>>
           delete: (name: string) => Promise<IpcResult<{ deleted: boolean }>>
           import: () => Promise<IpcResult<{ imported: boolean; profile: BrowserProfileSummary | null }>>
-          export: (name: string) => Promise<IpcResult<{ exported: boolean; path: string | null }>>
           syncProfile: (name: string) => Promise<IpcResult<{
             profile: BrowserProfileSummary
             siteCount: number

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -293,8 +293,8 @@ export const BrowserPanel: React.FC<Props> = ({
   useEffect(() => { void refreshProfiles() }, [tabs.length])
 
   // A jar per profile means one identity per tab, so this is a pick, not a set
-  // of toggles: it chooses which profile new tabs open under. Tabs already on
-  // screen keep the jar they were born on, so nothing visible changes.
+  // of toggles: it chooses the active profile. Tabs already on screen keep the
+  // jar they were born on, so nothing visible changes.
   const chooseDefaultProfile = async (name: string | null) => {
     setProfileBusy(true)
     try {
@@ -539,8 +539,8 @@ export const BrowserPanel: React.FC<Props> = ({
           type="button"
           style={{ ...styles.profileButton, ...(profileMenuOpen ? styles.profileButtonActive : null) }}
           title={activeProfile
-            ? `New tabs open in “${activeProfile}” — click to change`
-            : 'New tabs open without a profile — click to pick one'}
+            ? `Browsing as “${activeProfile}” — click to change`
+            : 'Browsing without a profile — click to pick one'}
           aria-label="Browser profile"
           aria-haspopup="menu"
           aria-expanded={profileMenuOpen}
@@ -581,7 +581,7 @@ export const BrowserPanel: React.FC<Props> = ({
 
       {profileMenuOpen && (
         <div ref={profileMenuRef} style={styles.profileMenu} role="menu" aria-label="Browser profiles">
-          <div style={styles.profileMenuHeading}>New tabs open in</div>
+          <div style={styles.profileMenuHeading}>Active profile</div>
           {profiles.length === 0 && (
             <div style={styles.profileMenuEmpty}>No profiles saved yet.</div>
           )}

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -26,8 +26,8 @@ function formatWhen(timestamp: number): string {
 
 /** The browser-profiles manager, shared by the browser toolbar (compact) and
  *  the Settings tab (full width). List, save the current session, import a
- *  session file, choose the default for new tabs, export and delete profiles
- *  through the main process's `window.codey.browser.profiles` bridge. */
+ *  session file, pick which profile is active, and delete profiles through the
+ *  main process's `window.codey.browser.profiles` bridge. */
 export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
   // Derived from the list itself, so it cannot disagree with the rows shown.
   const [profiles, setProfiles] = useState<BrowserProfileSummary[]>([])
@@ -132,7 +132,7 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
     const when = formatWhen(profile.updatedAt)
     if (when) bits.push(`updated ${when}`)
     if (profile.autoSync) bits.push('syncs with Chrome')
-    if (profile.active) bits.push('new tabs open here')
+    if (profile.active) bits.push('active')
     return bits.join(' · ')
   }
 
@@ -204,10 +204,10 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
             ...styles.defaultChoice,
             ...(!profiles.some(profile => profile.active) ? styles.defaultChoiceActive : null),
           }}
-          title="Open new tabs without a saved profile"
+          title="Browse without a saved profile"
         >
           <span aria-hidden="true">{profiles.some(profile => profile.active) ? '○' : '●'}</span>
-          New tabs open without a profile
+          No profile
         </button>
       )}
 
@@ -246,9 +246,9 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
               )}
             </div>
             <div style={{ flex: 1, minWidth: compact ? 180 : 0 }}>
-              {/* No "IN USE" pill next to the name: the toggle on this same
-                  row already says "In use" in the same green, so the pill was
-                  the same word twice with nothing extra to tell. */}
+              {/* No "IN USE" pill next to the name: the radio on this same row
+                  already says "Active", so the pill was the same word twice
+                  with nothing extra to tell. */}
               <div style={{ color: C.fg, fontSize: compact ? 12 : 13, fontWeight: 600 }}>{profile.name}</div>
               <button
                 type="button"
@@ -287,18 +287,11 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
               disabled={busy}
               onClick={() => void run(() => window.codey.browser.profiles.setDefault(profile.name))}
               style={{ ...styles.defaultChoice, ...(profile.active ? styles.defaultChoiceActive : null) }}
-              title={`Open new tabs in ${profile.name}`}
+              title={`Browse as ${profile.name}`}
             >
               <span aria-hidden="true">{profile.active ? '●' : '○'}</span>
-              {profile.active ? 'New tabs open here' : 'Use for new tabs'}
+              {profile.active ? 'Active' : 'Activate'}
             </button>
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => void run(() => window.codey.browser.profiles.export(profile.name))}
-              style={buttonStyle(compact)}
-              title="Write this profile to a shareable JSON file"
-            ><UIIcon name="copy" size={12} /></button>
             {confirmDelete === profile.name ? (
               <button
                 type="button"

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -57,12 +57,11 @@ there without a save step. The user chooses which profile new tabs open under
 by default - you can see the set and open your own tab in one, but you cannot
 change their default for them.
 
-- `profile list` - saved profiles, with the default one flagged
+- `profile list` - saved profiles, with the active one flagged
 - `profile save <name>` - snapshot the current session into a named profile
 - `profile import <path> [name]` - import a session file (a Codey profile or
   a Playwright storageState JSON) into a profile's jar
-- `profile default <name>` - choose which profile new tabs open under
-- `profile export <name> <path>` - write a saved profile to a shareable file
+- `profile default <name>` - choose the active profile
 - `profile delete <name>` - remove a saved profile
 
 To open a tab in a specific profile, put `--profile <name>` before a command


### PR DESCRIPTION
## What

Two browser-profile UI/surface cleanups, rebased on top of #432:

1. The per-profile picker now reads as a single identity — **Active / Activate** and **No profile** — instead of "new tabs open here". Open tabs keep their jar; only new commands and new tabs follow the active profile.
2. Remove the JSON export path entirely (UI button, IPC handler, agent `profile export` CLI, and `exportProfile`). Import remains.

## Changes

- `BrowserProfiles.tsx` / `BrowserPanel.tsx` — wording ("Active"/"Activate"/"No profile", "Browsing as …"), drop the export button.
- `main.ts` / `preload.ts` / `codey-api.d.ts` — remove the `browser:profiles:export` IPC surface.
- `browser-controller.ts` — remove `exportProfile`.
- `browser-agent-bridge.ts` / `browser-agent-cli.cjs` — remove the agent-facing `profile export` command.
- `browser/SKILL.md` — drop the `profile export` docs, align wording to "active".

## Verification

- Tests: `1066/1066` pass
- `tsc --noEmit` clean
- No dangling references to the removed export surface (`git grep` clean outside historical plan docs)

## Notes

- Rebases cleanly on `main` (already includes #432). The two features overlap in a few files but the changes are non-conflicting.
