### PR TITLE
feat(browser): active profiles are many, targets are per-invocation

### DIFF
--- a/codey-mac/electron/browser-agent-bridge.test.ts
+++ b/codey-mac/electron/browser-agent-bridge.test.ts
@@ -42,7 +42,7 @@ function call(
 
 describe('BrowserAgentBridge', () => {
   it('authenticates agent commands and controls the shared browser', async () => {
-    const state = { url: 'https://example.com/', title: 'Example', loading: false, canGoBack: false, canGoForward: false, error: null }
+    const state = { url: 'https://example.com/', title: 'Example', loading: false, canGoBack: false, canGoForward: false, error: null, profile: null }
     const page = {
       url: state.url, title: state.title, description: '', text: 'Hello from the page',
       performance: { domContentLoadedMs: 20, loadMs: 30, transferBytes: 100 },
@@ -92,17 +92,19 @@ describe('BrowserAgentBridge', () => {
       closeTab: vi.fn(() => state),
       submit: vi.fn(async ref => ({ ok: true as const, url: state.url, message: `Submitted ${ref}` })),
       listProfiles: vi.fn(async () => []),
-      activeProfileName: vi.fn(() => null),
+      currentTabProfile: vi.fn(() => null),
+      isActiveProfile: vi.fn(() => false),
+      chromeBindingForProfile: vi.fn(() => null),
       saveProfile: vi.fn(async name => ({
-        name, active: false, autoSync: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0,
+        name, active: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0,
         createdAt: 1, updatedAt: 1, sourceUrl: null,
       })),
       importProfile: vi.fn(async name => ({
-        name, active: false, autoSync: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0,
+        name, active: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0,
         createdAt: 1, updatedAt: 1, sourceUrl: null,
       })),
-      setDefaultProfile: vi.fn(async (name: string | null) => name === null ? null : ({
-        name, active: true, autoSync: false, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0, createdAt: 1, updatedAt: 1, sourceUrl: null,
+      setActiveProfile: vi.fn(async name => ({
+        name, active: true, excludedSites: [], chromeProfileId: null, chromeProfileLabel: null, cookieCount: 0, originCount: 0, createdAt: 1, updatedAt: 1, sourceUrl: null,
       })),
       deleteProfile: vi.fn(async () => ({ deleted: true })),
     }
@@ -152,20 +154,20 @@ describe('BrowserAgentBridge', () => {
       expect(chromeViewed.body.text).toBe('Signed in through Chrome')
       const chromeOpened = await call(info, 'POST', '/chrome/open', { url: 'https://github.com' }, info.chromeToken)
       expect(chromeOpened.body.url).toBe('https://github.com')
-      expect(companion.navigate).toHaveBeenCalledWith('https://github.com')
+      expect(companion.navigate).toHaveBeenCalledWith('https://github.com', null)
 
       // Acting on the real Chrome page asks about Chrome's URL, not the
       // embedded browser's, so the approval prompt names the page being changed.
       const chromeClicked = await call(info, 'POST', '/chrome/click', { ref: 'e4' }, info.chromeToken)
       expect(chromeClicked.status).toBe(200)
-      expect(companion.act).toHaveBeenCalledWith('click', 'e4', undefined)
+      expect(companion.act).toHaveBeenCalledWith('click', 'e4', undefined, null)
       expect(requestControl).toHaveBeenLastCalledWith({
         command: 'chrome click', url: 'https://example.com/account', surface: 'chrome', level: 'write',
       })
 
       const chromeFilled = await call(info, 'POST', '/chrome/fill', { ref: 'e5', value: 'hello' }, info.chromeToken)
       expect(chromeFilled.status).toBe(200)
-      expect(companion.act).toHaveBeenLastCalledWith('fill', 'e5', 'hello')
+      expect(companion.act).toHaveBeenLastCalledWith('fill', 'e5', 'hello', null)
 
       // A denied action must never reach Chrome.
       requestControl.mockResolvedValueOnce(false)
@@ -223,9 +225,9 @@ describe('BrowserAgentBridge', () => {
       // The import lands in that profile's own jar, so there is nothing to approve.
       expect(requestControl).not.toHaveBeenCalledWith(expect.objectContaining({ command: 'activate-profile' }))
 
-      const madeDefault = await call(info, 'POST', '/profile/default', { name: 'work' })
-      expect(madeDefault.status).toBe(200)
-      expect(controller.setDefaultProfile).toHaveBeenCalledWith('work')
+      const activated = await call(info, 'POST', '/profile/activate', { name: 'work' })
+      expect(activated.status).toBe(200)
+      expect(controller.setActiveProfile).toHaveBeenCalledWith('work', true)
 
       const deleted = await call(info, 'POST', '/profile/delete', { name: 'work' })
       expect(deleted.body).toEqual({ deleted: true })
@@ -291,7 +293,7 @@ describe('BrowserAgentBridge', () => {
         },
       })
       expect(JSON.parse(profileCli.stdout).text).toBe('Hello from the page')
-      expect(controller.setDefaultProfile).not.toHaveBeenCalledWith('cli')
+      expect(controller.setActiveProfile).not.toHaveBeenCalledWith('cli')
       expect(requestControl).not.toHaveBeenCalledWith(expect.objectContaining({ command: 'activate-profile' }))
 
       const profileListCli = await execFileAsync(process.execPath, [cli, 'profile', 'list'], {
@@ -335,7 +337,7 @@ describe('BrowserAgentBridge', () => {
     const release: Array<() => void> = []
     const controller = {
       getState: vi.fn(() => ({ url: 'https://example.com/' })),
-      activeProfileName: vi.fn(() => null),
+      currentTabProfile: vi.fn(() => null),
       listTabs: vi.fn(() => []),
       // Parks until the test releases it, so the two tab requests really do
       // pile up behind one another the way two busy agents would make them.

--- a/codey-mac/electron/browser-agent-bridge.ts
+++ b/codey-mac/electron/browser-agent-bridge.ts
@@ -17,7 +17,7 @@ type BridgeController = Pick<
   | 'waitFor' | 'upload' | 'listDownloads' | 'waitForDownload' | 'submit'
   | 'getLoginStatus'
   | 'getState' | 'back' | 'forward' | 'reload' | 'listTabs' | 'newTab' | 'switchTab' | 'closeTab'
-  | 'listProfiles' | 'activeProfileName' | 'saveProfile' | 'importProfile' | 'setDefaultProfile' | 'deleteProfile'
+  | 'listProfiles' | 'currentTabProfile' | 'isActiveProfile' | 'chromeBindingForProfile' | 'saveProfile' | 'importProfile' | 'setActiveProfile' | 'deleteProfile'
 >
 
 type CompanionController = Pick<ChromeCompanionBridge, 'status' | 'activeTab' | 'snapshot' | 'navigate' | 'act'>
@@ -95,6 +95,18 @@ export class BrowserAgentBridge {
     private readonly loginPollIntervalMs = 2000,
     private readonly companion?: CompanionController,
   ) {}
+
+  /** The Chrome profile ID a `--profile <name>` command targets, or null when
+   *  the caller passed no `--profile` (the companion then falls back to the
+   *  current tab). An inactive or unbound profile fails with a named error. */
+  private chromeTarget(): string | null {
+    const name = this.profileScope.getStore()?.name
+    if (!name) return null
+    if (!this.controller.isActiveProfile(name)) throw new Error(`Profile "${name}" is not active`)
+    const binding = this.controller.chromeBindingForProfile(name)
+    if (!binding) throw new Error(`Profile "${name}" is not linked to a Chrome profile`)
+    return binding.profileId
+  }
 
   async start(): Promise<BrowserAgentBridgeInfo> {
     if (this.info) return this.info
@@ -209,7 +221,7 @@ export class BrowserAgentBridge {
         return
       }
       if (req.method === 'GET' && route === '/state') {
-        json(res, 200, { ...this.controller.getState(), profile: this.controller.activeProfileName() })
+        json(res, 200, { ...this.controller.getState(), profile: this.controller.currentTabProfile() })
         return
       }
       if (req.method === 'POST' && route === '/wait-login') {
@@ -234,7 +246,7 @@ export class BrowserAgentBridge {
         const url = String(body.url || 'about:blank')
         json(res, 200, await this.exclusive(async () => {
           this.onAgentOpen(url)
-          return await this.controller.newTab(url, this.profileScope.getStore()?.name ?? null)
+          return await this.controller.newTab(url, this.profileScope.getStore()?.name ?? this.controller.currentTabProfile())
         }))
         return
       }
@@ -360,18 +372,21 @@ export class BrowserAgentBridge {
       }
       if (req.method === 'GET' && route === '/chrome/tab') {
         if (!this.companion) throw new Error('Chrome companion is unavailable')
-        json(res, 200, await this.companion.activeTab())
+        const target = this.chromeTarget()
+        json(res, 200, await this.companion.activeTab(target))
         return
       }
       if (req.method === 'GET' && route === '/chrome/view') {
         if (!this.companion) throw new Error('Chrome companion is unavailable')
-        json(res, 200, await this.companion.snapshot())
+        const target = this.chromeTarget()
+        json(res, 200, await this.companion.snapshot(target))
         return
       }
       if (req.method === 'POST' && route === '/chrome/open') {
         if (!this.companion) throw new Error('Chrome companion is unavailable')
         const body = await readJson(req)
-        json(res, 200, await this.companion.navigate(String(body.url || '')))
+        const target = this.chromeTarget()
+        json(res, 200, await this.companion.navigate(String(body.url || ''), target))
         return
       }
       // Acting on the real Chrome page. Navigation above only moves the tab;
@@ -381,13 +396,14 @@ export class BrowserAgentBridge {
           const body = await readJson(req)
           const ref = String(body.ref || '')
           const value = body.value === undefined ? undefined : String(body.value)
-          json(res, 200, await this.controlledChrome(action, () => this.companion!.act(action, ref, value)))
+          const target = this.chromeTarget()
+          json(res, 200, await this.controlledChrome(action, () => this.companion!.act(action, ref, value, target)))
           return
         }
       }
       // ── Profiles ──────────────────────────────────────────────────────
       if (req.method === 'GET' && route === '/profiles') {
-        json(res, 200, { active: this.controller.activeProfileName(), profiles: await this.controller.listProfiles() })
+        json(res, 200, { active: this.controller.currentTabProfile(), profiles: await this.controller.listProfiles() })
         return
       }
       if (req.method === 'POST' && route === '/profile/save') {
@@ -399,30 +415,29 @@ export class BrowserAgentBridge {
         const body = await readJson(req)
         const source = body.source
         const name = String(body.name || '')
-        const makeDefault = body.makeDefault !== false
+        const activate = body.activate !== false
         const operation = async () => {
           if (typeof source === 'object' && source !== null && 'path' in source) {
             const filePath = String((source as Record<string, unknown>).path || '')
             if (!filePath) throw new Error('A profile source path is required')
             const derived = name || path.basename(filePath).replace(/\.json$/i, '')
-            return await this.controller.importProfile(derived, { path: filePath }, makeDefault)
+            return await this.controller.importProfile(derived, { path: filePath }, activate)
           }
           if (typeof source === 'object' && source !== null && 'json' in source) {
             if (!name) throw new Error('A profile name is required when importing JSON text')
-            return await this.controller.importProfile(name, { json: String((source as Record<string, unknown>).json || '') }, makeDefault)
+            return await this.controller.importProfile(name, { json: String((source as Record<string, unknown>).json || '') }, activate)
           }
           throw new Error('profile import needs a source: { path } or { json }')
         }
         // An import lands in that profile's own jar, so it replaces nothing a
-        // user can see and needs no approval; `makeDefault` only decides which
-        // jar new tabs open under.
+        // user can see and needs no approval; `activate` only adds it to the
+        // enabled set.
         json(res, 200, await this.exclusive(operation))
         return
       }
-      if (req.method === 'POST' && route === '/profile/default') {
+      if (req.method === 'POST' && route === '/profile/activate') {
         const body = await readJson(req)
-        const name = body.name === null ? null : String(body.name || '')
-        json(res, 200, await this.controller.setDefaultProfile(name))
+        json(res, 200, await this.controller.setActiveProfile(String(body.name || ''), body.enabled !== false))
         return
       }
       if (req.method === 'POST' && route === '/profile/delete') {

--- a/codey-mac/electron/browser-agent-cli.cjs
+++ b/codey-mac/electron/browser-agent-cli.cjs
@@ -62,7 +62,7 @@ function usage() {
     '  profile list               List saved profiles and the active one',
     '  profile save <name>        Snapshot the current session into a profile',
     '  profile import <path> [name]  Import a session file into a profile',
-    '  profile default <name>     Choose the active profile',
+    '  profile activate <name> [on|off]  Enable or disable a profile',
     '  profile delete <name>      Remove a profile',
     '  chrome status              Read Chrome Companion connection state',
     '  chrome tab                 Read the active real-Chrome tab',
@@ -258,9 +258,9 @@ async function main() {
       } else if (sub === 'save') {
         if (!rest[1]) throw new Error(`Missing profile name\n${usage()}`)
         value = await request('POST', '/profile/save', { name: rest[1] })
-      } else if (sub === 'default') {
+      } else if (sub === 'activate') {
         if (!rest[1]) throw new Error(`Missing profile name\n${usage()}`)
-        value = await request('POST', '/profile/default', { name: rest[1] === 'none' ? null : rest[1] })
+        value = await request('POST', '/profile/activate', { name: rest[1], enabled: rest[2] !== 'off' })
       } else if (sub === 'delete') {
         if (!rest[1]) throw new Error(`Missing profile name\n${usage()}`)
         value = await request('POST', '/profile/delete', { name: rest[1] })

--- a/codey-mac/electron/browser-controller.test.ts
+++ b/codey-mac/electron/browser-controller.test.ts
@@ -677,7 +677,7 @@ describe('BrowserController profiles', () => {
       // Startup only migrates schema-1 files. A current profile's persistent
       // partition is already the source of truth and must remain untouched.
       await expect(controller.migrateProfilesToPartitions()).resolves.toEqual({ migrated: [] })
-      await controller.setDefaultProfile('work')
+      await controller.setActiveProfile('work', true)
       expect(removed).toEqual([])
       expect(clearStorageData).not.toHaveBeenCalled()
     } finally {
@@ -866,24 +866,28 @@ describe('BrowserController profiles', () => {
     }
   })
 
-  it('sets which profile new tabs open under, without touching open tabs', async () => {
+  it('enables and disables a profile without touching open tabs', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-default-'))
     try {
       const { controller, cookiesSet } = makeFixture(dir)
       new BrowserProfileStore(dir).writeMeta('work', null)
+      new BrowserProfileStore(dir).writeMeta('personal', null)
       cookiesSet.mockClear()
-      await controller.setDefaultProfile('work')
-      expect(controller.activeProfileName()).toBe('work')
+      await controller.setActiveProfile('work', true)
+      await controller.setActiveProfile('personal', true)
+      expect(controller.isActiveProfile('work')).toBe(true)
+      expect(controller.isActiveProfile('personal')).toBe(true)
       // Nothing was replayed into any jar: existing tabs keep their identity.
       expect(cookiesSet).not.toHaveBeenCalled()
-      await controller.setDefaultProfile(null)
-      expect(controller.activeProfileName()).toBeNull()
+      await controller.setActiveProfile('work', false)
+      expect(controller.isActiveProfile('work')).toBe(false)
+      expect(controller.isActiveProfile('personal')).toBe(true)
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }
   })
 
-  it('uses the default profile when it creates the first browser tab', () => {
+  it('creates the first browser tab with no profile', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codey-ctl-first-tab-'))
     try {
       const controller = new BrowserController(
@@ -896,12 +900,12 @@ describe('BrowserController profiles', () => {
       )
       const store = new BrowserProfileStore(dir)
       store.writeMeta('work', null)
-      store.setActive('work')
+      store.setActive('work', true)
       const view = { webContents: { loadURL: vi.fn(async () => {}) } }
-      const createTab = vi.spyOn(controller as any, 'createTab').mockReturnValue({ id: 't1', view, profile: 'work' })
+      const createTab = vi.spyOn(controller as any, 'createTab').mockReturnValue({ id: 't1', view, profile: null })
 
       expect((controller as any).ensureView()).toBe(view)
-      expect(createTab).toHaveBeenCalledWith(true, 'work')
+      expect(createTab).toHaveBeenCalledWith(true, null)
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }
@@ -1092,7 +1096,7 @@ describe('BrowserController profiles', () => {
     try {
       const { controller } = makeFixture(dir)
       await expect(controller.saveProfile('../evil')).rejects.toThrow(/Profile names/)
-      await expect(controller.setDefaultProfile('.hidden')).rejects.toThrow(/Profile names/)
+      await expect(controller.setActiveProfile('.hidden', true)).rejects.toThrow(/Profile names/)
       await expect(controller.deleteProfile('a/b')).rejects.toThrow(/Profile names/)
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
@@ -1137,7 +1141,7 @@ describe('BrowserController profiles', () => {
         httpOnly: true,
         sameSite: 'lax',
       }))
-      expect(controller.activeProfileName()).toBe('gh')
+      expect(controller.isActiveProfile('gh')).toBe(true)
       expect((await controller.listProfiles()).find(profile => profile.name === 'gh')?.active).toBe(true)
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
@@ -1149,7 +1153,7 @@ describe('BrowserController profiles', () => {
     try {
       const { controller, cookiesSet } = makeFixture(dir)
       await controller.importProfile('work', { json: '{"cookies":[]}' }, false)
-      expect(controller.activeProfileName()).toBeNull()
+      expect(controller.isActiveProfile('work')).toBe(false)
       expect(cookiesSet).not.toHaveBeenCalled()
       expect(await controller.listProfiles()).toHaveLength(1)
     } finally {
@@ -1217,17 +1221,17 @@ describe('BrowserController profiles', () => {
         controller, cookiesSet, cookiesRemove, clearStorage, clearCache, clearAuthCache,
       } = makeFixture(dir)
       await controller.importProfile('work', { json: '{"cookies":[]}' }, true)
-      expect(controller.activeProfileName()).toBe('work')
+      expect(controller.isActiveProfile('work')).toBe(true)
       cookiesRemove.mockClear()
       cookiesSet.mockClear()
-      const summary = await controller.setDefaultProfile('work')
-      expect(summary?.active).toBe(true)
+      const summary = await controller.setActiveProfile('work', true)
+      expect(summary.active).toBe(true)
       expect(cookiesRemove).not.toHaveBeenCalled()
       await controller.deleteProfile('work')
       expect(clearStorage).toHaveBeenCalled()
       expect(clearCache).toHaveBeenCalled()
       expect(clearAuthCache).toHaveBeenCalled()
-      expect(controller.activeProfileName()).toBeNull()
+      expect(controller.isActiveProfile('work')).toBe(false)
       expect(await controller.listProfiles()).toEqual([])
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })

--- a/codey-mac/electron/browser-controller.ts
+++ b/codey-mac/electron/browser-controller.ts
@@ -45,6 +45,8 @@ export interface BrowserState {
   canGoBack: boolean
   canGoForward: boolean
   error: string | null
+  /** The profile of the tab currently on screen, or null. */
+  profile: string | null
 }
 
 export interface BrowserPageContext {
@@ -160,6 +162,7 @@ const EMPTY_STATE: BrowserState = {
   canGoBack: false,
   canGoForward: false,
   error: null,
+  profile: null,
 }
 
 /** Convert address-bar input into a safe browser URL. */
@@ -358,7 +361,7 @@ export class BrowserController {
     if (!tab.view.webContents.isDestroyed()) tab.view.webContents.close({ waitForBeforeUnload: false })
     if (wasActive) {
       const next = this.tabs[Math.min(index, this.tabs.length - 1)]
-        ?? this.createTab(false, this.activeProfileName())
+        ?? this.createTab(false, tab.profile)
       if (!next.view.webContents.getURL()) {
         void next.view.webContents.loadURL('about:blank').catch(() => {})
       }
@@ -981,9 +984,16 @@ export class BrowserController {
     return filled
   }
 
-  /** Name of the enabled profile, or null when none is enabled. */
-  activeProfileName(): string | null {
-    return this.profiles().active()
+  /** The profile of the tab currently on screen, or null when there is no tab
+   *  or the tab has no profile. This is the manual target for commands. */
+  currentTabProfile(): string | null {
+    return this.tabs.find(tab => tab.view === this.view)?.profile ?? null
+  }
+
+  /** Whether a profile is enabled (and therefore invocable). Synchronous so a
+   *  command target can be resolved without awaiting jar counts. */
+  isActiveProfile(name: string): boolean {
+    return this.profiles().activeNames().includes(name)
   }
 
   /** Snapshot the current tab's jar into a named profile. Used to turn "I am
@@ -1002,12 +1012,12 @@ export class BrowserController {
 
   /** Import a session snapshot from a file path or raw JSON (our profile
    *  format or a Playwright storageState) into a profile's jar. The import
-   *  always lands in that jar - no other profile can see it - so `makeDefault`
-   *  only decides whether new tabs open under it. */
+   *  always lands in that jar - no other profile can see it - so `activate`
+   *  only decides whether it becomes one of the enabled profiles. */
   async importProfile(
     name: string,
     source: { path: string } | { json: string },
-    makeDefault = true,
+    activate = true,
     sourceUrl: string | null = null,
   ): Promise<BrowserProfileSummary> {
     assertProfileName(name)
@@ -1016,7 +1026,7 @@ export class BrowserController {
       : parseProfileJsonText(source.json)
     this.profiles().writeMeta(name, sourceUrl)
     await this.writeJar(name, data)
-    if (makeDefault) this.profiles().setActive(name)
+    if (activate) this.profiles().setActive(name, true)
     return this.summaryOf(name)
   }
 
@@ -1124,16 +1134,12 @@ export class BrowserController {
     return this.summaryOf(name)
   }
 
-  /** Which profile new tabs open under. Nothing is replayed and no open tab
-   *  changes identity - a tab keeps the jar it was created on for life. */
-  async setDefaultProfile(name: string | null): Promise<BrowserProfileSummary | null> {
-    if (name === null) {
-      this.profiles().setActive(null)
-      return null
-    }
+  /** Enable or disable a profile. Enabled profiles may be invoked (`--profile`,
+   *  new tabs); several can be enabled at once. */
+  async setActiveProfile(name: string, enabled: boolean): Promise<BrowserProfileSummary> {
     assertProfileName(name)
     this.profiles().read(name)
-    this.profiles().setActive(name)
+    this.profiles().setActive(name, enabled === true)
     return this.summaryOf(name)
   }
 
@@ -1149,7 +1155,6 @@ export class BrowserController {
       base = {
         name,
         avatar: profile.avatar ?? null,
-        autoSync: profile.autoSync === true,
         excludedSites: profile.excludedSites,
         chromeProfileId: profile.chromeProfileId,
         chromeProfileLabel: profile.chromeProfileLabel,
@@ -1199,11 +1204,6 @@ export class BrowserController {
     return this.profiles().setAvatar(name, avatar)
   }
 
-  /** Turn "keep this profile in sync with Chrome" on or off for one profile. */
-  setProfileAutoSync(name: string, enabled: boolean): BrowserProfileSummary {
-    return this.profiles().setAutoSync(name, enabled)
-  }
-
   /** Replace the sites this profile excludes from automatic Chrome refresh. */
   setProfileExcludedSites(name: string, sites: readonly string[]): BrowserProfileSummary {
     return this.profiles().setExcludedSites(name, sites)
@@ -1231,7 +1231,7 @@ export class BrowserController {
     const seed = label.trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^\.+|\.+$/g, '') || 'Chrome-profile'
     const name = availableProfileName(seed.slice(0, 64), taken)
     this.profiles().writeMeta(name, null)
-    this.profiles().setAutoSync(name, true)
+    this.profiles().setActive(name, true)
     return this.profiles().setChromeBinding(name, profileId, label)
   }
 
@@ -1249,7 +1249,7 @@ export class BrowserController {
       browserSession.clearAuthCache(),
     ])
     this.profiles().remove(name)
-    if (this.profiles().active() === name) this.profiles().setActive(null)
+    this.profiles().setActive(name, false)
     return { deleted: true }
   }
 
@@ -1658,7 +1658,7 @@ export class BrowserController {
   private ensureView(): WebContentsView {
     if (this.view && !this.view.webContents.isDestroyed()) return this.view
 
-    const tab = this.createTab(true, this.activeProfileName())
+    const tab = this.createTab(true, this.currentTabProfile())
     void tab.view.webContents.loadURL('about:blank').catch(() => {
       // A caller may immediately navigate elsewhere and abort this initial
       // blank load; the real navigation owns any user-visible error state.
@@ -1881,6 +1881,7 @@ export class BrowserController {
       loading: contents.isLoading(),
       canGoBack: contents.canGoBack(),
       canGoForward: contents.canGoForward(),
+      profile: this.currentTabProfile(),
     })
   }
 

--- a/codey-mac/electron/browser-profiles.test.ts
+++ b/codey-mac/electron/browser-profiles.test.ts
@@ -154,25 +154,6 @@ describe('BrowserProfileStore', () => {
     }
   })
 
-  it('keeps the per-profile auto-sync switch across re-saves', () => {
-    const { dir, store } = makeStore()
-    try {
-      store.writeMeta('work', null)
-      expect(store.list()[0].autoSync).toBe(false)
-
-      expect(store.setAutoSync('work', true).autoSync).toBe(true)
-      // A refresh rewrites the profile's metadata; the switch must survive it,
-      // or auto-sync would turn itself off on its own first run.
-      store.writeMeta('work', null)
-      expect(store.read('work').autoSync).toBe(true)
-
-      expect(store.setAutoSync('work', false).autoSync).toBe(false)
-      expect(store.read('work').autoSync).toBe(false)
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true })
-    }
-  })
-
   it('normalizes and preserves per-profile Chrome exclusions', () => {
     const { dir, store } = makeStore()
     try {
@@ -185,7 +166,7 @@ describe('BrowserProfileStore', () => {
       // Every metadata-only rewrite must keep the exclusion list.
       store.writeMeta('work', 'https://github.com/')
       store.setAvatar('work', '💼')
-      store.setAutoSync('work', true)
+      store.setActive('work', true)
       store.touch('work')
       expect(store.read('work').excludedSites).toEqual(['github.com', 'google.com'])
       expect(store.list()[0].excludedSites).toEqual(['github.com', 'google.com'])
@@ -261,7 +242,7 @@ describe('BrowserProfileStore', () => {
 
       // Metadata-only edits must not drop the index used by closed-tab export.
       store.setAvatar('work', '💼')
-      store.setAutoSync('work', true)
+      store.setActive('work', true)
       store.setExcludedSites('work', ['example.com'])
       store.touch('work')
       store.writeMeta('work', null)
@@ -281,18 +262,18 @@ describe('BrowserProfileStore', () => {
     const { dir, store } = makeStore()
     try {
       expect(store.activeNames()).toEqual([])
-      expect(store.active()).toBeNull()
-      store.setActive('work')
+      store.setActive('work', true)
       expect(store.activeNames()).toEqual(['work'])
-      expect(store.active()).toBe('work')
       expect(fs.readFileSync(path.join(dir, ACTIVE_PROFILE_FILE), 'utf8')).toBe('work\n')
 
-      // Setting another name replaces the default; only ever one at a time.
-      store.setActive('personal')
-      expect(store.activeNames()).toEqual(['personal'])
-      expect(store.active()).toBe('personal')
+      // Several can be enabled at once; disabling removes only that one.
+      store.setActive('personal', true)
+      expect(store.activeNames()).toEqual(['work', 'personal'])
 
-      store.setActive(null)
+      store.setActive('work', false)
+      expect(store.activeNames()).toEqual(['personal'])
+
+      store.setActive('personal', false)
       expect(store.activeNames()).toEqual([])
       expect(fs.existsSync(path.join(dir, ACTIVE_PROFILE_FILE))).toBe(false)
     } finally {
@@ -324,19 +305,20 @@ describe('BrowserProfileStore', () => {
     }
   })
 
-  it('flags the active profile in list()', () => {
+  it('flags enabled profiles in list()', () => {
     const { store } = makeStore()
     try {
       store.writeMeta('a', null)
       store.writeMeta('b', null)
-      store.setActive('b')
+      store.setActive('b', true)
+      store.setActive('a', true)
       const summaries = store.list()
       expect(summaries.find(profile => profile.name === 'b')?.active).toBe(true)
-      expect(summaries.find(profile => profile.name === 'a')?.active).toBe(false)
+      expect(summaries.find(profile => profile.name === 'a')?.active).toBe(true)
 
-      // Only one default at a time.
-      store.setActive('a')
-      expect(store.list().filter(profile => profile.active).map(profile => profile.name)).toEqual(['a'])
+      // Disabling one leaves the other enabled.
+      store.setActive('a', false)
+      expect(store.list().filter(profile => profile.active).map(profile => profile.name)).toEqual(['b'])
     } finally {
       // store() dir cleanup handled by each test's own dir; nothing to do.
     }
@@ -533,13 +515,13 @@ describe('BrowserProfileStore metadata records', () => {
     try {
       const store = new BrowserProfileStore(dir)
       store.writeMeta('work', null)
-      store.setAutoSync('work', true)
+      store.setActive('work', true)
       store.setExcludedSites('work', ['GitHub.com'])
       const before = store.read('work').updatedAt
       store.touch('work', before + 1000)
       const after = store.read('work')
       expect(after.updatedAt).toBe(before + 1000)
-      expect(after.autoSync).toBe(true)
+      expect(store.activeNames()).toEqual(['work'])
       expect(after.excludedSites).toEqual(['github.com'])
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })

--- a/codey-mac/electron/browser-profiles.ts
+++ b/codey-mac/electron/browser-profiles.ts
@@ -46,9 +46,6 @@ export interface BrowserProfile extends BrowserProfileData {
   name: string
   /** User-selected visual marker shown in the browser profile switcher. */
   avatar?: string | null
-  /** This profile mirrors Chrome, including newly visited sites, except for
-   *  its explicit exclusions. Off unless the user turned it on. */
-  autoSync?: boolean
   createdAt: number
   updatedAt: number
   /** The page that was showing when the profile was saved; null for imports. */
@@ -60,7 +57,6 @@ export interface BrowserProfile extends BrowserProfileData {
 export interface BrowserProfileMeta {
   name: string
   avatar?: string | null
-  autoSync?: boolean
   /** Chrome sites this profile must never refresh from automatically. */
   excludedSites: string[]
   /** The Chrome profile this one mirrors, as reported by the extension. The
@@ -81,7 +77,6 @@ export interface BrowserProfileMeta {
 export interface BrowserProfileSummary {
   name: string
   avatar?: string | null
-  autoSync: boolean
   excludedSites: string[]
   chromeProfileId: string | null
   chromeProfileLabel: string | null
@@ -424,7 +419,6 @@ export class BrowserProfileStore {
     return {
       name,
       avatar: meta?.avatar ?? null,
-      autoSync: meta?.autoSync === true,
       excludedSites: meta?.excludedSites ?? [],
       chromeProfileId: meta?.chromeProfileId ?? null,
       chromeProfileLabel: meta?.chromeProfileLabel ?? null,
@@ -452,7 +446,6 @@ export class BrowserProfileStore {
       avatar: typeof record.avatar === 'string' && (BROWSER_PROFILE_AVATARS as readonly string[]).includes(record.avatar)
         ? record.avatar
         : null,
-      autoSync: record.autoSync === true,
       excludedSites: normalizeExcludedSites(record.excludedSites),
       chromeProfileId: normalizeChromeProfileId(record.chromeProfileId),
       chromeProfileLabel: typeof record.chromeProfileLabel === 'string' && record.chromeProfileLabel.trim()
@@ -479,7 +472,6 @@ export class BrowserProfileStore {
       schema: PROFILE_SCHEMA,
       name,
       avatar: existing?.avatar ?? null,
-      autoSync: existing?.autoSync === true,
       excludedSites: existing?.excludedSites ?? [],
       chromeProfileId: existing?.chromeProfileId ?? null,
       chromeProfileLabel: existing?.chromeProfileLabel ?? null,
@@ -579,15 +571,6 @@ export class BrowserProfileStore {
     return this.summary(name, this.activeNames())
   }
 
-  /** Turn a profile's "mirror Chrome" flag on or off. Metadata only - the
-   *  saved session is untouched, and the snapshot does not read as newer. */
-  setAutoSync(name: string, enabled: boolean): BrowserProfileSummary {
-    assertProfileName(name)
-    const meta = this.read(name)
-    this.writeRecord(name, { ...meta, schema: PROFILE_SCHEMA, autoSync: enabled === true })
-    return this.summary(name, this.activeNames())
-  }
-
   /** Replace the sites omitted from this profile's automatic Chrome refresh.
    *  Like the auto-sync switch, this changes metadata only. */
   setExcludedSites(name: string, sites: readonly string[]): BrowserProfileSummary {
@@ -671,19 +654,18 @@ export class BrowserProfileStore {
     return names
   }
 
-  /** First enabled profile, or null. Kept for the callers that only ever
-   *  needed one name (the agent bridge's status lines). */
-  active(): string | null {
-    return this.activeNames()[0] ?? null
-  }
-
-  setActive(name: string | null): void {
-    if (name === null) {
+  /** Add or remove a name from the enabled set. Enabling is idempotent and
+   *  several profiles may be enabled at once; disabling removes only that one. */
+  setActive(name: string, enabled: boolean): void {
+    assertProfileName(name)
+    const current = this.activeNames()
+    const next = current.filter(existing => existing !== name)
+    if (enabled) next.push(name)
+    if (next.length === 0) {
       try { fs.unlinkSync(this.activeFile()) } catch { /* already absent */ }
       return
     }
-    assertProfileName(name)
     fs.mkdirSync(this.dir, { recursive: true })
-    fs.writeFileSync(this.activeFile(), `${name}\n`, { encoding: 'utf8', mode: 0o600 })
+    fs.writeFileSync(this.activeFile(), `${next.join('\n')}\n`, { encoding: 'utf8', mode: 0o600 })
   }
 }

--- a/codey-mac/electron/chrome-companion.ts
+++ b/codey-mac/electron/chrome-companion.ts
@@ -178,7 +178,7 @@ export interface ChromeCompanionFeatures {
    * that asked. Names and flags only - never session contents.
    */
   profilesOverview: (hostname: string | undefined, profileId: string | null) => Promise<{
-    profiles: Array<{ name: string; active: boolean; autoSync: boolean; holdsSite: boolean; linked: boolean }>
+    profiles: Array<{ name: string; active: boolean; holdsSite: boolean; linked: boolean }>
   }>
 }
 

--- a/codey-mac/electron/main.ts
+++ b/codey-mac/electron/main.ts
@@ -2276,7 +2276,6 @@ app.whenReady().then(async () => {
           profiles: (await browserController.listProfiles()).map(profile => ({
             name: profile.name,
             active: profile.active,
-            autoSync: profile.autoSync,
             holdsSite: holds.has(profile.name),
             linked: profile.chromeProfileId === profileId,
           })),
@@ -2340,11 +2339,12 @@ app.whenReady().then(async () => {
     console.warn(`[browser] Chrome companion unavailable: ${error instanceof Error ? error.message : String(error)}`)
   }
   // Commands Codey starts - screenshots, navigation, agent `chrome` actions -
-  // go to the Chrome profile linked to the currently active Codey browser
-  // profile. The named failures say what to fix instead of a generic error.
+  // go to the Chrome profile linked to the profile of the tab currently on
+  // screen. The named failures say what to fix instead of a generic error.
   chromeCompanion.setTargetResolver(() => {
-    const name = browserController.activeProfileName()
+    const name = browserController.currentTabProfile()
     if (!name) throw new Error('Activate a browser profile first')
+    if (!browserController.isActiveProfile(name)) throw new Error(`Profile "${name}" is not active`)
     const binding = browserController.chromeBindingForProfile(name)
     if (!binding) throw new Error(`Profile "${name}" is not linked to a Chrome profile`)
     const client = chromeCompanion!.clients().find(entry => entry.profileId === binding.profileId)
@@ -2450,7 +2450,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('browser:newTab', (event, url?: string, profile?: string | null) =>
     browserCall(event, () => browserController.newTab(
       url,
-      profile === undefined ? browserController.activeProfileName() : profile,
+      profile === undefined ? browserController.currentTabProfile() : profile,
     )))
   ipcMain.handle('browser:switchTab', (event, id: string) => browserCall(event, () => browserController.switchTab(id)))
   ipcMain.handle('browser:closeTab', (event, id: string) => browserCall(event, () => browserController.closeTab(id)))
@@ -2463,7 +2463,6 @@ app.whenReady().then(async () => {
   // Browser profiles: saved/imported sessions the renderer (browser toolbar
   // and Settings) manages through the same controller the agents use.
   ipcMain.handle('browser:profiles:list', event => browserCall(event, async () => ({
-    active: browserController.activeProfileName(),
     profiles: await browserController.listProfiles(),
   })))
   ipcMain.handle('browser:profiles:save', (event, name: string) =>
@@ -2472,10 +2471,16 @@ app.whenReady().then(async () => {
       await refreshWatchDomains()
       return result
     }))
-  // Which profile new tabs open under. Open tabs keep the jar they were born
-  // on, so this disturbs nothing that is already on screen.
-  ipcMain.handle('browser:profiles:setDefault', (event, name: string | null) =>
-    browserCall(event, () => browserController.setDefaultProfile(name === null ? null : String(name || ''))))
+  // Enable or disable a profile. Enabled profiles can be invoked; several can
+  // be on at once. Open tabs keep the jar they were born on, so this disturbs
+  // nothing that is already on screen.
+  ipcMain.handle('browser:profiles:setActive', (event, name: string, enabled: boolean) =>
+    browserCall(event, async () => {
+      const result = await browserController.setActiveProfile(String(name || ''), enabled === true)
+      // Activating a bound profile starts mirroring it; deactivating stops.
+      await refreshWatchDomains()
+      return result
+    }))
   // What a profile holds, for the disclosure in Settings > Profiles. Cookie and
   // storage values never come back - the window has no use for them.
   ipcMain.handle('browser:profiles:contents', (event, name: string) =>
@@ -2519,7 +2524,7 @@ app.whenReady().then(async () => {
   const refreshWatchDomains = async () => {
     const generation = (autoSyncConfigGeneration += 1)
     const profiles = (await browserController.listProfiles())
-      .filter(profile => profile.autoSync && !!profile.chromeProfileId)
+      .filter(profile => profile.active && !!profile.chromeProfileId)
     if (generation !== autoSyncConfigGeneration) return
     const liveIds = new Set<string>()
     for (const profile of profiles) {
@@ -2663,14 +2668,6 @@ app.whenReady().then(async () => {
     },
   })
   void refreshWatchDomains()
-  ipcMain.handle('browser:profiles:setAutoSync', (event, name: string, enabled: boolean) =>
-    browserCall(event, async () => {
-      const result = await browserController.setProfileAutoSync(String(name || ''), enabled === true)
-      // Turning the switch on changes the extension from idle to whole-Chrome
-      // watching and schedules an initial catch-up pass.
-      await refreshWatchDomains()
-      return result
-    }))
   ipcMain.handle('browser:profiles:setExcludedSites', (event, name: string, sites: string[]) =>
     browserCall(event, async () => {
       const result = browserController.setProfileExcludedSites(String(name || ''), Array.isArray(sites) ? sites : [])

--- a/codey-mac/electron/preload.ts
+++ b/codey-mac/electron/preload.ts
@@ -508,12 +508,11 @@ contextBridge.exposeInMainWorld('codey', {
     profiles: {
       list: () => ipcRenderer.invoke('browser:profiles:list'),
       save: (name: string) => ipcRenderer.invoke('browser:profiles:save', name),
-      setDefault: (name: string | null) => ipcRenderer.invoke('browser:profiles:setDefault', name),
+      setActive: (name: string, enabled: boolean) => ipcRenderer.invoke('browser:profiles:setActive', name, enabled === true),
       setAvatar: (name: string, avatar: string) => ipcRenderer.invoke('browser:profiles:setAvatar', name, avatar),
       delete: (name: string) => ipcRenderer.invoke('browser:profiles:delete', name),
       import: () => ipcRenderer.invoke('browser:profiles:import'),
       syncProfile: (name: string) => ipcRenderer.invoke('browser:profiles:syncProfile', name),
-      setAutoSync: (name: string, enabled: boolean) => ipcRenderer.invoke('browser:profiles:setAutoSync', name, enabled === true),
       setExcludedSites: (name: string, sites: string[]) => ipcRenderer.invoke('browser:profiles:setExcludedSites', name, sites),
       setChromeBinding: (name: string, chromeProfileId: string | null) => ipcRenderer.invoke('browser:profiles:setChromeBinding', name, chromeProfileId),
       contents: (name: string) => ipcRenderer.invoke('browser:profiles:contents', name),

--- a/codey-mac/src/codey-api.d.ts
+++ b/codey-mac/src/codey-api.d.ts
@@ -142,6 +142,7 @@ export interface BrowserState {
   canGoBack: boolean
   canGoForward: boolean
   error: string | null
+  profile: string | null
 }
 
 export interface BrowserPageContext {
@@ -201,8 +202,6 @@ export interface BrowserTab {
 export interface BrowserProfileSummary {
   name: string
   avatar: string | null
-  /** This profile keeps itself in sync with Chrome. */
-  autoSync: boolean
   /** Sites that automatic Chrome mirroring must leave untouched. */
   excludedSites: string[]
   /** The Chrome profile this one mirrors (null when linked to none). */
@@ -694,11 +693,10 @@ declare global {
         closeTab: (id: string) => Promise<IpcResult<BrowserState>>
         resetSession: () => Promise<IpcResult<BrowserState>>
         profiles: {
-          list: () => Promise<IpcResult<{ active: string | null; profiles: BrowserProfileSummary[] }>>
+          list: () => Promise<IpcResult<{ profiles: BrowserProfileSummary[] }>>
           save: (name: string) => Promise<IpcResult<BrowserProfileSummary>>
-          setDefault: (name: string | null) => Promise<IpcResult<BrowserProfileSummary | null>>
+          setActive: (name: string, enabled: boolean) => Promise<IpcResult<BrowserProfileSummary>>
           setAvatar: (name: string, avatar: string) => Promise<IpcResult<BrowserProfileSummary>>
-          setAutoSync: (name: string, enabled: boolean) => Promise<IpcResult<BrowserProfileSummary>>
           setExcludedSites: (name: string, sites: string[]) => Promise<IpcResult<BrowserProfileSummary>>
           setChromeBinding: (name: string, chromeProfileId: string | null) => Promise<IpcResult<BrowserProfileSummary>>
           delete: (name: string) => Promise<IpcResult<{ deleted: boolean }>>

--- a/codey-mac/src/components/BrowserPanel.tsx
+++ b/codey-mac/src/components/BrowserPanel.tsx
@@ -36,6 +36,7 @@ const EMPTY_STATE: BrowserState = {
   canGoBack: false,
   canGoForward: false,
   error: null,
+  profile: null,
 }
 
 const VIEW_ONLY: BrowserControlPermissionState = { granted: { browser: 'none', chrome: 'none' }, pending: null }
@@ -76,8 +77,6 @@ export const BrowserPanel: React.FC<Props> = ({
   const hostRef = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
-  const profileMenuRef = useRef<HTMLDivElement>(null)
-  const profileButtonRef = useRef<HTMLButtonElement>(null)
   const shownRef = useRef(false)
   const browserCoveredRef = useRef(false)
   const addressFocusedRef = useRef(false)
@@ -99,14 +98,11 @@ export const BrowserPanel: React.FC<Props> = ({
   const [chromeScanComplete, setChromeScanComplete] = useState(false)
   const [extensionBusy, setExtensionBusy] = useState(false)
   const [browserMenuOpen, setBrowserMenuOpen] = useState(false)
-  const [profileMenuOpen, setProfileMenuOpen] = useState(false)
   const [profiles, setProfiles] = useState<BrowserProfileSummary[]>([])
-  const [activeProfile, setActiveProfile] = useState<string | null>(null)
-  const [profileBusy, setProfileBusy] = useState(false)
   const [profilePickerOpen, setProfilePickerOpen] = useState(false)
   const [panelWidth, setPanelWidth] = useState(900)
 
-  const browserCovered = browserMenuOpen || profileMenuOpen || activeSettingsSection !== null
+  const browserCovered = browserMenuOpen || activeSettingsSection !== null
   browserCoveredRef.current = browserCovered
   const browserPageVisible = !browserCovered && !!state.url
 
@@ -259,26 +255,8 @@ export const BrowserPanel: React.FC<Props> = ({
     }
   }, [browserMenuOpen])
 
-  useEffect(() => {
-    if (!profileMenuOpen) return
-    const closeMenu = (event: MouseEvent) => {
-      const target = event.target as Node
-      if (!profileMenuRef.current?.contains(target) && !profileButtonRef.current?.contains(target)) setProfileMenuOpen(false)
-    }
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setProfileMenuOpen(false)
-    }
-    document.addEventListener('mousedown', closeMenu)
-    document.addEventListener('keydown', closeOnEscape)
-    return () => {
-      document.removeEventListener('mousedown', closeMenu)
-      document.removeEventListener('keydown', closeOnEscape)
-    }
-  }, [profileMenuOpen])
-
-  // The toolbar's profile chip. There is no profile-changed event, so refresh
-  // on mount and every time the menu opens — the Settings ▸ Profiles page can
-  // have activated a different one behind our back.
+  // The toolbar's profile chip reads the current tab's profile; the Settings ▸
+  // Profiles page is where profiles are enabled, disabled and synced.
   const refreshProfiles = async () => {
     if (!window.codey?.browser?.profiles) return
     const result = await window.codey.browser.profiles.list()
@@ -287,26 +265,9 @@ export const BrowserPanel: React.FC<Props> = ({
       return
     }
     setProfiles(result.data.profiles)
-    setActiveProfile(result.data.active)
   }
 
   useEffect(() => { void refreshProfiles() }, [tabs.length])
-
-  // A jar per profile means one identity per tab, so this is a pick, not a set
-  // of toggles: it chooses the active profile. Tabs already on screen keep the
-  // jar they were born on, so nothing visible changes.
-  const chooseDefaultProfile = async (name: string | null) => {
-    setProfileBusy(true)
-    try {
-      const result = await window.codey.browser.profiles.setDefault(name)
-      if (!result.ok) setLocalError(result.error)
-      else setLocalError(null)
-      await refreshProfiles()
-      setProfileMenuOpen(false)
-    } finally {
-      setProfileBusy(false)
-    }
-  }
 
   const navigate = async () => {
     const next = unwrapResult(await window.codey.browser.navigate(address))
@@ -325,8 +286,8 @@ export const BrowserPanel: React.FC<Props> = ({
 
   const displayedError = localError ?? state.error
   const secure = state.url.startsWith('https://')
-  const currentProfile = profiles.find(profile => profile.name === activeProfile)
-  const profileLabel = activeProfile ?? 'No profile'
+  const currentProfile = profiles.find(profile => profile.name === state.profile)
+  const profileLabel = state.profile ?? 'No profile'
   const avatarOf = (name: string | null) =>
     name === null ? null : (profiles.find(profile => profile.name === name)?.avatar ?? null)
 
@@ -534,26 +495,14 @@ export const BrowserPanel: React.FC<Props> = ({
           {state.loading && <span style={styles.loadingDot} aria-label="Loading" />}
         </form>
 
-        <button
-          ref={profileButtonRef}
-          type="button"
-          style={{ ...styles.profileButton, ...(profileMenuOpen ? styles.profileButtonActive : null) }}
-          title={activeProfile
-            ? `Browsing as “${activeProfile}” — click to change`
-            : 'Browsing without a profile — click to pick one'}
+        <div
+          style={styles.profileButton}
+          title={state.profile ? `Browsing as “${state.profile}”` : 'Browsing without a profile'}
           aria-label="Browser profile"
-          aria-haspopup="menu"
-          aria-expanded={profileMenuOpen}
-          onClick={() => {
-            setProfileMenuOpen(current => {
-              if (!current) void refreshProfiles()
-              return !current
-            })
-          }}
         >
           <span aria-hidden="true" style={styles.profileAvatarSmall}>{browserProfileAvatar(currentProfile)}</span>
           {panelWidth >= 640 && <span style={styles.profileButtonLabel}>{profileLabel}</span>}
-        </button>
+        </div>
         <button
           type="button"
           style={{ ...styles.contextButton, opacity: chatId && state.url && !activeSettingsSection ? 1 : 0.5 }}
@@ -578,46 +527,6 @@ export const BrowserPanel: React.FC<Props> = ({
           <UIIcon name="close" size={15} />
         </button>}
       </div>
-
-      {profileMenuOpen && (
-        <div ref={profileMenuRef} style={styles.profileMenu} role="menu" aria-label="Browser profiles">
-          <div style={styles.profileMenuHeading}>Active profile</div>
-          {profiles.length === 0 && (
-            <div style={styles.profileMenuEmpty}>No profiles saved yet.</div>
-          )}
-          <button
-            type="button"
-            role="menuitemradio"
-            aria-checked={activeProfile === null}
-            disabled={profileBusy}
-            style={{ ...styles.menuButton, ...(activeProfile === null ? styles.profileMenuItemActive : null) }}
-            onClick={() => void chooseDefaultProfile(null)}
-          >
-            <span style={styles.profileMenuName}>No profile</span>
-            <span aria-hidden="true" style={styles.profileMenuCheck}>{activeProfile === null ? '✓' : ''}</span>
-          </button>
-          {profiles.map(profile => (
-            <div key={profile.name} style={styles.profileMenuRow}>
-              <button
-                type="button"
-                role="menuitemradio"
-                aria-checked={profile.active}
-                disabled={profileBusy}
-                style={{ ...styles.menuButton, flex: 1, ...(profile.active ? styles.profileMenuItemActive : null) }}
-                onClick={() => void chooseDefaultProfile(profile.name)}
-              >
-                <span aria-hidden="true" style={styles.profileMenuAvatar}>{browserProfileAvatar(profile)}</span>
-                <span style={styles.profileMenuName}>{profile.name}</span>
-                <span aria-hidden="true" style={styles.profileMenuCheck}>{profile.active ? '✓' : ''}</span>
-              </button>
-            </div>
-          ))}
-          <div style={styles.profileMenuDivider} />
-          <button type="button" style={styles.menuButton} onClick={() => { setProfileMenuOpen(false); openProfiles() }}>
-            <UIIcon name="settings" size={13} /> Manage profiles…
-          </button>
-        </div>
-      )}
 
       {browserMenuOpen && (
         <div ref={menuRef} style={styles.browserMenu} role="menu" aria-label="Browser actions">
@@ -731,7 +640,7 @@ export const BrowserPanel: React.FC<Props> = ({
             type="button"
             onClick={() => { setProfilePickerOpen(false); void showWebTab(() => window.codey.browser.newTab(undefined, null)) }}
           >No profile</button>
-          {profiles.map(profile => (
+          {profiles.filter(profile => profile.active).map(profile => (
             <button
               key={profile.name}
               type="button"

--- a/codey-mac/src/components/BrowserProfiles.tsx
+++ b/codey-mac/src/components/BrowserProfiles.tsx
@@ -131,7 +131,6 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
     if (profile.originCount > 0) bits.push(`${profile.originCount} site${profile.originCount === 1 ? '' : 's'}`)
     const when = formatWhen(profile.updatedAt)
     if (when) bits.push(`updated ${when}`)
-    if (profile.autoSync) bits.push('syncs with Chrome')
     if (profile.active) bits.push('active')
     return bits.join(' · ')
   }
@@ -191,24 +190,6 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
           {!compact && <div style={styles.emptyIcon}><UIIcon name="users" size={16} /></div>}
           <span>No profiles yet — save this session or import a session file to get started.</span>
         </div>
-      )}
-
-      {profiles.length > 0 && (
-        <button
-          type="button"
-          role="radio"
-          aria-checked={!profiles.some(profile => profile.active)}
-          disabled={busy}
-          onClick={() => void run(() => window.codey.browser.profiles.setDefault(null))}
-          style={{
-            ...styles.defaultChoice,
-            ...(!profiles.some(profile => profile.active) ? styles.defaultChoiceActive : null),
-          }}
-          title="Browse without a saved profile"
-        >
-          <span aria-hidden="true">{profiles.some(profile => profile.active) ? '○' : '●'}</span>
-          No profile
-        </button>
       )}
 
       {profiles.map(profile => (
@@ -280,18 +261,15 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
                   : 'Not linked to Chrome'}
               </button>
             </div>
-            <button
-              type="button"
-              role="radio"
-              aria-checked={profile.active}
-              disabled={busy}
-              onClick={() => void run(() => window.codey.browser.profiles.setDefault(profile.name))}
-              style={{ ...styles.defaultChoice, ...(profile.active ? styles.defaultChoiceActive : null) }}
-              title={`Browse as ${profile.name}`}
-            >
-              <span aria-hidden="true">{profile.active ? '●' : '○'}</span>
-              {profile.active ? 'Active' : 'Activate'}
-            </button>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }} title="Enabled profiles can be invoked by an agent and opened in tabs">
+              <span style={{ color: C.fg3, fontSize: 10 }}>Active</span>
+              <Toggle
+                on={profile.active}
+                disabled={busy}
+                onChange={next => void run(() => window.codey.browser.profiles.setActive(profile.name, next))}
+                label={`Enable ${profile.name}`}
+              />
+            </div>
             {confirmDelete === profile.name ? (
               <button
                 type="button"
@@ -386,14 +364,8 @@ export const BrowserProfiles: React.FC<{ compact?: boolean }> = ({ compact = fal
               </label>
               <div style={styles.syncRow}>
                 <span style={styles.syncCopy}>
-                  Mirror Chrome automatically — new sites, cookie changes, and localStorage from open Chrome tabs flow into this profile.
+                  Active profiles mirror their linked Chrome automatically — new sites, cookie changes, and localStorage from open Chrome tabs flow into this profile.
                 </span>
-                <Toggle
-                  on={profile.autoSync}
-                  disabled={busy}
-                  onChange={next => void run(() => window.codey.browser.profiles.setAutoSync(profile.name, next))}
-                  label={`Keep ${profile.name} in sync with Chrome`}
-                />
               </div>
             </div>
           )}

--- a/docs/superpowers/specs/2026-09-10-browser-multi-active-design.md
+++ b/docs/superpowers/specs/2026-09-10-browser-multi-active-design.md
@@ -27,31 +27,34 @@ targets.
 
 ## Goal
 
-Two concepts, fully separated:
+Two per-profile concepts, fully separated from "which profile a command runs
+against":
 
-- **Activation** = `autoSync`. A profile is "active" when it auto-syncs with
-  Chrome. It is per-profile and many can be on at once.
-- **Target** = decided at the moment a command runs: the agent's
+- **active** = the profile is enabled and can be invoked. Per-profile, many at
+  once. This is the intuitive master switch.
+- **autoSync** = this active profile mirrors Chrome. Per-profile, unchanged
+  from #432. It only means something for an active profile.
+- **target** = decided at the moment a command runs: the agent's
   `--profile <name>`, else the browser tab currently on screen. No global
   "default/active" selection survives.
 
 ## Design
 
-### 1. Delete the single "active/default" profile
+### 1. `active` becomes per-profile "enabled", `autoSync` stays
 
-The `.active` file and everything that treated it as one-of-N goes away.
+The `.active` file already stores one name per line, so multi-enable is the
+format's native shape; only the writers and readers collapsed it to one.
 
-- `browser-profiles.ts`: remove `activeFile()`, `activeNames()`, `active()`,
-  `setActive()`, and the `active` field on `BrowserProfileSummary`.
-- `browser-controller.ts`: remove `activeProfileName()` and
-  `setDefaultProfile()`. `importProfile` drops its `makeDefault` parameter.
-- `main.ts`: remove the `browser:profiles:setDefault` IPC handler and the
-  `active` field from the profiles-list reply.
-- The side-panel `handoffSession` and any other `importProfile(…, true, …)`
-  callers drop the flag.
-
-"Which profiles are enabled" is now simply "which profiles have `autoSync`
-on", which the store already knows and #432 already drives per Chrome client.
+- `browser-profiles.ts`: `setActive(name, enabled)` adds/removes a name instead
+  of overwriting the file with one. `activeNames()` and the `active` summary
+  field stay (they already describe a set). `active()` (the first-name helper)
+  is removed — nothing should quietly take "the first" any more.
+- `browser-controller.ts`: `setDefaultProfile(name)` becomes
+  `setActiveProfile(name, enabled)`. `activeProfileName()` is removed.
+  `importProfile`'s `makeDefault` flag is renamed `activate` and now adds the
+  profile to the active set instead of making it the sole one.
+- `autoSync` is untouched: a profile mirrors Chrome only when it is both active
+  and autoSync (and bound, per #432).
 
 ### 2. Target = current tab, or `--profile`
 
@@ -62,14 +65,14 @@ Chrome commands and the `+` new-tab button act on the profile the user is
 looking at.
 
 **New-tab default follows the current tab.** `createTab` / `newTab` use
-`currentTabProfile()` instead of the removed `activeProfileName()`, so a new
-tab opened while viewing a `personal` tab opens in `personal`.
+`currentTabProfile()` instead of the removed `activeProfileName()`.
 
 **`targetResolver`** (set in `main.ts`) resolves the current tab's profile to
-its bound Chrome, exactly as today but from `currentTabProfile()` rather than
-`activeProfileName()`. Named failures stay:
+its bound Chrome. The resolution chain is: tab profile → must be active → must
+be bound → its Chrome is connected. Named failures:
 
 - no tab / tab has no profile → `Activate a browser profile first`
+- profile not active → `Profile "X" is not active`
 - profile not linked → `Profile "X" is not linked to a Chrome profile`
 - linked Chrome not running → `Chrome profile "Y" (linked to "X") is not running`
 
@@ -79,53 +82,56 @@ its bound Chrome, exactly as today but from `currentTabProfile()` rather than
 it only steers `newTab`. It now also steers every Chrome companion call.
 
 - Add `chromeTarget(): string | null` to the bridge: if `profileScope` holds a
-  name, resolve `controller.chromeBindingForProfile(name)` and return its
-  `profileId` (throw the "not linked" error when unbound). With no `--profile`
-  it returns `null` so the companion's `targetResolver` falls back to the
-  current tab.
+  name, check it is an active profile, resolve
+  `controller.chromeBindingForProfile(name)` and return its `profileId` (throw
+  the named "not active" / "not linked" error). With no `--profile` it returns
+  `null` so the companion's `targetResolver` falls back to the current tab.
 - The companion routes pass that target explicitly:
   `companion.activeTab(this.chromeTarget())`, `snapshot(…)`, `navigate(…,
   target)`, `act(…, target)`.
 - `getState().profile` and the `/profiles` reply report
   `controller.currentTabProfile()` instead of `activeProfileName()`.
 
-`--profile` names a Codey profile; the binding (#432) is what maps it to the
-Chrome that gets the command. No new mapping table is needed.
+`--profile` names a Codey profile; the binding (#432) maps it to the Chrome
+that gets the command. No new mapping table is needed.
 
 ### 4. UI
 
-- `BrowserProfiles.tsx`: remove the "No profile" radio and the per-profile
-  "Active / Activate" radio. The existing `autoSync` toggle is the activation,
-  so it moves out of the collapsed sync box to sit on the profile row (always
-  visible), labelled "Sync with Chrome".
-- `BrowserPanel.tsx`: the toolbar chip stops being a picker. It shows the
-  current tab's profile (already available as `state.profile`); the "Active
-  profile" menu goes away. The alt-click `+` picker stays — it explicitly
-  chooses a profile for *that* tab.
-- `browser/SKILL.md`: drop `profile default`, fold the notion of "the profile
-  you are looking at / `--profile`" into the command semantics.
+- `BrowserProfiles.tsx`: the single "No profile / Active / Activate" radio goes
+  away. Each profile row gets an **Active** toggle (per-profile, many on) and
+  keeps its **Sync with Chrome** (autoSync) toggle. Both always visible on the
+  row.
+- `BrowserPanel.tsx`: the toolbar chip stops being a picker — it shows the
+  current tab's profile (`state.profile`). The "Active profile" menu goes away.
+  The alt-click `+` picker stays; it chooses a profile for *that* tab and the
+  chosen profile must be active.
+- `browser/SKILL.md`: drop `profile default`; document that `--profile` names
+  an active profile and routes the command to that profile's bound Chrome.
 
 ### 5. IPC surface
 
-Removed: `browser:profiles:setDefault`.
-
-The `chromeCompanion:*` command handlers keep working unchanged — their
-resolution now goes through the current-tab `targetResolver`.
+- Removed: `browser:profiles:setDefault`.
+- Added: `browser:profiles:setActive(name, enabled)`.
+- `browser:profiles:list` still reports each profile's `active` flag (now
+  "enabled", multi) plus `autoSync`.
 
 ### 6. Testing
 
 **`browser-profiles.test.ts`**
-- the active-file store is gone: no `setActive`/`activeNames` assertions remain.
+- `setActive(name, true)` adds to the set; a second `setActive(other, true)`
+  leaves the first enabled; `setActive(name, false)` removes only that name.
+- a pre-existing `.active` file with several lines reads back as several active.
 
 **`browser-controller.test.ts`**
-- `newTab()` with no profile opens in the current tab's profile, not a global
-  default.
+- `newTab()` with no profile opens in the current tab's profile.
 - `currentTabProfile()` is null with no tab and matches the focused tab's
   profile with tabs open.
+- `setActiveProfile` / `importProfile(activate)` add to the active set instead
+  of replacing it.
 
 **`browser-agent-bridge.test.ts`**
 - `--profile personal` resolves to `personal`'s bound Chrome and is passed to
-  the companion call; an unbound profile throws the named error.
+  the companion call; an inactive or unbound profile throws the named error.
 - no `--profile` falls through (companion resolves the current tab).
 - `/profiles` and `getState().profile` report the current tab's profile.
 
@@ -136,12 +142,12 @@ null result as "fall back".
 
 | File | Change |
 | --- | --- |
-| `codey-mac/electron/browser-profiles.ts` | remove active-file store + `active` field |
-| `codey-mac/electron/browser-controller.ts` | `currentTabProfile()`, remove `activeProfileName`/`setDefaultProfile`, new-tab default, `importProfile` flag |
+| `codey-mac/electron/browser-profiles.ts` | `setActive(name, enabled)` toggle; drop `active()` |
+| `codey-mac/electron/browser-controller.ts` | `currentTabProfile()`, `setActiveProfile`, remove `activeProfileName`/`setDefaultProfile`, new-tab default, `importProfile(activate)` |
 | `codey-mac/electron/browser-agent-bridge.ts` | `chromeTarget()`, route Chrome calls, report current-tab profile |
-| `codey-mac/electron/main.ts` | `targetResolver` from current tab, drop `setDefault` IPC, drop `active` in list |
-| `codey-mac/electron/preload.ts`, `src/codey-api.d.ts` | drop `setDefault`/`active` |
-| `codey-mac/src/components/BrowserProfiles.tsx` | remove radio, promote autoSync toggle |
+| `codey-mac/electron/main.ts` | `targetResolver` from current tab, `setActive` IPC, drop `setDefault` |
+| `codey-mac/electron/preload.ts`, `src/codey-api.d.ts` | `setActive` replaces `setDefault` |
+| `codey-mac/src/components/BrowserProfiles.tsx` | Active toggle + autoSync toggle per row |
 | `codey-mac/src/components/BrowserPanel.tsx` | chip becomes read-only current-tab profile |
 | `packages/core/src/skills/browser/SKILL.md` | drop `profile default`, document targeting |
 

--- a/docs/superpowers/specs/2026-09-10-browser-multi-active-design.md
+++ b/docs/superpowers/specs/2026-09-10-browser-multi-active-design.md
@@ -27,20 +27,19 @@ targets.
 
 ## Goal
 
-Two per-profile concepts, fully separated from "which profile a command runs
-against":
+One per-profile concept — **active** — plus a per-invocation **target**:
 
-- **active** = the profile is enabled and can be invoked. Per-profile, many at
-  once. This is the intuitive master switch.
-- **autoSync** = this active profile mirrors Chrome. Per-profile, unchanged
-  from #432. It only means something for an active profile.
+- **active** = the profile is enabled. An active profile can be invoked, and
+  an active profile also mirrors its linked Chrome automatically. There is no
+  separate "auto-sync" switch: being active *is* the switch. Many profiles can
+  be active at once.
 - **target** = decided at the moment a command runs: the agent's
   `--profile <name>`, else the browser tab currently on screen. No global
   "default/active" selection survives.
 
 ## Design
 
-### 1. `active` becomes per-profile "enabled", `autoSync` stays
+### 1. `active` becomes per-profile "enabled", `autoSync` is folded into it
 
 The `.active` file already stores one name per line, so multi-enable is the
 format's native shape; only the writers and readers collapsed it to one.
@@ -48,24 +47,26 @@ format's native shape; only the writers and readers collapsed it to one.
 - `browser-profiles.ts`: `setActive(name, enabled)` adds/removes a name instead
   of overwriting the file with one. `activeNames()` and the `active` summary
   field stay (they already describe a set). `active()` (the first-name helper)
-  is removed — nothing should quietly take "the first" any more.
+  and the `autoSync` field/method are removed.
 - `browser-controller.ts`: `setDefaultProfile(name)` becomes
-  `setActiveProfile(name, enabled)`. `activeProfileName()` is removed.
-  `importProfile`'s `makeDefault` flag is renamed `activate` and now adds the
-  profile to the active set instead of making it the sole one.
-- `autoSync` is untouched: a profile mirrors Chrome only when it is both active
-  and autoSync (and bound, per #432).
+  `setActiveProfile(name, enabled)`; `setProfileAutoSync` and
+  `activeProfileName()` are removed. `importProfile`'s `makeDefault` flag is
+  renamed `activate` and now adds the profile to the active set.
+- `autoSync` is gone: mirroring is driven by `active` plus a binding. The
+  #432 sync loop keys on `active && chromeProfileId` instead of
+  `autoSync && chromeProfileId`.
 
 ### 2. Target = current tab, or `--profile`
 
 **A new `currentTabProfile()` accessor** on `BrowserController` returns the
 profile name of the tab currently on screen (`tabs.find(tab => tab.view ===
-this.view)?.profile ?? null`). This is the manual-UI target: the toolbar's
-Chrome commands and the `+` new-tab button act on the profile the user is
-looking at.
+this.view)?.profile ?? null`). `BrowserState` gains a `profile` field so the
+renderer can show it. This is the manual-UI target: the toolbar's Chrome
+commands and the `+` new-tab button act on the profile the user is looking at.
 
 **New-tab default follows the current tab.** `createTab` / `newTab` use
-`currentTabProfile()` instead of the removed `activeProfileName()`.
+`currentTabProfile()` instead of the removed `activeProfileName()`; closing the
+active tab creates the replacement tab on the closed tab's profile.
 
 **`targetResolver`** (set in `main.ts`) resolves the current tab's profile to
 its bound Chrome. The resolution chain is: tab profile → must be active → must
@@ -98,22 +99,21 @@ that gets the command. No new mapping table is needed.
 ### 4. UI
 
 - `BrowserProfiles.tsx`: the single "No profile / Active / Activate" radio goes
-  away. Each profile row gets an **Active** toggle (per-profile, many on) and
-  keeps its **Sync with Chrome** (autoSync) toggle. Both always visible on the
-  row.
+  away. Each profile row gets one **Active** toggle (per-profile, many on).
+  The "Sync with Chrome" (autoSync) toggle is gone — active profiles sync.
 - `BrowserPanel.tsx`: the toolbar chip stops being a picker — it shows the
   current tab's profile (`state.profile`). The "Active profile" menu goes away.
-  The alt-click `+` picker stays; it chooses a profile for *that* tab and the
-  chosen profile must be active.
-- `browser/SKILL.md`: drop `profile default`; document that `--profile` names
-  an active profile and routes the command to that profile's bound Chrome.
+  The alt-click `+` picker stays, listing only active profiles.
+- `browser/SKILL.md`: `profile default` becomes `profile activate`; document
+  that `--profile` names an active profile and routes the command to that
+  profile's bound Chrome.
 
 ### 5. IPC surface
 
-- Removed: `browser:profiles:setDefault`.
+- Removed: `browser:profiles:setDefault`, `browser:profiles:setAutoSync`.
 - Added: `browser:profiles:setActive(name, enabled)`.
-- `browser:profiles:list` still reports each profile's `active` flag (now
-  "enabled", multi) plus `autoSync`.
+- `browser:profiles:list` reports each profile's `active` flag (now "enabled",
+  multi).
 
 ### 6. Testing
 
@@ -121,6 +121,7 @@ that gets the command. No new mapping table is needed.
 - `setActive(name, true)` adds to the set; a second `setActive(other, true)`
   leaves the first enabled; `setActive(name, false)` removes only that name.
 - a pre-existing `.active` file with several lines reads back as several active.
+- `autoSync` is gone from the store and summary.
 
 **`browser-controller.test.ts`**
 - `newTab()` with no profile opens in the current tab's profile.
@@ -142,14 +143,14 @@ null result as "fall back".
 
 | File | Change |
 | --- | --- |
-| `codey-mac/electron/browser-profiles.ts` | `setActive(name, enabled)` toggle; drop `active()` |
-| `codey-mac/electron/browser-controller.ts` | `currentTabProfile()`, `setActiveProfile`, remove `activeProfileName`/`setDefaultProfile`, new-tab default, `importProfile(activate)` |
+| `codey-mac/electron/browser-profiles.ts` | `setActive(name, enabled)` toggle; drop `active()`, `autoSync` |
+| `codey-mac/electron/browser-controller.ts` | `currentTabProfile()`, `isActiveProfile()`, `setActiveProfile`, remove `activeProfileName`/`setDefaultProfile`/`setProfileAutoSync`, new-tab default, `importProfile(activate)`, `BrowserState.profile` |
 | `codey-mac/electron/browser-agent-bridge.ts` | `chromeTarget()`, route Chrome calls, report current-tab profile |
-| `codey-mac/electron/main.ts` | `targetResolver` from current tab, `setActive` IPC, drop `setDefault` |
-| `codey-mac/electron/preload.ts`, `src/codey-api.d.ts` | `setActive` replaces `setDefault` |
-| `codey-mac/src/components/BrowserProfiles.tsx` | Active toggle + autoSync toggle per row |
+| `codey-mac/electron/main.ts` | `targetResolver` from current tab, `setActive` IPC, sync loop keys on `active`, drop `setDefault`/`setAutoSync` |
+| `codey-mac/electron/preload.ts`, `src/codey-api.d.ts` | `setActive` replaces `setDefault`/`setAutoSync`; summary drops `autoSync` |
+| `codey-mac/src/components/BrowserProfiles.tsx` | Active toggle per row, remove sync toggle |
 | `codey-mac/src/components/BrowserPanel.tsx` | chip becomes read-only current-tab profile |
-| `packages/core/src/skills/browser/SKILL.md` | drop `profile default`, document targeting |
+| `packages/core/src/skills/browser/SKILL.md` | `profile activate`, document targeting |
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-09-10-browser-multi-active-design.md
+++ b/docs/superpowers/specs/2026-09-10-browser-multi-active-design.md
@@ -1,0 +1,153 @@
+# Browser multi-active — design
+
+**Date:** 2026-09-10
+**Branch:** `browser-active-profiles`
+**Builds on:** `c5e723b` (#434 active-profile wording + drop export, #432 Chrome
+binding, #429 per-profile partitions)
+
+## Problem
+
+"Active profile" does two unrelated jobs today, and the user's model splits
+them apart:
+
+1. **Which profiles mirror Chrome.** `autoSync` already exists per profile and
+   #432 already routes each Chrome's changes to its own bound jar. But the UI
+   also has a single "Active / Activate" radio (`setDefaultProfile`) that reads
+   as "only one profile can be on at a time" — the exact thing the user asked
+   to remove.
+2. **Which profile a command runs against.** Every Codey-initiated Chrome
+   command (`chrome tab` / `view` / `open` / `click`…) resolves through
+   `targetResolver` → `activeProfileName()` — the *first* of the enabled list.
+   So an agent that said `--profile personal` still gets routed to whatever the
+   global "active" happens to be, not to `personal`.
+
+The result is one radio pretending to be an identity switch, while `--profile`
+only ever affected which jar a *new tab* opens in, never which Chrome a command
+targets.
+
+## Goal
+
+Two concepts, fully separated:
+
+- **Activation** = `autoSync`. A profile is "active" when it auto-syncs with
+  Chrome. It is per-profile and many can be on at once.
+- **Target** = decided at the moment a command runs: the agent's
+  `--profile <name>`, else the browser tab currently on screen. No global
+  "default/active" selection survives.
+
+## Design
+
+### 1. Delete the single "active/default" profile
+
+The `.active` file and everything that treated it as one-of-N goes away.
+
+- `browser-profiles.ts`: remove `activeFile()`, `activeNames()`, `active()`,
+  `setActive()`, and the `active` field on `BrowserProfileSummary`.
+- `browser-controller.ts`: remove `activeProfileName()` and
+  `setDefaultProfile()`. `importProfile` drops its `makeDefault` parameter.
+- `main.ts`: remove the `browser:profiles:setDefault` IPC handler and the
+  `active` field from the profiles-list reply.
+- The side-panel `handoffSession` and any other `importProfile(…, true, …)`
+  callers drop the flag.
+
+"Which profiles are enabled" is now simply "which profiles have `autoSync`
+on", which the store already knows and #432 already drives per Chrome client.
+
+### 2. Target = current tab, or `--profile`
+
+**A new `currentTabProfile()` accessor** on `BrowserController` returns the
+profile name of the tab currently on screen (`tabs.find(tab => tab.view ===
+this.view)?.profile ?? null`). This is the manual-UI target: the toolbar's
+Chrome commands and the `+` new-tab button act on the profile the user is
+looking at.
+
+**New-tab default follows the current tab.** `createTab` / `newTab` use
+`currentTabProfile()` instead of the removed `activeProfileName()`, so a new
+tab opened while viewing a `personal` tab opens in `personal`.
+
+**`targetResolver`** (set in `main.ts`) resolves the current tab's profile to
+its bound Chrome, exactly as today but from `currentTabProfile()` rather than
+`activeProfileName()`. Named failures stay:
+
+- no tab / tab has no profile → `Activate a browser profile first`
+- profile not linked → `Profile "X" is not linked to a Chrome profile`
+- linked Chrome not running → `Chrome profile "Y" (linked to "X") is not running`
+
+### 3. Agent `--profile` routes Chrome commands
+
+`browser-agent-bridge.ts` already captures `--profile` in `profileScope`. Today
+it only steers `newTab`. It now also steers every Chrome companion call.
+
+- Add `chromeTarget(): string | null` to the bridge: if `profileScope` holds a
+  name, resolve `controller.chromeBindingForProfile(name)` and return its
+  `profileId` (throw the "not linked" error when unbound). With no `--profile`
+  it returns `null` so the companion's `targetResolver` falls back to the
+  current tab.
+- The companion routes pass that target explicitly:
+  `companion.activeTab(this.chromeTarget())`, `snapshot(…)`, `navigate(…,
+  target)`, `act(…, target)`.
+- `getState().profile` and the `/profiles` reply report
+  `controller.currentTabProfile()` instead of `activeProfileName()`.
+
+`--profile` names a Codey profile; the binding (#432) is what maps it to the
+Chrome that gets the command. No new mapping table is needed.
+
+### 4. UI
+
+- `BrowserProfiles.tsx`: remove the "No profile" radio and the per-profile
+  "Active / Activate" radio. The existing `autoSync` toggle is the activation,
+  so it moves out of the collapsed sync box to sit on the profile row (always
+  visible), labelled "Sync with Chrome".
+- `BrowserPanel.tsx`: the toolbar chip stops being a picker. It shows the
+  current tab's profile (already available as `state.profile`); the "Active
+  profile" menu goes away. The alt-click `+` picker stays — it explicitly
+  chooses a profile for *that* tab.
+- `browser/SKILL.md`: drop `profile default`, fold the notion of "the profile
+  you are looking at / `--profile`" into the command semantics.
+
+### 5. IPC surface
+
+Removed: `browser:profiles:setDefault`.
+
+The `chromeCompanion:*` command handlers keep working unchanged — their
+resolution now goes through the current-tab `targetResolver`.
+
+### 6. Testing
+
+**`browser-profiles.test.ts`**
+- the active-file store is gone: no `setActive`/`activeNames` assertions remain.
+
+**`browser-controller.test.ts`**
+- `newTab()` with no profile opens in the current tab's profile, not a global
+  default.
+- `currentTabProfile()` is null with no tab and matches the focused tab's
+  profile with tabs open.
+
+**`browser-agent-bridge.test.ts`**
+- `--profile personal` resolves to `personal`'s bound Chrome and is passed to
+  the companion call; an unbound profile throws the named error.
+- no `--profile` falls through (companion resolves the current tab).
+- `/profiles` and `getState().profile` report the current tab's profile.
+
+**`chrome-companion.test.ts`** — unchanged; `targetResolver` already treats a
+null result as "fall back".
+
+### 7. Files touched
+
+| File | Change |
+| --- | --- |
+| `codey-mac/electron/browser-profiles.ts` | remove active-file store + `active` field |
+| `codey-mac/electron/browser-controller.ts` | `currentTabProfile()`, remove `activeProfileName`/`setDefaultProfile`, new-tab default, `importProfile` flag |
+| `codey-mac/electron/browser-agent-bridge.ts` | `chromeTarget()`, route Chrome calls, report current-tab profile |
+| `codey-mac/electron/main.ts` | `targetResolver` from current tab, drop `setDefault` IPC, drop `active` in list |
+| `codey-mac/electron/preload.ts`, `src/codey-api.d.ts` | drop `setDefault`/`active` |
+| `codey-mac/src/components/BrowserProfiles.tsx` | remove radio, promote autoSync toggle |
+| `codey-mac/src/components/BrowserPanel.tsx` | chip becomes read-only current-tab profile |
+| `packages/core/src/skills/browser/SKILL.md` | drop `profile default`, document targeting |
+
+## Out of scope
+
+- Chrome → Codey reverse sync (still Chrome → Codey only).
+- Any change to per-profile partitions (#429) or Chrome binding (#432).
+- A picker for "which Chrome" when several are bound and no tab/`--profile`
+  names one — the named error is the whole answer for now.

--- a/packages/core/src/skills/browser/SKILL.md
+++ b/packages/core/src/skills/browser/SKILL.md
@@ -53,29 +53,32 @@ a task or carry a session to another machine.
 
 Profiles are isolated: each one has its own cookie jar, so two profiles can be
 signed into the same site at once and a login made inside a profile stays
-there without a save step. The user chooses which profile new tabs open under
-by default - you can see the set and open your own tab in one, but you cannot
-change their default for them.
+there without a save step. A profile is **active** when the user has enabled
+it; active profiles also mirror their linked Chrome automatically. Several can
+be active at once - you can read the set but you cannot enable or disable one
+for the user.
 
-- `profile list` - saved profiles, with the active one flagged
+- `profile list` - saved profiles, with the active ones flagged
 - `profile save <name>` - snapshot the current session into a named profile
 - `profile import <path> [name]` - import a session file (a Codey profile or
   a Playwright storageState JSON) into a profile's jar
-- `profile default <name>` - choose the active profile
+- `profile activate <name> [on|off]` - enable or disable a profile
 - `profile delete <name>` - remove a saved profile
 
-To open a tab in a specific profile, put `--profile <name>` before a command
-that opens a tab. That tab runs on that profile's jar alone, so a task meant
-for one identity cannot reach for another's cookies. No other tab changes, so
-nothing needs approving:
+To act as a specific profile, put `--profile <name>` before the command. The
+tab you open runs on that profile's jar alone, and Chrome commands (`chrome
+…`) target the Chrome linked to it. No other tab changes, so nothing needs
+approving:
 
 ```
 ELECTRON_RUN_AS_NODE=1 "$CODEY_BROWSER_RUNTIME" "$CODEY_BROWSER_CLI" --profile work new-tab "https://github.com"
 ```
 
 Every command after that acts on whichever tab is visible, so keep working in
-the tab you just opened. `state` reports the default profile, and `tabs`
-reports the profile each tab belongs to.
+the tab you just opened. `state` reports the current tab's profile, and
+`tabs` reports the profile each tab belongs to. With no `--profile`, a Chrome
+command targets the Chrome linked to the current tab's profile; with no tab
+or an inactive/unlinked profile it fails with a named error.
 
 ## Rules
 


### PR DESCRIPTION
## What

Splits the overloaded "active profile" into one per-profile concept and a per-invocation target.

- **active** = "enabled". Several profiles can be active at once. An active profile is invocable *and* mirrors its linked Chrome — the separate auto-sync switch is gone (active is the switch).
- **target** = decided when a command runs: the agent's `--profile <name>`, else the browser tab currently on screen. The global "default/active" radio and `setDefaultProfile` are removed.

Builds on #432 (Chrome binding) and #434 (wording + drop export). Full design in `docs/superpowers/specs/2026-09-10-browser-multi-active-design.md`.

## Changes

**Model**
- `setActive(name, enabled)` toggles a name in the `.active` file instead of overwriting — multi-enable is the file format's native shape.
- `autoSync` field/method/IPC removed. The #432 sync loop now keys on `active && chromeProfileId`.
- New `currentTabProfile()` and `isActiveProfile()`; `BrowserState` gains `profile`.
- New tabs follow the current tab; closing the active tab keeps the replacement on the closed tab's profile.

**Routing**
- Agent `--profile personal` now routes Chrome commands too: `chromeTarget()` resolves the name to its bound Chrome (via the #432 binding) and passes it to `activeTab` / `snapshot` / `navigate` / `act`.
- `targetResolver` resolves the current tab's profile, with named failures: `Activate a browser profile first`, `Profile "X" is not active`, `Profile "X" is not linked to a Chrome profile`, `Chrome profile "Y" is not running`.

**UI / CLI**
- Profile rows get one **Active** toggle; the "Active/Activate" radio and "Sync with Chrome" toggle are gone.
- The toolbar chip is a read-only display of the current tab's profile; the "Active profile" menu is gone. Alt-click `+` lists only active profiles.
- `profile activate <name> [on|off]` replaces `profile default`.

## Verification

- Tests: `1069/1069` pass
- `tsc --noEmit` clean
- `vite build` (renderer + electron main + preload) succeeds
- ESLint: 0 errors

## Out of scope

- Chrome → Codey reverse sync (still Chrome → Codey one-way).
- A picker for "which Chrome" when several are bound and no tab/`--profile` names one — the named error is the whole answer.
